### PR TITLE
Further migrate to Provider and some bug fixes

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -24,6 +24,7 @@ import 'package:friend_private/providers/memory_provider.dart';
 import 'package:friend_private/providers/message_provider.dart';
 import 'package:friend_private/providers/onboarding_provider.dart';
 import 'package:friend_private/providers/plugin_provider.dart';
+import 'package:friend_private/providers/speech_profile_provider.dart';
 import 'package:friend_private/services/notification_service.dart';
 import 'package:friend_private/utils/analytics/growthbook.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
@@ -156,6 +157,11 @@ class _MyAppState extends State<MyApp> {
                 (previous?..setDeviceProvider(value)) ?? OnboardingProvider(),
           ),
           ListenableProvider(create: (context) => HomeProvider()),
+          ChangeNotifierProxyProvider<DeviceProvider, SpeechProfileProvider>(
+            create: (context) => SpeechProfileProvider(),
+            update: (BuildContext context, value, SpeechProfileProvider? previous) =>
+                (previous?..setProvider(value)) ?? SpeechProfileProvider(),
+          ),
         ],
         builder: (context, child) {
           return WithForegroundTask(

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -133,7 +133,6 @@ class _MyAppState extends State<MyApp> {
     return MultiProvider(
         providers: [
           ChangeNotifierProvider(create: (context) => AuthenticationProvider()),
-          // ChangeNotifierProvider(create: (context) => DeviceProvider()),
           ChangeNotifierProvider(create: (context) => MemoryProvider()),
           ListenableProvider(create: (context) => PluginProvider()),
           ChangeNotifierProxyProvider<PluginProvider, MessageProvider>(

--- a/app/lib/pages/capture/connect.dart
+++ b/app/lib/pages/capture/connect.dart
@@ -40,7 +40,7 @@ class _ConnectDevicePageState extends State<ConnectDevicePage> {
             const DeviceAnimationWidget(),
             FindDevicesPage(
               goNext: () {
-                debugPrint('onConnected');
+                debugPrint('onConnected from FindDevicesPage');
                 routeToPage(context, const HomePageWrapper(), replace: true);
               },
               includeSkip: false,

--- a/app/lib/pages/capture/logic/phone_recorder_mixin.dart
+++ b/app/lib/pages/capture/logic/phone_recorder_mixin.dart
@@ -7,7 +7,6 @@ import 'package:friend_private/utils/enums.dart';
 import 'package:friend_private/utils/websockets.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
-import 'package:record/record.dart';
 import 'package:web_socket_channel/io.dart';
 
 import 'mic_background_service.dart';

--- a/app/lib/pages/capture/logic/phone_recorder_mixin.dart
+++ b/app/lib/pages/capture/logic/phone_recorder_mixin.dart
@@ -2,9 +2,11 @@ import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_background_service/flutter_background_service.dart';
+import 'package:friend_private/providers/capture_provider.dart';
 import 'package:friend_private/utils/enums.dart';
 import 'package:friend_private/utils/websockets.dart';
 import 'package:permission_handler/permission_handler.dart';
+import 'package:provider/provider.dart';
 import 'package:record/record.dart';
 import 'package:web_socket_channel/io.dart';
 
@@ -21,12 +23,12 @@ mixin PhoneRecorderMixin<T extends StatefulWidget> on State<T> {
   int iosDuration = 30;
   int androidDuration = 30;
   bool isTranscribing = false;
-  RecordingState recordingState = RecordingState.stop;
+  // RecordingState recordingState = RecordingState.stop;
 
   // stream related
   List<Uint8List> audioChunks = [];
   int totalBytes = 0;
-  var record = AudioRecorder();
+  // var record = AudioRecorder();
 
   WebsocketConnectionStatus? wsConnectionState2;
   IOWebSocketChannel? websocketChannel2;
@@ -47,11 +49,12 @@ mixin PhoneRecorderMixin<T extends StatefulWidget> on State<T> {
       });
       FlutterBackgroundService().on('stateUpdate').listen((event) {
         if (event!['state'] == 'recording') {
-          setState(() => recordingState = RecordingState.record);
+          context.read<CaptureProvider>().updateRecordingState(RecordingState.record);
         } else if (event['state'] == 'initializing') {
-          setState(() => recordingState = RecordingState.initialising);
+          context.read<CaptureProvider>().updateRecordingState(RecordingState.initialising);
         } else if (event['state'] == 'stopped') {
-          setState(() => recordingState = RecordingState.stop);
+          //   setState(() => recordingState = RecordingState.stop);
+          context.read<CaptureProvider>().updateRecordingState(RecordingState.stop);
         }
       });
     }
@@ -63,7 +66,8 @@ mixin PhoneRecorderMixin<T extends StatefulWidget> on State<T> {
       websocketChannel2 = websocketChannel;
     });
     await Permission.microphone.request();
-    setState(() => recordingState = RecordingState.initialising);
+    context.read<CaptureProvider>().updateRecordingState(RecordingState.initialising);
+    // setState(() => recordingState = RecordingState.initialising);
     await initializeMicBackgroundService();
     startBackgroundService();
     await listenToBackgroundService();
@@ -73,30 +77,33 @@ mixin PhoneRecorderMixin<T extends StatefulWidget> on State<T> {
     stopBackgroundService();
   }
 
-  startStreamRecording(WebsocketConnectionStatus wsConnectionState, IOWebSocketChannel? websocketChannel) async {
-    await Permission.microphone.request();
-    debugPrint("input device: ${await record.listInputDevices()}");
-    InputDevice? inputDevice;
-    // if (Platform.isIOS) {
-    //   inputDevice = const InputDevice(id: "Built-In Microphone", label: "iPhone Microphone");
-    // } else {}
-    var stream = await record.startStream(
-      RecordConfig(encoder: AudioEncoder.pcm16bits, sampleRate: 16000, numChannels: 1, device: inputDevice),
-    );
-    setState(() => recordingState = RecordingState.record);
-    stream.listen((data) async {
-      if (wsConnectionState == WebsocketConnectionStatus.connected) websocketChannel?.sink.add(data);
-    });
-  }
+  // startStreamRecording(WebsocketConnectionStatus wsConnectionState, IOWebSocketChannel? websocketChannel) async {
+  //   await Permission.microphone.request();
+  //   debugPrint("input device: ${await record.listInputDevices()}");
+  //   InputDevice? inputDevice;
+  //   // if (Platform.isIOS) {
+  //   //   inputDevice = const InputDevice(id: "Built-In Microphone", label: "iPhone Microphone");
+  //   // } else {}
+  //   var stream = await record.startStream(
+  //     RecordConfig(encoder: AudioEncoder.pcm16bits, sampleRate: 16000, numChannels: 1, device: inputDevice),
+  //   );
+  //   setState(() => recordingState = RecordingState.record);
+  //   stream.listen((data) async {
+  //     print('ws connection state: $wsConnectionState');
+  //     if (wsConnectionState == WebsocketConnectionStatus.connected) {
+  //       websocketChannel?.sink.add(data);
+  //     }
+  //   });
+  // }
 
-  stopStreamRecording(WebsocketConnectionStatus wsConnectionState, IOWebSocketChannel? websocketChannel) async {
-    if (await record.isRecording()) await record.stop();
-    setState(() => recordingState = RecordingState.stop);
-  }
+  // stopStreamRecording(WebsocketConnectionStatus wsConnectionState, IOWebSocketChannel? websocketChannel) async {
+  //   if (await record.isRecording()) await record.stop();
+  //   setState(() => recordingState = RecordingState.stop);
+  // }
 
   @override
   void dispose() async {
-    await record.dispose();
+    //  await record.dispose();
     super.dispose();
   }
 }

--- a/app/lib/pages/capture/page.dart
+++ b/app/lib/pages/capture/page.dart
@@ -260,7 +260,7 @@ class CapturePageState extends State<CapturePage>
               ...connectionStatusWidgets(context, provider.segments, wsConnectionState, _internetStatus),
               const SizedBox(height: 16)
             ]),
-            getPhoneMicRecordingButton(_recordingToggled(provider), provider.recordingState),
+            getPhoneMicRecordingButton(() => _recordingToggled(provider), provider.recordingState),
           ],
         ),
       );

