### PR TITLE
App data privacy

### DIFF
--- a/app/lib/pages/apps/app_detail/app_detail.dart
+++ b/app/lib/pages/apps/app_detail/app_detail.dart
@@ -458,14 +458,7 @@ class _AppDetailPageState extends State<AppDetailPage> {
                                               title: 'Data Access Notice',
                                               description:
                                                   'This app will access your data. Omi AI is not responsible for how your data is used, modified, or deleted by this app',
-                                              checkboxText: "Don't show it again",
-                                              checkboxValue: !showInstallAppConfirmation,
-                                              onCheckboxChanged: (value) {
-                                                setState(() {
-                                                  showInstallAppConfirmation = !value;
-                                                  SharedPreferencesUtil().showInstallAppConfirmation = !value;
-                                                });
-                                              },
+                                              
                                               onConfirm: () {
                                                 _toggleApp(app.id, true);
                                                 Navigator.pop(context);

--- a/backend/routers/plugins.py
+++ b/backend/routers/plugins.py
@@ -5,8 +5,8 @@ from fastapi import APIRouter
 router = APIRouter()
 
 
-@router.get('/v1/plugin-categories', tags=['v1'])
-def get_plugin_categories():
+@router.get('/v1/app-categories', tags=['v1'])
+def get_app_categories():
     return [
         {'title': 'Conversation Analysis', 'id': 'conversation-analysis'},
         {'title': 'Personality Emulation', 'id': 'personality-emulation'},


### PR DESCRIPTION
When you install an app with external integration, it warns you that the data is going to another server that Omi is not responsible for.  You can check the box to never see this message again.
I have removed the checkbox, because:

1: Without this, the user will not know which other apps (owned by different parties) may have their data
2: We really need to expand this popup with app owner privacy policies.
3: There may be legal implications to showing this message or not, so we should show this message every time.
![IMG_E32F41159AC4-1](https://github.com/user-attachments/assets/108a01ed-6d7c-441d-99f2-0b38c9822aa5)

The fact is that enabling any of these external apps means that anything is said by anyone around the user can be read and processed with impunity, with no checks and balances is a massive red flag.