### PR TITLE
fix: check if thumb file exists before unlinking

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -387,7 +387,8 @@ def upload_file_chat(files: List[UploadFile] = File(...), uid: str = Depends(aut
             fc.thumbnail = thumb_path
             # cleanup file thumb
             thumb_file = Path(fc.thumb_name)
-            thumb_file.unlink()
+            if thumb_file.exists():
+                thumb_file.unlink()
 
     # save db
     files_chat_dict = [fc.dict() for fc in files_chat]


### PR DESCRIPTION
closes #2707 

This was failing because `thumb_file.unlink()` was called without checking if the thumbnail file existed first.

https://github.com/user-attachments/assets/88609efa-08f2-41f7-a5d6-ff949dd5c4bb

demo: 

https://github.com/user-attachments/assets/5b01a9b6-f353-4cae-898b-687e33958425