### PR TITLE
Feature/speech profile post-training

### DIFF
--- a/app/lib/backend/http/api/memories.dart
+++ b/app/lib/backend/http/api/memories.dart
@@ -6,7 +6,6 @@ import 'package:friend_private/backend/database/geolocation.dart';
 import 'package:friend_private/backend/database/memory.dart';
 import 'package:friend_private/backend/database/transcript_segment.dart';
 import 'package:friend_private/backend/http/shared.dart';
-import 'package:friend_private/backend/http/webhooks.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/memory.dart';
 import 'package:friend_private/env/env.dart';
@@ -163,4 +162,31 @@ Future<List<MemoryPhoto>> getMemoryPhotos(String memoryId) async {
     return (jsonDecode(response.body) as List<dynamic>).map((photo) => MemoryPhoto.fromJson(photo)).toList();
   }
   return [];
+}
+
+Future<bool> hasMemoryRecording(String memoryId) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/memories/$memoryId/recording',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+  if (response == null) return false;
+  debugPrint('getMemoryPhotos: ${response.body}');
+  if (response.statusCode == 200) {
+    return jsonDecode(response.body)['has_recording'] ?? false;
+  }
+  return false;
+}
+
+Future<bool> setMemoryTranscriptSegmentIsUser(String memoryId, int segmentIdx, bool value) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/memories/$memoryId/segments/$segmentIdx/is_user?value=$value',
+    headers: {},
+    method: 'PATCH',
+    body: '',
+  );
+  if (response == null) return false;
+  debugPrint('setMemoryTranscriptSegmentIsUser: ${response.body}');
+  return response.statusCode == 200;
 }

--- a/app/lib/backend/http/api/speech_profile.dart
+++ b/app/lib/backend/http/api/speech_profile.dart
@@ -22,18 +22,18 @@ Future<bool> userHasSpeakerProfile() async {
   return true; // to avoid showing the banner if the request fails or there's no internet.
 }
 
-// Future<List<SpeakerIdSample>> getUserSamplesState() async {
-//   debugPrint('getUserSamplesState for uid: ${SharedPreferencesUtil().uid}');
-//   var response = await makeApiCall(
-//     url: '${Env.apiBaseUrl}v1/speech-profile/samples',
-//     headers: {},
-//     method: 'GET',
-//     body: '',
-//   );
-//   if (response == null) return [];
-//   debugPrint('getUserSamplesState: ${response.body}');
-//   return SpeakerIdSample.fromJsonList(jsonDecode(response.body));
-// }
+Future<String?> getUserSpeechProfile() async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v4/speech-profile',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+  if (response == null) return null;
+  debugPrint('userHasSpeakerProfile: ${response.body}');
+  if (response.statusCode == 200) return jsonDecode(response.body)['url'];
+  return null;
+}
 
 Future<bool> uploadProfileBytes(List<List<int>> bytes, int duration) async {
   var response = await makeApiCall(
@@ -71,4 +71,24 @@ Future<bool> uploadProfile(File file) async {
     debugPrint('An error occurred uploadSample: $e');
     throw Exception('An error occurred uploadSample: $e');
   }
+}
+
+/**/
+
+Future<List<String>> getExpandedProfileSamples() async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v3/speech-profile/expand',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+  if (response == null) return [];
+  debugPrint('getExpandedProfileSamples: ${response.body}');
+  if (response.statusCode == 200) {
+    var data = jsonDecode(response.body);
+    if (data != null) {
+      return List<String>.from(data);
+    }
+  }
+  return [];
 }

--- a/app/lib/backend/http/api/speech_profile.dart
+++ b/app/lib/backend/http/api/speech_profile.dart
@@ -92,3 +92,32 @@ Future<List<String>> getExpandedProfileSamples() async {
   }
   return [];
 }
+
+// DELETE v3/speech-profile/expand?memory_id&segment_idx
+// POST v3/speech-profile/expand?memory_id&segment_idx
+
+Future<bool> expandProfileSample(String memoryId, int segmentIdx) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v3/speech-profile/expand?memory_id=$memoryId&segment_idx=$segmentIdx',
+    headers: {},
+    method: 'POST',
+    body: '',
+  );
+  if (response == null) return false;
+  debugPrint('expandProfileSample: ${response.body}');
+  if (response.statusCode == 200) return true;
+  return false;
+}
+
+Future<bool> deleteProfileSample(String memoryId, int segmentIdx) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v3/speech-profile/expand?memory_id=$memoryId&segment_idx=$segmentIdx',
+    headers: {},
+    method: 'DELETE',
+    body: '',
+  );
+  if (response == null) return false;
+  debugPrint('deleteProfileSample: ${response.body}');
+  if (response.statusCode == 200) return true;
+  return false;
+}

--- a/app/lib/backend/http/api/users.dart
+++ b/app/lib/backend/http/api/users.dart
@@ -1,0 +1,45 @@
+import 'dart:convert';
+
+import 'package:flutter/material.dart';
+import 'package:friend_private/backend/http/shared.dart';
+import 'package:friend_private/env/env.dart';
+
+Future<bool> setRecordingPermission(bool value) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/users/store-recording-permission?value=$value',
+    headers: {},
+    method: 'POST',
+    body: '',
+  );
+  if (response == null) return false;
+  debugPrint('storeRecordingPermission response: ${response.body}');
+  return response.statusCode == 200;
+}
+
+Future<bool?> getStoreRecordingPermission() async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/users/store-recording-permission',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+  if (response == null) return null;
+  debugPrint('getStoreRecordingPermission response: ${response.body}');
+  if (response.statusCode == 200) {
+    var jsonResponse = jsonDecode(response.body);
+    return jsonResponse['store_recording_permission'] as bool?;
+  }
+  return null;
+}
+
+Future<bool> deletePermissionAndRecordings() async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/users/store-recording-permission',
+    headers: {},
+    method: 'DELETE',
+    body: '',
+  );
+  if (response == null) return false;
+  debugPrint('deletePermissionAndRecordings response: ${response.body}');
+  return response.statusCode == 200;
+}

--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -38,8 +38,8 @@ Future<http.Response?> makeApiCall({
       return null;
     }
     if (url.contains(Env.apiBaseUrl!)) {
-      // headers['Authorization'] = await getAuthHeader();
-      headers['Authorization'] = '123caLCFj7IisV85UX9XrrV1aVf3pk1'; // set admin key + uid here for testing
+      headers['Authorization'] = await getAuthHeader();
+      // headers['Authorization'] = ''; // set admin key + uid here for testing
     }
 
     final client = InstabugHttpClient();

--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -38,8 +38,8 @@ Future<http.Response?> makeApiCall({
       return null;
     }
     if (url.contains(Env.apiBaseUrl!)) {
-      headers['Authorization'] = await getAuthHeader();
-      // headers['Authorization'] = ''; // set admin key + uid here for testing
+      // headers['Authorization'] = await getAuthHeader();
+      headers['Authorization'] = '123caLCFj7IisV85UX9XrrV1aVf3pk1'; // set admin key + uid here for testing
     }
 
     final client = InstabugHttpClient();
@@ -51,6 +51,8 @@ Future<http.Response?> makeApiCall({
       return await client.get(Uri.parse(url), headers: headers);
     } else if (method == 'DELETE') {
       return await client.delete(Uri.parse(url), headers: headers);
+    } else if (method == 'PATCH') {
+      return await client.patch(Uri.parse(url), headers: headers);
     } else {
       throw Exception('Unsupported HTTP method: $method');
     }

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -96,6 +96,10 @@ class SharedPreferencesUtil {
 
   set devModeEnabled(bool value) => saveBool('devModeEnabled', value);
 
+  bool get permissionStoreRecordingsEnabled => getBool('permissionStoreRecordingsEnabled') ?? false;
+
+  set permissionStoreRecordingsEnabled(bool value) => saveBool('permissionStoreRecordingsEnabled', value);
+
   bool get coachNotificationIsChecked => getBool('coachIsChecked') ?? true;
 
   set coachNotificationIsChecked(bool value) => saveBool('coachIsChecked', value);

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -180,11 +180,6 @@ class _MyAppState extends State<MyApp> {
                     secondary: Colors.deepPurple,
                     surface: Colors.black38,
                   ),
-                  // dialogTheme: const DialogTheme(
-                  //   backgroundColor: Colors.black,
-                  //   titleTextStyle: TextStyle(fontSize: 18, color: Colors.white),
-                  //   contentTextStyle: TextStyle(fontSize: 16, color: Colors.white),
-                  // ),
                   snackBarTheme: SnackBarThemeData(
                     backgroundColor: Colors.grey.shade900,
                     contentTextStyle: const TextStyle(fontSize: 16, color: Colors.white, fontWeight: FontWeight.w500),
@@ -202,29 +197,9 @@ class _MyAppState extends State<MyApp> {
               themeMode: ThemeMode.dark,
               home: (SharedPreferencesUtil().onboardingCompleted && widget.isAuth)
                   ? const HomePageWrapper()
-                  : const OnboardingWrapper(),
+                  : const HomePageWrapper(),
             ),
           );
         });
   }
 }
