### PR TITLE
fix: add pull requests permission

### DIFF
--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Related to https://github.com/BasedHardware/omi/pull/2142

Only enable 'Allow GitHub Actions to create and approve pull requests.' No need to grant 'Read and write permissions.'