### PR TITLE
Rollback DG to release-250626 and increase minReplicas of backend-listen to 10

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -261,11 +261,11 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
+    cpu: 0.7
+    memory: 2Gi
+  limits:
     cpu: 1
     memory: 4Gi
-  limits:
-    cpu: 2
-    memory: 6Gi
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
@@ -289,7 +289,7 @@ startupProbe:
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: true
-  minReplicas: 5
+  minReplicas: 10
   maxReplicas: 50
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70

--- a/backend/charts/deepgram-self-hosted/nova-3/dev_omi_values.yaml
+++ b/backend/charts/deepgram-self-hosted/nova-3/dev_omi_values.yaml
@@ -75,7 +75,7 @@ scaling:
 api:
   image:
     path: us-central1-docker.pkg.dev/based-hardware-dev/deepgram/self-hosted-api
-    tag: release-250710
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -108,7 +108,7 @@ api:
 engine:
   image:
     path: us-central1-docker.pkg.dev/based-hardware-dev/deepgram/self-hosted-engine
-    tag: release-250710
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -144,7 +144,7 @@ licenseProxy:
   enabled: true
   image:
     path: us-central1-docker.pkg.dev/based-hardware-dev/deepgram/self-hosted-license-proxy
-    tag: release-250710
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/backend/charts/deepgram-self-hosted/nova-3/prod_omi_values.yaml
+++ b/backend/charts/deepgram-self-hosted/nova-3/prod_omi_values.yaml
@@ -75,7 +75,7 @@ scaling:
 api:
   image:
     path: us-central1-docker.pkg.dev/based-hardware/deepgram/self-hosted-api
-    tag: release-250710
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -108,7 +108,7 @@ api:
 engine:
   image:
     path: us-central1-docker.pkg.dev/based-hardware/deepgram/self-hosted-engine
-    tag: release-250710
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -144,7 +144,7 @@ licenseProxy:
   enabled: true
   image:
     path: us-central1-docker.pkg.dev/based-hardware/deepgram/self-hosted-license-proxy
-    tag: release-250710
+    tag: release-250626
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -238,7 +238,7 @@ prometheus-adapter:
   # you can force it to not be installed by setting this to `false`.
   includeDependency:
   prometheus:
-    url: http://dg-prometheus-stack-prometheus.{{ .Release.Namespace }}.svc
+    url: http://prod-omi-kube-prometheus-s-prometheus.prod-omi-monitoring.svc
   rules:
     default: false
     external:

--- a/backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/dev_omi_monitoring_values.yaml
@@ -106,5 +106,10 @@ prometheus:
                   values:
                     - dev
 
+kube-state-metrics:
+  enabled: true
+  metricLabelsAllowlist:
+    - namespaces=[{{ .Release.Namespace }}],deployments=[app]
+
 nodeExporter:
   enabled: true

--- a/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
+++ b/backend/charts/monitoring/kube-prometheus-stack/prod_omi_monitoring_values.yaml
@@ -106,5 +106,10 @@ prometheus:
                   values:
                     - prod
 
+kube-state-metrics:
+  enabled: true
+  metricLabelsAllowlist:
+    - namespaces=[{{ .Release.Namespace }}],deployments=[app]
+
 nodeExporter:
   enabled: true


### PR DESCRIPTION
**Changes:**

- Rollback DG image to **release-250626**
- Increase **minReplicas** of backend-listen to 10 and balance its resource utilization.
- Fix missing **HPA metrics** issue for Deepgram self-hosted