### PR TITLE
Fixed plugin description for map notes

### DIFF
--- a/community-plugins.json
+++ b/community-plugins.json
@@ -629,7 +629,7 @@
     "id": "map-notes",
     "name": "Map Notes",
     "author": "Blockchain at Berkeley",
-    "description": "Drop notes as pins on the world around you by saying 'start', your note, then 'finish.'",
+    "description": "Drop notes as pins on the world around you by saying 'start map note' or 'clip this', your note, then 'end map note' or clip that",
     "image": "/plugins/logos/map-notes-logo.png",
     "capabilities": [
       "external_integration"

--- a/community-plugins.json
+++ b/community-plugins.json
@@ -629,7 +629,7 @@
     "id": "map-notes",
     "name": "Map Notes",
     "author": "Blockchain at Berkeley",
-    "description": "Drop notes as pins on the world around you by saying 'start map note' or 'clip this', your note, then 'end map note' or clip that",
+    "description": "Drop notes as pins on the world around you by saying 'start map note' or 'clip this', your note, then 'end map note' or 'clip that'.",
     "image": "/plugins/logos/map-notes-logo.png",
     "capabilities": [
       "external_integration"


### PR DESCRIPTION
Changed plugin description of map notes in plugins json to have the correct start and end phrases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated voice commands for the "Map Notes" plugin to enhance user clarity.
  
- **Bug Fixes**
	- Removed outdated plugins: "Psychologist," "News checker," and "Multion Amazon."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->