### PR TITLE
Improve events

### DIFF
--- a/app/lib/backend/schema/structured.dart
+++ b/app/lib/backend/schema/structured.dart
@@ -49,7 +49,7 @@ class Structured {
         if (event.isEmpty) continue;
         structured.events.add(Event(
           event['title'],
-          DateTime.parse(event['startsAt'] ?? event['start']),
+          DateTime.parse(event['startsAt'] ?? event['start']).toLocal(),
           event['duration'],
           description: event['description'] ?? '',
           created: event['created'] ?? false,

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -235,8 +235,7 @@ class EventsListWidget extends StatelessWidget {
                             );
                             ScaffoldMessenger.of(context).showSnackBar(
                               const SnackBar(
-                                content: Text(
-                                    'Event added to calendar! It may take a few minutes to reflect in your calendar 📆'),
+                                content: Text('Event added! It may take a few minutes to show up in your calendar. 📆'),
                               ),
                             );
                           },

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -206,7 +206,7 @@ class EventsListWidget extends StatelessWidget {
                   subtitle: Padding(
                     padding: const EdgeInsets.only(top: 4.0),
                     child: Text(
-                      '${dateTimeFormat('MMM d, yyyy', utcToLocal(event.startsAt))} at ${dateTimeFormat('h:mm a', utcToLocal(event.startsAt))} ~ ${minutesConversion(event.duration)}',
+                      '${dateTimeFormat('MMM d, yyyy', event.startsAt)} at ${dateTimeFormat('h:mm a', event.startsAt)} ~ ${minutesConversion(event.duration)}',
                       style: const TextStyle(color: Colors.grey, fontSize: 15),
                     ),
                   ),
@@ -248,14 +248,6 @@ class EventsListWidget extends StatelessWidget {
         );
       },
     );
-  }
-}
-
-DateTime utcToLocal(DateTime dateTime) {
-  if (dateTime.isUtc) {
-    return dateTime.toLocal();
-  } else {
-    return dateTime;
   }
 }
 

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -206,7 +206,7 @@ class EventsListWidget extends StatelessWidget {
                   subtitle: Padding(
                     padding: const EdgeInsets.only(top: 4.0),
                     child: Text(
-                      '${dateTimeFormat('MMM d, yyyy', utcToLocal(event.startsAt))} at ${dateTimeFormat('h:mm a', utcToLocal(event.startsAt))} ~ ${minutesConversion(event.duration)}.',
+                      '${dateTimeFormat('MMM d, yyyy', utcToLocal(event.startsAt))} at ${dateTimeFormat('h:mm a', utcToLocal(event.startsAt))} ~ ${minutesConversion(event.duration)}',
                       style: const TextStyle(color: Colors.grey, fontSize: 15),
                     ),
                   ),
@@ -263,9 +263,17 @@ String minutesConversion(int minutes) {
   if (minutes < 60) {
     return '$minutes minutes';
   } else if (minutes < 1440) {
-    return '${minutes / 60} hours';
+    var hrs = minutes / 60;
+    if (hrs % 1 == 0) {
+      return '${hrs.toInt()} hours';
+    }
+    return '${minutes / 60} hour${hrs > 1 ? 's' : ''}';
   } else {
-    return '${minutes / 1440} days';
+    var days = minutes / 1440;
+    if (days % 1 == 0) {
+      return '${days.toInt()} days';
+    }
+    return '${minutes / 1440} day${days > 1 ? 's' : ''}';
   }
 }
 

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -235,7 +235,8 @@ class EventsListWidget extends StatelessWidget {
                             );
                             ScaffoldMessenger.of(context).showSnackBar(
                               const SnackBar(
-                                content: Text('Event added to calendar'),
+                                content: Text(
+                                    'Event added to calendar! It may take a few minutes to reflect in your calendar 📆'),
                               ),
                             );
                           },

