### PR TITLE
Stop scanning if device is connected

### DIFF
--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -68,6 +68,12 @@ class DeviceService implements IDeviceService {
       return;
     }
 
+    if (_connection?.status == DeviceConnectionState.connected) {
+      debugPrint("A device is already connected or is being connected. Skipping scan.");
+      stop();
+      return;
+    }
+
     // Listen to scan results, always re-emits previous results
     var discoverSubscription = FlutterBluePlus.scanResults.listen(
       (results) async {


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

```
---
- Bug Fix: Enhanced the device scanning process in our services. The application will now avoid unnecessary scans when a device is already connected or in the process of connecting. This improvement leads to better performance and less resource usage, providing a smoother user experience.
```
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->