### PR TITLE
Change app name from friend to omi

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -40,12 +40,12 @@ android {
         prod {
             dimension "flavor-type"
             applicationId "com.friend.ios"
-            resValue "string", "app_name", "Friend"
+            resValue "string", "app_name", "Omi"
         }
         dev {
             dimension "flavor-type"
             applicationId "com.friend.ios.dev"
-            resValue "string", "app_name", "Friend Dev"
+            resValue "string", "app_name", "Omi Dev"
         }
     }
 

--- a/app/assets/device_assets/frame_lib.lua
+++ b/app/assets/device_assets/frame_lib.lua
@@ -179,11 +179,11 @@ function mainLoop()
 					color = "GREY"
 				})
 				if status == 1 then
-					frame.display.text('DISCONNECTED from Friend app', 10, 70, {
+					frame.display.text('DISCONNECTED from Omi app', 10, 70, {
 						color = "RED"
 					})
 				elseif status == 2 then
-					frame.display.text('CONNECTED to Friend app', 10, 70, {
+					frame.display.text('CONNECTED to Omi app', 10, 70, {
 						color = "GREY"
 					})
 				end

--- a/app/flavorizr.yaml
+++ b/app/flavorizr.yaml
@@ -1,7 +1,7 @@
 flavors:
   prod:
     app:
-      name: "Friend"
+      name: "Omi"
       icon: "assets/images/app_launcher_icon.png"
     android:
       applicationId: "com.friend.ios"
@@ -15,7 +15,7 @@ flavors:
         config: "app/ios/Config/Prod/GoogleService-Info.plist"
   dev:
     app:
-      name: "Friend Dev"
+      name: "Omi Dev"
       icon: "assets/images/app_launcher_icon.png"
     android:
       icon: "assets/images/app_launcher_icon.png"

--- a/app/ios/Flutter/devDebug.xcconfig
+++ b/app/ios/Flutter/devDebug.xcconfig
@@ -2,5 +2,5 @@
 #include "Generated.xcconfig"
 
 ASSET_PREFIX=dev
-BUNDLE_NAME=Friend Dev
-BUNDLE_DISPLAY_NAME=Friend Dev
+BUNDLE_NAME=Omi Dev
+BUNDLE_DISPLAY_NAME=Omi Dev

--- a/app/ios/Flutter/devProfile.xcconfig
+++ b/app/ios/Flutter/devProfile.xcconfig
@@ -2,5 +2,5 @@
 #include "Generated.xcconfig"
 
 ASSET_PREFIX=dev
-BUNDLE_NAME=Friend Dev
-BUNDLE_DISPLAY_NAME=Friend Dev
+BUNDLE_NAME=Omi Dev
+BUNDLE_DISPLAY_NAME=Omi Dev

--- a/app/ios/Flutter/devRelease.xcconfig
+++ b/app/ios/Flutter/devRelease.xcconfig
@@ -2,5 +2,5 @@
 #include "Generated.xcconfig"
 
 ASSET_PREFIX=dev
-BUNDLE_NAME=Friend Dev
-BUNDLE_DISPLAY_NAME=Friend Dev
+BUNDLE_NAME=Omi Dev
+BUNDLE_DISPLAY_NAME=Omi Dev

--- a/app/ios/Flutter/prodDebug.xcconfig
+++ b/app/ios/Flutter/prodDebug.xcconfig
@@ -2,5 +2,5 @@
 #include "Generated.xcconfig"
 
 ASSET_PREFIX=prod
-BUNDLE_NAME=Friend
-BUNDLE_DISPLAY_NAME=Friend
+BUNDLE_NAME=Omi
+BUNDLE_DISPLAY_NAME=Omi

--- a/app/ios/Flutter/prodProfile.xcconfig
+++ b/app/ios/Flutter/prodProfile.xcconfig
@@ -2,5 +2,5 @@
 #include "Generated.xcconfig"
 
 ASSET_PREFIX=prod
-BUNDLE_NAME=Friend
-BUNDLE_DISPLAY_NAME=Friend
+BUNDLE_NAME=Omi
+BUNDLE_DISPLAY_NAME=Omi

--- a/app/ios/Flutter/prodRelease.xcconfig
+++ b/app/ios/Flutter/prodRelease.xcconfig
@@ -2,5 +2,5 @@
 #include "Generated.xcconfig"
 
 ASSET_PREFIX=prod
-BUNDLE_NAME=Friend
-BUNDLE_DISPLAY_NAME=Friend
+BUNDLE_NAME=Omi
+BUNDLE_DISPLAY_NAME=Omi

--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -444,6 +444,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_ENTITLEMENTS = "Runner/RunnerDebug-prod.entitlements";
 				DEVELOPMENT_TEAM = 9536L8KLMP;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.friend-app-with-wearable.ios12";
 				PRODUCT_NAME = Runner;
@@ -459,6 +460,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_ENTITLEMENTS = "Runner/RunnerProfile-prod.entitlements";
 				DEVELOPMENT_TEAM = 9536L8KLMP;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.friend-app-with-wearable.ios12";
 				PRODUCT_NAME = Runner;
@@ -474,6 +476,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_ENTITLEMENTS = "Runner/RunnerRelease-prod.entitlements";
 				DEVELOPMENT_TEAM = 9536L8KLMP;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.friend-app-with-wearable.ios12";
 				PRODUCT_NAME = Runner;
@@ -489,6 +492,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_ENTITLEMENTS = "Runner/RunnerDebug-dev.entitlements";
 				DEVELOPMENT_TEAM = 9536L8KLMP;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.friend-app-with-wearable.ios12.development";
 				PRODUCT_NAME = Runner;
@@ -504,6 +508,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_ENTITLEMENTS = "Runner/RunnerProfile-dev.entitlements";
 				DEVELOPMENT_TEAM = 9536L8KLMP;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.friend-app-with-wearable.ios12.development";
 				PRODUCT_NAME = Runner;
@@ -519,6 +524,7 @@
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CODE_SIGN_ENTITLEMENTS = "Runner/RunnerRelease-dev.entitlements";
 				DEVELOPMENT_TEAM = 9536L8KLMP;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.friend-app-with-wearable.ios12.development";
 				PRODUCT_NAME = Runner;
@@ -530,7 +536,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -597,6 +603,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -626,7 +633,7 @@
 			baseConfigurationReference = 08E3947A4217EF205E22BD44 /* prodDebug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(ASSET_PREFIX)AppIcon";
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -701,7 +708,7 @@
 			baseConfigurationReference = 35656BCB5CBAA7C0BB162EE0 /* prodRelease.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(ASSET_PREFIX)AppIcon";
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -771,7 +778,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -828,7 +835,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
@@ -896,6 +903,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -940,6 +948,7 @@
 					"$(PROJECT_DIR)/Flutter",
 				);
 				INFOPLIST_FILE = Runner/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = Omi;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -969,7 +978,7 @@
 			baseConfigurationReference = 79B00761CB247C7EC7C8983B /* devRelease.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(ASSET_PREFIX)AppIcon";
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1040,7 +1049,7 @@
 			baseConfigurationReference = 556416C8748DD3DD2C06A9DB /* devProfile.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(ASSET_PREFIX)AppIcon";
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1110,7 +1119,7 @@
 			baseConfigurationReference = B52E83A1CC630E163A04DC50 /* prodProfile.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(ASSET_PREFIX)AppIcon";
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;
@@ -1180,7 +1189,7 @@
 			baseConfigurationReference = 17DD34CA2CFE6F3845E13C99 /* devDebug.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$ARCHS_STANDARD_64_BIT";
+				ARCHS = $ARCHS_STANDARD_64_BIT;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "$(ASSET_PREFIX)AppIcon";
 				BUILD_LIBRARY_FOR_DISTRIBUTION = NO;
 				CLANG_ANALYZER_NONNULL = YES;

--- a/app/lib/flavors.dart
+++ b/app/lib/flavors.dart
@@ -9,7 +9,7 @@ enum Environment {
     return Environment.values.firstWhere(
       (e) => e.name == appFlavor?.toLowerCase(),
       orElse: () {
-        debugPrint ('Warning: Unknown flavor "$appFlavor", defaulting to dev');
+        debugPrint('Warning: Unknown flavor "$appFlavor", defaulting to dev');
         return Environment.dev;
       },
     );
@@ -22,11 +22,11 @@ class F {
   static String get title {
     switch (env) {
       case Environment.prod:
-        return 'Friend';
+        return 'Omi';
       case Environment.dev:
-        return 'Friend Dev';
+        return 'Omi Dev';
       default:
-        return 'Friend Dev';
+        return 'Omi Dev';
     }
   }
 }

--- a/app/lib/pages/onboarding/permissions/notification_permission.dart
+++ b/app/lib/pages/onboarding/permissions/notification_permission.dart
@@ -57,7 +57,7 @@ class _NotificationPermissionWidgetState extends State<NotificationPermissionWid
                 }
               },
               title: const Text(
-                'Enable notification access for Friend\'s full experience.',
+                'Enable notification access for Omi\'s full experience.',
                 style: TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
               ),
               contentPadding: const EdgeInsets.only(left: 8),


### PR DESCRIPTION
related to #849 
<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Chore: Updated the application name from "Friend" to "Omi" across the entire application. This change impacts both Android and iOS configurations, as well as in-app text and notification messages.
- Refactor: Renamed the app bundle and display names for various iOS build configurations from "Friend Dev" to "Omi Dev". This update enhances consistency across development, profile, and release environments.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->