### PR TITLE
feature: Dim or turn off led light

### DIFF
--- a/omi/firmware/devkit/src/led.c
+++ b/omi/firmware/devkit/src/led.c
@@ -1,9 +1,15 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/pwm.h>
 #include "led.h"
 #include "utils.h"
 
 LOG_MODULE_REGISTER(led, CONFIG_LOG_DEFAULT_LEVEL);
+
+// Define PWM devices for LEDs
+static const struct pwm_dt_spec pwm_led_red = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led0));
+static const struct pwm_dt_spec pwm_led_green = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led1));
+static const struct pwm_dt_spec pwm_led_blue = PWM_DT_SPEC_GET(DT_ALIAS(pwm_led2));
 
 int led_start()
 {
@@ -13,7 +19,12 @@ int led_start()
     ASSERT_OK(gpio_pin_configure_dt(&led_green, GPIO_OUTPUT_INACTIVE));
     ASSERT_TRUE(gpio_is_ready_dt(&led_blue));
     ASSERT_OK(gpio_pin_configure_dt(&led_blue, GPIO_OUTPUT_INACTIVE));
-    LOG_INF("LEDs started");
+    
+    ASSERT_TRUE(pwm_is_ready_dt(&pwm_led_red));
+    ASSERT_TRUE(pwm_is_ready_dt(&pwm_led_green));
+    ASSERT_TRUE(pwm_is_ready_dt(&pwm_led_blue));
+    
+    LOG_INF("LEDs started with PWM support");
     return 0;
 }
 
@@ -30,4 +41,47 @@ void set_led_green(bool on)
 void set_led_blue(bool on)
 {
     gpio_pin_set_dt(&led_blue, on);
+}
+
+void set_led_brightness(const struct pwm_dt_spec *pwm_led, uint8_t brightness)
+{
+    if (brightness > 100) brightness = 100; // Cap brightness at 100%
+    uint32_t pulse_width = (pwm_led->period * brightness) / 100;
+    pwm_set_dt(pwm_led, pwm_led->period, pulse_width);
+}
+
+void set_led_red_brightness(uint8_t brightness)
+{
+    set_led_brightness(&pwm_led_red, brightness);
+}
+
+void set_led_green_brightness(uint8_t brightness)
+{
+    set_led_brightness(&pwm_led_green, brightness);
+}
+
+void set_led_blue_brightness(uint8_t brightness)
+{
+    set_led_brightness(&pwm_led_blue, brightness);
+}
+
+// API to set brightness for a specific LED
+void set_led_brightness_api(const char *led_color, uint8_t brightness)
+{
+    if (strcmp(led_color, "red") == 0)
+    {
+        set_led_red_brightness(brightness);
+    }
+    else if (strcmp(led_color, "green") == 0)
+    {
+        set_led_green_brightness(brightness);
+    }
+    else if (strcmp(led_color, "blue") == 0)
+    {
+        set_led_blue_brightness(brightness);
+    }
+    else
+    {
+        LOG_ERR("Invalid LED color: %s", led_color);
+    }
 }

--- a/omiGlass/public/led_control_example.js
+++ b/omiGlass/public/led_control_example.js
@@ -1,0 +1,38 @@
+// Example placeholder for UI integration with LED brightness control API
+
+// Function to send brightness control commands to the firmware
+function setLEDBrightness(color, brightness) {
+    if (brightness < 0 || brightness > 100) {
+        console.error("Brightness must be between 0 and 100.");
+        return;
+    }
+
+    // Example API call to the firmware (replace with actual implementation)
+    fetch('/api/set_led_brightness', {
+        method: 'POST',
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+            color: color,
+            brightness: brightness,
+        }),
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('Failed to set LED brightness');
+        }
+        return response.json();
+    })
+    .then(data => {
+        console.log(`Successfully set ${color} LED brightness to ${brightness}%`);
+    })
+    .catch(error => {
+        console.error('Error:', error);
+    });
+}
+
+// Example usage
+setLEDBrightness('red', 50); // Set red LED to 50% brightness
+setLEDBrightness('green', 75); // Set green LED to 75% brightness
+setLEDBrightness('blue', 100); // Set blue LED to full brightness


### PR DESCRIPTION
This pull request introduces support for PWM (Pulse Width Modulation) to control LED brightness in the firmware and provides an example integration for a UI to interact with this functionality. The changes include adding PWM configurations, new functions for setting LED brightness, and a JavaScript example for API-based control.

Related issue: #2317 

### Firmware Enhancements for LED Brightness Control:

* Added PWM device definitions for red, green, and blue LEDs in `omi/firmware/devkit/src/led.c` to enable brightness control.
* Updated the `led_start` function to check the readiness of the PWM devices and log that PWM support is enabled.
* Introduced new functions in `omi/firmware/devkit/src/led.c` to set LED brightness using PWM, including `set_led_brightness`, `set_led_red_brightness`, `set_led_green_brightness`, and `set_led_blue_brightness`. 
* Added a high-level API function `set_led_brightness_api` to allow setting brightness for specific LEDs by color name, with error handling for invalid inputs. 

### UI Integration Example:

* Created a new JavaScript example in `omiGlass/public/led_control_example.js` to demonstrate how to send brightness control commands to the firmware via an API. This includes input validation and error handling for the API calls.