### PR TITLE
Fix: App not transcribing after coming from speech profile

### DIFF
--- a/app/lib/pages/speaker_id/page.dart
+++ b/app/lib/pages/speaker_id/page.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
-import 'package:friend_private/providers/websocket_provider.dart';
 import 'package:friend_private/pages/home/page.dart';
 import 'package:friend_private/pages/settings/people.dart';
 import 'package:friend_private/pages/speaker_id/user_speech_samples.dart';
@@ -29,9 +28,6 @@ class SpeakerIdPage extends StatefulWidget {
 class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateMixin {
   @override
   void initState() {
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
-      context.read<SpeechProfileProvider>().initialise(false);
-    });
     super.initState();
   }
 
@@ -264,6 +260,7 @@ class _SpeakerIdPageState extends State<SpeakerIdPage> with TickerProviderStateM
                             children: [
                               MaterialButton(
                                 onPressed: () async {
+                                  context.read<SpeechProfileProvider>().initialise(false);
                                   BleAudioCodec codec;
                                   try {
                                     codec = await getAudioCodec(provider.device!.id);

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -179,9 +179,8 @@ class SpeechProfileProvider extends ChangeNotifier with MessageNotifierMixin {
     if (isFromOnboarding) {
       await createMemory();
       captureProvider?.clearTranscripts();
-      captureProvider?.resetState(restartBytesProcessing: true);
     }
-
+    captureProvider?.resetState(restartBytesProcessing: true);
     uploadingProfile = false;
     profileCompleted = true;
     updateLoadingText("You're all set!");


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Refactor: Changed the initialization flow of the Speech Profile Provider. The initialization now occurs when a specific button is pressed, providing more control over when this process starts.
- Chore: Removed unnecessary state reset in the Speech Profile Provider based on `isFromOnboarding` flag, simplifying the code and reducing potential points of failure.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->