### PR TITLE
Fix: Keep Done button visible with large Dynamic Type on iOS

### DIFF
--- a/app/lib/pages/onboarding/primary_language/primary_language_widget.dart
+++ b/app/lib/pages/onboarding/primary_language/primary_language_widget.dart
@@ -80,13 +80,19 @@ class _LanguageSelectorWidgetState extends State<LanguageSelectorWidget> {
         children: [
           Row(
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            textBaseline: TextBaseline.alphabetic,
             children: [
-              const Text(
-                'Select your primary language',
-                style: TextStyle(
-                  fontSize: 18,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.white,
+              const Flexible(
+                child: Text(
+                  'Select your primary language',
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  softWrap: true,
+                  style: TextStyle(
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.white,
+                  ),
                 ),
               ),
               TextButton(
@@ -102,7 +108,8 @@ class _LanguageSelectorWidgetState extends State<LanguageSelectorWidget> {
                 child: Text(
                   'Done',
                   style: TextStyle(
-                    color: currentSelectedLanguage == null ? null : Colors.white,
+                    color:
+                        currentSelectedLanguage == null ? null : Colors.white,
                   ),
                 ),
               ),


### PR DESCRIPTION
Related issue: https://github.com/BasedHardware/omi/issues/2207

Refactors the language picker header:
* Swaps Expanded for Flexible (loose fit)
* Uses baseline alignment and caps the label at 2 lines  
When the user enlarges the system font, the title now wraps instead of
pushing the Done button off-screen, ensuring full accessibility.

![Before](https://github.com/user-attachments/assets/e75507f1-31b3-4d5d-bf7d-e21b30eb89e4)
![After](https://github.com/user-attachments/assets/d4be8cc9-bb13-435e-9f48-ea021f1ec5f4)
