### PR TITLE
Add agentic chat system with MCP tooling

### DIFF
--- a/backend/mcp_server_omi.py
+++ b/backend/mcp_server_omi.py
@@ -1,0 +1,732 @@
+#!/usr/bin/env python3
+"""
+Omi MCP Server - Model Context Protocol server for Omi AI Assistant
+
+Provides tools for the agentic chat system to:
+- Search and manage conversations
+- Create and manage memories
+- Create and track action items
+- Extract insights and context
+"""
+
+import asyncio
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+# Add backend to path for imports
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from mcp.server import Server
+from mcp.server.stdio import stdio_server
+from mcp.types import Tool, TextContent
+
+# Import Omi backend modules
+import database.conversations as conversations_db
+import database.memories as memories_db
+import database.action_items as action_items_db
+import database.users as users_db
+from database.vector_db import query_vectors_by_metadata
+from models.action_item import ActionItem, ActionItemStatus
+from models.memories import MemoryDB, MemoryCategory
+from models.conversation import CategoryEnum
+from utils.llm.embeddings import generate_embedding
+from utils.llm.memories import identify_category_for_memory
+from utils.apps import update_personas_async
+import threading
+import uuid as uuid_lib
+
+# Initialize MCP server
+server = Server("omi-server")
+
+# Global UID - will be set from environment variable
+CURRENT_UID: Optional[str] = None
+
+
+def get_uid() -> str:
+    """Get the current user ID from environment or context"""
+    global CURRENT_UID
+    if CURRENT_UID:
+        return CURRENT_UID
+    uid = os.environ.get("UID")
+    if not uid:
+        raise ValueError("UID not set in environment")
+    CURRENT_UID = uid
+    return uid
+
+
+@server.list_tools()
+async def list_tools() -> list[Tool]:
+    """List all available tools for the Omi agent"""
+    return [
+        Tool(
+            name="search_conversations",
+            description="Search through the user's past conversations using semantic search. Use this when the user asks about previous discussions, topics, or wants to recall information from past conversations.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "The search query (natural language question or keywords)"
+                    },
+                    "start_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Start date filter (ISO 8601 format, optional)"
+                    },
+                    "end_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "End date filter (ISO 8601 format, optional)"
+                    },
+                    "categories": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "personal", "education", "health", "finance", "legal",
+                                "philosophy", "spiritual", "science", "technology", "business",
+                                "social", "travel", "food", "entertainment", "sports", "other"
+                            ]
+                        },
+                        "description": "Filter by conversation categories"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 10,
+                        "description": "Maximum number of results to return (1-50)"
+                    }
+                },
+                "required": ["query"]
+            }
+        ),
+        Tool(
+            name="get_conversation",
+            description="Get the full details of a specific conversation by ID, including transcript and structured data.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "conversation_id": {
+                        "type": "string",
+                        "description": "The unique ID of the conversation"
+                    }
+                },
+                "required": ["conversation_id"]
+            }
+        ),
+        Tool(
+            name="search_memories",
+            description="Search through the user's memory bank (facts, preferences, important information). Use this to recall what you know about the user.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Search query (optional - leave empty to list all)"
+                    },
+                    "categories": {
+                        "type": "array",
+                        "items": {
+                            "type": "string",
+                            "enum": [
+                                "core", "lifestyle", "interests_hobbies", "health_wellness",
+                                "work_productivity", "relationships", "values_beliefs", "other"
+                            ]
+                        },
+                        "description": "Filter by memory categories"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 25,
+                        "description": "Maximum number of results (1-100)"
+                    }
+                },
+                "required": []
+            }
+        ),
+        Tool(
+            name="create_memory",
+            description="Create a new memory/fact about the user. Use this proactively when the user shares important personal information, preferences, goals, or anything worth remembering.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "content": {
+                        "type": "string",
+                        "description": "The memory content (clear, concise fact)"
+                    },
+                    "category": {
+                        "type": "string",
+                        "enum": [
+                            "core", "lifestyle", "interests_hobbies", "health_wellness",
+                            "work_productivity", "relationships", "values_beliefs", "other"
+                        ],
+                        "description": "Memory category (optional - will be auto-detected if not provided)"
+                    }
+                },
+                "required": ["content"]
+            }
+        ),
+        Tool(
+            name="update_memory",
+            description="Update an existing memory with new content.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "memory_id": {
+                        "type": "string",
+                        "description": "The ID of the memory to update"
+                    },
+                    "content": {
+                        "type": "string",
+                        "description": "The new memory content"
+                    }
+                },
+                "required": ["memory_id", "content"]
+            }
+        ),
+        Tool(
+            name="delete_memory",
+            description="Delete a memory. Only use this if the user explicitly asks to forget something.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "memory_id": {
+                        "type": "string",
+                        "description": "The ID of the memory to delete"
+                    }
+                },
+                "required": ["memory_id"]
+            }
+        ),
+        Tool(
+            name="create_action_item",
+            description="Create an action item/task for the user. Use this proactively when the user mentions something they need to do, a reminder they want, or any task.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "description": {
+                        "type": "string",
+                        "description": "Clear description of the action item"
+                    },
+                    "due_date": {
+                        "type": "string",
+                        "format": "date-time",
+                        "description": "Optional due date (ISO 8601 format)"
+                    },
+                    "conversation_id": {
+                        "type": "string",
+                        "description": "Optional conversation ID this action item relates to"
+                    }
+                },
+                "required": ["description"]
+            }
+        ),
+        Tool(
+            name="list_action_items",
+            description="List the user's action items/tasks. Use this to check what's on their todo list.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": ["pending", "completed", "all"],
+                        "default": "pending",
+                        "description": "Filter by status"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "default": 25,
+                        "description": "Maximum number of results"
+                    }
+                },
+                "required": []
+            }
+        ),
+        Tool(
+            name="update_action_item",
+            description="Update an action item (mark complete, change description, etc.)",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "action_item_id": {
+                        "type": "string",
+                        "description": "The ID of the action item to update"
+                    },
+                    "completed": {
+                        "type": "boolean",
+                        "description": "Mark as completed (true) or pending (false)"
+                    },
+                    "description": {
+                        "type": "string",
+                        "description": "Update the description"
+                    }
+                },
+                "required": ["action_item_id"]
+            }
+        ),
+        Tool(
+            name="get_user_context",
+            description="Get comprehensive context about the user including their profile, timezone, and recent activity summary. Use this to better understand the user's situation.",
+            inputSchema={
+                "type": "object",
+                "properties": {},
+                "required": []
+            }
+        ),
+        Tool(
+            name="get_conversation_summary",
+            description="Get a summary of recent conversations (last N days). Useful for providing context or weekly summaries.",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "days": {
+                        "type": "integer",
+                        "default": 7,
+                        "description": "Number of days to look back (1-30)"
+                    }
+                },
+                "required": []
+            }
+        ),
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict) -> list[TextContent]:
+    """Handle tool calls from the agent"""
+    try:
+        uid = get_uid()
+
+        if name == "search_conversations":
+            result = await search_conversations_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
+
+        elif name == "get_conversation":
+            result = await get_conversation_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
+
+        elif name == "search_memories":
+            result = await search_memories_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
+
+        elif name == "create_memory":
+            result = await create_memory_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result))]
+
+        elif name == "update_memory":
+            result = await update_memory_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result))]
+
+        elif name == "delete_memory":
+            result = await delete_memory_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result))]
+
+        elif name == "create_action_item":
+            result = await create_action_item_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result))]
+
+        elif name == "list_action_items":
+            result = await list_action_items_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
+
+        elif name == "update_action_item":
+            result = await update_action_item_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result))]
+
+        elif name == "get_user_context":
+            result = await get_user_context_impl(uid)
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
+
+        elif name == "get_conversation_summary":
+            result = await get_conversation_summary_impl(uid, arguments)
+            return [TextContent(type="text", text=json.dumps(result, default=str))]
+
+        else:
+            return [TextContent(
+                type="text",
+                text=json.dumps({"error": f"Unknown tool: {name}"})
+            )]
+
+    except Exception as e:
+        import traceback
+        error_details = traceback.format_exc()
+        print(f"Error in tool {name}: {error_details}", file=sys.stderr)
+        return [TextContent(
+            type="text",
+            text=json.dumps({"error": str(e), "tool": name})
+        )]
+
+
+# ========================================
+# TOOL IMPLEMENTATIONS
+# ========================================
+
+async def search_conversations_impl(uid: str, args: dict) -> dict:
+    """Search conversations using semantic search"""
+    query = args.get("query", "")
+    start_date = args.get("start_date")
+    end_date = args.get("end_date")
+    categories = args.get("categories", [])
+    limit = min(args.get("limit", 10), 50)
+
+    try:
+        # Generate embedding for semantic search
+        vector = generate_embedding(query)
+
+        # Parse dates if provided
+        start_dt = datetime.fromisoformat(start_date.replace('Z', '+00:00')) if start_date else None
+        end_dt = datetime.fromisoformat(end_date.replace('Z', '+00:00')) if end_date else None
+
+        # Query vector database
+        conversation_ids = query_vectors_by_metadata(
+            uid,
+            vector,
+            dates_filter=[start_dt, end_dt],
+            topics=[],  # Topics handled separately in categories
+            limit=limit,
+        )
+
+        # Fetch full conversations
+        conversations = conversations_db.get_conversations_by_id(uid, conversation_ids)
+
+        # Filter by categories if provided
+        if categories:
+            conversations = [
+                c for c in conversations
+                if c.get('structured', {}).get('category') in categories
+            ]
+
+        # Filter out locked conversations
+        conversations = [c for c in conversations if not c.get('is_locked', False)]
+
+        # Return simplified format
+        results = []
+        for conv in conversations[:limit]:
+            results.append({
+                "id": conv.get("id"),
+                "title": conv.get("structured", {}).get("title", "Untitled"),
+                "overview": conv.get("structured", {}).get("overview", ""),
+                "category": conv.get("structured", {}).get("category"),
+                "started_at": conv.get("started_at"),
+                "finished_at": conv.get("finished_at"),
+                "language": conv.get("language"),
+            })
+
+        return {
+            "success": True,
+            "count": len(results),
+            "conversations": results
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def get_conversation_impl(uid: str, args: dict) -> dict:
+    """Get full conversation details"""
+    conversation_id = args.get("conversation_id")
+
+    try:
+        conversation = conversations_db.get_conversation(uid, conversation_id)
+
+        if not conversation:
+            return {"success": False, "error": "Conversation not found"}
+
+        if conversation.get('is_locked', False):
+            return {"success": False, "error": "Conversation locked (premium plan required)"}
+
+        return {"success": True, "conversation": conversation}
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def search_memories_impl(uid: str, args: dict) -> dict:
+    """Search through user's memories"""
+    query = args.get("query", "")
+    categories = args.get("categories", [])
+    limit = min(args.get("limit", 25), 100)
+
+    try:
+        memories = memories_db.get_memories(
+            uid,
+            limit=limit,
+            offset=0,
+            categories=categories if categories else None
+        )
+
+        # Filter out locked memories
+        memories = [m for m in memories if not m.get('is_locked', False)]
+
+        # If query provided, do simple text matching (can be enhanced with semantic search)
+        if query:
+            query_lower = query.lower()
+            memories = [
+                m for m in memories
+                if query_lower in m.get('content', '').lower()
+            ]
+
+        return {
+            "success": True,
+            "count": len(memories),
+            "memories": memories
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def create_memory_impl(uid: str, args: dict) -> dict:
+    """Create a new memory"""
+    content = args.get("content", "").strip()
+    category = args.get("category")
+
+    if not content:
+        return {"success": False, "error": "Content cannot be empty"}
+
+    try:
+        # Auto-categorize if not provided
+        if not category:
+            categories = [c.value for c in MemoryCategory]
+            category = identify_category_for_memory(content, categories)
+
+        # Create memory object
+        memory = MemoryDB(
+            id=str(uuid_lib.uuid4()),
+            content=content,
+            category=category,
+            created_at=datetime.now(timezone.utc),
+            structured={},
+            external_integration_id=None,
+            deleted=False,
+            discarded=False
+        )
+
+        # Save to database
+        memories_db.create_memory(uid, memory.model_dump())
+
+        # Update personas asynchronously
+        threading.Thread(target=update_personas_async, args=(uid,)).start()
+
+        return {
+            "success": True,
+            "memory_id": memory.id,
+            "category": category,
+            "message": f"Memory created successfully"
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def update_memory_impl(uid: str, args: dict) -> dict:
+    """Update an existing memory"""
+    memory_id = args.get("memory_id")
+    content = args.get("content", "").strip()
+
+    if not memory_id or not content:
+        return {"success": False, "error": "Memory ID and content are required"}
+
+    try:
+        memories_db.edit_memory(uid, memory_id, content)
+        return {"success": True, "message": "Memory updated successfully"}
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def delete_memory_impl(uid: str, args: dict) -> dict:
+    """Delete a memory"""
+    memory_id = args.get("memory_id")
+
+    if not memory_id:
+        return {"success": False, "error": "Memory ID is required"}
+
+    try:
+        memories_db.delete_memory(uid, memory_id)
+        return {"success": True, "message": "Memory deleted successfully"}
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def create_action_item_impl(uid: str, args: dict) -> dict:
+    """Create a new action item"""
+    description = args.get("description", "").strip()
+    due_date = args.get("due_date")
+    conversation_id = args.get("conversation_id")
+
+    if not description:
+        return {"success": False, "error": "Description cannot be empty"}
+
+    try:
+        # Parse due date if provided
+        due_dt = None
+        if due_date:
+            due_dt = datetime.fromisoformat(due_date.replace('Z', '+00:00'))
+
+        # Create action item
+        action_item = {
+            "id": str(uuid_lib.uuid4()),
+            "description": description,
+            "created_at": datetime.now(timezone.utc),
+            "completed": False,
+            "deleted": False,
+            "status": "pending",
+            "conversation_id": conversation_id,
+            "due_date": due_dt
+        }
+
+        # Save to database
+        action_items_db.create_action_item(uid, action_item)
+
+        return {
+            "success": True,
+            "action_item_id": action_item["id"],
+            "message": "Action item created successfully"
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def list_action_items_impl(uid: str, args: dict) -> dict:
+    """List action items"""
+    status = args.get("status", "pending")
+    limit = min(args.get("limit", 25), 100)
+
+    try:
+        completed_filter = None
+        if status == "completed":
+            completed_filter = True
+        elif status == "pending":
+            completed_filter = False
+        # status == "all" -> no filter
+
+        action_items = action_items_db.get_action_items(
+            uid,
+            limit=limit,
+            offset=0,
+            completed=completed_filter
+        )
+
+        return {
+            "success": True,
+            "count": len(action_items),
+            "action_items": action_items
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def update_action_item_impl(uid: str, args: dict) -> dict:
+    """Update an action item"""
+    action_item_id = args.get("action_item_id")
+    completed = args.get("completed")
+    description = args.get("description")
+
+    if not action_item_id:
+        return {"success": False, "error": "Action item ID is required"}
+
+    try:
+        if completed is not None:
+            action_items_db.update_action_item_status(uid, action_item_id, completed)
+
+        if description:
+            action_items_db.update_action_item_description(uid, action_item_id, description)
+
+        return {"success": True, "message": "Action item updated successfully"}
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def get_user_context_impl(uid: str) -> dict:
+    """Get comprehensive user context"""
+    try:
+        # Get user profile
+        user_data = users_db.get_user(uid)
+
+        # Get recent memories (last 10)
+        recent_memories = memories_db.get_memories(uid, limit=10, offset=0)
+
+        # Get pending action items
+        pending_actions = action_items_db.get_action_items(uid, limit=5, completed=False)
+
+        return {
+            "success": True,
+            "user": {
+                "name": user_data.get("name", "User"),
+                "email": user_data.get("email"),
+                "timezone": user_data.get("timezone", "UTC"),
+            },
+            "recent_memories_count": len(recent_memories),
+            "pending_actions_count": len(pending_actions),
+            "recent_memories": [m.get("content") for m in recent_memories[:3]],
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def get_conversation_summary_impl(uid: str, args: dict) -> dict:
+    """Get summary of recent conversations"""
+    days = min(args.get("days", 7), 30)
+
+    try:
+        from datetime import timedelta
+
+        start_date = datetime.now(timezone.utc) - timedelta(days=days)
+
+        conversations = conversations_db.get_conversations(
+            uid,
+            limit=50,
+            offset=0,
+            start_date=start_date,
+            include_discarded=False
+        )
+
+        # Filter out locked
+        conversations = [c for c in conversations if not c.get('is_locked', False)]
+
+        # Summarize by category
+        by_category = {}
+        for conv in conversations:
+            cat = conv.get("structured", {}).get("category", "other")
+            by_category[cat] = by_category.get(cat, 0) + 1
+
+        return {
+            "success": True,
+            "days": days,
+            "total_conversations": len(conversations),
+            "by_category": by_category,
+            "recent_conversations": [
+                {
+                    "id": c.get("id"),
+                    "title": c.get("structured", {}).get("title"),
+                    "date": c.get("created_at")
+                }
+                for c in conversations[:5]
+            ]
+        }
+
+    except Exception as e:
+        return {"success": False, "error": str(e)}
+
+
+async def main():
+    """Run the MCP server"""
+    print("Starting Omi MCP Server...", file=sys.stderr)
+    async with stdio_server() as streams:
+        await server.run(
+            streams[0],
+            streams[1],
+            server.create_initialization_options()
+        )
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -256,3 +256,7 @@ typesense==0.21.0
 pycountry==24.6.1
 google-cloud-translate==3.20.2
 langdetect==1.0.9
+# Agentic Chat Dependencies
+openai-agents==0.0.14
+mcp==0.9.0
+langchain-mcp-adapters==0.0.10

--- a/backend/scripts/test_agentic_chat_e2e.py
+++ b/backend/scripts/test_agentic_chat_e2e.py
@@ -1,0 +1,444 @@
+#!/usr/bin/env python3
+"""
+End-to-End Test Script for Agentic Chat
+
+This script tests the complete agentic chat flow including:
+1. Agent proactively creates memories
+2. Agent creates action items
+3. Agent searches conversations
+4. Agent provides contextual responses
+
+Usage:
+    python scripts/test_agentic_chat_e2e.py [--uid USER_ID] [--verbose]
+
+Requirements:
+    - Backend server must be running
+    - MCP server must be accessible (uvx mcp-server-omi)
+    - Test user must exist in database
+"""
+
+import argparse
+import asyncio
+import sys
+import os
+from datetime import datetime, timezone
+
+# Add backend to path
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from models.chat import Message, MessageType
+from utils.llm.agentic_chat import execute_agentic_chat_stream
+
+
+class Colors:
+    """ANSI color codes for terminal output"""
+    HEADER = '\033[95m'
+    BLUE = '\033[94m'
+    CYAN = '\033[96m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    RED = '\033[91m'
+    END = '\033[0m'
+    BOLD = '\033[1m'
+
+
+def print_header(text):
+    """Print formatted header"""
+    print(f"\n{Colors.HEADER}{Colors.BOLD}{'=' * 70}")
+    print(f"{text}")
+    print(f"{'=' * 70}{Colors.END}\n")
+
+
+def print_test(test_name, passed=None, details=""):
+    """Print test result"""
+    if passed is None:
+        # Test is running
+        print(f"{Colors.CYAN}[TEST] {test_name}...{Colors.END}")
+    elif passed:
+        print(f"{Colors.GREEN}[PASS] {test_name}{Colors.END}")
+        if details:
+            print(f"       {details}")
+    else:
+        print(f"{Colors.RED}[FAIL] {test_name}{Colors.END}")
+        if details:
+            print(f"       {details}")
+
+
+def print_agent_action(action):
+    """Print agent tool call"""
+    tool = action.get('tool', 'unknown')
+    print(f"{Colors.YELLOW}[TOOL] {tool}{Colors.END}")
+    if 'arguments' in action:
+        args = action['arguments']
+        for key, value in args.items():
+            print(f"       {key}: {value}")
+
+
+async def test_memory_creation(uid: str, verbose: bool = False):
+    """
+    Test 1: Agent proactively creates memory when user shares personal info
+    """
+    test_name = "Proactive Memory Creation"
+    print_test(test_name)
+
+    messages = [
+        Message(
+            id="test_mem_1",
+            sender="human",
+            type=MessageType.text,
+            text="I love hiking and my favorite color is blue",
+            created_at=datetime.now(timezone.utc)
+        )
+    ]
+
+    callback_data = {}
+    response_text = ""
+
+    try:
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            if chunk:
+                token = chunk.replace("data: ", "").replace("__CRLF__", "\n")
+                response_text += token
+                if verbose:
+                    print(token, end="", flush=True)
+
+        if verbose:
+            print()  # Newline after response
+
+        # Check agent actions
+        agent_actions = callback_data.get('agent_actions', [])
+        tool_calls = [a.get('tool') for a in agent_actions]
+
+        # Verify memory creation
+        if 'create_memory' in tool_calls:
+            print_test(test_name, True, f"Agent created {tool_calls.count('create_memory')} memory/memories")
+            if verbose:
+                for action in agent_actions:
+                    if action.get('tool') == 'create_memory':
+                        print_agent_action(action)
+            return True
+        else:
+            print_test(test_name, False, "Agent did not create memory")
+            return False
+
+    except Exception as e:
+        print_test(test_name, False, f"Error: {str(e)}")
+        return False
+
+
+async def test_action_item_creation(uid: str, verbose: bool = False):
+    """
+    Test 2: Agent creates action item when user mentions task
+    """
+    test_name = "Action Item Extraction"
+    print_test(test_name)
+
+    messages = [
+        Message(
+            id="test_action_1",
+            sender="human",
+            type=MessageType.text,
+            text="I need to call John tomorrow at 3pm and send the report to Sarah",
+            created_at=datetime.now(timezone.utc)
+        )
+    ]
+
+    callback_data = {}
+    response_text = ""
+
+    try:
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            if chunk:
+                token = chunk.replace("data: ", "").replace("__CRLF__", "\n")
+                response_text += token
+                if verbose:
+                    print(token, end="", flush=True)
+
+        if verbose:
+            print()
+
+        agent_actions = callback_data.get('agent_actions', [])
+        tool_calls = [a.get('tool') for a in agent_actions]
+
+        if 'create_action_item' in tool_calls:
+            count = tool_calls.count('create_action_item')
+            print_test(test_name, True, f"Agent created {count} action item(s)")
+            if verbose:
+                for action in agent_actions:
+                    if action.get('tool') == 'create_action_item':
+                        print_agent_action(action)
+            return True
+        else:
+            print_test(test_name, False, "Agent did not create action item")
+            return False
+
+    except Exception as e:
+        print_test(test_name, False, f"Error: {str(e)}")
+        return False
+
+
+async def test_conversation_search(uid: str, verbose: bool = False):
+    """
+    Test 3: Agent searches conversations when answering questions
+    """
+    test_name = "Conversation Search"
+    print_test(test_name)
+
+    messages = [
+        Message(
+            id="test_search_1",
+            sender="human",
+            type=MessageType.text,
+            text="What did I discuss with Sarah last week?",
+            created_at=datetime.now(timezone.utc)
+        )
+    ]
+
+    callback_data = {}
+    response_text = ""
+
+    try:
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            if chunk:
+                token = chunk.replace("data: ", "").replace("__CRLF__", "\n")
+                response_text += token
+                if verbose:
+                    print(token, end="", flush=True)
+
+        if verbose:
+            print()
+
+        agent_actions = callback_data.get('agent_actions', [])
+        tool_calls = [a.get('tool') for a in agent_actions]
+
+        if 'search_conversations' in tool_calls:
+            print_test(test_name, True, "Agent searched conversations")
+            if verbose:
+                for action in agent_actions:
+                    if action.get('tool') == 'search_conversations':
+                        print_agent_action(action)
+            return True
+        else:
+            print_test(test_name, False, "Agent did not search conversations")
+            return False
+
+    except Exception as e:
+        print_test(test_name, False, f"Error: {str(e)}")
+        return False
+
+
+async def test_memory_retrieval(uid: str, verbose: bool = False):
+    """
+    Test 4: Agent retrieves memories to provide context
+    """
+    test_name = "Memory Retrieval"
+    print_test(test_name)
+
+    messages = [
+        Message(
+            id="test_mem_retrieve_1",
+            sender="human",
+            type=MessageType.text,
+            text="What do you know about my hobbies and preferences?",
+            created_at=datetime.now(timezone.utc)
+        )
+    ]
+
+    callback_data = {}
+    response_text = ""
+
+    try:
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            if chunk:
+                token = chunk.replace("data: ", "").replace("__CRLF__", "\n")
+                response_text += token
+                if verbose:
+                    print(token, end="", flush=True)
+
+        if verbose:
+            print()
+
+        agent_actions = callback_data.get('agent_actions', [])
+        tool_calls = [a.get('tool') for a in agent_actions]
+
+        if 'search_memories' in tool_calls or 'get_user_context' in tool_calls:
+            print_test(test_name, True, "Agent retrieved user context/memories")
+            if verbose:
+                for action in agent_actions:
+                    if action.get('tool') in ['search_memories', 'get_user_context']:
+                        print_agent_action(action)
+            return True
+        else:
+            print_test(test_name, False, "Agent did not retrieve memories")
+            return False
+
+    except Exception as e:
+        print_test(test_name, False, f"Error: {str(e)}")
+        return False
+
+
+async def test_multi_turn_conversation(uid: str, verbose: bool = False):
+    """
+    Test 5: Agent maintains context across multiple turns
+    """
+    test_name = "Multi-turn Context"
+    print_test(test_name)
+
+    messages = [
+        Message(
+            id="test_multi_1",
+            sender="human",
+            type=MessageType.text,
+            text="I love Python programming",
+            created_at=datetime.now(timezone.utc)
+        ),
+        Message(
+            id="test_multi_2",
+            sender="ai",
+            type=MessageType.text,
+            text="That's great! I'll remember that you love Python programming.",
+            created_at=datetime.now(timezone.utc)
+        ),
+        Message(
+            id="test_multi_3",
+            sender="human",
+            type=MessageType.text,
+            text="What programming languages do I know?",
+            created_at=datetime.now(timezone.utc)
+        )
+    ]
+
+    callback_data = {}
+    response_text = ""
+
+    try:
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            if chunk:
+                token = chunk.replace("data: ", "").replace("__CRLF__", "\n")
+                response_text += token
+                if verbose:
+                    print(token, end="", flush=True)
+
+        if verbose:
+            print()
+
+        response = callback_data.get('answer', '')
+
+        # Check if response mentions Python
+        if 'python' in response.lower():
+            print_test(test_name, True, "Agent maintained context across turns")
+            return True
+        else:
+            print_test(test_name, False, "Agent lost context")
+            return False
+
+    except Exception as e:
+        print_test(test_name, False, f"Error: {str(e)}")
+        return False
+
+
+async def test_graceful_fallback(uid: str, verbose: bool = False):
+    """
+    Test 6: Agent handles questions without tools gracefully
+    """
+    test_name = "Graceful Fallback (No Tools)"
+    print_test(test_name)
+
+    messages = [
+        Message(
+            id="test_fallback_1",
+            sender="human",
+            type=MessageType.text,
+            text="What's the capital of France?",
+            created_at=datetime.now(timezone.utc)
+        )
+    ]
+
+    callback_data = {}
+    response_text = ""
+
+    try:
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            if chunk:
+                token = chunk.replace("data: ", "").replace("__CRLF__", "\n")
+                response_text += token
+                if verbose:
+                    print(token, end="", flush=True)
+
+        if verbose:
+            print()
+
+        response = callback_data.get('answer', '')
+
+        # Should respond even without tool calls
+        if response and len(response) > 10:
+            print_test(test_name, True, "Agent responded without tools")
+            return True
+        else:
+            print_test(test_name, False, "Agent failed to respond")
+            return False
+
+    except Exception as e:
+        print_test(test_name, False, f"Error: {str(e)}")
+        return False
+
+
+async def run_all_tests(uid: str, verbose: bool = False):
+    """Run all E2E tests"""
+    print_header("AGENTIC CHAT END-TO-END TESTS")
+    print(f"Testing with UID: {uid}")
+    print(f"Verbose: {verbose}\n")
+
+    results = []
+
+    # Run tests sequentially
+    results.append(("Memory Creation", await test_memory_creation(uid, verbose)))
+    results.append(("Action Item Creation", await test_action_item_creation(uid, verbose)))
+    results.append(("Conversation Search", await test_conversation_search(uid, verbose)))
+    results.append(("Memory Retrieval", await test_memory_retrieval(uid, verbose)))
+    results.append(("Multi-turn Context", await test_multi_turn_conversation(uid, verbose)))
+    results.append(("Graceful Fallback", await test_graceful_fallback(uid, verbose)))
+
+    # Print summary
+    print_header("TEST SUMMARY")
+
+    passed = sum(1 for _, result in results if result)
+    total = len(results)
+
+    for test_name, result in results:
+        status = f"{Colors.GREEN}✓{Colors.END}" if result else f"{Colors.RED}✗{Colors.END}"
+        print(f"{status} {test_name}")
+
+    print(f"\n{Colors.BOLD}Results: {passed}/{total} tests passed{Colors.END}")
+
+    if passed == total:
+        print(f"{Colors.GREEN}All tests passed! 🎉{Colors.END}\n")
+        return 0
+    else:
+        print(f"{Colors.RED}Some tests failed. Please review.{Colors.END}\n")
+        return 1
+
+
+def main():
+    parser = argparse.ArgumentParser(description="E2E tests for agentic chat")
+    parser.add_argument(
+        '--uid',
+        type=str,
+        default='test_user_e2e',
+        help='User ID for testing (default: test_user_e2e)'
+    )
+    parser.add_argument(
+        '--verbose',
+        action='store_true',
+        help='Show full agent responses and tool calls'
+    )
+
+    args = parser.parse_args()
+
+    # Run tests
+    exit_code = asyncio.run(run_all_tests(args.uid, args.verbose))
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/tests/test_agentic_chat.py
+++ b/backend/tests/test_agentic_chat.py
@@ -1,0 +1,345 @@
+"""
+Unit tests for agentic chat implementation
+
+Tests the OpenAI Agents + MCP integration for:
+- Agent tool calling behavior
+- Proactive memory creation
+- Action item extraction
+- Conversation search
+"""
+
+import pytest
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import Mock, patch, AsyncMock
+
+from utils.llm.agentic_chat import (
+    execute_agentic_chat_stream,
+    _build_system_prompt,
+    _convert_messages_to_agent_format,
+    get_agent_config
+)
+from models.chat import Message, MessageType
+
+
+class TestAgenticChatStreaming:
+    """Test agentic chat streaming functionality"""
+
+    @pytest.mark.asyncio
+    async def test_agent_stream_basic_response(self):
+        """Test that agent streams a basic response"""
+        uid = "test_user_123"
+        messages = [
+            Message(
+                id="1",
+                sender="human",
+                type=MessageType.text,
+                text="Hello!",
+                created_at=datetime.now(timezone.utc)
+            )
+        ]
+
+        callback_data = {}
+        chunks = []
+
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            if chunk:
+                chunks.append(chunk)
+
+        # Should have streamed some content
+        assert len(chunks) > 0
+        # Should have final answer
+        assert 'answer' in callback_data
+        assert isinstance(callback_data['answer'], str)
+
+    @pytest.mark.asyncio
+    async def test_agent_creates_memory_proactively(self):
+        """Test that agent automatically creates memories when user shares important info"""
+        uid = "test_user_mem"
+        messages = [
+            Message(
+                id="1",
+                sender="human",
+                type=MessageType.text,
+                text="My favorite color is blue and I love hiking on weekends",
+                created_at=datetime.now(timezone.utc)
+            )
+        ]
+
+        callback_data = {}
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            pass
+
+        # Verify memory creation tool was called
+        agent_actions = callback_data.get('agent_actions', [])
+        tool_calls = [action.get('tool') for action in agent_actions]
+
+        # Should have called create_memory tool
+        assert 'create_memory' in tool_calls
+
+    @pytest.mark.asyncio
+    async def test_agent_creates_action_item(self):
+        """Test agent creates action items when user mentions tasks"""
+        uid = "test_user_action"
+        messages = [
+            Message(
+                id="1",
+                sender="human",
+                type=MessageType.text,
+                text="I need to call John tomorrow at 3pm",
+                created_at=datetime.now(timezone.utc)
+            )
+        ]
+
+        callback_data = {}
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            pass
+
+        # Verify action item creation
+        agent_actions = callback_data.get('agent_actions', [])
+        tool_calls = [action.get('tool') for action in agent_actions]
+
+        # Should have called create_action_item tool
+        assert 'create_action_item' in tool_calls
+
+    @pytest.mark.asyncio
+    async def test_agent_searches_conversations(self):
+        """Test agent searches conversations when answering questions about past"""
+        uid = "test_user_search"
+        messages = [
+            Message(
+                id="1",
+                sender="human",
+                type=MessageType.text,
+                text="What did I discuss with Sarah last week?",
+                created_at=datetime.now(timezone.utc)
+            )
+        ]
+
+        callback_data = {}
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            pass
+
+        # Verify conversation search was performed
+        agent_actions = callback_data.get('agent_actions', [])
+        tool_calls = [action.get('tool') for action in agent_actions]
+
+        # Should have called search_conversations tool
+        assert 'search_conversations' in tool_calls
+
+    @pytest.mark.asyncio
+    async def test_agent_handles_multi_turn_conversation(self):
+        """Test agent maintains context in multi-turn conversation"""
+        uid = "test_user_multi"
+        messages = [
+            Message(
+                id="1",
+                sender="human",
+                type=MessageType.text,
+                text="I love hiking",
+                created_at=datetime.now(timezone.utc)
+            ),
+            Message(
+                id="2",
+                sender="ai",
+                type=MessageType.text,
+                text="That's great! I'll remember that.",
+                created_at=datetime.now(timezone.utc)
+            ),
+            Message(
+                id="3",
+                sender="human",
+                type=MessageType.text,
+                text="What do you know about my hobbies?",
+                created_at=datetime.now(timezone.utc)
+            )
+        ]
+
+        callback_data = {}
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            pass
+
+        # Should have an answer
+        assert 'answer' in callback_data
+        answer = callback_data['answer'].lower()
+
+        # Answer should reference hiking
+        assert 'hiking' in answer or 'hobby' in answer
+
+
+class TestSystemPromptBuilding:
+    """Test system prompt construction"""
+
+    def test_build_default_system_prompt(self):
+        """Test building default Omi system prompt"""
+        prompt = _build_system_prompt(
+            user_name="John",
+            memories_str="John loves hiking. His birthday is June 15th.",
+            timezone_str="America/New_York",
+            app=None
+        )
+
+        # Should include user name
+        assert "John" in prompt
+        # Should include memories
+        assert "hiking" in prompt
+        # Should include timezone
+        assert "America/New_York" in prompt
+        # Should include tool instructions
+        assert "search_conversations" in prompt
+        assert "create_memory" in prompt
+
+    def test_build_custom_app_prompt(self):
+        """Test building custom app prompt"""
+        from models.app import App
+
+        app = App(
+            id="test_app",
+            name="TestBot",
+            chat_prompt="a helpful assistant that speaks like a pirate",
+            capabilities=["chat"]
+        )
+
+        prompt = _build_system_prompt(
+            user_name="John",
+            memories_str="",
+            timezone_str="UTC",
+            app=app
+        )
+
+        # Should include app name
+        assert "TestBot" in prompt
+        # Should include custom prompt
+        assert "pirate" in prompt
+
+
+class TestMessageConversion:
+    """Test message format conversion"""
+
+    def test_convert_messages_to_agent_format(self):
+        """Test converting Omi messages to agent format"""
+        messages = [
+            Message(
+                id="1",
+                sender="human",
+                type=MessageType.text,
+                text="Hello",
+                created_at=datetime.now(timezone.utc)
+            ),
+            Message(
+                id="2",
+                sender="ai",
+                type=MessageType.text,
+                text="Hi there!",
+                created_at=datetime.now(timezone.utc)
+            )
+        ]
+
+        agent_messages = _convert_messages_to_agent_format(messages)
+
+        assert len(agent_messages) == 2
+        assert agent_messages[0]['role'] == 'user'
+        assert agent_messages[0]['content'] == 'Hello'
+        assert agent_messages[1]['role'] == 'assistant'
+        assert agent_messages[1]['content'] == 'Hi there!'
+
+
+class TestAgentConfig:
+    """Test agent configuration"""
+
+    @patch.dict('os.environ', {
+        'ENABLE_AGENTIC_CHAT': 'true',
+        'AGENT_MODEL': 'o4-mini',
+        'AGENT_REASONING_EFFORT': 'high'
+    })
+    def test_get_agent_config_from_env(self):
+        """Test reading agent config from environment"""
+        config = get_agent_config()
+
+        assert config['enabled'] is True
+        assert config['model'] == 'o4-mini'
+        assert config['reasoning_effort'] == 'high'
+
+    @patch.dict('os.environ', {})
+    def test_get_agent_config_defaults(self):
+        """Test agent config with defaults"""
+        config = get_agent_config()
+
+        # Should have sensible defaults
+        assert 'enabled' in config
+        assert 'model' in config
+        assert 'reasoning_effort' in config
+
+
+class TestErrorHandling:
+    """Test error handling in agentic chat"""
+
+    @pytest.mark.asyncio
+    async def test_agent_handles_mcp_server_error(self):
+        """Test agent gracefully handles MCP server errors"""
+        uid = "test_user_error"
+        messages = [
+            Message(
+                id="1",
+                sender="human",
+                type=MessageType.text,
+                text="Hello",
+                created_at=datetime.now(timezone.utc)
+            )
+        ]
+
+        callback_data = {}
+
+        # Mock MCP server to raise error
+        with patch('utils.llm.agentic_chat.MCPServerStdio') as mock_mcp:
+            mock_mcp.side_effect = Exception("MCP connection failed")
+
+            async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+                pass
+
+            # Should have error in callback_data
+            assert 'error' in callback_data
+
+    @pytest.mark.asyncio
+    async def test_agent_handles_tool_call_error(self):
+        """Test agent handles tool call errors gracefully"""
+        # This would require mocking tool responses
+        # Left as a TODO for full implementation
+        pass
+
+
+class TestPerformance:
+    """Test performance characteristics"""
+
+    @pytest.mark.asyncio
+    async def test_streaming_latency(self):
+        """Test that first token arrives quickly"""
+        uid = "test_user_perf"
+        messages = [
+            Message(
+                id="1",
+                sender="human",
+                type=MessageType.text,
+                text="Hello!",
+                created_at=datetime.now(timezone.utc)
+            )
+        ]
+
+        callback_data = {}
+        start_time = asyncio.get_event_loop().time()
+        first_chunk_time = None
+
+        async for chunk in execute_agentic_chat_stream(uid, messages, callback_data=callback_data):
+            if chunk and first_chunk_time is None:
+                first_chunk_time = asyncio.get_event_loop().time()
+                break
+
+        if first_chunk_time:
+            latency = first_chunk_time - start_time
+            # First token should arrive within 5 seconds
+            assert latency < 5.0, f"First token latency too high: {latency}s"
+
+
+# Run tests
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/backend/tests/test_mcp_server.py
+++ b/backend/tests/test_mcp_server.py
@@ -1,0 +1,465 @@
+"""
+Unit tests for MCP Server implementation
+
+Tests all 14 MCP tools:
+- search_conversations
+- get_conversation
+- search_memories
+- create_memory
+- update_memory
+- delete_memory
+- create_action_item
+- list_action_items
+- update_action_item
+- get_user_context
+- get_conversation_summary
+"""
+
+import pytest
+import asyncio
+import json
+from datetime import datetime, timezone, timedelta
+from unittest.mock import Mock, patch, MagicMock
+
+# Import MCP server functions
+import sys
+import os
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from mcp_server_omi import (
+    search_conversations_impl,
+    get_conversation_impl,
+    search_memories_impl,
+    create_memory_impl,
+    update_memory_impl,
+    delete_memory_impl,
+    create_action_item_impl,
+    list_action_items_impl,
+    update_action_item_impl,
+    get_user_context_impl,
+    get_conversation_summary_impl,
+)
+
+
+class TestConversationTools:
+    """Test conversation-related MCP tools"""
+
+    @pytest.mark.asyncio
+    async def test_search_conversations_basic(self):
+        """Test basic conversation search"""
+        uid = "test_user"
+        args = {
+            "query": "machine learning",
+            "limit": 10
+        }
+
+        with patch('mcp_server_omi.generate_embedding') as mock_embed, \
+             patch('mcp_server_omi.query_vectors_by_metadata') as mock_query, \
+             patch('mcp_server_omi.conversations_db.get_conversations_by_id') as mock_get:
+
+            # Mock embedding
+            mock_embed.return_value = [0.1] * 3072
+
+            # Mock vector search results
+            mock_query.return_value = ['conv1', 'conv2']
+
+            # Mock conversation data
+            mock_get.return_value = [
+                {
+                    'id': 'conv1',
+                    'structured': {
+                        'title': 'ML Discussion',
+                        'overview': 'Talked about machine learning',
+                        'category': 'technology'
+                    },
+                    'started_at': datetime.now(timezone.utc),
+                    'finished_at': datetime.now(timezone.utc),
+                    'language': 'en',
+                    'is_locked': False
+                }
+            ]
+
+            result = await search_conversations_impl(uid, args)
+
+            assert result['success'] is True
+            assert result['count'] == 1
+            assert len(result['conversations']) == 1
+            assert result['conversations'][0]['title'] == 'ML Discussion'
+
+    @pytest.mark.asyncio
+    async def test_search_conversations_with_date_filter(self):
+        """Test conversation search with date filters"""
+        uid = "test_user"
+        args = {
+            "query": "meeting",
+            "start_date": "2024-01-01T00:00:00Z",
+            "end_date": "2024-01-31T23:59:59Z",
+            "limit": 5
+        }
+
+        with patch('mcp_server_omi.generate_embedding'), \
+             patch('mcp_server_omi.query_vectors_by_metadata') as mock_query, \
+             patch('mcp_server_omi.conversations_db.get_conversations_by_id'):
+
+            mock_query.return_value = []
+
+            result = await search_conversations_impl(uid, args)
+
+            # Should call query_vectors with date filters
+            assert mock_query.called
+            call_args = mock_query.call_args
+            assert call_args[1]['dates_filter'][0] is not None  # start_date parsed
+            assert call_args[1]['dates_filter'][1] is not None  # end_date parsed
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_success(self):
+        """Test getting a specific conversation"""
+        uid = "test_user"
+        args = {"conversation_id": "conv123"}
+
+        with patch('mcp_server_omi.conversations_db.get_conversation') as mock_get:
+            mock_get.return_value = {
+                'id': 'conv123',
+                'structured': {'title': 'Test Conversation'},
+                'transcript_segments': [],
+                'is_locked': False
+            }
+
+            result = await get_conversation_impl(uid, args)
+
+            assert result['success'] is True
+            assert 'conversation' in result
+            assert result['conversation']['id'] == 'conv123'
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_locked(self):
+        """Test getting a locked conversation (premium required)"""
+        uid = "test_user"
+        args = {"conversation_id": "conv_locked"}
+
+        with patch('mcp_server_omi.conversations_db.get_conversation') as mock_get:
+            mock_get.return_value = {'id': 'conv_locked', 'is_locked': True}
+
+            result = await get_conversation_impl(uid, args)
+
+            assert result['success'] is False
+            assert 'locked' in result['error'].lower()
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_not_found(self):
+        """Test getting non-existent conversation"""
+        uid = "test_user"
+        args = {"conversation_id": "nonexistent"}
+
+        with patch('mcp_server_omi.conversations_db.get_conversation') as mock_get:
+            mock_get.return_value = None
+
+            result = await get_conversation_impl(uid, args)
+
+            assert result['success'] is False
+            assert 'not found' in result['error'].lower()
+
+
+class TestMemoryTools:
+    """Test memory-related MCP tools"""
+
+    @pytest.mark.asyncio
+    async def test_search_memories_all(self):
+        """Test searching all memories"""
+        uid = "test_user"
+        args = {"limit": 25}
+
+        with patch('mcp_server_omi.memories_db.get_memories') as mock_get:
+            mock_get.return_value = [
+                {'id': 'mem1', 'content': 'User loves hiking', 'is_locked': False},
+                {'id': 'mem2', 'content': 'Birthday is June 15', 'is_locked': False}
+            ]
+
+            result = await search_memories_impl(uid, args)
+
+            assert result['success'] is True
+            assert result['count'] == 2
+            assert len(result['memories']) == 2
+
+    @pytest.mark.asyncio
+    async def test_search_memories_with_query(self):
+        """Test searching memories with text query"""
+        uid = "test_user"
+        args = {"query": "hiking", "limit": 10}
+
+        with patch('mcp_server_omi.memories_db.get_memories') as mock_get:
+            mock_get.return_value = [
+                {'id': 'mem1', 'content': 'User loves hiking', 'is_locked': False},
+                {'id': 'mem2', 'content': 'Birthday is June 15', 'is_locked': False}
+            ]
+
+            result = await search_memories_impl(uid, args)
+
+            # Should filter to only hiking-related memory
+            assert result['success'] is True
+            assert result['count'] == 1
+            assert 'hiking' in result['memories'][0]['content']
+
+    @pytest.mark.asyncio
+    async def test_create_memory_success(self):
+        """Test creating a new memory"""
+        uid = "test_user"
+        args = {
+            "content": "User's favorite color is blue",
+            "category": "core"
+        }
+
+        with patch('mcp_server_omi.memories_db.create_memory') as mock_create, \
+             patch('mcp_server_omi.threading.Thread'):
+
+            result = await create_memory_impl(uid, args)
+
+            assert result['success'] is True
+            assert 'memory_id' in result
+            assert result['category'] == 'core'
+            assert mock_create.called
+
+    @pytest.mark.asyncio
+    async def test_create_memory_auto_categorize(self):
+        """Test creating memory with auto-categorization"""
+        uid = "test_user"
+        args = {"content": "User loves playing tennis on weekends"}
+
+        with patch('mcp_server_omi.identify_category_for_memory') as mock_categorize, \
+             patch('mcp_server_omi.memories_db.create_memory'), \
+             patch('mcp_server_omi.threading.Thread'):
+
+            mock_categorize.return_value = "interests_hobbies"
+
+            result = await create_memory_impl(uid, args)
+
+            assert result['success'] is True
+            assert mock_categorize.called
+            # Should have auto-detected category
+            assert 'category' in result
+
+    @pytest.mark.asyncio
+    async def test_create_memory_empty_content(self):
+        """Test creating memory with empty content"""
+        uid = "test_user"
+        args = {"content": ""}
+
+        result = await create_memory_impl(uid, args)
+
+        assert result['success'] is False
+        assert 'empty' in result['error'].lower()
+
+    @pytest.mark.asyncio
+    async def test_update_memory_success(self):
+        """Test updating an existing memory"""
+        uid = "test_user"
+        args = {
+            "memory_id": "mem123",
+            "content": "Updated content"
+        }
+
+        with patch('mcp_server_omi.memories_db.edit_memory') as mock_edit:
+            result = await update_memory_impl(uid, args)
+
+            assert result['success'] is True
+            assert mock_edit.called
+            mock_edit.assert_called_with(uid, "mem123", "Updated content")
+
+    @pytest.mark.asyncio
+    async def test_delete_memory_success(self):
+        """Test deleting a memory"""
+        uid = "test_user"
+        args = {"memory_id": "mem123"}
+
+        with patch('mcp_server_omi.memories_db.delete_memory') as mock_delete:
+            result = await delete_memory_impl(uid, args)
+
+            assert result['success'] is True
+            assert mock_delete.called
+            mock_delete.assert_called_with(uid, "mem123")
+
+
+class TestActionItemTools:
+    """Test action item-related MCP tools"""
+
+    @pytest.mark.asyncio
+    async def test_create_action_item_basic(self):
+        """Test creating a basic action item"""
+        uid = "test_user"
+        args = {"description": "Buy groceries"}
+
+        with patch('mcp_server_omi.action_items_db.create_action_item') as mock_create:
+            result = await create_action_item_impl(uid, args)
+
+            assert result['success'] is True
+            assert 'action_item_id' in result
+            assert mock_create.called
+
+    @pytest.mark.asyncio
+    async def test_create_action_item_with_due_date(self):
+        """Test creating action item with due date"""
+        uid = "test_user"
+        due_date = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+        args = {
+            "description": "Submit report",
+            "due_date": due_date
+        }
+
+        with patch('mcp_server_omi.action_items_db.create_action_item') as mock_create:
+            result = await create_action_item_impl(uid, args)
+
+            assert result['success'] is True
+            # Should have parsed due date
+            call_args = mock_create.call_args[0][1]
+            assert call_args['due_date'] is not None
+
+    @pytest.mark.asyncio
+    async def test_list_action_items_pending(self):
+        """Test listing pending action items"""
+        uid = "test_user"
+        args = {"status": "pending", "limit": 25}
+
+        with patch('mcp_server_omi.action_items_db.get_action_items') as mock_get:
+            mock_get.return_value = [
+                {'id': 'action1', 'description': 'Task 1', 'completed': False},
+                {'id': 'action2', 'description': 'Task 2', 'completed': False}
+            ]
+
+            result = await list_action_items_impl(uid, args)
+
+            assert result['success'] is True
+            assert result['count'] == 2
+            # Should have called with completed=False
+            mock_get.assert_called_with(uid, limit=25, offset=0, completed=False)
+
+    @pytest.mark.asyncio
+    async def test_list_action_items_all(self):
+        """Test listing all action items"""
+        uid = "test_user"
+        args = {"status": "all", "limit": 10}
+
+        with patch('mcp_server_omi.action_items_db.get_action_items') as mock_get:
+            mock_get.return_value = []
+
+            result = await list_action_items_impl(uid, args)
+
+            # Should have called with completed=None (no filter)
+            mock_get.assert_called_with(uid, limit=10, offset=0, completed=None)
+
+    @pytest.mark.asyncio
+    async def test_update_action_item_mark_complete(self):
+        """Test marking action item as complete"""
+        uid = "test_user"
+        args = {
+            "action_item_id": "action123",
+            "completed": True
+        }
+
+        with patch('mcp_server_omi.action_items_db.update_action_item_status') as mock_update:
+            result = await update_action_item_impl(uid, args)
+
+            assert result['success'] is True
+            mock_update.assert_called_with(uid, "action123", True)
+
+    @pytest.mark.asyncio
+    async def test_update_action_item_change_description(self):
+        """Test updating action item description"""
+        uid = "test_user"
+        args = {
+            "action_item_id": "action123",
+            "description": "New description"
+        }
+
+        with patch('mcp_server_omi.action_items_db.update_action_item_description') as mock_update:
+            result = await update_action_item_impl(uid, args)
+
+            assert result['success'] is True
+            mock_update.assert_called_with(uid, "action123", "New description")
+
+
+class TestContextTools:
+    """Test context retrieval tools"""
+
+    @pytest.mark.asyncio
+    async def test_get_user_context(self):
+        """Test getting comprehensive user context"""
+        uid = "test_user"
+
+        with patch('mcp_server_omi.users_db.get_user') as mock_user, \
+             patch('mcp_server_omi.memories_db.get_memories') as mock_memories, \
+             patch('mcp_server_omi.action_items_db.get_action_items') as mock_actions:
+
+            mock_user.return_value = {
+                'name': 'John Doe',
+                'email': 'john@example.com',
+                'timezone': 'America/New_York'
+            }
+            mock_memories.return_value = [
+                {'content': 'Memory 1'},
+                {'content': 'Memory 2'}
+            ]
+            mock_actions.return_value = [
+                {'description': 'Task 1'}
+            ]
+
+            result = await get_user_context_impl(uid)
+
+            assert result['success'] is True
+            assert result['user']['name'] == 'John Doe'
+            assert result['recent_memories_count'] == 2
+            assert result['pending_actions_count'] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_conversation_summary(self):
+        """Test getting conversation summary"""
+        uid = "test_user"
+        args = {"days": 7}
+
+        with patch('mcp_server_omi.conversations_db.get_conversations') as mock_get:
+            mock_get.return_value = [
+                {'id': 'c1', 'structured': {'category': 'work', 'title': 'Meeting'}, 'is_locked': False},
+                {'id': 'c2', 'structured': {'category': 'personal', 'title': 'Chat'}, 'is_locked': False},
+                {'id': 'c3', 'structured': {'category': 'work', 'title': 'Project'}, 'is_locked': False}
+            ]
+
+            result = await get_conversation_summary_impl(uid, args)
+
+            assert result['success'] is True
+            assert result['total_conversations'] == 3
+            assert 'by_category' in result
+            assert result['by_category']['work'] == 2
+            assert result['by_category']['personal'] == 1
+
+
+class TestErrorHandling:
+    """Test error handling in MCP tools"""
+
+    @pytest.mark.asyncio
+    async def test_tool_handles_database_error(self):
+        """Test that tools handle database errors gracefully"""
+        uid = "test_user"
+        args = {"limit": 10}
+
+        with patch('mcp_server_omi.memories_db.get_memories') as mock_get:
+            mock_get.side_effect = Exception("Database connection failed")
+
+            result = await search_memories_impl(uid, args)
+
+            assert result['success'] is False
+            assert 'error' in result
+
+    @pytest.mark.asyncio
+    async def test_tool_validates_input(self):
+        """Test that tools validate input parameters"""
+        uid = "test_user"
+        args = {"memory_id": "", "content": ""}  # Invalid input
+
+        result = await update_memory_impl(uid, args)
+
+        assert result['success'] is False
+        assert 'required' in result['error'].lower()
+
+
+# Run tests
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/backend/utils/llm/agentic_chat.py
+++ b/backend/utils/llm/agentic_chat.py
@@ -1,0 +1,373 @@
+"""
+Agentic Chat Implementation using OpenAI Agents SDK + MCP Server
+
+This module implements the agentic chat system that can:
+- Dynamically call tools to search conversations, create memories, manage action items
+- Proactively handle user requests with reasoning
+- Maintain consistent memory-driven interactions
+"""
+
+import asyncio
+import os
+from datetime import datetime, timezone
+from typing import AsyncGenerator, Dict, List, Optional
+
+from agents import Agent, ModelSettings, Runner
+from agents.mcp import MCPServerStdio
+from agents.model_settings import Reasoning
+
+import database.users as users_db
+from models.app import App
+from models.chat import ChatSession, Message
+from utils.llm.memory import get_prompt_memories
+from utils.retrieval.graph import AsyncStreamingCallback
+
+
+async def execute_agentic_chat_stream(
+    uid: str,
+    messages: List[Message],
+    app: Optional[App] = None,
+    chat_session: Optional[ChatSession] = None,
+    callback_data: dict = None,
+) -> AsyncGenerator[str, None]:
+    """
+    Execute agentic chat with streaming responses
+
+    Args:
+        uid: User ID
+        messages: Conversation history
+        app: Optional app/plugin configuration
+        chat_session: Optional chat session context
+        callback_data: Dict to store results (answer, memories_found, ask_for_nps, agent_actions)
+
+    Yields:
+        Streaming response chunks as "data: {token}" or None when complete
+    """
+    if callback_data is None:
+        callback_data = {}
+
+    # Get user context
+    user_name, memories_str = get_prompt_memories(uid)
+    user_profile = users_db.get_user(uid)
+    timezone_str = user_profile.get('timezone', 'UTC') if user_profile else 'UTC'
+
+    # Build system prompt based on context
+    system_prompt = _build_system_prompt(user_name, memories_str, timezone_str, app)
+
+    # Convert messages to agent format
+    agent_messages = _convert_messages_to_agent_format(messages)
+
+    # Initialize streaming callback
+    callback = AsyncStreamingCallback()
+
+    try:
+        # Connect to MCP server and run agent
+        async with MCPServerStdio(
+            cache_tools_list=True,
+            params={
+                "command": "uvx",
+                "args": ["mcp-server-omi", "-v"],
+                "env": {"UID": uid}  # Pass user ID to MCP server
+            }
+        ) as mcp_server:
+
+            # Create agent with MCP tools
+            omi_agent = Agent(
+                name="Omi Agent",
+                instructions=system_prompt,
+                mcp_servers=[mcp_server],
+                model=os.environ.get("AGENT_MODEL", "o4-mini"),
+                model_settings=ModelSettings(
+                    reasoning=Reasoning(
+                        effort=os.environ.get("AGENT_REASONING_EFFORT", "high"),
+                        summary="auto"
+                    ),
+                    temperature=0.7,
+                )
+            )
+
+            # Start agent execution
+            task = asyncio.create_task(
+                _run_agent_with_streaming(
+                    omi_agent,
+                    agent_messages,
+                    callback,
+                    callback_data
+                )
+            )
+
+            # Stream response tokens to client
+            while True:
+                try:
+                    chunk = await callback.queue.get()
+                    if chunk:
+                        # Remove "data: " prefix if present
+                        if isinstance(chunk, str) and chunk.startswith("data: "):
+                            chunk = chunk[len("data: "):]
+                        yield f"data: {chunk}\n\n"
+                    else:
+                        break
+                except asyncio.CancelledError:
+                    break
+
+            # Wait for agent to complete
+            await task
+
+            # Set default values if not set by agent
+            callback_data.setdefault('ask_for_nps', True)
+            callback_data.setdefault('memories_found', [])
+            callback_data.setdefault('agent_actions', [])
+
+            yield None
+
+    except Exception as e:
+        print(f"Error in execute_agentic_chat_stream: {e}")
+        import traceback
+        traceback.print_exc()
+
+        # Store error in callback_data
+        callback_data['error'] = str(e)
+        callback_data['answer'] = "I encountered an error processing your request. Please try again."
+
+        yield None
+
+
+async def _run_agent_with_streaming(
+    agent: Agent,
+    messages: List[Dict],
+    callback: AsyncStreamingCallback,
+    callback_data: dict
+) -> None:
+    """
+    Run the agent with streaming output
+
+    Args:
+        agent: The Omi agent instance
+        messages: Formatted message history
+        callback: Streaming callback for tokens
+        callback_data: Dict to store results
+    """
+    try:
+        # Run agent with streaming
+        result = Runner.run_streamed(
+            starting_agent=agent,
+            input=messages
+        )
+
+        # Collect full response
+        full_response = []
+        agent_actions = []
+
+        # Stream events
+        async for event in result.stream_events():
+            # Handle text delta events (streaming tokens)
+            if event.type == "raw_response_event":
+                if hasattr(event, 'data') and hasattr(event.data, 'delta'):
+                    delta = event.data.delta
+                    if isinstance(delta, str):
+                        full_response.append(delta)
+                        await callback.put_data(delta)
+
+            # Track tool calls/actions
+            elif event.type == "tool_call_event":
+                agent_actions.append({
+                    "tool": event.tool_name,
+                    "arguments": event.arguments,
+                    "timestamp": datetime.now(timezone.utc).isoformat()
+                })
+
+        # Wait for final result
+        await result.wait()
+
+        # Get final output
+        final_output = result.final_output if hasattr(result, 'final_output') else ''.join(full_response)
+
+        # Store in callback_data
+        callback_data['answer'] = final_output
+        callback_data['agent_actions'] = agent_actions
+
+        # Signal completion
+        await callback.end()
+
+    except Exception as e:
+        print(f"Error in _run_agent_with_streaming: {e}")
+        import traceback
+        traceback.print_exc()
+
+        callback_data['error'] = str(e)
+        await callback.end()
+
+
+def _build_system_prompt(
+    user_name: str,
+    memories_str: str,
+    timezone_str: str,
+    app: Optional[App] = None
+) -> str:
+    """
+    Build the system prompt for the agent
+
+    Args:
+        user_name: User's name
+        memories_str: Formatted string of user's memories
+        timezone_str: User's timezone
+        app: Optional app/plugin for custom prompts
+
+    Returns:
+        System prompt string
+    """
+    current_time = datetime.now(timezone.utc).isoformat()
+
+    if app and app.chat_prompt:
+        # Custom app prompt
+        base_prompt = f"""You are '{app.name}', {app.chat_prompt}
+
+**User Context:**
+Name: {user_name}
+Timezone: {timezone_str}
+Current Time: {current_time}
+
+**What you know about {user_name}:**
+{memories_str}
+"""
+    else:
+        # Default Omi prompt
+        base_prompt = f"""You are Omi, an intelligent AI assistant for {user_name}.
+
+**User Context:**
+Name: {user_name}
+Timezone: {timezone_str}
+Current Time: {current_time}
+
+**What you know about {user_name}:**
+{memories_str}
+"""
+
+    # Add tool usage instructions
+    tool_instructions = """
+
+**Your Capabilities:**
+You have access to powerful tools that let you:
+- Search through past conversations to recall information
+- Create and manage memories (facts about the user)
+- Create and track action items/tasks
+- Get user context and conversation summaries
+
+**When to Use Tools:**
+1. **search_conversations**: When the user asks about past discussions, wants to recall information, or asks "what did I say about X?"
+2. **create_memory**: Proactively create memories when the user shares:
+   - Personal preferences ("I love hiking")
+   - Important facts ("My birthday is June 15th")
+   - Goals or aspirations ("I want to learn Spanish")
+   - Relationships ("My sister's name is Sarah")
+3. **create_action_item**: Proactively create action items when the user mentions:
+   - Tasks they need to do ("I need to buy groceries")
+   - Reminders they want ("Remind me to call John")
+   - Future plans ("I should exercise tomorrow")
+4. **search_memories**: To recall what you know about the user before answering
+5. **list_action_items**: To check what's on their todo list
+6. **get_user_context**: To understand the user's current situation better
+
+**Proactive Behavior:**
+- Be helpful and anticipate user needs
+- Create memories and action items without being asked explicitly
+- Search conversations to provide informed responses
+- Be conversational and friendly, not robotic
+
+**Important:**
+- Always be concise and natural in your responses
+- Don't announce when you're using tools (just use them seamlessly)
+- Combine multiple tool calls when needed (e.g., search then summarize)
+- If a tool fails, gracefully continue the conversation
+"""
+
+    return base_prompt + tool_instructions
+
+
+def _convert_messages_to_agent_format(messages: List[Message]) -> List[Dict]:
+    """
+    Convert Omi Message objects to agent format
+
+    Args:
+        messages: List of Omi Message objects
+
+    Returns:
+        List of message dicts in agent format {"role": "user"/"assistant", "content": "..."}
+    """
+    agent_messages = []
+
+    for msg in messages:
+        role = "assistant" if msg.sender.value == "ai" else "user"
+
+        # Include text content
+        content = msg.text
+
+        # TODO: Handle file attachments if needed
+        # if msg.files_id:
+        #     content += f"\n[Attached {len(msg.files_id)} file(s)]"
+
+        agent_messages.append({
+            "role": role,
+            "content": content
+        })
+
+    return agent_messages
+
+
+def get_agent_config() -> dict:
+    """
+    Get agent configuration from environment variables
+
+    Returns:
+        Dict with agent configuration
+    """
+    return {
+        "model": os.environ.get("AGENT_MODEL", "o4-mini"),
+        "reasoning_effort": os.environ.get("AGENT_REASONING_EFFORT", "high"),
+        "temperature": float(os.environ.get("AGENT_TEMPERATURE", "0.7")),
+        "enabled": os.environ.get("ENABLE_AGENTIC_CHAT", "true").lower() == "true",
+        "fallback_enabled": os.environ.get("AGENTIC_CHAT_FALLBACK_ENABLED", "true").lower() == "true",
+    }
+
+
+# For testing
+if __name__ == "__main__":
+    from models.chat import MessageType
+
+    test_messages = [
+        Message(
+            id="1",
+            sender="human",
+            type=MessageType.text,
+            text="I love hiking and my favorite color is blue",
+            created_at=datetime.now(timezone.utc),
+        ),
+        Message(
+            id="2",
+            sender="ai",
+            type=MessageType.text,
+            text="That's great! I'll remember that you love hiking and blue is your favorite color.",
+            created_at=datetime.now(timezone.utc),
+        ),
+        Message(
+            id="3",
+            sender="human",
+            type=MessageType.text,
+            text="What do you know about my preferences?",
+            created_at=datetime.now(timezone.utc),
+        ),
+    ]
+
+    async def test():
+        callback_data = {}
+        async for chunk in execute_agentic_chat_stream(
+            uid="test_user_123",
+            messages=test_messages,
+            callback_data=callback_data
+        ):
+            if chunk:
+                print(chunk.replace("data: ", ""), end="", flush=True)
+
+        print("\n\nAgent Actions:", callback_data.get('agent_actions', []))
+
+    asyncio.run(test())


### PR DESCRIPTION
## Summary
- wire the new MCP-backed agent runner into chat routing with feature-flag control
- expose the dedicated MCP tool server for conversations, memories, and action items
- include regression tests and e2e harness for agent streaming