--- a/app/lib/pages/capture/widgets/widgets.dart
+++ b/app/lib/pages/capture/widgets/widgets.dart
@@ -1,9 +1,10 @@
-import 'package:flutter/material.dart';
 import 'package:friend_private/backend/database/transcript_segment.dart';
+import 'package:flutter/material.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
 import 'package:friend_private/pages/capture/connect.dart';
 import 'package:friend_private/pages/speaker_id/page.dart';
+import 'package:friend_private/providers/device_provider.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/enums.dart';
 import 'package:friend_private/utils/other/temp.dart';
@@ -16,6 +17,7 @@ import 'package:friend_private/widgets/transcript.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:lottie/lottie.dart';
+import 'package:provider/provider.dart';
 import 'package:tuple/tuple.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -204,7 +206,7 @@ _getNoFriendConnectedYet(BuildContext context) {
   );
 }
 
-speechProfileWidget(BuildContext context, StateSetter setState, Function restartWebSocket) {
+speechProfileWidget(BuildContext context) {
   return !SharedPreferencesUtil().hasSpeakerProfile
       ? Stack(
           children: [
@@ -214,8 +216,9 @@ speechProfileWidget(BuildContext context, StateSetter setState, Function restart
                 bool hasSpeakerProfile = SharedPreferencesUtil().hasSpeakerProfile;
                 await routeToPage(context, const SpeakerIdPage());
                 if (hasSpeakerProfile != SharedPreferencesUtil().hasSpeakerProfile) {
-                  // setState(() {});
-                  restartWebSocket();
+                  if (context.mounted) {
+                    context.read<DeviceProvider>().restartWebSocket();
+                  }
                 }
               },
               child: Container(

--- a/app/lib/pages/chat/widgets/user_message.dart
+++ b/app/lib/pages/chat/widgets/user_message.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:friend_private/backend/schema/message.dart';
+import 'package:friend_private/widgets/extensions/string.dart';
 
 class HumanMessage extends StatelessWidget {
   final ServerMessage message;
@@ -20,7 +21,7 @@ class HumanMessage extends StatelessWidget {
             ),
             padding: const EdgeInsets.all(16.0),
             child: Text(
-              message.text,
+              message.text.decodeSting,
               style: Theme.of(context).textTheme.bodyMedium,
             ),
           ),

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -1,11 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
+import 'package:friend_private/providers/device_provider.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/ble/connect.dart';
 import 'package:friend_private/utils/ble/gatt_utils.dart';
 import 'package:friend_private/widgets/device_widget.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
+import 'package:provider/provider.dart';
 
 import 'device_settings.dart';
 
@@ -152,6 +154,9 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                     if (widget.device != null) {
                       await bleDisconnectDevice(widget.device!);
                     }
+                    context.read<DeviceProvider>().setIsConnected(false);
+                    context.read<DeviceProvider>().setConnectedDevice(null);
+                    context.read<DeviceProvider>().updateConnectingStatus(false);
                     Navigator.of(context).pop();
                     SharedPreferencesUtil().btDeviceStruct = BTDeviceStruct(id: '', name: '');
                     SharedPreferencesUtil().deviceName = '';

--- a/app/lib/pages/home/device_settings.dart
+++ b/app/lib/pages/home/device_settings.dart
@@ -4,11 +4,13 @@ import 'package:flutter/material.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
 import 'package:friend_private/pages/home/firmware_update.dart';
+import 'package:friend_private/providers/device_provider.dart';
+import 'package:friend_private/providers/onboarding_provider.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/ble/connect.dart';
 import 'package:gradient_borders/gradient_borders.dart';
+import 'package:provider/provider.dart';
 
-import 'device.dart';
 import 'support.dart';
 
 class DeviceSettings extends StatelessWidget {
@@ -108,6 +110,10 @@ class DeviceSettings extends StatelessWidget {
                     if (device != null) bleDisconnectDevice(device!);
                     SharedPreferencesUtil().btDeviceStruct = BTDeviceStruct(id: '', name: '');
                     SharedPreferencesUtil().deviceName = '';
+                    context.read<DeviceProvider>().setIsConnected(false);
+                    context.read<DeviceProvider>().setConnectedDevice(null);
+                    context.read<DeviceProvider>().updateConnectingStatus(false);
+                    context.read<OnboardingProvider>().stopFindDeviceTimer();
                     Navigator.of(context).pop();
                     Navigator.of(context).pop();
                     ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -45,7 +45,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> {
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      context.read<DeviceProvider>().periodicConnect(capturePageKey);
+      context.read<DeviceProvider>().periodicConnect('coming from HomePageWrapper');
     });
     super.initState();
   }
@@ -257,9 +257,6 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                             ),
                             CapturePage(
                               key: capturePageKey,
-                              updateMemory: (ServerMemory memory) {
-                                memProvider.updateMemory(memory);
-                              },
                             ),
                             ChatPage(
                               key: chatPageKey,
@@ -522,7 +519,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                         // TODO: this fails like 10 times, connects reconnects, until it finally works.
                         if (language != SharedPreferencesUtil().recordingsLanguage ||
                             hasSpeech != SharedPreferencesUtil().hasSpeakerProfile) {
-                          capturePageKey.currentState?.restartWebSocket();
+                          context.read<DeviceProvider>().restartWebSocket();
                         }
                       },
                     )

--- a/app/lib/pages/onboarding/find_device/found_devices.dart
+++ b/app/lib/pages/onboarding/find_device/found_devices.dart
@@ -1,8 +1,9 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
+import 'package:friend_private/pages/home/page.dart';
 import 'package:friend_private/providers/onboarding_provider.dart';
-import 'package:friend_private/widgets/extensions/functions.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:provider/provider.dart';
 
@@ -23,75 +24,89 @@ class FoundDevices extends StatefulWidget {
 class _FoundDevicesState extends State<FoundDevices> {
   @override
   void initState() {
-    _initiateConnectionListener();
+    //TODO: Already we have a listner in DeviceProvider, so we can remove this
+    // _initiateConnectionListener();
     super.initState();
-  }
-
-  _initiateConnectionListener() async {
-    () {
-      final onboarding = Provider.of<OnboardingProvider>(context, listen: false);
-      onboarding.initiateConnectionListener(
-        mounted: mounted,
-        goNext: widget.goNext,
-      );
-    }.withPostFrameCallback();
   }
 
   @override
   Widget build(BuildContext context) {
     return Consumer<OnboardingProvider>(builder: (context, provider, child) {
-      return Column(
-        mainAxisAlignment: MainAxisAlignment.start,
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          !provider.isConnected
-              ? Text(
-                  widget.deviceList.isEmpty
-                      ? 'Searching for devices...'
-                      : '${widget.deviceList.length} ${widget.deviceList.length == 1 ? "DEVICE" : "DEVICES"} FOUND NEARBY',
-                  style: const TextStyle(
-                    fontWeight: FontWeight.w400,
-                    fontSize: 14,
-                    color: Color(0x66FFFFFF),
-                  ),
-                )
-              : const Text(
-                  'PAIRING SUCCESSFUL',
-                  style: TextStyle(
-                    fontWeight: FontWeight.w400,
-                    fontSize: 12,
-                    color: Color(0x66FFFFFF),
-                  ),
-                ),
-          if (widget.deviceList.isNotEmpty) const SizedBox(height: 16),
-          if (!provider.isConnected) ..._devicesList(provider),
-          if (provider.isConnected)
-            Text(
-              '${provider.deviceName} (${BTDeviceStruct.shortId(provider.deviceId)})',
-              textAlign: TextAlign.center,
-              style: const TextStyle(
-                fontWeight: FontWeight.w500,
-                fontSize: 18,
-                color: Color(0xCCFFFFFF),
+      return MessageListener<OnboardingProvider>(
+        showError: (error) {
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+            content: Text(error),
+            backgroundColor: Colors.red,
+          ));
+        },
+        showInfo: (info) {
+          if (info == "DEVICE_CONNECTED") {
+            Navigator.of(context).pushAndRemoveUntil(
+              MaterialPageRoute(
+                builder: (context) => const HomePageWrapper(),
               ),
-            ),
-          if (provider.isConnected)
-            Padding(
-                padding: const EdgeInsets.symmetric(vertical: 10),
-                child: Text(
-                  '🔋 ${provider.batteryPercentage.toString()}%',
-                  textAlign: TextAlign.center,
-                  style: TextStyle(
-                    fontWeight: FontWeight.w500,
-                    fontSize: 18,
-                    color: provider.batteryPercentage <= 25
-                        ? Colors.red
-                        : provider.batteryPercentage > 25 && provider.batteryPercentage <= 50
-                            ? Colors.orange
-                            : Colors.green,
+              (route) => false,
+            );
+          } else {
+            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+              content: Text(info),
+              backgroundColor: Colors.green,
+            ));
+          }
+        },
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.start,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            !provider.isConnected
+                ? Text(
+                    widget.deviceList.isEmpty
+                        ? 'Searching for devices...'
+                        : '${widget.deviceList.length} ${widget.deviceList.length == 1 ? "DEVICE" : "DEVICES"} FOUND NEARBY',
+                    style: const TextStyle(
+                      fontWeight: FontWeight.w400,
+                      fontSize: 14,
+                      color: Color(0x66FFFFFF),
+                    ),
+                  )
+                : const Text(
+                    'PAIRING SUCCESSFUL',
+                    style: TextStyle(
+                      fontWeight: FontWeight.w400,
+                      fontSize: 12,
+                      color: Color(0x66FFFFFF),
+                    ),
                   ),
-                ))
-        ],
+            if (widget.deviceList.isNotEmpty) const SizedBox(height: 16),
+            if (!provider.isConnected) ..._devicesList(provider),
+            if (provider.isConnected)
+              Text(
+                '${provider.deviceName} (${BTDeviceStruct.shortId(provider.deviceId)})',
+                textAlign: TextAlign.center,
+                style: const TextStyle(
+                  fontWeight: FontWeight.w500,
+                  fontSize: 18,
+                  color: Color(0xCCFFFFFF),
+                ),
+              ),
+            if (provider.isConnected)
+              Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 10),
+                  child: Text(
+                    '🔋 ${provider.batteryPercentage.toString()}%',
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      fontWeight: FontWeight.w500,
+                      fontSize: 18,
+                      color: provider.batteryPercentage <= 25
+                          ? Colors.red
+                          : provider.batteryPercentage > 25 && provider.batteryPercentage <= 50
+                              ? Colors.orange
+                              : Colors.green,
+                    ),
+                  ))
+          ],
+        ),
       );
     });
   }

