### PR TITLE
Deploy alternative monitoring logging stack

### DIFF
--- a/backend/charts/deepgram-self-hosted/nova-3/dev_omi_values.yaml
+++ b/backend/charts/deepgram-self-hosted/nova-3/dev_omi_values.yaml
@@ -168,7 +168,7 @@ gpu-operator:
 
 kube-prometheus-stack:
   grafana:
-    enabled: true
+    enabled: false
     ingress:
       enabled: true
       annotations:
@@ -189,6 +189,7 @@ kube-prometheus-stack:
       finalizers:
         - kubernetes.io/pvc-protection
   prometheus:
+    enabled: false
     prometheusSpec:
       additionalScrapeConfigs:
         - job_name: "dg_engine_metrics"
@@ -224,6 +225,12 @@ kube-prometheus-stack:
           - source_labels: [__meta_kubernetes_pod_node_name]
             action: replace
             target_label: kubernetes_node
+
+  prometheusOperator:
+    enabled: false
+
+  kubeStateMetrics:
+    enabled: false
 
 prometheus-adapter:
   # -- Normally, this chart will be installed if `scaling.auto.enabled` is true. However, if you wish

--- a/backend/charts/deepgram-self-hosted/nova-3/prod_omi_values.yaml
+++ b/backend/charts/deepgram-self-hosted/nova-3/prod_omi_values.yaml
@@ -168,7 +168,7 @@ gpu-operator:
 
 kube-prometheus-stack:
   grafana:
-    enabled: true
+    enabled: false
     ingress:
       enabled: true
       annotations:
@@ -189,6 +189,7 @@ kube-prometheus-stack:
       finalizers:
         - kubernetes.io/pvc-protection
   prometheus:
+    enabled: false
     prometheusSpec:
       additionalScrapeConfigs:
         - job_name: "dg_engine_metrics"
@@ -224,6 +225,12 @@ kube-prometheus-stack:
           - source_labels: [__meta_kubernetes_pod_node_name]
             action: replace
             target_label: kubernetes_node
+
+  prometheusOperator:
+    enabled: false
+
+  kubeStateMetrics:
+    enabled: false
 
 prometheus-adapter:
   # -- Normally, this chart will be installed if `scaling.auto.enabled` is true. However, if you wish

--- a/backend/charts/monitoring/alloy/dev_omi_k8s_monitoring_values.yml
+++ b/backend/charts/monitoring/alloy/dev_omi_k8s_monitoring_values.yml
@@ -1,0 +1,56 @@
+cluster:
+  name: dev-omi-gke
+
+destinations:
+  - name: loki
+    type: loki
+    url: http://dev-omi-loki-gateway/loki/api/v1/push
+    tenantId: "dev-omi-gke"
+    auth:
+      type: basic
+      usernameKey: username
+      passwordKey: password
+    secret:
+      create: false
+      name: alloy-auth-secret
+
+clusterEvents:
+  enabled: true
+  collector: alloy-logs
+  namespaces:
+    - dev-omi-backend
+
+nodeLogs:
+  enabled: false
+
+podLogs:
+  enabled: true
+  gatherMethod: kubernetesApi
+  collector: alloy-logs
+  labelsToKeep: ["app_kubernetes_io_name","container","instance","job","level","namespace","service_name","service_namespace","deployment_environment","deployment_environment_name"]
+  structuredMetadata:
+    pod: pod  # Set structured metadata "pod" from label "pod"
+  namespaces:
+    - dev-omi-backend
+
+# Collectors
+alloy-singleton:
+  enabled: false
+
+alloy-metrics:
+  enabled: false
+
+alloy-logs:
+  enabled: true
+  alloy:
+    mounts:
+      varlog: false
+      dockercontainers: false
+    clustering:
+      enabled: true
+
+alloy-profiles:
+  enabled: false
+
+alloy-receiver:
+  enabled: false

--- a/backend/charts/monitoring/alloy/prod_omi_k8s_monitoring_values.yml
+++ b/backend/charts/monitoring/alloy/prod_omi_k8s_monitoring_values.yml
@@ -1,10 +1,10 @@
 cluster:
