### PR TITLE
Show timing for conversations

### DIFF
--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -220,6 +220,21 @@ class ServerConversation {
       return transcript;
     }
   }
+
+  /// Calculates the conversation duration in seconds based on transcript segments
+  int getDurationInSeconds() {
+    if (transcriptSegments.isEmpty) return 0;
+
+    // Find the last segment's end time
+    double lastEndTime = 0;
+    for (var segment in transcriptSegments) {
+      if (segment.end > lastEndTime) {
+        lastEndTime = segment.end;
+      }
+    }
+
+    return lastEndTime.toInt();
+  }
 }
 
 class SyncLocalFilesResponse {

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -878,7 +878,7 @@ class _GetShareOptionsState extends State<GetShareOptions> {
                   changeLoadingShareTranscript(true);
                   String content = '''
               ${widget.conversation.structured.title}
-              
+
               ${widget.conversation.getTranscript(generate: true)}
               '''
                       .replaceAll('  ', '')

--- a/app/lib/pages/conversation_detail/widgets.dart
+++ b/app/lib/pages/conversation_detail/widgets.dart
@@ -21,6 +21,7 @@ import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/other/temp.dart';
+import 'package:omi/utils/other/time_utils.dart';
 import 'package:omi/widgets/dialog.dart';
 import 'package:omi/widgets/extensions/string.dart';
 import 'package:provider/provider.dart';
@@ -40,6 +41,15 @@ class GetSummaryWidgets extends StatelessWidget {
 
   String setTimeSDCard(DateTime? startedAt, DateTime createdAt) {
     return startedAt == null ? dateTimeFormat('h:mm a', createdAt) : dateTimeFormat('h:mm a', startedAt);
+  }
+
+  String _getDuration(ServerConversation conversation) {
+    if (conversation.transcriptSegments.isEmpty) return '';
+
+    int durationSeconds = conversation.getDurationInSeconds();
+    if (durationSeconds <= 0) return '';
+
+    return secondsToHumanReadable(durationSeconds);
   }
 
   @override
@@ -72,6 +82,20 @@ class GetSummaryWidgets extends StatelessWidget {
                   : '${dateTimeFormat('MMM d,  yyyy', conversation.createdAt)} ${conversation.startedAt == null ? 'at' : 'from'} ${setTime(conversation.startedAt, conversation.createdAt, conversation.finishedAt)}',
               style: const TextStyle(color: Colors.grey, fontSize: 16),
             ),
+            if (conversation.transcriptSegments.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 4.0),
+                child: Row(
+                  children: [
+                    const Icon(Icons.access_time, color: Colors.grey, size: 14),
+                    const SizedBox(width: 4),
+                    Text(
+                      'Duration: ${_getDuration(conversation)}',
+                      style: const TextStyle(color: Colors.grey, fontSize: 14),
+                    ),
+                  ],
+                ),
+              ),
             const SizedBox(height: 16),
             conversation.discarded ? const SizedBox.shrink() : const SizedBox(height: 8),
           ],

--- a/app/lib/pages/conversations/widgets/conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/conversation_list_item.dart
@@ -230,18 +230,18 @@ class _ConversationListItemState extends State<ConversationListItem> {
                     alignment: Alignment.centerRight,
                     child: ConversationNewStatusIndicator(text: "New 🚀"),
                   )
-                : Column(
-                    crossAxisAlignment: CrossAxisAlignment.end,
+                : Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
                       Text(
                         dateTimeFormat('MMM d, h:mm a', widget.conversation.startedAt ?? widget.conversation.createdAt),
                         style: TextStyle(color: Colors.grey.shade400, fontSize: 14),
                         maxLines: 1,
-                        textAlign: TextAlign.end,
                       ),
-                      if (widget.conversation.transcriptSegments.isNotEmpty)
+                      if (widget.conversation.transcriptSegments.isNotEmpty && _getConversationDuration().isNotEmpty)
                         Padding(
-                          padding: const EdgeInsets.only(top: 2.0),
+                          padding: const EdgeInsets.only(left: 8.0),
                           child: Container(
                             padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
                             decoration: BoxDecoration(
@@ -252,7 +252,6 @@ class _ConversationListItemState extends State<ConversationListItem> {
                               _getConversationDuration(),
                               style: TextStyle(color: Colors.grey.shade300, fontSize: 11),
                               maxLines: 1,
-                              textAlign: TextAlign.end,
                             ),
                           ),
                         ),

--- a/app/lib/pages/conversations/widgets/conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/conversation_list_item.dart
@@ -10,6 +10,7 @@ import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/other/temp.dart';
+import 'package:omi/utils/other/time_utils.dart';
 import 'package:omi/widgets/confirmation_dialog.dart';
 import 'package:omi/widgets/dialog.dart';
 import 'package:omi/widgets/extensions/string.dart';
@@ -229,16 +230,38 @@ class _ConversationListItemState extends State<ConversationListItem> {
                     alignment: Alignment.centerRight,
                     child: ConversationNewStatusIndicator(text: "New 🚀"),
                   )
-                : Text(
-                    dateTimeFormat('MMM d, h:mm a', widget.conversation.startedAt ?? widget.conversation.createdAt),
-                    style: TextStyle(color: Colors.grey.shade400, fontSize: 14),
-                    maxLines: 1,
-                    textAlign: TextAlign.end,
+                : Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                      Text(
+                        dateTimeFormat('MMM d, h:mm a', widget.conversation.startedAt ?? widget.conversation.createdAt),
+                        style: TextStyle(color: Colors.grey.shade400, fontSize: 14),
+                        maxLines: 1,
+                        textAlign: TextAlign.end,
+                      ),
+                      if (widget.conversation.transcriptSegments.isNotEmpty)
+                        Text(
+                          _getConversationDuration(),
+                          style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                          maxLines: 1,
+                          textAlign: TextAlign.end,
+                        ),
+                    ],
                   ),
           )
         ],
       ),
     );
