### PR TITLE
Fix Memory Detail Page being stuck due to cached network image

### DIFF
--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -276,17 +276,25 @@ List<Widget> getPluginsWidgets(
                         imageBuilder: (context, imageProvider) {
                           return CircleAvatar(
                             backgroundColor: Colors.white,
-                            maxRadius: 16,
+                            radius: 16,
                             backgroundImage: imageProvider,
                           );
                         },
                         errorWidget: (context, url, error) {
                           return const CircleAvatar(
                             backgroundColor: Colors.white,
-                            maxRadius: 16,
+                            radius: 16,
                             child: Icon(Icons.error_outline_rounded),
                           );
                         },
+                        progressIndicatorBuilder: (context, url, progress) => CircleAvatar(
+                          backgroundColor: Colors.white,
+                          radius: 16,
+                          child: CircularProgressIndicator(
+                            value: progress.progress,
+                            valueColor: const AlwaysStoppedAnimation<Color>(Colors.white),
+                          ),
+                        ),
                       ),
                       title: Text(
                         plugin.name,


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Enhancement: Updated the `getPluginsWidgets` method in the memory detail page. Now, a loading indicator is displayed while images are being fetched, improving user experience by providing visual feedback during load times.
- Style: Adjusted the radius of the `CircleAvatar` widgets for a more refined look and feel when displaying images.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->