### PR TITLE
Fix Ruby Gem Permission  in Setup Script

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "fastlane"
+gem "cocoapods"
+gem "nkf"

--- a/app/README.md
+++ b/app/README.md
@@ -44,3 +44,37 @@ The Omi App is a Flutter-based mobile application that serves as the companion a
 ## Need Help?
 
 - 💬 Join our [Discord Community](http://discord.omi.me)
+
+## Troubleshooting
+
+### iOS Setup Issues with Ruby Gems
+
+If you encounter Ruby gem dependency errors during iOS setup (particularly with fastlane), follow these steps:
+
+1. Install Bundler (if not already installed):
+   ```bash
+   sudo gem install bundler
+   ```
+
+2. Create a Gemfile in the app directory with required gems:
+   ```bash
+   cat > Gemfile << EOL
+   source "https://rubygems.org"
+
+   gem "fastlane"
+   gem "cocoapods"
+   gem "nkf"
+   EOL
+   ```
+
+3. Install gems using Bundler:
+   ```bash
+   bundle install
+   ```
+
+4. Run the iOS setup using Bundler:
+   ```bash
+   bundle exec bash setup.sh ios
+   ```
+
+This approach ensures all required Ruby dependencies are properly installed and managed.

--- a/app/setup.sh
+++ b/app/setup.sh
@@ -9,7 +9,7 @@
 # - Android Studio (for Android)
 # - NDK 26.3.11579264 or above (to build Opus for ARM Devices)
 # - Opus Codec: https://opus-codec.org
-# Usages: 
+# Usages:
 # - $bash setup.sh ios
 # - $bash setup.sh android
 
@@ -88,10 +88,24 @@ function setup_provisioning_profile() {
         echo "Installing fastlane..."
         brew install fastlane
     fi
-    
-    MATCH_PASSWORD=omi fastlane match development --readonly \
-        --app_identifier com.friend-app-with-wearable.ios12.development \
-        --git_url "git@github.com:BasedHardware/omi-community-certs.git"
+
+    # Check if bundler is installed
+    if ! command -v bundle &> /dev/null; then
+        echo "Installing bundler..."
+        gem install bundler
+    fi
+
+    # Use bundler to run fastlane if Gemfile exists
+    if [ -f "Gemfile" ]; then
+        echo "Using bundler to run fastlane..."
+        MATCH_PASSWORD=omi bundle exec fastlane match development --readonly \
+            --app_identifier com.friend-app-with-wearable.ios12.development \
+            --git_url "git@github.com:BasedHardware/omi-community-certs.git"
+    else
+        MATCH_PASSWORD=omi fastlane match development --readonly \
+            --app_identifier com.friend-app-with-wearable.ios12.development \
+            --git_url "git@github.com:BasedHardware/omi-community-certs.git"
+    fi
 }
 
 


### PR DESCRIPTION
The setup script is failing during bundle install with permission errors when trying to install the JSON gem. This appears to be related to PR #1998 (commit 095f4ae8a), which introduced changes that led to permission issues during the gem installation process.

Testing Required:
- [ ] Test on macOS with a clean environment
- [ ] Verify bundle install succeeds without permission errors
- [ ] Confirm setup completes successfully for both iOS and Android targets
- [ ] Test with different user permission configurations