### PR TITLE
Tuning HPA of backend-listen for faster scale up

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -315,14 +315,14 @@ autoscaling:
       policies:
       - type: Percent
         value: 100
-        periodSeconds: 15
+        periodSeconds: 1
       - type: Pods
-        value: 4
-        periodSeconds: 15
+        value: 10
+        periodSeconds: 1
       selectPolicy: Max
   # targetCPUUtilizationPercentage: 70
   # targetMemoryUtilizationPercentage: 70
-  requestsPerPod: 10
+  requestsPerPod: 8
   failedResponseCode: 10
 
 # Additional volumes on the output Deployment definition.


### PR DESCRIPTION
**Changes:**

- Reduce requestPerPod threshold to 8
- Reduce periodSeconds to 1 for continuous scale-up