### PR TITLE
Drop support for openglass for now

### DIFF
--- a/app/lib/pages/onboarding/find_device/found_devices.dart
+++ b/app/lib/pages/onboarding/find_device/found_devices.dart
@@ -4,6 +4,7 @@ import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';
 import 'package:friend_private/backend/schema/bt_device.dart';
 import 'package:friend_private/pages/home/page.dart';
 import 'package:friend_private/providers/onboarding_provider.dart';
+import 'package:friend_private/widgets/dialog.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:provider/provider.dart';
 
@@ -48,6 +49,18 @@ class _FoundDevicesState extends State<FoundDevices> {
             //   (route) => false,
             // );
             Navigator.pop(context);
+          } else if (info == 'OPENGLASS_NOT_SUPPORTED') {
+            showDialog(
+                context: context,
+                builder: (context) {
+                  return getDialog(context, () {
+                    Navigator.pop(context);
+                  }, () {
+                    Navigator.pop(context);
+                  }, "OpenGlass isn't supported",
+                      "OpenGlass isn’t available in this version of the app. It will be added in a future update once it's ready",
+                      singleButton: true);
+                });
           } else {
             ScaffoldMessenger.of(context).showSnackBar(SnackBar(
               content: Text(info),

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -123,8 +123,11 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin {
     required bool isFromOnboarding,
     VoidCallback? goNext,
   }) async {
+    if (device.name.toLowerCase() == 'openglass' || device.type == DeviceType.openglass) {
+      notifyInfo('OPENGLASS_NOT_SUPPORTED');
+      return;
+    }
     if (isClicked) return; // if any item is clicked, don't do anything
-
     isClicked = true; // Prevent further clicks
     connectingToDeviceId = device.id; // Mark this device as being connected to
     notifyListeners();


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

---
- Refactor: Removed support for `openglass` devices in the onboarding process. This change affects the device selection behavior during onboarding.
- New Feature: Added a new dialog notification when an unsupported 'openglass' device is selected, enhancing user feedback and preventing further actions until a supported device is chosen.
---
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->