### PR TITLE
Align start seconds for transcript segment

### DIFF
--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -138,6 +138,11 @@ def update_memory_events(uid: str, memory_id: str, events: List[dict]):
     memory_ref = user_ref.collection('memories').document(memory_id)
     memory_ref.update({'structured.events': events})
 
+def update_memory_finished_at(uid: str, memory_id: str, finished_at: datetime):
+    user_ref = db.collection('users').document(uid)
+    memory_ref = user_ref.collection('memories').document(memory_id)
+    memory_ref.update({'finished_at': finished_at})
+
 
 # VISBILITY
 

--- a/backend/models/processing_memory.py
+++ b/backend/models/processing_memory.py
@@ -14,6 +14,7 @@ class ProcessingMemory(BaseModel):
     audio_url: Optional[str] = None
     created_at: datetime
     timer_start: float
+    timer_segment_start: Optional[float] = None
     timer_starts: List[float] = []
     language: Optional[str] = None  # applies only to Friend # TODO: once released migrate db to default 'en'
     transcript_segments: List[TranscriptSegment] = []

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -428,7 +428,8 @@ async def _websocket_util(
 
                     # merge
                     merge_file_path = f"_temp/{memory.id}_{uuid.uuid4()}_be"
-                    merge_wav_files(merge_file_path, [previous_file_path, file_path])
+                    nearest_timer_start = processing_memory.timer_starts[-2]
+                    merge_wav_files(merge_file_path, [previous_file_path, file_path], [math.ceil(timer_start-nearest_timer_start), 0])
 
                     # clean
                     os.remove(previous_file_path)

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -586,9 +586,8 @@ async def _websocket_util(
         # Longer 120s
         now = time.time()
         should_create_memory_time = True
-        timer_segment_start = timer_start + segment_start
         if time_validate:
-            should_create_memory_time = timer_segment_start + segment_end + min_seconds_limit < now
+            should_create_memory_time = timer_start + segment_end + min_seconds_limit < now
 
         # 1 words at least
         should_create_memory_time_words = min_words_limit == 0
@@ -602,7 +601,7 @@ async def _websocket_util(
 
         should_create_memory = should_create_memory_time and should_create_memory_time_words
         print(
-            f"Should create memory {should_create_memory} - {timer_segment_start} {segment_end} {min_seconds_limit} {now} - {time_validate}, session {session_id}")
+            f"Should create memory {should_create_memory} - {timer_start} {segment_end} {min_seconds_limit} {now} - {time_validate}, session {session_id}")
         if should_create_memory:
             memory = await _create_memory()
             if not memory:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -524,6 +524,10 @@ async def _websocket_util(
             memories_db.update_memory_segments(uid, memory.id,
                                                [segment.dict() for segment in memory.transcript_segments])
 
+            # Update finished at
+            memory.finished_at = datetime.fromtimestamp(memory.started_at.timestamp() + processing_memory.transcript_segments[-1].end, timezone.utc)
+            memories_db.update_memory_finished_at(uid, memory.id, memory.finished_at)
+
             # Process
             memory = process_memory(uid, memory.language, memory, force_process=True)
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -147,16 +147,14 @@ async def _websocket_util(
             return
 
         # Align the start, end segment
-        if len(segments) > 0:
-            # start
-            if not segment_start:
-                start = segments[0]["start"]
-                segment_start = start
+        if not segment_start:
+            start = segments[0]["start"]
+            segment_start = start
 
-            # end
-            end = segments[-1]["end"]
-            if not segment_end or segment_end < end:
-                segment_end = end
+        # end
+        end = segments[-1]["end"]
+        if not segment_end or segment_end < end:
+            segment_end = end
 
         for i, segment in enumerate(segments):
             segment["start"] -= segment_start
@@ -200,6 +198,7 @@ async def _websocket_util(
     timer_start = None
     segment_start = None
     segment_end = None
+    audio_frames_per_sec = 100
     # audio_buffer = None
     duration = 0
     try:
@@ -404,13 +403,12 @@ async def _websocket_util(
         processing_audio_frame_synced = len(processing_audio_frames)
 
         # Remove audio frames [start, end]
-        frames_per_sec = 100
         left = 0
         if segment_start:
-            left = max(left, math.floor(segment_start * frames_per_sec))
+            left = max(left, math.floor(segment_start * audio_frames_per_sec))
         right = processing_audio_frame_synced
         if segment_end:
-            right = min(math.ceil(segment_end * frames_per_sec), right)
+            right = min(math.ceil(segment_end * audio_frames_per_sec), right)
 
         file_path = f"_temp/{memory.id}_{uuid.uuid4()}_be"
         create_wav_from_bytes(file_path=file_path, frames=processing_audio_frames[left:right],

--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -3,14 +3,16 @@ import wave
 from pyogg import OpusDecoder
 from pydub import AudioSegment
 
-def merge_wav_files(dest_file_path: str, source_files: [str]):
+def merge_wav_files(dest_file_path: str, source_files: [str], silent_seconds: [int]):
     if len(source_files) == 0 or not dest_file_path:
         return
 
     combined_sounds = AudioSegment.empty()
-    for file_path in source_files:
+    for i in range(len(source_files)):
+        file_path = source_files[i]
         sound = AudioSegment.from_wav(file_path)
-        combined_sounds = combined_sounds + sound
+        silent_sec = silent_seconds[i]
+        combined_sounds = combined_sounds + sound + AudioSegment.silent(duration=silent_sec)
     combined_sounds.export(dest_file_path, format="wav")
 
 

--- a/backend/utils/processing_memories.py
+++ b/backend/utils/processing_memories.py
@@ -24,10 +24,11 @@ async def create_memory_by_processing_memory(uid: str, processing_memory_id: str
         print("Transcript segments is invalid")
         return
     timer_start = processing_memory.timer_start
+    segment_start = transcript_segments[0].start
     segment_end = transcript_segments[-1].end
     new_memory = CreateMemory(
-        started_at=datetime.fromtimestamp(timer_start, timezone.utc),
-        finished_at=datetime.fromtimestamp(timer_start + segment_end, timezone.utc),
+        started_at=datetime.fromtimestamp(timer_start + segment_start, timezone.utc),
+        finished_at=datetime.fromtimestamp(timer_start + segment_start + segment_end, timezone.utc),
         language=processing_memory.language,
         transcript_segments=transcript_segments,
     )

--- a/backend/utils/processing_memories.py
+++ b/backend/utils/processing_memories.py
@@ -23,12 +23,11 @@ async def create_memory_by_processing_memory(uid: str, processing_memory_id: str
     if not transcript_segments or len(transcript_segments) == 0:
         print("Transcript segments is invalid")
         return
-    timer_start = processing_memory.timer_start
-    segment_start = transcript_segments[0].start
+    timer_segment_start = processing_memory.timer_segment_start
     segment_end = transcript_segments[-1].end
     new_memory = CreateMemory(
-        started_at=datetime.fromtimestamp(timer_start + segment_start, timezone.utc),
-        finished_at=datetime.fromtimestamp(timer_start + segment_start + segment_end, timezone.utc),
+        started_at=datetime.fromtimestamp(timer_segment_start, timezone.utc),
+        finished_at=datetime.fromtimestamp(timer_segment_start + segment_end, timezone.utc),
         language=processing_memory.language,
         transcript_segments=transcript_segments,
     )

--- a/backend/utils/processing_memories.py
+++ b/backend/utils/processing_memories.py
@@ -23,7 +23,7 @@ async def create_memory_by_processing_memory(uid: str, processing_memory_id: str
     if not transcript_segments or len(transcript_segments) == 0:
         print("Transcript segments is invalid")
         return
-    timer_segment_start = processing_memory.timer_segment_start
+    timer_segment_start = processing_memory.timer_segment_start if processing_memory.timer_segment_start else processing_memory.timer_start
     segment_end = transcript_segments[-1].end
     new_memory = CreateMemory(
         started_at=datetime.fromtimestamp(timer_segment_start, timezone.utc),


### PR DESCRIPTION
Issue: #863 








<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Introduced an optional field `timer_segment_start` to the `ProcessingMemory` class for improved segment timing.
- Refactor: Updated audio processing and memory creation logic to align with the start seconds of transcript segments. This includes adjustments to segment start and end times, and handling of audio frames based on these boundaries.
- New Feature: Added a function `update_memory_finished_at` to update the 'finished_at' field in a memory document, enhancing data accuracy.
- New Feature: Enhanced the `merge_wav_files` function to support inserting silent segments between audio files, providing better control over audio merging.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->