### PR TITLE
read initial battery level after device connection

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -92,6 +92,14 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     return await connection.disconnect();
   }
 
+  Future<int> _retrieveBatteryLevel(String deviceId) async {
+    var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+    if (connection == null) {
+      return -1;
+    }
+    return connection.retrieveBatteryLevel();
+  }
+
   Future<StreamSubscription<List<int>>?> _getBleBatteryLevelListener(
     String deviceId, {
     void Function(int)? onBatteryLevelChange,
@@ -304,6 +312,13 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     setisDeviceStorageSupport();
     setIsConnected(true);
 
+    // Read initial battery level
+    int currentLevel = await _retrieveBatteryLevel(device.id);
+    if (currentLevel != -1) {
+      batteryLevel = currentLevel;
+    }
+
+    // Then set up listener for battery changes
     await initiateBleBatteryListener();
     if (batteryLevel != -1 && batteryLevel < 20) {
       _hasLowBatteryAlerted = false;

--- a/app/lib/services/devices/omi_connection.dart
+++ b/app/lib/services/devices/omi_connection.dart
@@ -43,13 +43,6 @@ class OmiDeviceConnection extends DeviceConnection {
     void Function(int)? onBatteryLevelChange,
   }) async {
     try {
-      // Read initial battery level
-      final initialLevel = await performRetrieveBatteryLevel();
-      if (initialLevel != -1 && onBatteryLevelChange != null) {
-        debugPrint('Initial battery level: $initialLevel');
-        onBatteryLevelChange(initialLevel);
-      }
-
       final stream = transport.getCharacteristicStream(batteryServiceUuid, batteryLevelCharacteristicUuid);
 
       final subscription = stream.listen((value) {


### PR DESCRIPTION
The listener uses lastValueStream in `ble_transport`, but the lastValueStream in `flutter_blue_plus` only emits values when the characteristic changes or when new notifications arrive. It does not emit the current/initial value immediately upon subscription. So we retrieve the battery level while setting up the listener