### PR TITLE
Update Event status in backend

### DIFF
--- a/app/lib/backend/http/api/memories.dart
+++ b/app/lib/backend/http/api/memories.dart
@@ -152,9 +152,9 @@ Future<ServerMemory?> getMemoryById(String memoryId) async {
 
 Future<bool> setEventCreatedServer(String memoryId, int eventIndex) async {
   var response = await makeApiCall(
-    url: '${Env.apiBaseUrl}v1/memories/$memoryId/mark-created?event_index=$eventIndex',
+    url: '${Env.apiBaseUrl}v1/memories/$memoryId/events?event_index=$eventIndex',
     headers: {},
-    method: 'PUT',
+    method: 'PATCH',
     body: '',
   );
   if (response == null) return false;

--- a/app/lib/backend/http/api/memories.dart
+++ b/app/lib/backend/http/api/memories.dart
@@ -150,6 +150,18 @@ Future<ServerMemory?> getMemoryById(String memoryId) async {
   return null;
 }
 
+Future<bool> setEventCreatedServer(String memoryId, int eventIndex) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/memories/$memoryId/mark-created?event_index=$eventIndex',
+    headers: {},
+    method: 'PUT',
+    body: '',
+  );
+  if (response == null) return false;
+  debugPrint('setEventCreatedServer: ${response.body}');
+  return response.statusCode == 200;
+}
+
 Future<List<MemoryPhoto>> getMemoryPhotos(String memoryId) async {
   var response = await makeApiCall(
     url: '${Env.apiBaseUrl}v1/memories/$memoryId/photos',

--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -53,6 +53,8 @@ Future<http.Response?> makeApiCall({
       return await client.delete(Uri.parse(url), headers: headers);
     } else if (method == 'PATCH') {
       return await client.patch(Uri.parse(url), headers: headers);
+    } else if (method == 'PUT') {
+      return await client.put(Uri.parse(url), headers: headers);
     } else {
       throw Exception('Unsupported HTTP method: $method');
     }

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -10,6 +10,7 @@ import 'package:friend_private/backend/schema/plugin.dart';
 import 'package:friend_private/pages/memory_detail/test_prompts.dart';
 import 'package:friend_private/pages/plugins/page.dart';
 import 'package:friend_private/pages/settings/calendar.dart';
+import 'package:friend_private/providers/memory_provider.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/connectivity_controller.dart';
 import 'package:friend_private/utils/features/calendar.dart';
@@ -17,6 +18,7 @@ import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:friend_private/widgets/expandable_text.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
+import 'package:provider/provider.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'maps_util.dart';
@@ -160,8 +162,7 @@ List<Widget> getSummaryWidgets(
                     ));
                     return;
                   }
-                  // TODO: calendar events in memory detail.
-                  // MemoryProvider().setEventCreated(event);
+                  context.read<MemoryProvider>().setEventCreated(memory, memory.structured.events.indexOf(event));
                   setState(() => event.created = true);
                   CalendarUtil().createEvent(
                     event.title,

--- a/app/lib/providers/memory_provider.dart
+++ b/app/lib/providers/memory_provider.dart
@@ -127,6 +127,13 @@ class MemoryProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  Future setEventCreated(ServerMemory memory, int eventIndex) async {
+    await setEventCreatedServer(memory.id, eventIndex);
+    memory.structured.events[eventIndex].created = true;
+    updateMemory(memory);
+    notifyListeners();
+  }
+
   // TODO: Move this to somewhere more suitable
   Future<ServerMemory?> _retrySingleFailed(ServerMemory memory) async {
     if (memory.transcriptSegments.isEmpty || memory.photos.isEmpty) return null;

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -14,6 +14,21 @@ from utils.plugins import trigger_external_integrations
 
 router = APIRouter()
 
+@router.put("/v1/memories/{memory_id}/mark-created", response_model=Memory, tags=['memories'])
+def mark_memory_as_created(memory_id: str, event_index: int, uid: str = Depends(auth.get_current_user_uid)):
+
+    memory = _get_memory_by_id(uid, memory_id)
+
+    structured = memory['structured'].copy()
+    
+    structured['events'][event_index]['created'] = True
+    
+    try:
+        memories_db.update_memory(uid, memory_id, {"structured": structured})
+        return {"status": "success"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=f"Failed to update memory: {str(e)}")
+
 
 def _get_memory_by_id(uid: str, memory_id: str) -> dict:
     memory = memories_db.get_memory(uid, memory_id)

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -14,7 +14,7 @@ from utils.plugins import trigger_external_integrations
 
 router = APIRouter()
 
-@router.put("/v1/memories/{memory_id}/mark-created", response_model=Memory, tags=['memories'])
+@router.patch("/v1/memories/{memory_id}/events", response_model=Memory, tags=['memories'])
 def mark_memory_as_created(memory_id: str, event_index: int, uid: str = Depends(auth.get_current_user_uid)):
 
     memory = _get_memory_by_id(uid, memory_id)


### PR DESCRIPTION
This PR adds the ability to update the status of an event in firestore when the event is added to the calendar.


<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Added functionality to mark a memory event as created in the application. This change allows users to update the status of an event within a memory structure.
- Improvement: Enhanced error handling for the new feature, ensuring that any issues encountered during the update process are properly managed and communicated.
- Refactor: Updated the `makeApiCall` function to support HTTP PUT method, enhancing its versatility for different API requests.
- New Feature: Implemented a new server-side endpoint to handle the marking of a memory event as created, improving the overall data consistency between client and server.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->