### PR TITLE
Add support enabling the stt services by env var, default deepgram nova-2

### DIFF
--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -38,26 +38,30 @@ soniox_multi_languages = soniox_supported_languages
 # Languages supported by Deepgram, nova-2/nova-3 model
 deepgram_supported_languages = {'multi','bg','ca', 'zh', 'zh-CN', 'zh-Hans', 'zh-TW', 'zh-Hant', 'zh-HK', 'cs', 'da', 'da-DK', 'nl', 'en', 'en-US', 'en-AU', 'en-GB', 'en-NZ', 'en-IN', 'et', 'fi', 'nl-BE', 'fr', 'fr-CA', 'de', 'de-CH', 'el' 'hi', 'hu', 'id', 'it', 'ja', 'ko', 'ko-KR', 'lv', 'lt', 'ms', 'no', 'pl', 'pt', 'pt-BR', 'pt-PT', 'ro', 'ru', 'sk', 'es', 'es-419', 'sv', 'sv-SE', 'th', 'th-TH', 'tr', 'uk', 'vi'}
 deepgram_nova2_multi_languages = ['multi', 'en', 'es']
-deepgram_multi_languages = ["multi", "en", "en-US", "en-AU", "en-GB", "en-NZ", "en-IN", "es", "es-419", "fr", "fr-CA", "de", "hi", "ru", "pt", "pt-BR", "pt-PT", "ja", "it", "nl", "nl-BE"]
+deepgram_nova3_multi_languages = ["multi", "en", "en-US", "en-AU", "en-GB", "en-NZ", "en-IN", "es", "es-419", "fr", "fr-CA", "de", "hi", "ru", "pt", "pt-BR", "pt-PT", "ja", "it", "nl", "nl-BE"]
+
+# Supported values: soniox-stt-rt,dg-nova-3,dg-nova-2
+stt_service_models = os.getenv('STT_SERVICE_MODELS', 'dg-nova-2').split(',')
 
 def get_stt_service_for_language(language: str):
-    # # Soniox's 'multi'
-    # if language in soniox_multi_languages:
-    #     return STTService.soniox, 'multi', 'stt-rt-preview'
+    # Picking STT service and STT language by following the order
+    for m in stt_service_models:
+        # Soniox
+        if m == 'soniox-stt-rt':
+            if language in soniox_multi_languages:
+                return STTService.soniox, 'multi', 'stt-rt-preview'
+        # DeepGram Nova-3
+        elif m == 'dg-nova-3':
+            if language in deepgram_nova3_multi_languages:
+                return STTService.deepgram, 'multi', 'nova-3'
+        # DeepGram Nova-2
+        elif m == 'dg-nova-2':
+            if language in deepgram_nova2_multi_languages:
+                return STTService.deepgram, 'multi', 'nova-2-general'
+            if language in deepgram_supported_languages:
+                return STTService.deepgram, language, 'nova-2-general'
 
-    # Deepgram's 'multi', nova-3
-    if language in deepgram_multi_languages:
-        return STTService.deepgram, 'multi', 'nova-3'
-
-    # Deepgram's 'multi', nova-2
-    if language in deepgram_nova2_multi_languages:
-        return STTService.deepgram, 'multi', 'nova-2-general'
-
-    # Deepgram
-    if language in deepgram_supported_languages:
-        return STTService.deepgram, language, 'nova-2-general'
-
-    # Fallback to Deepgram en
+    # Fallback to DeepGram Nova-2 en
     return STTService.deepgram, 'en', 'nova-2-general'
 
 


### PR DESCRIPTION
what's included ?
- enable/disable stt services via env var, supports: soniox-stt-rt,dg-nova-3,dg-nova-2, default: dg-nova-2

deploy plan.
- [ ] add new env var to backend, `STT_SERVICE_MODELS`

  ```
  # STT Services: soniox-stt-rt,dg-nova-3,dg-nova-2
  STT_SERVICE_MODELS=dg-nova-3,dg-nova-2
  ```
- [ ] deploy backend