### PR TITLE
Migrate Connectivity Controller to Connectivity Provider

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:friend_private/services/notification_service.dart';
 import 'package:friend_private/utils/analytics/gleap.dart';
 import 'package:friend_private/utils/analytics/growthbook.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/utils/features/calendar.dart';
 import 'package:gleap_sdk/gleap_sdk.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
@@ -133,6 +134,7 @@ class _MyAppState extends State<MyApp> {
   Widget build(BuildContext context) {
     return MultiProvider(
         providers: [
+          ListenableProvider(create: (context) => ConnectivityProvider()),
           ChangeNotifierProvider(create: (context) => AuthenticationProvider()),
           ChangeNotifierProvider(create: (context) => MemoryProvider()),
           ListenableProvider(create: (context) => PluginProvider()),

--- a/app/lib/pages/capture/page.dart
+++ b/app/lib/pages/capture/page.dart
@@ -15,10 +15,9 @@ import 'package:friend_private/providers/device_provider.dart';
 import 'package:friend_private/providers/onboarding_provider.dart';
 import 'package:friend_private/utils/audio/wav_bytes.dart';
 import 'package:friend_private/utils/ble/communication.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/utils/enums.dart';
 import 'package:friend_private/widgets/dialog.dart';
-import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 import 'package:location/location.dart';
 import 'package:provider/provider.dart';
 
@@ -76,10 +75,6 @@ class CapturePageState extends State<CapturePage> with AutomaticKeepAliveClientM
   //         ))
   //     .toList();
 
-  InternetStatus? _internetStatus;
-
-  late StreamSubscription<InternetStatus> _internetListener;
-
   setHasTranscripts(bool hasTranscripts) {
     context.read<CaptureProvider>().setHasTranscripts(hasTranscripts);
   }
@@ -131,26 +126,18 @@ class CapturePageState extends State<CapturePage> with AutomaticKeepAliveClientM
           ),
         );
       }
-    });
-    _internetListener = ConnectivityController().internetConnection.onStatusChange.listen((InternetStatus status) {
-      switch (status) {
-        case InternetStatus.connected:
-          _internetStatus = InternetStatus.connected;
-          break;
-        case InternetStatus.disconnected:
-          _internetStatus = InternetStatus.disconnected;
-          // so if you have a memory in progress, it doesn't get created, and you don't lose the remaining bytes.
-          context.read<CaptureProvider>().cancelMemoryCreationTimer();
-          break;
+      final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+      if (!connectivityProvider.isConnected) {
+        context.read<CaptureProvider>().cancelMemoryCreationTimer();
       }
     });
+
     super.initState();
   }
 
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    _internetListener.cancel();
     // context.read<WebSocketProvider>().closeWebSocket();
     super.dispose();
   }
@@ -238,11 +225,11 @@ class CapturePageState extends State<CapturePage> with AutomaticKeepAliveClientM
             ListView(children: [
               speechProfileWidget(context),
               ...getConnectionStateWidgets(context, provider.hasTranscripts, deviceProvider.connectedDevice,
-                  context.read<WebSocketProvider>().wsConnectionState, _internetStatus),
+                  context.read<WebSocketProvider>().wsConnectionState),
               getTranscriptWidget(
                   provider.memoryCreating, provider.segments, provider.photos, deviceProvider.connectedDevice),
               ...connectionStatusWidgets(
-                  context, provider.segments, context.read<WebSocketProvider>().wsConnectionState, _internetStatus),
+                  context, provider.segments, context.read<WebSocketProvider>().wsConnectionState),
               const SizedBox(height: 16)
             ]),
             getPhoneMicRecordingButton(() => _recordingToggled(provider), provider.recordingState),

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -9,7 +9,7 @@ import 'package:friend_private/backend/schema/plugin.dart';
 import 'package:friend_private/pages/chat/widgets/ai_message.dart';
 import 'package:friend_private/pages/chat/widgets/user_message.dart';
 import 'package:friend_private/providers/message_provider.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:provider/provider.dart';
 import 'package:uuid/uuid.dart';
