### PR TITLE
Conversation folders

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -246,7 +246,7 @@ def filter_conversations_by_date(uid, start_date, end_date):
 
 @prepare_for_read(decrypt_func=_prepare_conversation_for_read)
 @with_photos(get_conversation_photos)
-def get_conversations_by_id(uid, conversation_ids):
+def get_conversations_by_id(uid, conversation_ids, include_discarded=False):
     user_ref = db.collection('users').document(uid)
     conversations_ref = user_ref.collection(conversations_collection)
 
@@ -257,7 +257,7 @@ def get_conversations_by_id(uid, conversation_ids):
     for doc in docs:
         if doc.exists:
             data = doc.to_dict()
-            if data.get('discarded'):
+            if not include_discarded and data.get('discarded'):
                 continue
             conversations.append(data)
 

--- a/backend/database/folders.py
+++ b/backend/database/folders.py
@@ -1,0 +1,334 @@
+from datetime import datetime, timezone
+from typing import List, Optional
+import uuid
+from google.cloud.firestore_v1 import FieldFilter
+from ._client import db
+
+folders_collection = 'folders'
+conversations_collection = 'conversations'
+
+
+def get_or_create_default_folder(uid: str) -> dict:
+    """Get or create default folder for user"""
+    user_ref = db.collection('users').document(uid)
+    folders_ref = user_ref.collection(folders_collection)
+
+    # Check for existing default folder
+    default_folders = folders_ref.where(filter=FieldFilter('is_default', '==', True)).limit(1).stream()
+    default_folder_docs = list(default_folders)
+
+    if default_folder_docs:
+        return default_folder_docs[0].to_dict()
+
+    # Create default folder
+    folder_id = str(uuid.uuid4())
+    folder_data = {
+        'id': folder_id,
+        'name': 'General',
+        'color': '#6B7280',
+        'icon': 'folder',
+        'created_at': datetime.now(timezone.utc),
+        'updated_at': datetime.now(timezone.utc),
+        'order': 0,
+        'is_default': True,
+        'conversation_count': 0,
+    }
+
+    folders_ref.document(folder_id).set(folder_data)
+
+    # Count conversations without folder_id (they belong to default) using aggregation
+    conversations_ref = user_ref.collection(conversations_collection)
+
+    # Total non-discarded conversations
+    total_query = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
+    total_count = total_query.count().get()[0][0].value
+
+    # Conversations assigned to folders (where folder_id field exists and has a value)
+    assigned_query = conversations_ref.where(filter=FieldFilter('discarded', '==', False)).where(
+        filter=FieldFilter('folder_id', '>', '')
+    )
+    assigned_count = assigned_query.count().get()[0][0].value
+
+    # Default folder count = total - assigned
+    unassigned_count = total_count - assigned_count
+
+    folders_ref.document(folder_id).update({'conversation_count': unassigned_count})
+    folder_data['conversation_count'] = unassigned_count
+
+    return folder_data
+
+
+def create_folder(uid: str, name: str, color: Optional[str] = None, icon: Optional[str] = None) -> dict:
+    """Create a new folder"""
+    user_ref = db.collection('users').document(uid)
+    folders_ref = user_ref.collection(folders_collection)
+
+    # Get max order
+    existing_folders = folders_ref.order_by('order', direction='DESCENDING').limit(1).stream()
+    max_order = 0
+    for folder in existing_folders:
+        max_order = folder.to_dict().get('order', 0)
+
+    folder_id = str(uuid.uuid4())
+    folder_data = {
+        'id': folder_id,
+        'name': name,
+        'color': color or '#6B7280',  # allow users to pick color from frontend/UI
+        'icon': icon or 'folder',  # allow users to pick icon from frontend/UI
+        'created_at': datetime.now(timezone.utc),
+        'updated_at': datetime.now(timezone.utc),
+        'order': max_order + 1,
+        'is_default': False,
+        'conversation_count': 0,
+    }
+
+    folders_ref.document(folder_id).set(folder_data)
+    return folder_data
+
+
+def get_folders(uid: str) -> List[dict]:
+    """Get all folders for a user"""
+    # Ensure default folder exists
+    get_or_create_default_folder(uid)
+
+    user_ref = db.collection('users').document(uid)
+    folders_ref = user_ref.collection(folders_collection)
+
+    folders = []
+    for doc in folders_ref.order_by('order').stream():
+        folder_data = doc.to_dict()
+        folders.append(folder_data)
+
+    return folders
+
+
+def get_folder(uid: str, folder_id: str) -> Optional[dict]:
+    """Get a specific folder"""
+    user_ref = db.collection('users').document(uid)
+    folder_ref = user_ref.collection(folders_collection).document(folder_id)
+    folder_doc = folder_ref.get()
+
+    if not folder_doc.exists:
+        return None
+
+    return folder_doc.to_dict()
+
+
+def update_folder(uid: str, folder_id: str, update_data: dict) -> bool:
+    """Update folder metadata"""
+    user_ref = db.collection('users').document(uid)
+    folder_ref = user_ref.collection(folders_collection).document(folder_id)
+
+    # Prevent changing is_default flag
+    if 'is_default' in update_data:
+        del update_data['is_default']
+
+    update_data['updated_at'] = datetime.now(timezone.utc)
+    folder_ref.update(update_data)
+    return True
+
+
+def delete_folder(uid: str, folder_id: str, move_conversations_to_folder_id: Optional[str] = None) -> bool:
+    """Delete a folder and move conversations to another folder"""
+    user_ref = db.collection('users').document(uid)
+    folder_ref = user_ref.collection(folders_collection).document(folder_id)
+
+    # Check if it's default folder
+    folder_data = folder_ref.get().to_dict()
+    if folder_data and folder_data.get('is_default'):
+        raise ValueError("Cannot delete default folder")
+
+    # Get target folder (default if not specified)
+    if move_conversations_to_folder_id is None:
+        target_folder = get_or_create_default_folder(uid)
+        move_conversations_to_folder_id = target_folder['id']
+
+    # Move all conversations to target folder
+    conversations_ref = user_ref.collection(conversations_collection)
+    conversations_to_move = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id)).stream()
+
+    batch = db.batch()
+    count = 0
+
+    for conv_doc in conversations_to_move:
+        batch.update(conv_doc.reference, {'folder_id': move_conversations_to_folder_id})
+        count += 1
+
+        if count >= 450:
+            batch.commit()
+            batch = db.batch()
+            count = 0
+
+    if count > 0:
+        batch.commit()
+
+    # Update conversation counts
+    update_folder_conversation_count(uid, move_conversations_to_folder_id)
+
+    # Delete folder
+    folder_ref.delete()
+
+    return True
+
+
+def move_conversation_to_folder(uid: str, conversation_id: str, folder_id: Optional[str]) -> bool:
+    """Move a conversation to a folder"""
+    user_ref = db.collection('users').document(uid)
+    conversation_ref = user_ref.collection(conversations_collection).document(conversation_id)
+
+    # Get current folder_id
+    conv_data = conversation_ref.get().to_dict()
+    if not conv_data:
+        return False
+
+    old_folder_id = conv_data.get('folder_id')
+
+    # If folder_id is None, get default folder
+    if folder_id is None:
+        default_folder = get_or_create_default_folder(uid)
+        folder_id = default_folder['id']
+
+    # Update conversation
+    conversation_ref.update({'folder_id': folder_id})
+
+    # Update conversation counts
+    if old_folder_id:
+        update_folder_conversation_count(uid, old_folder_id)
+    else:
+        # It was in default folder
+        default_folder = get_or_create_default_folder(uid)
+        update_folder_conversation_count(uid, default_folder['id'])
+
+    update_folder_conversation_count(uid, folder_id)
+
+    return True
+
+
+def update_folder_conversation_count(uid: str, folder_id: str):
+    """Update the conversation count for a folder using Firestore aggregation"""
+    user_ref = db.collection('users').document(uid)
+    folder_ref = user_ref.collection(folders_collection).document(folder_id)
+
+    folder_data = folder_ref.get().to_dict()
+    if not folder_data:
+        return
+
+    conversations_ref = user_ref.collection(conversations_collection)
+
+    # Count conversations in this folder using Firestore aggregation queries
+    if folder_data.get('is_default'):
+        # For default folder: total non-discarded - conversations in other folders
+        total_query = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
+        total_count = total_query.count().get()[0][0].value
+
+        # Conversations assigned to other folders (where folder_id field exists)
+        assigned_query = conversations_ref.where(filter=FieldFilter('discarded', '==', False)).where(
+            filter=FieldFilter('folder_id', '>', '')
+        )
+        assigned_count = assigned_query.count().get()[0][0].value
+
+        count = total_count - assigned_count
+    else:
+        # For regular folders, count conversations with this folder_id
+        query = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id)).where(
+            filter=FieldFilter('discarded', '==', False)
+        )
+        count = query.count().get()[0][0].value
+
+    folder_ref.update({'conversation_count': count})
+
+
+def get_conversations_in_folder(
+    uid: str, folder_id: Optional[str], limit: int = 100, offset: int = 0, include_discarded: bool = False
+) -> List[str]:
+    """
+    Get all conversation IDs in a folder.
+    Returns list of conversation IDs to be fetched using conversations_db.get_conversations
+    """
+    user_ref = db.collection('users').document(uid)
+    conversations_ref = user_ref.collection(conversations_collection)
+
+    # Filter by folder
+    if folder_id is None:
+        # Get default folder
+        default_folder = get_or_create_default_folder(uid)
+        folder_id = default_folder['id']
+
+    folder_data = get_folder(uid, folder_id)
+
+    if folder_data and folder_data.get('is_default'):
+        # For default folder, get conversations without folder_id or with default folder_id
+        query = conversations_ref
+        if not include_discarded:
+            query = query.where(filter=FieldFilter('discarded', '==', False))
+
+        query = query.order_by('created_at', direction='DESCENDING')
+
+        all_conversations = list(query.stream())
+        filtered_ids = []
+        for doc in all_conversations:
+            doc_data = doc.to_dict()
+            if doc_data.get('folder_id') == folder_id or doc_data.get('folder_id') is None:
+                filtered_ids.append(str(doc.id))
+
+        return filtered_ids[offset : offset + limit]
+    else:
+        # Regular folder
+        query = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id))
+
+        if not include_discarded:
+            query = query.where(filter=FieldFilter('discarded', '==', False))
+
+        query = query.order_by('created_at', direction='DESCENDING')
+        query = query.limit(limit).offset(offset)
+
+        return [str(doc.id) for doc in query.stream()]
+
+
+def bulk_move_conversations_to_folder(uid: str, conversation_ids: List[str], folder_id: str) -> bool:
+    """Move multiple conversations to a folder at once"""
+    user_ref = db.collection('users').document(uid)
+    conversations_ref = user_ref.collection(conversations_collection)
+
+    # Ensure folder exists
+    folder_data = get_folder(uid, folder_id)
+    if not folder_data:
+        return False
+
+    # Track affected folders for count updates
+    affected_folders = set()
+
+    batch = db.batch()
+    count = 0
+
+    # Get all conversations to be moved
+    for conversation_id in conversation_ids:
+        conv_ref = conversations_ref.document(conversation_id)
+        conv_data = conv_ref.get().to_dict()
+
+        if conv_data:
+            old_folder_id = conv_data.get('folder_id')
+            if old_folder_id:
+                affected_folders.add(old_folder_id)
+            else:
+                # Was in default folder
+                default_folder = get_or_create_default_folder(uid)
+                affected_folders.add(default_folder['id'])
+
+            batch.update(conv_ref, {'folder_id': folder_id})
+            count += 1
+
+            if count >= 450:
+                batch.commit()
+                batch = db.batch()
+                count = 0
+
+    if count > 0:
+        batch.commit()
+
+    # Update all affected folder counts
+    affected_folders.add(folder_id)
+    for affected_folder_id in affected_folders:
+        update_folder_conversation_count(uid, affected_folder_id)
+
+    return True

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from routers import (
     payment,
     integration,
     conversations,
+    folders,
     memories,
     mcp,
     oauth,
@@ -44,6 +45,7 @@ app = FastAPI()
 
 app.include_router(transcribe.router)
 app.include_router(conversations.router)
+app.include_router(folders.router)
 app.include_router(action_items.router)
 app.include_router(memories.router)
 app.include_router(chat.router)

--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -254,6 +254,7 @@ class Conversation(BaseModel):
     status: Optional[ConversationStatus] = ConversationStatus.completed
     is_locked: bool = False
     data_protection_level: Optional[str] = None
+    folder_id: Optional[str] = None
 
     def __init__(self, **data):
         super().__init__(**data)

--- a/backend/models/folder.py
+++ b/backend/models/folder.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from typing import Optional
+from pydantic import BaseModel, Field
+
+
+class Folder(BaseModel):
+    id: str
+    name: str = Field(min_length=1, max_length=100)
+    color: Optional[str] = '#6B7280'
+    icon: Optional[str] = 'folder'
+    created_at: datetime
+    updated_at: datetime
+    order: int = 0
+    is_default: bool = False
+    conversation_count: int = 0
+
+
+class CreateFolderRequest(BaseModel):
+    name: str = Field(min_length=1, max_length=100)
+    color: Optional[str] = None
+    icon: Optional[str] = None
+
+
+class UpdateFolderRequest(BaseModel):
+    name: Optional[str] = Field(None, min_length=1, max_length=100)
+    color: Optional[str] = None
+    icon: Optional[str] = None
+    order: Optional[int] = None
+
+
+class MoveConversationRequest(BaseModel):
+    folder_id: Optional[str] = None
+
+
+class BulkMoveConversationsRequest(BaseModel):
+    conversation_ids: list[str]
+    folder_id: str
+
+
+class DeleteFolderRequest(BaseModel):
+    move_conversations_to_folder_id: Optional[str] = None

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -94,7 +94,9 @@ def get_conversations(
         if not conversation_ids:
             conversations = []
         else:
-            conversations = conversations_db.get_conversations_by_id(uid, conversation_ids)
+            conversations = conversations_db.get_conversations_by_id(
+                uid, conversation_ids, include_discarded=include_discarded
+            )
     else:
         # Existing logic
         # force convos statuses to processing, completed on the empty filter

--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -1,0 +1,149 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from typing import List, Optional
+
+import database.folders as folders_db
+import database.conversations as conversations_db
+from models.folder import (
+    Folder,
+    CreateFolderRequest,
+    UpdateFolderRequest,
+    MoveConversationRequest,
+    BulkMoveConversationsRequest,
+    DeleteFolderRequest,
+)
+from models.conversation import Conversation
+from utils.other import endpoints as auth
+
+router = APIRouter()
+
+
+@router.get('/v1/folders', response_model=List[Folder], tags=['folders'])
+def get_folders(uid: str = Depends(auth.get_current_user_uid)):
+    """Get all folders for the current user"""
+    folders = folders_db.get_folders(uid)
+    return folders
+
+
+@router.post('/v1/folders', response_model=Folder, tags=['folders'])
+def create_folder(request: CreateFolderRequest, uid: str = Depends(auth.get_current_user_uid)):
+    """Create a new folder"""
+    folder = folders_db.create_folder(uid, name=request.name, color=request.color, icon=request.icon)
+    return folder
+
+
+@router.get('/v1/folders/{folder_id}', response_model=Folder, tags=['folders'])
+def get_folder(folder_id: str, uid: str = Depends(auth.get_current_user_uid)):
+    """Get a specific folder"""
+    folder = folders_db.get_folder(uid, folder_id)
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+    return folder
+
+
+@router.patch('/v1/folders/{folder_id}', response_model=Folder, tags=['folders'])
+def update_folder(folder_id: str, request: UpdateFolderRequest, uid: str = Depends(auth.get_current_user_uid)):
+    """Update folder metadata"""
+    folder = folders_db.get_folder(uid, folder_id)
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    update_data = {}
+    if request.name is not None:
+        update_data['name'] = request.name
+    if request.color is not None:
+        update_data['color'] = request.color
+    if request.icon is not None:
+        update_data['icon'] = request.icon
+    if request.order is not None:
+        update_data['order'] = request.order
+
+    if update_data:
+        folders_db.update_folder(uid, folder_id, update_data)
+
+    # Return updated folder
+    return folders_db.get_folder(uid, folder_id)
+
+
+@router.delete('/v1/folders/{folder_id}', status_code=204, tags=['folders'])
+def delete_folder(
+    folder_id: str,
+    move_to_folder_id: Optional[str] = Query(None, description="Target folder for conversations"),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """Delete a folder and move its conversations"""
+    folder = folders_db.get_folder(uid, folder_id)
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    if folder.get('is_default'):
+        raise HTTPException(status_code=400, detail="Cannot delete default folder")
+
+    try:
+        folders_db.delete_folder(uid, folder_id, move_to_folder_id)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+    return {"status": "Ok"}
+
+
+@router.get('/v1/folders/{folder_id}/conversations', response_model=List[Conversation], tags=['folders'])
+def get_folder_conversations(
+    folder_id: str,
+    limit: int = Query(100, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    include_discarded: bool = Query(False),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """Get all conversations in a folder"""
+    folder = folders_db.get_folder(uid, folder_id)
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    # Get conversation IDs in folder
+    conversation_ids = folders_db.get_conversations_in_folder(
+        uid, folder_id, limit=limit, offset=offset, include_discarded=include_discarded
+    )
+
+    # Fetch full conversations with proper decryption
+    if not conversation_ids:
+        return []
+
+    conversations = conversations_db.get_conversations_by_id(uid, conversation_ids)
+    return conversations
+
+
+@router.patch('/v1/conversations/{conversation_id}/folder', tags=['folders', 'conversations'])
+def move_conversation_to_folder(
+    conversation_id: str, request: MoveConversationRequest, uid: str = Depends(auth.get_current_user_uid)
+):
+    """Move a conversation to a folder"""
+    conversation = conversations_db.get_conversation(uid, conversation_id)
+    if not conversation:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+
+    # Verify folder exists (if not moving to default)
+    if request.folder_id is not None:
+        folder = folders_db.get_folder(uid, request.folder_id)
+        if not folder:
+            raise HTTPException(status_code=404, detail="Folder not found")
+
+    folders_db.move_conversation_to_folder(uid, conversation_id, request.folder_id)
+
+    return {"status": "Ok"}
+
+
+@router.post('/v1/folders/{folder_id}/conversations/bulk-move', tags=['folders'])
+def bulk_move_conversations(
+    folder_id: str, request: BulkMoveConversationsRequest, uid: str = Depends(auth.get_current_user_uid)
+):
+    """Move multiple conversations to a folder"""
+    folder = folders_db.get_folder(uid, folder_id)
+    if not folder:
+        raise HTTPException(status_code=404, detail="Folder not found")
+
+    success = folders_db.bulk_move_conversations_to_folder(uid, request.conversation_ids, folder_id)
+
+    if not success:
+        raise HTTPException(status_code=400, detail="Failed to move conversations")
+
+    return {"status": "Ok", "moved_count": len(request.conversation_ids)}

--- a/backend/routers/folders.py
+++ b/backend/routers/folders.py
@@ -108,7 +108,7 @@ def get_folder_conversations(
     if not conversation_ids:
         return []
 
-    conversations = conversations_db.get_conversations_by_id(uid, conversation_ids)
+    conversations = conversations_db.get_conversations_by_id(uid, conversation_ids, include_discarded=include_discarded)
     return conversations
 
 


### PR DESCRIPTION
this PR is related to ref #2561 

### What problem does this PR solve?
Currently conversations can't be categorized/organized into folders. Apps like Granola and Apple Notes do this well, so I took inspiration from them to add folder organization for user conversations.

### How did I do it?
1. Added `folder_id` field to conversations in Firestore (optional, defaults to None)
2. Created database operations in `database/folders.py` for folder CRUD and conversation management
3. Added folder-specific API endpoints in `routers/folders.py` (create, list, update, delete folders, move conversations)
4. Implemented lazy migration strategy: default "General" folder is created on first access

### Key Features
- Create/read/update/delete folders
- Move conversations between folders
- Bulk move operations
- Default folder auto-creation
- Folder-based conversation filtering
- Zero data loss for existing users (backward compatible)

Any feedback is appreciated!