### PR TITLE
Fix: Improve plugin content visibility and styling on memory page

### DIFF
--- a/web/frontend/src/components/memories/plugins/plugins.tsx
+++ b/web/frontend/src/components/memories/plugins/plugins.tsx
@@ -20,7 +20,7 @@ export default function Plugins({ plugins }: PluginsProps) {
                 <IndentifyPlugin pluginId={puglin.plugin_id} />
               </ErrorBoundary>
               <div className="bg-bg-color px-4 md:px-12">
-                <Markdown className="prose prose-slate text-white md:prose-lg prose-p:m-0 prose-p:mt-3 prose-p:text-white last:prose-p:mt-8 last:prose-p:rounded-lg last:prose-p:bg-zinc-900 last:prose-p:p-2 last:prose-p:px-4 last:prose-p:text-zinc-200 prose-strong:text-white prose-ul:my-0 prose-ul:list-disc prose-li:text-zinc-300 md:last:prose-p:text-sm">
+                <Markdown className="prose md:prose-p:text-lg text-white prose-headings:text-gray-200 prose-strong:text-white prose-ul:text-gray-300 prose-li:text-gray-300 prose-p:m-0 prose-p:mt-3 last:prose-p:mt-8 last:prose-p:rounded-lg last:prose-p:bg-zinc-900 last:prose-p:p-2 last:prose-p:px-4 last:prose-p:text-zinc-200 md:last:prose-p:text-sm">
                   {puglin.content}
                 </Markdown>
               </div>


### PR DESCRIPTION
- Updated styling for Markdown-rendered content within the "Plugins" section on the memory detail page.
- Ensured headings and paragraph text are clearly visible against the dark background.
- Aligned font sizes of plugin content with other UI elements for better visual consistency.
- Includes minor cleanups to the memory page component.