### PR TITLE
Stop scanning devices when FindDevicePage disposed

### DIFF
--- a/app/lib/pages/memories/widgets/capture.dart
+++ b/app/lib/pages/memories/widgets/capture.dart
@@ -34,7 +34,7 @@ class LiteCaptureWidgetState extends State<LiteCaptureWidget>
     WidgetsBinding.instance.addObserver(this);
     SchedulerBinding.instance.addPostFrameCallback((_) async {
       if (context.read<DeviceProvider>().connectedDevice != null) {
-        context.read<OnboardingProvider>().stopFindDeviceTimer();
+        context.read<OnboardingProvider>().stopScanDevices();
       }
       if (mounted) {
         final connectivityProvider = Provider.of<ConnectivityProvider>(context, listen: false);

--- a/app/lib/pages/onboarding/find_device/page.dart
+++ b/app/lib/pages/onboarding/find_device/page.dart
@@ -25,9 +25,13 @@ class FindDevicesPage extends StatefulWidget {
 }
 
 class _FindDevicesPageState extends State<FindDevicesPage> {
+  OnboardingProvider? _provider;
+
   @override
   void initState() {
     super.initState();
+    _provider = Provider.of<OnboardingProvider>(context, listen: false);
+
     SchedulerBinding.instance.addPostFrameCallback((_) {
       if (widget.isFromOnboarding) {
         context.read<HomeProvider>().setupHasSpeakerProfile();
@@ -38,16 +42,14 @@ class _FindDevicesPageState extends State<FindDevicesPage> {
 
   @override
   dispose() {
-    _stopScanDevices();
+    _provider?.stopScanDevices();
+    _provider = null;
+
     super.dispose();
   }
 
-  void _stopScanDevices() {
-    Provider.of<OnboardingProvider>(context, listen: false).stopScanDevices();
-  }
-
   Future<void> _scanDevices() async {
-    Provider.of<OnboardingProvider>(context, listen: false).scanDevices(
+    _provider?.scanDevices(
       onShowDialog: () {
         if (mounted) {
           showDialog(

--- a/app/lib/pages/onboarding/find_device/page.dart
+++ b/app/lib/pages/onboarding/find_device/page.dart
@@ -38,8 +38,12 @@ class _FindDevicesPageState extends State<FindDevicesPage> {
 
   @override
   dispose() {
-    // context.read<OnboardingProvider>().dispose();
+    _stopScanDevices();
     super.dispose();
+  }
+
+  void _stopScanDevices() {
+    Provider.of<OnboardingProvider>(context, listen: false).stopScanDevices();
   }
 
   Future<void> _scanDevices() async {

--- a/app/lib/pages/settings/device_settings.dart
+++ b/app/lib/pages/settings/device_settings.dart
@@ -140,7 +140,7 @@ class _DeviceSettingsState extends State<DeviceSettings> {
                       provider.setIsConnected(false);
                       provider.setConnectedDevice(null);
                       provider.updateConnectingStatus(false);
-                      context.read<OnboardingProvider>().stopFindDeviceTimer();
+                      context.read<OnboardingProvider>().stopScanDevices();
                       Navigator.of(context).pop();
                       Navigator.of(context).pop();
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -139,12 +139,8 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
   //----------------- Onboarding Permissions -----------------
 
   void stopFindDeviceTimer() {
-    if (_findDevicesTimer != null && (_findDevicesTimer?.isActive ?? false)) {
-      _findDevicesTimer!.cancel();
-    }
-    if (connectionStateTimer?.isActive ?? false) {
-      connectionStateTimer?.cancel();
-    }
+    _findDevicesTimer?.cancel();
+    connectionStateTimer?.cancel();
     notifyListeners();
   }
 
@@ -226,6 +222,10 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
     notifyListeners();
   }
 
+  void stopScanDevices() {
+    stopFindDeviceTimer();
+  }
+
   Future<void> scanDevices({
     required VoidCallback onShowDialog,
   }) async {
@@ -248,13 +248,14 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
 
     ServiceManager.instance().device.subscribe(this, this);
 
-    _findDevicesTimer = Timer.periodic(const Duration(seconds: 4), (_) async {
-      if (deviceProvider != null && deviceProvider!.isConnected) {
-        _findDevicesTimer?.cancel();
+    _findDevicesTimer?.cancel();
+    _findDevicesTimer = Timer.periodic(const Duration(seconds: 4), (t) async {
+      if (deviceProvider?.isConnected ?? false) {
+        t.cancel();
         return;
-      } else {
-        ServiceManager.instance().device.discover();
       }
+
+      ServiceManager.instance().device.discover();
     });
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to stop device scanning, enhancing user control during the onboarding process.
- **Bug Fixes**
	- Improved error handling and state management during device connection attempts for a smoother user experience. 
- **Refactor**
	- Streamlined device scanning logic and timer management for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->