### PR TITLE
Do not show instabug popup

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -87,13 +87,12 @@ void main() async {
   // _setupAudioSession();
   bool isAuth = await _init();
   if (Env.instabugApiKey != null) {
-    Instabug.setWelcomeMessageMode(WelcomeMessageMode.disabled);
+    await Instabug.setWelcomeMessageMode(WelcomeMessageMode.disabled);
     runZonedGuarded(
       () async {
         Instabug.init(
           token: Env.instabugApiKey!,
-          invocationEvents: [InvocationEvent.shake, InvocationEvent.screenshot],
-          // invocationEvents: [],
+          invocationEvents: [InvocationEvent.none],
         );
         if (isAuth) {
           Instabug.identifyUser(


### PR DESCRIPTION
Closes #1228 

Do not show instabug popup without removing instabug so that we can keep receiving bug logs. The popup will show if there's any invocation event set (other than none)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified issue reporting by modifying Instabug invocation events to trigger only under specific conditions.
- **Bug Fixes**
	- Ensured proper sequencing of operations by awaiting the welcome message configuration for Instabug.
- **Documentation**
	- Updated method signatures for clarity in the initialization process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->