### PR TITLE
introduce subscription launch date for credit usage

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -231,6 +231,8 @@ env:
     value: "price_1RrxXL1F8wnoWYvwIddzR902"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvw3kDbWmjs"
+  - name: SUBSCRIPTION_LAUNCH_DATE
+    value: "2025-08-21"
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -255,7 +255,7 @@ env:
         name: prod-omi-backend-secrets
         key: ENCRYPTION_SECRET
   - name: BASIC_TIER_MINUTES_LIMIT_PER_MONTH
-    value: "1000000"
+    value: "1200"
   - name: BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH
     value: "0"
   - name: BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH
@@ -266,6 +266,8 @@ env:
     value: "price_1RtJPm1F8wnoWYvwhVJ38kLb"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RtJQ71F8wnoWYvwKMPaGlGY"
+  - name: SUBSCRIPTION_LAUNCH_DATE
+    value: "2025-08-21"
 
 resources:
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -526,9 +526,6 @@ def delete_cached_mcp_api_key(hashed_key: str):
     r.delete(f'mcp_api_key:{hashed_key}')
 
 
-    
-
-
 # ******************************************************
 # **************** DATA MIGRATION STATUS ***************
 # ******************************************************
@@ -577,3 +574,13 @@ def set_credit_limit_notification_sent(uid: str, ttl: int = 60 * 60 * 24):
 def has_credit_limit_notification_been_sent(uid: str) -> bool:
     """Check if credit limit notification was already sent to user recently"""
     return r.exists(f'users:{uid}:credit_limit_notification_sent')
+
+
+def set_silent_user_notification_sent(uid: str, ttl: int = 60 * 60 * 24):
+    """Cache that silent user notification was sent to user (24 hours TTL by default)"""
+    r.set(f'users:{uid}:silent_notification_sent', '1', ex=ttl)
+
+
+def has_silent_user_notification_been_sent(uid: str) -> bool:
+    """Check if silent user notification was already sent to user recently"""
+    return r.exists(f'users:{uid}:silent_notification_sent')

--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -100,6 +100,21 @@ def get_monthly_usage_stats(uid: str, date: datetime) -> dict:
     return _aggregate_stats(query)
 
 
