### PR TITLE
Use only ULID for App ID

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -43,8 +43,7 @@ def submit_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
     data['deleted'] = False
     data['status'] = 'under-review'
     data['name'] = data['name'].strip()
-    new_app_id = slugify(data['name']) + '-' + str(ULID())
-    data['id'] = new_app_id
+    data['id'] = str(ULID())
     if external_integration := data.get('external_integration'):
         # check if setup_instructions_file_path is a single url or a just a string of text
         if external_integration.get('setup_instructions_file_path'):

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -5,7 +5,6 @@ from typing import List
 import requests
 from ulid import ULID
 from fastapi import APIRouter, Depends, Form, UploadFile, File, HTTPException, Header
-from slugify import slugify
 
 from database.apps import change_app_approval_status, get_unapproved_public_apps_db, \
     add_app_to_db, update_app_in_db, delete_app_from_db, update_app_visibility_in_db

--- a/backend/routers/plugins.py
+++ b/backend/routers/plugins.py
@@ -8,7 +8,6 @@ from typing import List
 import requests
 from fastapi import APIRouter, HTTPException, Depends, UploadFile
 from fastapi.params import File, Form
-from slugify import slugify
 from ulid import ULID
 
 from database.apps import add_app_to_db
@@ -116,8 +115,7 @@ def add_plugin(plugin_data: str = Form(...), file: UploadFile = File(...), uid=D
     data = json.loads(plugin_data)
     data['approved'] = False
     data['name'] = data['name'].strip()
-    new_app_id = slugify(data['name']) + '-' + str(ULID())
-    data['id'] = new_app_id
+    data['id'] = str(ULID())
     os.makedirs(f'_temp/plugins', exist_ok=True)
     file_path = f"_temp/plugins/{file.filename}"
     with open(file_path, 'wb') as f:


### PR DESCRIPTION
Slugifying the name and including ULID was perhaps a mistake I believe because with the slugified names, the IDs become too long sometimes and the length is not always consistent, so only using ULID from now onwards