-
-// void _setupAudioSession() {
-//   AudioSession.instance.then((audioSession) async {
-//     await audioSession.configure(const AudioSessionConfiguration(
-//       avAudioSessionCategory: AVAudioSessionCategory.playback,
-//       avAudioSessionCategoryOptions: AVAudioSessionCategoryOptions.mixWithOthers,
-//       avAudioSessionMode: AVAudioSessionMode.spokenAudio,
-//       avAudioSessionRouteSharingPolicy: AVAudioSessionRouteSharingPolicy.defaultPolicy,
-//       avAudioSessionSetActiveOptions: AVAudioSessionSetActiveOptions.none,
-//       androidAudioAttributes: AndroidAudioAttributes(
-//         contentType: AndroidAudioContentType.speech,
-//         flags: AndroidAudioFlags.none,
-//         usage: AndroidAudioUsage.assistant,
-//       ),
-//       androidAudioFocusGainType: AndroidAudioFocusGainType.gain,
-//       androidWillPauseWhenDucked: true,
-//     ));
-//     audioSession.setActive(true);
-//   });
-// }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -197,7 +197,7 @@ class _MyAppState extends State<MyApp> {
               themeMode: ThemeMode.dark,
               home: (SharedPreferencesUtil().onboardingCompleted && widget.isAuth)
                   ? const HomePageWrapper()
-                  : const HomePageWrapper(),
+                  : const OnboardingWrapper(),
             ),
           );
         });

--- a/app/lib/pages/memory_detail/page.dart
+++ b/app/lib/pages/memory_detail/page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:friend_private/backend/database/memory.dart';
 import 'package:friend_private/backend/database/transcript_segment.dart';
 import 'package:friend_private/backend/http/api/memories.dart';
+import 'package:friend_private/backend/http/api/speech_profile.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/memory.dart';
 import 'package:friend_private/pages/memory_detail/share.dart';
@@ -43,6 +44,7 @@ class _MemoryDetailPageState extends State<MemoryDetailPage> with TickerProvider
   TabController? _controller;
 
   bool canDisplaySeconds = true;
+  bool hasAudioRecording = false;
 
   List<MemoryPhoto> photos = [];
 
@@ -59,6 +61,12 @@ class _MemoryDetailPageState extends State<MemoryDetailPage> with TickerProvider
       getMemoryPhotos(widget.memory.id).then((value) {
         photos = value;
         setState(() {}); // TODO: if left before this closes, fails
+      });
+    } else if (widget.memory.source == MemorySource.friend) {
+      hasMemoryRecording(widget.memory.id).then((value) {
+        print('VALUE $value');
+        hasAudioRecording = value;
+        setState(() {});
       });
     }
     super.initState();
@@ -224,6 +232,96 @@ class _MemoryDetailPageState extends State<MemoryDetailPage> with TickerProvider
               horizontalMargin: false,
               topMargin: false,
               canDisplaySeconds: canDisplaySeconds,
+              isMemoryDetail: true,
+              editSegment: (segmentIdx) {
+                print('editSegment');
+                showModalBottomSheet(
+                    context: context,
+                    isScrollControlled: true,
+                    shape: const RoundedRectangleBorder(
+                      borderRadius: BorderRadius.only(topLeft: Radius.circular(16), topRight: Radius.circular(16)),
+                    ),
+                    builder: (ctx) {
+                      bool isUserSegment = widget.memory.transcriptSegments[segmentIdx].isUser;
+                      bool useForProfileTraining = false;
+                      return StatefulBuilder(builder: (BuildContext context, StateSetter setModalState) {
+                        return Container(
+                          decoration: BoxDecoration(
+                            color: Colors.grey.shade800,
+                            borderRadius:
+                                const BorderRadius.only(topLeft: Radius.circular(16), topRight: Radius.circular(16)),
+                          ),
+                          height: 280,
+                          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 16),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              const SizedBox(height: 8),
+                              Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                                child: Text('Edit Segment', style: Theme.of(context).textTheme.titleLarge),
+                              ),
+                              CheckboxListTile(
+                                value: isUserSegment,
+                                onChanged: (v) {
+                                  setModalState(() {
+                                    isUserSegment = v!;
+                                  });
+                                },
+                                checkboxShape: const RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.all(Radius.circular(4)),
+                                ),
+                                title: const Text('Is this speech segment yours?'),
+                              ),
+                              isUserSegment && hasAudioRecording
+                                  ? CheckboxListTile(
+                                      value: useForProfileTraining,
+                                      onChanged: (v) {
+                                        setModalState(() {
+                                          useForProfileTraining = v!;
+                                        });
+                                      },
+                                      checkboxShape: const RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.all(Radius.circular(4)),
+                                      ),
+                                      title:
+                                          const Text('Should we train your speech profile further with this segment?'),
+                                    )
+                                  : const SizedBox(),
+                              Padding(
+                                padding: const EdgeInsets.all(16),
+                                child: TextButton(
+                                    style: TextButton.styleFrom(
+                                      backgroundColor: Theme.of(context).colorScheme.primary,
+                                      shape: const RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.all(Radius.circular(12)),
+                                      ),
+                                    ),
+                                    onPressed: () async {
+                                      widget.memory.transcriptSegments[segmentIdx].isUser = isUserSegment;
+                                      setMemoryTranscriptSegmentIsUser(widget.memory.id, segmentIdx, isUserSegment);
+                                      if (useForProfileTraining) expandProfileSample(widget.memory.id, segmentIdx);
+
+                                      Navigator.pop(context);
+                                      setState(() {});
+                                    },
+                                    child: const Padding(
+                                      padding: EdgeInsets.symmetric(
+                                        horizontal: 24,
+                                        vertical: 4,
+                                      ),
+                                      child: Text(
+                                        'Save',
+                                        style: TextStyle(color: Colors.white),
+                                      ),
+                                    )),
+                              ),
+                            ],
+                          ),
+                        );
+                      });
+                    });
+              },
             ),
       const SizedBox(height: 32)
     ];

