### PR TITLE
Prompt Update: Never discard single-line action items (e.g., “Remember to get milk”)

### DIFF
--- a/backend/utils/llm.py
+++ b/backend/utils/llm.py
@@ -83,8 +83,26 @@ def should_discard_conversation(transcript: str) -> bool:
     parser = PydanticOutputParser(pydantic_object=DiscardConversation)
     prompt = ChatPromptTemplate.from_messages([
         '''
-    You will be given a conversation transcript, and your task is to determine if the conversation is worth storing as a memory or not.
-    It is not worth storing if there are no interesting topics, facts, or information, in that case, output discard = True.
+    You will receive a transcript snippet. Length is never a reason to discard.
+
+        Task
+        Decide if the snippet should be saved as a memory.
+
+        KEEP  → output:  discard = False
+        DISCARD → output: discard = True
+
+        KEEP (discard = False) if it contains any of the following:
+        • a task, request, or action item
+        • a decision, commitment, or plan
+        • a question that requires follow-up
+        • personal facts, preferences, or details likely useful later
+        • an insight, summary, or key takeaway
+
+        If none of these are present, DISCARD (discard = True).
+
+        Return exactly one line:
+        discard = <True|False>
+
 
     Transcript: ```{transcript}```
 


### PR DESCRIPTION
This PR refines the memory-filter prompt so that length is no longer a discard factor.
Key points:

Bug / Gap: Short but critical directives like “Remember to get milk” were being flagged as unimportant and discarded.

Fix: Added explicit KEEP rules for any task, request, decision, follow-up question, personal detail, or key insight—regardless of snippet length.

Output unchanged: Still returns exactly discard = True|False, so downstream parsing stays intact.

Expected impact: Reduces false-negative discards, ensuring brief but actionable statements are saved for later summarization and reminders.