### PR TITLE
Stop discover service if device connected and misc changes

### DIFF
--- a/app/lib/pages/settings/device_settings.dart
+++ b/app/lib/pages/settings/device_settings.dart
@@ -35,8 +35,10 @@ class _DeviceSettingsState extends State<DeviceSettings> {
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) {
-      if (context.read<DeviceProvider>().connectedDevice!.modelNumber == 'Unknown') {
-        context.read<DeviceProvider>().getDeviceInfo();
+      if (context.read<DeviceProvider>().connectedDevice != null) {
+        if (context.read<DeviceProvider>().connectedDevice!.modelNumber == 'Unknown') {
+          context.read<DeviceProvider>().getDeviceInfo();
+        }
       }
     });
     super.initState();
@@ -183,36 +185,34 @@ List<Widget> deviceSettingsWidgets(BtDevice? device, BuildContext context) {
         ),
       ),
     ),
-  GestureDetector(
-    onTap: () {
-      if (!SharedPreferencesUtil().deviceIsV2) {
-        showDialog(
-          context: context,
-          builder: (c) => getDialog(
-            context,
-            () => Navigator.of(context).pop(),
-            () => {},
-            'V2 undetected',
-            'We see that you either have a V1 device or your device is not connected. SD Card functionality is available only for V2 devices.',
+    GestureDetector(
+      onTap: () {
+        if (!SharedPreferencesUtil().deviceIsV2) {
+          showDialog(
+            context: context,
+            builder: (c) => getDialog(
+              context,
+              () => Navigator.of(context).pop(),
+              () => {},
+              'V2 undetected',
+              'We see that you either have a V1 device or your device is not connected. SD Card functionality is available only for V2 devices.',
               singleButton: true,
             ),
           );
-      }
-      else {
-            var page = const SdCardCapturePage();
-            routeToPage(context, page);
-      }
-  },
-    child: ListTile(
-    title: const Text('SD Card Import'),
-    subtitle: Text(''),
-    trailing: const Icon(
-      Icons.arrow_forward_ios,
-      size: 16,
+        } else {
+          var page = const SdCardCapturePage();
+          routeToPage(context, page);
+        }
+      },
+      child: ListTile(
+        title: const Text('SD Card Import'),
+        subtitle: Text(''),
+        trailing: const Icon(
+          Icons.arrow_forward_ios,
+          size: 16,
+        ),
+      ),
     ),
-  ),
-  ),
-
     ListTile(
       title: const Text('Hardware Revision'),
       subtitle: Text(device?.hardwareRevision ?? 'XIAO'),

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -248,7 +248,7 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
 
     ServiceManager.instance().device.subscribe(this, this);
 
-    _findDevicesTimer = Timer.periodic(const Duration(seconds: 4), (timer) async {
+    _findDevicesTimer = Timer.periodic(const Duration(seconds: 4), (_) async {
       if (deviceProvider != null && deviceProvider!.isConnected) {
         _findDevicesTimer?.cancel();
         return;

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -249,7 +249,12 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
     ServiceManager.instance().device.subscribe(this, this);
 
     _findDevicesTimer = Timer.periodic(const Duration(seconds: 4), (timer) async {
-      ServiceManager.instance().device.discover();
+      if (deviceProvider != null && deviceProvider!.isConnected) {
+        _findDevicesTimer?.cancel();
+        return;
+      } else {
+        ServiceManager.instance().device.discover();
+      }
     });
   }
 


### PR DESCRIPTION
The _findDevicesTimer never stops if the user does not connect the device by tapping on the item in the found devices list. So the discover service will keep running forever if the device is connected automatically on the Find Device page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced device discovery process to optimize connection management.

- **Bug Fixes**
	- Improved null safety in device settings to prevent potential errors.

- **Refactor**
	- Reorganized code for better readability and clarity in device settings functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->