### PR TITLE
feat: create welcome conversation on user signup

### DIFF
--- a/app/lib/pages/conversation_detail/conversation_detail_provider.dart
+++ b/app/lib/pages/conversation_detail/conversation_detail_provider.dart
@@ -37,7 +37,10 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
 
   ServerConversation? _cachedConversation;
   ServerConversation get conversation {
-    if (conversationProvider == null || !conversationProvider!.groupedConversations.containsKey(selectedDate) || conversationProvider!.groupedConversations[selectedDate] == null || conversationProvider!.groupedConversations[selectedDate]!.length <= conversationIdx) {
+    if (conversationProvider == null ||
+        !conversationProvider!.groupedConversations.containsKey(selectedDate) ||
+        conversationProvider!.groupedConversations[selectedDate] == null ||
+        conversationProvider!.groupedConversations[selectedDate]!.length <= conversationIdx) {
       // Return cached conversation if available, otherwise create an empty one
       if (_cachedConversation == null) {
         throw StateError("No conversation available");
@@ -186,7 +189,10 @@ class ConversationDetailProvider extends ChangeNotifier with MessageNotifierMixi
       print('titleFocusNode focus changed');
       if (!titleFocusNode!.hasFocus) {
         conversation.structured.title = titleController!.text;
-        updateConversationTitle(conversation.id, titleController!.text);
+        // Skip updating title for the welcome conversation (it's local only)
+        if (conversation.id != 'welcome') {
+          updateConversationTitle(conversation.id, titleController!.text);
+        }
       }
     });
 

--- a/app/lib/pages/conversation_detail/page.dart
+++ b/app/lib/pages/conversation_detail/page.dart
@@ -89,8 +89,7 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
           index += query.length;
         }
       }
-    }
-    else if (selectedTab == ConversationTab.summary) {
+    } else if (selectedTab == ConversationTab.summary) {
       // Count matches in app summaries
       final summarizedApp = provider.getSummarizedApp();
       if (summarizedApp != null && summarizedApp.content.trim().isNotEmpty) {
@@ -103,11 +102,11 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
           index += query.length;
         }
       }
-     }
+    }
 