--- a/app/lib/pages/memory_detail/page.dart
+++ b/app/lib/pages/memory_detail/page.dart
@@ -64,7 +64,6 @@ class _MemoryDetailPageState extends State<MemoryDetailPage> with TickerProvider
       });
     } else if (widget.memory.source == MemorySource.friend) {
       hasMemoryRecording(widget.memory.id).then((value) {
-        print('VALUE $value');
         hasAudioRecording = value;
         setState(() {});
       });

--- a/app/lib/pages/settings/page.dart
+++ b/app/lib/pages/settings/page.dart
@@ -1,6 +1,3 @@
-import 'dart:math';
-
-import 'package:awesome_notifications/awesome_notifications.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:friend_private/backend/preferences.dart';
@@ -8,16 +5,16 @@ import 'package:friend_private/pages/plugins/page.dart';
 import 'package:friend_private/pages/settings/calendar.dart';
 import 'package:friend_private/pages/settings/developer.dart';
 import 'package:friend_private/pages/settings/privacy.dart';
+import 'package:friend_private/pages/settings/recordings.dart';
 import 'package:friend_private/pages/settings/webview.dart';
 import 'package:friend_private/pages/settings/widgets.dart';
 import 'package:friend_private/pages/speaker_id/page.dart';
-import 'package:friend_private/services/notification_service.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/dialog.dart';
+import 'package:gradient_borders/gradient_borders.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
-import 'package:gradient_borders/gradient_borders.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -178,47 +175,51 @@ class _SettingsPageState extends State<SettingsPage> {
                     MixpanelManager().recordingLanguageChanged(_selectedLanguage);
                   }, _selectedLanguage),
                   ...getPreferencesWidgets(
-                    onOptInAnalytics: () {
-                      setState(() {
-                        optInAnalytics = !SharedPreferencesUtil().optInAnalytics;
-                        SharedPreferencesUtil().optInAnalytics = !SharedPreferencesUtil().optInAnalytics;
-                        optInAnalytics ? MixpanelManager().optInTracking() : MixpanelManager().optOutTracking();
-                      });
-                    },
-                    onOptInEmotionalFeedback: () {
-                      var enabled = !SharedPreferencesUtil().optInEmotionalFeedback;
-                      SharedPreferencesUtil().optInEmotionalFeedback = enabled;
+                      onOptInAnalytics: () {
+                        setState(() {
+                          optInAnalytics = !SharedPreferencesUtil().optInAnalytics;
+                          SharedPreferencesUtil().optInAnalytics = !SharedPreferencesUtil().optInAnalytics;
+                          optInAnalytics ? MixpanelManager().optInTracking() : MixpanelManager().optOutTracking();
+                        });
+                      },
+                      onOptInEmotionalFeedback: () {
+                        var enabled = !SharedPreferencesUtil().optInEmotionalFeedback;
+                        SharedPreferencesUtil().optInEmotionalFeedback = enabled;
 
-                      setState(() {
-                        optInEmotionalFeedback = enabled;
-                      });
+                        setState(() {
+                          optInEmotionalFeedback = enabled;
+                        });
 
-                      // Show a mockup notifications to help user understand about Omi Feedback
-                      if (enabled) {
-                        _showMockupOmiFeebackNotification();
-                      }
-                    },
-                    viewPrivacyDetails: () {
-                      Navigator.of(context).push(MaterialPageRoute(builder: (c) => const PrivacyInfoPage()));
-                      MixpanelManager().privacyDetailsPageOpened();
-                    },
-                    optInEmotionalFeedback: optInEmotionalFeedback,
-                    optInAnalytics: optInAnalytics,
-                    devModeEnabled: devModeEnabled,
-                    onDevModeClicked: () {
-                      setState(() {
-                        if (devModeEnabled) {
-                          devModeEnabled = false;
-                          SharedPreferencesUtil().devModeEnabled = false;
-                          MixpanelManager().developerModeDisabled();
-                        } else {
-                          devModeEnabled = true;
-                          MixpanelManager().developerModeEnabled();
-                          SharedPreferencesUtil().devModeEnabled = true;
+                        // Show a mockup notifications to help user understand about Omi Feedback
+                        if (enabled) {
+                          _showMockupOmiFeebackNotification();
                         }
-                      });
-                    },
-                  ),
+                      },
+                      viewPrivacyDetails: () {
+                        Navigator.of(context).push(MaterialPageRoute(builder: (c) => const PrivacyInfoPage()));
+                        MixpanelManager().privacyDetailsPageOpened();
+                      },
+                      optInEmotionalFeedback: optInEmotionalFeedback,
+                      optInAnalytics: optInAnalytics,
+                      devModeEnabled: devModeEnabled,
+                      onDevModeClicked: () {
+                        setState(() {
+                          if (devModeEnabled) {
+                            devModeEnabled = false;
+                            SharedPreferencesUtil().devModeEnabled = false;
+                            MixpanelManager().developerModeDisabled();
+                          } else {
+                            devModeEnabled = true;
+                            MixpanelManager().developerModeEnabled();
+                            SharedPreferencesUtil().devModeEnabled = true;
+                          }
+                        });
+                      },
+                      authorizeSavingRecordings: SharedPreferencesUtil().permissionStoreRecordingsEnabled,
+                      onAuthorizeSavingRecordingsClicked: () async {
+                        await routeToPage(context, const AuthorizeRecordingsPage());
+                        setState(() {});
+                      }),
                   const SizedBox(height: 16),
                   ListTile(
                     title: const Text('Need help?', style: TextStyle(color: Colors.white)),

--- a/app/lib/pages/settings/recordings.dart
+++ b/app/lib/pages/settings/recordings.dart
@@ -26,13 +26,16 @@ class _AuthorizeRecordingsPageState extends State<AuthorizeRecordingsPage> {
     final permission = await getStoreRecordingPermission();
     setState(() {
       _hasPermission = permission;
+      if (permission != null) {
+        SharedPreferencesUtil().permissionStoreRecordingsEnabled = permission;
+      }
     });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      backgroundColor: Theme.of(context).colorScheme.background,
+      backgroundColor: Theme.of(context).colorScheme.primary,
       appBar: AppBar(
         backgroundColor: Theme.of(context).colorScheme.primary,
         title: const Text('Authorize Saving Recordings'),

--- a/app/lib/pages/settings/recordings.dart
+++ b/app/lib/pages/settings/recordings.dart
@@ -1,0 +1,189 @@
+import 'package:flutter/material.dart';
+import 'package:friend_private/backend/http/api/users.dart';
+import 'package:friend_private/backend/preferences.dart';
+import 'package:friend_private/widgets/dialog.dart';
+
+class AuthorizeRecordingsPage extends StatefulWidget {
+  const AuthorizeRecordingsPage({super.key});
+
+  @override
+  State<AuthorizeRecordingsPage> createState() => _AuthorizeRecordingsPageState();
+}
+
+class _AuthorizeRecordingsPageState extends State<AuthorizeRecordingsPage> {
+  bool? _hasPermission;
+  bool loading = false;
+
+  changeLoadingState() => setState(() => loading = !loading);
+
+  @override
+  void initState() {
+    super.initState();
+    _checkPermission();
+  }
+
+  Future<void> _checkPermission() async {
+    final permission = await getStoreRecordingPermission();
+    setState(() {
+      _hasPermission = permission;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.background,
+      appBar: AppBar(
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        title: const Text('Authorize Saving Recordings'),
+      ),
+      body: loading || _hasPermission == null
+          ? const Center(
+              child: CircularProgressIndicator(
+              color: Colors.white,
+            ))
+          : SingleChildScrollView(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      _hasPermission! ? "Thanks for authorizing!" : "We need your permission",
+                      style: Theme.of(context).textTheme.headlineSmall,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      _hasPermission!
+                          ? "You've already given us permission to save your recordings. Here's a reminder of why we need it:"
+                          : "We'd like your permission to save your voice recordings. Here's why:",
+                      style: Theme.of(context).textTheme.bodyLarge,
+                    ),
+                    const SizedBox(height: 32),
+                    _buildReasonTile(
+                      icon: Icons.person,
+                      title: "Improve Your Speech Profile",
+                      description: "We use recordings to further train and enhance your personal speech profile.",
+                    ),
+                    SizedBox(height: 16),
+                    _buildReasonTile(
+                      icon: Icons.group,
+                      title: "Train Profiles for Friends and Family",
+                      description: "Your recordings help us recognize and create profiles for your friends and family.",
+                    ),
+                    SizedBox(height: 16),
+                    _buildReasonTile(
+                      icon: Icons.trending_up,
+                      title: "Enhance Transcript Accuracy",
+                      description:
+                          "As our model improves, we can provide better transcription results for your recordings.",
+                    ),
+                    const SizedBox(height: 16),
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      child: Text(
+                        "Legal Notice: The legality of recording and storing voice data may vary depending on your location and how you use this feature. It's your responsibility to ensure compliance with local laws and regulations.",
+                        style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                              color: Theme.of(context).colorScheme.onSurfaceVariant,
+                            ),
+                      ),
+                    ),
+                    const SizedBox(height: 24),
+                    Center(
+                      child: MaterialButton(
+                        onPressed: _hasPermission! ? null : _authorize,
+                        child: Text(
+                          _hasPermission! ? "Already Authorized" : "Authorize",
+                          style: const TextStyle(
+                            color: Colors.white,
+                            decoration: TextDecoration.underline,
+                          ),
+                        ),
+                      ),
+                    ),
+                    if (_hasPermission!)
+                      Center(
+                        child: TextButton(
+                          onPressed: _revokeAuthorization,
+                          child: const Text(
+                            "Revoke Authorization",
+                            style: TextStyle(color: Colors.white),
+                          ),
+                        ),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+    );
+  }
+
+  Widget _buildReasonTile({required IconData icon, required String title, required String description}) {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 16.0),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(icon, size: 24),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(title, style: Theme.of(context).textTheme.titleMedium),
+                const SizedBox(height: 4),
+                Text(description, style: Theme.of(context).textTheme.bodyMedium),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Future<void> _authorize() async {
+    changeLoadingState();
+    final success = await setRecordingPermission(true);
+    changeLoadingState();
+    if (success) {
+      SharedPreferencesUtil().permissionStoreRecordingsEnabled = true;
+      setState(() => _hasPermission = true);
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Authorization successful!")));
+    } else {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text("Failed to authorize. Please try again.")));
+    }
+  }
+
+  Future<void> _revokeAuthorization() async {
+    changeLoadingState();
+    final success = await setRecordingPermission(false);
+    changeLoadingState();
+    if (success) {
+      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Authorization revoked.")));
+      setState(() {
+        _hasPermission = false;
+      });
+      SharedPreferencesUtil().permissionStoreRecordingsEnabled = false;
+      showDialog(
+        context: context,
+        builder: (c) => getDialog(
+          context,
+          () => Navigator.pop(context),
+          () {
+            deletePermissionAndRecordings();
+            ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text("Recordings deleted.")));
+            Navigator.pop(context);
+          },
+          'Permission Revoked',
+          'Do you want us to remove all your existing recordings too?',
+          okButtonText: 'Yes',
+        ),
+      );
+    } else {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text("Failed to revoke authorization. Please try again.")),
+      );
+    }
+  }
+}

