### PR TITLE
Firmware changed popup and other fixes

### DIFF
--- a/app/lib/pages/capture/page.dart
+++ b/app/lib/pages/capture/page.dart
@@ -204,8 +204,7 @@ class CapturePageState extends State<CapturePage>
     return Consumer2<CaptureProvider, DeviceProvider>(builder: (context, provider, deviceProvider, child) {
       return MessageListener<CaptureProvider>(
         showInfo: (info) {
-          // TODO: Fix this after onboarding
-          // Ideally this shouldn't even be required, because we can close the socket and restart it with the new codec
+          // This probably will never be called because this has been handled even before we start the audio stream. But it's here just in case.
           if (info == 'FIM_CHANGE') {
             showDialog(
               context: context,

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -342,6 +342,19 @@ class CaptureProvider extends ChangeNotifier with WebSocketMixin, OpenGlassMixin
     setAudioBytesConnected(false);
     setRestartAudioProcessing(restartBytesProcessing);
     startOpenGlass();
+    if (connectedDevice != null) {
+      BleAudioCodec codec = await getAudioCodec(connectedDevice!.id);
+      if (SharedPreferencesUtil().deviceCodec != codec) {
+        debugPrint('Device codec changed from ${SharedPreferencesUtil().deviceCodec} to $codec while resetting state');
+        SharedPreferencesUtil().deviceCodec = codec;
+        if (webSocketConnected) {
+          closeWebSocket();
+          await initiateWebsocket();
+        } else {
+          await initiateWebsocket();
+        }
+      }
+    }
     initiateFriendAudioStreaming();
     notifyListeners();
   }

--- a/app/lib/providers/plugin_provider.dart
+++ b/app/lib/providers/plugin_provider.dart
@@ -27,12 +27,10 @@ class PluginProvider extends BaseProvider {
 
   Future getPlugins() async {
     setLoadingState(true);
-    if (SharedPreferencesUtil().pluginsList.isEmpty) {
-      plugins = await retrievePlugins();
-      updatePrefPlugins();
-    } else {
-      setPlugins();
-    }
+    plugins = await retrievePlugins();
+    updatePrefPlugins();
+    setPlugins();
+    setLoadingState(false);
     notifyListeners();
   }
 


### PR DESCRIPTION
- Permanently remove the firmware changed popup, the app will now automatically restarts the websocket if there's a change in the firmware version
- Fix plugins not being updated
<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Refactor: Improved handling of firmware changes in the capture feature. The app now checks for device codec changes and restarts the websocket if necessary, enhancing stability and responsiveness.
- Refactor: Simplified the `getPlugins` method in the plugin provider. This change streamlines the logic flow and improves the user experience by setting a loading state before notifying listeners.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->