### PR TITLE
UX Improvements

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -50,7 +50,6 @@ Future<http.Response?> makeApiCall({
     final client = InstabugHttpClient();
 
     http.Response? response = await _performRequest(client, url, headers, body, method);
-
     if (response.statusCode == 401) {
       Logger.log('Token expired on 1st attempt');
       // Refresh the token
@@ -61,6 +60,17 @@ Future<http.Response?> makeApiCall({
         // Retry the request with the new token
         response = await _performRequest(client, url, headers, body, method);
         Logger.log('Token refreshed and request retried');
+        if (response.statusCode == 401) {
+          // Force user to sign in again
+          await signOut();
+          Logger.handle(Exception('Authentication failed. Please sign in again.'), StackTrace.current,
+              message: 'Authentication failed. Please sign in again.');
+        }
+      } else {
+        // Force user to sign in again
+        await signOut();
+        Logger.handle(Exception('Authentication failed. Please sign in again.'), StackTrace.current,
+            message: 'Authentication failed. Please sign in again.');
       }
     }
 

--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:friend_private/backend/auth.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/env/env.dart';
+import 'package:friend_private/utils/logger.dart';
 import 'package:http/http.dart' as http;
 import 'package:instabug_flutter/instabug_flutter.dart';
 import 'package:instabug_http_client/instabug_http_client.dart';
@@ -48,19 +49,22 @@ Future<http.Response?> makeApiCall({
 
     final client = InstabugHttpClient();
 
-    if (method == 'POST') {
-      headers['Content-Type'] = 'application/json';
-      return await client.post(Uri.parse(url), headers: headers, body: body);
-    } else if (method == 'GET') {
-      return await client.get(Uri.parse(url), headers: headers);
-    } else if (method == 'DELETE') {
-      return await client.delete(Uri.parse(url), headers: headers);
-    } else if (method == 'PATCH') {
-      headers['Content-Type'] = 'application/json';
-      return await client.patch(Uri.parse(url), headers: headers, body: body);
-    } else {
-      throw Exception('Unsupported HTTP method: $method');
+    http.Response? response = await _performRequest(client, url, headers, body, method);
+
+    if (response.statusCode == 401) {
+      Logger.log('Token expired on 1st attempt');
+      // Refresh the token
+      SharedPreferencesUtil().authToken = await getIdToken() ?? '';
+      if (SharedPreferencesUtil().authToken.isNotEmpty) {
+        // Update the header with the new token
+        headers['Authorization'] = 'Bearer ${SharedPreferencesUtil().authToken}';
+        // Retry the request with the new token
+        response = await _performRequest(client, url, headers, body, method);
+        Logger.log('Token refreshed and request retried');
+      }
     }
+
+    return response;
   } catch (e, stackTrace) {
     debugPrint('HTTP request failed: $e, $stackTrace');
     CrashReporting.reportHandledCrash(
@@ -71,6 +75,29 @@ Future<http.Response?> makeApiCall({
     );
     return null;
   } finally {}
+}
+
+Future<http.Response> _performRequest(
+  InstabugHttpClient client,
+  String url,
+  Map<String, String> headers,
+  String body,
+  String method,
+) async {
+  switch (method) {
+    case 'POST':
+      headers['Content-Type'] = 'application/json';
+      return await client.post(Uri.parse(url), headers: headers, body: body);
+    case 'GET':
+      return await client.get(Uri.parse(url), headers: headers);
+    case 'DELETE':
+      return await client.delete(Uri.parse(url), headers: headers);
+    case 'PATCH':
+      headers['Content-Type'] = 'application/json';
+      return await client.patch(Uri.parse(url), headers: headers, body: body);
+    default:
+      throw Exception('Unsupported HTTP method: $method');
+  }
 }
 
 // Function to extract content from the API response.

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -295,7 +295,7 @@ class _DeciderWidgetState extends State<DeciderWidget> {
   Widget build(BuildContext context) {
     return Consumer<AuthenticationProvider>(
       builder: (context, authProvider, child) {
-        if (SharedPreferencesUtil().onboardingCompleted && authProvider.isSignedIn()) {
+        if (SharedPreferencesUtil().onboardingCompleted && authProvider.user != null) {
           return const HomePageWrapper();
         } else {
           return const OnboardingWrapper();

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -75,8 +75,11 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
             Align(
               alignment: Alignment.topCenter,
               child: provider.isLoadingMessages
-                  ? const CircularProgressIndicator(
-                      color: Colors.white,
+                  ? const Padding(
+                      padding: EdgeInsets.only(top: 32.0),
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                      ),
                     )
                   : (provider.messages.isEmpty)
                       ? Text(

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -53,6 +53,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> {
       }
       context.read<DeviceProvider>().periodicConnect('coming from HomePageWrapper');
       await context.read<mp.MemoryProvider>().getInitialMemories();
+      context.read<PluginProvider>().setSelectedChatPluginId(null);
     });
     super.initState();
   }
@@ -457,17 +458,16 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                               padding: const EdgeInsets.symmetric(horizontal: 16),
                               child: DropdownButton<String>(
                                 menuMaxHeight: 350,
-                                value: SharedPreferencesUtil().selectedChatPluginId,
+                                value: provider.selectedChatPluginId,
                                 onChanged: (s) async {
                                   if ((s == 'no_selected' && provider.plugins.where((p) => p.enabled).isEmpty) ||
                                       s == 'enable') {
                                     await routeToPage(context, const PluginsPage(filterChatOnly: true));
                                     return;
                                   }
-                                  print('Selected: $s prefs: ${SharedPreferencesUtil().selectedChatPluginId}');
-                                  if (s == null || s == SharedPreferencesUtil().selectedChatPluginId) return;
-                                  SharedPreferencesUtil().selectedChatPluginId = s;
-                                  var plugin = provider.plugins.firstWhereOrNull((p) => p.id == s);
+                                  if (s == null || s == provider.selectedChatPluginId) return;
+                                  provider.setSelectedChatPluginId(s);
+                                  var plugin = provider.getSelectedPlugin();
                                   chatPageKey.currentState?.sendInitialPluginMessage(plugin);
                                 },
                                 icon: Container(),

--- a/app/lib/pages/memory_detail/page.dart
+++ b/app/lib/pages/memory_detail/page.dart
@@ -209,8 +209,9 @@ class _MemoryDetailPageState extends State<MemoryDetailPage> with TickerProvider
                       return TabBarView(
                         physics: const NeverScrollableScrollPhysics(),
                         children: [
-                          Consumer<MemoryDetailProvider>(builder: (context, provider, child) {
-                            return ListView(
+                          Consumer<MemoryDetailProvider>(
+                            builder: (context, provider, child) {
+                              return ListView(
                                 shrinkWrap: true,
                                 children: provider.memory.source == MemorySource.openglass
                                     ? [
@@ -219,16 +220,11 @@ class _MemoryDetailPageState extends State<MemoryDetailPage> with TickerProvider
                                         ),
                                         const SizedBox(height: 32)
                                       ]
-                                    : [const TranscriptWidgets()]);
-                          }),
-                          ListView(
-                            shrinkWrap: true,
-                            children: const [
-                              GetSummaryWidgets(),
-                              GetPluginsWidgets(),
-                              GetGeolocationWidgets(),
-                            ],
+                                    : [const TranscriptWidgets()],
+                              );
+                            },
                           ),
+                          const SummaryTab(),
                         ],
                       );
                     }),
@@ -240,6 +236,26 @@ class _MemoryDetailPageState extends State<MemoryDetailPage> with TickerProvider
         ),
       ),
     );
+  }
+}
+
+class SummaryTab extends StatelessWidget {
+  const SummaryTab({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Selector<MemoryDetailProvider, bool>(
+        selector: (context, provider) => provider.memory.discarded,
+        builder: (context, isDiscaarded, child) {
+          return ListView(
+            shrinkWrap: true,
+            children: [
+              const GetSummaryWidgets(),
+              isDiscaarded ? const ReprocessDiscardedWidget() : const GetPluginsWidgets(),
+              const GetGeolocationWidgets(),
+            ],
+          );
+        });
   }
 }
 

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -247,19 +247,22 @@ class ReprocessDiscardedWidget extends StatelessWidget {
     return Consumer<MemoryDetailProvider>(builder: (context, provider, child) {
       if (provider.loadingReprocessMemory) {
         return const Center(
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              CircularProgressIndicator(
-                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-              ),
-              SizedBox(width: 16),
-              Text(
-                'Reprocessing memory...\nThis may take a few seconds',
-                style: TextStyle(color: Colors.white, fontSize: 16),
-              ),
-            ],
+          child: Padding(
+            padding: EdgeInsets.only(top: 18.0),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                CircularProgressIndicator(
+                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                ),
+                SizedBox(width: 16),
+                Text(
+                  'Re-summarizing memory...\nThis may take a few seconds',
+                  style: TextStyle(color: Colors.white, fontSize: 16),
+                ),
+              ],
+            ),
           ),
         );
       }
@@ -268,7 +271,7 @@ class ReprocessDiscardedWidget extends StatelessWidget {
         children: [
           const SizedBox(height: 32),
           Text(
-            'This memory was discarded as no meaningful content was found.\n\nYou can re-summarize it to see if we can find something useful.',
+            'Nothing interesting found,\nwant to retry?',
             style: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20),
             textAlign: TextAlign.center,
           ),

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -239,6 +239,75 @@ class _GetEditTextFieldState extends State<GetEditTextField> {
   }
 }
 
+class ReprocessDiscardedWidget extends StatelessWidget {
+  const ReprocessDiscardedWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<MemoryDetailProvider>(builder: (context, provider, child) {
+      if (provider.loadingReprocessMemory) {
+        return const Center(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              CircularProgressIndicator(
+                valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+              ),
+              SizedBox(width: 16),
+              Text(
+                'Reprocessing memory...\nThis may take a few seconds',
+                style: TextStyle(color: Colors.white, fontSize: 16),
+              ),
+            ],
+          ),
+        );
+      }
+      return ListView(
+        shrinkWrap: true,
+        children: [
+          const SizedBox(height: 32),
+          Text(
+            'This memory was discarded as no meaningful content was found.\n\nYou can re-summarize it to see if we can find something useful.',
+            style: Theme.of(context).textTheme.titleLarge!.copyWith(fontSize: 20),
+            textAlign: TextAlign.center,
+          ),
+          const SizedBox(height: 24),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Container(
+                decoration: BoxDecoration(
+                  border: const GradientBoxBorder(
+                    gradient: LinearGradient(colors: [
+                      Color.fromARGB(127, 208, 208, 208),
+                      Color.fromARGB(127, 188, 99, 121),
+                      Color.fromARGB(127, 86, 101, 182),
+                      Color.fromARGB(127, 126, 190, 236)
+                    ]),
+                    width: 2,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: MaterialButton(
+                  onPressed: () async {
+                    await provider.reprocessMemory();
+                  },
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                  child: const Padding(
+                      padding: EdgeInsets.symmetric(horizontal: 16, vertical: 0),
+                      child: Text('Re-summarise', style: TextStyle(color: Colors.white, fontSize: 16))),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 32),
+        ],
+      );
+    });
+  }
+}
+
 class GetPluginsWidgets extends StatelessWidget {
   const GetPluginsWidgets({super.key});
 

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -43,6 +43,7 @@ class AuthenticationProvider extends BaseProvider {
           debugPrint('Failed to get token: $e');
         }
       }
+      notifyListeners();
     });
   }
 

--- a/app/lib/providers/plugin_provider.dart
+++ b/app/lib/providers/plugin_provider.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:friend_private/backend/http/api/plugins.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/plugin.dart';
@@ -14,6 +15,22 @@ class PluginProvider extends BaseProvider {
   String searchQuery = '';
 
   List<bool> pluginLoading = [];
+
+  String selectedChatPluginId = 'no_selected';
+
+  void setSelectedChatPluginId(String? pluginId) {
+    if (pluginId == null) {
+      selectedChatPluginId = SharedPreferencesUtil().selectedChatPluginId;
+    } else {
+      selectedChatPluginId = pluginId;
+      SharedPreferencesUtil().selectedChatPluginId = pluginId;
+    }
+    notifyListeners();
+  }
+
+  Plugin? getSelectedPlugin() {
+    return plugins.firstWhereOrNull((p) => p.id == selectedChatPluginId);
+  }
 
   void setPluginLoading(int index, bool value) {
     pluginLoading[index] = value;


### PR DESCRIPTION
- [x] Discarded memory, should have clearer the reprocess button. When I open a discarded memory, instead of "Enable Plugins UI, I want to see a button that suggests to force summarization
- [x] When back responses 401, we should handle a token refresh
- [x] Sign out user if token is empty or invalid
- [x] Fix selected chat plugin not reflecting correctly


https://github.com/user-attachments/assets/414afd60-a3c0-4fe0-80a7-9cdceadf6815


https://github.com/user-attachments/assets/4445ca8f-17dc-49e2-95c7-08721458b753


https://github.com/user-attachments/assets/0e2c0a0e-3066-4fca-b922-cc0073892c66

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Introduced a loading indicator and a reprocess button in the `ReprocessDiscardedWidget` for better user experience while handling discarded memories.
- Refactor: Extracted `SummaryTab` widget from `MemoryDetailPageState` class for improved code modularity. This change enhances the UI by conditionally rendering widgets based on the memory's discarded state.
- Refactor: Updated the `_DeciderWidgetState` class to check user authentication status more efficiently.
- Refactor: Improved HTTP request handling in `makeApiCall` function with token refresh logic and added logging for token expiration for better error handling and debugging.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->