### PR TITLE
Dependencies fix (fix broken .gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,9 +84,6 @@ dist/
 **/web/**/build/
 **/web/.dart_tool/
 
-# Version control
-.git/
-
 # Miscellaneous
 *.lock
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -86,7 +86,6 @@ dist/
 
 # Version control
 .git/
-.gitignore
 
 # Miscellaneous
 *.lock


### PR DESCRIPTION
NOTE: It's generally not recommended to add .gitignore to your .gitignore file.

If you do, you won't be able to track changes to your ignore rules in version control.