### PR TITLE
Introduce independent routing for API versions

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -16,29 +16,38 @@ else:
     firebase_admin.initialize_app()
 
 app = FastAPI()
-app.include_router(transcribe_v2.router)
-app.include_router(memories.router)
-app.include_router(facts.router)
-app.include_router(chat.router)
-app.include_router(plugins.router)
-app.include_router(speech_profile.router)
-# app.include_router(screenpipe.router)
-app.include_router(workflow.router)
-app.include_router(notifications.router)
-app.include_router(workflow.router)
-app.include_router(agents.router)
-app.include_router(users.router)
-app.include_router(processing_memories.router)
-app.include_router(trends.router)
 
-app.include_router(firmware.router)
+app.include_router(transcribe_v2.v2_router)
+app.include_router(transcribe_v2.v3_router)
+
+app.include_router(memories.v1_router)
+app.include_router(memories.v2_router)
+
+app.include_router(facts.v1_router)
+app.include_router(facts.v2_router)
+
+app.include_router(chat.v1_router)
+app.include_router(chat.v2_router)
+
+app.include_router(speech_profile.v3_router)
+app.include_router(speech_profile.v4_router)
+
+app.include_router(firmware.v1_router)
+app.include_router(firmware.v2_router)
+
+app.include_router(workflow.v1_router)
+app.include_router(notifications.v1_router)
+app.include_router(agents.v1_router)
+app.include_router(users.v1_router)
+app.include_router(processing_memories.v1_router)
+app.include_router(trends.v1_router)
+app.include_router(sync.v1_router)
+app.include_router(apps.v1_router)
+app.include_router(custom_auth.v1_router)
+app.include_router(payment.v1_router)
+
 app.include_router(sdcard.router)
