### PR TITLE
Set minimum ver for collection to 1.18.0

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -42,7 +42,7 @@ dependencies:
   mixpanel_flutter: ^2.2.0
 
   # Utils
-  collection: ^1.19.0
+  collection: ^1.18.0
   equatable: 2.0.5
   flutter_blue_plus: 1.33.6
   http: ^1.2.1


### PR DESCRIPTION
Setting collection to minimum `^1.19.0` breaks on flutter versions prior `3.27.0`

<img width="1068" alt="Screenshot 2025-01-01 at 3 58 20 PM" src="https://github.com/user-attachments/assets/c8df4577-fd5d-4409-97ab-0ea8ac3b25f1" />