+def get_monthly_usage_stats_since(uid: str, date: datetime, start_date: datetime) -> dict:
+    """Aggregates hourly usage stats for a given month from Firestore, starting from a specific date."""
+    user_ref = db.collection('users').document(uid)
+    hourly_usage_collection = user_ref.collection('hourly_usage')
+
+    start_doc_id = f'{start_date.year}-{start_date.month:02d}-{start_date.day:02d}-00'
+
+    query = (
+        hourly_usage_collection.where(filter=FieldFilter('year', '==', date.year))
+        .where(filter=FieldFilter('month', '==', date.month))
+        .where(filter=FieldFilter('id', '>=', start_doc_id))
+    )
+    return _aggregate_stats(query)
+
+
 def get_yearly_usage_stats(uid: str, date: datetime) -> dict:
     """Aggregates hourly usage stats for a given year from Firestore."""
     user_ref = db.collection('users').document(uid)

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -142,7 +142,7 @@ async def _listen(
         nonlocal last_audio_received_time, last_transcript_time
 
         while websocket_active:
-            await asyncio.sleep(30)
+            await asyncio.sleep(60)
             if not websocket_active:
                 break
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -18,6 +18,7 @@ import database.conversations as conversations_db
 import database.users as user_db
 from database import redis_db
 from database.redis_db import get_cached_user_geolocation
+from models.users import PlanType
 from models.conversation import (
     Conversation,
     TranscriptSegment,
@@ -61,7 +62,7 @@ from utils.subscription import has_transcription_credits
 
 from utils.other import endpoints as auth
 from utils.other.storage import get_profile_audio_if_exists
-from utils.notifications import send_credit_limit_notification
+from utils.notifications import send_credit_limit_notification, send_silent_user_notification
 
 router = APIRouter()
 
@@ -134,14 +135,18 @@ async def _listen(
     first_audio_byte_timestamp: Optional[float] = None
     last_usage_record_timestamp: Optional[float] = None
     words_transcribed_since_last_record: int = 0
+    last_transcript_time: Optional[float] = None
 
     async def _record_usage_periodically():
         nonlocal websocket_active, last_usage_record_timestamp, words_transcribed_since_last_record
+        nonlocal last_audio_received_time, last_transcript_time
+
         while websocket_active:
             await asyncio.sleep(30)
             if not websocket_active:
                 break
 
+            # Record usages
             if last_usage_record_timestamp:
                 current_time = time.time()
                 transcription_seconds = int(current_time - last_usage_record_timestamp)
@@ -153,8 +158,8 @@ async def _listen(
                     record_usage(uid, transcription_seconds=transcription_seconds, words_transcribed=words_to_record)
                 last_usage_record_timestamp = current_time
 
+            # Send credit limit notification
             if not has_transcription_credits(uid):
-                # Send credit limit notification (with Redis caching to prevent spam)
                 try:
                     await send_credit_limit_notification(uid)
                 except Exception as e:
@@ -164,6 +169,21 @@ async def _listen(
                 websocket_close_code = 4002
                 websocket_active = False
                 break
+
+            # Silence notification logic for basic plan users
+            user_subscription = user_db.get_user_valid_subscription(uid)
+            if not user_subscription or user_subscription.plan == PlanType.basic:
+                time_of_last_words = last_transcript_time or first_audio_byte_timestamp
+                if (
+                    last_audio_received_time
+                    and time_of_last_words
+                    and (last_audio_received_time - time_of_last_words) > 15 * 60
+                ):
+                    print(f"User {uid} has been silent for over 15 minutes. Sending notification.")
+                    try:
+                        await send_silent_user_notification(uid)
+                    except Exception as e:
+                        print(f"Error sending silent user notification: {e}")
 
     async def _asend_message_event(msg: MessageEvent):
         nonlocal websocket_active
@@ -747,7 +767,7 @@ async def _listen(
 
     async def stream_transcript_process():
         nonlocal websocket_active, realtime_segment_buffers, realtime_photo_buffers, websocket, seconds_to_trim
-        nonlocal current_conversation_id, including_combined_segments, translation_enabled, speech_profile_processed, speaker_to_person_map, suggested_segments, words_transcribed_since_last_record
+        nonlocal current_conversation_id, including_combined_segments, translation_enabled, speech_profile_processed, speaker_to_person_map, suggested_segments, words_transcribed_since_last_record, last_transcript_time
 
         while websocket_active or len(realtime_segment_buffers) > 0 or len(realtime_photo_buffers) > 0:
             await asyncio.sleep(0.6)
@@ -766,6 +786,7 @@ async def _listen(
 
             transcript_segments = []
             if segments_to_process:
+                last_transcript_time = time.time()
                 if seconds_to_trim is None:
                     seconds_to_trim = segments_to_process[0]["start"]
 

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -35,7 +35,7 @@ from datetime import datetime
 
 from models.users import WebhookType, UserSubscriptionResponse, SubscriptionPlan, PlanType, PricingOption
 from utils.apps import get_available_app_by_id
-from utils.subscription import get_plan_limits, get_plan_features
+from utils.subscription import get_plan_limits, get_plan_features, get_monthly_usage_for_subscription
 from utils import stripe as stripe_utils
 from utils.llm.followup import followup_question_prompt
 from utils.other import endpoints as auth
@@ -489,7 +489,7 @@ def get_user_subscription_endpoint(uid: str = Depends(auth.get_current_user_uid)
     subscription.features = get_plan_features(subscription.plan)
 
     # Get current usage
-    usage = user_usage_db.get_monthly_usage_stats(uid, datetime.utcnow())
+    usage = get_monthly_usage_for_subscription(uid)
 
     # Calculate usage metrics
     transcription_seconds_used = usage.get('transcription_seconds', 0)

--- a/backend/utils/llm/notifications.py
+++ b/backend/utils/llm/notifications.py
@@ -96,7 +96,7 @@ async def generate_credit_limit_notification(uid: str, name: str) -> Tuple[str, 
     Key Points to Include:
     - They've been actively using transcription (show appreciation)
     - Unlimited plan removes all limits
-    - Can check usage/plans in app or search 'omi unlimited subs' in marketplace
+    - Can check usage/plans in the app under Settings > Plan & Usages
     - Make it feel like you're helping them, not selling to them
     """
 
@@ -109,7 +109,7 @@ async def generate_credit_limit_notification(uid: str, name: str) -> Tuple[str, 
 
     The message should:
     - Acknowledge their active usage positively
-    - Suggest checking plans in the app or searching 'omi unlimited subs' in marketplace
+    - Suggest checking plans in the app under Settings > Plan & Usages
     - Feel helpful, not sales-y
     - Be warm and personal to {name}
     
@@ -125,5 +125,5 @@ async def generate_credit_limit_notification(uid: str, name: str) -> Tuple[str, 
     # Fallback message
     return (
         "omi",
-        f"Hey {name}! You've been actively using transcription - that's awesome! You've hit your limit, but unlimited plans remove all restrictions. Check your usage in the app or search 'omi unlimited subs' in the marketplace!",
+        f"Hey {name}! You've been actively using transcription - that's awesome! You've hit your limit, but unlimited plans remove all restrictions. You can check your usage and upgrade in the app under Settings > Plan & Usages.",
     )

--- a/backend/utils/llm/notifications.py
+++ b/backend/utils/llm/notifications.py
@@ -1,3 +1,4 @@
+import random
 from typing import Tuple, List
 from .clients import llm_medium
 from database.memories import get_memories
@@ -127,3 +128,23 @@ async def generate_credit_limit_notification(uid: str, name: str) -> Tuple[str, 
         "omi",
         f"Hey {name}! You've been actively using transcription - that's awesome! You've hit your limit, but unlimited plans remove all restrictions. You can check your usage and upgrade in the app under Settings > Plan & Usages.",
     )
+
+
+def generate_silent_user_notification(name: str) -> Tuple[str, str]:
+    """
+    Generate a funny notification for a user who has been silent for a while.
+    """
+    messages = [
+        f"Hey {name}, just checking in! My ears are open if you've got something to say.",
+        f"Is this thing on? Tapping my mic here, {name}. Let me know when you're ready to chat!",
+        f"Quiet on the set! {name}, are we rolling? Just waiting for your cue.",
+        f"The sound of silence... is nice, but I'm here for the words, {name}! What's on your mind?",
+        f"{name}, you've gone quiet! Just a heads up, I'm still here listening and using up your free minutes.",
+        f"Psst, {name}... My virtual ears are getting a little lonely. Anything to share?",
+        f"Enjoying the quiet time, {name}? Just remember, I'm on the clock, ready to transcribe!",
+        f"Hello from the other side... of silence! {name}, ready to talk again?",
+        f"I'm all ears, {name}! Just letting you know the recording is still live.",
+        f"Silence is golden, but words are what I live for, {name}! Let's chat when you're ready.",
+    ]
+    body = random.choice(messages)
+    return "omi", body

--- a/backend/utils/notifications.py
+++ b/backend/utils/notifications.py
@@ -2,8 +2,17 @@ import asyncio
 import math
 from firebase_admin import messaging, auth
 import database.notifications as notification_db
-from database.redis_db import set_credit_limit_notification_sent, has_credit_limit_notification_been_sent
-from .llm.notifications import generate_notification_message, generate_credit_limit_notification
+from database.redis_db import (
+    set_credit_limit_notification_sent,
+    has_credit_limit_notification_been_sent,
+    set_silent_user_notification_sent,
+    has_silent_user_notification_been_sent,
+)
+from .llm.notifications import (
+    generate_notification_message,
+    generate_credit_limit_notification,
+    generate_silent_user_notification,
+)
 
 
 def send_notification(token: str, title: str, body: str, data: dict = None):
@@ -84,6 +93,42 @@ async def send_credit_limit_notification(user_id: str):
     # Cache that notification was sent (6 hours TTL)
     set_credit_limit_notification_sent(user_id)
     print(f"Credit limit notification sent to user {user_id}")
+
+
+async def send_silent_user_notification(user_id: str):
+    """Send a notification if a basic-plan user is silent for too long."""
+    # Check if notification was sent recently (within 24 hours)
+    if has_silent_user_notification_been_sent(user_id):
+        print(f"Silent user notification already sent recently for user {user_id}")
+        return
+
+    # Get user's notification token
+    token = notification_db.get_token_only(user_id)
+    if not token:
+        print(f"No notification token found for user {user_id}")
+        return
+
+    # Get user name from Firebase Auth
+    try:
+        user = auth.get_user(user_id)
+        name = user.display_name
+        if not name and user.email:
+            name = user.email.split('@')[0].capitalize()
+        if not name:
+            name = "there"
+    except Exception as e:
+        print(f"Error getting user info from Firebase Auth: {e}")
+        name = "there"
+
+    # Generate personalized credit limit message
+    title, body = generate_silent_user_notification(name)
+
+    # Send notification
+    send_notification(token, title, body)
+
+    # Cache that notification was sent (24 hours TTL)
+    set_silent_user_notification_sent(user_id)
+    print(f"Silent user notification sent to user {user_id}")
 
 
 async def send_bulk_notification(user_tokens: list, title: str, body: str):


### PR DESCRIPTION
what's included?  
- credit usage counts from the launch date; usage analytics are not affected  
- propose the launch date and the basic plan limits  
- make the notification on hitting credit limits clearer with next actions  

deploy:
- [x] create firestore index  https://console.firebase.google.com/v1/r/project/based-hardware/firestore/indexes?create_composite=Cldwcm9qZWN0cy9iYXNlZC1oYXJkd2FyZS1kZXYvZGF0YWJhc2VzLyhkZWZhdWx0KS9jb2xsZWN0aW9uR3JvdXBzL2hvdXJseV91c2FnZS9pbmRleGVzL18QARoJCgVtb250aBABGggKBHllYXIQARoGCgJpZBABGgwKCF9fbmFtZV9fEAE
- [ ] add the new env var `SUBSCRIPTION_LAUNCH_DATE`
- [ ] deploy backend(s)