### PR TITLE
Fix broken link to Python JSON example. Fixes #2389

### DIFF
--- a/docs/docs/developer/apps/Integrations.mdx
+++ b/docs/docs/developer/apps/Integrations.mdx
@@ -138,7 +138,7 @@ uid as query parameters. Here's the structure:
 Remember to handle errors gracefully and consider performance, especially for lengthy conversations!
 
 > Check the Realtime News checker [Python Example](https://github.com/BasedHardware/omi/blob/bab12a678f3cfe43ab1a7aba62645222de4378fb/plugins/example/main.py#L100)
-> and it's respective JSON format [here](https://github.com/BasedHardware/Omi/blob/bab12a678f3cfe43ab1a7aba62645222de4378fb/community-apps.json#L379).
+> and it's respective JSON format [here](https://github.com/BasedHardware/Omi/blob/bab12a678f3cfe43ab1a7aba62645222de4378fb/community-plugins.json#L379).
 
 ### Step 3: Test Your App 🧪
 


### PR DESCRIPTION
Fixes #2389

The broken link to the Python JSON example in docs/docs/developer/apps/Integrations.mdx is now fixed. I myself faced this error when I was contributing an app. Decided to fix it and help. 