### PR TITLE
chore: fix formatting issue of the docs

### DIFF
--- a/docs/docs/get_started/introduction.mdx
+++ b/docs/docs/get_started/introduction.mdx
@@ -53,23 +53,23 @@ Simply connect Omi to your mobile device and enjoy:
 
 ## 🌟 Key Features
 
-🚀 **Fully Open-Source**
-🔋 **4 days Battery Life**
-🎙️ **Live Transcription**
-🧠 **Conversation Memory**
-⚡ **Instant Summarization**
-📡 **Offline Transcription**
-🌐 **App Marketplace**
+- 🚀 **Fully Open-Source**
+- 🔋 **4 days Battery Life** 
+- 🎙️ **Live Transcription**
+- 🧠 **Conversation Memory**
+- ⚡ **Instant Summarization**
+- 📡 **Offline Transcription**
+- 🌐 **App Marketplace**
 
 ---
 
 ## 📲 Get the App
 
 <div style={{ display: 'flex', justifyContent: 'center', gap: '20px', margin: '20px 0' }}>
-  <a href="https://play.google.com/store/apps/details?id=com.friend.ios" target="_blank" style={{ display: 'block', width: '200px' }}>
-    <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" style={{ width: '100%', borderRadius: '5px', boxShadow: '0 2px 5px rgba(0, 0, 0, 0.2)' }} />
+  <a href="https://play.google.com/store/apps/details?id=com.friend.ios" target="_blank" style={{ display: 'block', width: '180px', height: '60px' }}>
+    <img src="https://play.google.com/intl/en_us/badges/static/images/badges/en_badge_web_generic.png" alt="Get it on Google Play" style={{ width: '100%', height: '100%', objectFit: 'contain', borderRadius: '5px', boxShadow: '0 2px 5px rgba(0, 0, 0, 0.2)' }} />
   </a>
-  <a href="https://apps.apple.com/us/app/friend-ai-wearable/id6502156163" target="_blank" style={{ display: 'block', width: '200px' }}>
-    <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" style={{ width: '100%', borderRadius: '5px', boxShadow: '0 2px 5px rgba(0, 0, 0, 0.2)' }} />
+  <a href="https://apps.apple.com/us/app/friend-ai-wearable/id6502156163" target="_blank" style={{ display: 'block', width: '180px', height: '60px' }}>
+    <img src="https://tools.applemediaservices.com/api/badges/download-on-the-app-store/black/en-us?size=250x83" alt="Download on the App Store" style={{ width: '100%', height: '100%', objectFit: 'contain', borderRadius: '5px', boxShadow: '0 2px 5px rgba(0, 0, 0, 0.2)' }} />
   </a>
 </div>


### PR DESCRIPTION
Description:

On this page, https://docs.omi.me/docs/get_started/introduction the formatting isn't applied to the `Key Features` section and the app store images differ in size. This PR aims to fix that

<img width="1507" alt="image" src="https://github.com/user-attachments/assets/5e5aa621-74b1-42ac-ad89-f36406fe246f" />
