### PR TITLE
fix: typo in InfoCardWidget in app_details

### DIFF
--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -452,7 +452,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
                     onTap: () {
                       if (widget.app.chatPrompt!.decodeString.characters.length > 200) {
                         routeToPage(context,
-                            MarkdownViewer(title: 'Chat Persoality', markdown: widget.app.chatPrompt!.decodeString));
+                            MarkdownViewer(title: 'Chat Personality', markdown: widget.app.chatPrompt!.decodeString));
                       }
                     },
                     title: 'Chat Personality',


### PR DESCRIPTION
This PR fixes a simple typo Error in App_details.dart file. 

All functionalities remain same.
Tests are passing.
No other file was modified