### PR TITLE
bugfix: add tags to from_memory + made text optional

### DIFF
--- a/backend/models/integrations.py
+++ b/backend/models/integrations.py
@@ -31,7 +31,7 @@ class ExternalIntegrationMemory(BaseModel):
 
 
 class ExternalIntegrationCreateMemory(BaseModel):
-    text: str = Field(description="The original text from which the fact was extracted")
+    text: Optional[str] = Field(description="The original text from which the fact was extracted")
     text_source: ExternalIntegrationMemorySource = Field(description="The source of the text",
                                                          default=ExternalIntegrationMemorySource.other)
     text_source_spec: Optional[str] = Field(description="Additional specification about the source", default=None)

--- a/backend/models/memories.py
+++ b/backend/models/memories.py
@@ -99,6 +99,7 @@ class MemoryDB(Memory):
             uid=uid,
             content=memory.content,
             category=memory.category,
+            tags=memory.tags,
             created_at=datetime.now(timezone.utc),
             updated_at=datetime.now(timezone.utc),
             conversation_id=conversation_id,


### PR DESCRIPTION
Text can be optional for create memory, and it is checked on a router level, but strict str typing doesn't allow to skip text;