### PR TITLE
Fix auto-summarizer for photo-only conversations and improve device UI consistency

### DIFF
--- a/app/lib/backend/schema/conversation.dart
+++ b/app/lib/backend/schema/conversation.dart
@@ -194,7 +194,6 @@ class ServerConversation {
 
   String getTag() {
     if (source == ConversationSource.screenpipe) return 'Screenpipe';
-    if (source == ConversationSource.openglass) return 'Openglass';
     if (source == ConversationSource.sdcard) return 'SD Card';
     if (discarded) return 'Discarded';
     return structured.category.substring(0, 1).toUpperCase() + structured.category.substring(1);

--- a/app/lib/pages/conversations/widgets/processing_capture.dart
+++ b/app/lib/pages/conversations/widgets/processing_capture.dart
@@ -249,19 +249,18 @@ class _ConversationCaptureWidgetState extends State<ConversationCaptureWidget> {
     
     if (isHavingRecordingDevice) {
       // Device is recording - PRIORITY: glasses take precedence over phone mic
-      if (transcriptServiceStateOk) {
-        var lastEvent = captureProvider.transcriptionServiceStatuses.lastOrNull;
-        if (lastEvent?.status == "ready") {
-          stateText = "Capturing";
-          statusIndicator = const RecordingStatusIndicator();
+      bool hasActiveCapture = captureProvider.allImages.isNotEmpty || 
+                             (transcriptServiceStateOk && captureProvider.transcriptionServiceStatuses.lastOrNull?.status == "ready");
+      
+      if (hasActiveCapture) {
+        stateText = "Capturing";
+        statusIndicator = const RecordingStatusIndicator();
+      } else if (!internetConnectionStateOk) {
+        stateText = "Waiting for network";
       } else {
         bool transcriptionDiagnosticEnabled = SharedPreferencesUtil().transcriptionDiagnosticEnabled;
-        stateText = transcriptionDiagnosticEnabled ? (lastEvent?.statusText ?? "") : "Connecting";
-      }
-    } else if (!internetConnectionStateOk) {
-      stateText = "Waiting for network";
-      } else {
-      stateText = "Connecting";
+        var lastEvent = captureProvider.transcriptionServiceStatuses.lastOrNull;
+        stateText = transcriptionDiagnosticEnabled ? (lastEvent?.statusText ?? "Connecting") : "Connecting";
       }
     } else if (isUsingPhoneMic) {
       // Phone mic is actively recording - only if no device connected


### PR DESCRIPTION
## Problem
- OpenGlass photo-only conversations failed auto-summarization with "transcript is empty" error
- Generic "Openglass" tags shown instead of actual conversation categories
- Inconsistent device status display when multiple devices active

## Solution
- Unified content detection logic for both auto-summarizer and apps
- Treat photo descriptions as valid content source equivalent to transcripts
- Remove device-specific tags to show actual conversation categories
- Prioritize device status (glasses > phone mic) for consistent "Capturing" display

## Changes
**Backend:**
- Add unified `has_photos` and `has_transcript` validation logic
- Fix auto-summarizer fallback to handle photo-only conversations
- Ensure apps and auto-summarizer use identical content processing

**Frontend:**
- Remove generic "Openglass" tag logic from conversation schema
- Update device status priority in processing capture widget
- Modular capture status logic for current and future device types
