### PR TITLE
Use synchronizing when set btDeviceStruct to preferences

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -31,6 +31,10 @@ class SharedPreferencesUtil {
     saveString('btDeviceStruct', jsonEncode(value.toJson()));
   }
 
+  Future<void> btDeviceStructSet(BTDeviceStruct value) async {
+    await saveString('btDeviceStruct', jsonEncode(value.toJson()));
+  }
+
   BTDeviceStruct get btDeviceStruct {
     final String device = getString('btDeviceStruct') ?? '';
     if (device.isEmpty) return BTDeviceStruct(id: '', name: '');

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -171,7 +171,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                 ),
                 child: TextButton(
                   onPressed: () async {
-                    SharedPreferencesUtil().btDeviceStruct = BTDeviceStruct(id: '', name: '');
+                    await SharedPreferencesUtil().btDeviceStructSet(BTDeviceStruct(id: '', name: ''));
                     SharedPreferencesUtil().deviceName = '';
                     if (widget.device != null) {
                       await _bleDisconnectDevice(widget.device!);

--- a/app/lib/pages/home/device_settings.dart
+++ b/app/lib/pages/home/device_settings.dart
@@ -115,11 +115,11 @@ class DeviceSettings extends StatelessWidget {
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: TextButton(
-                  onPressed: () {
-                    SharedPreferencesUtil().btDeviceStruct = BTDeviceStruct(id: '', name: '');
+                  onPressed: () async {
+                    await SharedPreferencesUtil().btDeviceStructSet(BTDeviceStruct(id: '', name: ''));
                     SharedPreferencesUtil().deviceName = '';
                     if (device != null) {
-                      _bleDisconnectDevice(device!);
+                      await _bleDisconnectDevice(device!);
                     }
                     context.read<DeviceProvider>().setIsConnected(false);
                     context.read<DeviceProvider>().setConnectedDevice(null);

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -266,7 +266,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     }
 
     // Connect to first founded device
-    var connection = await ServiceManager.instance().device.ensureConnection(devices.first.id);
+    var connection = await ServiceManager.instance().device.ensureConnection(devices.first.id, force: true);
     if (connection == null) {
       return;
     }

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -145,10 +145,10 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
     isClicked = true; // Prevent further clicks
     connectingToDeviceId = device.id; // Mark this device as being connected to
     notifyListeners();
-    await ServiceManager.instance().device.ensureConnection(device.id);
+    await ServiceManager.instance().device.ensureConnection(device.id, force: true);
     print('Connected to device: ${device.name}');
     deviceId = device.id;
-    SharedPreferencesUtil().btDeviceStruct = device;
+    await SharedPreferencesUtil().btDeviceStructSet(device);
     deviceName = device.name;
     var cDevice = await _getConnectedDevice(deviceId);
     if (cDevice != null) {

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -12,7 +12,7 @@ abstract class IDeviceService {
   void stop();
   Future<void> discover({String? desirableDeviceId, int timeout = 5});
 
-  Future<DeviceConnection?> ensureConnection(String deviceId);
+  Future<DeviceConnection?> ensureConnection(String deviceId, {bool force = false});
 
   void subscribe(IDeviceServiceSubsciption subscription, Object context);
   void unsubscribe(Object context);
@@ -202,15 +202,39 @@ class DeviceService implements IDeviceService {
   // Warn: Should use a better solution to prevent race conditions
   bool mutex = false;
   @override
-  Future<DeviceConnection?> ensureConnection(String deviceId) async {
+  Future<DeviceConnection?> ensureConnection(String deviceId, {bool force = false}) async {
     while (mutex) {
       await Future.delayed(const Duration(milliseconds: 50));
     }
     mutex = true;
 
+    debugPrint("ensureConnection ${_connection?.device.id} ${_connection?.status} ${force}");
     try {
-      debugPrint("ensureConnection ${_connection?.device.id} ${_connection?.status}");
-      if (_connection?.status == DeviceConnectionState.connected) {
+      // Not force
+      if (!force && _connection != null) {
+        if (_connection?.device.id != deviceId || _connection?.status != DeviceConnectionState.connected) {
+          return null;
+        }
+
+        // connected
+        var pongAt = _connection?.pongAt;
+        var shouldPing = (pongAt == null || pongAt.isBefore(DateTime.now().subtract(const Duration(seconds: 5))));
+        if (shouldPing) {
+          var ok = await _connection?.ping() ?? false;
+          if (!ok) {
+            await _connection?.disconnect();
+
+            // try re-connecting
+            await _connectToDevice(deviceId);
+            return _connection;
+          }
+        }
+
+        return _connection;
+      }
+
+      // Force
+      if (deviceId == _connection?.device.id && _connection?.status == DeviceConnectionState.connected) {
         var pongAt = _connection?.pongAt;
         var shouldPing = (pongAt == null || pongAt.isBefore(DateTime.now().subtract(const Duration(seconds: 5))));
         if (shouldPing) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Introduced a new method for setting Bluetooth device preferences, enhancing the efficiency of preference updates.
- Refactor: Updated various files to utilize the new method for setting Bluetooth device preferences, improving code maintainability.
- Bug Fix: Adjusted the logic flow in device connection handling by introducing a `force` parameter. This change ensures more reliable device connections under certain conditions.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->