### PR TITLE
frontend trends limit 6 topics

### DIFF
--- a/frontend/src/components/trends/get-trends-main-page.tsx
+++ b/frontend/src/components/trends/get-trends-main-page.tsx
@@ -25,10 +25,11 @@ export default async function GetTrendsMainPage() {
 
     if (!acc[category]) acc[category] = { best: [], worst: [] };
 
-    acc[category][type === 'best' ? 'best' : 'worst'] = [
-      ...acc[category][type === 'best' ? 'best' : 'worst'],
+    const topicsToPush = type === 'best' ? 'best' : 'worst';
+    acc[category][topicsToPush] = [
+      ...acc[category][topicsToPush],
       ...topics,
-    ];
+    ].slice(0, 6); // Limit to max 6
 
     return acc;
   }, {});


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Refactor: Updated the Trends Main Page component to limit the number of topics displayed per category to a maximum of 6. This change enhances the user interface by preventing overcrowding and improving readability.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->