### PR TITLE
Fresh firmware-1.0 build in VSCode fails with 'No prj.conf file(s) wass found' #1045

### DIFF
--- a/Friend/firmware/firmware_v1.0/CMakePresets.json
+++ b/Friend/firmware/firmware_v1.0/CMakePresets.json
@@ -51,6 +51,7 @@
 				"PLATFORM": "nrf52840",
 				"BOARD": "xiao_ble_sense",
 				"CACHED_CONF_FILE": "${sourceDir}/prj_xiao_ble_sense_devkitv2-adafruit.conf",
+				"CONF_FILE": "${sourceDir}/prj_xiao_ble_sense_devkitv2-adafruit.conf",
 				"DTC_OVERLAY_FILE": "${sourceDir}/overlay/xiao_ble_sense_devkitv2-adafruit_module.overlay"
             }
         }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new cache variable for the "Devkit V2" configuration, enhancing build customization for the "xiao_ble_sense" device.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->