### PR TITLE
Manually create memory

### DIFF
--- a/app/lib/pages/memory_capturing/page.dart
+++ b/app/lib/pages/memory_capturing/page.dart
@@ -4,6 +4,8 @@ import 'package:friend_private/pages/capture/widgets/widgets.dart';
 import 'package:friend_private/pages/memory_detail/page.dart';
 import 'package:friend_private/providers/capture_provider.dart';
 import 'package:friend_private/providers/device_provider.dart';
+import 'package:friend_private/widgets/dialog.dart';
+import 'package:gradient_borders/box_borders/gradient_box_border.dart';
 import 'package:provider/provider.dart';
 
 class MemoryCapturingPage extends StatefulWidget {
@@ -134,12 +136,59 @@ class _MemoryCapturingPageState extends State<MemoryCapturingPage> with TickerPr
                               child: Text(
                                 provider.segments.isEmpty
                                     ? "No summary"
-                                    : "Available once the conversation finishes.\nBe quiet for 2 minutes 🤫",
+                                    : "We summarize conversations 2 minutes after they end\n\n\nWant to end it now?",
                                 textAlign: TextAlign.center,
                                 style: const TextStyle(fontSize: 16),
                               ),
                             ),
                           ),
+                          const SizedBox(
+                            height: 16,
+                          ),
+                          provider.segments.isEmpty
+                              ? const SizedBox()
+                              : Container(
+                                  decoration: BoxDecoration(
+                                    border: const GradientBoxBorder(
+                                      gradient: LinearGradient(colors: [
+                                        Color.fromARGB(127, 208, 208, 208),
+                                        Color.fromARGB(127, 188, 99, 121),
+                                        Color.fromARGB(127, 86, 101, 182),
+                                        Color.fromARGB(127, 126, 190, 236)
+                                      ]),
+                                      width: 2,
+                                    ),
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  margin: const EdgeInsets.symmetric(horizontal: 48),
+                                  child: MaterialButton(
+                                    onPressed: () async {
+                                      context.read<CaptureProvider>().createMemory();
+                                      showDialog(
+                                        context: context,
+                                        builder: (context) => getDialog(
+                                          context,
+                                          () {
+                                            Navigator.pop(context);
+                                            Navigator.pop(context);
+                                          },
+                                          () {
+                                            Navigator.pop(context);
+                                            Navigator.pop(context);
+                                          },
+                                          "Creating Memory",
+                                          "Memory creation has been started. You will be notified once it is ready.",
+                                          singleButton: true,
+                                        ),
+                                      );
+                                    },
+                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                                    child: const Padding(
+                                        padding: EdgeInsets.symmetric(horizontal: 12, vertical: 0),
+                                        child:
+                                            Text('Summarise Now', style: TextStyle(color: Colors.white, fontSize: 16))),
+                                  ),
+                                ),
                         ],
                       ),
                     ],

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -30,6 +30,7 @@ import 'package:friend_private/utils/features/calendar.dart';
 import 'package:friend_private/utils/logger.dart';
 import 'package:friend_private/utils/memories/integrations.dart';
 import 'package:friend_private/utils/memories/process.dart';
+import 'package:friend_private/utils/other/notifications.dart';
 import 'package:friend_private/utils/pure_socket.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:uuid/uuid.dart';
@@ -153,6 +154,10 @@ class CaptureProvider extends ChangeNotifier
       debugPrint("Memory is not found, processing memory ${event.processingMemoryId}");
       return;
     }
+    createNotification(
+      title: event.memory!.structured.title,
+      body: event.memory!.structured.overview,
+    );
     _processOnMemoryCreated(event.memory, event.messages ?? []);
   }
 


### PR DESCRIPTION
- [x] A button that let's me cut the memory until that point, and let's me summarize whatever is in there (this should never be discarded).
- [x] an explanation, that conversations get processed when there's no more transcript detected for 2 minutes. This has to look good, and be clear, easy to catch up for people.


https://github.com/user-attachments/assets/51882812-6eaf-4d15-aa3f-e5ccb2f8a812


<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Added an immediate conversation summarization button to the `MemoryCapturingPage`. This allows users to summarize their conversations instantly.
- Enhancement: Introduced UI improvements including a gradient border for better visual appeal.
- New Feature: Implemented a dialog notification system in the `CaptureProvider` class. Users will now be notified about memory creation, enhancing user interaction and experience.
- Bug Fix: Improved error handling in the `CaptureProvider` class. If a memory is not found before processing, a new notification based on memory details is created, ensuring smoother operation.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->