### PR TITLE
Support memory context for proactive notification apps

### DIFF
--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -879,5 +879,6 @@ def get_proactive_message(uid: str, plugin_prompt: str, params: [str], context: 
             prompt = prompt.replace("{{user_context}}", context if context else "")
             continue
     prompt = prompt.replace('    ', '').strip()
+    #print(prompt)
 
     return llm_mini.invoke(prompt).content

--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -861,10 +861,10 @@ def provide_advice_message(uid: str, segments: List[TranscriptSegment], context:
 
 
 # **************************************************
-# ************* MENTOR PLUGIN **************
+# ************* PROACTIVE NOTIFICATION PLUGIN **************
 # **************************************************
 
-def get_metoring_message(uid: str, plugin_prompt: str, params: [str]) -> str:
+def get_proactive_message(uid: str, plugin_prompt: str, params: [str], context: str) -> str:
     user_name, facts_str = get_prompt_facts(uid)
 
     prompt = plugin_prompt
@@ -874,6 +874,9 @@ def get_metoring_message(uid: str, plugin_prompt: str, params: [str]) -> str:
             continue
         if param == "user_facts":
             prompt = prompt.replace("{{user_facts}}", facts_str)
+            continue
+        if param == "user_context":
+            prompt = prompt.replace("{{user_context}}", context if context else "")
             continue
     prompt = prompt.replace('    ', '').strip()
 

--- a/backend/utils/plugins.py
+++ b/backend/utils/plugins.py
@@ -260,7 +260,7 @@ def _process_proactive_notification(uid: str, token: str, plugin: App, data):
     # context
     context = None
     if 'user_context' in filter_scopes:
-        memories = _retrieve_contextual_memories(uid, data.get('user_context', {}))
+        memories = _retrieve_contextual_memories(uid, data.get('context', {}))
         if len(memories) > 0:
             context = Memory.memories_to_string(memories, True)
 

--- a/backend/utils/plugins.py
+++ b/backend/utils/plugins.py
@@ -264,7 +264,7 @@ def _process_proactive_notification(uid: str, token: str, plugin: App, data):
         if len(memories) > 0:
             context = Memory.memories_to_string(memories, True)
 
-    print(f'_process_proactive_notification context {context[100] if context else "empty"}')
+    print(f'_process_proactive_notification context {context[:100] if context else "empty"}')
 
     # retrive message
     message = get_proactive_message(uid, prompt, filter_scopes, context)

--- a/plugins/example/basic/mentor.py
+++ b/plugins/example/basic/mentor.py
@@ -43,6 +43,7 @@ def mentoring(data: RealtimePluginRequest):
 
     user_name = "{{user_name}}"
     user_facts = "{{user_facts}}"
+    user_context = "{{user_context}}"
 
     prompt = f"""
     You are an experienced mentor, that helps people achieve their goals during the meeting.
@@ -67,15 +68,27 @@ def mentoring(data: RealtimePluginRequest):
     Output your response in plain text, without markdown.
 
     If you cannot find the topic or problem of the meeting, respond 'Nah 🤷 ~'.
+
+    Conversation:
     ```
     ${transcript}
     ```
+
+    Context:
+    ```
+    {user_context}
+    ```
     """.replace('    ', '').strip()
 
-    # 3. Respond with the format {notification: {prompt, params}}
-    return {'session_id': data.session_id,
-            'notification': {'prompt': prompt,
-                       'params': ['user_name', 'user_facts']}}
+    # 3. Respond with the format {notification: {prompt, params, context}}
+    #   - context: {question, filters: {people, topics, entities, dates}} | None
+    return {
+        'session_id': data.session_id,
+        'notification': {
+            'prompt': prompt,
+            'params': ['user_name', 'user_facts', 'user_context'],
+        }
+    }
 
 @ router.get('/setup/mentor', tags=['mentor'])
 def is_setup_completed(uid: str):

--- a/plugins/example/basic/mentor.py
+++ b/plugins/example/basic/mentor.py
@@ -2,7 +2,7 @@ import re
 
 from fastapi import APIRouter
 
-from models import TranscriptSegment, MentorEndpointResponse, RealtimePluginRequest
+from models import TranscriptSegment, ProactiveNotificationEndpointResponse, RealtimePluginRequest
 from db import get_upsert_segment_to_transcript_plugin
 
 router = APIRouter()
@@ -10,10 +10,10 @@ router = APIRouter()
 scan_segment_session = {}
 
 # *******************************************************
-# ************ Basic Mentor Plugin ************
+# ************ Basic Proactive Notification Plugin ************
 # *******************************************************
 
-@router.post('/mentor', tags=['mentor', 'basic', 'realtime'], response_model=MentorEndpointResponse)
+@router.post('/mentor', tags=['mentor', 'basic', 'realtime', 'proactive_notification'], response_model=ProactiveNotificationEndpointResponse)
 def mentoring(data: RealtimePluginRequest):
     def normalize(text):
         return re.sub(r' +', ' ',re.sub(r'[,?.!]', ' ', text)).lower().strip()

--- a/plugins/example/basic/mentor.py
+++ b/plugins/example/basic/mentor.py
@@ -81,7 +81,7 @@ def mentoring(data: RealtimePluginRequest):
     """.replace('    ', '').strip()
 
     # 3. Respond with the format {notification: {prompt, params, context}}
-    #   - context: {question, filters: {people, topics, entities, dates}} | None
+    #   - context: {question, filters: {people, topics, entities}} | None
     return {
         'session_id': data.session_id,
         'notification': {

--- a/plugins/example/basic/mentor.py
+++ b/plugins/example/basic/mentor.py
@@ -13,7 +13,7 @@ scan_segment_session = {}
 # ************ Basic Proactive Notification Plugin ************
 # *******************************************************
 
-@router.post('/mentor', tags=['mentor', 'basic', 'realtime', 'proactive_notification'], response_model=ProactiveNotificationEndpointResponse)
+@router.post('/mentor', tags=['mentor', 'basic', 'realtime', 'proactive_notification'], response_model=ProactiveNotificationEndpointResponse, response_model_exclude_none=True)
 def mentoring(data: RealtimePluginRequest):
     def normalize(text):
         return re.sub(r' +', ' ',re.sub(r'[,?.!]', ' ', text)).lower().strip()

--- a/plugins/example/models.py
+++ b/plugins/example/models.py
@@ -168,10 +168,20 @@ class RealtimePluginRequest(BaseModel):
     segments: List[TranscriptSegment]
 
 
-class MentorResponse(BaseModel):
+class ProactiveNotificationContextFitlersResponse(BaseModel):
+    people: List[str] = Field(description="A list of people. ", default=[])
+    entities: List[str] = Field(description="A list of entity. ", default=[])
+    topics: List[str] = Field(description="A list of topic. ", default=[])
+
+class ProactiveNotificationContextResponse(BaseModel):
+    question: str = Field(description="A question to query the embeded vector database.", default='')
+    filters: ProactiveNotificationContextFitlersResponse = Field(description="Filter options to query the embeded vector database. ", default=None)
+
+class ProactiveNotificationResponse(BaseModel):
     prompt: str = Field(description="A prompt or a template with the parameters such as {{user_name}} {{user_facts}}.", default='')
     params: List[str] = Field(description="A list of string that match with proactive notification scopes. ", default=[])
+    context: ProactiveNotificationContextResponse = Field(description="An object to guide the system in retrieving the users context", default=None)
 
-class MentorEndpointResponse(BaseModel):
+class ProactiveNotificationEndpointResponse(BaseModel):
     message: str = Field(description="A short message to be sent as notification to the user, if needed.", default='')
-    notification: MentorResponse = Field(description="An object to guide the system in generating the proactive notification", default=None)
+    notification: ProactiveNotificationResponse = Field(description="An object to guide the system in generating the proactive notification", default=None)


### PR DESCRIPTION
Issue: #1313


## Usages
- In the webhook, respond with model: 
    ```
    {
      ...
      "notification": {
        "prompt": "this is a system instruction with the {{user_context}} string. you could also include {{user_name}} and {{user_facts}} as well.",
        "params": [
          ...
          "user_context"
        ],
        "context": {
          "question": "",
          "filters": {
            "people": [],
            "entities": [],
            "topics": []
          }
        }
      }
    }
    ```
  <img width="501" alt="Screenshot 2024-11-16 at 12 19 02" src="https://github.com/user-attachments/assets/9ab20489-65b1-4699-a5e2-814cf31b0936">



## Deploy steps
- [ ] deploy Plugins
- [ ] deploy Pusher