### PR TITLE
uncomment learnings category for facts

### DIFF
--- a/backend/models/facts.py
+++ b/backend/models/facts.py
@@ -18,7 +18,7 @@ class FactCategory(str, Enum):
     work = "work"
     skills = "skills"
     # world = "world"
-    # learnings = "learnings"
+    learnings = "learnings"
     other = "other"
 
 


### PR DESCRIPTION
Currently in app there's a learning category but that same category is commented on the backend. Creating a new fact in learning category will throw an error

![Screenshot 2025-03-18 at 6 08 19 PM](https://github.com/user-attachments/assets/845ee55a-49aa-45b4-b11d-259a5fb18377)
