### PR TITLE
Refactor export to include OmiConnection module

### DIFF
--- a/sdks/react-native/src/index.js
+++ b/sdks/react-native/src/index.js
@@ -147,4 +147,4 @@ function cleanupSubscriptionsForDevice(deviceId) {
     }
 }
 export { OmiModule };
-export * from './omi';
+export * from './OmiConnection';


### PR DESCRIPTION
This pull request includes a small change to the `sdks/react-native/src/index.js` file. The change updates the export to use `OmiConnection` instead of `omi`.

This has been done to solve the #2704 issue.

- I was working with the omi sdk and faced the import issue( explained in detail here #2704 ).
- I cloned the repository and placed the sdk source code manually there and resolved the import. Now its working.