--- a/app/lib/pages/settings/widgets.dart
+++ b/app/lib/pages/settings/widgets.dart
@@ -204,6 +204,8 @@ getPreferencesWidgets({
   required bool optInEmotionalFeedback,
   required VoidCallback onDevModeClicked,
   required bool devModeEnabled,
+  required VoidCallback onAuthorizeSavingRecordingsClicked,
+  required bool authorizeSavingRecordings,
 }) {
   return [
     const Align(
@@ -361,6 +363,45 @@ getPreferencesWidgets({
         ),
       ),
     ),
+    Padding(
+      padding: const EdgeInsets.fromLTRB(0, 0, 8, 0),
+      child: InkWell(
+        onTap: onAuthorizeSavingRecordingsClicked,
+        child: Padding(
+          padding: const EdgeInsets.symmetric(vertical: 12.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Text(
+                'Authorize saving recordings',
+                style: TextStyle(color: Color.fromARGB(255, 150, 150, 150), fontSize: 16),
+              ),
+              Container(
+                decoration: BoxDecoration(
+                  color: authorizeSavingRecordings
+                      ? const Color.fromARGB(255, 150, 150, 150)
+                      : Colors.transparent, // Fill color when checked
+                  border: Border.all(
+                    color: const Color.fromARGB(255, 150, 150, 150),
+                    width: 2,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                width: 22,
+                height: 22,
+                child: authorizeSavingRecordings // Show the icon only when checked
+                    ? const Icon(
+                        Icons.check,
+                        color: Colors.white, // Tick color
+                        size: 18,
+                      )
+                    : null, // No icon when unchecked
+              ),
+            ],
+          ),
+        ),
+      ),
+    )
   ];
 }
 

--- a/app/lib/pages/speaker_id/page.dart
+++ b/app/lib/pages/speaker_id/page.dart
@@ -8,6 +8,7 @@ import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
 import 'package:friend_private/pages/capture/logic/websocket_mixin.dart';
 import 'package:friend_private/pages/home/page.dart';
+import 'package:friend_private/pages/speaker_id/samples.dart';
 import 'package:friend_private/utils/audio/wav_bytes.dart';
 import 'package:friend_private/utils/ble/communication.dart';
 import 'package:friend_private/utils/ble/connected.dart';
@@ -301,7 +302,7 @@ class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateM
                     const DeviceAnimationWidget(sizeMultiplier: 0.2, animatedBackground: false),
                     !startedRecording
                         ? const SizedBox(height: 0)
-                        : Text(
+                        : const Text(
                             'Tell your Friend\nabout yourself',
                             style:
                                 TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w500, height: 1.4),
@@ -376,59 +377,72 @@ class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateM
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(24, 0, 24, 48),
                 child: !startedRecording
-                    ? MaterialButton(
-                        onPressed: () async {
-                          BleAudioCodec codec;
-                          try {
-                            codec = await getAudioCodec(_device!.id);
-                          } catch (e) {
-                            showDialog(
-                              context: context,
-                              barrierDismissible: false,
-                              builder: (c) => getDialog(
-                                context,
-                                () {
-                                  Navigator.of(context).pop();
-                                  Navigator.of(context).pop();
-                                },
-                                () => {},
-                                'Device Disconnected',
-                                'Please make sure your device is turned on and nearby, and try again.',
-                                singleButton: true,
-                              ),
-                            );
-                            return;
-                          }
+                    ? Column(
+                        mainAxisAlignment: MainAxisAlignment.end,
+                        children: [
+                          MaterialButton(
+                            onPressed: () async {
+                              BleAudioCodec codec;
+                              try {
+                                codec = await getAudioCodec(_device!.id);
+                              } catch (e) {
+                                showDialog(
+                                  context: context,
+                                  barrierDismissible: false,
+                                  builder: (c) => getDialog(
+                                    context,
+                                    () {
+                                      Navigator.of(context).pop();
+                                      Navigator.of(context).pop();
+                                    },
+                                    () => {},
+                                    'Device Disconnected',
+                                    'Please make sure your device is turned on and nearby, and try again.',
+                                    singleButton: true,
+                                  ),
+                                );
+                                return;
+                              }
 
-                          if (codec != BleAudioCodec.opus) {
-                            showDialog(
-                              context: context,
-                              builder: (c) => getDialog(
-                                context,
-                                () => Navigator.pop(context),
-                                () {
-                                  Navigator.pop(context);
-                                  launchUrl(
-                                      Uri.parse('https://github.com/BasedHardware/Omi/releases/tag/v1.0.4-firmware'));
-                                },
-                                'Firmware Update Required',
-                                'Please update your device firmware to set-up your speech profile.',
-                                okButtonText: 'Do now',
-                              ),
-                              barrierDismissible: false,
-                            );
-                            return;
-                          }
+                              if (codec != BleAudioCodec.opus) {
+                                showDialog(
+                                  context: context,
+                                  builder: (c) => getDialog(
+                                    context,
+                                    () => Navigator.pop(context),
+                                    () {
+                                      Navigator.pop(context);
+                                      launchUrl(Uri.parse(
+                                          'https://github.com/BasedHardware/Omi/releases/tag/v1.0.4-firmware'));
+                                    },
+                                    'Firmware Update Required',
+                                    'Please update your device firmware to set-up your speech profile.',
+                                    okButtonText: 'Do now',
+                                  ),
+                                  barrierDismissible: false,
+                                );
+                                return;
+                              }
 
-                          initiateWebsocket();
-                          // 1.5 minutes seems reasonable
-                          _forceCompletionTimer = Timer(Duration(seconds: maxDuration), finalize);
-                          setState(() => startedRecording = true);
-                        },
-                        color: Colors.white,
-                        padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 14),
-                        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
-                        child: const Text('Get Started', style: TextStyle(color: Colors.black)),
+                              initiateWebsocket();
+                              // 1.5 minutes seems reasonable
+                              _forceCompletionTimer = Timer(Duration(seconds: maxDuration), finalize);
+                              setState(() => startedRecording = true);
+                            },
+                            color: Colors.white,
+                            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 14),
+                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+                            child: const Text('Get Started', style: TextStyle(color: Colors.black)),
+                          ),
+                          TextButton(
+                              onPressed: () {
+                                routeToPage(context, const ProfileSamples());
+                              },
+                              child: const Text(
+                                'Listen to existing samples ✅',
+                                style: TextStyle(color: Colors.white, decoration: TextDecoration.underline),
+                              ))
+                        ],
                       )
                     : profileCompleted
                         ? Container(

--- a/app/lib/pages/speaker_id/page.dart
+++ b/app/lib/pages/speaker_id/page.dart
@@ -271,7 +271,24 @@ class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateM
           ),
           actions: [
             !widget.onbording
-                ? const SizedBox()
+                ? IconButton(
+                    onPressed: () {
+                      showDialog(
+                        context: context,
+                        builder: (c) => getDialog(
+                          context,
+                          () => Navigator.pop(context),
+                          () => Navigator.pop(context),
+                          'How to take a good sample?',
+                          '1. Make sure you are in a quiet place.\n2. Speak clearly and naturally.\n3. Make sure your device is in it\'s natural position, on your neck.\n\nOnce it\'s created, you can always improve it or do it again.',
+                          singleButton: true,
+                        ),
+                      );
+                    },
+                    icon: const Icon(
+                      Icons.question_mark,
+                      size: 20,
+                    ))
                 : TextButton(
                     onPressed: () {
                       routeToPage(context, const HomePageWrapper(), replace: true);
@@ -439,8 +456,8 @@ class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateM
                                 routeToPage(context, const ProfileSamples());
                               },
                               child: const Text(
-                                'Listen to existing samples ✅',
-                                style: TextStyle(color: Colors.white, decoration: TextDecoration.underline),
+                                'Listen to existing samples ➡️',
+                                style: TextStyle(color: Colors.white),
                               ))
                         ],
                       )