-  name: dev-omi-gke
+  name: prod-omi-gke
 
 destinations:
   - name: loki
     type: loki
-    url: http://dev-omi-loki-gateway/loki/api/v1/push
+    url: http://prod-omi-loki-gateway/loki/api/v1/push
     auth:
       type: basic
       usernameKey: username
@@ -17,7 +17,7 @@ clusterEvents:
   enabled: true
   collector: alloy-logs
   namespaces:
-    - dev-omi-backend
+    - prod-omi-backend
 
 nodeLogs:
   enabled: false
@@ -30,7 +30,7 @@ podLogs:
   structuredMetadata:
     pod: pod  # Set structured metadata "pod" from label "pod"
   namespaces:
-    - dev-omi-backend
+    - prod-omi-backend
 
 # Collectors
 alloy-singleton:

--- a/backend/charts/monitoring/kube-prometheus-stack/dev_omi_grafana_alb_cert.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/dev_omi_grafana_alb_cert.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: dev-omi-grafana-alb-cert
+  namespace: dev-omi-monitoring
+spec:
+  domains:
+    - monitor.omiapi.com

--- a/backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml
@@ -1,0 +1,110 @@
+grafana:
+  enabled: true
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "gce"
+      kubernetes.io/ingress.global-static-ip-name: "dev-omi-grafana-alb-ip-address"
+      networking.gke.io/managed-certificates: "dev-omi-grafana-alb-cert"
+      kubernetes.io/ingress.allow-http: "false"
+    hosts:
+      - monitor.omiapi.com
+    path: /
+  persistence:
+    enabled: true
+    type: sts
+    storageClassName: standard-rwo
+    accessModes:
+      - ReadWriteOnce
+    size: 20Gi
+    finalizers:
+      - kubernetes.io/pvc-protection
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: service
+                operator: In
+                values:
+                  - monitoring
+              - key: env
+                operator: In
+                values:
+                  - dev
+
+prometheus:
+  enabled: true
+  prometheusSpec:
+    persistentVolumeClaimRetentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Delete
+    # Define metrics retention period
+    retention: 10d
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2G
+      limits:
+        cpu: "2"
+        memory: 4Gi
+    storageSpec:
+    # Using PersistentVolumeClaim
+      volumeClaimTemplate:
+        spec:
+          storageClassName: standard-rwo
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 50Gi
+    additionalScrapeConfigs:
+      # Additional scrape configs for Deepgram Engine metrics
+      - job_name: "dg_engine_metrics"
+        scrape_interval: "2s"
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+                - "dev-omi-dg-self-hosted"
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            regex: "(.*)-metrics"
+            action: keep
+          - source_labels: [__meta_kubernetes_endpoint_port_name]
+            regex: "metrics"
+            action: keep
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_service_name]
+            target_label: service
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+      - job_name: gpu-metrics
+        scrape_interval: 1s
+        metrics_path: /metrics
+        scheme: http
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - gke-managed-system
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          action: replace
+          target_label: kubernetes_node
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: service
+                  operator: In
+                  values:
+                    - monitoring
+                - key: env
+                  operator: In
+                  values:
+                    - dev
+
+nodeExporter:
+  enabled: true

--- a/backend/charts/monitoring/kube-prometheus-stack/prod_omi_grafana_alb_cert.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/prod_omi_grafana_alb_cert.yaml
@@ -1,0 +1,8 @@
+apiVersion: networking.gke.io/v1
+kind: ManagedCertificate
+metadata:
+  name: prod-omi-grafana-alb-cert
+  namespace: prod-omi-monitoring
+spec:
+  domains:
+    - monitor.omi.me

