### PR TITLE
Fix connect later from onboarding

### DIFF
--- a/app/lib/pages/onboarding/find_device/page.dart
+++ b/app/lib/pages/onboarding/find_device/page.dart
@@ -14,9 +14,11 @@ import 'found_devices.dart';
 class FindDevicesPage extends StatefulWidget {
   final bool isFromOnboarding;
   final VoidCallback goNext;
+  final VoidCallback? onSkip;
   final bool includeSkip;
 
-  const FindDevicesPage({super.key, required this.goNext, this.includeSkip = true, this.isFromOnboarding = false});
+  const FindDevicesPage(
+      {super.key, required this.goNext, this.includeSkip = true, this.isFromOnboarding = false, this.onSkip});
 
   @override
   State<FindDevicesPage> createState() => _FindDevicesPageState();
@@ -96,7 +98,11 @@ class _FindDevicesPageState extends State<FindDevicesPage> {
             if (widget.includeSkip && provider.deviceList.isEmpty)
               ElevatedButton(
                 onPressed: () {
-                  widget.goNext();
+                  if (widget.isFromOnboarding) {
+                    widget.onSkip!();
+                  } else {
+                    widget.goNext();
+                  }
                   MixpanelManager().useWithoutDeviceOnboardingFindDevices();
                 },
                 child: Container(

--- a/app/lib/pages/onboarding/wrapper.dart
+++ b/app/lib/pages/onboarding/wrapper.dart
@@ -131,6 +131,9 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                       ),
                       FindDevicesPage(
                         isFromOnboarding: true,
+                        onSkip: () {
+                          routeToPage(context, const HomePageWrapper(), replace: true);
+                        },
                         goNext: () async {
                           var provider = context.read<OnboardingProvider>();
                           if (SharedPreferencesUtil().hasSpeakerProfile) {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Introduced a 'Skip' functionality in the device finding stage of the onboarding process. Users can now opt to skip this step and directly navigate to the Home Page if they wish to configure their devices later. This enhances user flexibility during the onboarding process.

<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->