### PR TITLE
Set triggers_on as empty string if in case of actions app

### DIFF
--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -85,6 +85,8 @@ def create_app(app_data: str = Form(...), file: UploadFile = File(...), uid=Depe
                     external_integration['is_instructions_url'] = True
                 else:
                     external_integration['is_instructions_url'] = False
+        else:
+            external_integration['triggers_on'] = ''
 
         # Acitons
         if actions := external_integration.get('actions'):


### PR DESCRIPTION
When `external_integrations` is being used, the pydantic model for external integrations expect the `triggers_on` field to be not null. Recently actions have been introduced and they do not make use of `triggers_on` field, making them null. If the app being submitted is an external integration app with actions and does not makes use of `triggers_on` field, then it is set to an empty string in this PR