+  }
+
+  String _getConversationDuration() {
+    if (widget.conversation.transcriptSegments.isEmpty) return '';
+
+    // Get the total duration in seconds
+    int durationSeconds = widget.conversation.getDurationInSeconds();
+    if (durationSeconds <= 0) return '';
+
+    return secondsToCompactDuration(durationSeconds);
   }
 }
 

--- a/app/lib/pages/conversations/widgets/conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/conversation_list_item.dart
@@ -240,11 +240,21 @@ class _ConversationListItemState extends State<ConversationListItem> {
                         textAlign: TextAlign.end,
                       ),
                       if (widget.conversation.transcriptSegments.isNotEmpty)
-                        Text(
-                          _getConversationDuration(),
-                          style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
-                          maxLines: 1,
-                          textAlign: TextAlign.end,
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2.0),
+                          child: Container(
+                            padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                            decoration: BoxDecoration(
+                              color: Colors.grey.shade800,
+                              borderRadius: BorderRadius.circular(4),
+                            ),
+                            child: Text(
+                              _getConversationDuration(),
+                              style: TextStyle(color: Colors.grey.shade300, fontSize: 11),
+                              maxLines: 1,
+                              textAlign: TextAlign.end,
+                            ),
+                          ),
                         ),
                     ],
                   ),

--- a/app/lib/pages/conversations/widgets/synced_conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/synced_conversation_list_item.dart
@@ -5,6 +5,7 @@ import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart'
 import 'package:omi/pages/conversation_detail/page.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/utils/other/temp.dart';
+import 'package:omi/utils/other/time_utils.dart';
 import 'package:omi/widgets/extensions/string.dart';
 import 'package:provider/provider.dart';
 
@@ -174,15 +175,37 @@ class _SyncedConversationListItemState extends State<SyncedConversationListItem>
             width: 16,
           ),
           Expanded(
-            child: Text(
-              dateTimeFormat('MMM d, h:mm a', conversation.startedAt ?? conversation.createdAt),
-              style: TextStyle(color: Colors.grey.shade400, fontSize: 14),
-              maxLines: 1,
-              textAlign: TextAlign.end,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(
+                  dateTimeFormat('MMM d, h:mm a', conversation.startedAt ?? conversation.createdAt),
+                  style: TextStyle(color: Colors.grey.shade400, fontSize: 14),
+                  maxLines: 1,
+                  textAlign: TextAlign.end,
+                ),
+                if (conversation.transcriptSegments.isNotEmpty)
+                  Text(
+                    _getConversationDuration(),
+                    style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                    maxLines: 1,
+                    textAlign: TextAlign.end,
+                  ),
+              ],
             ),
           )
         ],
       ),
     );
