### PR TITLE
Fetch public plugins from cache for triggers

### DIFF
--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -5,8 +5,14 @@ from database.apps import get_private_apps_db, get_public_unapproved_apps_db, \
 from database.redis_db import get_enabled_plugins, get_plugin_installs_count, get_plugin_reviews, get_generic_cache, \
     set_generic_cache
 from models.app import App
-from utils.plugins import weighted_rating
 
+
+def weighted_rating(plugin):
+    C = 3.0  # Assume 3.0 is the mean rating across all plugins
+    m = 5  # Minimum number of ratings required to be considered
+    R = plugin.rating_avg or 0
+    v = plugin.rating_count or 0
+    return (v / (v + m) * R) + (m / (v + m) * C)
 
 def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
     private_data = []

--- a/backend/utils/memories/process_memory.py
+++ b/backend/utils/memories/process_memory.py
@@ -14,11 +14,13 @@ import database.tasks as tasks_db
 import database.trends as trends_db
 from database.plugins import record_plugin_usage
 from database.vector_db import upsert_vector2, update_vector_metadata
+from models.app import App
 from models.facts import FactDB
 from models.memory import *
 from models.plugin import Plugin, UsageHistoryType
 from models.task import Task, TaskStatus, TaskAction, TaskActionProvider
 from models.trend import Trend
+from utils.apps import get_available_apps
 from utils.llm import obtain_emotional_message, retrieve_metadata_fields_from_transcript
 from utils.llm import summarize_open_glass, get_transcript_structure, generate_embedding, \
     get_plugin_result, should_discard_memory, summarize_experience_text, new_facts_extractor, \
@@ -102,7 +104,7 @@ def _get_memory_obj(uid: str, structured: Structured, memory: Union[Memory, Crea
 
 
 def _trigger_plugins(uid: str, memory: Memory, is_reprocess: bool = False):
-    plugins: List[Plugin] = get_plugins_data_from_db(uid)
+    plugins: List[App] = get_available_apps(uid)
     filtered_plugins = [plugin for plugin in plugins if plugin.works_with_memories() and plugin.enabled]
     memory.plugins_results = []
     threads = []

--- a/backend/utils/plugins.py
+++ b/backend/utils/plugins.py
@@ -13,7 +13,7 @@ from models.app import App
 from models.memory import Memory, MemorySource
 from models.notification_message import NotificationMessage
 from models.plugin import Plugin, UsageHistoryType
-from utils.apps import get_available_apps
+from utils.apps import get_available_apps, weighted_rating
 from utils.notifications import send_notification
 from utils.other.endpoints import timeit
 from utils.llm import get_metoring_message
@@ -71,14 +71,6 @@ def get_plugin_by_id(plugin_id: str) -> Optional[Plugin]:
         return None
     plugins = get_plugins_data('', include_reviews=False)
     return next((p for p in plugins if p.id == plugin_id), None)
-
-
-def weighted_rating(plugin):
-    C = 3.0  # Assume 3.0 is the mean rating across all plugins
-    m = 5  # Minimum number of ratings required to be considered
-    R = plugin.rating_avg or 0
-    v = plugin.rating_count or 0
-    return (v / (v + m) * R) + (m / (v + m) * C)
 
 
 def get_plugins_data_from_db(uid: str, include_reviews: bool = False) -> List[Plugin]:


### PR DESCRIPTION
Replace get_plugins_data_from_db with get_available_apps to get public apps from cache. This should reduce the direct firestore reads as now the public plugins for triggers will be fetched from redis first

Related to #1338 