### PR TITLE
Fix memory detail page crash while viewing in progress memory

### DIFF
--- a/app/lib/pages/memory_capturing/page.dart
+++ b/app/lib/pages/memory_capturing/page.dart
@@ -48,10 +48,10 @@ class _MemoryCapturingPageState extends State<MemoryCapturingPage> with TickerPr
     return Consumer2<CaptureProvider, DeviceProvider>(
       builder: (context, provider, deviceProvider, child) {
         // Track memory
-        if ((provider.memoryProvider?.memories ?? []).isNotEmpty &&
-            (provider.memoryProvider!.memories.first.id != widget.topMemoryId || widget.topMemoryId == null)) {
-          _pushNewMemory(context, provider.memoryProvider!.memories.first);
-        }
+        // if ((provider.memoryProvider?.memories ?? []).isNotEmpty &&
+        //     (provider.memoryProvider!.memories.first.id != widget.topMemoryId || widget.topMemoryId == null)) {
+        //   _pushNewMemory(context, provider.memoryProvider!.memories.first);
+        // }
 
         // Memory source
         var memorySource = MemorySource.friend;

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
 
-import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_foreground_task/flutter_foreground_task.dart';
 import 'package:flutter_provider_utilities/flutter_provider_utilities.dart';


### PR DESCRIPTION
Commented out the top memory tracking on the `MemoryCapturingPage` because the recently improved `memory_detail_provider` no longer creates a copy of the memory to be viewed. Instead, it directly accesses the memory from the `memory_provider`'s list of memories. As a result, the `MemoryCapturingPage` will always have the memory at the 0th index from the `memory_provider`'s memories (which is also the in-progress memory).



https://github.com/user-attachments/assets/11690174-2195-4469-9f44-dfe50e2eb11a


<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

---
- Refactor: Updated the memory tracking logic in `_MemoryCapturingPageState`. The first memory from `memory_provider` is no longer pushed due to changes in how memory is accessed, improving the efficiency of memory usage.
- Chore: Removed unnecessary import of `collection` package, simplifying the codebase and reducing dependencies.
---
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->