### PR TITLE
Facts to memories db migration

### DIFF
--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -6,6 +6,8 @@ from google.cloud.firestore_v1 import FieldFilter
 
 from ._client import db
 
+memories_collection = 'memories'
+
 
 def get_memories(uid: str, limit: int = 100, offset: int = 0):
     print('get_memories', uid, limit, offset)
@@ -58,6 +60,11 @@ def create_memory(uid: str, data: dict):
     memories_ref = user_ref.collection('facts')
     memory_ref = memories_ref.document(data['id'])
     memory_ref.set(data)
+    # TODO: remove after migration
+    new_memories_ref = user_ref.collection(memories_collection)
+    new_memory_ref = new_memories_ref.document(data['id'])
+    new_memory_ref.set(data)
+    ##############################
 
 
 def save_memories(uid: str, data: List[dict]):
@@ -68,6 +75,13 @@ def save_memories(uid: str, data: List[dict]):
         memory_ref = memories_ref.document(memory['id'])
         batch.set(memory_ref, memory)
     batch.commit()
+    # TODO: remove after migration
+    new_memories_ref = user_ref.collection(memories_collection)
+    for memory in data:
+        memory_ref = new_memories_ref.document(memory['id'])
+        batch.set(memory_ref, memory)
+    batch.commit()
+    ##############################
 
 
 def delete_memories(uid: str):
@@ -77,6 +91,12 @@ def delete_memories(uid: str):
     for doc in memories_ref.stream():
         batch.delete(doc.reference)
     batch.commit()
+    # TODO: remove after migration
+    new_memories_ref = user_ref.collection(memories_collection)
+    for doc in new_memories_ref.stream():
+        batch.delete(doc.reference)
+    batch.commit()
+    ##############################
 
 
 def get_memory(uid: str, memory_id: str):
@@ -91,6 +111,11 @@ def review_memory(uid: str, memory_id: str, value: bool):
     memories_ref = user_ref.collection('facts')
     memory_ref = memories_ref.document(memory_id)
     memory_ref.update({'reviewed': True, 'user_review': value})
+    # TODO: remove after migration
+    new_memories_ref = user_ref.collection(memories_collection)
+    new_memory_ref = new_memories_ref.document(memory_id)
+    new_memory_ref.update({'reviewed': True, 'user_review': value})
+    ##############################
 
 
 def change_memory_visibility(uid: str, memory_id: str, value: str):
@@ -98,6 +123,11 @@ def change_memory_visibility(uid: str, memory_id: str, value: str):
     memories_ref = user_ref.collection('facts')
     memory_ref = memories_ref.document(memory_id)
     memory_ref.update({'visibility': value})
+    # TODO: remove after migration
+    new_memories_ref = user_ref.collection(memories_collection)
+    new_memory_ref = new_memories_ref.document(memory_id)
+    new_memory_ref.update({'visibility': value})
+    ##############################
 
 
 def edit_memory(uid: str, memory_id: str, value: str):
@@ -105,6 +135,11 @@ def edit_memory(uid: str, memory_id: str, value: str):
     memories_ref = user_ref.collection('facts')
     memory_ref = memories_ref.document(memory_id)
     memory_ref.update({'content': value, 'edited': True, 'updated_at': datetime.now(timezone.utc)})
+    # TODO: remove after migration
+    new_memories_ref = user_ref.collection(memories_collection)
+    new_memory_ref = new_memories_ref.document(memory_id)
+    new_memory_ref.update({'content': value, 'edited': True, 'updated_at': datetime.now(timezone.utc)})
+    ##############################
 
 
 def delete_memory(uid: str, memory_id: str):
@@ -112,6 +147,11 @@ def delete_memory(uid: str, memory_id: str):
     memories_ref = user_ref.collection('facts')
     memory_ref = memories_ref.document(memory_id)
     memory_ref.update({'deleted': True})
+    # TODO: remove after migration
+    new_memories_ref = user_ref.collection(memories_collection)
+    new_memory_ref = new_memories_ref.document(memory_id)
+    new_memory_ref.update({'deleted': True})
+    ##############################
 
 
 def delete_all_memories(uid: str):
@@ -122,6 +162,14 @@ def delete_all_memories(uid: str):
     for doc in query.stream():
         batch.update(doc.reference, {'deleted': True})
     batch.commit()
+    # TODO: remove after migration
+    new_memories_ref = user_ref.collection(memories_collection)
+    query = new_memories_ref.where(filter=FieldFilter('deleted', '==', False))
+    batch = db.batch()
+    for doc in query.stream():
+        batch.update(doc.reference, {'deleted': True})
+    batch.commit()
+    ##############################
 
 
 def delete_memories_for_conversation(uid: str, memory_id: str):

--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -62,6 +62,12 @@ def create_memory(uid: str, data: dict):
     memory_ref.set(data)
     # TODO: remove after migration
     new_memories_ref = user_ref.collection(memories_collection)
