### PR TITLE
Increase modal timeout to 35m, transcribe soft timeout to 30m

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -54,7 +54,7 @@ image = (
     memory=(512, 1024),
     cpu=2,
     allow_concurrent_inputs=10,
-    timeout=60 * 10,
+    timeout=60 * 35,
 )
 @asgi_app()
 def api():

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1,4 +1,7 @@
 import threading
+import asyncio
+import time
+from typing import List
 import uuid
 from datetime import datetime, timezone
 from enum import Enum
@@ -126,8 +129,8 @@ async def _websocket_util(
     speech_profile_stream_id = 2
     loop = asyncio.get_event_loop()
 
-    # Soft timeout
-    timeout_seconds = 420  # 7m ~ MODAL_TIME_OUT - 3m
+    # Soft timeout, should < MODAL_TIME_OUT - 3m
+    timeout_seconds = 1800  # 30m
     started_at = time.time()
 
     def stream_transcript(segments, stream_id):


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- Chore: Increased the modal timeout from 10 minutes to 35 minutes in `main.py` to accommodate longer running processes.
- Chore: Extended the soft timeout to 30 minutes in `transcribe.py`, allowing for more time-consuming transcription tasks.
- Refactor: Added necessary imports for asyncio and time in `transcribe.py` to support the extended timeout functionality. 

These changes aim to improve the user experience by reducing the likelihood of timeouts during long-running operations.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->