### PR TITLE
Added endpoint for updating action items

### DIFF
--- a/backend/models/memory.py
+++ b/backend/models/memory.py
@@ -266,3 +266,8 @@ class SetMemoryActionItemsStateRequest(BaseModel):
 class DeleteActionItemRequest(BaseModel):
     description: str
     completed: bool
+
+
+class UpdateActionItemRequest(BaseModel):
+    description: str  # Original Action Item description to find the item
+    new_description: str  # New Action Item description to update to

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -145,6 +145,20 @@ def set_action_item_status(data: SetMemoryActionItemsStateRequest, memory_id: st
     return {"status": "Ok"}
 
 
+@router.patch("/v1/memories/{memory_id}/action-items/update", response_model=dict, tags=['memories'])
+def update_action_item(data: UpdateActionItemRequest, memory_id: str, uid=Depends(auth.get_current_user_uid)):
+    memory = _get_memory_by_id(uid, memory_id)
+    memory = Memory(**memory)
+    action_items = memory.structured.action_items
+    
+    for action_item in action_items:
+        if action_item.description == data.description:
+            action_item.description = data.new_description
+            
+    memories_db.update_memory_action_items(uid, memory_id, [action_item.dict() for action_item in action_items])
+    return {"status": "Ok"}
+
+
 @router.delete("/v1/memories/{memory_id}/action-items", response_model=dict, tags=['memories'])
 def delete_action_item(data: DeleteActionItemRequest, memory_id: str, uid=Depends(auth.get_current_user_uid)):
     print('here inside of delete action item')


### PR DESCRIPTION
Add UpdateActionItemRequest model and endpoint for updating action items descriptions

- Introduced UpdateActionItemRequest model to facilitate updating action item descriptions.
- Implemented a new PATCH endpoint at /v1/memories/{memory_id}/action-items/update to handle action item updates.
- Updated action item descriptions based on the provided original and new descriptions in the request.