### PR TITLE
fix: ensure docs sync works with protected branch

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -68,16 +68,15 @@ jobs:
             fi
           done
 
-      - name: Commit and push changes
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions@github.com"
-
-          git add sdks/*/README.md
-
-          if git diff --staged --quiet; then
-            echo "No changes to commit."
-          else
-            git commit -m "chore: sync docs to SDK README files"
-            git push
-          fi
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: sync docs to SDK README files"
+          title: "chore: sync docs to SDK README files"
+          body: |
+            This PR was automatically created by the Sync Docs workflow.
+          branch: sync-docs
+          base: main
+          committer: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
+          author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>


### PR DESCRIPTION
Because `main` is a protected branch, direct pushes from GitHub Actions are blocked. The only way to fix this is by having the action create a pull request when changes are made to sync the documentation.  

To enable this, you need to check the "Allow GitHub Actions to create and approve pull requests" option.  
Go to Repo Settings → Actions → General, then tick the checkbox for "Allow GitHub Actions to create and approve pull requests."

<img width="913" alt="Screenshot 2025-04-01 at 6 28 55 PM" src="https://github.com/user-attachments/assets/e36e8947-8822-42a1-a702-95635cf1446a" />

I've tested it in my own repo, and it works as expected: https://github.com/krushnarout/omi-docs-test/pull/1


