### PR TITLE
Update requirements.txt final

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -254,3 +254,7 @@ yarl==1.9.4
 stripe==11.3.0
 typesense==0.21.0
 pycountry==24.6.1
+google-auth==2.23.0
+google-auth-oauthlib==1.2.0
+google-auth-httplib2==0.2.0
+google-api-python-client==2.142.0


### PR DESCRIPTION
---

### Why This Works with `main.py`
- **Import Style:** `from routers import google_calendar` and `app.include_router(google_calendar.router)` match the pattern in `main.py` (e.g., `transcribe.router`).
- **Dependencies:** Your `requirements.txt` update ensures Google libs are available, and Modal’s `image` uses it.
- **Environment:** `.env` keys (`OPENAI_API _KEY`, `PINECONE_API_KEY`) are already part of Omi’s setup.

#### Assumptions
- Modal deployment handles `requirements.txt` automatically, so no image update needed.
- Pinecone index is `omi-memory` or set in `.env`.
