### PR TITLE
windows backend compatibility

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -88,7 +88,7 @@ This README provides a quick setup guide for the Omi backend. For a comprehensiv
 
 15. Start the backend server:
     ```bash
-    uvicorn main:app --reload --env-file .env
+    python -m uvicorn main:app --reload --env-file .env
     ```
 
 16. Troubleshooting: If you get any error mentioning "no internet connection" while downloading models, add the following lines in the `utils/stt/vad.py` file after the import statements:

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -244,7 +244,6 @@ umap-learn==0.5.6
 uritemplate==4.1.1
 urllib3==2.2.2
 uvicorn==0.30.5
-uvloop==0.20.0
 watchdog==4.0.2
 watchfiles==0.22.0
 wcwidth==0.2.13


### PR DESCRIPTION
removed uvloop: seems to not be neccessary and prevents the backend from running on windows