### PR TITLE
improve the BLE scan mechanism to reduce battery consumption by the mobile app, its basically by 8/10

### DIFF
--- a/app/lib/pages/conversations/widgets/capture.dart
+++ b/app/lib/pages/conversations/widgets/capture.dart
@@ -1,12 +1,7 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
-import 'package:omi/backend/schema/bt_device/bt_device.dart';
 import 'package:omi/pages/capture/widgets/widgets.dart';
 import 'package:omi/providers/capture_provider.dart';
-import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/device_provider.dart';
-import 'package:omi/providers/onboarding_provider.dart';
-import 'package:omi/services/services.dart';
 import 'package:omi/utils/audio/wav_bytes.dart';
 import 'package:provider/provider.dart';
 
@@ -28,21 +23,7 @@ class LiteCaptureWidgetState extends State<LiteCaptureWidget> with AutomaticKeep
   @override
   void initState() {
     WavBytesUtil.clearTempWavFiles();
-    SchedulerBinding.instance.addPostFrameCallback((_) async {
-      if (context.read<DeviceProvider>().connectedDevice != null) {
-        context.read<OnboardingProvider>().stopScanDevices();
-      }
-    });
-
     super.initState();
-  }
-
-  Future<BleAudioCodec> _getAudioCodec(String deviceId) async {
-    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
-    if (connection == null) {
-      return BleAudioCodec.pcm8;
-    }
-    return connection.getAudioCodec();
   }
 
   @override

--- a/app/lib/pages/onboarding/find_device/page.dart
+++ b/app/lib/pages/onboarding/find_device/page.dart
@@ -42,7 +42,6 @@ class _FindDevicesPageState extends State<FindDevicesPage> {
 
   @override
   dispose() {
-    _provider?.stopScanDevices();
     _provider = null;
 
     super.dispose();

--- a/app/lib/pages/onboarding/welcome/page.dart
+++ b/app/lib/pages/onboarding/welcome/page.dart
@@ -1,10 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:omi/providers/onboarding_provider.dart';
-import 'package:omi/utils/analytics/intercom.dart';
-import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/widgets/dialog.dart';
-import 'package:gradient_borders/box_borders/gradient_box_border.dart';
 import 'package:permission_handler/permission_handler.dart';
 import 'package:provider/provider.dart';
 
@@ -174,15 +171,19 @@ class _WelcomePageState extends State<WelcomePage> with TickerProviderStateMixin
                     AnimatedContainer(
                       duration: const Duration(milliseconds: 800),
                       curve: Curves.easeInOut,
-                      height: _isExpandingTop ? MediaQuery.of(context).size.height : MediaQuery.of(context).size.height * _expansionAnimation.value,
+                      height: _isExpandingTop
+                          ? MediaQuery.of(context).size.height
+                          : MediaQuery.of(context).size.height * _expansionAnimation.value,
                       child: Container(
                         width: double.infinity,
                         decoration: BoxDecoration(
                           image: DecorationImage(
                             image: ResizeImage(
                               const AssetImage('assets/images/onboarding-bg-5-1.jpg'),
-                              width: (MediaQuery.of(context).size.width * MediaQuery.of(context).devicePixelRatio).round(),
-                              height: (MediaQuery.of(context).size.height * MediaQuery.of(context).devicePixelRatio).round(),
+                              width:
+                                  (MediaQuery.of(context).size.width * MediaQuery.of(context).devicePixelRatio).round(),
+                              height: (MediaQuery.of(context).size.height * MediaQuery.of(context).devicePixelRatio)
+                                  .round(),
                             ),
                             fit: BoxFit.cover,
                           ),
@@ -268,8 +269,10 @@ class _WelcomePageState extends State<WelcomePage> with TickerProviderStateMixin
                             image: DecorationImage(
                               image: ResizeImage(
                                 const AssetImage('assets/images/onboarding-bg-5-2.jpg'),
-                                width: (MediaQuery.of(context).size.width * MediaQuery.of(context).devicePixelRatio).round(),
-                                height: (MediaQuery.of(context).size.height * MediaQuery.of(context).devicePixelRatio).round(),
+                                width: (MediaQuery.of(context).size.width * MediaQuery.of(context).devicePixelRatio)
+                                    .round(),
+                                height: (MediaQuery.of(context).size.height * MediaQuery.of(context).devicePixelRatio)
+                                    .round(),
                               ),
                               fit: BoxFit.cover,
                             ),

--- a/app/lib/pages/settings/device_settings.dart
+++ b/app/lib/pages/settings/device_settings.dart
@@ -136,7 +136,6 @@ class _DeviceSettingsState extends State<DeviceSettings> {
                       provider.setIsConnected(false);
                       provider.setConnectedDevice(null);
                       provider.updateConnectingStatus(false);
-                      context.read<OnboardingProvider>().stopScanDevices();
                       Navigator.of(context).pop();
                       Navigator.of(context).pop();
                       ScaffoldMessenger.of(context).showSnackBar(SnackBar(

--- a/app/lib/services/devices.dart
+++ b/app/lib/services/devices.dart
@@ -212,7 +212,7 @@ class DeviceService implements IDeviceService {
 
         // connected
         var pongAt = _connection?.pongAt;
-        var shouldPing = (pongAt == null || pongAt.isBefore(DateTime.now().subtract(const Duration(seconds: 5))));
+        var shouldPing = (pongAt == null || pongAt.isBefore(DateTime.now().subtract(const Duration(seconds: 10))));
         if (shouldPing) {
           var ok = await _connection?.ping() ?? false;
           if (!ok) {
@@ -227,7 +227,7 @@ class DeviceService implements IDeviceService {
       // Force
       if (deviceId == _connection?.device.id && _connection?.status == DeviceConnectionState.connected) {
         var pongAt = _connection?.pongAt;
-        var shouldPing = (pongAt == null || pongAt.isBefore(DateTime.now().subtract(const Duration(seconds: 5))));
+        var shouldPing = (pongAt == null || pongAt.isBefore(DateTime.now().subtract(const Duration(seconds: 10))));
         if (shouldPing) {
           var ok = await _connection?.ping() ?? false;
           if (!ok) {

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -122,7 +122,7 @@ abstract class DeviceConnection {
 
   Future<bool> ping() async {
     try {
-      int rssi = await bleDevice.readRssi();
+      int rssi = await bleDevice.readRssi(timeout: 10);
       device.rssi = rssi;
       _pongAt = DateTime.now();
       return true;


### PR DESCRIPTION
**what's included?**
- improve BLE scanning, reducing phone battery consumption by 8/10  
  - remove redundant continuous BLE scanning (5 times, sleep 2s each)
  - centralize BLE scan to the device provider, helping remove edge cases with multiple scans at a time
  - adjust the scanning threshold: now 10s instead of 7s, RSSI checking time 10s instead of 5s

**deploy:**
- [x] deploy mobile app https://codemagic.io/app/66c95e6ec76853c447b8bcbb/build/68a70fb6ebfe8b20a1da0179
