### PR TITLE
Make notif and device setup less skippable + other minor fixes

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -18,7 +18,11 @@ Future<String> getAuthHeader() async {
     SharedPreferencesUtil().authToken = await getIdToken() ?? '';
   }
   if (SharedPreferencesUtil().authToken == '') {
-    throw Exception('No auth token found');
+    if (isSignedIn()) {
+      // should only throw if the user is signed in but the token is not found
+      // if the user is not signed in, the token will always be empty
+      throw Exception('No auth token found');
+    }
   }
   return 'Bearer ${SharedPreferencesUtil().authToken}';
 }

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -470,46 +470,47 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                         );
                       }
                     }),
-                    _controller!.index == 2
-                        ? Consumer<PluginProvider>(builder: (context, provider, child) {
-                            return Padding(
-                              padding: const EdgeInsets.only(left: 0),
-                              child: Container(
-                                // decoration: BoxDecoration(
-                                //   border: Border.all(color: Colors.grey),
-                                //   borderRadius: BorderRadius.circular(30),
-                                // ),
-                                padding: const EdgeInsets.symmetric(horizontal: 16),
-                                child: DropdownButton<String>(
-                                  menuMaxHeight: 350,
-                                  value: SharedPreferencesUtil().selectedChatPluginId,
-                                  onChanged: (s) async {
-                                    if ((s == 'no_selected' && provider.plugins.where((p) => p.enabled).isEmpty) ||
-                                        s == 'enable') {
-                                      await routeToPage(context, const PluginsPage(filterChatOnly: true));
-                                      return;
-                                    }
-                                    print('Selected: $s prefs: ${SharedPreferencesUtil().selectedChatPluginId}');
-                                    if (s == null || s == SharedPreferencesUtil().selectedChatPluginId) return;
+                    Consumer2<PluginProvider, HomeProvider>(
+                      builder: (context, provider, home, child) {
+                        if (home.selectedIndex != 2) {
+                          return const SizedBox(
+                            width: 16,
+                          );
+                        }
+                        return Padding(
+                          padding: const EdgeInsets.only(left: 0),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 16),
+                            child: DropdownButton<String>(
+                              menuMaxHeight: 350,
+                              value: SharedPreferencesUtil().selectedChatPluginId,
+                              onChanged: (s) async {
+                                if ((s == 'no_selected' && provider.plugins.where((p) => p.enabled).isEmpty) ||
+                                    s == 'enable') {
+                                  await routeToPage(context, const PluginsPage(filterChatOnly: true));
+                                  return;
+                                }
+                                print('Selected: $s prefs: ${SharedPreferencesUtil().selectedChatPluginId}');
+                                if (s == null || s == SharedPreferencesUtil().selectedChatPluginId) return;
 
-                                    SharedPreferencesUtil().selectedChatPluginId = s;
-                                    var plugin = provider.plugins.firstWhereOrNull((p) => p.id == s);
-                                    chatPageKey.currentState?.sendInitialPluginMessage(plugin);
-                                  },
-                                  icon: Container(),
-                                  alignment: Alignment.center,
-                                  dropdownColor: Colors.black,
-                                  style: const TextStyle(color: Colors.white, fontSize: 16),
-                                  underline: Container(height: 0, color: Colors.transparent),
-                                  isExpanded: false,
-                                  itemHeight: 48,
-                                  padding: EdgeInsets.zero,
-                                  items: _getPluginsDropdownItems(context, provider),
-                                ),
-                              ),
-                            );
-                          })
-                        : const SizedBox(width: 16),
+                                SharedPreferencesUtil().selectedChatPluginId = s;
+                                var plugin = provider.plugins.firstWhereOrNull((p) => p.id == s);
+                                chatPageKey.currentState?.sendInitialPluginMessage(plugin);
+                              },
+                              icon: Container(),
+                              alignment: Alignment.center,
+                              dropdownColor: Colors.black,
+                              style: const TextStyle(color: Colors.white, fontSize: 16),
+                              underline: Container(height: 0, color: Colors.transparent),
+                              isExpanded: false,
+                              itemHeight: 48,
+                              padding: EdgeInsets.zero,
+                              items: _getPluginsDropdownItems(context, provider),
+                            ),
+                          ),
+                        );
+                      },
+                    ),
                     IconButton(
                       icon: const Icon(Icons.settings, color: Colors.white, size: 30),
                       onPressed: () async {

--- a/app/lib/pages/onboarding/permissions/notification_permission.dart
+++ b/app/lib/pages/onboarding/permissions/notification_permission.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:friend_private/providers/onboarding_provider.dart';
+import 'package:friend_private/widgets/dialog.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
 import 'package:provider/provider.dart';
 
@@ -61,7 +62,25 @@ class _NotificationPermissionWidgetState extends State<NotificationPermissionWid
                     child: MaterialButton(
                       padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
                       onPressed: () {
-                        widget.goNext();
+                        if (provider.hasNotificationPermission) {
+                          widget.goNext();
+                        } else {
+                          showDialog(
+                            context: context,
+                            builder: (c) => getDialog(
+                              context,
+                              () {
+                                Navigator.of(context).pop();
+                              },
+                              () {
+                                Navigator.of(context).pop();
+                              },
+                              'Allow Notifications',
+                              'This app needs notification permissions to improve your experience.',
+                              singleButton: true,
+                            ),
+                          );
+                        }
                       },
                       child: const Text(
                         'Continue',

--- a/app/lib/pages/onboarding/permissions/notification_permission.dart
+++ b/app/lib/pages/onboarding/permissions/notification_permission.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:friend_private/providers/onboarding_provider.dart';
-import 'package:friend_private/services/notification_service.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
 import 'package:provider/provider.dart';
 
@@ -22,16 +21,9 @@ class _NotificationPermissionWidgetState extends State<NotificationPermissionWid
         child: Column(
           mainAxisAlignment: MainAxisAlignment.end,
           children: [
-            // Text(
-            //   'For a personalized experience, we need permissions to send you notifications and read your location information.',
-            //   style: TextStyle(color: Colors.grey.shade300, fontSize: 16),
-            //   textAlign: TextAlign.center,
-            // ),
-            // const SizedBox(height: 80),
             CheckboxListTile(
               value: provider.hasNotificationPermission,
               onChanged: (s) async {
-                print('s: $s');
                 if (s != null) {
                   if (s) {
                     await provider.askForNotificationPermissions();
@@ -54,31 +46,27 @@ class _NotificationPermissionWidgetState extends State<NotificationPermissionWid
                 Expanded(
                   child: Container(
                     width: double.infinity,
-                    decoration: provider.hasNotificationPermission
-                        ? BoxDecoration(
-                            border: const GradientBoxBorder(
-                              gradient: LinearGradient(colors: [
-                                Color.fromARGB(127, 208, 208, 208),
-                                Color.fromARGB(127, 188, 99, 121),
-                                Color.fromARGB(127, 86, 101, 182),
-                                Color.fromARGB(127, 126, 190, 236)
-                              ]),
-                              width: 2,
-                            ),
-                            borderRadius: BorderRadius.circular(12),
-                          )
-                        : null,
+                    decoration: BoxDecoration(
+                      border: const GradientBoxBorder(
+                        gradient: LinearGradient(colors: [
+                          Color.fromARGB(127, 208, 208, 208),
+                          Color.fromARGB(127, 188, 99, 121),
+                          Color.fromARGB(127, 86, 101, 182),
+                          Color.fromARGB(127, 126, 190, 236)
+                        ]),
+                        width: 2,
+                      ),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
                     child: MaterialButton(
                       padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 16),
                       onPressed: () {
-                        // TODO: if toggle not on, show ignore
                         widget.goNext();
                       },
-                      child: Text(
-                        provider.hasNotificationPermission ? 'Continue' : 'Skip',
+                      child: const Text(
+                        'Continue',
                         style: TextStyle(
-                          decoration:
-                              provider.hasNotificationPermission ? TextDecoration.none : TextDecoration.underline,
+                          decoration: TextDecoration.none,
                         ),
                       ),
                     ),

--- a/app/lib/pages/onboarding/welcome/page.dart
+++ b/app/lib/pages/onboarding/welcome/page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:friend_private/providers/onboarding_provider.dart';
-import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
 import 'package:permission_handler/permission_handler.dart';
@@ -9,9 +8,8 @@ import 'package:provider/provider.dart';
 
 class WelcomePage extends StatefulWidget {
   final VoidCallback goNext;
-  final VoidCallback skipDevice;
 
-  const WelcomePage({super.key, required this.goNext, required this.skipDevice});
+  const WelcomePage({super.key, required this.goNext});
 
   @override
   State<WelcomePage> createState() => _WelcomePageState();
@@ -103,19 +101,6 @@ class _WelcomePageState extends State<WelcomePage> with SingleTickerProviderStat
             ),
           );
         }),
-        TextButton(
-            onPressed: () {
-              widget.skipDevice();
-              MixpanelManager().useWithoutDeviceOnboardingWelcome();
-            },
-            child: const Text(
-              'Skip for now',
-              style: TextStyle(
-                  color: Colors.white,
-                  // decoration: TextDecoration.underline,
-                  fontSize: 14,
-                  fontWeight: FontWeight.normal),
-            )),
         const SizedBox(height: 16)
       ],
     );

--- a/app/lib/pages/onboarding/wrapper.dart
+++ b/app/lib/pages/onboarding/wrapper.dart
@@ -57,6 +57,26 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
       onTap: () => FocusScope.of(context).unfocus(),
       child: Scaffold(
         backgroundColor: Theme.of(context).colorScheme.primary,
+        appBar: AppBar(
+          backgroundColor: Theme.of(context).colorScheme.primary,
+          elevation: 0,
+          actions: [
+            if (_controller!.index == 2 || _controller!.index == 3)
+              TextButton(
+                onPressed: () {
+                  if (_controller!.index == 2) {
+                    _controller!.animateTo(_controller!.index + 1);
+                  } else {
+                    routeToPage(context, const HomePageWrapper(), replace: true);
+                  }
+                },
+                child: Text(
+                  'Skip',
+                  style: TextStyle(color: Colors.grey.shade200),
+                ),
+              ),
+          ],
+        ),
         body: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: ListView(
@@ -122,10 +142,6 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                       WelcomePage(
                         goNext: () {
                           _goNext();
-                          MixpanelManager().onboardingStepICompleted('Welcome');
-                        },
-                        skipDevice: () {
-                          routeToPage(context, const HomePageWrapper(), replace: true);
                           MixpanelManager().onboardingStepICompleted('Welcome');
                         },
                       ),

--- a/app/lib/services/notification_service.dart
+++ b/app/lib/services/notification_service.dart
@@ -38,6 +38,9 @@ class NotificationService {
 
   Future<void> initialize() async {
     await _initializeAwesomeNotifications();
+    // Calling it here because the APNS token can sometimes arrive early or it might take some time (like a few seconds)
+    // Reference: https://github.com/firebase/flutterfire/issues/12244#issuecomment-1969286794
+    await _firebaseMessaging.getAPNSToken();
     listenForMessages();
   }
 

--- a/app/lib/widgets/device_widget.dart
+++ b/app/lib/widgets/device_widget.dart
@@ -37,7 +37,7 @@ class _DeviceAnimationWidgetState extends State<DeviceAnimationWidget> with Tick
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: MediaQuery.sizeOf(context).height <= 700 ? 280 * widget.sizeMultiplier : 400 * widget.sizeMultiplier,
+      height: MediaQuery.sizeOf(context).height <= 700 ? 220 * widget.sizeMultiplier : 340 * widget.sizeMultiplier,
       child: Center(
         child: Stack(
           alignment: Alignment.center,


### PR DESCRIPTION
- Make notification and device setup during onboarding less skippable
- Fix `Select a Plugin` disappearing
- Fix no token found exception being thrown even when the user hasn't signed in. Now it only throws an exception if the user is signed in but there's no token
- Fetch APNS tokens in advance
<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Made device setup and notification permissions mandatory during onboarding to ensure full functionality of the app.
- Bug Fix: Resolved issues related to token handling, preventing unnecessary exceptions for unsigned users.
- Bug Fix: Fixed the disappearance of the plugin selection during certain scenarios.
- Refactor: Improved dropdown button rendering logic in the home page for better performance.
- New Feature: Added functionality to fetch Apple Push Notification Service (APNS) tokens in advance, enhancing the reliability of push notifications for iOS users.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->