### PR TITLE
Improve speech profile widget handling

### DIFF
--- a/app/lib/pages/capture/_page.dart
+++ b/app/lib/pages/capture/_page.dart
@@ -218,7 +218,7 @@ class CapturePageState extends State<CapturePage> with AutomaticKeepAliveClientM
         child: Stack(
           children: [
             ListView(children: [
-              speechProfileWidget(context),
+              SpeechProfileCardWidget(),
               ...getConnectionStateWidgets(
                 context,
                 provider.hasTranscripts,

--- a/app/lib/pages/capture/widgets/widgets.dart
+++ b/app/lib/pages/capture/widgets/widgets.dart
@@ -6,6 +6,7 @@ import 'package:friend_private/pages/capture/connect.dart';
 import 'package:friend_private/pages/speech_profile/page.dart';
 import 'package:friend_private/providers/connectivity_provider.dart';
 import 'package:friend_private/providers/device_provider.dart';
+import 'package:friend_private/providers/home_provider.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/enums.dart';
 import 'package:friend_private/utils/other/temp.dart';
@@ -207,61 +208,71 @@ _getNoFriendConnectedYet(BuildContext context) {
   );
 }
 
-speechProfileWidget(BuildContext context) {
-  return !SharedPreferencesUtil().hasSpeakerProfile
-      ? Stack(
-          children: [
-            GestureDetector(
-              onTap: () async {
-                MixpanelManager().pageOpened('Speech Profile Memories');
-                bool hasSpeakerProfile = SharedPreferencesUtil().hasSpeakerProfile;
-                await routeToPage(context, const SpeechProfilePage());
-                if (hasSpeakerProfile != SharedPreferencesUtil().hasSpeakerProfile) {
-                  if (context.mounted) {
-                    // TODO: is the websocket restarting once the user comes back?
-                    context.read<DeviceProvider>().restartWebSocket();
-                  }
-                }
-              },
-              child: Container(
-                decoration: BoxDecoration(
-                  color: Colors.grey.shade900,
-                  borderRadius: const BorderRadius.all(Radius.circular(12)),
-                ),
-                margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
-                padding: const EdgeInsets.all(16),
-                child: const Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Expanded(
-                      child: Row(
+class SpeechProfileCardWidget extends StatelessWidget {
+  const SpeechProfileCardWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<HomeProvider>(
+      builder: (context, provider, child) {
+        if (provider.isLoading) return const SizedBox();
+        return provider.hasSpeakerProfile
+            ? const SizedBox()
+            : Stack(
+                children: [
+                  GestureDetector(
+                    onTap: () async {
+                      MixpanelManager().pageOpened('Speech Profile Memories');
+                      bool hasSpeakerProfile = SharedPreferencesUtil().hasSpeakerProfile;
+                      await routeToPage(context, const SpeechProfilePage());
+                      if (hasSpeakerProfile != SharedPreferencesUtil().hasSpeakerProfile) {
+                        if (context.mounted) {
+                          // TODO: is the websocket restarting once the user comes back?
+                          context.read<DeviceProvider>().restartWebSocket();
+                        }
+                      }
+                    },
+                    child: Container(
+                      decoration: BoxDecoration(
+                        color: Colors.grey.shade900,
+                        borderRadius: const BorderRadius.all(Radius.circular(12)),
+                      ),
+                      margin: const EdgeInsets.fromLTRB(16, 0, 16, 16),
+                      padding: const EdgeInsets.all(16),
+                      child: const Row(
+                        mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
-                          Icon(Icons.multitrack_audio),
-                          SizedBox(width: 16),
-                          Text(
-                            'Teach Omi your voice',
-                            style: TextStyle(color: Colors.white, fontSize: 16),
+                          Expanded(
+                            child: Row(
+                              children: [
+                                Icon(Icons.multitrack_audio),
+                                SizedBox(width: 16),
+                                Text(
+                                  'Teach Omi your voice',
+                                  style: TextStyle(color: Colors.white, fontSize: 16),
+                                ),
+                              ],
+                            ),
                           ),
+                          Icon(Icons.arrow_forward_ios)
                         ],
                       ),
                     ),
-                    Icon(Icons.arrow_forward_ios)
-                  ],
-                ),
-              ),
-            ),
-            Positioned(
-              top: 12,
-              right: 24,
-              child: Container(
-                width: 12,
-                height: 12,
-                decoration: const BoxDecoration(color: Colors.red, shape: BoxShape.circle),
-              ),
-            ),
-          ],
-        )
-      : const SizedBox(height: 0);
+                  ),
+                  Positioned(
+                    top: 12,
+                    right: 24,
+                    child: Container(
+                      width: 12,
+                      height: 12,
+                      decoration: const BoxDecoration(color: Colors.red, shape: BoxShape.circle),
+                    ),
+                  ),
+                ],
+              );
+      },
+    );
+  }
 }
 
 getTranscriptWidget(

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -53,6 +53,7 @@ class _HomePageWrapperState extends State<HomePageWrapper> {
       context.read<DeviceProvider>().periodicConnect('coming from HomePageWrapper');
       await context.read<mp.MemoryProvider>().getInitialMemories();
       context.read<PluginProvider>().setSelectedChatPluginId(null);
+      await context.read<HomeProvider>().setupHasSpeakerProfile();
     });
     super.initState();
   }
@@ -131,10 +132,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
       await ForegroundUtil.initializeForegroundService();
       ForegroundUtil.startForegroundTask();
       if (mounted) {
-        await context.read<HomeProvider>().setupHasSpeakerProfile();
-        if (mounted) {
-          await context.read<HomeProvider>().setUserPeople();
-        }
+        await context.read<HomeProvider>().setUserPeople();
       }
     });
 

--- a/app/lib/pages/memories/page.dart
+++ b/app/lib/pages/memories/page.dart
@@ -95,7 +95,7 @@ class _MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClie
         child: CustomScrollView(
           slivers: [
             const SliverToBoxAdapter(child: SizedBox(height: 32)),
-            SliverToBoxAdapter(child: speechProfileWidget(context)),
+            const SliverToBoxAdapter(child: SpeechProfileCardWidget()),
             SliverToBoxAdapter(child: getMemoryCaptureWidget()),
             if (memoryProvider.memoriesWithDates.isEmpty && !memoryProvider.isLoadingMemories)
               const SliverToBoxAdapter(

--- a/app/lib/pages/onboarding/wrapper.dart
+++ b/app/lib/pages/onboarding/wrapper.dart
@@ -127,7 +127,7 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
         SpeechProfileWidget(
           goNext: () {
             if (context.read<SpeechProfileProvider>().memory == null) {
-              _controller!.animateTo(_controller!.index + 2);
+              routeToPage(context, const HomePageWrapper(), replace: true);
             } else {
               _goNext();
             }

--- a/app/lib/pages/speech_profile/page.dart
+++ b/app/lib/pages/speech_profile/page.dart
@@ -211,7 +211,7 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> with TickerProvid
                     padding: const EdgeInsets.fromLTRB(40, 0, 40, 48),
                     child: !provider.startedRecording
                         ? const Text(
-                            'Now, Friend needs to learn your voice to be able to recognise you.',
+                            'Now, Omi needs to learn your voice to be able to recognise you.',
                             textAlign: TextAlign.center,
                             style: TextStyle(
                               color: Colors.white,

--- a/app/lib/providers/home_provider.dart
+++ b/app/lib/providers/home_provider.dart
@@ -10,6 +10,8 @@ class HomeProvider extends ChangeNotifier {
   final FocusNode chatFieldFocusNode = FocusNode();
   bool isMemoryFieldFocused = false;
   bool isChatFieldFocused = false;
+  bool hasSpeakerProfile = false;
+  bool isLoading = false;
 
   HomeProvider() {
     memoryFieldFocusNode.addListener(_onFocusChange);
@@ -27,10 +29,24 @@ class HomeProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  void setIsLoading(bool loading) {
+    isLoading = loading;
+    notifyListeners();
+  }
+
+  void setSpeakerProfile(bool? value) {
+    hasSpeakerProfile = value ?? SharedPreferencesUtil().hasSpeakerProfile;
+    notifyListeners();
+  }
+
   Future setupHasSpeakerProfile() async {
-    SharedPreferencesUtil().hasSpeakerProfile = await userHasSpeakerProfile();
+    setIsLoading(true);
+    var res = await userHasSpeakerProfile();
+    setSpeakerProfile(res);
+    SharedPreferencesUtil().hasSpeakerProfile = res;
     debugPrint('_setupHasSpeakerProfile: ${SharedPreferencesUtil().hasSpeakerProfile}');
     MixpanelManager().setUserProperty('Speaker Profile', SharedPreferencesUtil().hasSpeakerProfile);
+    setIsLoading(false);
     notifyListeners();
   }
 


### PR DESCRIPTION
- [x] Speech profile is not being set on first time the app opens, which causes to people with speech profile already and maybe switching phones, to see speech profile in onboarding again but also in home/memories page item asking for speech profile


https://github.com/user-attachments/assets/3e1d3320-3a59-4de1-a1ba-dc07a6d4dd33




<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Introduced `SpeechProfileCardWidget`, a new widget for managing speech profiles, enhancing the user interface and experience.
- Refactor: Optimized the flow of the onboarding process by replacing an animation call with a route navigation to `HomePageWrapper`.
- Refactor: Improved initialization in `HomePageWrapper` and `HomePage` classes, ensuring smoother setup of speaker profile and user people.
- Bug Fix: Updated a text string in the UI for better clarity during the voice learning phase.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->