### PR TITLE
move summary app ids from env to redis

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -658,3 +658,31 @@ def set_silent_user_notification_sent(uid: str, ttl: int = 60 * 60 * 24):
 def has_silent_user_notification_been_sent(uid: str) -> bool:
     """Check if silent user notification was already sent to user recently"""
     return r.exists(f'users:{uid}:silent_notification_sent')
+
+
+# ******************************************************
+# ******** CONVERSATION SUMMARY APP IDS ****************
+# ******************************************************
+
+CONVERSATION_SUMMARY_APPS_KEY = 'conversation_summary_app_ids'
+
+
+@try_catch_decorator
+def get_conversation_summary_app_ids() -> List[str]:
+    """Get list of conversation summary app IDs from Redis"""
+    app_ids = r.smembers(CONVERSATION_SUMMARY_APPS_KEY)
+    return [app_id.decode('utf-8') if isinstance(app_id, bytes) else app_id for app_id in app_ids] if app_ids else []
+
+
+@try_catch_decorator
+def add_conversation_summary_app_id(app_id: str) -> bool:
+    """Add an app ID to the conversation summary apps set"""
+    result = r.sadd(CONVERSATION_SUMMARY_APPS_KEY, app_id)
+    return result > 0
+
+
+@try_catch_decorator
+def remove_conversation_summary_app_id(app_id: str) -> bool:
+    """Remove an app ID from the conversation summary apps set"""
+    result = r.srem(CONVERSATION_SUMMARY_APPS_KEY, app_id)
+    return result > 0

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -40,6 +40,9 @@ from database.redis_db import (
     delete_app_cache_by_id,
     is_username_taken,
     save_username,
+    get_conversation_summary_app_ids,
+    add_conversation_summary_app_id,
+    remove_conversation_summary_app_id,
 )
 from utils.apps import (
     get_available_apps,
@@ -1053,3 +1056,45 @@ def delete_api_key(app_id: str, key_id: str, uid: str = Depends(auth.get_current
     delete_api_key_db(app_id, key_id)
 
     return {'status': 'ok', 'message': 'API key deleted'}
+
+
+# ******************************************************
+# ******** CONVERSATION SUMMARY APP IDS ****************
+# ******************************************************
+
+
+@router.get('/v1/summary-app-ids', tags=['v1'])
+def get_summary_app_ids(secret_key: str = Header(...)):
+    """Get all conversation summary app IDs from Redis"""
+    if secret_key != os.getenv('ADMIN_KEY'):
+        raise HTTPException(status_code=403, detail='Forbidden')
+
+    app_ids = get_conversation_summary_app_ids()
+    print(app_ids)
+    return {'app_ids': app_ids or []}
+
+
+@router.post('/v1/summary-app-ids/{app_id}', tags=['v1'])
+def add_summary_app_id(app_id: str, secret_key: str = Header(...)):
+    """Add an app ID to the conversation summary apps list"""
+    if secret_key != os.getenv('ADMIN_KEY'):
+        raise HTTPException(status_code=403, detail='Forbidden')
+
+    success = add_conversation_summary_app_id(app_id)
+    if success:
+        return {'status': 'ok', 'message': f'App {app_id} added to conversation summary apps'}
+    else:
+        return {'status': 'ok', 'message': f'App {app_id} already exists in conversation summary apps'}
+
+
+@router.delete('/v1/summary-app-ids/{app_id}', tags=['v1'])
+def delete_summary_app_id(app_id: str, secret_key: str = Header(...)):
+    """Remove an app ID from the conversation summary apps list"""
+    if secret_key != os.getenv('ADMIN_KEY'):
+        raise HTTPException(status_code=403, detail='Forbidden')
+
+    success = remove_conversation_summary_app_id(app_id)
+    if success:
+        return {'status': 'ok', 'message': f'App {app_id} removed from conversation summary apps'}
+    else:
+        raise HTTPException(status_code=404, detail=f'App {app_id} not found in conversation summary apps')

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -158,19 +158,33 @@ def _get_conversation_obj(
     return conversation
 
 
-# Get default conversation summary app IDs from environment variable
-CONVERSATION_SUMMARIZED_APP_IDS = os.getenv(
-    'CONVERSATION_SUMMARIZED_APP_IDS', 'summary_assistant,action_item_extractor,insight_analyzer'
-).split(',')
-
-
-# Function to get default memory apps
+# Function to get conversation summary apps from Redis
 def get_default_conversation_summarized_apps():
+    """
+    Get conversation summary apps from Redis.
+    Falls back to environment variable if Redis is empty.
+    """
     default_apps = []
-    for app_id in CONVERSATION_SUMMARIZED_APP_IDS:
-        app_data = get_app_by_id_db(app_id.strip())
-        if app_data:
-            default_apps.append(App(**app_data))
+
+    # Try to get from Redis first
+    redis_app_ids = redis_db.get_conversation_summary_app_ids()
+
+    if redis_app_ids:
+        # Use apps from Redis
+        for app_id in redis_app_ids:
+            app_data = get_app_by_id_db(app_id.strip())
+            if app_data:
+                default_apps.append(App(**app_data))
+    else:
+        # Fallback to environment variable for backward compatibility
+        env_app_ids = os.getenv(
+            'CONVERSATION_SUMMARIZED_APP_IDS', 'summary_assistant,action_item_extractor,insight_analyzer'
+        ).split(',')
+
+        for app_id in env_app_ids:
+            app_data = get_app_by_id_db(app_id.strip())
+            if app_data:
+                default_apps.append(App(**app_data))
 
     return default_apps
 


### PR DESCRIPTION
move summary app ids from env to redis so that they can be easily managed from the admin dashboard

<img width="1644" height="697" alt="Screenshot 2025-10-04 at 11 40 36 PM" src="https://github.com/user-attachments/assets/ae9cfbe7-ee3d-4cd4-89cf-651bb019d077" />
