### PR TITLE
Tuning hpa backend listen for faster scale up

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_cronjob.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_cronjob.yaml
@@ -5,7 +5,7 @@ metadata:
   name: prod-omi-backend-listen-scale-down
   namespace: prod-omi-backend
 spec:
-  schedule: "0 0 * * *"  # Reduce minReplicas to 10 at 00:00 UTC
+  schedule: "0 1 * * *"  # Reduce minReplicas to 10 at 01:00 UTC
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 0
   timeZone: UTC
@@ -29,7 +29,7 @@ metadata:
   name: prod-omi-backend-listen-scale-up
   namespace: prod-omi-backend
 spec:
-  schedule: "0 12 * * *"  # Increase minReplicas to 40 at 12:00 UTC
+  schedule: "0 11 * * *"  # Increase minReplicas to 30 at 11:00 UTC
   successfulJobsHistoryLimit: 0
   failedJobsHistoryLimit: 0
   timeZone: UTC
@@ -44,7 +44,7 @@ spec:
             command: ["/bin/sh", "-c"]
             args:
             - kubectl -n prod-omi-backend patch hpa prod-omi-backend-listen
-              --patch '{"spec":{"minReplicas":40}}'
+              --patch '{"spec":{"minReplicas":30}}'
           restartPolicy: OnFailure
 ---
 apiVersion: v1


### PR DESCRIPTION
**Changes:**
- Change minReplicas to 30 for time-based scaling
- Change timeframe to run minReplicas as 10 (1:00 - 11:00 UTC)