### PR TITLE
Fix broken link in Compile_firmware.mdx

### DIFF
--- a/docs/docs/developer/Compile_firmware.mdx
+++ b/docs/docs/developer/Compile_firmware.mdx
@@ -7,7 +7,7 @@ description: "Step-by-step guide to compile and install firmware for your OMI de
 
 ### Prefer a Pre-Built Firmware?
 
-Navigate to [Flash Device](https://docs.omi.me/get_started/Flash_device/) to install a pre-built firmware version.
+Navigate to [Flash Device](https://docs.omi.me/docs/get_started/Flash_device) to install a pre-built firmware version.
 
 ---
 


### PR DESCRIPTION
Old link missed "/docs" in URL

https://docs.omi.me/get_started/Flash_device
=>
https://docs.omi.me/docs/get_started/Flash_device