--- a/app/lib/pages/onboarding/find_device/page.dart
+++ b/app/lib/pages/onboarding/find_device/page.dart
@@ -29,6 +29,12 @@ class _FindDevicesPageState extends State<FindDevicesPage> {
     });
   }
 
+  @override
+  dispose() {
+    // context.read<OnboardingProvider>().dispose();
+    super.dispose();
+  }
+
   Future<void> _scanDevices() async {
     Provider.of<OnboardingProvider>(context, listen: false).scanDevices(
       onShowDialog: () {

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -15,8 +15,21 @@ import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-class DeveloperSettingsPage extends StatelessWidget {
+class DeveloperSettingsPage extends StatefulWidget {
   const DeveloperSettingsPage({super.key});
+
+  @override
+  State<DeveloperSettingsPage> createState() => _DeveloperSettingsPageState();
+}
+
+class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
+  @override
+  void initState() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      Provider.of<DeveloperModeProvider>(context, listen: false).initialize();
+    });
+    super.initState();
+  }
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/pages/speaker_id/page.dart
+++ b/app/lib/pages/speaker_id/page.dart
@@ -1,23 +1,18 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_blue_plus/flutter_blue_plus.dart';
-import 'package:friend_private/backend/database/transcript_segment.dart';
-import 'package:friend_private/backend/http/api/speech_profile.dart';
-import 'package:friend_private/backend/preferences.dart';
+import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
 import 'package:friend_private/pages/capture/logic/websocket_mixin.dart';
 import 'package:friend_private/pages/home/page.dart';
 import 'package:friend_private/pages/speaker_id/samples.dart';
-import 'package:friend_private/utils/audio/wav_bytes.dart';
+import 'package:friend_private/providers/speech_profile_provider.dart';
 import 'package:friend_private/utils/ble/communication.dart';
-import 'package:friend_private/utils/ble/connected.dart';
-import 'package:friend_private/utils/ble/scan.dart';
 import 'package:friend_private/utils/other/temp.dart';
-import 'package:friend_private/utils/websockets.dart';
 import 'package:friend_private/widgets/device_widget.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
+import 'package:provider/provider.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class SpeakerIdPage extends StatefulWidget {
@@ -30,205 +25,19 @@ class SpeakerIdPage extends StatefulWidget {
 }
 
 class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateMixin, WebSocketMixin {
-  final targetWordsCount = 45;
-  final maxDuration = 90;
-
-  StreamSubscription<OnConnectionStateChangedEvent>? _connectionStateListener;
-  BTDeviceStruct? _device;
-
-  List<TranscriptSegment> segments = [];
-  double? streamStartedAtSecond;
-  WavBytesUtil audioStorage = WavBytesUtil(codec: BleAudioCodec.opus);
-  StreamSubscription? _bleBytesStream;
-
-  bool startedRecording = false;
-  double percentageCompleted = 0;
-  bool uploadingProfile = false;
-  bool profileCompleted = false;
-  Timer? _forceCompletionTimer;
-
-  _init() async {
-    _device = await getConnectedDevice();
-    _device ??= await scanAndConnectDevice(timeout: true);
-    if (_device != null) initiateFriendAudioStreaming(_device!);
-    _initiateConnectionListener();
-    setState(() {});
-  }
-
-  _initiateConnectionListener() async {
-    if (_device == null || _connectionStateListener != null) return;
-    _connectionStateListener = getConnectionStateListener(
-        deviceId: _device!.id,
-        onDisconnected: () => setState(() => _device = null),
-        onConnected: ((device) {
-          setState(() => _device = device);
-          initiateFriendAudioStreaming(device);
-        }));
-  }
-
-  _validateSingleSpeaker() {
-    int speakersCount = segments.map((e) => e.speaker).toSet().length;
-    debugPrint('_validateSingleSpeaker speakers count: $speakersCount');
-    if (speakersCount > 1) {
-      var speakerToWords = segments.fold<Map<int, int>>(
-        {},
-        (previousValue, element) {
-          previousValue[element.speakerId] = (previousValue[element.speakerId] ?? 0) + element.text.split(' ').length;
-          return previousValue;
-        },
-      );
-      debugPrint('speakerToWords: $speakerToWords');
-      if (speakerToWords.values.every((element) => element / segments.length > 0.2)) {
-        showDialog(
-          context: context,
-          builder: (c) => getDialog(
-            context,
-            () {
-              Navigator.pop(context);
-              segments.clear();
-              streamStartedAtSecond = null;
-              audioStorage.clearAudioBytes();
-              setState(() {});
-            },
-            () {},
-            'Invalid recording detected',
-            'It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.',
-            okButtonText: 'Try Again',
-            singleButton: true,
-          ),
-          barrierDismissible: false,
-        );
-      }
-    }
-  }
-
-  _handleCompletion() async {
-    if (uploadingProfile || profileCompleted) return;
-    String text = segments.map((e) => e.text).join(' ').trim();
-    int wordsCount = text.split(' ').length;
-    setState(() => percentageCompleted = (wordsCount / targetWordsCount).clamp(0, 1));
-    if (percentageCompleted == 1) finalize();
-  }
-
-  finalize() async {
-    if (uploadingProfile || profileCompleted) return;
-
-    int duration = segments.isEmpty ? 0 : segments.last.end.toInt();
-    if (duration < 5 || duration > 120) {
-      showDialog(
-        context: context,
-        builder: (c) => getDialog(
-          context,
-          () {
-            Navigator.pop(context);
-            Navigator.pop(context);
-          },
-          () {},
-          // TODO: improve this
-          'Invalid recording detected',
-          'Please make sure you speak for at least 5 seconds and not more than 90.',
-          okButtonText: 'Ok',
-          singleButton: true,
-        ),
-        barrierDismissible: false,
-      );
-      return;
-    }
-
-    String text = segments.map((e) => e.text).join(' ').trim();
-    if (text.split(' ').length < (targetWordsCount / 2)) {
-      // 25 words
-      showDialog(
-        context: context,
-        builder: (c) => getDialog(
-          context,
-          () {
-            Navigator.pop(context);
-            Navigator.pop(context);
-          },
-          () {},
-          'Invalid recording detected',
-          'There is not enough speech detected. Please speak more and try again.',
-          okButtonText: 'Ok',
-          singleButton: true,
-        ),
-        barrierDismissible: false,
-      );
-      return;
-    }
-    setState(() => uploadingProfile = true);
-    closeWebSocket();
-    _forceCompletionTimer?.cancel();
-    _connectionStateListener?.cancel();
-    _bleBytesStream?.cancel();
-
-    List<List<int>> raw = List.from(audioStorage.rawPackets);
-    var data = await audioStorage.createWavFile(filename: 'speaker_profile.wav');
-    await uploadProfile(data.item1);
-    await uploadProfileBytes(raw, duration);
-
-    SharedPreferencesUtil().hasSpeakerProfile = true;
-    setState(() {
-      uploadingProfile = false;
-      profileCompleted = true;
-    });
-  }
-
-  Future<void> initiateWebsocket() async {
-    await initWebSocket(
-      codec: BleAudioCodec.opus,
-      sampleRate: 16000,
-      includeSpeechProfile: false,
-      onConnectionSuccess: () => setState(() {}),
-      onConnectionFailed: (err) => setState(() {}),
-      onConnectionClosed: (int? closeCode, String? closeReason) {},
-      onConnectionError: (err) => setState(() {}),
-      onMessageReceived: (List<TranscriptSegment> newSegments) {
-        if (newSegments.isEmpty) return;
-        if (segments.isEmpty) {
-          audioStorage.removeFramesRange(fromSecond: 0, toSecond: newSegments[0].start.toInt());
-        }
-        streamStartedAtSecond ??= newSegments[0].start;
-
-        TranscriptSegment.combineSegments(
-          segments,
-          newSegments,
-          toRemoveSeconds: streamStartedAtSecond ?? 0,
-        );
-        _validateSingleSpeaker();
-        _handleCompletion();
-        setState(() {});
-        scrollDown();
-        debugPrint('Memory creation timer restarted');
-      },
-    );
-  }
-
-  Future<void> initiateFriendAudioStreaming(BTDeviceStruct btDevice) async {
-    _bleBytesStream = await getBleAudioBytesListener(
-      btDevice.id,
-      onAudioBytesReceived: (List<int> value) {
-        if (value.isEmpty) return;
-        audioStorage.storeFramePacket(value);
-        value.removeRange(0, 3);
-        if (wsConnectionState == WebsocketConnectionStatus.connected) {
-          websocketChannel?.sink.add(value);
-        }
-      },
-    );
-  }
-
   @override
   void initState() {
-    _init();
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
+      context.read<SpeechProfileProvider>().initialise();
+    });
     super.initState();
   }
 
   @override
   void dispose() {
-    _connectionStateListener?.cancel();
-    _bleBytesStream?.cancel();
-    _forceCompletionTimer?.cancel();
+    if (mounted) {
+      context.read<SpeechProfileProvider>().dispose();
+    }
     super.dispose();
   }
 
