### PR TITLE
Local vad service

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   visibility_detector: ^0.4.0+2
   flutter_rating_bar: ^4.0.1
   dotted_border: ^2.1.0
-  skeletonizer: ^1.4.2
+  skeletonizer: ^2.0.1
   shimmer: ^3.0.0
 
   # Firebase
@@ -48,7 +48,7 @@ dependencies:
   flutter_blue_plus: 1.33.6
   http: ^1.2.1
   pdf: ^3.11.0
-  intl: ^0.19.0
+  intl: ^0.20.2
   permission_handler: ^11.3.1
   share_plus: 10.0.1
   shared_preferences: ^2.2.3
@@ -110,7 +110,6 @@ dependency_overrides:
   http: ^1.2.1
   uuid: ^4.4.0
   js: ^0.7.1
-  google_sign_in_ios: 5.7.5
   google_sign_in_ios: 5.7.5
   opus_flutter_ios:
     git:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -111,6 +111,7 @@ dependency_overrides:
   uuid: ^4.4.0
   js: ^0.7.1
   google_sign_in_ios: 5.7.5
+  google_sign_in_ios: 5.7.5
   opus_flutter_ios:
     git:
       url: https://github.com/mdmohsin7/opus_flutter.git

--- a/backend/database/_client.py
+++ b/backend/database/_client.py
@@ -6,7 +6,15 @@ import uuid
 from google.cloud import firestore
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
-    service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
+    service_account_json = os.environ["SERVICE_ACCOUNT_JSON"]
+    if os.path.isfile(service_account_json):
+    # If it's a file path, read the file
+        with open(service_account_json, "r") as f:
+            service_account_info = json.load(f)
+    else:
+        # If it's a JSON string, parse directly
+        service_account_info = json.loads(service_account_json)
+
     # create google-credentials.json
     with open('google-credentials.json', 'w') as f:
         json.dump(service_account_info, f)

--- a/backend/main.py
+++ b/backend/main.py
@@ -12,7 +12,15 @@ from routers import workflow, chat, firmware, plugins, transcribe, notifications
 from utils.other.timeout import TimeoutMiddleware
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
-    service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
+    service_account_json = os.environ["SERVICE_ACCOUNT_JSON"]
+    if os.path.isfile(service_account_json):
+    # If it's a file path, read the file
+        with open(service_account_json, "r") as f:
+            service_account_info = json.load(f)
+    else:
+        # If it's a JSON string, parse directly
+        service_account_info = json.loads(service_account_json)
+        
     credentials = firebase_admin.credentials.Certificate(service_account_info)
     firebase_admin.initialize_app(credentials)
 else:

--- a/backend/modal/Dockerfile
+++ b/backend/modal/Dockerfile
@@ -1,32 +1,24 @@
-FROM python:3.11 AS builder
-
-ENV PATH="/opt/venv/bin:$PATH"
-RUN python -m venv /opt/venv
-
-COPY backend/requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
-
-FROM python:3.11-slim
-# Python 3.11 on Debian 12 (Bookworm)
+FROM nvidia/cuda:12.6.2-cudnn-runtime-ubuntu22.04
 
 WORKDIR /app
-ENV PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/venv/bin:$PATH"
-ENV LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64"
 