--- a/app/lib/pages/memory_detail/widgets.dart
+++ b/app/lib/pages/memory_detail/widgets.dart
@@ -206,7 +206,7 @@ class EventsListWidget extends StatelessWidget {
                   subtitle: Padding(
                     padding: const EdgeInsets.only(top: 4.0),
                     child: Text(
-                      '${dateTimeFormat('MMM d, yyyy', event.startsAt)} at ${dateTimeFormat('h:mm a', event.startsAt)} ~ ${minutesConversion(event.duration)}.',
+                      '${dateTimeFormat('MMM d, yyyy', utcToLocal(event.startsAt))} at ${dateTimeFormat('h:mm a', utcToLocal(event.startsAt))} ~ ${minutesConversion(event.duration)}.',
                       style: const TextStyle(color: Colors.grey, fontSize: 15),
                     ),
                   ),
@@ -248,6 +248,14 @@ class EventsListWidget extends StatelessWidget {
         );
       },
     );
+  }
+}
+
+DateTime utcToLocal(DateTime dateTime) {
+  if (dateTime.isUtc) {
+    return dateTime.toLocal();
+  } else {
+    return dateTime;
   }
 }
 

--- a/app/lib/pages/settings/calendar.dart
+++ b/app/lib/pages/settings/calendar.dart
@@ -104,7 +104,8 @@ class _CalendarPageState extends State<CalendarPage> {
 
                 RadioListTile(
                   title: const Text('Manual'),
-                  subtitle: const Text('Your memories will contain the discussed events, and you can decide to schedule them.'),
+                  subtitle: const Text(
+                      'Your memories will contain the discussed events, and you can decide to schedule them.'),
                   value: 'manual',
                   groupValue: SharedPreferencesUtil().calendarType,
                   onChanged: provider.onCalendarTypeChanged,

--- a/app/lib/providers/calendar_provider.dart
+++ b/app/lib/providers/calendar_provider.dart
@@ -45,23 +45,20 @@ class CalenderProvider extends ChangeNotifier {
         setLoading(true);
 
         await _getCalendars();
-
-        if (calendars.isEmpty) {
-          // try to get calendars again
+        // try to get calendars again after 3 seconds
+        // Delay is necessary because the calendar plugin does not return the calendars immediately
+        // While testing, on first call I got only 1 calendar, but on the second call I got all the calendars
+        await Future.delayed(const Duration(seconds: 3), () async {
           await _getCalendars();
-          setLoading(false);
-          if (calendars.isEmpty) {
-            AppSnackbar.showSnackbar(
-              'No calendars found. Please check your device settings.',
-              duration: const Duration(seconds: 5),
-            );
-            calendarEnabled = false;
-          } else {
-            calendarEnabled = true;
-            _mixpanelManager.calendarEnabled();
-          }
+        });
+        setLoading(false);
+        if (calendars.isEmpty) {
+          AppSnackbar.showSnackbar(
+            'No calendars found. Please check your device settings.',
+            duration: const Duration(seconds: 5),
+          );
+          calendarEnabled = false;
         } else {
-          setLoading(false);
           calendarEnabled = true;
           _mixpanelManager.calendarEnabled();
         }

--- a/app/lib/utils/features/calendar.dart
+++ b/app/lib/utils/features/calendar.dart
@@ -53,9 +53,10 @@ class CalendarUtil {
     DateTime startDate = startsAt.toLocal();
     DateTime endDate = startDate.add(Duration(minutes: durationMinutes));
     String calendarId = SharedPreferencesUtil().calendarId;
-    Duration utcOffset = DateTime.now().timeZoneOffset;
-    startDate = startDate.subtract(utcOffset);
-    endDate = endDate.subtract(utcOffset);
+    // utcOffset is not needed. Previously sometimes OpenAI was returning in UTC and sometimes in local time.
+    // Duration utcOffset = DateTime.now().timeZoneOffset;
+    // startDate = startDate.subtract(utcOffset);
+    // endDate = endDate.subtract(utcOffset);
     CalendarEvent newEvent = CalendarEvent(
       title: title,
       description: description,

--- a/backend/database/notifications.py
+++ b/backend/database/notifications.py
@@ -8,6 +8,13 @@ from ._client import db
 def save_token(uid: str, data: dict):
     db.collection('users').document(uid).set(data, merge=True)
 
+def get_user_time_zone(uid: str):
+    user_ref = db.collection('users').document(uid)
+    user_ref = user_ref.get()
+    if user_ref.exists:
+        user_ref = user_ref.to_dict()
+        return user_ref.get('time_zone')
+    return None
 
 def get_token_only(uid: str):
     user_ref = db.collection('users').document(uid)

--- a/backend/models/memory.py
+++ b/backend/models/memory.py
@@ -61,6 +61,11 @@ class Event(BaseModel):
     duration: int = Field(description="The duration of the event in minutes", default=30)
     created: bool = False
 
+    def as_dict_cleaned_dates(self):
+        event_dict = self.dict()
+        event_dict['start'] = event_dict['start'].isoformat()
+        return event_dict
+
 
 class Structured(BaseModel):
     title: str = Field(description="A title/name for this conversation", default='')
@@ -189,6 +194,7 @@ class Memory(BaseModel):
         return TranscriptSegment.segments_as_string(self.transcript_segments, include_timestamps=include_timestamps)
 
     def as_dict_cleaned_dates(self):
+        self.structured.events = [event.as_dict_cleaned_dates() for event in self.structured.events]
         memory_dict = self.dict()
         memory_dict['created_at'] = memory_dict['created_at'].isoformat()
         memory_dict['started_at'] = memory_dict['started_at'].isoformat() if memory_dict['started_at'] else None

--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -96,7 +96,6 @@ def get_transcript_structure(transcript: str, started_at: datetime, language_cod
         'started_at': started_at.isoformat(),
         'tz': tz,
     })
-    print(response)
 
     for event in (response.events or []):
         if event.duration > 180:

--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -71,7 +71,7 @@ def should_discard_memory(transcript: str) -> bool:
         return False
 
 
-def get_transcript_structure(transcript: str, started_at: datetime, language_code: str) -> Structured:
+def get_transcript_structure(transcript: str, started_at: datetime, language_code: str, tz: str) -> Structured:
     prompt = ChatPromptTemplate.from_messages([(
         'system',
         '''Your task is to provide structure and clarity to the recording transcription of a conversation.
@@ -81,7 +81,7 @@ def get_transcript_structure(transcript: str, started_at: datetime, language_cod
         For the overview, condense the conversation into a summary with the main topics discussed, make sure to capture the key points and important details from the conversation.
         For the action items, include a list of commitments, specific tasks or actionable next steps from the conversation. Specify which speaker is responsible for each action item. 
         For the category, classify the conversation into one of the available categories.
-        For Calendar Events, include a list of events extracted from the conversation, that the user must have on his calendar. For date context, this conversation happened on {started_at}. Use UTC timezone strictly
+        For Calendar Events, include a list of events extracted from the conversation, that the user must have on his calendar. For date context, this conversation happened on {started_at}. {tz} is the user's timezone, convert it to UTC and respond in UTC.
             
         Transcript: ```{transcript}```
 
@@ -94,7 +94,9 @@ def get_transcript_structure(transcript: str, started_at: datetime, language_cod
         'format_instructions': parser.get_format_instructions(),
         'language_code': language_code,
         'started_at': started_at.isoformat(),
+        'tz': tz,
     })
+    print(response)
 
     for event in (response.events or []):
         if event.duration > 180:

--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -81,7 +81,7 @@ def get_transcript_structure(transcript: str, started_at: datetime, language_cod
         For the overview, condense the conversation into a summary with the main topics discussed, make sure to capture the key points and important details from the conversation.
         For the action items, include a list of commitments, specific tasks or actionable next steps from the conversation. Specify which speaker is responsible for each action item. 
         For the category, classify the conversation into one of the available categories.
-        For Calendar Events, include a list of events extracted from the conversation, that the user must have on his calendar. For date context, this conversation happened on {started_at}.
+        For Calendar Events, include a list of events extracted from the conversation, that the user must have on his calendar. For date context, this conversation happened on {started_at}. Use UTC timezone strictly
             
         Transcript: ```{transcript}```
 
@@ -100,7 +100,7 @@ def get_transcript_structure(transcript: str, started_at: datetime, language_cod
         if event.duration > 180:
             event.duration = 180
         event.created = False
-
+        
     return response
 
 

--- a/backend/utils/memories/process_memory.py
+++ b/backend/utils/memories/process_memory.py
@@ -52,15 +52,16 @@ def _get_structured(
             return summarize_open_glass(memory.photos), False
 
         # from Friend
+        tz = notification_db.get_user_time_zone(uid)
         if force_process:
             # reprocess endpoint
-            return get_transcript_structure(memory.get_transcript(False), memory.started_at, language_code), False
+            return get_transcript_structure(memory.get_transcript(False), memory.started_at, language_code,tz), False
 
         discarded = should_discard_memory(memory.get_transcript(False))
         if discarded:
             return Structured(emoji=random.choice(['🧠', '🎉'])), True
 
-        return get_transcript_structure(memory.get_transcript(False), memory.started_at, language_code), False
+        return get_transcript_structure(memory.get_transcript(False), memory.started_at, language_code,tz), False
     except Exception as e:
         print(e)
         if retries == 2:

--- a/backend/utils/memories/process_memory.py
+++ b/backend/utils/memories/process_memory.py
@@ -35,9 +35,10 @@ def _get_structured(
         force_process: bool = False, retries: int = 1
 ) -> Tuple[Structured, bool]:
     try:
+        tz = notification_db.get_user_time_zone(uid)
         if memory.source == MemorySource.workflow:
             if memory.text_source == WorkflowMemorySource.audio:
-                structured = get_transcript_structure(memory.text, memory.started_at, language_code)
+                structured = get_transcript_structure(memory.text, memory.started_at, language_code, tz)
                 return structured, False
 
             if memory.text_source == WorkflowMemorySource.other:
@@ -52,7 +53,6 @@ def _get_structured(
             return summarize_open_glass(memory.photos), False
 
         # from Friend
-        tz = notification_db.get_user_time_zone(uid)
         if force_process:
             # reprocess endpoint
             return get_transcript_structure(memory.get_transcript(False), memory.started_at, language_code,tz), False


### PR DESCRIPTION
Should close: #1100 
- [x] Fetch calendars twice with delay (because it does not always return all the calendars in one attempt most of the time)
<img width="1061" alt="Screenshot 2024-10-19 at 10 25 30 PM" src="https://github.com/user-attachments/assets/d1f12a45-fff7-4471-9fea-ef96003e5810">

- [x] Mention about events adding delay
- [x] Pass the user's timezone to GPT and force it to always return events in UTC (previously it was assuming the time mentioned by user in transcript to be in UTC)
- [x] Remove utc offset addition and convert UTC to local timezone on the front
- [x] Minor UI improvements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced user feedback with updated SnackBar message after adding an event to the calendar.
	- Improved clarity in shared content when using the sharing options.
	- Adjusted event start time handling to reflect local time for better user experience.
	- Added a method to retrieve user time zone for improved memory processing.

- **Bug Fixes**
	- Implemented a delay for calendar access requests to ensure calendars are fetched correctly.
	- Adjusted subtitle formatting for better readability in the calendar settings.

- **Documentation**
	- Updated comments for clarity regarding the new delay mechanism in calendar access handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->