### PR TITLE
Adding Google Calendar support 

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -6,17 +6,17 @@ from fastapi import FastAPI
 
 from modal import Image, App, asgi_app, Secret
 from routers import workflow, chat, firmware, plugins, memories, transcribe, notifications, \
-    speech_profile, agents, facts, users, processing_memories, trends, sdcard, sync, apps, custom_auth, payment, \
-    integration
+ speech_profile, agents, facts, users, processing_memories, trends, sdcard, sync, apps, custom_auth, payment, \
+ integration, google_calendar # Add google_calendar here
 
 from utils.other.timeout import TimeoutMiddleware
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
-    service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
-    credentials = firebase_admin.credentials.Certificate(service_account_info)
-    firebase_admin.initialize_app(credentials)
+ service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
+ credentials = firebase_admin.credentials.Certificate(service_account_info)
+ firebase_admin.initialize_app(credentials)
 else:
-    firebase_admin.initialize_app()
+ firebase_admin.initialize_app()
 
 app = FastAPI()
 app.include_router(transcribe.router)
@@ -33,51 +33,46 @@ app.include_router(agents.router)
 app.include_router(users.router)
 app.include_router(processing_memories.router)
 app.include_router(trends.router)
-
 app.include_router(firmware.router)
 app.include_router(sdcard.router)
 app.include_router(sync.router)
-
 app.include_router(apps.router)
 app.include_router(custom_auth.router)
-
 app.include_router(payment.router)
-
+app.include_router(google_calendar.router ) # Add this line
 
 methods_timeout = {
-    "GET": os.environ.get('HTTP_GET_TIMEOUT'),
-    "PUT": os.environ.get('HTTP_PUT_TIMEOUT'),
-    "PATCH": os.environ.get('HTTP_PATCH_TIMEOUT'),
-    "DELETE": os.environ.get('HTTP_DELETE_TIMEOUT'),
+ "GET": os.environ.get('HTTP_GET_TIMEOUT'),
+ "PUT": os.environ.get('HTTP_PUT_TIMEOUT'),
+ "PATCH": os.environ.get('HTTP_PATCH_TIMEOUT'),
+ "DELETE": os.environ.get('HTTP_DELETE_TIMEOUT'),
 }
 
-app.add_middleware(TimeoutMiddleware,methods_timeout=methods_timeout)
+app.add_middleware(TimeoutMiddleware, methods_timeout=methods_timeout)
 
 modal_app = App(
-    name='backend',
-    secrets=[Secret.from_name("gcp-credentials"), Secret.from_name('envs')],
+ name='backend',
+ secrets=[Secret.from_name("gcp-credentials"), Secret.from_name('envs')],
 )
 image = (
-    Image.debian_slim()
-    .apt_install('ffmpeg', 'git', 'unzip')
-    .pip_install_from_requirements('requirements.txt')
+ Image.debian_slim()
+ .apt_install('ffmpeg', 'git', 'unzip')
+ .pip_install_from_requirements('requirements.txt')
 )
 
-
 @modal_app.function(
-    image=image,
-    keep_warm=0,
-    memory=(512, 1024),
-    cpu=2,
-    allow_concurrent_inputs=10,
-    timeout=60 * 10,
+ image=image,
+ keep_warm=0,
+ memory=(512, 1024),
+ cpu=2,
+ allow_concurrent_inputs=10,
+ timeout=60 * 10,
 )
 @asgi_app()
 def api():
-    return app
-
+ return app
 
 paths = ['_temp', '_samples', '_segments', '_speech_profiles']
 for path in paths:
-    if not os.path.exists(path):
-        os.makedirs(path)
+ if not os.path.exists(path):
+ os.makedirs(path)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -254,3 +254,7 @@ yarl==1.9.4
 stripe==11.3.0
 typesense==0.21.0
 pycountry==24.6.1
