### PR TITLE
Dk2 sync logic and UI and other fixes

### DIFF
--- a/app/lib/pages/memories/page.dart
+++ b/app/lib/pages/memories/page.dart
@@ -135,14 +135,17 @@ class _MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClie
                       var date = memoryProvider.groupedMemories.keys.elementAt(index);
                       List<ServerMemory> memoriesForDate = memoryProvider.groupedMemories[date]!;
                       bool hasDiscarded = memoriesForDate.any((element) => element.discarded);
+                      bool hasNonDiscarded = memoriesForDate.any((element) => !element.discarded);
 
                       return Column(
                         mainAxisSize: MainAxisSize.min,
                         children: [
                           if (index == 0) const SizedBox(height: 16),
                           MemoriesGroupWidget(
+                            isFirst: index == 0,
                             memories: memoriesForDate,
                             date: date,
+                            hasNonDiscardedMemories: hasNonDiscarded,
                             showDiscardedMemories: memoryProvider.showDiscardedMemories,
                             hasDiscardedMemories: hasDiscarded,
                           ),

--- a/app/lib/pages/memories/widgets/memories_group_widget.dart
+++ b/app/lib/pages/memories/widgets/memories_group_widget.dart
@@ -9,12 +9,16 @@ class MemoriesGroupWidget extends StatelessWidget {
   final DateTime date;
   final bool showDiscardedMemories;
   final bool hasDiscardedMemories;
+  final bool hasNonDiscardedMemories;
+  final bool isFirst;
   const MemoriesGroupWidget(
       {super.key,
       required this.memories,
       required this.date,
+      required this.hasNonDiscardedMemories,
       required this.showDiscardedMemories,
-      required this.hasDiscardedMemories});
+      required this.hasDiscardedMemories,
+      required this.isFirst});
 
   @override
   Widget build(BuildContext context) {
@@ -22,19 +26,20 @@ class MemoriesGroupWidget extends StatelessWidget {
       return Column(
         mainAxisSize: MainAxisSize.min,
         children: [
-          if (showDiscardedMemories && hasDiscardedMemories)
-            DateListItem(date: date, isFirst: true)
-          else if (!showDiscardedMemories)
-            DateListItem(date: date, isFirst: true)
+          if (!showDiscardedMemories && hasDiscardedMemories && !hasNonDiscardedMemories)
+            const SizedBox.shrink()
           else
-            const SizedBox.shrink(),
+            DateListItem(date: date, isFirst: isFirst),
           ...memories.map((memory) {
             if (!showDiscardedMemories && memory.discarded) {
               return const SizedBox.shrink();
             }
             return MemoryListItem(memory: memory, memoryIdx: memories.indexOf(memory), date: date);
           }),
-          const SizedBox(height: 16),
+          if (!showDiscardedMemories && hasDiscardedMemories && !hasNonDiscardedMemories)
+            const SizedBox.shrink()
+          else
+            const SizedBox(height: 16),
         ],
       );
     } else {

--- a/app/lib/pages/sdcard/page.dart
+++ b/app/lib/pages/sdcard/page.dart
@@ -56,15 +56,17 @@ class _SdCardCapturePageState extends State<SdCardCapturePage> {
             mainAxisAlignment: MainAxisAlignment.center,
             mainAxisSize: MainAxisSize.min,
             children: [
-              Container(
+              SizedBox(
                 height: MediaQuery.sizeOf(context).height * 0.365,
                 child: SdCardTransferProgress(
                   displayPercentage: provider.totalStorageFileBytes == 0
                       ? '0.0'
-                      : (provider.totalBytesReceived / provider.totalStorageFileBytes * 100).toStringAsFixed(2),
-                  progress: provider.sdCardSecondsReceived /
+                      : ((provider.currentTotalBytesReceived) / provider.totalStorageFileBytes * 100)
+                          .toStringAsFixed(2),
+                  progress: provider.currentSdCardSecondsReceived /
                       (provider.sdCardSecondsTotal == 0 ? 1 : provider.sdCardSecondsTotal),
-                  secondsRemaining: (provider.sdCardSecondsTotal - provider.sdCardSecondsReceived).toStringAsFixed(2),
+                  secondsRemaining:
+                      (provider.sdCardSecondsTotal - provider.currentSdCardSecondsReceived).toStringAsFixed(2),
                 ),
               ),
               provider.sdCardIsDownloading || provider.sdCardDownloadDone

--- a/app/lib/pages/sdcard/sdcard_transfer_progress.dart
+++ b/app/lib/pages/sdcard/sdcard_transfer_progress.dart
@@ -74,7 +74,7 @@ class _SdCardTransferProgressState extends State<SdCardTransferProgress> with Ti
             TweenAnimationBuilder(
               tween: Tween<double>(
                 begin: 0.0,
-                end: widget.progress > 0.01 ? 1.0 : 0.0,
+                end: widget.progress > 0.0 ? 1.0 : 0.0,
               ),
               duration: const Duration(milliseconds: 800),
               builder: (context, double value, child) {

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -516,15 +516,14 @@ class CaptureProvider extends ChangeNotifier
 
   Future<void> updateStorageList() async {
     currentStorageFiles = await _getStorageList(_recordingDevice!.id);
-    if (currentStorageFiles.isEmpty || currentStorageFiles.length < 2) {
+    if (currentStorageFiles.isEmpty) {
       debugPrint('No storage files found');
       SharedPreferencesUtil().deviceIsV2 = false;
       debugPrint('Device is not V2');
-
       return;
     }
     totalStorageFileBytes = currentStorageFiles[0];
-    var storageOffset = currentStorageFiles[1];
+    var storageOffset = currentStorageFiles.length < 2 ? 0 : currentStorageFiles[1];
     totalBytesReceived = storageOffset;
     notifyListeners();
   }
@@ -534,11 +533,10 @@ class CaptureProvider extends ChangeNotifier
 
     if (_recordingDevice == null) return;
     currentStorageFiles = await _getStorageList(_recordingDevice!.id);
-    if (currentStorageFiles.isEmpty || currentStorageFiles.length < 2) {
+    if (currentStorageFiles.isEmpty) {
       debugPrint('No storage files found');
       SharedPreferencesUtil().deviceIsV2 = false;
       debugPrint('Device is not V2');
-
       return;
     }
     SharedPreferencesUtil().deviceIsV2 = true;
@@ -546,7 +544,7 @@ class CaptureProvider extends ChangeNotifier
     debugPrint('Device model name: ${_recordingDevice!.name}');
     debugPrint('Storage files: $currentStorageFiles');
     totalStorageFileBytes = currentStorageFiles[0];
-    var storageOffset = currentStorageFiles[1];
+    var storageOffset = currentStorageFiles.length < 2 ? 0 : currentStorageFiles[1];
     debugPrint('storageOffset: $storageOffset');
     // SharedPreferencesUtil().previousStorageBytes = totalStorageFileBytes;
     //check if new or old file
@@ -565,7 +563,8 @@ class CaptureProvider extends ChangeNotifier
         ((totalStorageFileBytes.toDouble() / 80.0) / 100.0) * 2.2; // change 2.2 depending on empirical dl speed
     sdCardSecondsReceived = ((storageOffset.toDouble() / 80.0) / 100.0) * 2.2;
     debugPrint('totalBytesReceived in initiateStorageBytesStreaming: $totalBytesReceived');
-    debugPrint('previousStorageBytes in initiateStorageBytesStreaming: $SharedPreferencesUtil().previousStorageBytes');
+    debugPrint(
+        'previousStorageBytes in initiateStorageBytesStreaming: ${SharedPreferencesUtil().previousStorageBytes}');
     btConnectedTime = DateTime.now().toUtc().toString();
     sdCardSocket.setupSdCardWebSocket(
       //replace


### PR DESCRIPTION
- [x] Improve grouped mems ui (reported on instabug)
- [x] check for currentStorageFiles.length only while setting storage offset (v2.0.1 does not return the offset, only 2.0.2 does)
- [x] use separate variables to track current sdcard progress (tested on both 2.0.1 and 2.0.2)
- [x] reduce the tween end to 0.0 so that it flips right after pressing button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced memory display with improved tracking of non-discarded memories.
	- Updated progress tracking for SD card transfers, focusing on current metrics for better accuracy.
  
- **Bug Fixes**
	- Improved responsiveness of the SD card transfer animation.

- **Refactor**
	- Streamlined logic for storage management and data streaming in the capture provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->