### PR TITLE
Fix errors on query plugins collection by multi field

### DIFF
--- a/backend/database/plugins.py
+++ b/backend/database/plugins.py
@@ -72,14 +72,10 @@ def get_unapproved_public_plugins_db() -> List:
 
 
 def get_public_plugins_db(uid: str) -> List:
-    public_plugins = db.collection('plugins_data').where('approved', '==', True).stream()
+    public_plugins = db.collection('plugins_data').stream()
     data = [doc.to_dict() for doc in public_plugins]
 
-    # Include the doc if it is not approved but uid matches
-    unapproved = db.collection('plugins_data').where('approved', '==', False).where('uid', '==', uid).stream()
-    data.extend([doc.to_dict() for doc in unapproved])
-
-    return data
+    return [plugin for plugin in data if plugin['approved'] == True or plugin['uid'] == uid]
 
 
 def public_plugin_id_exists_db(plugin_id: str) -> bool:


### PR DESCRIPTION
Error:
```
/opt/homebrew/lib/python3.11/site-packages/google/cloud/firestore_v1/base_collection.py:300: UserWarning: Detected filter using positional arguments. Prefer using the 'filter' keyword argument instead.
  return query.where(field_path, op_string, value)
/private/tmp/x.py:41: UserWarning: Detected filter using positional arguments. Prefer using the 'filter' keyword argument instead.
  unapproved = db.collection('plugins_data').where('approved', '==', False).where('uid', '==', uid).stream()
Traceback (most recent call last):
  File "/private/tmp/x.py", line 70, in <module>
    print(get_plugins_data_from_db("eLCxTds6QyUAHraZug48i8ZlGL23"))
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/x.py", line 58, in get_plugins_data_from_db
    public_data = get_public_plugins_db(uid)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/x.py", line 42, in get_public_plugins_db
    data.extend([doc.to_dict() for doc in unapproved])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/tmp/x.py", line 42, in <listcomp>
    data.extend([doc.to_dict() for doc in unapproved])
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/cloud/firestore_v1/query.py", line 357, in _make_stream
    response_iterator, expected_prefix = self._get_stream_iterator(
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/cloud/firestore_v1/query.py", line 223, in _get_stream_iterator
    request, expected_prefix, kwargs = self._prep_stream(
                                       ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/cloud/firestore_v1/base_query.py", line 1027, in _prep_stream
    "structured_query": self._to_protobuf(),
                        ^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/cloud/firestore_v1/base_query.py", line 968, in _to_protobuf
    "where": self._filters_pb(),
             ^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/lib/python3.11/site-packages/google/cloud/firestore_v1/base_query.py", line 847, in _filters_pb
    composite_filter.filters.append(_filter_pb(filter_))
TypeError: Parameter to MergeFrom() must be instance of same class: expected google.firestore.v1.StructuredQuery.Filter got Filter.
```