### PR TITLE
Fix broken Discord invite links 

### DIFF
--- a/docs/doc/developer/apps/Notifications.mdx
+++ b/docs/doc/developer/apps/Notifications.mdx
@@ -200,5 +200,5 @@ function sendServiceUpdate(userId, serviceName, status) {
 ## Need Help? 🤝
 
 - Check our [API Reference](https://docs.omi.me/docs/api)
-- Join our [Discord community](https://discord.com/invite/omi)
+- Join our [Discord community](https://discord.gg/ACa4FDwJCA)
 - Contact [support](https://docs.omi.me/docs/info/Support) 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -104,7 +104,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/BasedHardware/omi",
-      "discord": "https://discord.com/invite/omi",
+      "discord": "https://discord.gg/ACa4FDwJCA",
       "x": "https://x.com/omedotme",
       "linkedin": "https://www.linkedin.com/company/omi-ai/",
       "instagram": "https://www.instagram.com/based_hardware/"


### PR DESCRIPTION
Replaced all instances of the invalid Discord invite (https://discord.com/invite/omi) with the correct invite link: https://discord.gg/ACa4FDwJCA.

Resolved Issue: #2696 