### PR TITLE
fix: openapi docs authorization

### DIFF
--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -1,43 +1,47 @@
 import json
 import os
 import time
+from typing import Annotated
 
-from fastapi import Header, HTTPException
+from fastapi import Depends, HTTPException
 from fastapi import Request
 from firebase_admin import auth
-from firebase_admin.auth import InvalidIdTokenError
+from firebase_admin.auth import ExpiredIdTokenError, InvalidIdTokenError
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
+security = HTTPBearer()
 
 def get_user(uid: str):
     user = auth.get_user(uid)
     return user
 
 
-def get_current_user_uid(authorization: str = Header(None)):
-    if authorization and os.getenv('ADMIN_KEY') in authorization:
-        return authorization.split(os.getenv('ADMIN_KEY'))[1]
-
-    if not authorization:
-        raise HTTPException(status_code=401, detail="Authorization header not found")
-    elif len(str(authorization).split(' ')) != 2:
-        raise HTTPException(status_code=401, detail="Invalid authorization token")
+def get_current_user_uid(authorization: Annotated[HTTPAuthorizationCredentials, Depends(security)]):
+    token = authorization.credentials
+    key = os.getenv("ADMIN_KEY")
+    if key and key in token:
+        return token.split(key)[1]
 
     try:
-        token = authorization.split(' ')[1]
-        decoded_token = auth.verify_id_token(token)
-        # print('get_current_user_uid', decoded_token['uid'])
-        return decoded_token['uid']
-    except InvalidIdTokenError as e:
-        if os.getenv('LOCAL_DEVELOPMENT') == 'true':
-            return '123'
-        print(e)
+        decoded_token = auth.verify_id_token(authorization.credentials)
+        return decoded_token["uid"]
+    except KeyError:
+        raise HTTPException(status_code=400, detail="User ID not found")
+    except InvalidIdTokenError:
         raise HTTPException(status_code=401, detail="Invalid authorization token")
+    except ExpiredIdTokenError:
+        raise HTTPException(status_code=401, detail="Authorization token has expired")
+    except Exception as e:
+        print(e)
+        raise HTTPException(status_code=400, detail="Authorization failed")
 
 
 cached = {}
 
 
-def rate_limit_custom(endpoint: str, request: Request, requests_per_window: int, window_seconds: int):
+def rate_limit_custom(
+    endpoint: str, request: Request, requests_per_window: int, window_seconds: int
+):
     ip = request.client.host
     key = f"rate_limit:{endpoint}:{ip}"
 
@@ -71,7 +75,9 @@ def rate_limit_custom(endpoint: str, request: Request, requests_per_window: int,
 
 
 # Dependency to enforce custom rate limiting for specific endpoints
-def rate_limit_dependency(endpoint: str = "", requests_per_window: int = 60, window_seconds: int = 60):
+def rate_limit_dependency(
+    endpoint: str = "", requests_per_window: int = 60, window_seconds: int = 60
+):
     def rate_limit(request: Request):
         return rate_limit_custom(endpoint, request, requests_per_window, window_seconds)
 
@@ -86,8 +92,10 @@ def timeit(func):
     def measure_time(*args, **kw):
         start_time = time.time()
         result = func(*args, **kw)
-        print("Processing time of %s(): %.2f seconds."
-              % (func.__qualname__, time.time() - start_time))
+        print(
+            "Processing time of %s(): %.2f seconds."
+            % (func.__qualname__, time.time() - start_time)
+        )
         return result
 
     return measure_time


### PR DESCRIPTION
Add HTTPBearer Authorization to OpenAPI docs.
Automatic authorization for all endpoints that require it.

![omi-docs-auth](https://github.com/user-attachments/assets/068f8419-d451-4d3c-97c0-856c4e31df6f)
