### PR TITLE
Set mixpanel events for location and notification

### DIFF
--- a/app/lib/pages/capture/page.dart
+++ b/app/lib/pages/capture/page.dart
@@ -13,6 +13,7 @@ import 'package:friend_private/pages/capture/widgets/widgets.dart';
 import 'package:friend_private/providers/capture_provider.dart';
 import 'package:friend_private/providers/device_provider.dart';
 import 'package:friend_private/providers/onboarding_provider.dart';
+import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/audio/wav_bytes.dart';
 import 'package:friend_private/utils/ble/communication.dart';
 import 'package:friend_private/utils/connectivity_controller.dart';
@@ -173,6 +174,7 @@ class CapturePageState extends State<CapturePage> with AutomaticKeepAliveClientM
     } else {
       PermissionStatus permissionGranted = await locationService.requestPermission();
       SharedPreferencesUtil().locationEnabled = permissionGranted == PermissionStatus.granted;
+      MixpanelManager().setUserProperty('Location Enabled', SharedPreferencesUtil().locationEnabled);
       if (permissionGranted == PermissionStatus.denied) {
         debugPrint('Location permission not granted');
       } else if (permissionGranted == PermissionStatus.deniedForever) {

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -29,6 +29,7 @@ import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/upgrade_alert.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:upgrader/upgrader.dart';
 
@@ -45,6 +46,14 @@ class _HomePageWrapperState extends State<HomePageWrapper> {
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (SharedPreferencesUtil().notificationsEnabled != await Permission.notification.isGranted) {
+        SharedPreferencesUtil().notificationsEnabled = await Permission.notification.isGranted;
+        MixpanelManager().setUserProperty('Notifications Enabled', SharedPreferencesUtil().notificationsEnabled);
+      }
+      if (SharedPreferencesUtil().locationEnabled != await Permission.location.isGranted) {
+        SharedPreferencesUtil().locationEnabled = await Permission.location.isGranted;
+        MixpanelManager().setUserProperty('Location Enabled', SharedPreferencesUtil().locationEnabled);
+      }
       context.read<DeviceProvider>().periodicConnect('coming from HomePageWrapper');
       await context.read<mp.MemoryProvider>().getInitialMemories();
     });

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -11,6 +11,7 @@ import 'package:friend_private/backend/schema/bt_device.dart';
 import 'package:friend_private/providers/base_provider.dart';
 import 'package:friend_private/providers/device_provider.dart';
 import 'package:friend_private/services/notification_service.dart';
+import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/ble/connect.dart';
 import 'package:friend_private/utils/ble/connected.dart';
 import 'package:friend_private/utils/ble/find.dart';
@@ -53,12 +54,14 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin {
   void updateLocationPermission(bool value) {
     hasLocationPermission = value;
     SharedPreferencesUtil().locationEnabled = value;
+    MixpanelManager().setUserProperty('Location Enabled', SharedPreferencesUtil().locationEnabled);
     notifyListeners();
   }
 
   void updateNotificationPermission(bool value) {
     hasNotificationPermission = value;
     SharedPreferencesUtil().notificationsEnabled = value;
+    MixpanelManager().setUserProperty('Notifications Enabled', SharedPreferencesUtil().notificationsEnabled);
     notifyListeners();
   }
 


### PR DESCRIPTION
Set mixpanel events for location and notification. This should get updated whenever the permission status changes. For existing users it will get triggered if they enabled permissions at any point in their usage of the previous versions (because the default value is false, and if they did enable permissions, then the value will be true)
<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Enhanced user analytics with Mixpanel integration. The application now tracks and updates user properties based on location and notification permission status, providing us with more insights to improve user experience.
- New Feature: Added event tracking for changes in location and notification permissions. This will help us understand user behavior better and make data-driven decisions for future updates.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->