### PR TITLE
removed monotic timer

### DIFF
--- a/omi/firmware/omi/src/lib/dk2/button.c
+++ b/omi/firmware/omi/src/lib/dk2/button.c
@@ -253,10 +253,8 @@ void check_button_level(struct k_work *work_item)
         notify_unpress();
 
         // Reset
-        current_time = 0;
         btn_press_start_time = 0;
         btn_release_time = 0;
-        btn_last_tap_time = 0;
     }
     if (event == BUTTON_EVENT_RELEASE)
     {


### PR DESCRIPTION
Hi,

I’m building some functionality around button clicking on the Python SDK for Devkit2 and noticed this line of code where it resets the current_time to zero when a long press is released. As I understand it, current_time is used for a monotonic counter, and because current_time is being reset on button released for long press, an overflow occurs when you long press the button a second time.
