### PR TITLE
fix: improve logging for document deletion in delete_user_data function

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -104,7 +104,8 @@ def delete_user_data(uid: str):
             docs = list(docs_query.stream())
 
             if not docs:
-                print(f"No more documents to delete in {collection_ref.path}")
+                collection_path = f"{collection_ref.parent.path}/{collection_ref.id}"
+                print(f"No more documents to delete in {collection_path}")
                 break
 
             batch = db.batch()

--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -102,6 +102,7 @@ def delete_user_data(uid: str):
         while True:
             docs_query = collection_ref.limit(batch_size)
             docs = list(docs_query.stream())
+            collection_path = f"{collection_ref.parent.path}/{collection_ref.id}"
 
             if not docs:
                 collection_path = f"{collection_ref.parent.path}/{collection_ref.id}"
@@ -115,7 +116,7 @@ def delete_user_data(uid: str):
             batch.commit()
 
             if len(docs) < batch_size:
-                print(f"Processed all documents in {collection_ref.path}")
+                print(f"Processed all documents in {collection_path}")
                 break
 
     # delete the user document itself


### PR DESCRIPTION
## Description
This PR fixes a logging issue in the delete_user_data function when handling document deletion.

Previously, the code attempted to log the collection path with `collection_ref.path`, but `CollectionReference` objects do not have a `path` attribute by default, leading to the error:
`AttributeError: 'CollectionReference' object has no attribute 'path'`

## Changes
- Replaced usage of `collection_ref.path` with a constructed path:
`collection_path = f"{collection_ref.parent.path}/{collection_ref.id}"
`
- Updated log message to use `collection_path` when no more documents remain in the collection.

## Result
Logging now works correctly without raising errors, ensuring better traceability during user data deletion.
