### PR TITLE
Fixes #1768 : Add a notification to charge device when battery is smaller than 20%

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -10,8 +10,7 @@ import 'package:friend_private/services/services.dart';
 import 'package:friend_private/utils/analytics/mixpanel.dart';
 import 'package:instabug_flutter/instabug_flutter.dart';
 
-class DeviceProvider extends ChangeNotifier
-    implements IDeviceServiceSubsciption {
+class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption {
   CaptureProvider? captureProvider;
 
   bool isConnecting = false;
@@ -48,13 +47,10 @@ class DeviceProvider extends ChangeNotifier
 
   Future getDeviceInfo() async {
     if (connectedDevice != null) {
-      if (pairedDevice?.firmwareRevision != null &&
-          pairedDevice?.firmwareRevision != 'Unknown') {
+      if (pairedDevice?.firmwareRevision != null && pairedDevice?.firmwareRevision != 'Unknown') {
         return;
       }
-      var connection = await ServiceManager.instance()
-          .device
-          .ensureConnection(connectedDevice!.id);
+      var connection = await ServiceManager.instance().device.ensureConnection(connectedDevice!.id);
       pairedDevice = await connectedDevice!.getDeviceInfo(connection);
       SharedPreferencesUtil().btDevice = pairedDevice!;
     } else {
@@ -73,19 +69,16 @@ class DeviceProvider extends ChangeNotifier
     void Function(int)? onBatteryLevelChange,
   }) async {
     {
-      var connection =
-          await ServiceManager.instance().device.ensureConnection(deviceId);
+      var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
       if (connection == null) {
         return Future.value(null);
       }
-      return connection.getBleBatteryLevelListener(
-          onBatteryLevelChange: onBatteryLevelChange);
+      return connection.getBleBatteryLevelListener(onBatteryLevelChange: onBatteryLevelChange);
     }
   }
 
   Future<List<int>> _getStorageList(String deviceId) async {
-    var connection =
-        await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
     if (connection == null) {
       return [];
     }
@@ -97,8 +90,7 @@ class DeviceProvider extends ChangeNotifier
     if (deviceId.isEmpty) {
       return null;
     }
-    var connection =
-        await ServiceManager.instance().device.ensureConnection(deviceId);
+    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
     return connection?.device;
   }
 
@@ -115,8 +107,7 @@ class DeviceProvider extends ChangeNotifier
           _hasLowBatteryAlerted = true;
           NotificationService.instance.createNotification(
             title: "Low Battery Alert",
-            body:
-                "Your device is running low on battery. Time for a recharge! 🔋",
+            body: "Your device is running low on battery. Time for a recharge! 🔋",
           );
         } else if (batteryLevel > 20) {
           _hasLowBatteryAlerted = true;
@@ -130,8 +121,7 @@ class DeviceProvider extends ChangeNotifier
   Future periodicConnect(String printer) async {
     debugPrint("period connect");
     _reconnectionTimer?.cancel();
-    _reconnectionTimer =
-        Timer.periodic(Duration(seconds: connectionCheckSeconds), (t) async {
+    _reconnectionTimer = Timer.periodic(Duration(seconds: connectionCheckSeconds), (t) async {
       debugPrint("period connect...");
       print('seconds: $connectionCheckSeconds');
       print('triggered timer at ${DateTime.now()}');
@@ -139,8 +129,7 @@ class DeviceProvider extends ChangeNotifier
       if (SharedPreferencesUtil().btDevice.id.isEmpty) {
         return;
       }
-      print(
-          "isConnected: $isConnected, isConnecting: $isConnecting, connectedDevice: $connectedDevice");
+      print("isConnected: $isConnected, isConnecting: $isConnecting, connectedDevice: $connectedDevice");
       if ((!isConnected && connectedDevice == null)) {
         if (isConnecting) {
           return;
@@ -152,8 +141,7 @@ class DeviceProvider extends ChangeNotifier
     });
   }
 
-  Future<BtDevice?> _scanAndConnectDevice(
-      {bool autoConnect = true, bool timeout = false}) async {
+  Future<BtDevice?> _scanAndConnectDevice({bool autoConnect = true, bool timeout = false}) async {
     var device = await _getConnectedDevice();
     if (device != null) {
       return device;
@@ -162,9 +150,7 @@ class DeviceProvider extends ChangeNotifier
     int timeoutCounter = 0;
     while (true) {
       if (timeout && timeoutCounter >= 10) return null;
-      await ServiceManager.instance()
-          .device
-          .discover(desirableDeviceId: SharedPreferencesUtil().btDevice.id);
+      await ServiceManager.instance().device.discover(desirableDeviceId: SharedPreferencesUtil().btDevice.id);
       if (connectedDevice != null) {
         return connectedDevice;
       }
@@ -296,14 +282,11 @@ class DeviceProvider extends ChangeNotifier
   }
 
   @override
-  void onDeviceConnectionStateChanged(
-      String deviceId, DeviceConnectionState state) async {
-    debugPrint(
-        "provider > device connection state changed...${deviceId}...${state}...${connectedDevice?.id}");
+  void onDeviceConnectionStateChanged(String deviceId, DeviceConnectionState state) async {
+    debugPrint("provider > device connection state changed...${deviceId}...${state}...${connectedDevice?.id}");
     switch (state) {
       case DeviceConnectionState.connected:
-        var connection =
-            await ServiceManager.instance().device.ensureConnection(deviceId);
+        var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
         if (connection == null) {
           return;
         }


### PR DESCRIPTION
claim #1768
Fixes #1768 

This PR introduces a notification alert when the connected device's battery drops below 20%. It ensures users are notified once per connection session to prevent spamming while handling reconnections properly.