### PR TITLE
Add zapier trigger memory example route

### DIFF
--- a/backend/routers/workflow.py
+++ b/backend/routers/workflow.py
@@ -1,10 +1,11 @@
 import os
-from typing import Annotated
+from typing import Annotated, List
 from datetime import datetime, timedelta
 from fastapi import APIRouter, Header
 from fastapi import Request, HTTPException
 import models.memory as memory_models
 import models.integrations as integration_models
+import database.memories as memories_db
 
 from utils.memories.location import get_google_maps_location
 from routers.memories import process_memory, trigger_external_integrations
@@ -12,7 +13,7 @@ from routers.memories import process_memory, trigger_external_integrations
 router = APIRouter()
 
 
-@router.post('/v1/integrations/workflow/memories', response_model=integration_models.EmptyResponse)
+@router.post('/v1/integrations/workflow/memories', response_model=integration_models.EmptyResponse, tags=['integration', 'workflow', 'memories'])
 def create_memory(request: Request, uid: str, api_key: Annotated[str | None, Header()], create_memory: memory_models.WorkflowCreateMemory):
     if api_key != os.getenv('WORKFLOW_API_KEY'):
         raise HTTPException(status_code=401, detail="Invalid API Key")
@@ -46,3 +47,14 @@ def create_memory(request: Request, uid: str, api_key: Annotated[str | None, Hea
 
     # Empty response
     return {}
+
+@router.get('/v1/integrations/workflow/memories', response_model=List[memory_models.Memory], tags=['integration', 'workflow', 'memories'])
+def get_memory(request: Request, uid: str, api_key: Annotated[str | None, Header()], limit: int = 1):
+    if api_key != os.getenv('WORKFLOW_API_KEY'):
+        raise HTTPException(status_code=401, detail="Invalid API Key")
+
+    # max 12
+    limit = min(limit, 12)
+
+    print('get_memories', uid, limit)
+    return memories_db.get_memories(uid, limit, 0, include_discarded=False)

--- a/plugins/example/zapier/memory_created.py
+++ b/plugins/example/zapier/memory_created.py
@@ -98,7 +98,6 @@ async def unsubscribe_zapier_trigger(subscriber: ZapierSubcribeModel, uid: str):
 
     if not subscriber.target_url or subscriber.target_url == "":
         raise HTTPException(status_code=400, detail='Target url is invalid.')
-        return
 
     # Validate user status
     status = get_zapier_user_status(uid)
@@ -108,6 +107,61 @@ async def unsubscribe_zapier_trigger(subscriber: ZapierSubcribeModel, uid: str):
     print({'uid': uid, 'target_url': subscriber.target_url})
     remove_zapier_subscribes(uid, subscriber.target_url)
     return {}
+
+
+@router.get('/zapier/trigger/memory/sample', tags=['zapier'], response_model=ZapierCreateMemory)
+async def get_trigger_memory_sample(request: Request, uid: str):
+    """
+    Get the latest memory or a sample to fullfill the triggers On memory created
+    """
+
+    if not uid:
+        raise HTTPException(status_code=400, detail='UID is required')
+
+    # Genrate sample
+    sample = ZapierCreateMemory(
+            icon={
+                "type": "emoji",
+                "emoji": "🧠",
+            },
+            title='Omi\'s sammple memory',
+            speakers=0,
+            category="other",
+            duration=300,
+            overview="Meet Omi today, the world’s leading open-source AI wearables that revolutionize how you capture and manage conversations. Simply connect Omi to your mobile device and enjoy automatic, high-quality transcriptions of meetings, chats, and voice memos wherever you are.",
+    )
+
+    # Get latest from Omi
+    ok = get_friend().get_latest_memory(uid)
+    print(ok)
+    if "error" in ok:
+        err = ok["error"]
+        print(err)
+        raise HTTPException(status_code=err["status"] if "status" in err else 500,
+                            detail='Can not create memory')
+
+    memory = ok["result"]
+    if memory is not None:
+        try:
+            emoji = memory.structured.emoji.encode('latin1').decode('utf-8')
+        except UnicodeEncodeError:
+            emoji = memory.structured.emoji
+
+        sample = ZapierCreateMemory(
+            icon={
+                "type": "emoji",
+                "emoji": f"{emoji}"
+            },
+            title=f'{memory.structured.title}',
+            speakers=len(
+                set(map(lambda x: x.speaker, memory.transcript_segments))),
+            category=memory.structured.category,
+            duration=int((memory.finished_at -
+                          memory.started_at).total_seconds() if memory.finished_at is not None else 0),
+            overview=memory.structured.overview,
+        )
+
+    return sample
 
 
 @router.get('/zapier/me', tags=['zapier'], response_model=EndpointResponse)
@@ -202,7 +256,7 @@ def create_zapier_memory(uid: str, memory: Memory):
                 set(map(lambda x: x.speaker, memory.transcript_segments))),
             category=memory.structured.category,
             duration=int((memory.finished_at -
-                      memory.started_at).total_seconds() if memory.finished_at is not None else 0),
+                          memory.started_at).total_seconds() if memory.finished_at is not None else 0),
             overview=memory.structured.overview,
         )
         ok = get_zapier().send_hook_memory_created(target_url, data)


### PR DESCRIPTION
Issue: https://github.com/BasedHardware/Omi/issues/620

**Todos:**

- [x] Allow Omi Zapier App trigger on getting sample memory via plugin API
- [x] Get the lasted users memory instead of the sample, if user having at least 1 memory

**UAT**
 - [x] https://www.getcurl.app/5ac9e067-fb/GET-zapier-trigger-memory-sample