### PR TITLE
Update Flashing Instructions on Omi Docs (https://docs.omi.me/) and fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Start speaking, you'll see Real-time transcript on [webhook.site ](https://webho
 - [omi App setup](https://docs.omi.me/docs/developer/AppSetup)
 - [Buying Guide](https://docs.omi.me/docs/assembly/Buying_Guide/)
 - [Build the device](https://docs.omi.me/docs/assembly/Build_the_device/)
-- [Install firmware](https://docs.omi.me/docs/get_started/Flash_device/)
+- [Install firmware](https://docs.omi.me/doc/get_started/Flash_device/)
 - [Create your own app in 1 minute](https://docs.omi.me/docs/developer/apps/Introduction).
 
 ## Contributions

--- a/docs/doc/get_started/Flash_device.mdx
+++ b/docs/doc/get_started/Flash_device.mdx
@@ -26,6 +26,10 @@ description: "To update the firmware of your OMI device, you can either:"
   </video>
 </div>
 
+---
+
+# Flashing Instructions for DevKit Versions (DK1 & DK2)
+
 ## Manual Update Process[​](#manual-update-process "Direct link to Manual Update Process")
 
 ### 1. Download Required Files[​](#1-download-required-files "Direct link to 1. Download Required Files")
@@ -84,6 +88,114 @@ Before starting:
 * For additional help: See [DevKit2 Firmware Guide](https://help.omi.me/en/articles/9995941-updating-your-devkit2-firmware)
 
 ***
+
+# Flashing Instructions for Consumer Version 1 (CV1)
+
+## Flashing Omi Firmware v3.0.8
+
+This guide provides step-by-step instructions for flashing the Omi firmware using J-Link on both macOS and Windows systems.
+
+### Prerequisites
+
+- Omi CV1 device connected via USB  
+- J-Link software installed (see installation instructions below)  
+- Appropriate USB drivers for your device  
+- Latest firmware files downloaded from GitHub releases  
+
+### Special Hardware Requirement
+
+To flash the Omi CV1, you must use a **special flashing cable** that connects the device to the J-Link programmer.  
+This cable provides the required SWD/JTAG interface and must be acquired before attempting to flash.  
+Without this cable, the CV1 cannot be programmed. Ensure that:
+
+- The cable is properly connected to both the Omi CV1 and the J-Link programmer (pinout must match SWDIO, SWCLK, GND, VCC).  
+- The cable is secure and undamaged before starting the flashing process.  
+
+⚠️ If you do not have this cable, you will need to source one before proceeding with the CV1 flashing steps.
+
+### Important: Update Firmware Files Before Flashing
+
+⚠️ **Critical Step**: Before flashing, you must replace the existing firmware files with the latest versions from GitHub releases.
+
+#### Step 1: Download Latest Firmware
+
+1. Go to the [Omi GitHub Releases page](https://github.com/BasedHardware/omi/releases)  
+2. Find the latest release version  
+3. Download the following files:  
+   - `merged.hex` — Application core firmware  
+   - `merged_CPUNET.hex` — Network core firmware  
+
+#### Step 2: Replace Existing Firmware Files
+
+**For macOS:**
+1. Navigate to the `MAC/` folder in your FLASH_3.0.8 directory  
+2. (Optional) Backup existing files:
+   ```bash
+   mv merged.hex merged.hex.backup
+   mv merged_CPUNET.hex merged_CPUNET.hex.backup
+   ```
+3. Copy the downloaded `merged.hex` and `merged_CPUNET.hex` into the `MAC/` folder  
+
+**For Windows:**
+1. Navigate to the `WINDOWS\` folder in your FLASH_3.0.8 directory  
+2. (Optional) Backup existing files:
+   - Rename `merged.hex` → `merged.hex.backup`  
+   - Rename `merged_CPUNET.hex` → `merged_CPUNET.hex.backup`  
+3. Copy the downloaded `merged.hex` and `merged_CPUNET.hex` into the `WINDOWS\` folder  
+
+#### Step 3: Verify File Replacement
+
+- Ensure both `merged.hex` and `merged_CPUNET.hex` are updated  
+- File sizes should match the downloaded versions  
+- Modification dates should reflect the replacement  
+
+### macOS Instructions
+
+1. Install J-Link Software from [SEGGER](https://www.segger.com/downloads/jlink/)  
+2. Navigate to the `MAC` folder:
+   ```bash
+   cd MAC
+   ```
+3. Flash the firmware:
+   ```bash
+   # Flash network core first
+   JLinkExe -CommanderScript program_net.jlink
+   
+   # Then flash application core
+   JLinkExe -CommanderScript program_app.jlink
+   ```
+
+### Windows Instructions
+
+1. Install J-Link Software from [SEGGER](https://www.segger.com/downloads/jlink/)  
+   - Add J-Link installation path to your Windows PATH (default: `C:\Program Files\SEGGER\JLink\`)  
+2. Navigate to the `WINDOWS` folder:
+   ```cmd
+   cd WINDOWS
+   ```
+3. Flash the firmware:
+   ```cmd
+   # Flash network core first
+   JLink.exe -CommanderScript program_net.jlink
+   
+   # Then flash application core
+   JLink.exe -CommanderScript program_app.jlink
+   ```
+
+### Verification
+
+- If LEDs start blinking → flashing was successful 🎉  
+- Device should now run the latest firmware  
+- Confirm firmware version in the Omi app or device interface  
+
+### Troubleshooting
+
+1. **JLinkExe not found** → Recheck installation and PATH  
+2. **Connection issues** → Try another USB port/cable, ensure programming mode  
+3. **Flashing fails** → Flash network core first, wait for commands to complete  
+4. **Firmware file errors** → Ensure files are latest, re-download if corrupted  
+
+---
 
 ## Congratulations\![​](#congratulations "Direct link to Congratulations!")
 

--- a/omi/firmware/readme.md
+++ b/omi/firmware/readme.md
@@ -43,7 +43,7 @@ For detailed instructions, see [docker-build.md](./scripts/docker-build.md).
 
 ## Flashing the Firmware
 
-Follow the instructions at https://docs.omi.me/docs/get_started/Flash_device
+Follow the instructions at https://docs.omi.me/doc/get_started/Flash_device
 
 For Docker builds, the output files will be in `build/docker_build/`.
 For nRF Connect builds, locate the `zephyr.uf2` file in your build output directory.

--- a/omi/firmware/scripts/docker-build.md
+++ b/omi/firmware/scripts/docker-build.md
@@ -142,4 +142,4 @@ copy firmware\firmware\build\docker_build\zephyr.uf2 D:\
 ```
 (where D: is the drive letter of the XIAO-SENSE board)
 
-For more detailed flashing instructions, see our [official documentation](https://docs.omi.me/docs/get_started/Flash_device).
+For more detailed flashing instructions, see our [official documentation](https://docs.omi.me/doc/get_started/Flash_device).


### PR DESCRIPTION
CV1 flash instructions mostly copied over from `https://github.com/BasedHardware/omi/edit/main/omi/firmware/FLASH_3.0.8/README.md` with an added section about needing the special cable