### PR TITLE
Fix auth on macos safari

### DIFF
--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -148,8 +148,6 @@ PODS:
   - flutter_sound_core (9.28.0)
   - flutter_timezone (0.0.1):
     - Flutter
-  - flutter_web_auth_2 (5.0.0-alpha.2):
-    - Flutter
   - frame_sdk (0.0.2):
     - Flutter
   - geolocator_apple (1.2.0):
@@ -291,7 +289,6 @@ DEPENDENCIES:
   - flutter_native_splash (from `.symlinks/plugins/flutter_native_splash/ios`)
   - flutter_sound (from `.symlinks/plugins/flutter_sound/ios`)
   - flutter_timezone (from `.symlinks/plugins/flutter_timezone/ios`)
-  - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
   - frame_sdk (from `.symlinks/plugins/frame_sdk/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/darwin`)
   - google_sign_in_ios (from `.symlinks/plugins/google_sign_in_ios/darwin`)
@@ -393,8 +390,6 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_sound/ios"
   flutter_timezone:
     :path: ".symlinks/plugins/flutter_timezone/ios"
-  flutter_web_auth_2:
-    :path: ".symlinks/plugins/flutter_web_auth_2/ios"
   frame_sdk:
     :path: ".symlinks/plugins/frame_sdk/ios"
   geolocator_apple:
@@ -478,7 +473,6 @@ SPEC CHECKSUMS:
   flutter_sound: b9236a5875299aaa4cef1690afd2f01d52a3f890
   flutter_sound_core: 427465f72d07ab8c3edbe8ffdde709ddacd3763c
   flutter_timezone: ee50ce7786b5fde27e2fe5375bbc8c9661ffc13f
-  flutter_web_auth_2: c35a99b4799ad94b0dc140880f406cf59a4af866
   frame_sdk: 4d4df786d828557bf57e05f6f1856613896cc9db
   geolocator_apple: ab36aa0e8b7d7a2d7639b3b4e48308394e8cef5e
   google_sign_in_ios: 39f46834c156be9a4dfef914258e0145b7117725

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -1,5 +1,6 @@
 import Cocoa
 import FlutterMacOS
+import app_links
 
 @main
 class AppDelegate: FlutterAppDelegate {
@@ -14,4 +15,25 @@ class AppDelegate: FlutterAppDelegate {
             }
         }
     }
+
+    override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+      return true
+    }
+  
+    override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
+      return true
+    }
+
+    public override func application(_ application: NSApplication,
+                                 continue userActivity: NSUserActivity,
+                                 restorationHandler: @escaping ([any NSUserActivityRestoring]) -> Void) -> Bool {
+
+    guard let url = AppLinks.shared.getUniversalLink(userActivity) else {
+      return false
+    }
+  
+    AppLinks.shared.handleLink(link: url.absoluteString)
+  
+    return false // Returning true will stop the propagation to other packages
+  }
 }

--- a/app/macos/Runner/Info.plist
+++ b/app/macos/Runner/Info.plist
@@ -34,6 +34,16 @@
 			<key>CFBundleTypeRole</key>
 			<string>Editor</string>
 			<key>CFBundleURLName</key>
+			<string>omi.auth</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>omi</string>
+			</array>
+		</dict>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
 			<string>h.omi.me</string>
 			<key>CFBundleURLSchemes</key>
 			<array>

--- a/app/pubspec.lock
+++ b/app/pubspec.lock
@@ -361,14 +361,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
-  desktop_webview_window:
-    dependency: transitive
-    description:
-      name: desktop_webview_window
-      sha256: "57cf20d81689d5cbb1adfd0017e96b669398a669d927906073b0e42fc64111c0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.2.3"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -821,22 +813,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
-  flutter_web_auth_2:
-    dependency: "direct main"
-    description:
-      name: flutter_web_auth_2
-      sha256: "2483d1fd3c45fe1262446e8d5f5490f01b864f2e7868ffe05b4727e263cc0182"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.0-alpha.3"
-  flutter_web_auth_2_platform_interface:
-    dependency: transitive
-    description:
-      name: flutter_web_auth_2_platform_interface
-      sha256: e25eb45c50b3eef5a80d0ae73c7ecf82e291c152387da8d2008bfd607ba43087
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.0.0-alpha.4"
   flutter_web_plugins:
     dependency: transitive
     description: flutter
@@ -2420,14 +2396,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.7"
-  window_to_front:
-    dependency: transitive
-    description:
-      name: window_to_front
-      sha256: "7aef379752b7190c10479e12b5fd7c0b9d92adc96817d9e96c59937929512aee"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -45,7 +45,6 @@ dependencies:
   firebase_crashlytics: 4.3.2
 
   # Auth
-  flutter_web_auth_2: 5.0.0-alpha.3
   google_sign_in: 6.2.2
   sign_in_with_apple: ^6.1.1
 


### PR DESCRIPTION
The `flutter_web_auth_2` dep had an issue with safari on macos, so replaced it with `url_launcher` and `app_links` combination. url_launcher will launch the auth url in default browser, at the end of the auth flow the user will be redirected to `omi://` scheme which is automatically picked by the app and is opened