+  }
+
+  String _getConversationDuration() {
+    if (conversation.transcriptSegments.isEmpty) return '';
+
+    // Get the total duration in seconds
+    int durationSeconds = conversation.getDurationInSeconds();
+    if (durationSeconds <= 0) return '';
+
+    return secondsToCompactDuration(durationSeconds);
   }
 }

--- a/app/lib/pages/conversations/widgets/synced_conversation_list_item.dart
+++ b/app/lib/pages/conversations/widgets/synced_conversation_list_item.dart
@@ -185,11 +185,21 @@ class _SyncedConversationListItemState extends State<SyncedConversationListItem>
                   textAlign: TextAlign.end,
                 ),
                 if (conversation.transcriptSegments.isNotEmpty)
-                  Text(
-                    _getConversationDuration(),
-                    style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
-                    maxLines: 1,
-                    textAlign: TextAlign.end,
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2.0),
+                    child: Container(
+                      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: Colors.grey.shade800,
+                        borderRadius: BorderRadius.circular(4),
+                      ),
+                      child: Text(
+                        _getConversationDuration(),
+                        style: TextStyle(color: Colors.grey.shade300, fontSize: 11),
+                        maxLines: 1,
+                        textAlign: TextAlign.end,
+                      ),
+                    ),
                   ),
               ],
             ),

--- a/app/lib/utils/other/time_utils.dart
+++ b/app/lib/utils/other/time_utils.dart
@@ -37,6 +37,30 @@ String secondsToHumanReadable(int seconds) {
   }
 }
 
+/// Returns a compact representation of seconds (e.g., "10s", "5m", "2h 15m")
+/// Designed for use in small UI elements like list items
+String secondsToCompactDuration(int seconds) {
+  if (seconds < 60) {
+    return '${seconds}s';
+  } else if (seconds < 3600) {
+    var minutes = (seconds / 60).floor();
+    var remainingSeconds = seconds % 60;
+    if (remainingSeconds == 0) {
+      return '${minutes}m';
+    } else {
+      return '${minutes}m ${remainingSeconds}s';
+    }
+  } else {
+    var hours = (seconds / 3600).floor();
+    var remainingMinutes = (seconds % 3600 / 60).floor();
+    if (remainingMinutes == 0) {
+      return '${hours}h';
+    } else {
+      return '${hours}h ${remainingMinutes}m';
+    }
+  }
+}
+
 // convert seconds to hh:mm:ss format
 String secondsToHMS(int seconds) {
   var hours = (seconds / 3600).floor();

--- a/app/lib/utils/other/time_utils.dart
+++ b/app/lib/utils/other/time_utils.dart
@@ -45,15 +45,16 @@ String secondsToCompactDuration(int seconds) {
   } else if (seconds < 3600) {
     var minutes = (seconds / 60).floor();
     var remainingSeconds = seconds % 60;
-    if (remainingSeconds == 0) {
+    if (remainingSeconds == 0 || minutes >= 10) {
       return '${minutes}m';
     } else {
+      // Only show seconds for durations less than 10 minutes
       return '${minutes}m ${remainingSeconds}s';
     }
   } else {
     var hours = (seconds / 3600).floor();
     var remainingMinutes = (seconds % 3600 / 60).floor();
-    if (remainingMinutes == 0) {
+    if (remainingMinutes == 0 || hours >= 10) {
       return '${hours}h';
     } else {
       return '${hours}h ${remainingMinutes}m';


### PR DESCRIPTION
I really miss info - how long this conversation was. so here is tiny UX update:

---


before:
![CleanShot 2025-05-06 at 00 14 16@2x](https://github.com/user-attachments/assets/55eae4f8-5b9b-44be-bfaa-1d2c2ae28943)

Now:
![CleanShot 2025-05-06 at 00 14 43@2x](https://github.com/user-attachments/assets/427b39f0-4b55-4dbe-bc0a-1cca634238be)

---

Before
![CleanShot 2025-05-06 at 00 15 22@2x](https://github.com/user-attachments/assets/b6eeab1d-8fbc-460f-ab70-864359b8c904)

NOw:

![CleanShot 2025-05-06 at 00 15 05@2x](https://github.com/user-attachments/assets/2f482145-277d-4ae6-b6a9-73576c404eb8)
