### PR TITLE
WebSocket handling improvements

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -13,6 +13,7 @@ import 'package:friend_private/env/prod_env.dart';
 import 'package:friend_private/firebase_options_dev.dart' as dev;
 import 'package:friend_private/firebase_options_prod.dart' as prod;
 import 'package:friend_private/flavors.dart';
+import 'package:friend_private/providers/websocket_provider.dart';
 import 'package:friend_private/pages/home/page.dart';
 import 'package:friend_private/pages/onboarding/wrapper.dart';
 import 'package:friend_private/providers/auth_provider.dart';
@@ -133,15 +134,16 @@ class _MyAppState extends State<MyApp> {
             update: (BuildContext context, value, MessageProvider? previous) =>
                 (previous?..updatePluginProvider(value)) ?? MessageProvider(),
           ),
-          ChangeNotifierProxyProvider2<MemoryProvider, MessageProvider, CaptureProvider>(
+          ChangeNotifierProvider(create: (context) => WebSocketProvider()),
+          ChangeNotifierProxyProvider3<MemoryProvider, MessageProvider, WebSocketProvider, CaptureProvider>(
             create: (context) => CaptureProvider(),
-            update: (BuildContext context, memory, message, CaptureProvider? previous) =>
-                (previous?..updateProviderInstances(memory, message)) ?? CaptureProvider(),
+            update: (BuildContext context, memory, message, wsProvider, CaptureProvider? previous) =>
+                (previous?..updateProviderInstances(memory, message, wsProvider)) ?? CaptureProvider(),
           ),
-          ChangeNotifierProxyProvider<CaptureProvider, DeviceProvider>(
+          ChangeNotifierProxyProvider2<CaptureProvider, WebSocketProvider, DeviceProvider>(
             create: (context) => DeviceProvider(),
-            update: (BuildContext context, value, DeviceProvider? previous) =>
-                (previous?..setProvider(value)) ?? DeviceProvider(),
+            update: (BuildContext context, captureProvider, wsProvider, DeviceProvider? previous) =>
+                (previous?..setProviders(captureProvider, wsProvider)) ?? DeviceProvider(),
           ),
           ChangeNotifierProxyProvider<DeviceProvider, OnboardingProvider>(
             create: (context) => OnboardingProvider(),
@@ -149,10 +151,10 @@ class _MyAppState extends State<MyApp> {
                 (previous?..setDeviceProvider(value)) ?? OnboardingProvider(),
           ),
           ListenableProvider(create: (context) => HomeProvider()),
-          ChangeNotifierProxyProvider2<DeviceProvider, CaptureProvider, SpeechProfileProvider>(
+          ChangeNotifierProxyProvider3<DeviceProvider, CaptureProvider, WebSocketProvider, SpeechProfileProvider>(
             create: (context) => SpeechProfileProvider(),
-            update: (BuildContext context, device, capture, SpeechProfileProvider? previous) =>
-                (previous?..setProvider(device, capture)) ?? SpeechProfileProvider(),
+            update: (BuildContext context, device, capture, wsProvider, SpeechProfileProvider? previous) =>
+                (previous?..setProviders(device, capture, wsProvider)) ?? SpeechProfileProvider(),
           ),
         ],
         builder: (context, child) {

--- a/app/lib/pages/capture/location_service.dart
+++ b/app/lib/pages/capture/location_service.dart
@@ -52,15 +52,12 @@ class LocationService {
   Future hasPermission() async => (await location.hasPermission()) == PermissionStatus.granted;
 
   Future<void> getDeviceLocation() async {
-    print("Getting location data");
     locationData = await location.getLocation();
-    print("Location data: $locationData");
   }
 
   Future<Geolocation?> getGeolocationDetails() async {
     try {
       if (await hasPermission()) {
-        print('background mode enabled: ${await location.isBackgroundModeEnabled()}');
         if (await location.isBackgroundModeEnabled()) {
           if (await location.serviceEnabled()) {
             await location.requestService();

--- a/app/lib/pages/onboarding/find_device/found_devices.dart
+++ b/app/lib/pages/onboarding/find_device/found_devices.dart
@@ -9,12 +9,10 @@ import 'package:provider/provider.dart';
 
 class FoundDevices extends StatefulWidget {
   final bool isFromOnboarding;
-  final List<BTDeviceStruct> deviceList;
   final VoidCallback goNext;
 
   const FoundDevices({
     super.key,
-    required this.deviceList,
     required this.goNext,
     required this.isFromOnboarding,
   });
@@ -62,9 +60,9 @@ class _FoundDevicesState extends State<FoundDevices> {
           children: [
             !provider.isConnected
                 ? Text(
-                    widget.deviceList.isEmpty
+                    provider.deviceList.isEmpty
                         ? 'Searching for devices...'
-                        : '${widget.deviceList.length} ${widget.deviceList.length == 1 ? "DEVICE" : "DEVICES"} FOUND NEARBY',
+                        : '${provider.deviceList.length} ${provider.deviceList.length == 1 ? "DEVICE" : "DEVICES"} FOUND NEARBY',
                     style: const TextStyle(
                       fontWeight: FontWeight.w400,
                       fontSize: 14,
@@ -79,7 +77,7 @@ class _FoundDevicesState extends State<FoundDevices> {
                       color: Color(0x66FFFFFF),
                     ),
                   ),
-            if (widget.deviceList.isNotEmpty) const SizedBox(height: 16),
+            if (provider.deviceList.isNotEmpty) const SizedBox(height: 16),
             if (!provider.isConnected) ..._devicesList(provider),
             if (provider.isConnected)
               Text(
@@ -114,7 +112,7 @@ class _FoundDevicesState extends State<FoundDevices> {
   }
 
   _devicesList(OnboardingProvider provider) {
-    return (widget.deviceList.mapIndexed(
+    return (provider.deviceList.mapIndexed(
       (index, device) {
         bool isConnecting = provider.connectingToDeviceId == device.id;
 

--- a/app/lib/pages/onboarding/find_device/page.dart
+++ b/app/lib/pages/onboarding/find_device/page.dart
@@ -71,7 +71,6 @@ class _FindDevicesPageState extends State<FindDevicesPage> {
           crossAxisAlignment: CrossAxisAlignment.center,
           children: [
             FoundDevices(
-              deviceList: provider.deviceList,
               goNext: widget.goNext,
               isFromOnboarding: widget.isFromOnboarding,
             ),

--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:friend_private/backend/preferences.dart';
-import 'package:friend_private/pages/capture/logic/websocket_mixin.dart';
+import 'package:friend_private/providers/websocket_provider.dart';
 import 'package:friend_private/providers/speech_profile_provider.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
@@ -18,7 +18,7 @@ class SpeechProfileWidget extends StatefulWidget {
   State<SpeechProfileWidget> createState() => _SpeechProfileWidgetState();
 }
 
-class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerProviderStateMixin, WebSocketMixin {
+class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerProviderStateMixin {
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {

--- a/app/lib/pages/speaker_id/page.dart
+++ b/app/lib/pages/speaker_id/page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
-import 'package:friend_private/pages/capture/logic/websocket_mixin.dart';
+import 'package:friend_private/providers/websocket_provider.dart';
 import 'package:friend_private/pages/home/page.dart';
 import 'package:friend_private/pages/settings/people.dart';
 import 'package:friend_private/pages/speaker_id/user_speech_samples.dart';
@@ -26,7 +26,7 @@ class SpeakerIdPage extends StatefulWidget {
   State<SpeakerIdPage> createState() => _SpeakerIdPageState();
 }
 
-class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateMixin, WebSocketMixin {
+class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateMixin {
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((timeStamp) {

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -12,7 +12,7 @@ import 'package:friend_private/backend/http/api/speech_profile.dart';
 import 'package:friend_private/backend/http/api/users.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
-import 'package:friend_private/pages/capture/logic/websocket_mixin.dart';
+import 'package:friend_private/providers/websocket_provider.dart';
 import 'package:friend_private/providers/capture_provider.dart';
 import 'package:friend_private/providers/device_provider.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';


### PR DESCRIPTION
This PR moves the WebSocket implementation to a completely separate Provider named `websocket_provider`. It decouples the reliance on capture provider for websocket completely. This PR also replaces the usage of internet listener with the connectivity controller.

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Refactor: Moved WebSocket implementation to a separate provider for better modularity and maintainability.
- New Feature: Introduced connectivity controller replacing the internet listener, enhancing the app's responsiveness to network changes.
- Refactor: Updated `CaptureProvider`, `DeviceProvider`, and `SpeechProfileProvider` classes to include a `WebSocketProvider` instance, improving code organization.
- Bug Fix: Removed print statements from `getDeviceLocation` method in `location_service.dart`, enhancing data security.
- Refactor: Removed direct access to `provider.deviceList` in `FoundDevices` widget, promoting encapsulation.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->