-# Install CUDA Toolkit 12.6 Update 3
-RUN apt-get update && apt-get -y install build-essential ffmpeg curl unzip wget software-properties-common && \ 
-wget https://developer.download.nvidia.com/compute/cuda/12.6.3/local_installers/cuda-repo-debian12-12-6-local_12.6.3-560.35.05-1_amd64.deb && \
-dpkg -i cuda-repo-debian12-12-6-local_12.6.3-560.35.05-1_amd64.deb && \
-cp /var/cuda-repo-debian12-12-6-local/cuda-*-keyring.gpg /usr/share/keyrings/ && \
-add-apt-repository contrib && \
-apt-get update && \
-apt-get -y install cuda-toolkit-12-6 && \
-rm -rf /var/lib/apt/lists/* cuda-repo-debian11-12-6-local_12.6.3-560.35.05-1_amd64.deb
+# Install Python and system dependencies
+RUN apt-get update && \
+    apt-get install -y python3 python3-pip python3-venv ffmpeg curl unzip wget git && \
+    rm -rf /var/lib/apt/lists/*
+# Copy requirements and install
+COPY backend/requirements.txt /tmp/requirements.txt
+RUN python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --upgrade pip && \
+    /opt/venv/bin/pip install --no-cache-dir -r /tmp/requirements.txt
 
-COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:$PATH"
+
+# Copy your app code
 COPY backend/database /app/database
 COPY backend/utils /app/utils
 COPY backend/modal/ .
+RUN if [ -f service-account.json ]; then cp service-account.json /app/service-account.json; fi
 
-EXPOSE 8080
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+EXPOSE 8091
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8091"]

--- a/backend/modal/job.py
+++ b/backend/modal/job.py
@@ -7,7 +7,15 @@ import asyncio
 from utils.other.notifications import start_cron_job
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
-    service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
+    service_account_json = os.environ["SERVICE_ACCOUNT_JSON"]
+    if os.path.isfile(service_account_json):
+    # If it's a file path, read the file
+        with open(service_account_json, "r") as f:
+            service_account_info = json.load(f)
+    else:
+        # If it's a JSON string, parse directly
+        service_account_info = json.loads(service_account_json)
+
     credentials = firebase_admin.credentials.Certificate(service_account_info)
     firebase_admin.initialize_app(credentials)
 else:

--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -16,5 +16,5 @@ RUN apt-get update && apt-get -y install ffmpeg curl unzip && rm -rf /var/lib/ap
 COPY --from=builder /opt/venv /opt/venv
 COPY backend/ .
 
-EXPOSE 8080
-CMD ["uvicorn", "pusher.main:app", "--host", "0.0.0.0", "--port", "8080"]
+EXPOSE 8090
+CMD ["uvicorn", "pusher.main:app", "--host", "0.0.0.0", "--port", "8090"]

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -8,7 +8,14 @@ from modal import Image, App, asgi_app, Secret
 from routers import pusher
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
-    service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
+    service_account_json = os.environ["SERVICE_ACCOUNT_JSON"]
+    if os.path.isfile(service_account_json):
+    # If it's a file path, read the file
+        with open(service_account_json, "r") as f:
+            service_account_info = json.load(f)
+    else:
+        # If it's a JSON string, parse directly
+        service_account_info = json.loads(service_account_json)
     credentials = firebase_admin.credentials.Certificate(service_account_info)
     firebase_admin.initialize_app(credentials)
 else:

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -529,7 +529,7 @@ async def _listen(
     # Transcripts
     #
     current_conversation_id = None
-    translation_enabled = including_combined_segments and stt_language == 'multi'
+    translation_enabled = including_combined_segments and stt_language == 'multi' and os.getenv('TRANSLATION_ENABLED', 'true') == 'true'
     language_cache = TranscriptSegmentLanguageCache()
 
     async def translate(segments: List[TranscriptSegment], conversation_id: str):

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -10,7 +10,15 @@ from google.cloud.storage import transfer_manager
 from database.redis_db import cache_signed_url, get_cached_signed_url
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
-    service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
+    service_account_json = os.environ["SERVICE_ACCOUNT_JSON"]
+    if os.path.isfile(service_account_json):
+    # If it's a file path, read the file
+        with open(service_account_json, "r") as f:
+            service_account_info = json.load(f)
+    else:
+        # If it's a JSON string, parse directly
+        service_account_info = json.loads(service_account_json)
+
     credentials = service_account.Credentials.from_service_account_info(service_account_info)
     storage_client = storage.Client(credentials=credentials)
 else:

--- a/docs/@deprecated/docs-old/developer/backend/Backend_Setup.mdx
+++ b/docs/@deprecated/docs-old/developer/backend/Backend_Setup.mdx
@@ -103,7 +103,7 @@ Before you start, make sure you have the following:
       ```bash
       cp .env.template .env
       ```
-    - Set the `SERVICE_ACCOUNT_JSON` environment variable in the `.env` file to the string representation of your Google Cloud service account credentials (`google-credentials.json`). This is used to authenticate with Google Cloud
+    - Set the `SERVICE_ACCOUNT_JSON` environment variable in the `.env` file to the filename or string representation of your Google Cloud service account credentials (`google-credentials.json`). This is used to authenticate with Google Cloud
     - Move back to the backend directory and run the following command to start the Pusher service:
        ```bash
        uvicorn pusher.main:app --reload --env-file .env --port 8000

--- a/docs/docs/developer/backend/Backend_Setup.mdx
+++ b/docs/docs/developer/backend/Backend_Setup.mdx
@@ -100,7 +100,7 @@ Before you start, make sure you have the following:
       ```bash
       cp .env.template .env
       ```
-    - Set the `SERVICE_ACCOUNT_JSON` environment variable in the `.env` file to the string representation of your Google Cloud service account credentials (`google-credentials.json`). This is used to authenticate with Google Cloud
+    - Set the `SERVICE_ACCOUNT_JSON` environment variable in the `.env` file to the string representation or filename of your Google Cloud service account credentials (`google-credentials.json`). This is used to authenticate with Google Cloud
     - Move back to the backend directory and run the following command to start the Pusher service:
        ```bash
        uvicorn pusher.main:app --reload --env-file .env --port 8000
@@ -118,8 +118,15 @@ Before you start, make sure you have the following:
       - Create `typesense_sync` collection and add a document named `backfill` with data `{'trigger' : true}` (required only if you already have memories in Firestore and want to sync them to Typesense)
     - Set the `TYPESENSE_HOST`, `TYPESENSE_HOST_PORT` and `TYPESENSE_API_KEY` environment variables in the `.env` file to the host URL and API key provided by Typesense
 
+5. **Set up VAD service [Optional]**
+    - If you don't use this, it will default to using the Silero model on the omi server which isn't as good at voice detection
+    - Create an account on [huggingface](https://huggingface.co/)
+    - Create a token
+    - Go to https://huggingface.co/pyannote/voice-activity-detection and request access.
+    - set the HUGGINGFACE_TOKEN in the .env file
+    - Go to the backend/modal directory and run PYTHONPATH=.. uvicorn main:app --reload --port 8001 (Alternatively start the docker container)
 
-5. **Set up the Environment File: 📝**
+6. **Set up the Environment File: 📝**
     - Create a copy of the `.env.template` file and rename it to `.env`:
       ```bash
       cp .env.template .env
@@ -131,6 +138,7 @@ Before you start, make sure you have the following:
         - **Modal API Key:**  Obtained from your [Modal Dashboard](https://modal.com/settings#tokens)
         - **ADMIN_KEY:** Set to a temporary value (e.g., `123`) for local development
         - **HOSTED_PUSHER_API_URL:** Endpoint of your hosted pusher service (if you are using it, see step 3)
+        - **HOSTED_VAD_API_URL:** Endpoint of your vad service if you're using it (see step 5)
         - **Typesense Credentials:** Host, port, and API key from your [Typesense Cloud Dashboard](https://cloud.typesense.org/clusters)
         - **NO_SOCKET_TIMEOUT: (Optional)** Set to `True` to disable the socket timeout for the backend server (socket will stay connected for as long as the app is open)
         - **Other API Keys:** Fill in any other API keys required by your integrations (e.g., [Google Maps API key](https://console.cloud.google.com/google/maps-apis/credentials))


### PR DESCRIPTION
On a local environment the speech detection was not working, leading to the "teach omi your voice" being present all the time.  
- The silero model was not returning segments as it needs 16000Hz and not 8000Hz
- The code was hardcoded to look for a seperate vad service which can be configured in backend/modal

This PR:
- Fixes silero model use
- Adds logic to fallback to silero if the HOSTED_VAD_API_URL is not set
- Simplified the docker container to import the nvidia cuda image directly instead of building from scratch
- Changed default vad port so doesn't conflict with server
- Updated the code to call the correct /v1/vad endpoint instead of root
- Added logic to either be able to give the google service account as a file or a json string
- Updated docs
- Updated a couple of libraries that were failing on the ios app build