### PR TITLE
fix: self hosting with non-ssl backend

### DIFF
--- a/app/lib/services/sockets/transcription_connection.dart
+++ b/app/lib/services/sockets/transcription_connection.dart
@@ -60,7 +60,11 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
         '&include_speech_profile=$includeSpeechProfile&stt_service=${SharedPreferencesUtil().transcriptionModel}'
         '&conversation_timeout=${SharedPreferencesUtil().conversationSilenceDuration}';
 
-    String url = '${Env.apiBaseUrl!.replaceAll('https', 'wss')}v4/listen$params';
+    String url = Env.apiBaseUrl!
+    .replaceFirst('https://', 'wss://')
+    .replaceFirst('http://', 'ws://') +
+    'v4/listen$params';
+
 
     _socket = PureSocket(url);
     _socket.setListener(this);


### PR DESCRIPTION
This pull request updates the way the WebSocket URL is constructed in the `TranscriptSegmentSocketService` class to more robustly handle both `http` and `https` base URLs. This ensures the correct WebSocket protocol (`ws://` or `wss://`) is used regardless of the original API base URL scheme.

**WebSocket URL construction improvement:**

* Updated the URL construction logic in `transcription_connection.dart` to replace both `https://` with `wss://` and `http://` with `ws://`, ensuring compatibility with different API base URL schemes.

The issue previously was that it would not replace http so transcription would not work.