### PR TITLE
Metadata Prompt Improvements

### DIFF
--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -710,7 +710,7 @@ def extract_question_from_conversation(messages: List[Message]) -> str:
 
 
 def retrieve_metadata_fields_from_transcript(
-        uid: str, created_at: datetime, transcript_segment: List[dict], summary: str
+        uid: str, created_at: datetime, transcript_segment: List[dict]
 ) -> ExtractedInformation:
     transcript = ''
     for segment in transcript_segment:
@@ -719,14 +719,10 @@ def retrieve_metadata_fields_from_transcript(
     # TODO: ask it to use max 2 words? to have more standardization possibilities
     prompt = f'''
     You will be given the raw transcript of a conversation, this transcript has about 20% word error rate, 
-    and diarization is also made very poorly. But that is not a problem for you as you are an expert transcriptionist who has been doing this for years with 99% accuracy.
+    and diarization is also made very poorly.
 
     Your task is to extract the most accurate information from the conversation in the output object indicated below.
-    
-    A lot of words might be misspelled, and some might be missing, but you can infer the correct word based on the context and your knowledge.
-    
-    You have the summary of the conversation as well, which can help you to understand the context of the conversation.
-    
+
     Make sure as a first step, you infer and fix the raw transcript errors and then proceed to extract the information.
 
     For context when extracting dates, today is {created_at.strftime('%Y-%m-%d')}.
@@ -739,11 +735,6 @@ def retrieve_metadata_fields_from_transcript(
     Conversation Transcript:
     ```
     {transcript}
-    ```
-    
-    Conversation Summary:
-    ```
-    {summary}
     ```
     '''.replace('    ', '')
     try:

--- a/backend/utils/memories/process_memory.py
+++ b/backend/utils/memories/process_memory.py
@@ -141,7 +141,7 @@ def save_structured_vector(uid: str, memory: Memory, update_only: bool = False):
     vector = generate_embedding(str(memory.structured)) if not update_only else None
 
     segments = [t.dict() for t in memory.transcript_segments]
-    metadata = retrieve_metadata_fields_from_transcript(uid, memory.created_at, segments)
+    metadata = retrieve_metadata_fields_from_transcript(uid, memory.created_at, segments, memory.structured.overview)
     metadata['created_at'] = int(memory.created_at.timestamp())
     if not update_only:
         print('save_structured_vector creating vector')

--- a/backend/utils/memories/process_memory.py
+++ b/backend/utils/memories/process_memory.py
@@ -141,7 +141,7 @@ def save_structured_vector(uid: str, memory: Memory, update_only: bool = False):
     vector = generate_embedding(str(memory.structured)) if not update_only else None
 
     segments = [t.dict() for t in memory.transcript_segments]
-    metadata = retrieve_metadata_fields_from_transcript(uid, memory.created_at, segments, memory.structured.overview)
+    metadata = retrieve_metadata_fields_from_transcript(uid, memory.created_at, segments)
     metadata['created_at'] = int(memory.created_at.timestamp())
     if not update_only:
         print('save_structured_vector creating vector')


### PR DESCRIPTION
- Use 4o instead of 4o mini as it is able to identify the metadata (`people`, `topics`, `entities`) better when compared to 4o mini
- ~Improved prompt and also passing the conversation summary to improve the output~

Experimented with various iterations of the prompts with both 4o and 4o mini, and 4o has had the better output always. It corrected the words as well. ~Passing the summary seems to help improve the context as the summary most of the times includes the corrected words and also conveyed the connection between various entities~