### PR TITLE
Limit filters categories to 1K; Limit vector resutls to top 1K

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -423,8 +423,15 @@ def get_user_webhook_db(uid: str, wtype: str) -> str:
     return url.decode()
 
 
-def get_filter_category_items(uid: str, category: str) -> List[str]:
-    val = r.smembers(f'users:{uid}:filters:{category}')
+def get_filter_category_items(uid: str, category: str, limit: Optional[int] = None) -> List[str]:
+    key = f'users:{uid}:filters:{category}'
+    if limit:
+        # Get random sample if limit specified
+        val = r.srandmember(key, limit)
+    else:
+        # Get all items (existing behavior)
+        val = r.smembers(key)
+
     if not val:
         return []
     return [x.decode() for x in val]

--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -96,10 +96,10 @@ def query_vectors_by_metadata(
             {'created_at': {'$gte': int(dates_filter[0].timestamp()), '$lte': int(dates_filter[1].timestamp())}}
         )
 
-    print('query_vectors_by_metadata:', json.dumps(filter_data))
+    # print('query_vectors_by_metadata:', json.dumps(filter_data))
 
     xc = index.query(
-        vector=vector, filter=filter_data, namespace="ns1", include_values=False, include_metadata=True, top_k=10000
+        vector=vector, filter=filter_data, namespace="ns1", include_values=False, include_metadata=True, top_k=1000
     )
     if not xc['matches']:
         if len(filter_data['$and']) == 3:

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -806,8 +806,9 @@ def select_structured_filters(question: str, filters_available: dict) -> dict:
     Based on a question asked by the user to an AI, the AI needs to search for the user information related to topics, entities, people, and dates that will help it answering.
     Your task is to identify the correct fields that can be related to the question and can help answering.
 
-    You must choose for each field, only the ones available in the JSON below.
-    Find as many as possible that can relate to the question asked.
+    The JSON below contains samples of available filters as suggestions, but you are not limited to only these options. 
+    However, you must choose from the ones that are actually available in the provided lists.
+    Find as many as possible that can relate to the question asked, prioritizing the most relevant ones.
     ```
     {json.dumps(filters_available, indent=2)}
     ```

--- a/backend/utils/retrieval/graph.py
+++ b/backend/utils/retrieval/graph.py
@@ -244,9 +244,9 @@ def context_dependent_conversation(state: GraphState):
 def retrieve_topics_filters(state: GraphState):
     print("retrieve_topics_filters")
     filters = {
-        "people": get_filter_category_items(state.get("uid"), "people"),
-        "topics": get_filter_category_items(state.get("uid"), "topics"),
-        "entities": get_filter_category_items(state.get("uid"), "entities"),
+        "people": get_filter_category_items(state.get("uid"), "people", limit=1000),
+        "topics": get_filter_category_items(state.get("uid"), "topics", limit=1000),
+        "entities": get_filter_category_items(state.get("uid"), "entities", limit=1000),
         # 'dates': get_filter_category_items(state.get('uid'), 'dates'),
     }
     result = select_structured_filters(state.get("parsed_question", ""), filters)


### PR DESCRIPTION
what's included?
- limit the filter categories to 1000 instead of unlimited  
- limit the topK on vector queries to 1000 instead of 10000  

-> these help speed up the chat feature and improve safety when dealing with large amounts of topics from power users.

\\---
redis-13151.c1.us-central1-2.gce.redns.redis-cloud.com:13151> SCARD users:xyz:filters:topics
(integer) 13340
\\---

deploy:
- [ ] deploy backend
