### PR TITLE
Define FRAME_SIZE for opus

### DIFF
--- a/OpenGlass/firmware/firmware.ino
+++ b/OpenGlass/firmware/firmware.ino
@@ -35,6 +35,7 @@ OpusEncoder *opus_encoder = nullptr;
 #define CHANNELS 1
 #define MAX_PACKET_SIZE 1000
 
+#define FRAME_SIZE 160
 #define SAMPLE_RATE 16000
 #define SAMPLE_BITS 16
 


### PR DESCRIPTION
Building with opus would result in
```
error: 'FRAME_SIZE' was not declared in this scope
 static size_t recording_buffer_size = FRAME_SIZE * 2;
 ```