### PR TITLE
Integrate datadog to pusher for logs and traces

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -62,7 +62,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./backend/pusher/Dockerfile
+          file: ./backend/pusher/Dockerfile.datadog
           push: true
           tags: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
           cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache

--- a/backend/pusher/Dockerfile.datadog
+++ b/backend/pusher/Dockerfile.datadog
@@ -1,0 +1,24 @@
+FROM python:3.11 AS builder
+
+ENV PATH="/opt/venv/bin:$PATH"
+RUN python -m venv /opt/venv
+
+COPY backend/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /tmp/requirements.txt
+
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN apt-get update && apt-get -y install ffmpeg curl unzip && rm -rf /var/lib/apt/lists/* && \
+    pip install --target /dd_tracer/python/ ddtrace
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=gcr.io/datadoghq/serverless-init:1 /datadog-init /app/datadog-init
+COPY backend/ .
+
+EXPOSE 8080
+ENTRYPOINT ["/app/datadog-init"]
+CMD ["/dd_tracer/python/bin/ddtrace-run", "uvicorn", "pusher.main:app", "--host", "0.0.0.0", "--port", "8080"]
+


### PR DESCRIPTION
Issue https://github.com/BasedHardware/omi/issues/1217

**Key changes:**
- Add ddtrace library for pusher
- Wrap application to datadog serverless-init to collect traces and logs
