### PR TITLE
Fix get person ids on the external conversation creation

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -94,7 +94,9 @@ class ActionItem(BaseModel):
     updated_at: Optional[datetime] = Field(default=None, description="When the action item was last updated")
     due_at: Optional[datetime] = Field(default=None, description="When the action item is due")
     completed_at: Optional[datetime] = Field(default=None, description="When the action item was completed")
-    conversation_id: Optional[str] = Field(default=None, description="ID of the conversation this action item came from")
+    conversation_id: Optional[str] = Field(
+        default=None, description="ID of the conversation this action item came from"
+    )
 
     @staticmethod
     def actions_to_string(action_items: List['ActionItem']) -> str:
@@ -391,6 +393,9 @@ class ExternalIntegrationCreateConversation(BaseModel):
 
     def get_transcript(self, include_timestamps: bool) -> str:
         return self.text
+
+    def get_person_ids(self) -> List[str]:
+        return []
 
 
 class CreateConversationResponse(BaseModel):

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -298,10 +298,10 @@ def _save_action_items(uid: str, conversation: Conversation):
     """
     if not conversation.structured or not conversation.structured.action_items:
         return
-    
+
     action_items_data = []
     now = datetime.now(timezone.utc)
-    
+
     for action_item in conversation.structured.action_items:
         action_item_data = {
             'description': action_item.description,
@@ -310,10 +310,10 @@ def _save_action_items(uid: str, conversation: Conversation):
             'updated_at': action_item.updated_at or now,
             'due_at': action_item.due_at,
             'completed_at': action_item.completed_at,
-            'conversation_id': conversation.id
+            'conversation_id': conversation.id,
         }
         action_items_data.append(action_item_data)
-    
+
     if action_items_data:
         # Delete existing action items for this conversation first (in case of reprocessing)
         action_items_db.delete_action_items_for_conversation(uid, conversation.id)
@@ -378,7 +378,7 @@ def process_conversation(
     is_reprocess: bool = False,
     app_id: Optional[str] = None,
 ) -> Conversation:
-    person_ids = [segment.person_id for segment in conversation.transcript_segments if segment.person_id]
+    person_ids = conversation.get_person_ids()
     people = []
     if person_ids:
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -397,7 +397,7 @@ def qa_rag_stream(
 
 
 def retrieve_memory_context_params(uid: str, memory: Conversation) -> List[str]:
-    person_ids = [s.person_id for s in memory.transcript_segments if s.person_id]
+    person_ids = memory.get_person_ids()
     people = []
     if person_ids:
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))
@@ -431,7 +431,7 @@ def retrieve_memory_context_params(uid: str, memory: Conversation) -> List[str]:
 def obtain_emotional_message(uid: str, memory: Conversation, context: str, emotion: str) -> str:
     user_name, memories_str = get_prompt_memories(uid)
 
-    person_ids = [s.person_id for s in memory.transcript_segments if s.person_id]
+    person_ids = memory.get_person_ids()
     people = []
     if person_ids:
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))
@@ -838,7 +838,7 @@ def select_structured_filters(question: str, filters_available: dict) -> dict:
 def extract_question_from_transcript(uid: str, segments: List[TranscriptSegment]) -> str:
     user_name, memories_str = get_prompt_memories(uid)
 
-    person_ids = [s.person_id for s in segments if s.person_id]
+    person_ids = list(set(segment.person_id for segment in segments if segment.person_id))
     people = []
     if person_ids:
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -46,12 +46,12 @@ def get_message_structure(
         if event.duration > 180:
             event.duration = 180
         event.created = False
-    
+
     # Set created_at for action items if not already set
     for action_item in response.action_items or []:
         if action_item.created_at is None:
             action_item.created_at = datetime.now(timezone.utc)
-    
+
     return response
 
 
@@ -68,14 +68,14 @@ def summarize_experience_text(text: str, text_source_spec: str = None) -> Struct
       '''.replace(
         '    ', ''
     ).strip()
-    
+
     response = llm_mini.with_structured_output(Structured).invoke(prompt)
-    
+
     # Set created_at for action items if not already set
     for action_item in response.action_items or []:
         if action_item.created_at is None:
             action_item.created_at = datetime.now(timezone.utc)
-    
+
     return response
 
 
@@ -84,7 +84,7 @@ def get_conversation_summary(uid: str, memories: List[Conversation]) -> str:
 
     all_person_ids = []
     for m in memories:
-        all_person_ids.extend([s.person_id for s in m.transcript_segments if s.person_id])
+        all_person_ids.extend(m.get_person_ids())
 
     people = []
     if all_person_ids:

--- a/backend/utils/llm/trends.py
+++ b/backend/utils/llm/trends.py
@@ -27,7 +27,7 @@ class ExpectedOutput(BaseModel):
 
 
 def trends_extractor(uid: str, memory: Conversation) -> List[Item]:
-    person_ids = [s.person_id for s in memory.transcript_segments if s.person_id]
+    person_ids = memory.get_person_ids()
     people = []
     if person_ids:
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))

--- a/backend/utils/retrieval/rag.py
+++ b/backend/utils/retrieval/rag.py
@@ -83,7 +83,7 @@ def retrieve_rag_conversation_context(uid: str, memory: Conversation) -> Tuple[s
 
     all_person_ids = []
     for m in memories:
-        all_person_ids.extend([s.person_id for s in m.transcript_segments if s.person_id])
+        all_person_ids.extend(m.get_person_ids())
 
     people = []
     if all_person_ids:


### PR DESCRIPTION
what's included ?
- fix the error on importing convos from integration

deploy:
- [ ] deploy backend integration

error:

```
2025-08-28 07:49:16.401	
AttributeError: 'ExternalIntegrationCreateConversation' object has no attribute 'transcript_segments'
	
	
2025-08-28 07:49:15.273	
    raise AttributeError(f'{type(self).__name__!r} object has no attribute {item!r}')
	
	
2025-08-28 07:49:15.273	
  File "/opt/venv/lib/python3.11/site-packages/pydantic/main.py", line 828, in __getattr__
	
	
2025-08-28 07:49:15.273	
                                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	
	
2025-08-28 07:49:15.273	
    person_ids = [segment.person_id for segment in conversation.transcript_segments if segment.person_id]
	
	
2025-08-28 07:49:15.273	
  File "/app/utils/conversations/process_conversation.py", line 381, in process_conversation
	
	
2025-08-28 07:49:15.273	
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	
	
2025-08-28 07:49:15.273	
    conversation = process_conversation(uid, language_code, create_conversation)
	
	
2025-08-28 07:49:15.273	
  File "/app/routers/integration.py", line 131, in create_conversation_via_integration
	
	
2025-08-28 07:49:15.273	
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	
	
2025-08-28 07:49:15.273	
    return await dependant.call(**values)
	
	
2025-08-28 07:49:15.273	
  File "/opt/venv/lib/python3.11/site-packages/fastapi/routing.py", line 191, in run_endpoint_function
	
	
2025-08-28 07:49:15.273	
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
	
	
2025-08-28 07:49:15.273	
    raw_response = await run_endpoint_function(
    ```