### PR TITLE
Use custom check options with 12s timeout for slow internet

### DIFF
--- a/app/lib/services/sockets/pure_socket.dart
+++ b/app/lib/services/sockets/pure_socket.dart
@@ -50,20 +50,26 @@ class PureCore {
 
   PureCore.createInstance() {
     internetConnection = InternetConnection.createInstance(
-        /*
+      useDefaultOptions: false,
       customCheckOptions: [
         InternetCheckOption(
-          uri: Uri.parse(Env.apiBaseUrl!),
-          timeout: const Duration(
-            seconds: 30,
-          ),
-          responseStatusFn: (resp) {
-            return resp.statusCode < 500;
-          },
+          uri: Uri.parse('https://one.one.one.one'),
+          timeout: const Duration(seconds: 12),
+        ),
+        InternetCheckOption(
+          uri: Uri.parse('https://icanhazip.com/'),
+          timeout: const Duration(seconds: 12),
+        ),
+        InternetCheckOption(
+          uri: Uri.parse('https://jsonplaceholder.typicode.com/todos/1'),
+          timeout: const Duration(seconds: 12),
+        ),
+        InternetCheckOption(
+          uri: Uri.parse('https://reqres.in/api/users/1'),
+          timeout: const Duration(seconds: 12),
         ),
       ],
-		*/
-        );
+    );
   }
 }
 


### PR DESCRIPTION
Part of #1474 

The no internet connection banner shows up even when there's an internet connection. This happens when the connection speed drops and the checkpoints do not return a response within 3 seconds. This PR adds custom check points with increased timeout to 12 seconds