### PR TITLE
improve memory_detail provider for performance

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -183,10 +183,10 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
             update: (BuildContext context, device, capture, wsProvider, SpeechProfileProvider? previous) =>
                 (previous?..setProviders(device, capture, wsProvider)) ?? SpeechProfileProvider(),
           ),
-          ChangeNotifierProxyProvider<PluginProvider, MemoryDetailProvider>(
+          ChangeNotifierProxyProvider2<PluginProvider, MemoryProvider, MemoryDetailProvider>(
             create: (context) => MemoryDetailProvider(),
-            update: (BuildContext context, value, MemoryDetailProvider? previous) =>
-                (previous?..setPluginProvider(value)) ?? MemoryDetailProvider(),
+            update: (BuildContext context, plugin, memory, MemoryDetailProvider? previous) =>
+                (previous?..setProviders(plugin, memory)) ?? MemoryDetailProvider(),
           ),
         ],
         builder: (context, child) {

--- a/app/lib/pages/memories/widgets/memory_list_item.dart
+++ b/app/lib/pages/memories/widgets/memory_list_item.dart
@@ -35,7 +35,7 @@ class _MemoryListItemState extends State<MemoryListItem> {
     return GestureDetector(
       onTap: () async {
         MixpanelManager().memoryListItemClicked(widget.memory, widget.memoryIdx);
-        context.read<MemoryDetailProvider>().updateMemory(widget.memory, widget.memoryIdx);
+        context.read<MemoryDetailProvider>().updateMemory(widget.memoryIdx);
         var result = await Navigator.of(context).push(MaterialPageRoute(
           builder: (c) => MemoryDetailPage(
             memory: widget.memory,

--- a/app/lib/pages/memory_detail/memory_detail_provider.dart
+++ b/app/lib/pages/memory_detail/memory_detail_provider.dart
@@ -6,6 +6,7 @@ import 'package:friend_private/backend/schema/memory.dart';
 import 'package:friend_private/backend/schema/plugin.dart';
 import 'package:friend_private/backend/schema/structured.dart';
 import 'package:friend_private/backend/schema/transcript_segment.dart';
+import 'package:friend_private/providers/memory_provider.dart';
 import 'package:friend_private/providers/plugin_provider.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
@@ -13,7 +14,8 @@ import 'package:tuple/tuple.dart';
 
 class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
   PluginProvider? pluginProvider;
-  late ServerMemory memory;
+  MemoryProvider? memoryProvider;
+  // late ServerMemory memory;
 
   int memoryIdx = 0;
 
@@ -26,7 +28,8 @@ class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
   final focusOverviewField = FocusNode();
   List<Plugin> pluginsList = [];
 
-  Structured get structured => memory.structured;
+  Structured get structured => memoryProvider!.memoriesWithDates[memoryIdx].structured;
+  ServerMemory get memory => memoryProvider!.memoriesWithDates[memoryIdx];
   List<bool> pluginResponseExpanded = [];
 
   bool editingTitle = false;
@@ -75,8 +78,10 @@ class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
     notifyListeners();
   }
 
-  void setPluginProvider(PluginProvider provider) {
+  void setProviders(PluginProvider provider, MemoryProvider memoryProvider) {
+    this.memoryProvider = memoryProvider;
     pluginProvider = provider;
+    notifyListeners();
   }
 
   updateSelectedTab(int index) {
@@ -94,10 +99,9 @@ class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
     notifyListeners();
   }
 
-  void updateMemory(ServerMemory memory, int memIdx) {
+  void updateMemory(int memIdx) {
     memoryIdx = memIdx;
     pluginResponseExpanded = List.filled(memory.pluginsResults.length, false);
-    this.memory = memory;
     notifyListeners();
   }
 
@@ -142,7 +146,7 @@ class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
         notifyListeners();
         return false;
       } else {
-        updateMemory(updatedMemory, memoryIdx);
+        memoryProvider!.updateMemory(updatedMemory);
         SharedPreferencesUtil().modifiedMemoryDetails = updatedMemory;
         notifyInfo('REPROCESS_SUCCESS');
         notifyListeners();

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -819,10 +819,7 @@ class GetSheetMainOptions extends StatelessWidget {
                       : () async {
                           final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);
                           if (connectivityProvider.isConnected) {
-                            var res = await provider.reprocessMemory();
-                            if (res) {
-                              context.read<MemoryProvider>().updateMemory(provider.memory);
-                            }
+                            await provider.reprocessMemory();
                           } else {
                             showDialog(
                               builder: (c) => getDialog(

--- a/app/lib/pages/onboarding/memory_created_widget.dart
+++ b/app/lib/pages/onboarding/memory_created_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:friend_private/pages/memories/widgets/memory_list_item.dart';
 import 'package:friend_private/pages/memory_detail/page.dart';
+import 'package:friend_private/providers/memory_provider.dart';
 import 'package:friend_private/providers/speech_profile_provider.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
@@ -55,6 +56,7 @@ class MemoryCreatedWidget extends StatelessWidget {
                 onPressed: () async {
                   // goNext();
                   MixpanelManager().memoryListItemClicked(provider.memory!, 0);
+                  context.read<MemoryProvider>().addMemory(provider.memory!);
                   var result = await Navigator.of(context).push(MaterialPageRoute(
                     builder: (c) => MemoryDetailPage(
                       memory: provider.memory!,


### PR DESCRIPTION
The MemoryDetailProvider will not make a copy of the selected memory anymore. instead it will rely on the memories in the MemoryProvider and will directly perform operations on them. Thereby eliminating the need of copying the memory to device memory everytime a memory is opened to view in detail

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Refactor: Enhanced the performance of memory operations by directly using `MemoryProvider` in `MemoryDetailProvider` and `MemoryCreatedWidget`, eliminating unnecessary memory copying.
- Refactor: Simplified the logic in `widgets.dart` for updating memory details, removing redundant operations for improved performance.
- Refactor: Streamlined the process of updating memory details in `MemoryListItemState`, improving code maintainability.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->