### PR TITLE
Add APp User Non-Exempt Encryption / False to by pass to compliance w…

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>daily-summary</string>


### PR DESCRIPTION
…henever export iOS build
<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Chore: Updated the iOS app's `Info.plist` file to include the `ITSAppUsesNonExemptEncryption` key with a value of `false`. This change indicates that the application does not use non-exempt encryption, which may simplify the app submission process to the App Store by reducing the need for additional export compliance documentation.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->