### PR TITLE
Upgrade self-hosted Deepgram images to release-250626

### DIFF
--- a/backend/charts/deepgram-self-hosted/nova-3/dev_omi_values.yaml
+++ b/backend/charts/deepgram-self-hosted/nova-3/dev_omi_values.yaml
@@ -75,7 +75,7 @@ scaling:
 api:
   image:
     path: us-central1-docker.pkg.dev/based-hardware-dev/deepgram/self-hosted-api
-    tag: release-250610
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -90,7 +90,7 @@ api:
       kubernetes.io/ingress.class: "gce-internal"
       kubernetes.io/ingress.regional-static-ip-name: "dev-omi-deepgram-ilb-ip-address"
       kubernetes.io/ingress.allow-http: "false"
-      ingress.gcp.kubernetes.io/pre-shared-cert: "dev-omi-deepgram-ilb-cert"
+      ingress.gcp.kubernetes.io/pre-shared-cert: "dev-omi-deepgram-ilb-cert-20250705"
     hosts:
       - host: dg.omiapi.com
         paths:
@@ -108,7 +108,7 @@ api:
 engine:
   image:
     path: us-central1-docker.pkg.dev/based-hardware-dev/deepgram/self-hosted-engine
-    tag: release-250610
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -144,7 +144,7 @@ licenseProxy:
   enabled: true
   image:
     path: us-central1-docker.pkg.dev/based-hardware-dev/deepgram/self-hosted-license-proxy
-    tag: release-250610
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/backend/charts/deepgram-self-hosted/nova-3/prod_omi_values.yaml
+++ b/backend/charts/deepgram-self-hosted/nova-3/prod_omi_values.yaml
@@ -75,7 +75,7 @@ scaling:
 api:
   image:
     path: us-central1-docker.pkg.dev/based-hardware/deepgram/self-hosted-api
-    tag: release-250610
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -108,7 +108,7 @@ api:
 engine:
   image:
     path: us-central1-docker.pkg.dev/based-hardware/deepgram/self-hosted-engine
-    tag: release-250610
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -144,7 +144,7 @@ licenseProxy:
   enabled: true
   image:
     path: us-central1-docker.pkg.dev/based-hardware/deepgram/self-hosted-license-proxy
-    tag: release-250610
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
**Change:**

- Upgrade self-hosted Deepgram images to release-250626