@@ -247,284 +56,339 @@ class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateM
 
   @override
   Widget build(BuildContext context) {
-    String text = segments.map((e) => e.text).join(' ').trim();
-    int wordsCount = text.split(' ').length;
-    String message = 'Keep speaking until you get 100%.';
-    if (wordsCount > 10) {
-      message = 'Keep going, you are doing great';
-    } else if (wordsCount > 25) {
-      message = 'Great job, you are almost there';
-    } else if (wordsCount > 40) {
-      message = 'So close, just a little more';
-    }
-
     return PopScope(
       canPop: true,
-      child: Scaffold(
-        backgroundColor: Theme.of(context).colorScheme.primary,
-        appBar: AppBar(
-          backgroundColor: Theme.of(context).colorScheme.primary,
-          automaticallyImplyLeading: true,
-          title: const Text(
-            '',
-            style: TextStyle(color: Colors.white, fontSize: 20),
-          ),
-          actions: [
-            !widget.onbording
-                ? IconButton(
-                    onPressed: () {
-                      showDialog(
-                        context: context,
-                        builder: (c) => getDialog(
-                          context,
-                          () => Navigator.pop(context),
-                          () => Navigator.pop(context),
-                          'How to take a good sample?',
-                          '1. Make sure you are in a quiet place.\n2. Speak clearly and naturally.\n3. Make sure your device is in it\'s natural position, on your neck.\n\nOnce it\'s created, you can always improve it or do it again.',
-                          singleButton: true,
+      child: Consumer<SpeechProfileProvider>(builder: (context, provider, child) {
+        return MessageListener<SpeechProfileProvider>(
+          showInfo: (info) {
+            if (info == 'SCROLL_DOWN') {
+              scrollDown();
+            }
+          },
+          showError: (error) {
+            if (error == 'MULTIPLE_SPEAKERS') {
+              showDialog(
+                context: context,
+                builder: (c) => getDialog(
+                  context,
+                  () {
+                    provider.resetSegments();
+                    Navigator.pop(context);
+                  },
+                  () {},
+                  'Invalid recording detected',
+                  'It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.',
+                  okButtonText: 'Try Again',
+                  singleButton: true,
+                ),
+                barrierDismissible: false,
+              );
+            } else if (error == 'TOO_SHORT') {
+              showDialog(
+                context: context,
+                builder: (c) => getDialog(
+                  context,
+                  () {
+                    Navigator.pop(context);
+                    Navigator.pop(context);
+                  },
+                  () {},
+                  'Invalid recording detected',
+                  'There is not enough speech detected. Please speak more and try again.',
+                  okButtonText: 'Ok',
+                  singleButton: true,
+                ),
+                barrierDismissible: false,
+              );
+            } else if (error == 'INVALID_RECORDING') {
+              showDialog(
+                context: context,
+                builder: (c) => getDialog(
+                  context,
+                  () {
+                    Navigator.pop(context);
+                    Navigator.pop(context);
+                  },
+                  () {},
+                  // TODO: improve this
+                  'Invalid recording detected',
+                  'Please make sure you speak for at least 5 seconds and not more than 90.',
+                  okButtonText: 'Ok',
+                  singleButton: true,
+                ),
+                barrierDismissible: false,
+              );
+            }
+          },
+          child: Scaffold(
+            backgroundColor: Theme.of(context).colorScheme.primary,
+            appBar: AppBar(
+              backgroundColor: Theme.of(context).colorScheme.primary,
+              automaticallyImplyLeading: true,
+              title: const Text(
+                '',
+                style: TextStyle(color: Colors.white, fontSize: 20),
+              ),
+              actions: [
+                !widget.onbording
+                    ? IconButton(
+                        onPressed: () {
+                          showDialog(
+                            context: context,
+                            builder: (c) => getDialog(
+                              context,
+                              () => Navigator.pop(context),
+                              () => Navigator.pop(context),
+                              'How to take a good sample?',
+                              '1. Make sure you are in a quiet place.\n2. Speak clearly and naturally.\n3. Make sure your device is in it\'s natural position, on your neck.\n\nOnce it\'s created, you can always improve it or do it again.',
+                              singleButton: true,
+                            ),
+                          );
+                        },
+                        icon: const Icon(
+                          Icons.question_mark,
+                          size: 20,
+                        ))
+                    : TextButton(
+                        onPressed: () {
+                          routeToPage(context, const HomePageWrapper(), replace: true);
+                        },
+                        child: const Text(
+                          'Skip',
+                          style: TextStyle(color: Colors.white, decoration: TextDecoration.underline),
                         ),
-                      );
-                    },
-                    icon: const Icon(
-                      Icons.question_mark,
-                      size: 20,
-                    ))
-                : TextButton(
-                    onPressed: () {
-                      routeToPage(context, const HomePageWrapper(), replace: true);
-                    },
-                    child: const Text(
-                      'Skip',
-                      style: TextStyle(color: Colors.white, decoration: TextDecoration.underline),
+                      ),
+              ],
+              centerTitle: true,
+              elevation: 0,
+              leading: widget.onbording
+                  ? const SizedBox()
+                  : IconButton(
+                      icon: const Icon(Icons.arrow_back_ios_new),
+                      onPressed: () => Navigator.pop(context),
+                    ),
+            ),
+            body: Stack(
+              children: [
+                Align(
+                  alignment: Alignment.topCenter,
+                  child: Padding(
+                    padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
+                    child: Column(
+                      children: [
+                        const DeviceAnimationWidget(sizeMultiplier: 0.2, animatedBackground: false),
+                        !provider.startedRecording
+                            ? const SizedBox(height: 0)
+                            : const Text(
+                                'Tell your Friend\nabout yourself',
+                                style: TextStyle(
+                                    color: Colors.white, fontSize: 18, fontWeight: FontWeight.w500, height: 1.4),
+                                textAlign: TextAlign.center,
+                              ),
+                      ],
                     ),
                   ),
-          ],
-          centerTitle: true,
-          elevation: 0,
-          leading: widget.onbording
-              ? const SizedBox()
-              : IconButton(
-                  icon: const Icon(Icons.arrow_back_ios_new),
-                  onPressed: () => Navigator.pop(context),
                 ),
-        ),
-        body: Stack(
-          children: [
-            Align(
-              alignment: Alignment.topCenter,
-              child: Padding(
-                padding: EdgeInsets.fromLTRB(16, 8, 16, 0),
-                child: Column(
-                  children: [
-                    const DeviceAnimationWidget(sizeMultiplier: 0.2, animatedBackground: false),
-                    !startedRecording
-                        ? const SizedBox(height: 0)
-                        : const Text(
-                            'Tell your Friend\nabout yourself',
-                            style:
-                                TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w500, height: 1.4),
+                Align(
+                  alignment: Alignment.center,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(40, 0, 40, 48),
+                    child: !provider.startedRecording
+                        ? const Text(
+                            'Now, Friend needs to learn your voice to be able to recognise you.',
                             textAlign: TextAlign.center,
-                          ),
-                  ],
-                ),
-              ),
-            ),
-            Align(
-              alignment: Alignment.center,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(40, 0, 40, 48),
-                child: !startedRecording
-                    ? const Text(
-                        'Now, Friend needs to learn your voice to be able to recognise you.',
-                        textAlign: TextAlign.center,
-                        style: TextStyle(
-                          color: Colors.white,
-                          fontSize: 20,
-                          height: 1.4,
-                          fontWeight: FontWeight.w400,
-                        ),
-                      )
-                    : text.isEmpty
-                        ? const DeviceAnimationWidget(
-                            sizeMultiplier: 0.7,
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 20,
+                              height: 1.4,
+                              fontWeight: FontWeight.w400,
+                            ),
                           )
-                        : LayoutBuilder(
-                            builder: (context, constraints) {
-                              return ShaderMask(
-                                shaderCallback: (bounds) {
-                                  if (text.split(' ').length < 10) {
-                                    return const LinearGradient(colors: [Colors.white, Colors.white])
-                                        .createShader(bounds);
-                                  }
-                                  return const LinearGradient(
-                                    colors: [Colors.transparent, Colors.white],
-                                    stops: [0.0, 0.5],
-                                    begin: Alignment.topCenter,
-                                    end: Alignment.bottomCenter,
-                                  ).createShader(bounds);
-                                },
-                                blendMode: BlendMode.dstIn,
-                                child: SizedBox(
-                                  height: 120,
-                                  child: ListView(
-                                    controller: _scrollController,
-                                    shrinkWrap: true,
-                                    physics: const NeverScrollableScrollPhysics(),
-                                    children: [
-                                      Text(
-                                        text,
-                                        textAlign: TextAlign.center,
-                                        style: const TextStyle(
-                                          color: Colors.white,
-                                          fontSize: 20,
-                                          fontWeight: FontWeight.w400,
-                                          height: 1.5,
-                                        ),
+                        : provider.text.isEmpty
+                            ? const DeviceAnimationWidget(
+                                sizeMultiplier: 0.7,
+                              )
+                            : LayoutBuilder(
+                                builder: (context, constraints) {
+                                  return ShaderMask(
+                                    shaderCallback: (bounds) {
+                                      if (provider.text.split(' ').length < 10) {
+                                        return const LinearGradient(colors: [Colors.white, Colors.white])
+                                            .createShader(bounds);
+                                      }
+                                      return const LinearGradient(
+                                        colors: [Colors.transparent, Colors.white],
+                                        stops: [0.0, 0.5],
+                                        begin: Alignment.topCenter,
+                                        end: Alignment.bottomCenter,
+                                      ).createShader(bounds);
+                                    },
+                                    blendMode: BlendMode.dstIn,
+                                    child: SizedBox(
+                                      height: 120,
+                                      child: ListView(
+                                        controller: _scrollController,
+                                        shrinkWrap: true,
+                                        physics: const NeverScrollableScrollPhysics(),
+                                        children: [
+                                          Text(
+                                            provider.text,
+                                            textAlign: TextAlign.center,
+                                            style: const TextStyle(
+                                              color: Colors.white,
+                                              fontSize: 20,
+                                              fontWeight: FontWeight.w400,
+                                              height: 1.5,
+                                            ),
+                                          ),
+                                        ],
                                       ),
-                                    ],
+                                    ),
+                                  );
+                                },
+                              ),
+                  ),
+                ),
+                Align(
+                  alignment: Alignment.bottomCenter,
+                  child: Padding(
+                    padding: const EdgeInsets.fromLTRB(24, 0, 24, 48),
+                    child: !provider.startedRecording
+                        ? Column(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              MaterialButton(
+                                onPressed: () async {
+                                  BleAudioCodec codec;
+                                  try {
+                                    codec = await getAudioCodec(provider.device!.id);
+                                  } catch (e) {
+                                    showDialog(
+                                      context: context,
+                                      barrierDismissible: false,
+                                      builder: (c) => getDialog(
+                                        context,
+                                        () {
+                                          Navigator.of(context).pop();
+                                          Navigator.of(context).pop();
+                                        },
+                                        () => {},
+                                        'Device Disconnected',
+                                        'Please make sure your device is turned on and nearby, and try again.',
+                                        singleButton: true,
+                                      ),
+                                    );
+                                    return;
+                                  }
+
+                                  if (codec != BleAudioCodec.opus) {
+                                    showDialog(
+                                      context: context,
+                                      builder: (c) => getDialog(
+                                        context,
+                                        () => Navigator.pop(context),
+                                        () {
+                                          Navigator.pop(context);
+                                          launchUrl(Uri.parse(
+                                              'https://github.com/BasedHardware/Omi/releases/tag/v1.0.4-firmware'));
+                                        },
+                                        'Firmware Update Required',
+                                        'Please update your device firmware to set-up your speech profile.',
+                                        okButtonText: 'Do now',
+                                      ),
+                                      barrierDismissible: false,
+                                    );
+                                    return;
+                                  }
+
+                                  provider.initiateWebsocket();
+                                  // 1.5 minutes seems reasonable
+                                  provider.forceCompletionTimer =
+                                      Timer(Duration(seconds: provider.maxDuration), provider.finalize);
+                                  provider.updateStartedRecording(true);
+                                },
+                                color: Colors.white,
+                                padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 14),
+                                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
+                                child: const Text('Get Started', style: TextStyle(color: Colors.black)),
+                              ),
+                              TextButton(
+                                  onPressed: () {
+                                    routeToPage(context, const ProfileSamples());
+                                  },
+                                  child: const Text(
+                                    'Listen to existing samples ➡️',
+                                    style: TextStyle(color: Colors.white),
+                                  ))
+                            ],
+                          )
+                        : provider.profileCompleted
+                            ? Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
+                                decoration: BoxDecoration(
+                                  border: const GradientBoxBorder(
+                                    gradient: LinearGradient(colors: [
+                                      Color.fromARGB(127, 208, 208, 208),
+                                      Color.fromARGB(127, 188, 99, 121),
+                                      Color.fromARGB(127, 86, 101, 182),
+                                      Color.fromARGB(127, 126, 190, 236)
+                                    ]),
+                                    width: 2,
+                                  ),
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                child: TextButton(
+                                  onPressed: () {
+                                    Navigator.pop(context);
+                                  },
+                                  child: const Text(
+                                    "All done!",
+                                    style: TextStyle(color: Colors.white, fontSize: 16),
                                   ),
                                 ),
-                              );
-                            },
-                          ),
-              ),
-            ),
-            Align(
-              alignment: Alignment.bottomCenter,
-              child: Padding(
-                padding: const EdgeInsets.fromLTRB(24, 0, 24, 48),
-                child: !startedRecording
-                    ? Column(
-                        mainAxisAlignment: MainAxisAlignment.end,
-                        children: [
-                          MaterialButton(
-                            onPressed: () async {
-                              BleAudioCodec codec;
-                              try {
-                                codec = await getAudioCodec(_device!.id);
-                              } catch (e) {
-                                showDialog(
-                                  context: context,
-                                  barrierDismissible: false,
-                                  builder: (c) => getDialog(
-                                    context,
-                                    () {
-                                      Navigator.of(context).pop();
-                                      Navigator.of(context).pop();
-                                    },
-                                    () => {},
-                                    'Device Disconnected',
-                                    'Please make sure your device is turned on and nearby, and try again.',
-                                    singleButton: true,
-                                  ),
-                                );
-                                return;
-                              }
-
-                              if (codec != BleAudioCodec.opus) {
-                                showDialog(
-                                  context: context,
-                                  builder: (c) => getDialog(
-                                    context,
-                                    () => Navigator.pop(context),
-                                    () {
-                                      Navigator.pop(context);
-                                      launchUrl(Uri.parse(
-                                          'https://github.com/BasedHardware/Omi/releases/tag/v1.0.4-firmware'));
-                                    },
-                                    'Firmware Update Required',
-                                    'Please update your device firmware to set-up your speech profile.',
-                                    okButtonText: 'Do now',
-                                  ),
-                                  barrierDismissible: false,
-                                );
-                                return;
-                              }
-
-                              initiateWebsocket();
-                              // 1.5 minutes seems reasonable
-                              _forceCompletionTimer = Timer(Duration(seconds: maxDuration), finalize);
-                              setState(() => startedRecording = true);
-                            },
-                            color: Colors.white,
-                            padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 14),
-                            shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(24)),
-                            child: const Text('Get Started', style: TextStyle(color: Colors.black)),
-                          ),
-                          TextButton(
-                              onPressed: () {
-                                routeToPage(context, const ProfileSamples());
-                              },
-                              child: const Text(
-                                'Listen to existing samples ➡️',
-                                style: TextStyle(color: Colors.white),
-                              ))
-                        ],
-                      )
-                    : profileCompleted
-                        ? Container(
-                            padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 0),
-                            decoration: BoxDecoration(
-                              border: const GradientBoxBorder(
-                                gradient: LinearGradient(colors: [
-                                  Color.fromARGB(127, 208, 208, 208),
-                                  Color.fromARGB(127, 188, 99, 121),
-                                  Color.fromARGB(127, 86, 101, 182),
-                                  Color.fromARGB(127, 126, 190, 236)
-                                ]),
-                                width: 2,
-                              ),
-                              borderRadius: BorderRadius.circular(12),
-                            ),
-                            child: TextButton(
-                              onPressed: () {
-                                Navigator.pop(context);
-                              },
-                              child: const Text(
-                                "All done!",
-                                style: TextStyle(color: Colors.white, fontSize: 16),
-                              ),
-                            ),
-                          )
-                        : uploadingProfile
-                            ? const CircularProgressIndicator(
-                                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
                               )
-                            : Column(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Text(
-                                    message,
-                                    style: TextStyle(color: Colors.grey.shade300, fontSize: 14, height: 1.4),
-                                    textAlign: TextAlign.center,
-                                  ),
-                                  const SizedBox(height: 24),
-                                  Padding(
-                                    padding: const EdgeInsets.symmetric(horizontal: 32),
-                                    child: Stack(
-                                      children: [
-                                        // LinearProgressIndicator(
-                                        //   backgroundColor: Colors.grey[300],
-                                        //   valueColor: AlwaysStoppedAnimation<Color>(Colors.grey.withOpacity(0.3)),
-                                        // ),
-                                        LinearProgressIndicator(
-                                          value: percentageCompleted,
-                                          backgroundColor: Colors.grey.shade300, // Make sure background is transparent
-                                          valueColor: const AlwaysStoppedAnimation<Color>(Colors.deepPurple),
+                            : provider.uploadingProfile
+                                ? const CircularProgressIndicator(
+                                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                                  )
+                                : Column(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Text(
+                                        provider.message,
+                                        style: TextStyle(color: Colors.grey.shade300, fontSize: 14, height: 1.4),
+                                        textAlign: TextAlign.center,
+                                      ),
+                                      const SizedBox(height: 24),
+                                      Padding(
+                                        padding: const EdgeInsets.symmetric(horizontal: 32),
+                                        child: Stack(
+                                          children: [
+                                            // LinearProgressIndicator(
+                                            //   backgroundColor: Colors.grey[300],
+                                            //   valueColor: AlwaysStoppedAnimation<Color>(Colors.grey.withOpacity(0.3)),
+                                            // ),
+                                            LinearProgressIndicator(
+                                              value: provider.percentageCompleted,
+                                              backgroundColor:
+                                                  Colors.grey.shade300, // Make sure background is transparent
+                                              valueColor: const AlwaysStoppedAnimation<Color>(Colors.deepPurple),
+                                            ),
+                                          ],
                                         ),
-                                      ],
-                                    ),
+                                      ),
+                                      const SizedBox(height: 12),
+                                      Text('${(provider.percentageCompleted * 100).toInt()}%',
+                                          style: const TextStyle(color: Colors.white)),
+                                    ],
                                   ),
-                                  const SizedBox(height: 12),
-                                  Text('${(percentageCompleted * 100).toInt()}%',
-                                      style: const TextStyle(color: Colors.white)),
-                                ],
-                              ),
-              ),
+                  ),
+                ),
+              ],
             ),
-          ],
-        ),
-      ),
+          ),
+        );
+      }),
     );
   }
 }