-app.include_router(sync.router)
-
-app.include_router(apps.router)
-app.include_router(custom_auth.router)
-
-app.include_router(payment.router)
+app.include_router(plugins.router)
 
 modal_app = App(
     name='backend',

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -15,7 +15,7 @@ else:
     firebase_admin.initialize_app()
 
 app = FastAPI()
-app.include_router(pusher.router)
+app.include_router(pusher.v1_router)
 
 modal_app = App(
     name='pusher',

--- a/backend/routers/agents.py
+++ b/backend/routers/agents.py
@@ -6,10 +6,10 @@ from models import task
 from utils.memories.process_memory import process_user_expression_measurement_callback
 from utils.other import hume
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1", tags=['agent'])
 
 
-@router.post('/v1/agents/hume/callback', response_model=shared.EmptyResponse, tags=['agent', 'hume', 'callback'])
+@v1_router.post('/agents/hume/callback', response_model=shared.EmptyResponse, tags=['agent', 'hume', 'callback'])
 async def hume_expression_measurement_callback(request: Request, data: dict):
     job_callback = hume.HumeJobCallbackModel.from_dict("prosody", data)
     if job_callback is None:

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -23,24 +23,24 @@ from utils.other import endpoints as auth
 from models.app import App
 from utils.other.storage import upload_plugin_logo, delete_plugin_logo
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1", tags=['apps'])
 
 
 # ******************************************************
 # ********************* APPS CRUD **********************
 # ******************************************************
 
-@router.get('/v1/apps', tags=['v1'], response_model=List[App])
+@v1_router.get('/apps', response_model=List[App])
 def get_apps(uid: str = Depends(auth.get_current_user_uid), include_reviews: bool = True):
     return get_available_apps(uid, include_reviews=include_reviews)
 
 
-@router.get('/v1/approved-apps', tags=['v1'], response_model=List[App])
+@v1_router.get('/approved-apps', response_model=List[App])
 def get_approved_apps(include_reviews: bool = False):
     return get_approved_available_apps(include_reviews=include_reviews)
 
 
-@router.post('/v1/apps', tags=['v1'])
+@v1_router.post('/apps')
 def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depends(auth.get_current_user_uid)):
     data = json.loads(app_data)
     data['approved'] = False
@@ -87,7 +87,7 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
     return {'status': 'ok'}
 
 
-@router.patch('/v1/apps/{app_id}', tags=['v1'])
+@v1_router.patch('/apps/{app_id}')
 def update_app(app_id: str, app_data: str = Form(...), file: UploadFile = File(None),
                uid=Depends(auth.get_current_user_uid)):
     data = json.loads(app_data)
@@ -118,7 +118,7 @@ def update_app(app_id: str, app_data: str = Form(...), file: UploadFile = File(N
     return {'status': 'ok'}
 
 
-@router.delete('/v1/apps/{app_id}', tags=['v1'])
+@v1_router.delete('/apps/{app_id}')
 def delete_app(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
     plugin = get_available_app_by_id(app_id, uid)
     if not plugin:
@@ -132,7 +132,7 @@ def delete_app(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
     return {'status': 'ok'}
 
 
-@router.get('/v1/apps/{app_id}', tags=['v1'])
+@v1_router.get('/apps/{app_id}')
 def get_app_details(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
     app = get_available_app_by_id_with_reviews(app_id, uid)
     app = App(**app) if app else None
@@ -154,7 +154,7 @@ def get_app_details(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
     return app
 
 
-@router.post('/v1/apps/review', tags=['v1'])
+@v1_router.post('/apps/review')
 def review_app(app_id: str, data: dict, uid: str = Depends(auth.get_current_user_uid)):
     if 'score' not in data:
         raise HTTPException(status_code=422, detail='Score is required')
@@ -182,7 +182,7 @@ def review_app(app_id: str, data: dict, uid: str = Depends(auth.get_current_user
     return {'status': 'ok'}
 
 
-@router.patch('/v1/apps/{app_id}/review', tags=['v1'])
+@v1_router.patch('/apps/{app_id}/review')
 def update_app_review(app_id: str, data: dict, uid: str = Depends(auth.get_current_user_uid)):
     if 'score' not in data:
         raise HTTPException(status_code=422, detail='Score is required')
@@ -213,7 +213,7 @@ def update_app_review(app_id: str, data: dict, uid: str = Depends(auth.get_curre
     return {'status': 'ok'}
 
 
-@router.patch('/v1/apps/{app_id}/review/reply', tags=['v1'])
+@v1_router.patch('/apps/{app_id}/review/reply')
 def reply_to_review(app_id: str, data: dict, uid: str = Depends(auth.get_current_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     app = App(**app) if app else None
@@ -236,7 +236,7 @@ def reply_to_review(app_id: str, data: dict, uid: str = Depends(auth.get_current
     return {'status': 'ok'}
 
 
-@router.get('/v1/apps/{app_id}/reviews', tags=['v1'])
+@v1_router.get('/apps/{app_id}/reviews')
 def app_reviews(app_id: str):
     reviews = get_app_reviews(app_id)
     reviews = [
@@ -245,7 +245,7 @@ def app_reviews(app_id: str):
     return reviews
 
 
-@router.patch('/v1/apps/{app_id}/change-visibility', tags=['v1'])
+@v1_router.patch('/apps/{app_id}/change-visibility')
 def change_app_visibility(app_id: str, private: bool, uid: str = Depends(auth.get_current_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     app = App(**app) if app else None
@@ -258,7 +258,7 @@ def change_app_visibility(app_id: str, private: bool, uid: str = Depends(auth.ge
     return {'status': 'ok'}
 
 
-@router.get('/v1/app/proactive-notification-scopes', tags=['v1'])
+@v1_router.get('/app/proactive-notification-scopes')
 def get_notification_scopes():
     return [
         {'title': 'User Name', 'id': 'user_name'},
@@ -268,7 +268,7 @@ def get_notification_scopes():
     ]
 
 
-@router.get('/v1/app-capabilities', tags=['v1'])
+@v1_router.get('/app-capabilities')
 def get_plugin_capabilities():
     return [
         {'title': 'Chat', 'id': 'chat'},
@@ -287,14 +287,14 @@ def get_plugin_capabilities():
 
 
 # @deprecated
-@router.get('/v1/app/payment-plans', tags=['v1'])
+@v1_router.get('/app/payment-plans')
 def get_payment_plans_v1():
     return [
         {'title': 'Monthly Recurring', 'id': 'monthly_recurring'},
     ]
 
 
-@router.get('/v1/app/plans', tags=['v1'])
+@v1_router.get('/app/plans')
 def get_payment_plans(uid: str = Depends(auth.get_current_user_uid)):
     if not uid or len(uid) == 0 or not is_permit_payment_plan_get(uid):
         return []
@@ -303,7 +303,7 @@ def get_payment_plans(uid: str = Depends(auth.get_current_user_uid)):
     ]
 
 
-@router.post('/v1/app/generate-description', tags=['v1'])
+@v1_router.post('/app/generate-description')
 def generate_description_endpoint(data: dict, uid: str = Depends(auth.get_current_user_uid)):
     if data['name'] == '':
         raise HTTPException(status_code=422, detail='App Name is required')
@@ -319,7 +319,7 @@ def generate_description_endpoint(data: dict, uid: str = Depends(auth.get_curren
 # **************** ENABLE/DISABLE APPS *****************
 # ******************************************************
 
-@router.post('/v1/apps/enable')
+@v1_router.post('/apps/enable')
 def enable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     app = App(**app) if app else None
@@ -344,7 +344,7 @@ def enable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_user_ui
     return {'status': 'ok'}
 
 
-@router.post('/v1/apps/disable')
+@v1_router.post('/apps/disable')
 def disable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_user_uid)):
     app = get_available_app_by_id(app_id, uid)
     app = App(**app) if app else None
@@ -363,7 +363,7 @@ def disable_app_endpoint(app_id: str, uid: str = Depends(auth.get_current_user_u
 # ******************* TEAM ENDPOINTS *******************
 # ******************************************************
 
-@router.post('/v1/apps/tester', tags=['v1'])
+@v1_router.post('/apps/tester')
 def add_new_tester(data: dict, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
@@ -376,7 +376,7 @@ def add_new_tester(data: dict, secret_key: str = Header(...)):
     return {'status': 'ok'}
 
 
-@router.post('/v1/apps/tester/access', tags=['v1'])
+@v1_router.post('/apps/tester/access')
 def add_app_access_tester(data: dict, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
@@ -388,7 +388,7 @@ def add_app_access_tester(data: dict, secret_key: str = Header(...)):
     return {'status': 'ok'}
 
 
-@router.delete('/v1/apps/tester/access', tags=['v1'])
+@v1_router.delete('/apps/tester/access')
 def remove_app_access_tester(data: dict, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
@@ -400,14 +400,14 @@ def remove_app_access_tester(data: dict, secret_key: str = Header(...)):
     return {'status': 'ok'}
 
 
-@router.get('/v1/apps/tester/check', tags=['v1'])
+@v1_router.get('/apps/tester/check')
 def check_is_tester(uid: str = Depends(auth.get_current_user_uid)):
     if is_tester(uid):
         return {'is_tester': True}
     return {'is_tester': False}
 
 
-@router.get('/v1/apps/public/unapproved', tags=['v1'])
+@v1_router.get('/apps/public/unapproved')
 def get_unapproved_public_apps(secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
@@ -415,7 +415,7 @@ def get_unapproved_public_apps(secret_key: str = Header(...)):
     return apps
 
 
-@router.post('/v1/apps/{app_id}/approve', tags=['v1'])
+@v1_router.post('/apps/{app_id}/approve')
 def approve_app(app_id: str, uid: str, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
@@ -429,7 +429,7 @@ def approve_app(app_id: str, uid: str, secret_key: str = Header(...)):
     return {'status': 'ok'}
 
 
-@router.post('/v1/apps/{app_id}/reject', tags=['v1'])
+@v1_router.post('/apps/{app_id}/reject')
 def reject_app(app_id: str, uid: str, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
@@ -444,7 +444,7 @@ def reject_app(app_id: str, uid: str, secret_key: str = Header(...)):
     return {'status': 'ok'}
 
 
-@router.delete('/v1/personas/{persona_id}', tags=['v1'])
+@v1_router.delete('/personas/{persona_id}')
 def delete_persona(persona_id: str, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')
@@ -455,7 +455,7 @@ def delete_persona(persona_id: str, secret_key: str = Header(...)):
     return {'status': 'ok'}
 
 
-@router.get('/v1/personas/{persona_id}', tags=['v1'])
+@v1_router.get('/personas/{persona_id}')
 def get_personas(persona_id: str, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')

--- a/backend/routers/custom_auth.py
+++ b/backend/routers/custom_auth.py
@@ -5,7 +5,7 @@ from firebase_admin import auth
 import os
 import requests
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1", tags=["custom_auth"])
 
 
 class UserCredentials(BaseModel):
@@ -14,7 +14,7 @@ class UserCredentials(BaseModel):
     name: Optional[str] = None
 
 
-@router.post("/v1/signup")
+@v1_router.post("/signup")
 def sign_up(credentials: UserCredentials):
     try:
         user = auth.create_user(
@@ -27,7 +27,7 @@ def sign_up(credentials: UserCredentials):
         raise HTTPException(status_code=400, detail=str(e))
 
 
-@router.post("/v1/signin")
+@v1_router.post("/signin")
 def sign_in(credentials: UserCredentials):
     try:
         api_key = os.getenv("CUSTOM_AUTH_FIREBASE_API_KEY")

--- a/backend/routers/facts.py
+++ b/backend/routers/facts.py
@@ -6,10 +6,11 @@ import database.facts as facts_db
 from models.facts import FactDB, Fact
 from utils.other import endpoints as auth
 
-router = APIRouter()
+v1_router = APIRouter(prefix='/v1', tags=['facts'])
+v2_router = APIRouter(prefix='/v2', tags=['facts'])
 
 
-@router.post('/v1/facts', tags=['facts'], response_model=FactDB)
+@v1_router.post('/facts', response_model=FactDB)
 def create_fact(fact: Fact, uid: str = Depends(auth.get_current_user_uid)):
     fact_db = FactDB.from_fact(fact, uid, None, None)
     fact_db.manually_added = True
@@ -17,7 +18,7 @@ def create_fact(fact: Fact, uid: str = Depends(auth.get_current_user_uid)):
     return fact_db
 
 
-@router.get('/v1/facts', tags=['facts'], response_model=List[FactDB])  # filters
+@v1_router.get('/facts', response_model=List[FactDB])  # filters
 def get_facts_v1(limit: int = 5000, offset: int = 0, uid: str = Depends(auth.get_current_user_uid)):
     facts = facts_db.get_facts(uid, limit, offset)
     # facts = list(filter(lambda x: x['category'] == 'skills', facts))
@@ -45,7 +46,7 @@ def get_facts_v1(limit: int = 5000, offset: int = 0, uid: str = Depends(auth.get
     # return facts
 
 
-@router.get('/v2/facts', tags=['facts'], response_model=List[FactDB])
+@v2_router.get('/facts', response_model=List[FactDB])
 def get_facts(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_current_user_uid)):
     # Use high limits for the first page
     # Warn: should remove
@@ -55,19 +56,19 @@ def get_facts(limit: int = 100, offset: int = 0, uid: str = Depends(auth.get_cur
     return facts
 
 
-@router.delete('/v1/facts/{fact_id}', tags=['facts'])
+@v1_router.delete('/facts/{fact_id}')
 def delete_fact(fact_id: str, uid: str = Depends(auth.get_current_user_uid)):
     facts_db.delete_fact(uid, fact_id)
     return {'status': 'ok'}
 
 
-@router.post('/v1/facts/{fact_id}/review', tags=['facts'])
+@v1_router.post('/facts/{fact_id}/review')
 def review_fact(fact_id: str, value: bool, uid: str = Depends(auth.get_current_user_uid)):
     facts_db.review_fact(uid, fact_id, value)
     return {'status': 'ok'}
 
 
-@router.patch('/v1/facts/{fact_id}', tags=['facts'])
+@v1_router.patch('/facts/{fact_id}')
 def edit_fact(fact_id: str, value: str, uid: str = Depends(auth.get_current_user_uid)):
     # first_word = value.split(' ')[0]
     # user_name = get_user_name(uid, use_default=False)

--- a/backend/routers/firmware.py
+++ b/backend/routers/firmware.py
@@ -11,7 +11,8 @@ class DeviceModel(int, Enum):
     OPEN_GLASS = 3
 
 
-router = APIRouter()
+v1_router = APIRouter(prefix='/v1', tags=['firmware'])
+v2_router = APIRouter(prefix='/v2', tags=['firmware'])
 
 
 # Device Model Number
@@ -28,7 +29,7 @@ def _get_device_by_model_number(device_model: str):
 
     return None
 
-@router.get("/v2/firmware/latest")
+@v2_router.get("/firmware/latest")
 async def get_latest_version(device_model: str, firmware_revision: str, hardware_revision: str, manufacturer_name: str):
     device = _get_device_by_model_number(device_model)
     if not device:
@@ -95,7 +96,7 @@ async def get_latest_version(device_model: str, firmware_revision: str, hardware
         }
 
 
-@router.get("/v1/firmware/latest")
+@v1_router.get("/firmware/latest")
 async def get_latest_version_v1(device: int):
     # if device = 1 : Friend
     # if device = 2 : OpenGlass

--- a/backend/routers/notifications.py
+++ b/backend/routers/notifications.py
@@ -10,10 +10,10 @@ from utils.other import endpoints as auth
 
 # logger = logging.getLogger('uvicorn.error')
 # logger.setLevel(logging.DEBUG)
-router = APIRouter()
+v1_router = APIRouter(prefix='/v1', tags=['notifications'])
 
 
-@router.post('/v1/users/fcm-token')
+@v1_router.post('/users/fcm-token')
 def save_token(data: SaveFcmTokenRequest, uid: str = Depends(auth.get_current_user_uid)):
     notification_db.save_token(uid, data.dict())
     return {'status': 'Ok'}
@@ -23,7 +23,7 @@ def save_token(data: SaveFcmTokenRequest, uid: str = Depends(auth.get_current_us
 # ******************* TEAM ENDPOINTS *******************
 # ******************************************************
 
-@router.post('/v1/notification')
+@v1_router.post('/notification')
 def send_notification_to_user(data: dict, secret_key: str = Header(...)):
     if secret_key != os.getenv('ADMIN_KEY'):
         raise HTTPException(status_code=403, detail='You are not authorized to perform this action')

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -3,9 +3,9 @@ import stripe
 from utils import stripe as stripe_utils
 from utils.apps import paid_app
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1", tags=['stripe', 'payment'])
 
-@router.post('/v1/stripe/webhook', tags=['v1', 'stripe', 'webhook'])
+@v1_router.post('/stripe/webhook', tags=['stripe', 'webhook'])
 async def stripe_webhook(request: Request, stripe_signature: str = Header(None)):
     payload = await request.body()
 

--- a/backend/routers/processing_memories.py
+++ b/backend/routers/processing_memories.py
@@ -8,11 +8,13 @@ from models.processing_memory import DetailProcessingMemoryResponse, \
 from database.redis_db import cache_user_geolocation
 from utils.other import endpoints as auth
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1", tags=['processing_memories'])
 
-# Deprecated
-@router.patch("/v1/processing-memories/{processing_memory_id}", response_model=UpdateProcessingMemoryResponse,
-              tags=['processing_memories'])
+@v1_router.patch(
+        "/processing-memories/{processing_memory_id}",
+        response_model=UpdateProcessingMemoryResponse,
+        deprecated=True
+)
 def update_processing_memory(
         processing_memory_id: str,
         updates_processing_memory: UpdateProcessingMemory,
@@ -40,10 +42,9 @@ def update_processing_memory(
     return UpdateProcessingMemoryResponse(result=BasicProcessingMemory(**processing_memory.dict()))
 
 
-@router.get(
-    "/v1/processing-memories/{processing_memory_id}",
+@v1_router.get(
+    "/processing-memories/{processing_memory_id}",
     response_model=DetailProcessingMemoryResponse,
-    tags=['processing_memories']
 )
 def get_processing_memory(processing_memory_id: str, uid: str = Depends(auth.get_current_user_uid)):
     """
@@ -61,8 +62,10 @@ def get_processing_memory(processing_memory_id: str, uid: str = Depends(auth.get
     return DetailProcessingMemoryResponse(result=processing_memory)
 
 
-@router.get("/v1/processing-memories", response_model=DetailProcessingMemoriesResponse,
-            tags=['processing_memories'])
+@v1_router.get(
+        "/processing-memories",
+        response_model=DetailProcessingMemoriesResponse,
+)
 def list_processing_memory(uid: str = Depends(auth.get_current_user_uid), filter_ids: Optional[str] = None):
     """
     List ProcessingMemory endpoint.

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -10,7 +10,7 @@ from utils.plugins import trigger_realtime_integrations
 from utils.webhooks import send_audio_bytes_developer_webhook, realtime_transcript_webhook, \
     get_audio_bytes_webhook_seconds
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1")
 
 async def _websocket_util_trigger(
         websocket: WebSocket, uid: str, sample_rate: int = 8000,
@@ -112,7 +112,7 @@ async def _websocket_util_trigger(
                 print(f"Error closing WebSocket: {e}")
 
 
-@router.websocket("/v1/trigger/listen")
+@v1_router.websocket("/trigger/listen")
 async def websocket_endpoint_trigger(
         websocket: WebSocket, uid: str, sample_rate: int = 8000,
 ):

--- a/backend/routers/speech_profile.py
+++ b/backend/routers/speech_profile.py
@@ -16,15 +16,16 @@ from utils.other.storage import upload_profile_audio, get_profile_audio_if_exist
     delete_speech_sample_for_people, get_user_has_speech_profile
 from utils.stt.vad import apply_vad_for_speech_profile
 
-router = APIRouter()
+v3_router = APIRouter(prefix="/v3", tags=['speech-profile'])
+v4_router = APIRouter(prefix="/v4", tags=['speech-profile'])
 
 
-@router.get('/v3/speech-profile', tags=['v3'])
+@v3_router.get('/speech-profile')
 def has_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
     return {'has_profile': get_user_has_speech_profile(uid) > 0}
 
 
-@router.get('/v4/speech-profile', tags=['v3'])
+@v4_router.get('/speech-profile')
 def get_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
     return {'url': get_profile_audio_if_exists(uid, download=False)}
 
@@ -36,7 +37,7 @@ def get_speech_profile(uid: str = Depends(auth.get_current_user_uid)):
 # Consist of bytes (for initiating deepgram)
 # and audio itself, which we use on post-processing to use speechbrain model
 
-@router.post('/v3/upload-bytes', tags=['v3'])
+@v3_router.post('/upload-bytes')
 def upload_profile(data: UploadProfile, uid: str = Depends(auth.get_current_user_uid)):
     if data.duration < 10:
         raise HTTPException(status_code=400, detail="Audio duration is too short")
@@ -46,7 +47,7 @@ def upload_profile(data: UploadProfile, uid: str = Depends(auth.get_current_user
     return {'status': 'ok'}
 
 
-@router.post('/v3/upload-audio', tags=['v3'])
+@v3_router.post('/upload-audio')
 def upload_profile(file: UploadFile, uid: str = Depends(auth.get_current_user_uid)):
     os.makedirs(f'_temp/{uid}', exist_ok=True)
     file_path = f"_temp/{uid}/{file.filename}"
@@ -115,7 +116,7 @@ def expand_speech_profile(
     return {"status": 'ok'}
 
 
-@router.delete('/v3/speech-profile/expand', tags=['v3'])
+@v3_router.delete('/speech-profile/expand')
 def delete_extra_speech_profile_sample(
         memory_id: str, segment_idx: int, person_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)
 ):
@@ -132,7 +133,7 @@ def delete_extra_speech_profile_sample(
     return {'status': 'ok'}
 
 
-@router.get('/v3/speech-profile/expand', tags=['v3'])
+@v3_router.get('/speech-profile/expand')
 def get_extra_speech_profile_samples(person_id: Optional[str] = None, uid: str = Depends(auth.get_current_user_uid)):
     if person_id:
         return get_user_person_speech_samples(uid, person_id)

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -18,7 +18,7 @@ from utils.other.storage import get_syncing_file_temporal_signed_url, delete_syn
 from utils.stt.pre_recorded import fal_whisperx, fal_postprocessing
 from utils.stt.vad import vad_is_empty
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1", tags=['sync'])
 
 import shutil
 import wave
@@ -208,7 +208,7 @@ def process_segment(path: str, uid: str, response: dict):
         update_memory_segments(uid, closest_memory['id'], segments)
 
 
-@router.post("/v1/sync-local-files")
+@v1_router.post("/sync-local-files")
 async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_current_user_uid)):
     # Improve a version without timestamp, to consider uploads from the stored in v2 device bytes.
     paths = retrieve_file_paths(files, uid)

--- a/backend/routers/transcribe_v2.py
+++ b/backend/routers/transcribe_v2.py
@@ -28,7 +28,8 @@ from utils.other import endpoints as auth
 
 import wave
 
-router = APIRouter()
+v2_router = APIRouter(prefix="/v2", tags=['transcribe'])
+v3_router = APIRouter(prefix="/v3", tags=['transcribe'])
 
 
 class STTService(str, Enum):
@@ -619,14 +620,14 @@ async def _websocket_util(
                 print(f"Error closing Pusher: {e}", uid)
 
 
-@router.websocket("/v2/listen")
+@v2_router.websocket("/listen")
 async def websocket_endpoint(
         websocket: WebSocket, uid: str, language: str = 'en', sample_rate: int = 8000, codec: str = 'pcm8',
         channels: int = 1, include_speech_profile: bool = True, stt_service: STTService = STTService.soniox
 ):
     await _websocket_util(websocket, uid, language, sample_rate, codec, channels, include_speech_profile, stt_service)
 
-@router.websocket("/v3/listen")
+@v3_router.websocket("/listen")
 async def websocket_endpoint_v3(
         websocket: WebSocket, uid: str = Depends(auth.get_current_user_uid), language: str = 'en', sample_rate: int = 8000, codec: str = 'pcm8',
         channels: int = 1, include_speech_profile: bool = True, stt_service: STTService = STTService.soniox

--- a/backend/routers/trends.py
+++ b/backend/routers/trends.py
@@ -4,9 +4,9 @@ from fastapi import APIRouter
 
 import database.trends as trends_db
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1", tags=['trends'])
 
 
-@router.get("/v1/trends", response_model=List, tags=['trends'])
+@v1_router.get("/trends", response_model=List)
 def get_trends():
     return trends_db.get_trends_data()

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -17,10 +17,10 @@ from utils.other.storage import delete_all_memory_recordings, get_user_person_sp
     delete_user_person_speech_samples
 from utils.webhooks import webhook_first_time_setup
 
-router = APIRouter()
+v1_router = APIRouter(prefix='/v1', tags=['users'])
 
 
-@router.delete('/v1/users/delete-account', tags=['v1'])
+@v1_router.delete('/users/delete-account')
 def delete_account(uid: str = Depends(auth.get_current_user_uid)):
     try:
         delete_user_data(uid)
@@ -32,7 +32,7 @@ def delete_account(uid: str = Depends(auth.get_current_user_uid)):
         raise HTTPException(status_code=500, detail=str(e))
 
 
-@router.patch('/v1/users/geolocation', tags=['v1'])
+@v1_router.patch('/users/geolocation')
 def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_current_user_uid)):
     cache_user_geolocation(uid, geolocation.dict())
     return {'status': 'ok'}
@@ -43,7 +43,7 @@ def set_user_geolocation(geolocation: Geolocation, uid: str = Depends(auth.get_c
 # ***********************************************
 
 
-@router.post('/v1/users/developer/webhook/{wtype}', tags=['v1'])
+@v1_router.post('/users/developer/webhook/{wtype}')
 def set_user_webhook_endpoint(wtype: WebhookType, data: dict, uid: str = Depends(auth.get_current_user_uid)):
     url = data['url']
     if url == '' or url == ',':
@@ -52,24 +52,24 @@ def set_user_webhook_endpoint(wtype: WebhookType, data: dict, uid: str = Depends
     return {'status': 'ok'}
 
 
-@router.get('/v1/users/developer/webhook/{wtype}', tags=['v1'])
+@v1_router.get('/users/developer/webhook/{wtype}')
 def get_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_current_user_uid)):
     return {'url': get_user_webhook_db(uid, wtype)}
 
 
-@router.post('/v1/users/developer/webhook/{wtype}/disable', tags=['v1'])
+@v1_router.post('/users/developer/webhook/{wtype}/disable')
 def disable_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_current_user_uid)):
     disable_user_webhook_db(uid, wtype)
     return {'status': 'ok'}
 
 
-@router.post('/v1/users/developer/webhook/{wtype}/enable', tags=['v1'])
+@v1_router.post('/users/developer/webhook/{wtype}/enable')
 def enable_user_webhook_endpoint(wtype: WebhookType, uid: str = Depends(auth.get_current_user_uid)):
     enable_user_webhook_db(uid, wtype)
     return {'status': 'ok'}
 
 
-@router.get('/v1/users/developer/webhooks/status', tags=['v1'])
+@v1_router.get('/users/developer/webhooks/status')
 def get_user_webhooks_status(uid: str = Depends(auth.get_current_user_uid)):
     # This only happens the first time because the user_webhook_status_db function will return None for existing users
     audio_bytes = user_webhook_status_db(uid, WebhookType.audio_bytes)
@@ -96,18 +96,18 @@ def get_user_webhooks_status(uid: str = Depends(auth.get_current_user_uid)):
 # ************* RECORDING PERMISSION **************
 # *************************************************
 
-@router.post('/v1/users/store-recording-permission', tags=['v1'])
+@v1_router.post('/users/store-recording-permission')
 def store_recording_permission(value: bool, uid: str = Depends(auth.get_current_user_uid)):
     set_user_store_recording_permission(uid, value)
     return {'status': 'ok'}
 
 
-@router.get('/v1/users/store-recording-permission', tags=['v1'])
+@v1_router.get('/users/store-recording-permission')
 def get_store_recording_permission(uid: str = Depends(auth.get_current_user_uid)):
     return {'store_recording_permission': get_user_store_recording_permission(uid)}
 
 
-@router.delete('/v1/users/store-recording-permission', tags=['v1'])
+@v1_router.delete('/users/store-recording-permission')
 def delete_permission_and_recordings(uid: str = Depends(auth.get_current_user_uid)):
     set_user_store_recording_permission(uid, False)
     delete_all_memory_recordings(uid)
@@ -119,7 +119,7 @@ def delete_permission_and_recordings(uid: str = Depends(auth.get_current_user_ui
 # ****************************************
 
 # TODO: consider adding person photo.
-@router.post('/v1/users/people', tags=['v1'], response_model=Person)
+@v1_router.post('/users/people', response_model=Person)
 def create_new_person(data: CreatePerson, uid: str = Depends(auth.get_current_user_uid)):
     data = {
         'id': str(uuid.uuid4()),
@@ -132,7 +132,7 @@ def create_new_person(data: CreatePerson, uid: str = Depends(auth.get_current_us
     return result
 
 
-@router.get('/v1/users/people/{person_id}', tags=['v1'], response_model=Person)
+@v1_router.get('/users/people/{person_id}', response_model=Person)
 def get_single_person(
         person_id: str, include_speech_samples: bool = False, uid: str = Depends(auth.get_current_user_uid)
 ):
@@ -144,7 +144,7 @@ def get_single_person(
     return person
 
 
-@router.get('/v1/users/people', tags=['v1'], response_model=List[Person])
+@v1_router.get('/users/people', response_model=List[Person])
 def get_all_people(include_speech_samples: bool = True, uid: str = Depends(auth.get_current_user_uid)):
     print('get_all_people', include_speech_samples)
     people = get_people(uid)
@@ -158,7 +158,7 @@ def get_all_people(include_speech_samples: bool = True, uid: str = Depends(auth.
     return people
 
 
-@router.patch('/v1/users/people/{person_id}/name', tags=['v1'])
+@v1_router.patch('/users/people/{person_id}/name')
 def update_person_name(
         person_id: str,
         value: str,  # = Field(min_length=2, max_length=40),
@@ -168,7 +168,7 @@ def update_person_name(
     return {'status': 'ok'}
 
 
-@router.delete('/v1/users/people/{person_id}', tags=['v1'], status_code=204)
+@v1_router.delete('/users/people/{person_id}', status_code=204)
 def delete_person_endpoint(person_id: str, uid: str = Depends(auth.get_current_user_uid)):
     delete_person(uid, person_id)
     delete_user_person_speech_samples(uid, person_id)
@@ -180,7 +180,7 @@ def delete_person_endpoint(person_id: str, uid: str = Depends(auth.get_current_u
 # **********************************************************
 
 
-@router.delete('/v1/joan/{memory_id}/followup-question', tags=['v1'], status_code=204)
+@v1_router.delete('/joan/{memory_id}/followup-question', status_code=204)
 def delete_person_endpoint(memory_id: str, uid: str = Depends(auth.get_current_user_uid)):
     if memory_id == '0':
         memory = get_in_progress_memory(uid)
@@ -196,7 +196,7 @@ def delete_person_endpoint(memory_id: str, uid: str = Depends(auth.get_current_u
 # ************* Analytics **************
 # **************************************
 
-@router.post('/v1/users/analytics/memory_summary', tags=['v1'])
+@v1_router.post('/users/analytics/memory_summary')
 def set_memory_summary_rating(
         memory_id: str,
         value: int,  # 0, 1, -1 (shown)
@@ -206,7 +206,7 @@ def set_memory_summary_rating(
     return {'status': 'ok'}
 
 
-@router.get('/v1/users/analytics/memory_summary', tags=['v1'])
+@v1_router.get('/users/analytics/memory_summary')
 def get_memory_summary_rating(
         memory_id: str,
         _: str = Depends(auth.get_current_user_uid),
@@ -218,7 +218,7 @@ def get_memory_summary_rating(
     return {'has_rating': rating.get('value', -1) != -1, 'rating': rating.get('value', -1)}
 
 
-@router.post('/v1/users/analytics/chat_message', tags=['v1'])
+@v1_router.post('/users/analytics/chat_message')
 def set_chat_message_analytics(
         message_id: str,
         value: int,

--- a/backend/routers/workflow.py
+++ b/backend/routers/workflow.py
@@ -11,11 +11,10 @@ import models.memory as memory_models
 from routers.memories import process_memory, trigger_external_integrations
 from utils.memories.location import get_google_maps_location
 
-router = APIRouter()
+v1_router = APIRouter(prefix="/v1", tags=['integration', 'workflow', 'memories'])
 
 
-@router.post('/v1/integrations/workflow/memories', response_model=integration_models.EmptyResponse,
-             tags=['integration', 'workflow', 'memories'])
+@v1_router.post('/integrations/workflow/memories', response_model=integration_models.EmptyResponse)
 def create_memory(request: Request, uid: str, api_key: Annotated[str | None, Header()],
                   create_memory: memory_models.WorkflowCreateMemory):
     if api_key != os.getenv('WORKFLOW_API_KEY'):
@@ -52,8 +51,7 @@ def create_memory(request: Request, uid: str, api_key: Annotated[str | None, Hea
     return {}
 
 
-@router.get('/v1/integrations/workflow/memories', response_model=List[memory_models.Memory],
-            tags=['integration', 'workflow', 'memories'])
+@v1_router.get('/integrations/workflow/memories', response_model=List[memory_models.Memory])
 def get_memory(request: Request, uid: str, api_key: Annotated[str | None, Header()], limit: int = 1):
     if api_key != os.getenv('WORKFLOW_API_KEY'):
         raise HTTPException(status_code=401, detail="Invalid API Key")


### PR DESCRIPTION
### Problem
The API lacked recommended versioning patterns. Additionally, tagging endpoints with "v1" or "v2" in their paths leads to redundancy

### Changes
- Introduced dedicated routers for handling different API versions
- Removed explicit version tags ("v1" or "v2") from the API paths
- Add missing relevant tags where necessary
- Remove commented `# app.include_router(screenpipe.router)` from `backend/main.py`

### Impact
- Simplifies adding new features to future routes without affecting existing
- Prepares the API architecture for future versioning requirements

NOTE: I did not apply the same changes to `backend/routers/plugins.py` because one of the routes does not include versioning, and further modifications may require additional context.

Additionally, I considered reorganizing the defined endpoints in a more structured way, such as:

```py
v3_router = APIRouter(prefix="/v3")

# v3 endpoints

v2_router = APIRouter(prefix="/v2")

# v2 endpoints

# and so on...
```

This reorganization can be addressed in a separate effort to avoid making the PR larger