--- a/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
@@ -1,0 +1,110 @@
+grafana:
+  enabled: true
+  ingress:
+    enabled: true
+    annotations:
+      kubernetes.io/ingress.class: "gce"
+      kubernetes.io/ingress.global-static-ip-name: "prod-omi-grafana-alb-ip-address"
+      networking.gke.io/managed-certificates: "prod-omi-grafana-alb-cert"
+      kubernetes.io/ingress.allow-http: "false"
+    hosts:
+      - monitor.omi.me
+    path: /
+  persistence:
+    enabled: true
+    type: sts
+    storageClassName: standard-rwo
+    accessModes:
+      - ReadWriteOnce
+    size: 20Gi
+    finalizers:
+      - kubernetes.io/pvc-protection
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: service
+                operator: In
+                values:
+                  - monitoring
+              - key: env
+                operator: In
+                values:
+                  - prod
+
+prometheus:
+  enabled: true
+  prometheusSpec:
+    persistentVolumeClaimRetentionPolicy:
+      whenDeleted: Retain
+      whenScaled: Delete
+    # Define metrics retention period
+    retention: 10d
+    resources:
+      requests:
+        cpu: "1"
+        memory: 2G
+      limits:
+        cpu: "2"
+        memory: 4Gi
+    storageSpec:
+    # Using PersistentVolumeClaim
+      volumeClaimTemplate:
+        spec:
+          storageClassName: standard-rwo
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 50Gi
+    additionalScrapeConfigs:
+      # Additional scrape configs for Deepgram Engine metrics
+      - job_name: "dg_engine_metrics"
+        scrape_interval: "2s"
+        kubernetes_sd_configs:
+          - role: endpoints
+            namespaces:
+              names:
+                - "prod-omi-dg-self-hosted"
+        relabel_configs:
+          - source_labels: [__meta_kubernetes_service_name]
+            regex: "(.*)-metrics"
+            action: keep
+          - source_labels: [__meta_kubernetes_endpoint_port_name]
+            regex: "metrics"
+            action: keep
+          - source_labels: [__meta_kubernetes_namespace]
+            target_label: namespace
+          - source_labels: [__meta_kubernetes_service_name]
+            target_label: service
+          - source_labels: [__meta_kubernetes_pod_name]
+            target_label: pod
+      - job_name: gpu-metrics
+        scrape_interval: 1s
+        metrics_path: /metrics
+        scheme: http
+        kubernetes_sd_configs:
+        - role: pod
+          namespaces:
+            names:
+            - gke-managed-system
+        relabel_configs:
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          action: replace
+          target_label: kubernetes_node
+    affinity:
+      nodeAffinity:
+        requiredDuringSchedulingIgnoredDuringExecution:
+          nodeSelectorTerms:
+            - matchExpressions:
+                - key: service
+                  operator: In
+                  values:
+                    - monitoring
+                - key: env
+                  operator: In
+                  values:
+                    - prod
+
+nodeExporter:
+  enabled: true