--- a/app/lib/providers/memory_provider.dart
+++ b/app/lib/providers/memory_provider.dart
@@ -35,7 +35,7 @@ class MemoryProvider extends ChangeNotifier {
   }
 
   void initFilteredMemories() {
-    filteredMemories = memories;
+    filterMemories('');
     populateMemoriesWithDates();
     notifyListeners();
   }

--- a/app/lib/providers/memory_provider.dart
+++ b/app/lib/providers/memory_provider.dart
@@ -95,6 +95,7 @@ class MemoryProvider extends ChangeNotifier {
     setLoadingMemories(true);
     var newMemories = await getMemories(offset: memories.length);
     memories.addAll(newMemories);
+    filterMemories('');
     setLoadingMemories(false);
     notifyListeners();
   }
@@ -120,6 +121,8 @@ class MemoryProvider extends ChangeNotifier {
 
   void deleteMemory(ServerMemory memory, int index) {
     memories.removeAt(index);
+    deleteMemoryServer(memory.id);
+    filterMemories('');
     notifyListeners();
   }
 

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -1,12 +1,197 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
+import 'package:flutter_blue_plus/flutter_blue_plus.dart';
+import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
+import 'package:friend_private/backend/database/transcript_segment.dart';
+import 'package:friend_private/backend/http/api/speech_profile.dart';
 import 'package:friend_private/backend/http/api/users.dart';
 import 'package:friend_private/backend/preferences.dart';
+import 'package:friend_private/backend/schema/bt_device.dart';
+import 'package:friend_private/pages/capture/logic/websocket_mixin.dart';
+import 'package:friend_private/providers/device_provider.dart';
+import 'package:friend_private/utils/audio/wav_bytes.dart';
+import 'package:friend_private/utils/ble/communication.dart';
+import 'package:friend_private/utils/ble/connected.dart';
+import 'package:friend_private/utils/websockets.dart';
 
-class SpeechProfileProvider extends ChangeNotifier {
+class SpeechProfileProvider extends ChangeNotifier with MessageNotifierMixin, WebSocketMixin {
+  DeviceProvider? deviceProvider;
   bool? permissionEnabled;
   bool loading = false;
+  BTDeviceStruct? device;
 
-  changeLoadingState() => loading = !loading;
+  final targetWordsCount = 45;
+  final maxDuration = 90;
+  StreamSubscription<OnConnectionStateChangedEvent>? connectionStateListener;
+  List<TranscriptSegment> segments = [];
+  double? streamStartedAtSecond;
+  WavBytesUtil audioStorage = WavBytesUtil(codec: BleAudioCodec.opus);
+  StreamSubscription? _bleBytesStream;
+
+  bool startedRecording = false;
+  double percentageCompleted = 0;
+  bool uploadingProfile = false;
+  bool profileCompleted = false;
+  Timer? forceCompletionTimer;
+
+  String text = '';
+  String message = '';
+
+  void setProvider(DeviceProvider provider) {
+    deviceProvider = provider;
+    notifyListeners();
+  }
+
+  initialise() async {
+    device = deviceProvider?.connectedDevice;
+    device ??= await deviceProvider?.scanAndConnectToDevice();
+    if (device != null) initiateFriendAudioStreaming();
+    initiateConnectionListener();
+    notifyListeners();
+  }
+
+  void updateStartedRecording(bool value) {
+    startedRecording = value;
+    notifyListeners();
+  }
+
+  changeLoadingState() {
+    loading = !loading;
+    notifyListeners();
+  }
+
+  initiateConnectionListener() async {
+    if (device == null || connectionStateListener != null) return;
+    connectionStateListener = getConnectionStateListener(
+        deviceId: device!.id,
+        onDisconnected: () {
+          device = null;
+          notifyListeners();
+        },
+        onConnected: ((d) {
+          device = d;
+          notifyListeners();
+          initiateFriendAudioStreaming();
+        }));
+  }
+
+  Future<void> initiateWebsocket() async {
+    await initWebSocket(
+      codec: BleAudioCodec.opus,
+      sampleRate: 16000,
+      includeSpeechProfile: false,
+      onConnectionSuccess: () {
+        notifyListeners();
+      },
+      onConnectionFailed: (err) {
+        notifyError('WS_ERR');
+      },
+      onConnectionClosed: (int? closeCode, String? closeReason) {},
+      onConnectionError: (err) {
+        notifyError('WS_ERR');
+      },
+      onMessageReceived: (List<TranscriptSegment> newSegments) {
+        if (newSegments.isEmpty) return;
+        if (segments.isEmpty) {
+          audioStorage.removeFramesRange(fromSecond: 0, toSecond: newSegments[0].start.toInt());
+        }
+        streamStartedAtSecond ??= newSegments[0].start;
+
+        TranscriptSegment.combineSegments(
+          segments,
+          newSegments,
+          toRemoveSeconds: streamStartedAtSecond ?? 0,
+        );
+        updateProgressMessage();
+        _validateSingleSpeaker();
+        _handleCompletion();
+        notifyInfo('SCROLL_DOWN');
+        debugPrint('Memory creation timer restarted');
+      },
+    );
+  }
+
+  _handleCompletion() async {
+    if (uploadingProfile || profileCompleted) return;
+    String text = segments.map((e) => e.text).join(' ').trim();
+    int wordsCount = text.split(' ').length;
+    percentageCompleted = (wordsCount / targetWordsCount).clamp(0, 1);
+    notifyListeners();
+    if (percentageCompleted == 1) finalize();
+    notifyListeners();
+  }
+
+  finalize() async {
+    if (uploadingProfile || profileCompleted) return;
+
+    int duration = segments.isEmpty ? 0 : segments.last.end.toInt();
+    if (duration < 5 || duration > 120) {
+      notifyError('INVALID_RECORDING');
+    }
+
+    String text = segments.map((e) => e.text).join(' ').trim();
+    if (text.split(' ').length < (targetWordsCount / 2)) {
+      // 25 words
+      notifyError('TOO_SHORT');
+    }
+    uploadingProfile = true;
+    notifyListeners();
+    closeWebSocket();
+    forceCompletionTimer?.cancel();
+    connectionStateListener?.cancel();
+    _bleBytesStream?.cancel();
+
+    List<List<int>> raw = List.from(audioStorage.rawPackets);
+    var data = await audioStorage.createWavFile(filename: 'speaker_profile.wav');
+    await uploadProfile(data.item1);
+    await uploadProfileBytes(raw, duration);
+
+    SharedPreferencesUtil().hasSpeakerProfile = true;
+
+    uploadingProfile = false;
+    profileCompleted = true;
+    notifyListeners();
+  }
+
+  Future<void> initiateFriendAudioStreaming() async {
+    _bleBytesStream = await getBleAudioBytesListener(
+      device!.id,
+      onAudioBytesReceived: (List<int> value) {
+        if (value.isEmpty) return;
+        audioStorage.storeFramePacket(value);
+        value.removeRange(0, 3);
+        if (wsConnectionState == WebsocketConnectionStatus.connected) {
+          websocketChannel?.sink.add(value);
+        }
+      },
+    );
+  }
+
+  _validateSingleSpeaker() {
+    int speakersCount = segments.map((e) => e.speaker).toSet().length;
+    debugPrint('_validateSingleSpeaker speakers count: $speakersCount');
+    if (speakersCount > 1) {
+      var speakerToWords = segments.fold<Map<int, int>>(
+        {},
+        (previousValue, element) {
+          previousValue[element.speakerId] = (previousValue[element.speakerId] ?? 0) + element.text.split(' ').length;
+          return previousValue;
+        },
+      );
+      debugPrint('speakerToWords: $speakerToWords');
+      if (speakerToWords.values.every((element) => element / segments.length > 0.2)) {
+        notifyError('MULTIPLE_SPEAKERS');
+      }
+    }
+  }
+
+  void resetSegments() {
+    segments.clear();
+    streamStartedAtSecond = null;
+    audioStorage.clearAudioBytes();
+    notifyListeners();
+  }
 
   Future setupSpeechRecording() async {
     final permission = await getStoreRecordingPermission();
@@ -14,5 +199,29 @@ class SpeechProfileProvider extends ChangeNotifier {
     if (permission != null) {
       SharedPreferencesUtil().permissionStoreRecordingsEnabled = permission;
     }
+    notifyListeners();
+  }
+
+  void updateProgressMessage() {
+    text = segments.map((e) => e.text).join(' ').trim();
+    int wordsCount = text.split(' ').length;
+    message = 'Keep speaking until you get 100%.';
+    if (wordsCount > 10) {
+      message = 'Keep going, you are doing great';
+    } else if (wordsCount > 25) {
+      message = 'Great job, you are almost there';
+    } else if (wordsCount > 40) {
+      message = 'So close, just a little more';
+    }
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    // This won't be called unless the provider is removed from the widget tree. So we need to manually call this in the widget's dispose method.
+    connectionStateListener?.cancel();
+    _bleBytesStream?.cancel();
+    forceCompletionTimer?.cancel();
+    super.dispose();
   }
 }

--- a/app/lib/utils/other/temp.dart
+++ b/app/lib/utils/other/temp.dart
@@ -12,7 +12,9 @@ String dateTimeFormat(String format, DateTime? dateTime, {String? locale}) {
 Future routeToPage(BuildContext context, Widget page, {bool replace = false}) {
   var route = Platform.isIOS ? CupertinoPageRoute(builder: (c) => page) : MaterialPageRoute(builder: (c) => page);
   if (replace) {
-    return Navigator.of(context).pushAndRemoveUntil(route, (route) => false);
+    if (context.mounted) {
+      return Navigator.of(context).pushAndRemoveUntil(route, (route) => false);
+    }
   }
   return Navigator.of(context).push(route);
 }


### PR DESCRIPTION
- Fix non english msgs not rendered correctly
- Fix saved developer settings not visible
- Fix memories not deleted permanently
- Fix old memories not showing up even after refreshing
- Fix phone recording
- Remove reliance on capturePageKey in provider
- Further migrate capture page to Provider
- Fix onboarding provider issues
- Fix disconnected device still showing up in find devices
- Migrate Speech Profile to Provider
- Fix discarded memories issue


<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Added audio streaming, websocket communication, and profile finalization functionality to `SpeechProfileProvider`.
- Refactor: Major refactoring of state management using `Provider` for better code organization and maintainability.
- Refactor: Converted `DeveloperSettingsPage` from a `StatelessWidget` to a `StatefulWidget` for proper initialization.
- UI Enhancement: Improved UI rendering, error handling, navigation logic, and lifecycle management in the onboarding process.
- Bug Fix: Added check for `context.mounted` before navigating to a new route to prevent potential errors.
- Chore: Removed unused methods and commented-out code for cleaner codebase.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->