### PR TITLE
Do not use cache for public plugins (for now)

### DIFF
--- a/backend/routers/plugins.py
+++ b/backend/routers/plugins.py
@@ -155,7 +155,7 @@ def add_plugin(plugin_data: str = Form(...), file: UploadFile = File(...), uid=D
         add_private_plugin(data, data['uid'])
     else:
         add_public_plugin(data)
-    delete_generic_cache('get_public_plugins_data')
+    # delete_generic_cache('get_public_plugins_data')
     return {'status': 'ok'}
 
 

--- a/backend/utils/plugins.py
+++ b/backend/utils/plugins.py
@@ -39,15 +39,15 @@ def get_plugins_data_from_db(uid: str, include_reviews: bool = False) -> List[Pl
     private_data = []
     public_data = []
     all_plugins = []
-    if cachedPlugins := get_generic_cache('get_public_plugins_data'):
-        print('get_public_plugins_data from cache')
-        public_data = cachedPlugins
-        private_data = get_private_plugins_db(uid)
-        pass
-    else:
-        private_data = get_private_plugins_db(uid)
-        public_data = get_public_plugins_db(uid)
-    set_generic_cache('get_public_plugins_data', public_data, 60 * 10)  # 10 minutes cached
+    # if cachedPlugins := get_generic_cache('get_public_plugins_data'):
+    #     print('get_public_plugins_data from cache')
+    #     public_data = cachedPlugins
+    #     private_data = get_private_plugins_db(uid)
+    #     pass
+    # else:
+    private_data = get_private_plugins_db(uid)
+    public_data = get_public_plugins_db(uid)
+    # set_generic_cache('get_public_plugins_data', public_data, 60 * 10)  # 10 minutes cached
     user_enabled = set(get_enabled_plugins(uid))
     all_plugins = private_data + public_data
     plugins = []


### PR DESCRIPTION
Do not cache the public plugins for now because the get plugins route will also return unapproved plugins of that specific user. Caching the response will break this functionality. I'll add an improvised functionality to cache only public approved plugins tomorrow. This is sort of an hotfix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced plugin management with improved security checks for approving and rejecting plugins.
	- Added a new version of the `get_plugins` function for better clarity on output.

- **Bug Fixes**
	- Improved error handling for changing plugin visibility by checking for plugin existence.

- **Chores**
	- Removed caching logic for public plugins, streamlining data retrieval from the database. 
	- Cleaned up code by removing unnecessary debug print statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->