### PR TITLE
Fix the battery skew on omicv firmware based-on the latest schematics

### DIFF
--- a/omi/firmware/omi/src/battery.c
+++ b/omi/firmware/omi/src/battery.c
@@ -95,8 +95,8 @@ int battery_get_millivolt(uint16_t *battery_millivolt)
     int err;
 
     // Voltage divider circuit
-    const uint16_t R1 = 1037; // Calibrated from 1M ohm
-    const uint16_t R2 = 510;  // 510K ohm
+    const uint16_t R1 = 1000;
+    const uint16_t R2 = 499;
 
     k_mutex_lock(&battery_mut, K_FOREVER);
 


### PR DESCRIPTION
what's included ?

- fix the battery skewed issue on omicv firmware by adjusting the R1 R2 value



![image](https://github.com/user-attachments/assets/99fb83c3-4d68-4bc0-99fc-67e25c4a6a22)
