### PR TITLE
Add uid and app_id in stripe subscription metadata

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -37,6 +37,13 @@ async def stripe_webhook(request: Request, stripe_signature: str = Header(None))
             raise HTTPException(status_code=400, detail="Invalid client")
         uid = client_reference_id[4:]
 
+        if session.get("subscription"):
+            subscription_id = session["subscription"]
+            stripe.Subscription.modify(
+                subscription_id,
+                metadata={"uid": uid, "app_id": app_id}
+            )
+
         # paid
         paid_app(app_id, uid)
 

--- a/backend/utils/stripe.py
+++ b/backend/utils/stripe.py
@@ -111,7 +111,6 @@ def refresh_connect_account_link(account_id: str, base_url: str):
     }
 
 
-
 def is_onboarding_complete(account_id: str):
     account = stripe.Account.retrieve(account_id)
     return account.charges_enabled and account.payouts_enabled and account.details_submitted


### PR DESCRIPTION
Add uid and app_id to the Stripe subscription metadata from the webhook to link subscriptions to users (so that they can be retrieved by uid in future to allow cancellation and management of subscriptions)

<img width="381" alt="Screenshot 2025-02-09 at 7 33 48 PM" src="https://github.com/user-attachments/assets/9ff3f5e9-e80f-46b0-aa70-37aae40ebb07" />
