### PR TITLE
Add Python Version Compatibility Documentation for Backend Setup

### DIFF
--- a/docs/doc/developer/backend/Backend_Setup.mdx
+++ b/docs/doc/developer/backend/Backend_Setup.mdx
@@ -217,6 +217,7 @@ Before you start, make sure you have the following:
     You have two options for installing the required Python packages:
 
     **Option A: Using a Virtual Environment (Recommended) 🐍**
+    - Use Compatible Python Version (>=3.9,<3.13)
     - It's recommended to use a virtual environment to isolate your project dependencies and avoid conflicts
     - Create a new virtual environment in the backend directory:
       ```bash


### PR DESCRIPTION
I tried to setup the Omi backend using Python 3.13 encounter installation errors due to dependency version constraints. The current `langchain-pinecone==0.2.0` dependency requires Python `>=3.9,<3.13`, making it incompatible with Python 3.13
