### PR TITLE
UI Improvements and bug fixes

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -71,6 +71,10 @@ class SharedPreferencesUtil {
 
   set gcpBucketName(String value) => saveString('gcpBucketName', value);
 
+  bool get showSummarizeConfirmation => getBool('showSummarizeConfirmation') ?? true;
+
+  set showSummarizeConfirmation(bool value) => saveBool('showSummarizeConfirmation', value);
+
   String get webhookOnMemoryCreated => getString('webhookUrl') ?? '';
 
   set webhookOnMemoryCreated(String value) => saveString('webhookUrl', value);

--- a/app/lib/pages/memories/page.dart
+++ b/app/lib/pages/memories/page.dart
@@ -48,6 +48,7 @@ class _MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClie
           slivers: [
             const SliverToBoxAdapter(child: SizedBox(height: 32)),
             const SliverToBoxAdapter(child: SpeechProfileCardWidget()),
+            const SliverToBoxAdapter(child: UpdateFirmwareCardWidget()),
             SliverToBoxAdapter(child: getMemoryCaptureWidget()),
             getProcessingMemoriesWidget(memoryProvider.processingMemories),
             if (memoryProvider.groupedMemories.isEmpty && !memoryProvider.isLoadingMemories)
@@ -99,7 +100,6 @@ class _MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClie
                     } else {
                       var date = memoryProvider.groupedMemories.keys.elementAt(index);
                       List<ServerMemory> memoriesForDate = memoryProvider.groupedMemories[date]!;
-                      print('date: $date, memories: ${memoriesForDate.length}');
 
                       return Column(
                         mainAxisSize: MainAxisSize.min,

--- a/app/lib/pages/memories/widgets/processing_capture.dart
+++ b/app/lib/pages/memories/widgets/processing_capture.dart
@@ -144,9 +144,7 @@ class _MemoryCaptureWidgetState extends State<MemoryCaptureWidget> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
-          deviceProvider.connectedDevice == null &&
-                  !isUsingPhoneMic &&
-                  havingCapturingMemory
+          deviceProvider.connectedDevice == null && !isUsingPhoneMic && havingCapturingMemory
               ? Row(
                   children: [
                     const Text(

--- a/app/lib/pages/memory_capturing/page.dart
+++ b/app/lib/pages/memory_capturing/page.dart
@@ -1,10 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/backend/schema/memory.dart';
 import 'package:friend_private/pages/capture/widgets/widgets.dart';
 import 'package:friend_private/pages/memory_detail/page.dart';
 import 'package:friend_private/providers/capture_provider.dart';
 import 'package:friend_private/providers/device_provider.dart';
-import 'package:friend_private/widgets/dialog.dart';
+import 'package:friend_private/widgets/confirmation_dialog.dart';
 import 'package:gradient_borders/box_borders/gradient_box_border.dart';
 import 'package:provider/provider.dart';
 
@@ -23,11 +24,13 @@ class MemoryCapturingPage extends StatefulWidget {
 class _MemoryCapturingPageState extends State<MemoryCapturingPage> with TickerProviderStateMixin {
   final scaffoldKey = GlobalKey<ScaffoldState>();
   TabController? _controller;
+  late bool showSummarizeConfirmation;
 
   @override
   void initState() {
     _controller = TabController(length: 2, vsync: this, initialIndex: 0);
     _controller!.addListener(() => setState(() {}));
+    showSummarizeConfirmation = SharedPreferencesUtil().showSummarizeConfirmation;
     super.initState();
   }
 
@@ -126,70 +129,95 @@ class _MemoryCapturingPageState extends State<MemoryCapturingPage> with TickerPr
                                   deviceProvider.connectedDevice)
                         ],
                       ),
-                      ListView(
-                        shrinkWrap: true,
-                        children: [
-                          const SizedBox(height: 80),
-                          Center(
-                            child: Padding(
-                              padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                              child: Text(
-                                provider.segments.isEmpty
-                                    ? "No summary"
-                                    : "We summarize conversations 2 minutes after they end\n\n\nWant to end it now?",
-                                textAlign: TextAlign.center,
-                                style: const TextStyle(fontSize: 16),
+                      Padding(
+                        padding: const EdgeInsets.only(top: 140),
+                        child: ListView(
+                          shrinkWrap: true,
+                          children: [
+                            const SizedBox(height: 80),
+                            Center(
+                              child: Padding(
+                                padding: const EdgeInsets.symmetric(horizontal: 32.0),
+                                child: Text(
+                                  provider.segments.isEmpty
+                                      ? "No summary"
+                                      : "We summarize conversations 2 minutes after they end\n\nWant to end it now?",
+                                  textAlign: TextAlign.center,
+                                  style: const TextStyle(fontSize: 16),
+                                ),
                               ),
                             ),
-                          ),
-                          const SizedBox(
-                            height: 16,
-                          ),
-                          provider.segments.isEmpty
-                              ? const SizedBox()
-                              : Container(
-                                  decoration: BoxDecoration(
-                                    border: const GradientBoxBorder(
-                                      gradient: LinearGradient(colors: [
-                                        Color.fromARGB(127, 208, 208, 208),
-                                        Color.fromARGB(127, 188, 99, 121),
-                                        Color.fromARGB(127, 86, 101, 182),
-                                        Color.fromARGB(127, 126, 190, 236)
-                                      ]),
-                                      width: 2,
+                            const SizedBox(
+                              height: 16,
+                            ),
+                            provider.segments.isEmpty
+                                ? const SizedBox()
+                                : Container(
+                                    decoration: BoxDecoration(
+                                      border: const GradientBoxBorder(
+                                        gradient: LinearGradient(colors: [
+                                          Color.fromARGB(127, 208, 208, 208),
+                                          Color.fromARGB(127, 188, 99, 121),
+                                          Color.fromARGB(127, 86, 101, 182),
+                                          Color.fromARGB(127, 126, 190, 236)
+                                        ]),
+                                        width: 2,
+                                      ),
+                                      borderRadius: BorderRadius.circular(12),
                                     ),
-                                    borderRadius: BorderRadius.circular(12),
-                                  ),
-                                  margin: const EdgeInsets.symmetric(horizontal: 48),
-                                  child: MaterialButton(
-                                    onPressed: () async {
-                                      context.read<CaptureProvider>().createMemory();
-                                      showDialog(
-                                        context: context,
-                                        builder: (context) => getDialog(
-                                          context,
-                                          () {
-                                            Navigator.pop(context);
-                                            Navigator.pop(context);
-                                          },
-                                          () {
-                                            Navigator.pop(context);
-                                            Navigator.pop(context);
-                                          },
-                                          "Creating Memory",
-                                          "Memory creation has been started. You will be notified once it is ready.",
-                                          singleButton: true,
-                                        ),
-                                      );
-                                    },
-                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                                    child: const Padding(
+                                    margin: const EdgeInsets.symmetric(horizontal: 48),
+                                    child: MaterialButton(
+                                      onPressed: () async {
+                                        print(showSummarizeConfirmation);
+                                        if (!showSummarizeConfirmation) {
+                                          context.read<CaptureProvider>().createMemory();
+                                          return;
+                                        }
+                                        showDialog(
+                                            context: context,
+                                            builder: (context) {
+                                              return StatefulBuilder(builder: (context, setState) {
+                                                return ConfirmationDialog(
+                                                  title: "Stop Recording?",
+                                                  description:
+                                                      "Are you sure you want to stop recording and summarise the conversation now?",
+                                                  checkboxValue: !showSummarizeConfirmation,
+                                                  checkboxText: "Don't ask me again",
+                                                  updateCheckboxValue: (value) {
+                                                    if (value != null) {
+                                                      setState(() {
+                                                        showSummarizeConfirmation = !value;
+                                                      });
+                                                    }
+                                                  },
+                                                  onCancel: () {
+                                                    Navigator.of(context).pop();
+                                                  },
+                                                  onConfirm: () {
+                                                    SharedPreferencesUtil().showSummarizeConfirmation =
+                                                        showSummarizeConfirmation;
+                                                    context.read<CaptureProvider>().createMemory();
+                                                    Navigator.of(context).pop();
+                                                  },
+                                                );
+                                              });
+                                            });
+                                      },
+                                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
+                                      child: const Padding(
                                         padding: EdgeInsets.symmetric(horizontal: 12, vertical: 0),
-                                        child:
-                                            Text('Summarise Now', style: TextStyle(color: Colors.white, fontSize: 16))),
+                                        child: Text(
+                                          'Stop Recording',
+                                          style: TextStyle(
+                                            color: Colors.white,
+                                            fontSize: 16,
+                                          ),
+                                        ),
+                                      ),
+                                    ),
                                   ),
-                                ),
-                        ],
+                          ],
+                        ),
                       ),
                     ],
                   ),

--- a/app/lib/pages/memory_detail/memory_detail_provider.dart
+++ b/app/lib/pages/memory_detail/memory_detail_provider.dart
@@ -23,6 +23,7 @@ class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
   int selectedTab = 0;
   bool isLoading = false;
   bool loadingReprocessMemory = false;
+  String reprocessMemoryId = '';
 
   final scaffoldKey = GlobalKey<ScaffoldState>();
   final focusTitleField = FocusNode();
@@ -100,6 +101,11 @@ class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
     notifyListeners();
   }
 
+  void updateRepocessMemoryId(String id) {
+    reprocessMemoryId = id;
+    notifyListeners();
+  }
+
   void updateMemory(int memIdx, DateTime date) {
     memoryIdx = memIdx;
     selectedDate = date;
@@ -139,10 +145,12 @@ class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
   Future<bool> reprocessMemory() async {
     debugPrint('_reProcessMemory');
     updateReprocessMemoryLoadingState(true);
+    updateRepocessMemoryId(memory.id);
     try {
       var updatedMemory = await reProcessMemoryServer(memory.id);
       MixpanelManager().reProcessMemory(memory);
       updateReprocessMemoryLoadingState(false);
+      updateRepocessMemoryId('');
       if (updatedMemory == null) {
         notifyError('REPROCESS_FAILED');
         notifyListeners();
@@ -163,6 +171,7 @@ class MemoryDetailProvider extends ChangeNotifier with MessageNotifierMixin {
       });
       notifyError('REPROCESS_FAILED');
       updateReprocessMemoryLoadingState(false);
+      updateRepocessMemoryId('');
       notifyListeners();
       return false;
     }

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -300,7 +300,7 @@ class ReprocessDiscardedWidget extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Consumer<MemoryDetailProvider>(builder: (context, provider, child) {
-      if (provider.loadingReprocessMemory) {
+      if (provider.loadingReprocessMemory && provider.reprocessMemoryId == provider.memory.id) {
         return const Center(
           child: Padding(
             padding: EdgeInsets.only(top: 18.0),

--- a/app/lib/pages/settings/calendar.dart
+++ b/app/lib/pages/settings/calendar.dart
@@ -68,11 +68,14 @@ class _CalendarPageState extends State<CalendarPage> {
                   ],
                 ),
               ),
-              const Text(
-                'Omi can automatically schedule events from your conversations, or ask for your confirmation first.',
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  color: Colors.grey,
+              const Padding(
+                padding: EdgeInsets.symmetric(horizontal: 12, vertical: 2),
+                child: Text(
+                  'Omi can automatically schedule events from your conversations, or ask for your confirmation first.',
+                  textAlign: TextAlign.center,
+                  style: TextStyle(
+                    color: Colors.grey,
+                  ),
                 ),
               ),
               const SizedBox(height: 32),

--- a/app/lib/pages/settings/delete_account.dart
+++ b/app/lib/pages/settings/delete_account.dart
@@ -43,7 +43,7 @@ class _DeleteAccountState extends State<DeleteAccount> {
   @override
   Widget build(BuildContext context) {
     return PopScope(
-      canPop: isDeleteing,
+      canPop: !isDeleteing,
       child: Scaffold(
         backgroundColor: Theme.of(context).colorScheme.primary,
         appBar: AppBar(

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -30,7 +30,6 @@ import 'package:friend_private/utils/features/calendar.dart';
 import 'package:friend_private/utils/logger.dart';
 import 'package:friend_private/utils/memories/integrations.dart';
 import 'package:friend_private/utils/memories/process.dart';
-import 'package:friend_private/utils/other/notifications.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:uuid/uuid.dart';
 
@@ -246,10 +245,6 @@ class CaptureProvider extends ChangeNotifier
       debugPrint("Memory is not found, processing memory ${event.processingMemoryId}");
       return;
     }
-    createNotification(
-      title: event.memory!.structured.title,
-      body: event.memory!.structured.overview,
-    );
     _processOnMemoryCreated(event.memory, event.messages ?? []);
   }
 

--- a/app/lib/utils/analytics/intercom.dart
+++ b/app/lib/utils/analytics/intercom.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/env/env.dart';
 import 'package:intercom_flutter/intercom_flutter.dart';
@@ -26,6 +28,10 @@ class IntercomManager {
 
   Future displayChargingArticle() async {
     return await intercom.displayArticle('9907475-how-to-charge-the-device');
+  }
+
+  Future displayFirmwareUpdateArticle() async {
+    return await intercom.displayArticle('9918118-updating-your-friend-device-firmware');
   }
 
   Future logEvent(String eventName, {Map<String, dynamic>? metaData}) async {

--- a/app/lib/widgets/confirmation_dialog.dart
+++ b/app/lib/widgets/confirmation_dialog.dart
@@ -1,0 +1,118 @@
+import 'dart:io';
+
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class ConfirmationDialog extends StatelessWidget {
+  final String title;
+  final String description;
+  final String checkboxText;
+  final bool checkboxValue;
+  final void Function(bool? value) updateCheckboxValue;
+  final String? cancelText;
+  final String? confirmText;
+  final void Function() onConfirm;
+  final void Function() onCancel;
+
+  const ConfirmationDialog({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.checkboxText,
+    required this.checkboxValue,
+    required this.updateCheckboxValue,
+    this.cancelText,
+    this.confirmText,
+    required this.onConfirm,
+    required this.onCancel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    if (Platform.isAndroid) {
+      return AlertDialog(
+        contentPadding: const EdgeInsets.only(top: 10, left: 24, right: 24, bottom: 10),
+        title: Text(title),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 16),
+            Text(
+              description,
+              textAlign: TextAlign.start,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              children: [
+                SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: Checkbox(
+                    value: checkboxValue,
+                    onChanged: updateCheckboxValue,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(checkboxText),
+              ],
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: onCancel,
+            child: Text(cancelText ?? "Cancel", style: const TextStyle(color: Colors.white)),
+          ),
+          TextButton(
+            onPressed: () {
+              Navigator.of(context).pop();
+            },
+            child: Text(confirmText ?? "Confirm", style: const TextStyle(color: Colors.white)),
+          ),
+        ],
+      );
+    } else {
+      return CupertinoAlertDialog(
+        title: Text(title),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const SizedBox(height: 16),
+            Text(
+              description,
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CupertinoCheckbox(
+                    value: checkboxValue,
+                    onChanged: updateCheckboxValue,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Text(checkboxText),
+              ],
+            ),
+          ],
+        ),
+        actions: [
+          CupertinoDialogAction(
+            onPressed: onCancel,
+            child: Text(cancelText ?? "Cancel", style: const TextStyle(color: Colors.white)),
+          ),
+          CupertinoDialogAction(
+            onPressed: onConfirm,
+            child: Text(confirmText ?? "Confirm", style: const TextStyle(color: Colors.white)),
+          ),
+        ],
+      );
+    }
+  }
+}


### PR DESCRIPTION
- [x] Teach omi your voice should not appear if 1.0.2 device is connected, also not if no device is connected
- [x] on memories page, when 1.0.2 instead of "Teach omi your voice" should appear update your firmware
- [x] Article on memories (https://intercom.help/omi-37041f50f654/en/articles/9932672-what-are-memories-in-omi-and-how-are-they-created)
- [x] Confirmation dialog for summarise now and change summarise now to stop recording
- [x] Reusable confirmation dialog widget with check
- [x] All discarded memories showing as reporcessing when only one is memory is triggered for reporcessing
- [x] Remove notification on when memory created
- [x] Fix delete account back navigation
<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Added a confirmation dialog for stopping recording and summarizing conversations, enhancing user control over these actions.
- New Feature: Introduced an `UpdateFirmwareCardWidget` to facilitate device firmware updates directly from the Memories page.
- Refactor: Improved state management in `MemoryDetailProvider` for memory reprocessing, ensuring smoother UI transitions.
- Style: Adjusted text display padding and style on the Calendar settings page for better readability.
- Chore: Removed automatic notifications for memories in the `CaptureProvider` class, reducing unnecessary alerts.
- New Feature: Added a function to display articles related to device firmware updates, providing users with helpful information.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->