### PR TITLE
feat: migrate from GPT-4o to Gemini 2.5 Pro/Flash

### DIFF
--- a/app/lib/env/dev_env.dart
+++ b/app/lib/env/dev_env.dart
@@ -13,6 +13,10 @@ final class DevEnv implements EnvFields {
   final String? openAIAPIKey = _DevEnv.openAIAPIKey;
 
   @override
+  @EnviedField(varName: 'OPENROUTER_API_KEY', obfuscate: true)
+  final String? openRouterAPIKey = _DevEnv.openRouterAPIKey;
+
+  @override
   @EnviedField(varName: 'MIXPANEL_PROJECT_TOKEN', obfuscate: true)
   final String? mixpanelProjectToken = _DevEnv.mixpanelProjectToken;
 

--- a/app/lib/env/env.dart
+++ b/app/lib/env/env.dart
@@ -9,6 +9,8 @@ abstract class Env {
 
   static String? get openAIAPIKey => _instance.openAIAPIKey;
 
+  static String? get openRouterAPIKey => _instance.openRouterAPIKey;
+
   static String? get mixpanelProjectToken => _instance.mixpanelProjectToken;
 
   static String? get apiBaseUrl => _instance.apiBaseUrl;
@@ -30,6 +32,8 @@ abstract class Env {
 
 abstract class EnvFields {
   String? get openAIAPIKey;
+
+  String? get openRouterAPIKey;
 
   String? get mixpanelProjectToken;
 

--- a/app/lib/env/prod_env.dart
+++ b/app/lib/env/prod_env.dart
@@ -13,6 +13,10 @@ final class ProdEnv implements EnvFields {
   final String? openAIAPIKey = _ProdEnv.openAIAPIKey;
 
   @override
+  @EnviedField(varName: 'OPENROUTER_API_KEY', obfuscate: true)
+  final String? openRouterAPIKey = _ProdEnv.openRouterAPIKey;
+
+  @override
   @EnviedField(varName: 'MIXPANEL_PROJECT_TOKEN', obfuscate: true)
   final String? mixpanelProjectToken = _ProdEnv.mixpanelProjectToken;
 

--- a/backend/scripts/nps.py
+++ b/backend/scripts/nps.py
@@ -4,7 +4,12 @@ from collections import defaultdict
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
-llm_mini = ChatOpenAI(model="gpt-4o-mini")
+# Import from clients.py for consistent model usage
+from utils.llm.clients import llm_mini
+
+# ===== ORIGINAL LOCAL MODEL DEFINITION (COMMENTED OUT FOR ROLLBACK) =====
+# llm_mini = ChatOpenAI(model="gpt-4o-mini")
+
 embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
 
 from database.users import get_all_ratings

--- a/backend/scripts/users/retrieval.py
+++ b/backend/scripts/users/retrieval.py
@@ -6,7 +6,12 @@ from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
 from models.conversation import Conversation
 
-llm_mini = ChatOpenAI(model='gpt-4o-mini')
+# Import from clients.py for consistent model usage
+from utils.llm.clients import llm_mini
+
+# ===== ORIGINAL LOCAL MODEL DEFINITION (COMMENTED OUT FOR ROLLBACK) =====
+# llm_mini = ChatOpenAI(model='gpt-4o-mini')
+
 embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
 
 load_dotenv('../../.env')

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -8,15 +8,57 @@ import tiktoken
 from models.conversation import Structured
 
 
-llm_mini = ChatOpenAI(model='gpt-4o-mini')
-llm_mini_stream = ChatOpenAI(model='gpt-4o-mini', streaming=True)
+# ===== GEMINI 2.5 MODELS (PRIMARY CHAT) =====
+# Light tasks - replaces gpt-4o-mini
+llm_mini = ChatOpenAI(
+    temperature=0.2,
+    model="google/gemini-2.5-flash",
+    api_key=os.environ.get('OPENROUTER_API_KEY'),
+    base_url="https://openrouter.ai/api/v1",
+    default_headers={"X-Title": "Omi Chat"},
+    streaming=False,
+)
+
+llm_mini_stream = ChatOpenAI(
+    temperature=0.2,
+    model="google/gemini-2.5-flash",
+    api_key=os.environ.get('OPENROUTER_API_KEY'),
+    base_url="https://openrouter.ai/api/v1",
+    default_headers={"X-Title": "Omi Chat"},
+    streaming=True,
+)
+
+# Heavy tasks - replaces gpt-4o
+llm_medium = ChatOpenAI(
+    temperature=0.3,
+    model="google/gemini-2.5-pro",
+    api_key=os.environ.get('OPENROUTER_API_KEY'),
+    base_url="https://openrouter.ai/api/v1",
+    default_headers={"X-Title": "Omi Chat"},
+    streaming=False,
+)
+
+llm_medium_stream = ChatOpenAI(
+    temperature=0.3,
+    model="google/gemini-2.5-pro",
+    api_key=os.environ.get('OPENROUTER_API_KEY'),
+    base_url="https://openrouter.ai/api/v1",
+    default_headers={"X-Title": "Omi Chat"},
+    streaming=True,
+)
+
+# ===== ORIGINAL GPT MODELS (COMMENTED OUT FOR ROLLBACK) =====
+# llm_mini = ChatOpenAI(model='gpt-4o-mini')
+# llm_mini_stream = ChatOpenAI(model='gpt-4o-mini', streaming=True)
+# llm_medium = ChatOpenAI(model='gpt-4o')
+# llm_medium_stream = ChatOpenAI(model='gpt-4o', streaming=True)
+
+# ===== LEGACY MODELS (KEPT FOR SPECIFIC USE CASES) =====
 llm_large = ChatOpenAI(model='o1-preview')
 llm_large_stream = ChatOpenAI(model='o1-preview', streaming=True, temperature=1)
 llm_high = ChatOpenAI(model='o4-mini')
 llm_high_stream = ChatOpenAI(model='o4-mini', streaming=True, temperature=1)
-llm_medium = ChatOpenAI(model='gpt-4o')
 llm_medium_experiment = ChatOpenAI(model='gpt-4.1')
-llm_medium_stream = ChatOpenAI(model='gpt-4o', streaming=True)
 llm_persona_mini_stream = ChatOpenAI(
     temperature=0.8,
     model="google/gemini-flash-1.5-8b",

--- a/backend/utils/retrieval/graph.py
+++ b/backend/utils/retrieval/graph.py
@@ -40,9 +40,12 @@ from utils.llm.persona import answer_persona_question_stream
 from utils.other.chat_file import FileChatTool
 from utils.other.endpoints import timeit
 from utils.app_integrations import get_github_docs_content
+from utils.llm.clients import llm_mini as model, llm_medium_stream
 
-model = ChatOpenAI(model="gpt-4o-mini")
-llm_medium_stream = ChatOpenAI(model='gpt-4o', streaming=True)
+# ===== ORIGINAL LOCAL MODEL DEFINITIONS (COMMENTED OUT FOR ROLLBACK) =====
+# To rollback to GPT models, comment out the import above and uncomment these:
+# model = ChatOpenAI(model="gpt-4o-mini")
+# llm_medium_stream = ChatOpenAI(model='gpt-4o', streaming=True)
 
 
 class StructuredFilters(TypedDict):


### PR DESCRIPTION
## **Migrate from GPT-4o to Gemini 2.5 Pro/Flash (Just for Chat)**

### **Overview**
Complete migration from OpenAI GPT models to Google's Gemini 2.5 models via OpenRouter API for improved performance, cost efficiency, and enhanced reasoning capabilities across all chat functionality.