### PR TITLE
Fixed firebase AppleAuth validate issue

### DIFF
--- a/app/lib/backend/auth.dart
+++ b/app/lib/backend/auth.dart
@@ -55,6 +55,7 @@ Future<UserCredential?> signInWithApple() async {
     final oauthCredential = OAuthProvider("apple.com").credential(
       idToken: appleCredential.identityToken,
       rawNonce: rawNonce,
+      accessToken: appleCredential.authorizationCode
     );
 
     debugPrint('OAuth Credential created.');


### PR DESCRIPTION
Login via Apple was failing on dev.  Resolved by applying this fix
https://medium.com/@muhammad.fathy/resolving-the-firebase-auth-invalid-credential-invalid-oauth-response-from-apple-com-6bca6b6a8575
