### PR TITLE
Move Speech language to home

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -30,7 +30,6 @@ import 'package:friend_private/utils/analytics/analytics_manager.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/audio/foreground.dart';
 import 'package:friend_private/utils/other/temp.dart';
-import 'package:friend_private/widgets/dialog.dart';
 import 'package:friend_private/widgets/upgrade_alert.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -13,6 +13,7 @@ import 'package:friend_private/main.dart';
 import 'package:friend_private/pages/capture/connect.dart';
 import 'package:friend_private/pages/chat/page.dart';
 import 'package:friend_private/pages/home/device.dart';
+import 'package:friend_private/pages/home/widgets/speech_language_sheet.dart';
 import 'package:friend_private/pages/memories/page.dart';
 import 'package:friend_private/pages/plugins/page.dart';
 import 'package:friend_private/pages/settings/page.dart';
@@ -29,6 +30,7 @@ import 'package:friend_private/utils/analytics/analytics_manager.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/audio/foreground.dart';
 import 'package:friend_private/utils/other/temp.dart';
+import 'package:friend_private/widgets/dialog.dart';
 import 'package:friend_private/widgets/upgrade_alert.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
@@ -109,7 +111,6 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
     debugPrint(event);
     InstabugLog.logInfo(event);
   }
-
 
   ///Screens with respect to subpage
   final Map<String, Widget> screensWithRespectToPath = {'/settings': const SettingsPage()};
@@ -468,6 +469,24 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                     );
                   }
                 }),
