### PR TITLE
Update paths in docker build scripts

### DIFF
--- a/omi/firmware/scripts/build-docker.sh
+++ b/omi/firmware/scripts/build-docker.sh
@@ -61,7 +61,7 @@ docker run --rm -it $PLATFORM_FLAG \
     -e PATH="/root/.local/bin:$PATH" \
     ghcr.io/zephyrproject-rtos/ci \
     bash -c "pip install --user adafruit-nrfutil && \
-             /omi/firmware/build-firmware-in-docker.sh"
+             /omi/firmware/scripts/build-firmware-in-docker.sh"
 
 # Check if the build was successful
 if [ -d "$REPO_ROOT/firmware/build/docker_build" ] && [ "$(ls -A "$REPO_ROOT/firmware/build/docker_build")" ]; then

--- a/omi/firmware/scripts/build-firmware-in-docker.sh
+++ b/omi/firmware/scripts/build-firmware-in-docker.sh
@@ -27,14 +27,14 @@ west zephyr-export
 
 # Build firmware with exact same parameters as used in the IDE
 echo "Building firmware for xiao_ble/nrf52840/sense board..."
-west build -b xiao_ble/nrf52840/sense --pristine always ../app -- \
+west build -b xiao_ble/nrf52840/sense --pristine always ../devkit -- \
     -DNCS_TOOLCHAIN_VERSION="NONE" \
     -DCONF_FILE="prj_xiao_ble_sense_devkitv2-adafruit.conf" \
-    -DDTC_OVERLAY_FILE="/omi/firmware/app/overlay/xiao_ble_sense_devkitv2-adafruit.overlay" \
+    -DDTC_OVERLAY_FILE="/omi/firmware/devkit/overlay/xiao_ble_sense_devkitv2-adafruit.overlay" \
     -DCMAKE_EXPORT_COMPILE_COMMANDS="YES" \
     -DCMAKE_BUILD_TYPE="Debug" \
     -DPLATFORM=nrf52840 \
-    -DCACHED_CONF_FILE="/omi/firmware/app/prj_xiao_ble_sense_devkitv2-adafruit.conf"
+    -DCACHED_CONF_FILE="/omi/firmware/devkit/prj_xiao_ble_sense_devkitv2-adafruit.conf"
 
 # Copy build artifacts to output directory
 echo "Copying build artifacts to output directory..."


### PR DESCRIPTION
The location of files within omi/firmware have been changed.
Rename: app -> devkit 
Move: build-in-docker.sh -> scripts/build-in-docker.sh

This broke the build scripts. The PR updates these paths.
Thanks for the scripts @skywinder !
Tested and flashed the ble_throughput_test by thinh, build completes successfully.