### PR TITLE
Add guideline to create interal ALB for private networking

### DIFF
--- a/docs/docs/developer/CreateInternalALBForBackend.mdx
+++ b/docs/docs/developer/CreateInternalALBForBackend.mdx
@@ -1,0 +1,60 @@
+---
+title: Create internal Application Load Balancer for internal connections in backend
+description: ''
+---
+
+# Create internal Application Load Balancer for connections between Cloud Run services in private networking
+
+This guide will walk you through setting up an internal ALB to connect Cloud Run services (backend to pusher) internally inside VPC network.
+
+## Create new VPC and subnet with Private Google Access is on
+Choose VPC Network > VPC Networks > Create VPC Network
+
+- VPC name: omi-dev-vpc-1
+
+- Subnet: 
+   - Name: omi-us-central1-dev-vpc-1-subnet-1 
+   - Network: 172.16.16.0/20
+
+Create Reserved proxy-only subnets for load balancing
+- Name: pusher-lb-subnet-dev
+- Network: 172.16.32.0/20
+
+Make sure Private Google Access option is on
+
+## Create internal Application Load Balancer
+
+Choose Network services > Load Balancing > Create Load Balancer
+
+- Type: Application Load Balancer (HTTP/HTTPS)
+- Internal
+- Best for regional workloads
+- LB name: pusher-lb-dev
+- Network: omi-dev-vpc-1
+- Backend configuration:
+   - Name: pusher-service-dev
+   - Backend type: CloudRun
+   - Serverless network endpoint group: pusher-ep-group-dev
+
+- Frontend configuration:
+   - Name: pusher-ep-dev
+   - Protocol: HTTP
+   - New Frontend IP and port
+   - IP address: Ephemeral (Custom) - 172.16.16.250
+   - Service label: internal-alb
+
+Get internal ALB DNS name for later use
+
+## Change network config for pusher and backend in Cloud Run
+- pusher:
+   - Cloud Run > pusher > Networking > Ingress Control: Internal and Allow traffic from external Application Load Balancers
+
+- backend:
+   - Cloud Run > backend > Edit and deploy new revision
+   - Networking:
+      Choose Connect to a VPC for outbound traffic
+      - Send traffic directly to a VPC
+      - Route only requests to private IPs to the VPC
+   - Variable and servers:
+      - HOSTED_PUSHER_API_URL: internal ALB DNS name
+


### PR DESCRIPTION
Add guideline to create internal Application Load Balancer for connections between Cloud Run services in private networking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a comprehensive guide for creating an internal Application Load Balancer (ALB) to enhance connectivity between Cloud Run services within a private VPC network.
  
- **Documentation**
	- Added detailed instructions covering VPC setup, ALB configurations, and necessary network adjustments for backend services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->