-     _totalSearchResults = count;
-     _currentSearchIndex = count > 0 ? 1 : 0;
-   }
+    _totalSearchResults = count;
+    _currentSearchIndex = count > 0 ? 1 : 0;
+  }
 
   void _navigateSearch(bool next) {
     if (_totalSearchResults == 0) return;
@@ -159,7 +158,17 @@ class _ConversationDetailPageState extends State<ConversationDetailPage> with Ti
       // Ensure the provider has the conversation data from the widget parameter
       provider.setCachedConversation(widget.conversation);
 
-      // Find the proper date and index for this conversation in the grouped conversations
+      if (widget.isFromOnboarding) {
+        // For onboarding, skip provider lookup; use local date/index
+        final d = DateTime(
+            widget.conversation.createdAt.year, widget.conversation.createdAt.month, widget.conversation.createdAt.day);
+        provider.conversationIdx = 0;
+        provider.selectedDate = d;
+        await provider.initConversation();
+        return;
+      }
+
+      // Normal conversations: find date/index from provider
       var (date, index) = conversationProvider.getConversationDateAndIndex(widget.conversation);
       provider.conversationIdx = index >= 0 ? index : 0;
       provider.selectedDate = date;

--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -7,13 +7,13 @@ import 'package:omi/pages/conversations/widgets/search_widget.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
 import 'package:omi/services/app_review_service.dart';
+import 'package:omi/pages/conversations/welcome_conversation.dart';
 import 'package:omi/utils/ui_guidelines.dart';
 import 'package:omi/widgets/custom_refresh_indicator.dart';
 import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
-import 'widgets/empty_conversations.dart';
 import 'widgets/conversations_group_widget.dart';
 
 class ConversationsPage extends StatefulWidget {
@@ -38,7 +38,7 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
       if (conversationProvider.conversations.isEmpty) {
         await conversationProvider.getInitialConversations();
       }
-      
+
       // Check if we should show the app review prompt for first conversation
       if (mounted && conversationProvider.conversations.isNotEmpty) {
         await _appReviewService.showReviewPromptIfNeeded(context, isProcessingFirstConversation: true);
@@ -156,13 +156,21 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
             const SliverToBoxAdapter(child: SearchResultHeaderWidget()),
             getProcessingConversationsWidget(convoProvider.processingConversations),
             if (convoProvider.groupedConversations.isEmpty && !convoProvider.isLoadingConversations)
-              const SliverToBoxAdapter(
-                child: Center(
-                  child: Padding(
-                    padding: EdgeInsets.only(top: 32.0),
-                    child: EmptyConversationsWidget(),
-                  ),
-                ),
+              SliverToBoxAdapter(
+                child: Builder(builder: (context) {
+                  final welcome = buildWelcomeConversation();
+                  final dateKey = DateTime(welcome.createdAt.year, welcome.createdAt.month, welcome.createdAt.day);
+                  return Column(
+                    children: [
+                      const SizedBox(height: 32),
+                      ConversationsGroupWidget(
+                        isFirst: true,
+                        conversations: [welcome],
+                        date: dateKey,
+                      ),
+                    ],
+                  );
+                }),
               )
             else if (convoProvider.groupedConversations.isEmpty && convoProvider.isLoadingConversations)
               _buildLoadingShimmer()

--- a/app/lib/pages/conversations/welcome_conversation.dart
+++ b/app/lib/pages/conversations/welcome_conversation.dart
@@ -1,0 +1,35 @@
+import 'package:omi/backend/schema/conversation.dart';
+import 'package:omi/backend/schema/structured.dart';
+
+ServerConversation buildWelcomeConversation() {
+  final now = DateTime.now();
+
+  final structured = Structured(
+    'Welcome to Omi',
+    "Omi captures moments, meetings or thoughts and turns them into clear summaries with action items.\n"
+        "1) Start recording 🎙️: Tap the big Record button to begin recording, and Omi will capture your conversation or thoughts.\n"
+        "2) Stop or auto-finish ⏹️: Tap the red stop button to stop. If you're silent for ~2 minutes, Omi auto-finishes and summarizes.\n"
+        "3) Review your summary 📝: The new conversation appears at the top with a title, overview, and TODOs.\n"
+        "4) Share when needed 🔗: Open a conversation, tap Share, then Send web URL.\n"
+        "5) Automate workflows ⚙️: Connect apps to trigger actions when conversations finish - like creating reminders, or updating other tools.",
+    emoji: '👋',
+    category: 'education',
+  );
+
+  structured.actionItems = [
+    ActionItem('Try a quick 1-2 minute test recording from the Home screen'),
+    ActionItem('Open the new conversation and read the summary'),
+    ActionItem('Share the URL with someone'),
+  ];
+
+  return ServerConversation(
+    id: 'welcome',
+    createdAt: now,
+    startedAt: now,
+    finishedAt: now,
+    structured: structured,
+    source: ConversationSource.omi,
+    language: 'en',
+    status: ConversationStatus.completed,
+  );
+}

--- a/app/lib/pages/conversations/widgets/conversations_group_widget.dart
+++ b/app/lib/pages/conversations/widgets/conversations_group_widget.dart
@@ -19,7 +19,11 @@ class ConversationsGroupWidget extends StatelessWidget {
           DateListItem(date: date, isFirst: isFirst),
           ...conversations.map((conversation) {
             return ConversationListItem(
-                conversation: conversation, conversationIdx: conversations.indexOf(conversation), date: date);
+              conversation: conversation,
+              conversationIdx: conversations.indexOf(conversation),
+              date: date,
+              isFromOnboarding: conversation.id == 'welcome',
+            );
           }),
           const SizedBox(height: 10),
         ],


### PR DESCRIPTION
For first time users create a default "welcome" conversation

It also creates 3 TODOs based on that welcome 


<img width="504" height="981" alt="Screenshot 2025-08-14 at 8 41 34 AM" src="https://github.com/user-attachments/assets/f85d5140-1a84-439a-8229-b4b2bad5f960" />

<img width="504" height="981" alt="Screenshot 2025-08-14 at 8 42 25 AM" src="https://github.com/user-attachments/assets/0d05cd06-6616-4e1e-8464-4dd4f5d841ee" />