--- a/backend/charts/monitoring/loki/dev_omi_loki_values.yaml
+++ b/backend/charts/monitoring/loki/dev_omi_loki_values.yaml
@@ -1,0 +1,146 @@
+loki_anchors:
+  chunkBucketName: &chunkBucketName dev-omi-loki-chunks
+  rulerBucketName: &rulerBucketName dev-omi-loki-ruler
+  nodeSelector: &nodeSelector
+    service: monitoring
+    env: dev
+
+loki:
+  schemaConfig:
+    configs:
+      - from: "2024-04-01"
+        store: tsdb
+        object_store: gcs
+        schema: v13
+        index:
+          prefix: loki_index_
+          period: 24h
+  storage_config:
+    gcs:
+      bucket_name: *chunkBucketName # Your actual gcs bucket name, for example, loki-gcp-chunks
+  ingester:
+    chunk_encoding: snappy
+  pattern_ingester:
+    enabled: true
+  limits_config:
+    allow_structured_metadata: true
+    volume_enabled: true
+    retention_period: 360h # 15 days retention
+  compactor:
+    retention_enabled: true 
+    delete_request_store: gcs
+  ruler:
+    enable_api: true
+    storage_config:
+      type: gcs
+      gcs_storage_config:
+        region: us-central1 # The GCS region, for example europe-west4
+        bucketnames: *rulerBucketName # Your actual gcs bucket name, for example, loki-gcp-ruler
+      alertmanager_url: http://dev-kube-prometheus-stack-alertmanager:9093 # The URL of the Alertmanager to send alerts (Prometheus, Mimir, etc.)
+  querier:
+    max_concurrent: 4
+  storage:
+    type: gcs
+    bucketNames:
+      chunks: *chunkBucketName # Your actual gcs bucket name, for example, loki-gcp-chunks
+      ruler: *rulerBucketName # Your actual gcs bucket name, for example, loki-gcp-ruler
+
+serviceAccount:
+  create: false
+  name: dev-omi-loki-ksa
+
+deploymentMode: Distributed
+
+ingester:
+  replicas: 2
+  zoneAwareReplication:
+    enabled: false
+  nodeSelector:
+    <<: *nodeSelector
+  
+querier:
+  replicas: 2
+  maxUnavailable: 2
+  nodeSelector:
+    <<: *nodeSelector
+
+queryFrontend:
+  replicas: 2
+  maxUnavailable: 1
+  nodeSelector:
+    <<: *nodeSelector
+
+queryScheduler:
+  replicas: 2
+  nodeSelector:
+    <<: *nodeSelector
+
+distributor:
+  replicas: 2
+  maxUnavailable: 2
+  nodeSelector:
+    <<: *nodeSelector
+
+compactor:
+  replicas: 1
+  nodeSelector:
+    <<: *nodeSelector
+
+indexGateway:
+  replicas: 2
+  maxUnavailable: 1
+  nodeSelector:
+    <<: *nodeSelector
+
+ruler:
+  replicas: 1
+  maxUnavailable: 1
+  nodeSelector:
+    <<: *nodeSelector
+
+# This exposes the Loki gateway so it can be written to and queried externaly
+gateway:
+  service:
+    type: ClusterIP
+  basicAuth: 
+    enabled: true
+    existingSecret: loki-basic-auth
+  nodeSelector:
+    <<: *nodeSelector
+
+memcached:
+  nodeSelector:
+    <<: *nodeSelector
+
+# Since we are using basic auth, we need to pass the username and password to the canary
+lokiCanary:
+  extraArgs:
+    - -pass=$(LOKI_PASS)
+    - -user=$(LOKI_USER)
+  extraEnv:
+    - name: LOKI_PASS
+      valueFrom:
+        secretKeyRef:
+          name: canary-basic-auth
+          key: password
+    - name: LOKI_USER
+      valueFrom:
+        secretKeyRef:
+          name: canary-basic-auth
+          key: username
+  nodeSelector:
+    <<: *nodeSelector
+
+# Enable minio for storage
+minio:
+  enabled: false
+
+backend:
+  replicas: 0
+read:
+  replicas: 0
+write:
+  replicas: 0
+
+singleBinary:
+  replicas: 0

--- a/backend/charts/monitoring/loki/prod_omi_loki_values.yaml
+++ b/backend/charts/monitoring/loki/prod_omi_loki_values.yaml
@@ -1,9 +1,9 @@
 loki_anchors:
-  chunkBucketName: &chunkBucketName dev-omi-loki-chunks
-  rulerBucketName: &rulerBucketName dev-omi-loki-ruler
+  chunkBucketName: &chunkBucketName prod-omi-loki-chunks
+  rulerBucketName: &rulerBucketName prod-omi-loki-ruler
   nodeSelector: &nodeSelector
     service: monitoring
-    env: dev
+    env: prod
 
 loki:
   schemaConfig:
@@ -36,7 +36,7 @@ loki:
       gcs_storage_config:
         region: us-central1 # The GCS region, for example europe-west4
         bucketnames: *rulerBucketName # Your actual gcs bucket name, for example, loki-gcp-ruler
-      alertmanager_url: http://dev-kube-prometheus-stack-alertmanager:9093 # The URL of the Alertmanager to send alerts (Prometheus, Mimir, etc.)
+      alertmanager_url: http://prod-kube-prometheus-stack-alertmanager:9093 # The URL of the Alertmanager to send alerts (Prometheus, Mimir, etc.)
   querier:
     max_concurrent: 4
   storage:
@@ -47,7 +47,7 @@ loki:
 
 serviceAccount:
   create: false
-  name: dev-omi-loki-ksa
+  name: prod-omi-loki-ksa
 
 deploymentMode: Distributed
 


### PR DESCRIPTION
**Changes:**
- Disable built-in Grafana, Prometheus from Deepgram self-hosted Helm chart.
- Update Helm chart values files for monitoring and logging stack (kube-prometheus-stack, Loki, Alloy)