+google-auth==2.23.0
+google-auth-oauthlib==1.2.0
+google-auth-httplib2==0.2.0
+google-api-python-client==2.142.0

--- a/backend/routers/google_calendar.py
+++ b/backend/routers/google_calendar.py
@@ -1,0 +1,70 @@
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import RedirectResponse
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from openai import OpenAI
+import pinecone
+import os
+from datetime import datetime, timedelta
+
+ router = APIRouter(prefix="/google_calendar", tags=["google_calendar"])
+
+# OAuth 2.0 scopes
+SCOPES = ['https://www.googleapis.com/auth/calendar.readonly']
+CREDENTIALS_FILE = os.path.join(os.path.dirname(__file__), "../credentials.json")
+
+# In-memory credentials (simple for testing)
+stored_credentials = None
+
+@router.get("/auth")
+def initiate_auth():
+ """Redirects to Google for authentication."""
+ if not os.path.exists(CREDENTIALS_FILE):
+ raise HTTPException(status_code=500, detail="Add credentials.json to backend/")
+ flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+ flow.redirect_uri = "http://localhost:8000/google_calendar/callback"
+ authorization_url, _ = flow.authorization_url(prompt="consent")
+ return RedirectResponse(authorization_url)
+
+@router.get("/callback")
+def auth_callback(code: str):
+ """Stores credentials after Google redirect."""
+ global stored_credentials
+ flow = InstalledAppFlow.from_client_secrets_file(CREDENTIALS_FILE, SCOPES)
+ flow.redirect_uri = "http://localhost:8000/google_calendar/callback"
+ flow.fetch_token(code=code)
+ stored_credentials = flow.credentials
+ return {"message": "Authenticated"}
+
+@router.get("/sync")
+def sync_calendar():
+ """Fetches events, converts to text, and stores in Pinecone memory."""
+ global stored_credentials
+ if not stored_credentials:
+ raise HTTPException(status_code=401, detail="Authenticate first at /google_calendar/auth")
+
+ # Fetch events
+ service = build('calendar', 'v3', credentials=stored_credentials)
+ now = datetime.utcnow().isoformat() + 'Z'
+ end = (datetime.utcnow() + timedelta(days=30)).isoformat() + 'Z'
+ events_result = service.events().list(calendarId='primary', timeMin=now, timeMax=end,
+ maxResults=10, singleEvents=True,
+ orderBy='startTime').execute()
+ events = events_result.get('items', [])
+
+ # Convert to text
+ text = ""
+ for event in events:
+ start = event['start'].get('dateTime', event['start'].get('date'))
+ end = event['end'].get('dateTime', event['end'].get('date'))
+ text += f"{event.get('summary', 'No Title')} - {start} to {end}\n"
+
+ # Store in Pinecone memory
+ client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+ pinecone.init(api_key=os.environ.get("PINECONE_API_KEY"), environment="us-west1-gcp")
+ index = pinecone.Index(os.environ.get("PINECONE_INDEX_NAME", "omi-memory"))
+ response = client.embeddings.create(model="text-embedding-ada-002", input=text or "No events")
+ embedding = response.data[0].embedding
+ index.upsert([(f"cal_{datetime.now().isoformat()}", embedding, {"text": text, "source": "google_calendar"})])
+
+ return {"message": "Events synced to memory", "events_text": text}


### PR DESCRIPTION
---

### Why This Works with `main.py`
- **Import Style:** `from routers import google_calendar` and `app.include_router(google_calendar.router)` match the pattern in `main.py` (e.g., `transcribe.router`).
- **Dependencies:** Your `requirements.txt` update ensures Google libs are available, and Modal’s `image` uses it.
- **Environment:** `.env` keys (`OPENAI_API _KEY`, `PINECONE_API_KEY`) are already part of Omi’s setup.

#### Assumptions
- Modal deployment handles `requirements.txt` automatically, so no image update needed.
- Pinecone index is `omi-memory` or set in `.env`.
