### PR TITLE
Migrate Plugins to GCP and integrate datadog to Plugins

### DIFF
--- a/.github/workflows/gcp_plugins.yml
+++ b/.github/workflows/gcp_plugins.yml
@@ -29,11 +29,14 @@ jobs:
         uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
       - run: gcloud auth configure-docker
+
       - name: Build and Push Docker image
         run: |
-          docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }} -f plugins/example/Dockerfile .
+          docker build -t gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }} -f plugins/example/Dockerfile.datadog .
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+
       - name: Deploy to Cloud Run
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2

--- a/.github/workflows/gcp_plugins.yml
+++ b/.github/workflows/gcp_plugins.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Google Auth
         id: auth
-        uses: 'google-github-actions/auth@v0'
+        uses: 'google-github-actions/auth@v2'
         with:
           credentials_json: ${{ secrets.GCP_CREDENTIALS }}
       - run: gcloud auth configure-docker
@@ -36,7 +36,7 @@ jobs:
           docker push gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
       - name: Deploy to Cloud Run
         id: deploy
-        uses: google-github-actions/deploy-cloudrun@v0
+        uses: google-github-actions/deploy-cloudrun@v2
         with:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}

--- a/plugins/example/Dockerfile
+++ b/plugins/example/Dockerfile
@@ -1,16 +1,20 @@
-FROM tiangolo/uvicorn-gunicorn:python3.11
+FROM python:3.11 AS builder
 
-RUN apt-get update && apt-get install --no-install-recommends --no-install-suggests -y curl
-RUN apt-get install unzip
-RUN apt-get -y install python3
-RUN apt-get -y install python3-pip
-RUN apt-get -y install git
-RUN apt-get -y install ffmpeg
+ENV PATH="/opt/venv/bin:$PATH"
+RUN python -m venv /opt/venv
 
 COPY plugins/example/requirements.txt /tmp/requirements.txt
 RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
-COPY plugins/example/ /app
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN apt-get update && apt-get -y install ffmpeg curl unzip && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /opt/venv /opt/venv
+COPY plugins/example/ .
 
 EXPOSE 8080
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/plugins/example/Dockerfile.datadog
+++ b/plugins/example/Dockerfile.datadog
@@ -1,0 +1,23 @@
+FROM python:3.11 AS builder
+
+ENV PATH="/opt/venv/bin:$PATH"
+RUN python -m venv /opt/venv
+
+COPY plugins/example/requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
+
+FROM python:3.11-slim
+
+WORKDIR /app
+ENV PATH="/opt/venv/bin:$PATH"
+
+RUN apt-get update && apt-get -y install ffmpeg curl unzip && rm -rf /var/lib/apt/lists/* && \
+    pip install --target /dd_tracer/python/ ddtrace
+
+COPY --from=builder /opt/venv /opt/venv
+COPY --from=gcr.io/datadoghq/serverless-init:1 /datadog-init /app/datadog-init
+COPY plugins/example/ .
+
+EXPOSE 8080
+ENTRYPOINT ["/app/datadog-init"]
+CMD ["/dd_tracer/python/bin/ddtrace-run", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
Issue #1361

**Key changes:**

- Optimize Dockerfile for Plugins and migrate to Cloud Run
- Add ddtrace library
- Wrap application to datadog-init to collect traces and logs
- Update version for actions of Plugins pipeline 

![image](https://github.com/user-attachments/assets/7af7594e-7a8b-4dfc-a628-fd96c44e834d)