+    if 'memory_id' in data:
+        data['conversation_id'] = data['memory_id']
+        del data['memory_id']
+    if 'memory_category' in data:
+        data['conversation_category'] = data['memory_category']
+        del data['memory_category']
     new_memory_ref = new_memories_ref.document(data['id'])
     new_memory_ref.set(data)
     ##############################
@@ -78,6 +84,12 @@ def save_memories(uid: str, data: List[dict]):
     # TODO: remove after migration
     new_memories_ref = user_ref.collection(memories_collection)
     for memory in data:
+        if 'memory_id' in memory:
+            memory['conversation_id'] = memory['memory_id']
+            del memory['memory_id']
+        if 'memory_category' in memory:
+            memory['conversation_category'] = memory['memory_category']
+            del memory['memory_category']
         memory_ref = new_memories_ref.document(memory['id'])
         batch.set(memory_ref, memory)
     batch.commit()

--- a/backend/routers/integration.py
+++ b/backend/routers/integration.py
@@ -93,7 +93,7 @@ async def create_conversation_via_integration(
         raise HTTPException(status_code=403, detail="App is not enabled for this user")
 
     # Check if the app has the capability external_integration > action > create_conversation
-    if not apps_utils.app_has_action(app, 'create_conversation'):
+    if not apps_utils.app_can_create_conversation(app):
         raise HTTPException(status_code=403, detail="App does not have the capability to create conversations")
 
     # Time
@@ -158,8 +158,8 @@ async def create_memories_via_integration(
     if app_id not in enabled_plugins:
         raise HTTPException(status_code=403, detail="App is not enabled for this user")
 
-    # Check if the app has the capability external_integration > action > create_facts
-    if not apps_utils.app_has_action(app, 'create_facts'):
+    # Check if the app has the capability external_integration > action > create_memories / create_facts
+    if not apps_utils.app_can_create_memories(app):
         raise HTTPException(status_code=403, detail="App does not have the capability to create memories")
 
     # Validate that text is provided or explicit facts are provided
@@ -201,9 +201,9 @@ async def create_facts_via_integration(
     if app_id not in enabled_plugins:
         raise HTTPException(status_code=403, detail="App is not enabled for this user")
 
-    # Check if the app has the capability external_integration > action > create_facts
-    if not apps_utils.app_has_action(app, 'create_facts'):
-        raise HTTPException(status_code=403, detail="App does not have the capability to create facts")
+    # Check if the app has the capability external_integration > action > create_facts / create_memories
+    if not apps_utils.app_can_create_memories(app):
+        raise HTTPException(status_code=403, detail="App does not have the capability to create memories")
 
     # Validate that text is provided or explicit facts are provided
     if (not fact_data.text or len(fact_data.text.strip()) == 0) and \
@@ -249,7 +249,7 @@ async def get_memories_via_integration(
         raise HTTPException(status_code=403, detail="App is not enabled for this user")
 
     # Check if the app has the capability to read memories
-    if not apps_utils.app_has_action(app, 'read_memories'):
+    if not apps_utils.app_can_read_memories(app):
         raise HTTPException(status_code=403, detail="App does not have the capability to read memories")
 
     memories = memory_db.get_memories(uid, limit=limit, offset=offset)
@@ -300,7 +300,7 @@ async def get_conversations_via_integration(
         raise HTTPException(status_code=403, detail="App is not enabled for this user")
 
     # Check if the app has the capability to read conversations
-    if not apps_utils.app_has_action(app, 'read_conversations'):
+    if not apps_utils.app_can_read_conversations(app):
         raise HTTPException(status_code=403, detail="App does not have the capability to read conversations")
 
     # Convert string dates to datetime objects if needed
@@ -381,7 +381,7 @@ async def search_conversations_via_integration(
         raise HTTPException(status_code=403, detail="App is not enabled for this user")
 
     # Check if the app has the capability to read conversations
-    if not apps_utils.app_has_action(app, 'read_conversations'):
+    if not apps_utils.app_can_read_conversations(app):
         raise HTTPException(status_code=403, detail="App does not have the capability to read conversations")
 
     # Convert ISO datetime strings to Unix timestamps if provided

--- a/backend/routers/integration.py
+++ b/backend/routers/integration.py
@@ -160,7 +160,7 @@ async def create_memories_via_integration(
 
     # Check if the app has the capability external_integration > action > create_facts
     if not apps_utils.app_has_action(app, 'create_facts'):
-        raise HTTPException(status_code=403, detail="App does not have the capability to create facts")
+        raise HTTPException(status_code=403, detail="App does not have the capability to create memories")
 
     # Validate that text is provided or explicit facts are provided
     if (not fact_data.text or len(fact_data.text.strip()) == 0) and \

--- a/backend/routers/integration.py
+++ b/backend/routers/integration.py
@@ -252,8 +252,8 @@ async def get_memories_via_integration(
     if not apps_utils.app_has_action(app, 'read_memories'):
         raise HTTPException(status_code=403, detail="App does not have the capability to read memories")
 
-    facts = memory_db.get_memories(uid, limit=limit, offset=offset)
-    memory_items = [integration_models.MemoryItem(**fact) for fact in facts]
+    memories = memory_db.get_memories(uid, limit=limit, offset=offset)
+    memory_items = [integration_models.MemoryItem(**fact) for fact in memories]
 
     return {"memories": memory_items}
 

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -619,3 +619,23 @@ def app_has_action(app: dict, action_name: str) -> bool:
             return True
 
     return False
+
+
+def app_can_create_memories(app: dict) -> bool:
+    """Check if an app can create memories (facts)."""
+    return app_has_action(app, 'create_memories') or app_has_action(app, 'create_facts')
+
+
+def app_can_read_memories(app: dict) -> bool:
+    """Check if an app can read memories (facts)."""
+    return app_has_action(app, 'read_memories') or app_has_action(app, 'read_facts')
+
+
+def app_can_read_conversations(app: dict) -> bool:
+    """Check if an app can read conversations."""
+    return app_has_action(app, 'read_conversations')
+
+
+def app_can_create_conversation(app: dict) -> bool:
+    """Check if an app can create a conversation."""
+    return app_has_action(app, 'create_conversation')

--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -1366,7 +1366,7 @@ def new_memories_extractor(
         response: Memories = chain.invoke({
             'user_name': user_name,
             'conversation': content,
-            'facts_str': memories_str,
+            'memories_str': memories_str,
             'format_instructions': parser.get_format_instructions(),
         })
         # for fact in response:
@@ -1394,7 +1394,7 @@ def extract_memories_from_text(
             'user_name': user_name,
             'text_content': text,
             'text_source': text_source,
-            'facts_str': memories_str,
+            'memories_str': memories_str,
             'format_instructions': parser.get_format_instructions(),
         })
         return response.facts

--- a/backend/utils/llms/memory.py
+++ b/backend/utils/llms/memory.py
@@ -6,19 +6,19 @@ from models.memories import Memory
 
 
 def get_prompt_memories(uid: str) -> str:
-    user_name, user_made_facts, generated_facts = get_prompt_data(uid)
-    facts_str = f'you already know the following facts about {user_name}: \n{Memory.get_memories_as_str(generated_facts)}.'
-    if user_made_facts:
-        facts_str += f'\n\n{user_name} also shared the following about self: \n{Memory.get_memories_as_str(user_made_facts)}'
-    return user_name, facts_str + '\n'
+    user_name, user_made_memories, generated_memories = get_prompt_data(uid)
+    memories_str = f'you already know the following facts about {user_name}: \n{Memory.get_memories_as_str(generated_memories)}.'
+    if user_made_memories:
+        memories_str += f'\n\n{user_name} also shared the following about self: \n{Memory.get_memories_as_str(user_made_memories)}'
+    return user_name, memories_str + '\n'
 
 
 def get_prompt_data(uid: str) -> Tuple[str, List[Memory], List[Memory]]:
     # TODO: cache this
-    existing_facts = memories_db.get_memories(uid, limit=100)
-    user_made = [Memory(**fact) for fact in existing_facts if fact['manually_added']]
+    existing_memories = memories_db.get_memories(uid, limit=100)
+    user_made = [Memory(**memory) for memory in existing_memories if memory['manually_added']]
     # TODO: filter only reviewed True
-    generated = [Memory(**fact) for fact in existing_facts if not fact['manually_added']]
+    generated = [Memory(**memory) for memory in existing_memories if not memory['manually_added']]
     user_name = get_user_name(uid)
     # print('get_prompt_data', user_name, len(user_made), len(generated))
     return user_name, user_made, generated

--- a/backend/utils/prompts.py
+++ b/backend/utils/prompts.py
@@ -60,7 +60,7 @@ extract_memories_prompt = ChatPromptTemplate.from_messages([
 
     **Existing facts you already know about {user_name} (DO NOT REPEAT ANY)**:
     ```
-    {facts_str}
+    {memories_str}
     ```
 
     **Conversation transcript**:
@@ -140,7 +140,7 @@ extract_memories_text_content_prompt = ChatPromptTemplate.from_messages([
     **Existing facts about {user_name} and learnings {user_name} already has**:**:
 
     ```
-    {facts_str}
+    {memories_str}
     ```
 
     ---
@@ -216,7 +216,7 @@ extract_memories_text_content_prompt_v1 = ChatPromptTemplate.from_messages([
 
     **Existing facts you already know about {user_name} (DO NOT REPEAT ANY)**:
     ```
-    {facts_str}
+    {memories_str}
     ```
 
     **Text Content**:


### PR DESCRIPTION
- [x] save facts to both facts and memories collections (revert the changes once facts are migrated)
- [x] Improve actions checking to support facts to memories rename
- [x] Rename `memory_id` to `conversation_id` and `memory_category` to `conversation_category` in `memories` collection when adding a new memory (fact)

This can be deployed without issues as it does not have any breaking changes.