### PR TITLE
Update DevKit firmware flashing documentation

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -1,3 +1,48 @@
-## Friend App
+# Friend App
 
-Check out https://docs.omi.me/docs/get_started/Setup/ for a guide on how to set up the app.
+The Friend App is a Flutter-based mobile application that serves as the companion app for Omi devices. This app enables users to interact with their Omi device, manage apps, and customize their experience.
+
+### Automated Setup (Recommended)
+
+1. Navigate to the app directory:
+   ```bash
+   cd app
+   ```
+
+2. Run setup script:
+   ```bash
+   # For iOS
+   bash setup.sh ios
+
+   # For Android
+   bash setup.sh android
+   ```
+
+3. Run the app:
+   ```bash
+   flutter run --flavor dev
+   ```
+
+For detailed setup instructions, including manual setup and Firebase configuration, visit our [App Setup Guide](https://docs.omi.me/docs/developer/AppSetup).
+
+## Key Features
+
+- **Device Management**: Connect and manage Omi devices
+- **App Marketplace**: Browse, install, and manage apps
+- **Chat Interface**: Interact with your Omi device
+- **External Integrations**: Support for various services and APIs
+- **Payment Integration**: Secure payment processing through Stripe
+- **Developer Tools**: Create and publish your own apps
+
+## Project Structure
+
+- `lib/`: Main application code
+  - `pages/`: UI screens and components
+  - `providers/`: State management
+  - `backend/`: API and backend services
+  - `utils/`: Utility functions and helpers
+
+## Support
+
+- Discord: http://discord.omi.me
+- Documentation: https://docs.omi.me

--- a/app/README.md
+++ b/app/README.md
@@ -2,7 +2,25 @@
 
 The Friend App is a Flutter-based mobile application that serves as the companion app for Omi devices. This app enables users to interact with their Omi device, manage apps, and customize their experience.
 
-### Automated Setup (Recommended)
+## 📚 **[View Full App setup instructions in the documentation](https://docs.omi.me/docs/developer/AppSetup)**
+
+## What's in the Documentation?
+
+### 🛠 Development Setup
+- **Firebase Setup**: Complete guide for configuring Firebase authentication and services
+- **Environment Setup**: Step-by-step guide for .env configuration and API keys
+- **Build Configuration**: Instructions for build runner and platform-specific setups
+- **Manual Setup Option**: Alternative to automated setup for custom configurations
+- **Troubleshooting Guide**: Common setup issues and their solutions
+
+### 🚀 Advanced Topics
+- **Backend Integration**: Guide for connecting to custom backend services
+- **Production Setup**: Detailed Firebase configuration for production environment
+- **Authentication**: Complete OAuth setup including SHA key generation
+- **Multi-Environment**: Managing development and production configurations
+- **Platform Specifics**: iOS and Android platform-specific requirements
+
+### Quick Setup
 
 1. Navigate to the app directory:
    ```bash
@@ -23,26 +41,6 @@ The Friend App is a Flutter-based mobile application that serves as the companio
    flutter run --flavor dev
    ```
 
-For detailed setup instructions, including manual setup and Firebase configuration, visit our [App Setup Guide](https://docs.omi.me/docs/developer/AppSetup).
+## Need Help?
 
-## Key Features
-
-- **Device Management**: Connect and manage Omi devices
-- **App Marketplace**: Browse, install, and manage apps
-- **Chat Interface**: Interact with your Omi device
-- **External Integrations**: Support for various services and APIs
-- **Payment Integration**: Secure payment processing through Stripe
-- **Developer Tools**: Create and publish your own apps
-
-## Project Structure
-
-- `lib/`: Main application code
-  - `pages/`: UI screens and components
-  - `providers/`: State management
-  - `backend/`: API and backend services
-  - `utils/`: Utility functions and helpers
-
-## Support
-
-- Discord: http://discord.omi.me
-- Documentation: https://docs.omi.me
+- 💬 Join our [Discord Community](http://discord.omi.me)

--- a/docs/docs/get_started/Flash_device.mdx
+++ b/docs/docs/get_started/Flash_device.mdx
@@ -18,10 +18,10 @@ To update the firmware of your OMI device, you can either:
     preload="metadata"
   >
     <source
-      src="/docs/static/images/updating_your_friend.mp4"
+      src="../../static/images/updating_your_friend.mp4"
       type="video/mp4"
     />
-    Your browser does not support the video tag. <a href="/docs/static/images/updating_your_friend.mp4">
+    Your browser does not support the video tag. <a href="../../static/images/updating_your_friend.mp4">
       Click here to download the video
     </a>.
   </video>
@@ -52,9 +52,9 @@ Before starting:
 1. Connect your device via USB
 2. Locate the DFU/Reset button:
    - **DevKit 2**: Remove lid, find button labeled "RST"
-     ![DFU Button Location, DevKit 2](/docs/static/images/dk2_rst_button.jpeg)
+     ![DFU Button Location, DevKit 2](../../static/images/dk2_rst_button.jpeg)
    - **DevKit 1**: Use button shown below
-     ![DFU Button Location, DevKit 1](/docs/static/images/dfu_dev_kit_reset_button.png)
+     ![DFU Button Location, DevKit 1](../../static/images/dfu_dev_kit_reset_button.png)
 3. Double-click the reset button quickly
 4. Your computer should show a drive named `/Volumes/XIAO-SENSE`
 

--- a/docs/docs/get_started/Flash_device.mdx
+++ b/docs/docs/get_started/Flash_device.mdx
@@ -18,10 +18,10 @@ To update the firmware of your OMI device, you can either:
     preload="metadata"
   >
     <source
-      src="/images/updating_your_friend.mp4"
+      src="/docs/static/images/updating_your_friend.mp4"
       type="video/mp4"
     />
-    Your browser does not support the video tag. <a href="/images/updating_your_friend.mp4">
+    Your browser does not support the video tag. <a href="/docs/static/images/updating_your_friend.mp4">
       Click here to download the video
     </a>.
   </video>
@@ -52,17 +52,9 @@ Before starting:
 1. Connect your device via USB
 2. Locate the DFU/Reset button:
    - **DevKit 2**: Remove lid, find button labeled "RST"
-     <img
-       src="/images/dk2_rst_button.jpeg"
-       title="DFU Button Location, DevKit 2"
-       width="300"
-     />
+     ![DFU Button Location, DevKit 2](/docs/static/images/dk2_rst_button.jpeg)
    - **DevKit 1**: Use button shown below
-     <img
-       src="/images/dfu_dev_kit_reset_button.png"
-       title="DFU Button Location, DevKit 1"
-       width="300"
-     />
+     ![DFU Button Location, DevKit 1](/docs/static/images/dfu_dev_kit_reset_button.png)
 3. Double-click the reset button quickly
 4. Your computer should show a drive named `/Volumes/XIAO-SENSE`
 

--- a/docs/docs/get_started/Flash_device.mdx
+++ b/docs/docs/get_started/Flash_device.mdx
@@ -3,24 +3,23 @@ title: Update OMI Firmware
 description: "This document outlines the process of updating the OMI firmware."
 ---
 
-To update the firmware of your OMI device, navigate to the OMI App:
-**Settings > Device Settings > Update Firmware.**
+To update the firmware of your OMI device, you can either:
+- Use the OMI App: **Settings > Device Settings > Update Firmware**
+- Or follow the manual update process below
 
----
-
-## Manually Update the Firmware
-
-### Video Tutorial
+## Video Tutorial
 
 <div style={{ textAlign: "center" }}>
-  <video width="100%" height="auto" controls playsInline>
+  <video
+    width="100%"
+    height="auto"
+    controls
+    playsInline
+    preload="metadata"
+  >
     <source
       src="/images/updating_your_friend.mp4"
       type="video/mp4"
-    />
-    <source
-      src="/images/updating_your_friend.mov"
-      type="video/quicktime"
     />
     Your browser does not support the video tag. <a href="/images/updating_your_friend.mp4">
       Click here to download the video
@@ -28,66 +27,66 @@ To update the firmware of your OMI device, navigate to the OMI App:
   </video>
 </div>
 
----
+## Manual Update Process
 
-## Flash Your DevKit
+### 1. Download Required Files
 
-To flash your DevKit, follow these steps:
+1. **Bootloader** (required for first-time setup or if corrupted):
+   - Download [bootloader0.9.0.uf2](https://github.com/BasedHardware/omi/releases/download/v2.0.1-Omi/bootloader0.9.0.uf2)
+   - Compatible with Seeed XIAO nRF52840 Sense (SoftDevice S140 7.3.0)
 
-1. **Download the Latest DevKit Firmware**
-   - Go to [the Omi GitHub Releases page](https://github.com/BasedHardware/omi/releases).
-   - Search for the release that includes **`Omi_DK`** in its name.
-   - Download the `.uf2` files for the **DevKit** from the release’s “Assets.”
+2. **Firmware**:
+   - Go to [Omi GitHub Releases](https://github.com/BasedHardware/omi/releases)
+   - Download the `.uf2` file marked as **`Omi_DK`**
+   - Ensure you select the correct version for your device (DK1 or DK2)
 
-2. **Put the DevKit in Bootloader Mode**
-   - Connect your DevKit via USB to your computer.
-   - Press and hold the BOOT/RESET button (on your DevKit) while plugging in or resetting the board.
-   - Your DevKit should now appear as a USB drive named something like `DEVKIT`.
+### 2. Prepare Your Device
 
-3. **Copy the Firmware to the DevKit**
-   - Drag and drop the **`.uf2`** file you downloaded onto the `DEVKIT` drive.
-   - The DevKit will automatically restart, running the newly flashed firmware.
+Before starting:
+- Ensure device battery is above 50%
+- Use a direct USB connection (avoid USB hubs)
+- Have a small pin ready for the reset button
 
-> **Note**: For additional documentation on updating your DevKit2 firmware, please see [Updating Your DevKit2 Firmware](https://help.omi.me/en/articles/9995941-updating-your-devkit2-firmware).
+### 3. Enter DFU Mode
 
+1. Connect your device via USB
+2. Locate the DFU/Reset button:
+   - **DevKit 2**: Remove lid, find button labeled "RST"
+     <img
+       src="/images/dk2_rst_button.jpeg"
+       title="DFU Button Location, DevKit 2"
+       width="300"
+     />
+   - **DevKit 1**: Use button shown below
+     <img
+       src="/images/dfu_dev_kit_reset_button.png"
+       title="DFU Button Location, DevKit 1"
+       width="300"
+     />
+3. Double-click the reset button quickly
+4. Your computer should show a drive named `/Volumes/XIAO-SENSE`
 
----
+### 4. Flash the Device
 
-### Putting OMI into DFU Mode
+1. **Install Bootloader** (if needed):
+   - Drag `bootloader0.9.0.uf2` to the `/Volumes/XIAO-SENSE` drive
+   - Wait for the drive to eject automatically
+   - Put device back in DFU mode (repeat step 3)
 
-1. Plug the OMI device into your computer using a USB cable.
-2. **Locate the DFU Button:**
-   - For Developer Kit 2, remove the lid to access the button which is labeled "RST"
-     - <img
-         src="/images/dk2_rst_button.jpeg"
-         title="DFU Button Location, DevKit 2"
-         width="300"
-       />
-   - For Developer Kit 1, see the image below for button location:
-     - <img
-         src="/images/dfu_dev_kit_reset_button.png"
-         title="DFU Button Location, DevKit 1"
-         width="300"
-       />
-3. **Prepare a Pin:** Use a small pin or similar tool to press the tiny button.
-4. **Press the DFU Button Twice:** Quickly press the button twice in succession using the pin.
-5. **Check for Recognition:** After pressing the button, your computer should recognize a new drive.
-6. **Verify the Drive Name:** Look for a drive named `/Volumes/XIAO-SENSE` on your computer. This confirms the device is in DFU mode.
+2. **Install Firmware**:
+   - Drag the firmware `.uf2` file to the `/Volumes/XIAO-SENSE` drive
+   - Wait for completion (ignore "transfer incomplete" messages)
+   - Device will restart automatically
 
----
+### Troubleshooting
 
-### Flashing the Firmware
-
-1. Locate the `.uf2` files downloaded earlier.
-2. Drag and drop the **bootloader** `.uf2` file onto the `/Volumes/XIAO-SENSE` drive.
-   - The device will automatically eject itself after completing the bootloader flashing process.
-3. Put the OMI device back into DFU mode by double-tapping the reset button.
-4. Drag and drop the **firmware** `.uf2` file onto the `/Volumes/XIAO-SENSE` drive.
-   - **Note:** If your computer reports the transfer was incomplete, it is likely still successful.
+- If device isn't recognized: Try a different USB cable or port
+- If update fails: Retry the process
+- If you see "transfer incomplete": Wait 30 seconds before checking device status
+- For additional help: See [DevKit2 Firmware Guide](https://help.omi.me/en/articles/9995941-updating-your-devkit2-firmware)
 
 ---
 
 ## Congratulations!
 
-You have successfully flashed the latest firmware onto your OMI device.
-Enjoy the enhanced functionality and features of your updated OMI!
+Your OMI device is now updated with the latest firmware. Enjoy the enhanced features!

--- a/docs/docs/get_started/Flash_device.mdx
+++ b/docs/docs/get_started/Flash_device.mdx
@@ -3,7 +3,7 @@ title: Update OMI Firmware
 description: "This document outlines the process of updating the OMI firmware."
 ---
 
-To update the firmware of your OMI device, navigate to the OMI App:  
+To update the firmware of your OMI device, navigate to the OMI App:
 **Settings > Device Settings > Update Firmware.**
 
 ---
@@ -13,27 +13,43 @@ To update the firmware of your OMI device, navigate to the OMI App:
 ### Video Tutorial
 
 <div style={{ textAlign: "center" }}>
-  <video width="100%" height="auto" controls>
+  <video width="100%" height="auto" controls playsInline>
     <source
-      src="https://github.com/BasedHardware/omi/blob/main/docs/static/images/updating_your_friend.mov"
+      src="/images/updating_your_friend.mp4"
       type="video/mp4"
     />
-    Your browser does not support the video tag. <a href="https://github.com/BasedHardware/omi/blob/main/docs/static/images/updating_your_friend.mov">
-      Click here to watch the video
+    <source
+      src="/images/updating_your_friend.mov"
+      type="video/quicktime"
+    />
+    Your browser does not support the video tag. <a href="/images/updating_your_friend.mp4">
+      Click here to download the video
     </a>.
   </video>
 </div>
 
 ---
 
-## Walkthrough
+## Flash Your DevKit
 
-### Downloading the Firmware
+To flash your DevKit, follow these steps:
 
-1. Visit the [OMI GitHub releases](https://github.com/BasedHardware/omi/releases).
-2. Download the latest firmware and bootloader `.uf2` files.  
-   **Important:** Ensure you select the correct files for your device:
-   - Developer Kit 2 firmware is **not** compatible with Developer Kit 1.
+1. **Download the Latest DevKit Firmware**
+   - Go to [the Omi GitHub Releases page](https://github.com/BasedHardware/omi/releases).
+   - Search for the release that includes **`Omi_DK`** in its name.
+   - Download the `.uf2` files for the **DevKit** from the release’s “Assets.”
+
+2. **Put the DevKit in Bootloader Mode**
+   - Connect your DevKit via USB to your computer.
+   - Press and hold the BOOT/RESET button (on your DevKit) while plugging in or resetting the board.
+   - Your DevKit should now appear as a USB drive named something like `DEVKIT`.
+
+3. **Copy the Firmware to the DevKit**
+   - Drag and drop the **`.uf2`** file you downloaded onto the `DEVKIT` drive.
+   - The DevKit will automatically restart, running the newly flashed firmware.
+
+> **Note**: For additional documentation on updating your DevKit2 firmware, please see [Updating Your DevKit2 Firmware](https://help.omi.me/en/articles/9995941-updating-your-devkit2-firmware).
+
 
 ---
 
@@ -73,5 +89,5 @@ To update the firmware of your OMI device, navigate to the OMI App:
 
 ## Congratulations!
 
-You have successfully flashed the latest firmware onto your OMI device.  
+You have successfully flashed the latest firmware onto your OMI device.
 Enjoy the enhanced functionality and features of your updated OMI!


### PR DESCRIPTION

- Added bootloader (v0.9.0) details and download link
- Improved video implementation:
  - Switched from GitHub-hosted to local video files
  - Added MP4 format with proper metadata
  - Fixed video playback and download links
- Enhanced documentation structure: 
  - Clear step-by-step flashing instructions
  - Added compatibility warnings between DevKit versions

- Added technical details:
  - Seeed XIAO nRF52840 Sense compatibility
  - Bootloader mode instructions

Added missed resources:
- DevKit2 Guide: help.omi.me/articles/9995941
- Bootloader: v2.0.1-Omi/bootloader0.9.0.uf2

partially fix https://github.com/BasedHardware/omi/issues/1808