@@ -68,8 +68,8 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return Consumer<MessageProvider>(
-      builder: (context, provider, child) {
+    return Consumer2<MessageProvider, ConnectivityProvider>(
+      builder: (context, provider, connectivityProvider, child) {
         return Stack(
           children: [
             Center(
@@ -79,7 +79,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                     )
                   : (provider.messages.isEmpty)
                       ? Text(
-                          ConnectivityController().isConnected.value
+                          connectivityProvider.isConnected
                               ? 'No messages yet!\nWhy don\'t you start a conversation?'
                               : 'Please check your internet connection and try again',
                           textAlign: TextAlign.center,
@@ -153,7 +153,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                           : () async {
                               String message = textController.text;
                               if (message.isEmpty) return;
-                              if (ConnectivityController().isConnected.value) {
+                              if (connectivityProvider.isConnected) {
                                 _sendMessageUtil(message);
                               } else {
                                 ScaffoldMessenger.of(context).showSnackBar(

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -11,9 +11,10 @@ import 'package:friend_private/backend/schema/message.dart';
 import 'package:friend_private/backend/schema/plugin.dart';
 import 'package:friend_private/pages/memory_detail/page.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/extensions/string.dart';
+import 'package:provider/provider.dart';
 
 class AIMessage extends StatefulWidget {
   final ServerMessage message;
@@ -124,7 +125,8 @@ class _AIMessageState extends State<AIMessage> {
                     padding: const EdgeInsetsDirectional.fromSTEB(0.0, 0.0, 0.0, 4.0),
                     child: GestureDetector(
                       onTap: () async {
-                        if (ConnectivityController().isConnected.value) {
+                        final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+                        if (connectivityProvider.isConnected) {
                           if (memoryDetailLoading[data.$1]) return;
                           setState(() => memoryDetailLoading[data.$1] = true);
 

--- a/app/lib/pages/facts/page.dart
+++ b/app/lib/pages/facts/page.dart
@@ -4,7 +4,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:friend_private/backend/schema/fact.dart';
 import 'package:friend_private/providers/facts_provider.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/widgets/extensions/functions.dart';
 import 'package:friend_private/widgets/extensions/string.dart';
 import 'package:provider/provider.dart';
@@ -88,8 +88,9 @@ class _FactsPageState extends State<_FactsPage> {
   }
 
   Future<void> _showFactDialog(BuildContext context, FactsProvider provider, {Fact? fact}) async {
-    if (!ConnectivityController().isConnected.value) {
-      ConnectivityController.showNoInternetDialog(context);
+    final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+    if (!connectivityProvider.isConnected) {
+      ConnectivityProvider.showNoInternetDialog(context);
       return;
     }
 

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -29,6 +29,7 @@ import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/upgrade_alert.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
+import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 import 'package:upgrader/upgrader.dart';
 
@@ -43,6 +44,14 @@ class _HomePageWrapperState extends State<HomePageWrapper> {
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (SharedPreferencesUtil().notificationsEnabled != await Permission.notification.isGranted) {
+        SharedPreferencesUtil().notificationsEnabled = await Permission.notification.isGranted;
+        MixpanelManager().setUserProperty('Notifications Enabled', SharedPreferencesUtil().notificationsEnabled);
+      }
+      if (SharedPreferencesUtil().locationEnabled != await Permission.location.isGranted) {
+        SharedPreferencesUtil().locationEnabled = await Permission.location.isGranted;
+        MixpanelManager().setUserProperty('Location Enabled', SharedPreferencesUtil().locationEnabled);
+      }
       context.read<DeviceProvider>().periodicConnect('coming from HomePageWrapper');
       await context.read<mp.MemoryProvider>().getInitialMemories();
     });

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -24,15 +24,13 @@ import 'package:friend_private/providers/plugin_provider.dart';
 import 'package:friend_private/services/notification_service.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/audio/foreground.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/upgrade_alert.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
 import 'package:provider/provider.dart';
 import 'package:upgrader/upgrader.dart';
-
-GlobalKey<CapturePageState> capturePageKey = GlobalKey();
 
 class HomePageWrapper extends StatefulWidget {
   const HomePageWrapper({super.key});
@@ -114,13 +112,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
 
   ///Screens with respect to subpage
   final Map<String, Widget> screensWithRespectToPath = {'/settings': const SettingsPage()};
-  ConnectivityController connectivityController = ConnectivityController();
   bool? previousConnection;
 
   @override
   void initState() {
     // TODO: Being triggered multiple times during navigation. It ideally shouldn't
-    connectivityController.init();
     _controller = TabController(
       length: 3,
       vsync: this,
@@ -179,358 +175,354 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
         child: MyUpgradeAlert(
       upgrader: _upgrader,
       dialogStyle: Platform.isIOS ? UpgradeDialogStyle.cupertino : UpgradeDialogStyle.material,
-      child: ValueListenableBuilder(
-          valueListenable: connectivityController.isConnected,
-          builder: (ctx, isConnected, child) {
-            previousConnection ??= true;
-            if (previousConnection != isConnected) {
-              previousConnection = isConnected;
-              if (!isConnected) {
-                Future.delayed(Duration.zero, () {
-                  ScaffoldMessenger.of(ctx).showMaterialBanner(
-                    MaterialBanner(
-                      content: const Text('No internet connection. Please check your connection.'),
-                      backgroundColor: Colors.red,
-                      actions: [
-                        TextButton(
-                          onPressed: () {
-                            ScaffoldMessenger.of(ctx).hideCurrentMaterialBanner();
-                          },
-                          child: const Text('Dismiss'),
-                        ),
-                      ],
-                    ),
-                  );
-                });
-              } else {
-                Future.delayed(Duration.zero, () {
-                  ScaffoldMessenger.of(ctx).hideCurrentMaterialBanner();
-                  ScaffoldMessenger.of(ctx).showMaterialBanner(
-                    MaterialBanner(
-                      content: const Text('Internet connection is restored.'),
-                      backgroundColor: Colors.green,
-                      actions: [
-                        TextButton(
-                          onPressed: () {
-                            ScaffoldMessenger.of(ctx).hideCurrentMaterialBanner();
-                          },
-                          child: const Text('Dismiss'),
-                        ),
-                      ],
-                      onVisible: () => Future.delayed(const Duration(seconds: 3), () {
+      child: Consumer<ConnectivityProvider>(builder: (ctx, connectivityProvider, child) {
+        bool isConnected = connectivityProvider.isConnected;
+        previousConnection ??= true;
+        if (previousConnection != isConnected) {
+          previousConnection = isConnected;
+          if (!isConnected) {
+            Future.delayed(Duration.zero, () {
+              ScaffoldMessenger.of(ctx).showMaterialBanner(
+                MaterialBanner(
+                  content: const Text('No internet connection. Please check your connection.'),
+                  backgroundColor: Colors.red,
+                  actions: [
+                    TextButton(
+                      onPressed: () {
                         ScaffoldMessenger.of(ctx).hideCurrentMaterialBanner();
-                      }),
+                      },
+                      child: const Text('Dismiss'),
                     ),
-                  );
+                  ],
+                ),
+              );
+            });
+          } else {
+            Future.delayed(Duration.zero, () {
+              ScaffoldMessenger.of(ctx).hideCurrentMaterialBanner();
+              ScaffoldMessenger.of(ctx).showMaterialBanner(
+                MaterialBanner(
+                  content: const Text('Internet connection is restored.'),
+                  backgroundColor: Colors.green,
+                  actions: [
+                    TextButton(
+                      onPressed: () {
+                        ScaffoldMessenger.of(ctx).hideCurrentMaterialBanner();
+                      },
+                      child: const Text('Dismiss'),
+                    ),
+                  ],
+                  onVisible: () => Future.delayed(const Duration(seconds: 3), () {
+                    ScaffoldMessenger.of(ctx).hideCurrentMaterialBanner();
+                  }),
+                ),
+              );
 
-                  WidgetsBinding.instance.addPostFrameCallback((_) async {
-                    if (mounted) {
-                      if (context.read<mp.MemoryProvider>().memories.isEmpty) {
-                        await context.read<mp.MemoryProvider>().getInitialMemories();
-                      }
-                      if (context.read<MessageProvider>().messages.isEmpty) {
-                        await context.read<MessageProvider>().refreshMessages();
-                      }
-                    }
-                  });
-                });
-              }
-            }
+              WidgetsBinding.instance.addPostFrameCallback((_) async {
+                if (mounted) {
+                  if (ctx.read<mp.MemoryProvider>().memories.isEmpty) {
+                    await ctx.read<mp.MemoryProvider>().getInitialMemories();
+                  }
+                  if (ctx.read<MessageProvider>().messages.isEmpty) {
+                    await ctx.read<MessageProvider>().refreshMessages();
+                  }
+                }
+              });
+            });
+          }
+        }
 
-            return Scaffold(
-              backgroundColor: Theme.of(context).colorScheme.primary,
-              body: GestureDetector(
-                onTap: () {
-                  FocusScope.of(context).unfocus();
-                  chatTextFieldFocusNode.unfocus();
-                  memoriesTextFieldFocusNode.unfocus();
-                },
-                child: Consumer2<HomeProvider, mp.MemoryProvider>(builder: (context, provider, memProvider, child) {
-                  return Stack(
-                    children: [
-                      Center(
-                        child: TabBarView(
-                          controller: _controller,
-                          physics: const NeverScrollableScrollPhysics(),
+        return Scaffold(
+          backgroundColor: Theme.of(context).colorScheme.primary,
+          body: GestureDetector(
+            onTap: () {
+              FocusScope.of(context).unfocus();
+              chatTextFieldFocusNode.unfocus();
+              memoriesTextFieldFocusNode.unfocus();
+            },
+            child: Consumer2<HomeProvider, mp.MemoryProvider>(builder: (context, provider, memProvider, child) {
+              return Stack(
+                children: [
+                  Center(
+                    child: TabBarView(
+                      controller: _controller,
+                      physics: const NeverScrollableScrollPhysics(),
+                      children: [
+                        MemoriesPage(
+                          textFieldFocusNode: memoriesTextFieldFocusNode,
+                        ),
+                        const CapturePage(),
+                        ChatPage(
+                          key: chatPageKey,
+                          textFieldFocusNode: chatTextFieldFocusNode,
+                          updateMemory: (ServerMemory memory) {
+                            memProvider.updateMemory(memory);
+                          },
+                        ),
+                      ],
+                    ),
+                  ),
+                  if (chatTextFieldFocusNode.hasFocus || memoriesTextFieldFocusNode.hasFocus)
+                    const SizedBox.shrink()
+                  else
+                    Align(
+                      alignment: Alignment.bottomCenter,
+                      child: Container(
+                        margin: const EdgeInsets.fromLTRB(16, 16, 16, 40),
+                        decoration: const BoxDecoration(
+                          color: Colors.black,
+                          borderRadius: BorderRadius.all(Radius.circular(16)),
+                          border: GradientBoxBorder(
+                            gradient: LinearGradient(colors: [
+                              Color.fromARGB(127, 208, 208, 208),
+                              Color.fromARGB(127, 188, 99, 121),
+                              Color.fromARGB(127, 86, 101, 182),
+                              Color.fromARGB(127, 126, 190, 236)
+                            ]),
+                            width: 2,
+                          ),
+                          shape: BoxShape.rectangle,
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
                           children: [
-                            MemoriesPage(
-                              textFieldFocusNode: memoriesTextFieldFocusNode,
+                            Expanded(
+                              child: MaterialButton(
+                                onPressed: () => _tabChange(0),
+                                child: Padding(
+                                  padding: const EdgeInsets.only(top: 20, bottom: 20),
+                                  child: Text(
+                                    'Memories',
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      color: provider.selectedIndex == 0 ? Colors.white : Colors.grey,
+                                      fontSize: 16,
+                                    ),
+                                  ),
+                                ),
+                              ),
                             ),
-                            CapturePage(
-                              key: capturePageKey,
+                            Expanded(
+                              child: MaterialButton(
+                                onPressed: () => _tabChange(1),
+                                child: Padding(
+                                  padding: const EdgeInsets.only(
+                                    top: 20,
+                                    bottom: 20,
+                                  ),
+                                  child: Text(
+                                    'Capture',
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      color: provider.selectedIndex == 1 ? Colors.white : Colors.grey,
+                                      fontSize: 16,
+                                    ),
+                                  ),
+                                ),
+                              ),
                             ),
-                            ChatPage(
-                              key: chatPageKey,
-                              textFieldFocusNode: chatTextFieldFocusNode,
-                              updateMemory: (ServerMemory memory) {
-                                memProvider.updateMemory(memory);
-                              },
+                            Expanded(
+                              child: MaterialButton(
+                                onPressed: () => _tabChange(2),
+                                child: Padding(
+                                  padding: const EdgeInsets.only(top: 20, bottom: 20),
+                                  child: Text(
+                                    'Chat',
+                                    maxLines: 1,
+                                    overflow: TextOverflow.ellipsis,
+                                    style: TextStyle(
+                                      color: provider.selectedIndex == 2 ? Colors.white : Colors.grey,
+                                      fontSize: 16,
+                                    ),
+                                  ),
+                                ),
+                              ),
                             ),
                           ],
                         ),
                       ),
-                      if (chatTextFieldFocusNode.hasFocus || memoriesTextFieldFocusNode.hasFocus)
-                        const SizedBox.shrink()
-                      else
-                        Align(
-                          alignment: Alignment.bottomCenter,
-                          child: Container(
-                            margin: const EdgeInsets.fromLTRB(16, 16, 16, 40),
-                            decoration: const BoxDecoration(
-                              color: Colors.black,
-                              borderRadius: BorderRadius.all(Radius.circular(16)),
-                              border: GradientBoxBorder(
-                                gradient: LinearGradient(colors: [
-                                  Color.fromARGB(127, 208, 208, 208),
-                                  Color.fromARGB(127, 188, 99, 121),
-                                  Color.fromARGB(127, 86, 101, 182),
-                                  Color.fromARGB(127, 126, 190, 236)
-                                ]),
-                                width: 2,
-                              ),
-                              shape: BoxShape.rectangle,
-                            ),
-                            child: Row(
-                              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                              children: [
-                                Expanded(
-                                  child: MaterialButton(
-                                    onPressed: () => _tabChange(0),
-                                    child: Padding(
-                                      padding: const EdgeInsets.only(top: 20, bottom: 20),
-                                      child: Text(
-                                        'Memories',
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: TextStyle(
-                                          color: provider.selectedIndex == 0 ? Colors.white : Colors.grey,
-                                          fontSize: 16,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                Expanded(
-                                  child: MaterialButton(
-                                    onPressed: () => _tabChange(1),
-                                    child: Padding(
-                                      padding: const EdgeInsets.only(
-                                        top: 20,
-                                        bottom: 20,
-                                      ),
-                                      child: Text(
-                                        'Capture',
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: TextStyle(
-                                          color: provider.selectedIndex == 1 ? Colors.white : Colors.grey,
-                                          fontSize: 16,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                                Expanded(
-                                  child: MaterialButton(
-                                    onPressed: () => _tabChange(2),
-                                    child: Padding(
-                                      padding: const EdgeInsets.only(top: 20, bottom: 20),
-                                      child: Text(
-                                        'Chat',
-                                        maxLines: 1,
-                                        overflow: TextOverflow.ellipsis,
-                                        style: TextStyle(
-                                          color: provider.selectedIndex == 2 ? Colors.white : Colors.grey,
-                                          fontSize: 16,
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                                ),
-                              ],
-                            ),
-                          ),
+                    ),
+                  if (scriptsInProgress)
+                    Center(
+                      child: Container(
+                        height: 150,
+                        width: 250,
+                        decoration: BoxDecoration(
+                          color: Colors.black,
+                          borderRadius: BorderRadius.circular(16),
+                          border: Border.all(color: Colors.white, width: 2),
                         ),
-                      if (scriptsInProgress)
-                        Center(
-                          child: Container(
-                            height: 150,
-                            width: 250,
-                            decoration: BoxDecoration(
-                              color: Colors.black,
-                              borderRadius: BorderRadius.circular(16),
-                              border: Border.all(color: Colors.white, width: 2),
+                        child: const Column(
+                          crossAxisAlignment: CrossAxisAlignment.center,
+                          mainAxisAlignment: MainAxisAlignment.center,
+                          children: [
+                            CircularProgressIndicator(
+                              valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
                             ),
-                            child: const Column(
-                              crossAxisAlignment: CrossAxisAlignment.center,
-                              mainAxisAlignment: MainAxisAlignment.center,
-                              children: [
-                                CircularProgressIndicator(
-                                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                                ),
-                                SizedBox(height: 16),
-                                Center(
-                                    child: Text(
-                                  'Running migration, please wait! 🚨',
-                                  style: TextStyle(color: Colors.white, fontSize: 16),
-                                  textAlign: TextAlign.center,
-                                )),
-                              ],
-                            ),
-                          ),
-                        )
-                      else
-                        const SizedBox.shrink(),
-                    ],
-                  );
-                }),
-              ),
-              appBar: AppBar(
-                automaticallyImplyLeading: false,
-                backgroundColor: Theme.of(context).colorScheme.surface,
-                title: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    Consumer<DeviceProvider>(builder: (context, deviceProvider, child) {
-                      if (deviceProvider.connectedDevice != null && deviceProvider.batteryLevel != -1) {
-                        return GestureDetector(
-                          onTap: deviceProvider.connectedDevice == null
-                              ? null
-                              : () {
-                                  Navigator.of(context).push(MaterialPageRoute(
-                                      builder: (c) => ConnectedDevice(
-                                            device: deviceProvider.connectedDevice!,
-                                            batteryLevel: deviceProvider.batteryLevel,
-                                          )));
-                                  MixpanelManager().batteryIndicatorClicked();
-                                },
-                          child: Container(
-                              padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
-                              decoration: BoxDecoration(
-                                color: Colors.transparent,
-                                borderRadius: BorderRadius.circular(10),
-                                border: Border.all(
-                                  color: Colors.grey,
-                                  width: 1,
-                                ),
-                              ),
-                              child: Row(
-                                mainAxisSize: MainAxisSize.min,
-                                children: [
-                                  Container(
-                                    width: 10,
-                                    height: 10,
-                                    decoration: BoxDecoration(
-                                      color: deviceProvider.batteryLevel > 75
-                                          ? const Color.fromARGB(255, 0, 255, 8)
-                                          : deviceProvider.batteryLevel > 20
-                                              ? Colors.yellow.shade700
-                                              : Colors.red,
-                                      shape: BoxShape.circle,
-                                    ),
-                                  ),
-                                  const SizedBox(width: 8.0),
-                                  Text(
-                                    '${deviceProvider.batteryLevel.toString()}%',
-                                    style: const TextStyle(
-                                      color: Colors.white,
-                                      fontSize: 12,
-                                      fontWeight: FontWeight.bold,
-                                    ),
-                                  ),
-                                ],
-                              )),
-                        );
-                      } else {
-                        print(deviceProvider.connectedDevice?.id);
-                        return TextButton(
-                          onPressed: () async {
-                            if (SharedPreferencesUtil().btDeviceStruct.id.isEmpty) {
-                              routeToPage(context, const ConnectDevicePage());
-                              MixpanelManager().connectFriendClicked();
-                            } else {
-                              await routeToPage(
-                                  context,
-                                  ConnectedDevice(
-                                      device: deviceProvider.connectedDevice,
-                                      batteryLevel: deviceProvider.batteryLevel));
-                            }
-                            // setState(() {});
-                          },
-                          style: TextButton.styleFrom(
-                            padding: EdgeInsets.zero,
-                            backgroundColor: Colors.transparent,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(10),
-                              side: const BorderSide(color: Colors.white, width: 1),
-                            ),
-                          ),
-                          child: Image.asset('assets/images/logo_transparent.png', width: 25, height: 25),
-                        );
-                      }
-                    }),
-                    _controller!.index == 2
-                        ? Consumer<PluginProvider>(builder: (context, provider, child) {
-                            return Padding(
-                              padding: const EdgeInsets.only(left: 0),
-                              child: Container(
-                                // decoration: BoxDecoration(
-                                //   border: Border.all(color: Colors.grey),
-                                //   borderRadius: BorderRadius.circular(30),
-                                // ),
-                                padding: const EdgeInsets.symmetric(horizontal: 16),
-                                child: DropdownButton<String>(
-                                  menuMaxHeight: 350,
-                                  value: SharedPreferencesUtil().selectedChatPluginId,
-                                  onChanged: (s) async {
-                                    if ((s == 'no_selected' && provider.plugins.where((p) => p.enabled).isEmpty) ||
-                                        s == 'enable') {
-                                      await routeToPage(context, const PluginsPage(filterChatOnly: true));
-                                      return;
-                                    }
-                                    print('Selected: $s prefs: ${SharedPreferencesUtil().selectedChatPluginId}');
-                                    if (s == null || s == SharedPreferencesUtil().selectedChatPluginId) return;
-
-                                    SharedPreferencesUtil().selectedChatPluginId = s;
-                                    var plugin = provider.plugins.firstWhereOrNull((p) => p.id == s);
-                                    chatPageKey.currentState?.sendInitialPluginMessage(plugin);
-                                  },
-                                  icon: Container(),
-                                  alignment: Alignment.center,
-                                  dropdownColor: Colors.black,
-                                  style: const TextStyle(color: Colors.white, fontSize: 16),
-                                  underline: Container(height: 0, color: Colors.transparent),
-                                  isExpanded: false,
-                                  itemHeight: 48,
-                                  padding: EdgeInsets.zero,
-                                  items: _getPluginsDropdownItems(context, provider),
-                                ),
-                              ),
-                            );
-                          })
-                        : const SizedBox(width: 16),
-                    IconButton(
-                      icon: const Icon(Icons.settings, color: Colors.white, size: 30),
-                      onPressed: () async {
-                        MixpanelManager().settingsOpened();
-                        String language = SharedPreferencesUtil().recordingsLanguage;
-                        bool hasSpeech = SharedPreferencesUtil().hasSpeakerProfile;
-                        await routeToPage(context, const SettingsPage());
-                        // TODO: this fails like 10 times, connects reconnects, until it finally works.
-                        if (language != SharedPreferencesUtil().recordingsLanguage ||
-                            hasSpeech != SharedPreferencesUtil().hasSpeakerProfile) {
-                          context.read<DeviceProvider>().restartWebSocket();
-                        }
-                      },
+                            SizedBox(height: 16),
+                            Center(
+                                child: Text(
+                              'Running migration, please wait! 🚨',
+                              style: TextStyle(color: Colors.white, fontSize: 16),
+                              textAlign: TextAlign.center,
+                            )),
+                          ],
+                        ),
+                      ),
                     )
-                  ],
-                ),
-                elevation: 0,
-                centerTitle: true,
-              ),
-            );
-          }),
+                  else
+                    const SizedBox.shrink(),
+                ],
+              );
+            }),
+          ),
+          appBar: AppBar(
+            automaticallyImplyLeading: false,
+            backgroundColor: Theme.of(context).colorScheme.surface,
+            title: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Consumer<DeviceProvider>(builder: (context, deviceProvider, child) {
+                  if (deviceProvider.connectedDevice != null && deviceProvider.batteryLevel != -1) {
+                    return GestureDetector(
+                      onTap: deviceProvider.connectedDevice == null
+                          ? null
+                          : () {
+                              Navigator.of(context).push(MaterialPageRoute(
+                                  builder: (c) => ConnectedDevice(
+                                        device: deviceProvider.connectedDevice!,
+                                        batteryLevel: deviceProvider.batteryLevel,
+                                      )));
+                              MixpanelManager().batteryIndicatorClicked();
+                            },
+                      child: Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+                          decoration: BoxDecoration(
+                            color: Colors.transparent,
+                            borderRadius: BorderRadius.circular(10),
+                            border: Border.all(
+                              color: Colors.grey,
+                              width: 1,
+                            ),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Container(
+                                width: 10,
+                                height: 10,
+                                decoration: BoxDecoration(
+                                  color: deviceProvider.batteryLevel > 75
+                                      ? const Color.fromARGB(255, 0, 255, 8)
+                                      : deviceProvider.batteryLevel > 20
+                                          ? Colors.yellow.shade700
+                                          : Colors.red,
+                                  shape: BoxShape.circle,
+                                ),
+                              ),
+                              const SizedBox(width: 8.0),
+                              Text(
+                                '${deviceProvider.batteryLevel.toString()}%',
+                                style: const TextStyle(
+                                  color: Colors.white,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                            ],
+                          )),
+                    );
+                  } else {
+                    print(deviceProvider.connectedDevice?.id);
+                    return TextButton(
+                      onPressed: () async {
+                        if (SharedPreferencesUtil().btDeviceStruct.id.isEmpty) {
+                          routeToPage(context, const ConnectDevicePage());
+                          MixpanelManager().connectFriendClicked();
+                        } else {
+                          await routeToPage(
+                              context,
+                              ConnectedDevice(
+                                  device: deviceProvider.connectedDevice, batteryLevel: deviceProvider.batteryLevel));
+                        }
+                        // setState(() {});
+                      },
+                      style: TextButton.styleFrom(
+                        padding: EdgeInsets.zero,
+                        backgroundColor: Colors.transparent,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(10),
+                          side: const BorderSide(color: Colors.white, width: 1),
+                        ),
+                      ),
+                      child: Image.asset('assets/images/logo_transparent.png', width: 25, height: 25),
+                    );
+                  }
+                }),
+                _controller!.index == 2
+                    ? Consumer<PluginProvider>(builder: (context, provider, child) {
+                        return Padding(
+                          padding: const EdgeInsets.only(left: 0),
+                          child: Container(
+                            // decoration: BoxDecoration(
+                            //   border: Border.all(color: Colors.grey),
+                            //   borderRadius: BorderRadius.circular(30),
+                            // ),
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: DropdownButton<String>(
+                              menuMaxHeight: 350,
+                              value: SharedPreferencesUtil().selectedChatPluginId,
+                              onChanged: (s) async {
+                                if ((s == 'no_selected' && provider.plugins.where((p) => p.enabled).isEmpty) ||
+                                    s == 'enable') {
+                                  await routeToPage(context, const PluginsPage(filterChatOnly: true));
+                                  return;
+                                }
+                                print('Selected: $s prefs: ${SharedPreferencesUtil().selectedChatPluginId}');
+                                if (s == null || s == SharedPreferencesUtil().selectedChatPluginId) return;
+
+                                SharedPreferencesUtil().selectedChatPluginId = s;
+                                var plugin = provider.plugins.firstWhereOrNull((p) => p.id == s);
+                                chatPageKey.currentState?.sendInitialPluginMessage(plugin);
+                              },
+                              icon: Container(),
+                              alignment: Alignment.center,
+                              dropdownColor: Colors.black,
+                              style: const TextStyle(color: Colors.white, fontSize: 16),
+                              underline: Container(height: 0, color: Colors.transparent),
+                              isExpanded: false,
+                              itemHeight: 48,
+                              padding: EdgeInsets.zero,
+                              items: _getPluginsDropdownItems(context, provider),
+                            ),
+                          ),
+                        );
+                      })
+                    : const SizedBox(width: 16),
+                IconButton(
+                  icon: const Icon(Icons.settings, color: Colors.white, size: 30),
+                  onPressed: () async {
+                    MixpanelManager().settingsOpened();
+                    String language = SharedPreferencesUtil().recordingsLanguage;
+                    bool hasSpeech = SharedPreferencesUtil().hasSpeakerProfile;
+                    await routeToPage(context, const SettingsPage());
+                    // TODO: this fails like 10 times, connects reconnects, until it finally works.
+                    if (language != SharedPreferencesUtil().recordingsLanguage ||
+                        hasSpeech != SharedPreferencesUtil().hasSpeakerProfile) {
+                      context.read<DeviceProvider>().restartWebSocket();
+                    }
+                  },
+                )
+              ],
+            ),
+            elevation: 0,
+            centerTitle: true,
+          ),
+        );
+      }),
     ));
   }
 
@@ -597,7 +589,6 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
-    connectivityController.isConnected.dispose();
     _controller?.dispose();
     ForegroundUtil.stopForegroundTask();
     super.dispose();

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -462,46 +462,45 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                     );
                   }
                 }),
-                _controller!.index == 2
-                    ? Consumer<PluginProvider>(builder: (context, provider, child) {
-                        return Padding(
-                          padding: const EdgeInsets.only(left: 0),
-                          child: Container(
-                            // decoration: BoxDecoration(
-                            //   border: Border.all(color: Colors.grey),
-                            //   borderRadius: BorderRadius.circular(30),
-                            // ),
-                            padding: const EdgeInsets.symmetric(horizontal: 16),
-                            child: DropdownButton<String>(
-                              menuMaxHeight: 350,
-                              value: SharedPreferencesUtil().selectedChatPluginId,
-                              onChanged: (s) async {
-                                if ((s == 'no_selected' && provider.plugins.where((p) => p.enabled).isEmpty) ||
-                                    s == 'enable') {
-                                  await routeToPage(context, const PluginsPage(filterChatOnly: true));
-                                  return;
-                                }
-                                print('Selected: $s prefs: ${SharedPreferencesUtil().selectedChatPluginId}');
-                                if (s == null || s == SharedPreferencesUtil().selectedChatPluginId) return;
+                Consumer2<PluginProvider, HomeProvider>(builder: (context, provider, home, child) {
+                  if (home.selectedIndex != 2) {
+                    return SizedBox(
+                      width: 16,
+                    );
+                  }
+                  return Padding(
+                    padding: const EdgeInsets.only(left: 0),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 16),
+                      child: DropdownButton<String>(
+                        menuMaxHeight: 350,
+                        value: SharedPreferencesUtil().selectedChatPluginId,
+                        onChanged: (s) async {
+                          if ((s == 'no_selected' && provider.plugins.where((p) => p.enabled).isEmpty) ||
+                              s == 'enable') {
+                            await routeToPage(context, const PluginsPage(filterChatOnly: true));
+                            return;
+                          }
+                          print('Selected: $s prefs: ${SharedPreferencesUtil().selectedChatPluginId}');
+                          if (s == null || s == SharedPreferencesUtil().selectedChatPluginId) return;
 
-                                SharedPreferencesUtil().selectedChatPluginId = s;
-                                var plugin = provider.plugins.firstWhereOrNull((p) => p.id == s);
-                                chatPageKey.currentState?.sendInitialPluginMessage(plugin);
-                              },
-                              icon: Container(),
-                              alignment: Alignment.center,
-                              dropdownColor: Colors.black,
-                              style: const TextStyle(color: Colors.white, fontSize: 16),
-                              underline: Container(height: 0, color: Colors.transparent),
-                              isExpanded: false,
-                              itemHeight: 48,
-                              padding: EdgeInsets.zero,
-                              items: _getPluginsDropdownItems(context, provider),
-                            ),
-                          ),
-                        );
-                      })
-                    : const SizedBox(width: 16),
+                          SharedPreferencesUtil().selectedChatPluginId = s;
+                          var plugin = provider.plugins.firstWhereOrNull((p) => p.id == s);
+                          chatPageKey.currentState?.sendInitialPluginMessage(plugin);
+                        },
+                        icon: Container(),
+                        alignment: Alignment.center,
+                        dropdownColor: Colors.black,
+                        style: const TextStyle(color: Colors.white, fontSize: 16),
+                        underline: Container(height: 0, color: Colors.transparent),
+                        isExpanded: false,
+                        itemHeight: 48,
+                        padding: EdgeInsets.zero,
+                        items: _getPluginsDropdownItems(context, provider),
+                      ),
+                    ),
+                  );
+                }),
                 IconButton(
                   icon: const Icon(Icons.settings, color: Colors.white, size: 30),
                   onPressed: () async {

--- a/app/lib/pages/memory_detail/page.dart
+++ b/app/lib/pages/memory_detail/page.dart
@@ -12,7 +12,7 @@ import 'package:friend_private/pages/memory_detail/widgets.dart';
 import 'package:friend_private/pages/settings/people.dart';
 import 'package:friend_private/pages/settings/recordings_storage_permission.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/utils/memories/reprocess.dart';
 import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/dialog.dart';
@@ -20,6 +20,7 @@ import 'package:friend_private/widgets/expandable_text.dart';
 import 'package:friend_private/widgets/extensions/string.dart';
 import 'package:friend_private/widgets/photos_grid.dart';
 import 'package:friend_private/widgets/transcript.dart';
+import 'package:provider/provider.dart';
 import 'package:tuple/tuple.dart';
 
 class MemoryDetailPage extends StatefulWidget {
@@ -237,8 +238,9 @@ class _MemoryDetailPageState extends State<MemoryDetailPage> with TickerProvider
   }
 
   void editSegment(int segmentIdx) {
-    if (!ConnectivityController().isConnected.value) {
-      ConnectivityController.showNoInternetDialog(context);
+    final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+    if (!connectivityProvider.isConnected) {
+      ConnectivityProvider.showNoInternetDialog(context);
       return;
     }
     List<Person> people = SharedPreferencesUtil().cachedPeople;

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -11,12 +11,13 @@ import 'package:friend_private/pages/memory_detail/test_prompts.dart';
 import 'package:friend_private/pages/plugins/page.dart';
 import 'package:friend_private/pages/settings/calendar.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/utils/features/calendar.dart';
 import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:friend_private/widgets/expandable_text.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
+import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'maps_util.dart';
@@ -689,7 +690,8 @@ _getSheetMainOptions(
             onTap: loadingReprocessMemory
                 ? null
                 : () {
-                    if (ConnectivityController().isConnected.value) {
+                    final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+                    if (connectivityProvider.isConnected) {
                       reprocessMemory(context, memory, () {
                         changeLoadingReprocessMemory(!loadingReprocessMemory);
                       });
@@ -717,7 +719,8 @@ _getSheetMainOptions(
             onTap: loadingReprocessMemory
                 ? null
                 : () {
-                    if (ConnectivityController().isConnected.value) {
+                    final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+                    if (connectivityProvider.isConnected) {
                       showDialog(
                         context: context,
                         builder: (c) => getDialog(

--- a/app/lib/pages/plugins/page.dart
+++ b/app/lib/pages/plugins/page.dart
@@ -2,7 +2,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:friend_private/pages/plugins/plugin_detail.dart';
 import 'package:friend_private/providers/plugin_provider.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:gradient_borders/gradient_borders.dart';
@@ -184,7 +184,7 @@ class _PluginsPageState extends State<PluginsPage> {
                         padding: const EdgeInsets.only(top: 64, left: 14, right: 14),
                         child: Center(
                           child: Text(
-                            ConnectivityController().isConnected.value
+                            context.read<ConnectivityProvider>().isConnected
                                 ? 'No plugins found'
                                 : 'Unable to fetch plugins :(\n\nPlease check your internet connection and try again.',
                             style: const TextStyle(color: Colors.white, fontSize: 16),

--- a/app/lib/pages/plugins/plugin_detail.dart
+++ b/app/lib/pages/plugins/plugin_detail.dart
@@ -5,10 +5,11 @@ import 'package:friend_private/backend/http/api/plugins.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/pages/plugins/instructions.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:friend_private/widgets/extensions/string.dart';
+import 'package:provider/provider.dart';
 
 import '../../backend/schema/plugin.dart';
 
@@ -124,7 +125,8 @@ class _PluginDetailPageState extends State<PluginDetailPage> {
                         color: widget.plugin.enabled ? Colors.white : Colors.grey,
                       ),
                       onPressed: () {
-                        if (!ConnectivityController().isConnected.value) {
+                        final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+                        if (!connectivityProvider.isConnected) {
                           ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                             content: Text("Can't enable plugin without internet connection."),
                           ));
@@ -320,7 +322,8 @@ class _PluginDetailPageState extends State<PluginDetailPage> {
                 itemBuilder: (context, _) => const Icon(Icons.star, color: Colors.deepPurple),
                 maxRating: 5.0,
                 onRatingUpdate: (rating) {
-                  if (ConnectivityController().isConnected.value) {
+                  final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+                  if (connectivityProvider.isConnected) {
                     reviewPlugin(widget.plugin.id, rating);
                     bool hadReview = widget.plugin.userReview != null;
                     if (!hadReview) widget.plugin.ratingCount += 1;

--- a/app/lib/pages/settings/people.dart
+++ b/app/lib/pages/settings/people.dart
@@ -5,7 +5,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:friend_private/backend/schema/person.dart';
 import 'package:friend_private/providers/people_provider.dart';
-import 'package:friend_private/utils/connectivity_controller.dart';
+import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:friend_private/widgets/extensions/functions.dart';
 import 'package:just_audio/just_audio.dart';
@@ -131,8 +131,9 @@ class _UserPeoplePageState extends State<_UserPeoplePage> {
   }
 
   Future<void> _showPersonDialog(BuildContext context, PeopleProvider provider, {Person? person}) async {
-    if (!ConnectivityController().isConnected.value) {
-      ConnectivityController.showNoInternetDialog(context);
+    final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+    if (!connectivityProvider.isConnected) {
+      ConnectivityProvider.showNoInternetDialog(context);
       return;
     }
 
@@ -156,8 +157,9 @@ class _UserPeoplePageState extends State<_UserPeoplePage> {
   }
 
   Future<void> _confirmDeleteSample(int peopleIdx, Person person, String url, PeopleProvider provider) async {
-    if (!ConnectivityController().isConnected.value) {
-      ConnectivityController.showNoInternetDialog(context);
+    final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
+    if (!connectivityProvider.isConnected) {
+      ConnectivityProvider.showNoInternetDialog(context);
       return;
     }
     final confirmed = await showDialog<bool>(

--- a/app/lib/providers/connectivity_provider.dart
+++ b/app/lib/providers/connectivity_provider.dart
@@ -2,40 +2,41 @@ import 'package:flutter/material.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:internet_connection_checker_plus/internet_connection_checker_plus.dart';
 
-class ConnectivityController {
-  ValueNotifier<bool> isConnected = ValueNotifier(true);
-  bool previousConnection = true;
-  InternetConnection internetConnection = InternetConnection();
+class ConnectivityProvider extends ChangeNotifier {
+  bool _isConnected = true;
+  bool _previousConnection = true;
+  final InternetConnection _internetConnection = InternetConnection();
 
-  factory ConnectivityController() {
-    return _singleton;
+  bool get isConnected => _isConnected;
+  bool get previousConnection => _previousConnection;
+
+  ConnectivityProvider() {
+    init();
   }
 
-  static final ConnectivityController _singleton = ConnectivityController._internal();
-
-  ConnectivityController._internal();
-
   Future<void> init() async {
-    bool result = await internetConnection.hasInternetAccess;
-    isConnected.value = result;
-    previousConnection = result;
-    internetConnection.onStatusChange.listen((InternetStatus result) {
-      previousConnection = isConnected.value;
+    bool result = await _internetConnection.hasInternetAccess;
+    _isConnected = result;
+    _previousConnection = result;
+    _internetConnection.onStatusChange.listen((InternetStatus result) {
+      _previousConnection = _isConnected;
       isInternetConnected(result);
     });
   }
 
   bool isInternetConnected(InternetStatus? result) {
     if (result == InternetStatus.disconnected) {
-      isConnected.value = false;
+      _isConnected = false;
+      notifyListeners();
       return false;
     } else {
-      isConnected.value = true;
+      _isConnected = true;
+      notifyListeners();
       return true;
     }
   }
 
-  static showNoInternetDialog(BuildContext context) {
+  static void showNoInternetDialog(BuildContext context) {
     showDialog(
       context: context,
       builder: (c) => getDialog(


### PR DESCRIPTION
This PR makes changes to the Connectivity Controller to make use of Provider. This way we can avoid having multiple instances of the controller. This also eliminates the value notifier disposed issues as it gets rid of page specific listener variables.

This PR also removes the `capturePageKey` global key which is not being used anymore.


<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

---
- Refactor: Migrated the Connectivity Controller to use the Connectivity Provider for centralized connectivity management across multiple files.
- Bug Fix: Resolved issues related to value notifier disposal and enhanced error handling based on connection status.
- New Feature: Integrated dialog messages to inform users about connection status and errors.
- Refactor: Updated the `Consumer` in the `build` method to consume both `MessageProvider` and `ConnectivityProvider`, improving code organization.
- Style: Refactored methods to use private variables and added `notifyListeners()` calls for state changes, enhancing code readability and maintainability.
---
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->