--- a/app/lib/pages/speaker_id/samples.dart
+++ b/app/lib/pages/speaker_id/samples.dart
@@ -100,6 +100,26 @@ class _ProfileSamplesState extends State<ProfileSamples> {
       appBar: AppBar(
         title: const Text('Speech Samples'),
         backgroundColor: Theme.of(context).colorScheme.primary,
+        actions: [
+          IconButton(
+              onPressed: () {
+                showDialog(
+                  context: context,
+                  builder: (c) => getDialog(
+                    context,
+                    () => Navigator.pop(context),
+                    () => Navigator.pop(context),
+                    'How to take more samples?',
+                    '1. Authorize Omi to store your memories audio recordings.\n2. Once you create a new memory with this settings, you can edit your transcript, and select segments to expand your speech profile.',
+                    singleButton: true,
+                  ),
+                );
+              },
+              icon: const Icon(
+                Icons.question_mark,
+                size: 20,
+              ))
+        ],
       ),
       backgroundColor: Theme.of(context).colorScheme.primary,
       body: loading
@@ -108,8 +128,27 @@ class _ProfileSamplesState extends State<ProfileSamples> {
               color: Colors.white,
             ))
           : ListView.builder(
-              itemCount: samplesUrl.length,
+              itemCount: samplesUrl.length + 1,
               itemBuilder: (context, index) {
+                if (index == samplesUrl.length) {
+                  return const Padding(
+                    padding: EdgeInsets.symmetric(horizontal:20, vertical: 16),
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.start,
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'How to take more samples?',
+                          style: TextStyle(fontSize: 16),
+                        ),
+                        SizedBox(height: 16),
+                        Text('1. Authorize Omi to store your memories audio recordings.'),
+                        SizedBox(height: 8),
+                        Text('2. Once you create a new memory with this settings, you will be able to edit your transcript, and select which segments include.'),
+                      ],
+                    ),
+                  );
+                }
                 return Column(
                   children: [
                     ListTile(
@@ -119,7 +158,6 @@ class _ProfileSamplesState extends State<ProfileSamples> {
                         ),
                         onPressed: () => _playPause(index),
                       ),
-                      // TODO: explain people here, they can add if they enable permission
                       title: Text(index == 0 ? 'Speech Profile' : 'Additional Sample $index'),
                       // _getFileNameFromUrl(samplesUrl[index])
                       subtitle: FutureBuilder<Duration?>(

--- a/app/lib/pages/speaker_id/samples.dart
+++ b/app/lib/pages/speaker_id/samples.dart
@@ -120,7 +120,7 @@ class _ProfileSamplesState extends State<ProfileSamples> {
                         onPressed: () => _playPause(index),
                       ),
                       // TODO: explain people here, they can add if they enable permission
-                      title: Text(index == 0 ? 'Speech Profile' : 'Extra Sample $index'),
+                      title: Text(index == 0 ? 'Speech Profile' : 'Additional Sample $index'),
                       // _getFileNameFromUrl(samplesUrl[index])
                       subtitle: FutureBuilder<Duration?>(
                         future: AudioPlayer().setUrl(samplesUrl[index]),
@@ -132,6 +132,23 @@ class _ProfileSamplesState extends State<ProfileSamples> {
                           }
                         },
                       ),
+                      // TODO: view memory source and segment on tap
+                      trailing: index == 0
+                          ? const SizedBox()
+                          : IconButton(
+                              onPressed: () {
+                                String name = _getFileNameFromUrl(samplesUrl[index]);
+                                var parts = name.split('_segment_');
+                                deleteProfileSample(parts[0], int.tryParse(parts[1])!);
+                                samplesUrl.removeAt(index);
+                                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                                    content: Text(
+                                  'Additional Speech Sample Removed',
+                                )));
+                                setState(() {});
+                              },
+                              icon: const Icon(Icons.delete, size: 20),
+                            ),
                     ),
                     index == 0 ? SizedBox(height: 8) : const SizedBox(),
                     index == 0