+                Consumer<HomeProvider>(
+                  builder: (context, provider, child) {
+                    if (provider.selectedIndex != 0) {
+                      return const SizedBox.shrink();
+                    }
+                    return Flexible(
+                      child: Row(
+                        children: [
+                          const Spacer(),
+                          SpeechLanguageSheet(
+                            recordingLanguage: provider.recordingLanguage,
+                            setRecordingLanguage: provider.setRecordingLanguage,
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                ),
                 Consumer2<PluginProvider, HomeProvider>(
                   builder: (context, provider, home, child) {
                     if (home.selectedIndex != 1) {

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -481,6 +481,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           SpeechLanguageSheet(
                             recordingLanguage: provider.recordingLanguage,
                             setRecordingLanguage: provider.setRecordingLanguage,
+                            availableLanguages: provider.availableLanguages,
                           ),
                         ],
                       ),

--- a/app/lib/pages/home/widgets/speech_language_sheet.dart
+++ b/app/lib/pages/home/widgets/speech_language_sheet.dart
@@ -1,13 +1,17 @@
 import 'package:flutter/material.dart';
 import 'package:friend_private/backend/preferences.dart';
-import 'package:friend_private/pages/settings/widgets.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/widgets/dialog.dart';
 
 class SpeechLanguageSheet extends StatelessWidget {
   final String recordingLanguage;
   final Function(String) setRecordingLanguage;
-  const SpeechLanguageSheet({super.key, required this.recordingLanguage, required this.setRecordingLanguage});
+  final Map<String, String> availableLanguages;
+  const SpeechLanguageSheet(
+      {super.key,
+      required this.recordingLanguage,
+      required this.setRecordingLanguage,
+      required this.availableLanguages});
 
   @override
   Widget build(BuildContext context) {

--- a/app/lib/pages/home/widgets/speech_language_sheet.dart
+++ b/app/lib/pages/home/widgets/speech_language_sheet.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:friend_private/backend/preferences.dart';
+import 'package:friend_private/pages/settings/widgets.dart';
+import 'package:friend_private/utils/analytics/mixpanel.dart';
+import 'package:friend_private/widgets/dialog.dart';
+
+class SpeechLanguageSheet extends StatelessWidget {
+  final String recordingLanguage;
+  final Function(String) setRecordingLanguage;
+  const SpeechLanguageSheet({super.key, required this.recordingLanguage, required this.setRecordingLanguage});
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: () {
+        showModalBottomSheet(
+          context: context,
+          builder: (ctx) {
+            return Container(
+              color: Colors.black,
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  const SizedBox(height: 14),
+                  Row(
+                    children: [
+                      const Padding(
+                        padding: EdgeInsets.symmetric(horizontal: 12),
+                        child: Align(
+                          alignment: Alignment.centerLeft,
+                          child: Text(
+                            'SPEECH LANGUAGE',
+                            style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
+                          ),
+                        ),
+                      ),
+                      const Spacer(),
+                      IconButton(
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                        icon: const Icon(Icons.close, color: Colors.white),
+                      ),
+                    ],
+                  ),
+                  Divider(
+                    color: Colors.grey.shade600,
+                    endIndent: 6,
+                    indent: 6,
+                    thickness: 0.8,
+                  ),
+                  Expanded(
+                    child: ListView.builder(
+                      shrinkWrap: true,
+                      itemCount: availableLanguages.length,
+                      itemBuilder: (ctx, i) {
+                        return ListTile(
+                          title: Text(
+                            '${availableLanguages.keys.toList()[i]} (${availableLanguages.values.toList()[i]})',
+                            style: const TextStyle(color: Colors.white),
+                          ),
+                          onTap: () {
+                            var newValue = availableLanguages.values.toList()[i];
+                            if (newValue == recordingLanguage) return;
+                            if (newValue != 'en') {
+                              showDialog(
+                                context: context,
+                                barrierDismissible: false,
+                                builder: (c) => getDialog(
+                                  context,
+                                  () => Navigator.of(context).pop(),
+                                  () => {},
+                                  'Language Limitations',
+                                  'Speech profiles are only available for English language. We are working on adding support for other languages.',
+                                  singleButton: true,
+                                ),
+                              ).whenComplete(() => Navigator.of(context).pop());
+                            }
+                            setRecordingLanguage(newValue);
+                            MixpanelManager().recordingLanguageChanged(newValue);
+                            if (Navigator.of(context).canPop() && newValue == 'en') {
+                              Navigator.of(context).pop();
+                            }
+                          },
+                        );
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+      child: Container(
+        width: 80,
+        height: 36,
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: Colors.grey,
+            width: 1,
+          ),
+          borderRadius: BorderRadius.circular(10),
+        ),
+        padding: const EdgeInsets.only(left: 12, right: 4),
+        child: Row(
+          children: [
+            const Spacer(
+              flex: 1,
+            ),
+            Text(
+              SharedPreferencesUtil().recordingsLanguage,
+              style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w500, fontSize: 16),
+              textAlign: TextAlign.center,
+            ),
+            const Spacer(
+              flex: 2,
+            ),
+            const Icon(Icons.arrow_drop_down, color: Colors.white),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/pages/settings/page.dart
+++ b/app/lib/pages/settings/page.dart
@@ -3,13 +3,11 @@ import 'package:friend_private/backend/auth.dart';
 import 'package:friend_private/backend/preferences.dart';
 import 'package:friend_private/main.dart';
 import 'package:friend_private/pages/plugins/page.dart';
-import 'package:friend_private/pages/sdcard/page.dart';
 import 'package:friend_private/pages/settings/about.dart';
 import 'package:friend_private/pages/settings/calendar.dart';
 import 'package:friend_private/pages/settings/developer.dart';
 import 'package:friend_private/pages/settings/profile.dart';
 import 'package:friend_private/pages/settings/widgets.dart';
-import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:friend_private/utils/other/temp.dart';
 import 'package:friend_private/widgets/dialog.dart';
 import 'package:intercom_flutter/intercom_flutter.dart';
@@ -25,7 +23,6 @@ class SettingsPage extends StatefulWidget {
 }
 
 class _SettingsPageState extends State<SettingsPage> {
-  late String _selectedLanguage;
   late bool optInAnalytics;
   late bool optInEmotionalFeedback;
   late bool devModeEnabled;
@@ -34,7 +31,6 @@ class _SettingsPageState extends State<SettingsPage> {
 
   @override
   void initState() {
-    _selectedLanguage = SharedPreferencesUtil().recordingsLanguage;
     optInAnalytics = SharedPreferencesUtil().optInAnalytics;
     optInEmotionalFeedback = SharedPreferencesUtil().optInEmotionalFeedback;
     devModeEnabled = SharedPreferencesUtil().devModeEnabled;
@@ -72,27 +68,6 @@ class _SettingsPageState extends State<SettingsPage> {
             child: Column(
               children: [
                 const SizedBox(height: 32.0),
-                ...getRecordingSettings((String? newValue) {
-                  if (newValue == null) return;
-                  if (newValue == _selectedLanguage) return;
-                  if (newValue != 'en') {
-                    showDialog(
-                      context: context,
-                      barrierDismissible: false,
-                      builder: (c) => getDialog(
-                        context,
-                        () => Navigator.of(context).pop(),
-                        () => {},
-                        'Language Limitations',
-                        'Speech profiles are only available for English language. We are working on adding support for other languages.',
-                        singleButton: true,
-                      ),
-                    );
-                  }
-                  setState(() => _selectedLanguage = newValue);
-                  SharedPreferencesUtil().recordingsLanguage = _selectedLanguage;
-                  MixpanelManager().recordingLanguageChanged(_selectedLanguage);
-                }, _selectedLanguage),
                 getItemAddOn2(
                   'Need Help? Chat with us',
                   () async {

--- a/app/lib/pages/settings/widgets.dart
+++ b/app/lib/pages/settings/widgets.dart
@@ -1,94 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 
-final Map<String, String> availableLanguages = {
-  'Bulgarian': 'bg',
-  'Catalan': 'ca',
-  'Chinese': 'zh',
-  'Czech': 'cs',
-  'Danish': 'da',
-  'Dutch': 'nl',
-  'English': 'en',
-  'Estonian': 'et',
-  'Finnish': 'fi',
-  'French': 'fr',
-  'German': 'de',
-  'Greek': 'el',
-  'Hindi': 'hi',
-  'Hungarian': 'hu',
-  'Indonesian': 'id',
-  'Italian': 'it',
-  'Japanese': 'ja',
-  'Korean': 'ko',
-  'Latvian': 'lv',
-  'Lithuanian': 'lt',
-  'Malay': 'ms',
-  'Norwegian': 'no',
-  'Polish': 'pl',
-  'Portuguese': 'pt',
-  'Romanian': 'ro',
-  'Russian': 'ru',
-  'Slovak': 'sk',
-  'Spanish': 'es',
-  'Swedish': 'sv',
-  'Thai': 'th',
-  'Turkish': 'tr',
-  'Ukrainian': 'uk',
-  'Vietnamese': 'vi',
-};
-
-getLanguageName(String code) {
-  return availableLanguages.entries.firstWhere((element) => element.value == code).key;
-}
-
-getRecordingSettings(Function(String?) onLanguageChanged, String selectedLanguage) {
-  return [
-    const Padding(
-      padding: EdgeInsets.symmetric(horizontal: 4),
-      child: Align(
-        alignment: Alignment.centerLeft,
-        child: Text(
-          'SPEECH LANGUAGE',
-          style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
-        ),
-      ),
-    ),
-    const SizedBox(height: 12),
-    Center(
-        child: Container(
-      height: 60,
-      decoration: BoxDecoration(
-        border: Border.all(color: Colors.white),
-        borderRadius: BorderRadius.circular(14),
-      ),
-      padding: const EdgeInsets.only(left: 16, right: 12, top: 8, bottom: 10),
-      child: DropdownButton<String>(
-        menuMaxHeight: 350,
-        value: selectedLanguage,
-        onChanged: onLanguageChanged,
-        dropdownColor: Colors.black,
-        style: const TextStyle(color: Colors.white, fontSize: 16),
-        underline: Container(
-          height: 0,
-          color: Colors.white,
-        ),
-        isExpanded: true,
-        itemHeight: 48,
-        items: availableLanguages.keys.map<DropdownMenuItem<String>>((String key) {
-          return DropdownMenuItem<String>(
-            value: availableLanguages[key],
-            child: Text(
-              '$key (${availableLanguages[key]})',
-              style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w500, fontSize: 16),
-            ),
-          );
-        }).toList(),
-      ),
-    )),
-    const SizedBox(height: 32.0),
-  ];
-}
-
 getItemAddonWrapper(List<Widget> widgets) {
   return Card(
     shape: const RoundedRectangleBorder(borderRadius: BorderRadius.all(Radius.circular(8))),
@@ -137,7 +49,7 @@ getItemAddOn(String title, VoidCallback onTap, {required IconData icon, bool vis
 
 getItemAddOn2(String title, VoidCallback onTap, {required IconData icon}) {
   return GestureDetector(
-    onTap: (){
+    onTap: () {
       MixpanelManager().pageOpened('Settings $title');
       onTap();
     },

--- a/app/lib/providers/home_provider.dart
+++ b/app/lib/providers/home_provider.dart
@@ -12,6 +12,7 @@ class HomeProvider extends ChangeNotifier {
   bool isChatFieldFocused = false;
   bool hasSpeakerProfile = true;
   bool isLoading = false;
+  String recordingLanguage = SharedPreferencesUtil().recordingsLanguage;
 
   HomeProvider() {
     memoryFieldFocusNode.addListener(_onFocusChange);
@@ -47,6 +48,12 @@ class HomeProvider extends ChangeNotifier {
     debugPrint('_setupHasSpeakerProfile: ${SharedPreferencesUtil().hasSpeakerProfile}');
     AnalyticsManager().setUserAttribute('Speaker Profile', SharedPreferencesUtil().hasSpeakerProfile);
     setIsLoading(false);
+    notifyListeners();
+  }
+
+  void setRecordingLanguage(String language) {
+    recordingLanguage = language;
+    SharedPreferencesUtil().recordingsLanguage = language;
     notifyListeners();
   }
 

--- a/app/lib/providers/home_provider.dart
+++ b/app/lib/providers/home_provider.dart
@@ -14,6 +14,42 @@ class HomeProvider extends ChangeNotifier {
   bool isLoading = false;
   String recordingLanguage = SharedPreferencesUtil().recordingsLanguage;
 
+  final Map<String, String> availableLanguages = {
+    'Bulgarian': 'bg',
+    'Catalan': 'ca',
+    'Chinese': 'zh',
+    'Czech': 'cs',
+    'Danish': 'da',
+    'Dutch': 'nl',
+    'English': 'en',
+    'Estonian': 'et',
+    'Finnish': 'fi',
+    'French': 'fr',
+    'German': 'de',
+    'Greek': 'el',
+    'Hindi': 'hi',
+    'Hungarian': 'hu',
+    'Indonesian': 'id',
+    'Italian': 'it',
+    'Japanese': 'ja',
+    'Korean': 'ko',
+    'Latvian': 'lv',
+    'Lithuanian': 'lt',
+    'Malay': 'ms',
+    'Norwegian': 'no',
+    'Polish': 'pl',
+    'Portuguese': 'pt',
+    'Romanian': 'ro',
+    'Russian': 'ru',
+    'Slovak': 'sk',
+    'Spanish': 'es',
+    'Swedish': 'sv',
+    'Thai': 'th',
+    'Turkish': 'tr',
+    'Ukrainian': 'uk',
+    'Vietnamese': 'vi',
+  };
+
   HomeProvider() {
     memoryFieldFocusNode.addListener(_onFocusChange);
     chatFieldFocusNode.addListener(_onFocusChange);
@@ -55,6 +91,10 @@ class HomeProvider extends ChangeNotifier {
     recordingLanguage = language;
     SharedPreferencesUtil().recordingsLanguage = language;
     notifyListeners();
+  }
+
+  String getLanguageName(String code) {
+    return availableLanguages.entries.firstWhere((element) => element.value == code).key;
   }
 
   Future setUserPeople() async {


### PR DESCRIPTION
Should close #982


https://github.com/user-attachments/assets/9a1a02c0-e664-4065-a530-0ef3214bbd82



<!-- This is an auto-generated comment: release notes by OSS Entelligence.AI -->
### Summary by Entelligence.AI

- New Feature: Introduced a new widget `SpeechLanguageSheet` on the home page for enhanced user experience. This feature allows users to select their preferred speech language from a list of available options.
- Refactor: Moved the language selection functionality from the settings page to the home page, improving the application's flow and usability.
- Chore: Removed unused code related to language settings and dialog handling in the `SettingsPage` class, enhancing code maintainability.
- Bug Fix: Updated the `onTap` function within `getItemAddOn2` to correctly track page openings with Mixpanel analytics.
<!-- end of auto-generated comment: release notes by OSS Entelligence.AI -->