### PR TITLE
Set topic category as other if pydantic validation fails for chat

### DIFF
--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -5,7 +5,7 @@ import tiktoken
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ValidationError
 
 from models.chat import Message
 from models.facts import Fact
@@ -273,8 +273,11 @@ def retrieve_context_topics(messages: List[Message]) -> List[str]:
     {Message.get_messages_as_string(messages)}
     '''.replace('    ', '').strip()
     with_parser = llm_mini.with_structured_output(TopicsContext)
-    response: TopicsContext = with_parser.invoke(prompt)
-    topics = list(map(lambda x: str(x.value).capitalize(), response.topics))
+    try:
+        response: TopicsContext = with_parser.invoke(prompt)
+        topics = list(map(lambda x: str(x.value).capitalize(), response.topics))
+    except ValidationError:
+        topics = [CategoryEnum.other.value.capitalize()]
     return topics
 
 


### PR DESCRIPTION
<img width="1346" alt="Screenshot 2024-10-10 at 7 41 56 PM" src="https://github.com/user-attachments/assets/c39241e0-cd41-442f-a96e-d83cc7c6a71d">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for context topic retrieval, preventing application crashes due to validation errors.
	- Enhanced robustness of memory context parameter retrieval by handling exceptions gracefully.

These changes ensure a smoother user experience by maintaining application stability even when unexpected issues arise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->