--- a/app/lib/pages/speaker_id/samples.dart
+++ b/app/lib/pages/speaker_id/samples.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:friend_private/backend/http/api/speech_profile.dart';
+import 'package:friend_private/widgets/dialog.dart';
+import 'package:just_audio/just_audio.dart';
+
+class ProfileSamples extends StatefulWidget {
+  const ProfileSamples({super.key});
+
+  @override
+  State<ProfileSamples> createState() => _ProfileSamplesState();
+}
+
+class _ProfileSamplesState extends State<ProfileSamples> {
+  List<String> samplesUrl = [];
+  bool loading = true;
+  final AudioPlayer _audioPlayer = AudioPlayer();
+  int? _currentPlayingIndex;
+  bool _isPlaying = false;
+
+  @override
+  void initState() {
+    _init();
+    _setupAudioPlayerListeners();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    _audioPlayer.dispose();
+    super.dispose();
+  }
+
+  _init() async {
+    String? url = await getUserSpeechProfile();
+    if (url == null) {
+      showDialog(
+          context: context,
+          builder: (c) => getDialog(
+                context,
+                () {
+                  Navigator.of(context).pop();
+                  Navigator.of(context).pop();
+                },
+                () {},
+                'Unexpected error',
+                'Failed to get profile samples. Please try again later.',
+                okButtonText: 'Ok',
+                singleButton: true,
+              ));
+      return;
+    }
+    samplesUrl.add(url);
+    List<String> expandedSamples = await getExpandedProfileSamples();
+    samplesUrl.addAll(expandedSamples);
+    loading = false;
+    setState(() {});
+  }
+
+  String _getFileNameFromUrl(String url) {
+    Uri uri = Uri.parse(url);
+    String fileName = uri.pathSegments.last;
+    return fileName.split('.').first;
+  }
+
+  void _setupAudioPlayerListeners() {
+    _audioPlayer.playerStateStream.listen((playerState) {
+      if (playerState.processingState == ProcessingState.completed) {
+        setState(() {
+          _currentPlayingIndex = null;
+          _isPlaying = false;
+        });
+      }
+    });
+  }
+
+  Future<void> _playPause(int index) async {
+    if (_currentPlayingIndex == index) {
+      if (_isPlaying) {
+        _audioPlayer.pause();
+        _isPlaying = false;
+      } else {
+        _audioPlayer.play();
+        _isPlaying = true;
+      }
+    } else {
+      _audioPlayer.stop();
+      await _audioPlayer.setUrl(samplesUrl[index]);
+      setState(() {
+        _currentPlayingIndex = index;
+        _isPlaying = true;
+      });
+      await _audioPlayer.play();
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Speech Samples'),
+        backgroundColor: Theme.of(context).colorScheme.primary,
+      ),
+      backgroundColor: Theme.of(context).colorScheme.primary,
+      body: loading
+          ? const Center(
+              child: CircularProgressIndicator(
+              color: Colors.white,
+            ))
+          : ListView.builder(
+              itemCount: samplesUrl.length,
+              itemBuilder: (context, index) {
+                return Column(
+                  children: [
+                    ListTile(
+                      leading: IconButton(
+                        icon: Icon(
+                          _currentPlayingIndex == index && _isPlaying ? Icons.pause : Icons.play_arrow,
+                        ),
+                        onPressed: () => _playPause(index),
+                      ),
+                      // TODO: explain people here, they can add if they enable permission
+                      title: Text(index == 0 ? 'Speech Profile' : 'Extra Sample $index'),
+                      // _getFileNameFromUrl(samplesUrl[index])
+                      subtitle: FutureBuilder<Duration?>(
+                        future: AudioPlayer().setUrl(samplesUrl[index]),
+                        builder: (context, snapshot) {
+                          if (snapshot.hasData) {
+                            return Text('Duration: ${snapshot.data!.inSeconds} seconds');
+                          } else {
+                            return const Text('Loading duration...');
+                          }
+                        },
+                      ),
+                    ),
+                    index == 0 ? SizedBox(height: 8) : const SizedBox(),
+                    index == 0
+                        ? Divider(
+                            color: Colors.grey.shade600,
+                          )
+                        : const SizedBox(),
+                    index == 0 ? SizedBox(height: 8) : const SizedBox(),
+                  ],
+                );
+              },
+            ),
+    );
+  }
+}

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -115,8 +115,8 @@ class DeviceProvider extends ChangeNotifier {
 
   Future periodicConnect(GlobalKey<CapturePageState> capturePageKey) async {
     timer = Timer.periodic(Duration(seconds: connectionCheckSeconds), (timer) async {
-      print('seconds: $connectionCheckSeconds');
-      print('triggered timer at ${DateTime.now()}');
+      // print('seconds: $connectionCheckSeconds');
+      // print('triggered timer at ${DateTime.now()}');
       if (SharedPreferencesUtil().btDeviceStruct.id.isEmpty) {
         return;
       }

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+import 'package:friend_private/backend/http/api/users.dart';
+import 'package:friend_private/backend/preferences.dart';
+
+class SpeechProfileProvider extends ChangeNotifier {
+  bool? permissionEnabled;
+  bool loading = false;
+
+  changeLoadingState() => loading = !loading;
+
+  Future setupSpeechRecording() async {
+    final permission = await getStoreRecordingPermission();
+    permissionEnabled = permission;
+    if (permission != null) {
+      SharedPreferencesUtil().permissionStoreRecordingsEnabled = permission;
+    }
+  }
+}

--- a/app/lib/widgets/transcript.dart
+++ b/app/lib/widgets/transcript.dart
@@ -9,6 +9,8 @@ class TranscriptWidget extends StatefulWidget {
   final bool horizontalMargin;
   final bool topMargin;
   final bool canDisplaySeconds;
+  final bool isMemoryDetail;
+  final Function(int)? editSegment;
 
   const TranscriptWidget({
     super.key,
@@ -16,6 +18,8 @@ class TranscriptWidget extends StatefulWidget {
     this.horizontalMargin = true,
     this.topMargin = true,
     this.canDisplaySeconds = true,
+    this.isMemoryDetail = false,
+    this.editSegment,
   });
 
   @override
@@ -48,27 +52,44 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
             mainAxisSize: MainAxisSize.min,
             children: [
               Row(
-                mainAxisAlignment: MainAxisAlignment.start,
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
                 crossAxisAlignment: CrossAxisAlignment.center,
                 children: [
-                  Image.asset(data.isUser ? 'assets/images/speaker_0_icon.png' : 'assets/images/speaker_1_icon.png',
-                      width: 26, height: 26),
-                  const SizedBox(width: 12),
-                  Text(
-                    data.isUser
-                        ? SharedPreferencesUtil().givenName.isNotEmpty
-                            ? SharedPreferencesUtil().givenName
-                            : 'You'
-                        : 'Speaker ${data.speakerId}',
-                    style: const TextStyle(color: Colors.white, fontSize: 18),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      Image.asset(data.isUser ? 'assets/images/speaker_0_icon.png' : 'assets/images/speaker_1_icon.png',
+                          width: 26, height: 26),
+                      const SizedBox(width: 12),
+                      Text(
+                        data.isUser
+                            ? SharedPreferencesUtil().givenName.isNotEmpty
+                                ? SharedPreferencesUtil().givenName
+                                : 'You'
+                            : 'Speaker ${data.speakerId}',
+                        style: const TextStyle(color: Colors.white, fontSize: 18),
+                      ),
+                      widget.canDisplaySeconds ? const SizedBox(width: 12) : const SizedBox(),
+                      // pad as start-end as hours:minutes:seconds e.g. 01:23:45
+                      widget.canDisplaySeconds
+                          ? Text(
+                              data.getTimestampString(),
+                              style: const TextStyle(color: Colors.grey, fontSize: 14),
+                            )
+                          : const SizedBox(),
+                    ],
                   ),
-                  widget.canDisplaySeconds ? const SizedBox(width: 12) : const SizedBox(),
-                  // pad as start-end as hours:minutes:seconds e.g. 01:23:45
-                  widget.canDisplaySeconds
-                      ? Text(
-                          data.getTimestampString(),
-                          style: const TextStyle(color: Colors.grey, fontSize: 14),
-                        )
+                  widget.isMemoryDetail
+                      ? IconButton(
+                          icon: Icon(
+                            Icons.edit,
+                            color: Colors.grey.shade300,
+                            size: 20,
+                          ),
+                          onPressed: () {
+                            widget.editSegment?.call(idx - 1);
+                          })
                       : const SizedBox(),
                 ],
               ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -93,6 +93,8 @@ dependencies:
   webview_flutter: ^4.8.0
   flutter_sound: ^9.10.0
   audio_session:
+  audioplayers: ^6.0.0
+  just_audio: ^0.9.39
 
 
 dependency_overrides:

--- a/backend/database/facts.py
+++ b/backend/database/facts.py
@@ -7,7 +7,6 @@ from ._client import db
 
 
 def get_facts(uid: str, limit: int = 100, offset: int = 0):
-    # TODO: cache this
     facts_ref = db.collection('users').document(uid).collection('facts')
     facts_ref = facts_ref.order_by('created_at', direction=firestore.Query.DESCENDING).where(
         filter=FieldFilter('deleted', '==', False))

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -101,3 +101,16 @@ def get_cached_user_name(uid: str) -> str:
     if not name:
         return 'User'
     return name.decode()
+
+
+# TODO: cache facts if speed improves dramatically
+def cache_facts(uid: str, facts: List[dict]):
+    r.set(f'users:{uid}:facts', str(facts))
+    r.expire(f'users:{uid}:facts', 60 * 60)  # 1 hour, most people chat during a few minutes
+
+
+def get_cached_facts(uid: str) -> List[dict]:
+    facts = r.get(f'users:{uid}:facts')
+    if not facts:
+        return []
+    return eval(facts)

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -10,3 +10,32 @@ def get_user_store_recording_permission(uid: str):
 def set_user_store_recording_permission(uid: str, value: bool):
     user_ref = db.collection('users').document(uid)
     user_ref.update({'store_recording_permission': value})
+
+
+def create_person(uid: str, data: dict):
+    people_ref = db.collection('users').document(uid).collection('people')
+    people_ref.document(data['id']).set(data)
+    return data
+
+
+def get_person(uid: str, person_id: str):
+    person_ref = db.collection('users').document(uid).collection('people').document(person_id)
+    person_data = person_ref.get().to_dict()
+    return person_data
+
+
+def get_people(uid: str):
+    people_ref = db.collection('users').document(uid).collection('people')
+    people = people_ref.stream()
+    return [person.to_dict() for person in people]
+
+
+def update_person(uid: str, person_id: str, name: str):
+    person_ref = db.collection('users').document(uid).collection('people').document(person_id)
+    person_ref.update({'name': name})
+
+
+def delete_person(uid: str, person_id: str):
+    person_ref = db.collection('users').document(uid).collection('people').document(person_id)
+    person_ref.update({'deleted': True})
+

--- a/backend/modal/speech_profile_modal.py
+++ b/backend/modal/speech_profile_modal.py
@@ -1,6 +1,7 @@
 import json
 import os
-from typing import List
+from collections import defaultdict
+from typing import List, Optional
 
 import modal.gpu
 import torch
@@ -10,11 +11,18 @@ from pydantic import BaseModel
 from pydub import AudioSegment
 from speechbrain.inference.speaker import SpeakerRecognition
 
+from utils.stt.speech_profile import get_speech_profile_expanded, get_people_with_speech_samples
+
 
 class TranscriptSegment(BaseModel):
     start: float
     end: float
     text: str
+
+
+class ResponseItem(BaseModel):
+    is_user: bool
+    person_id: Optional[str] = None
 
 
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
@@ -28,17 +36,16 @@ model = SpeakerRecognition.from_hparams(
 def sample_same_speaker_as_segment(sample_audio: str, segment: str) -> bool:
     try:
         score, prediction = model.verify_files(sample_audio, segment)
-        # print(score, prediction)
-        # return bool(score[0] > 0.6)
         return bool(prediction[0])
     except Exception as e:
         print(e)
         return False
 
 
-def classify_segments(audio_file_path: str, transcript_segments: List[TranscriptSegment], profile_path: str):
-    print('classify_segments')
-    matches = [False] * len(transcript_segments)
+def classify_segments(
+        audio_file_path: str, profile_path: str, people: List[dict], segments: List[TranscriptSegment]
+):
+    matches = [{'is_user': False, 'person_id': None}] * len(segments)
     if not profile_path:
         return matches
 
@@ -48,10 +55,10 @@ def classify_segments(audio_file_path: str, transcript_segments: List[Transcript
     print('Duration:', AudioSegment.from_wav(audio_file_path).duration_seconds)
 
     file_name = os.path.basename(audio_file_path)
-    for i, segment in enumerate(transcript_segments):
+    for i, segment in enumerate(segments):
 
         duration = segment.end - segment.start
-        by_chunk_matches = []
+        by_chunk_matches = defaultdict(int)
 
         for j in range(0, int(duration), 30):
             start = segment.start + j
@@ -59,13 +66,18 @@ def classify_segments(audio_file_path: str, transcript_segments: List[Transcript
 
             temporal_file = f"_temp/{file_name}_{start}_{end}.wav"
             AudioSegment.from_wav(audio_file_path)[start * 1000:end * 1000].export(temporal_file, format="wav")
-            is_user = sample_same_speaker_as_segment(temporal_file, profile_path)
-            by_chunk_matches.append(is_user)
+
+            by_chunk_matches['user'] += sample_same_speaker_as_segment(temporal_file, profile_path)
+            for person in people:
+                by_chunk_matches[person['id']] += sample_same_speaker_as_segment(temporal_file, person['path'])
+
             os.remove(temporal_file)
 
-        is_user = sum(by_chunk_matches) / len(by_chunk_matches) > 0.5
-        print('Matches', by_chunk_matches, i + 1, is_user)
-        matches[i] = is_user
+        if not by_chunk_matches:
+            continue
+
+        max_match = max(by_chunk_matches, key=by_chunk_matches.get)
+        matches[i] = {'is_user': max_match == 'user', 'person_id': None if max_match == 'user' else max_match}
 
     return matches
 
@@ -76,8 +88,11 @@ image = (
     .apt_install('ffmpeg')
     .pip_install("torch")
     .pip_install("torchaudio")
+    .pip_install("torchvision")
     .pip_install("speechbrain")
     .pip_install("pydub")
+    .pip_install("requests")
+    .pip_install("google-cloud-storage")
 )
 
 os.makedirs('_temp', exist_ok=True)
@@ -90,14 +105,15 @@ os.makedirs('_temp', exist_ok=True)
     allow_concurrent_inputs=2,
     cpu=4,
     gpu=modal.gpu.T4(count=1),
-    secrets=[Secret.from_name('huggingface-token'), Secret.from_name('envs')],
+    secrets=[Secret.from_name('huggingface-token'), Secret.from_name('envs'), Secret.from_name("gcp-credentials")],
 )
 @web_endpoint(method='POST')
-def endpoint(
-        profile_path: UploadFile = File(...), audio_file: UploadFile = File(...), segments: str = Form(...)
-) -> List[bool]:
-    with open(profile_path.filename, 'wb') as f:
-        f.write(profile_path.file.read())
+def endpoint(uid: str, audio_file: UploadFile = File(...), segments: str = Form(...)) -> List[ResponseItem]:
+    profile_path = get_speech_profile_expanded(uid)
+    default = [{'is_user': False}] * len(json.loads(segments))
+
+    if not profile_path:
+        return default
 
     with open(audio_file.filename, 'wb') as f:
         f.write(audio_file.file.read())
@@ -105,10 +121,14 @@ def endpoint(
     segments_data = json.loads(segments)
     transcript_segments = [TranscriptSegment(**segment) for segment in segments_data]
 
+    people = get_people_with_speech_samples(uid)
+
     try:
-        result = classify_segments(audio_file.filename, transcript_segments, profile_path.filename)
+        result = classify_segments(audio_file.filename, profile_path, people, transcript_segments)
+        print(result)
         return result
+    except:
+        return default
     finally:
-        # Clean up temporary files
-        os.remove(profile_path.filename)
+        os.remove(profile_path)
         os.remove(audio_file.filename)

--- a/backend/models/memory.py
+++ b/backend/models/memory.py
@@ -75,11 +75,14 @@ class Structured(BaseModel):
     )
 
     def __str__(self):
-        result = f"{self.emoji} {self.title} ({self.category})\n\nSummary: {self.overview}\n\n"
+        result = (f"{str(self.title).capitalize()} ({str(self.category.value).capitalize()})\n"
+                  f"{str(self.overview).capitalize()}\n")
+
         if self.action_items:
             result += "Action Items:\n"
             for item in self.action_items:
                 result += f"- {item.description}\n"
+
         if self.events:
             result += "Events:\n"
             for event in self.events:
@@ -146,7 +149,7 @@ class Memory(BaseModel):
         result = []
         for i, memory in enumerate(memories):
             if isinstance(memory, dict):
-                memory = Memory(**memory)          
+                memory = Memory(**memory)
             formatted_date = memory.created_at.strftime("%d %b, at %H:%M")
             memory_str = (f"Memory #{i + 1}\n"
                           f"{formatted_date} ({str(memory.structured.category.value).capitalize()})\n"

--- a/backend/models/other.py
+++ b/backend/models/other.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import List
 
 from pydantic import BaseModel
@@ -11,3 +12,15 @@ class SaveFcmTokenRequest(BaseModel):
 class UploadProfile(BaseModel):
     bytes: List[List[int]]
     duration: int
+
+
+class CreatePerson(BaseModel):
+    name: str
+
+
+class Person(BaseModel):
+    id: str
+    name: str
+    created_at: datetime
+    updated_at: datetime
+    deleted: bool = False

--- a/backend/models/other.py
+++ b/backend/models/other.py
@@ -24,3 +24,4 @@ class Person(BaseModel):
     created_at: datetime
     updated_at: datetime
     deleted: bool = False
+    speech_samples: List[str] = []

--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -9,6 +9,7 @@ class TranscriptSegment(BaseModel):
     speaker: Optional[str] = 'SPEAKER_00'
     speaker_id: Optional[int] = None
     is_user: bool
+    person_id: Optional[str] = None
     start: float
     end: float
 

--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -46,7 +46,6 @@ class TranscriptSegment(BaseModel):
 class ImprovedTranscriptSegment(BaseModel):
     speaker_id: int = Field(..., description='The correctly assigned speaker id')
     text: str = Field(..., description='The corrected text of the segment')
-    # seconds: List[float] = Field(..., description='The start and end time of the segment')
 
 
 class ImprovedTranscript(BaseModel):

--- a/backend/routers/facts.py
+++ b/backend/routers/facts.py
@@ -1,4 +1,6 @@
-from fastapi import APIRouter, Depends
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException
 
 import database.facts as facts_db
 from database.redis_db import cache_user_name
@@ -30,8 +32,4 @@ def edit_fact(fact_id: str, value: str, uid: str = Depends(auth.get_current_user
     return {'status': 'ok'}
 
 
-@router.patch('/v1/users/name', tags=['users'])
-def edit_user_name_in_facts(prev: str, new: str, uid: str = Depends(auth.get_current_user_uid)):
-    # NOTIMPLEMENTED
-    cache_user_name(uid, new.capitalize())
-    return {'status': 'ok'}
+

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -138,7 +138,8 @@ def postprocess_memory(
         profile_path = get_speech_profile_expanded(uid) if aseg.frame_rate == 16000 else None
         matches = get_speech_profile_matching_predictions(file_path, profile_path, [s.dict() for s in segments])
         for i, segment in enumerate(segments):
-            segment.is_user = matches[i]
+            segment.is_user = matches[i]['is_user']
+            segment.person_id = matches[i]['person_id']
 
         # Store previous and new segments in DB as collection.
         memories_db.store_model_segments_result(uid, memory.id, 'deepgram_streaming', memory.transcript_segments)

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -133,7 +133,7 @@ def postprocess_memory(
             memories_db.set_postprocessing_status(uid, memory.id, PostProcessingStatus.canceled)
             raise HTTPException(status_code=500, detail="Post-processed transcript is too short")
 
-        # Speech profile matching using speechbrain
+        # Speech profile matching using speechbrain # TODO: if fal fails, still should use speech profile for deepgram.
         profile_path = get_speech_profile_expanded(uid) if aseg.frame_rate == 16000 else None
         matches = get_speech_profile_matching_predictions(file_path, profile_path, [s.dict() for s in segments])
         for i, segment in enumerate(segments):

--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -1,7 +1,7 @@
 import os
+from typing import Optional
 
 from fastapi import APIRouter, UploadFile, Depends, HTTPException
-from fastapi.responses import FileResponse
 from pydub import AudioSegment
 
 from database.memories import get_memory, update_memory_segments
@@ -10,7 +10,8 @@ from models.memory import Memory
 from models.other import UploadProfile
 from utils.other import endpoints as auth
 from utils.other.storage import upload_profile_audio, get_profile_audio_if_exists, get_memory_recording_if_exists, \
-    upload_additional_profile_audio, delete_additional_profile_audio, get_additional_profile_recordings
+    upload_additional_profile_audio, delete_additional_profile_audio, get_additional_profile_recordings, \
+    upload_user_person_speech_sample, delete_user_person_speech_sample, get_user_person_speech_samples
 from utils.stt.vad import apply_vad_for_speech_profile
 
 router = APIRouter()
@@ -20,6 +21,18 @@ router = APIRouter()
 def has_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
     return {'has_profile': len(get_user_speech_profile(uid)) > 0}
 
+
+@router.get('/v4/speech-profile', tags=['v3'])
+def get_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
+    return {'url': get_profile_audio_if_exists(uid, download=False)}
+
+
+# ******************************************
+# ************* UPLOAD SAMPLE **************
+# ******************************************
+
+# Consist of bytes (for initiating deepgram)
+# and audio itself, which we use on post-processing to use speechbrain model
 
 @router.post('/v3/upload-bytes', tags=['v3'])
 def upload_profile(data: UploadProfile, uid: str = Depends(auth.get_current_user_uid)):
@@ -51,14 +64,11 @@ def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_ui
     return {"url": upload_profile_audio(file_path, uid)}
 
 
-@router.post('/v3/speech-profile/expand', tags=['v3'])
-def expand_speech_profile(memory_id: str, segment_idx: int, uid: str = Depends(auth.get_current_user_uid)):
-    print('expand_speech_profile', memory_id, segment_idx, uid)
-    profile_path = get_profile_audio_if_exists(uid)
-    if not profile_path:
-        raise HTTPException(status_code=404, detail="Speech profile not found")
-    os.remove(profile_path)
+# ******************************************************
+# ************* SPEECH SAMPLES FROM MEMORY *************
+# ******************************************************
 
+def _validate(uid, memory_id):
     memory_recording_path = get_memory_recording_if_exists(uid, memory_id)
     if not memory_recording_path:
         raise HTTPException(status_code=404, detail="Memory recording not found")
@@ -67,9 +77,30 @@ def expand_speech_profile(memory_id: str, segment_idx: int, uid: str = Depends(a
     if not memory:
         raise HTTPException(status_code=404, detail="Memory not found")
 
+    return memory, memory_recording_path
+
+
+@router.post('/v3/speech-profile/expand', tags=['v3'])
+def expand_speech_profile(
+        memory_id: str, segment_idx: int, person_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
+):
+    print('expand_speech_profile', memory_id, segment_idx, person_id, uid)
+
+    if person_id is None:
+        profile_path = get_profile_audio_if_exists(uid)
+        if not profile_path:  # TODO: validate this in front
+            raise HTTPException(status_code=404, detail="Speech profile not found")
+        os.remove(profile_path)
+
+    memory, memory_recording_path = _validate(uid, memory_id)
+
     memory = Memory(**memory)
     segments = memory.transcript_segments
-    segments[segment_idx].is_user = True
+    if person_id:
+        segments[segment_idx].person_id = person_id
+    else:
+        segments[segment_idx].is_user = True
+
     update_memory_segments(uid, memory_id, [segment.dict() for segment in segments])
 
     segment = memory.transcript_segments[segment_idx]
@@ -80,31 +111,30 @@ def expand_speech_profile(memory_id: str, segment_idx: int, uid: str = Depends(a
     segment_recording_path = f'_temp/{memory_id}_segment_{segment_idx}.wav'
     segment_aseg.export(segment_recording_path, format='wav')
 
-    if aseg.frame_rate != 16000:
-        raise HTTPException(status_code=400, detail="Invalid codec, must be opus 16khz.")
-
-    # if aseg.duration_seconds < 5:
-    #     raise HTTPException(status_code=400, detail="Audio duration is too short")
-
-    # if aseg.duration_seconds > 30:
-    #     raise HTTPException(status_code=400, detail="Sample duration is too long")
-
     apply_vad_for_speech_profile(segment_recording_path)
-    upload_additional_profile_audio(segment_recording_path, uid)
+    if person_id:
+        upload_user_person_speech_sample(segment_recording_path, uid, person_id)
+    else:
+        upload_additional_profile_audio(segment_recording_path, uid)
     return {"status": 'ok'}
 
 
 @router.delete('/v3/speech-profile/expand', tags=['v3'])
-def delete_extra_speech_profile_sample(memory_id: str, segment_idx: int, uid: str = Depends(auth.get_current_user_uid)):
-    delete_additional_profile_audio(uid, f'{memory_id}_segment_{segment_idx}.wav')
+def delete_extra_speech_profile_sample(
+        memory_id: str, segment_idx: int, person_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
+):
+    file_name = f'{memory_id}_segment_{segment_idx}.wav'
+
+    if person_id:
+        delete_user_person_speech_sample(uid, person_id, file_name)
+    else:
+        delete_additional_profile_audio(uid, file_name)
+
     return {'status': 'ok'}
 
 
 @router.get('/v3/speech-profile/expand', tags=['v3'])
-def get_extra_speech_profile_samples(uid: str = Depends(auth.get_current_user_uid)):
+def get_extra_speech_profile_samples(person_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)):
+    if person_id:
+        return get_user_person_speech_samples(uid, person_id)
     return get_additional_profile_recordings(uid)
-
-
-@router.get('/v4/speech-profile', tags=['v3'])
-def get_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
-    return {'url': get_profile_audio_if_exists(uid, download=False)}

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -1,5 +1,7 @@
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 
+import database.facts as facts_db
+from database.redis_db import cache_user_name
 from database.users import set_user_store_recording_permission, get_user_store_recording_permission
 from utils.other import endpoints as auth
 from utils.other.storage import delete_all_memory_recordings
@@ -23,3 +25,24 @@ def delete_permission_and_recordings(uid: str = Depends(auth.get_current_user_ui
     set_user_store_recording_permission(uid, False)
     delete_all_memory_recordings(uid)
     return {'status': 'ok'}
+
+
+@router.patch('/v1/users/name', tags=['users'])  # TODO: shouldn't need params, instead shuold retrieve auth values
+def edit_user_name_in_facts(prev: str, new: str, uid: str = Depends(auth.get_current_user_uid)):
+    if len(new.split(' ')) > 1:
+        raise HTTPException(status_code=400, detail='Name must be a single word')
+    if len(new) < 2 or len(new) > 40:
+        raise HTTPException(status_code=400, detail='Name must be between 3 and 40 characters')
+
+    cache_user_name(uid, new.capitalize())
+    facts = facts_db.get_facts(uid, 1000, 0)
+    for fact in facts:
+        text = fact['content']
+        fact['content'] = text.replace(f'{prev.capitalize()}', f'{new.capitalize()}')
+        fact['content'] = text.replace(f'The User', f'{new.capitalize()}').replace(f'User', f'{new.capitalize()}')
+
+    facts_db.save_facts(uid, facts)
+
+    return {'status': 'ok'}
+
+

--- a/backend/utils/memories/facts.py
+++ b/backend/utils/memories/facts.py
@@ -7,6 +7,7 @@ from models.facts import Fact
 
 def get_prompt_data(uid: str, existing_facts: List[Fact] = None) -> Tuple[str, List[Fact]]:
     if not existing_facts:
+        # TODO: cache this
         existing_facts = facts_db.get_facts(uid)
         existing_facts = [Fact(**fact) for fact in existing_facts]
 

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -53,7 +53,8 @@ def upload_additional_profile_audio(file_path: str, uid: str) -> None:
 def delete_additional_profile_audio(uid: str, file_name: str) -> None:
     bucket = storage_client.bucket(speech_profiles_bucket)
     blob = bucket.blob(f'{uid}/additional_profile_recordings/{file_name}')
-    blob.delete()
+    if blob.exists():
+        blob.delete()
 
 
 def get_additional_profile_recordings(uid: str, download: bool = False) -> List[str]:

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -90,6 +90,12 @@ def delete_user_person_speech_sample(uid: str, person_id: str, file_name: str) -
         blob.delete()
 
 
+def get_user_people_ids(uid: str) -> List[str]:
+    bucket = storage_client.bucket(speech_profiles_bucket)
+    blobs = bucket.list_blobs(prefix=f'{uid}/people_profiles/')
+    return [blob.name.split("/")[-2] for blob in blobs]
+
+
 def get_user_person_speech_samples(uid: str, person_id: str, download: bool = False) -> List[str]:
     bucket = storage_client.bucket(speech_profiles_bucket)
     blobs = bucket.list_blobs(prefix=f'{uid}/people_profiles/{person_id}/')

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -73,6 +73,39 @@ def get_additional_profile_recordings(uid: str, download: bool = False) -> List[
 
 
 # ********************************************
+# ************* PEOPLE PROFILES **************
+# ********************************************
+
+def upload_user_person_speech_sample(file_path: str, uid: str, person_id: str) -> None:
+    bucket = storage_client.bucket(speech_profiles_bucket)
+    path = f'{uid}/people_profiles/{person_id}/{file_path.split("/")[-1]}'
+    blob = bucket.blob(path)
+    blob.upload_from_filename(file_path)
+
+
+def delete_user_person_speech_sample(uid: str, person_id: str, file_name: str) -> None:
+    bucket = storage_client.bucket(speech_profiles_bucket)
+    blob = bucket.blob(f'{uid}/people_profiles/{person_id}/{file_name}')
+    if blob.exists():
+        blob.delete()
+
+
+def get_user_person_speech_samples(uid: str, person_id: str, download: bool = False) -> List[str]:
+    bucket = storage_client.bucket(speech_profiles_bucket)
+    blobs = bucket.list_blobs(prefix=f'{uid}/people_profiles/{person_id}/')
+    if download:
+        paths = []
+        for blob in blobs:
+            file_path = f'_temp/{uid}_person_{blob.name.split("/")[-1]}'
+            blob.download_to_filename(file_path)
+            paths.append(file_path)
+        return paths
+
+    return [blob.generate_signed_url(version="v4", expiration=datetime.timedelta(minutes=60), method="GET") for blob in
+            blobs]
+
+
+# ********************************************
 # ************* POST PROCESSING **************
 # ********************************************
 def upload_postprocessing_audio(file_path: str):

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -77,7 +77,8 @@ def _words_cleaning(words: List[dict]):
             'end': round(w['timestamp'][1] or w['timestamp'][0] + 1, 2),
             'speaker': w['speaker'],
             'text': str(w['text']).strip(),
-            'is_user': False
+            'is_user': False,
+            'person_id': None,
         })
 
     for i, word in enumerate(words_cleaned):
@@ -152,6 +153,7 @@ def _segments_as_objects(segments: List[dict]) -> List[TranscriptSegment]:
         text=str(segment['text']).strip().capitalize(),
         speaker=segment['speaker'],
         is_user=segment['is_user'],
+        person_id=None,
         start=round(segment['start'] - starts_at, 2),
         end=round(segment['end'] - starts_at, 2),
     ) for segment in segments]

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -10,7 +10,6 @@ from starlette.websockets import WebSocket
 
 import database.notifications as notification_db
 from utils.plugins import trigger_realtime_integrations
-import numpy as np
 
 headers = {
     "Authorization": f"Token {os.getenv('DEEPGRAM_API_KEY')}",
@@ -104,7 +103,8 @@ async def process_audio_dg(
                     'start': word.start - preseconds,
                     'end': word.end - preseconds,
                     'text': word.punctuated_word,
-                    'is_user': is_user
+                    'is_user': is_user,
+                    'person_id': None,
                 })
             else:
                 last_segment = segments[-1]
@@ -117,7 +117,8 @@ async def process_audio_dg(
                         'start': word.start,
                         'end': word.end,
                         'text': word.punctuated_word,
-                        'is_user': is_user
+                        'is_user': is_user,
+                        'person_id': None,
                     })
 
         asyncio.run_coroutine_threadsafe(fast_socket.send_json(segments), loop)


### PR DESCRIPTION
- Allow users to do post training on their speech profile
- Allow users to fix their transcripts, by setting is_user value to each segment
- Authorization page for users to allow us to store their recordings.









<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Added functionality for users to manage their speech profile, including retrieving, expanding, and deleting profile samples.
- New Feature: Introduced a new UI feature allowing users to edit their speech segments post-training.
- New Feature: Implemented functions for managing recording permissions, including storing, retrieving, and deleting permissions.
- New Feature: Added a new page in the settings section of the app for users to authorize saving recordings.
- New Feature: Introduced support for CRUD operations on 'people' within a user's collection.
- Bug Fix: Enhanced robustness by checking if a blob exists before attempting deletion in the `delete_additional_profile_audio` function.
- Refactor: Added support for the PATCH HTTP method in the `makeApiCall` function and removed commented-out code.
- Chore: Improved formatting and readability in various parts of the codebase.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->