### PR TITLE
Fix: Enable clickable links in OMI chat responses #3210

### DIFF
--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -1,30 +1,24 @@
 import 'dart:convert';
-
 import 'package:auto_size_text/auto_size_text.dart';
-import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omi/pages/chat/widgets/files_handler_widget.dart';
 import 'package:omi/backend/http/api/conversations.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message.dart';
-import 'package:omi/gen/assets.gen.dart';
 import 'package:omi/pages/chat/widgets/typing_indicator.dart';
 import 'package:omi/pages/conversation_detail/conversation_detail_provider.dart';
 import 'package:omi/pages/conversation_detail/page.dart';
 import 'package:omi/providers/connectivity_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
-import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/widgets/extensions/string.dart';
 import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
-import 'package:share_plus/share_plus.dart';
-
+import '../../../utils/link_utils.dart';
 import 'markdown_message_widget.dart';
 
 class AIMessage extends StatefulWidget {
@@ -268,6 +262,20 @@ class NormalMessageWidget extends StatelessWidget {
     this.thinkings = const [],
   });
 
+  Widget _buildMessageText(BuildContext context, String text) {
+    if (LinkUtils.containsMarkdown(text)) {
+      return getMarkdownWidget(context, text);
+    }
+
+    return LinkUtils.buildRichText(
+      text,
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: 15,
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     var previousThinkingText = message.thinkings.length > 1
@@ -286,9 +294,9 @@ class NormalMessageWidget extends StatelessWidget {
         showTypingIndicator && messageText.isEmpty
             ? Container(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF1f1f25),
-                  borderRadius: const BorderRadius.only(
+                decoration: const BoxDecoration(
+                  color: Color(0xFF1f1f25),
+                  borderRadius: BorderRadius.only(
                     topLeft: Radius.circular(4.0),
                     topRight: Radius.circular(16.0),
                     bottomRight: Radius.circular(16.0),
@@ -348,16 +356,16 @@ class NormalMessageWidget extends StatelessWidget {
             ? const SizedBox.shrink()
             : Container(
                 padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-                decoration: BoxDecoration(
-                  color: const Color(0xFF1f1f25),
-                  borderRadius: const BorderRadius.only(
+                decoration: const BoxDecoration(
+                  color: Color(0xFF1f1f25),
+                  borderRadius: BorderRadius.only(
                     topLeft: Radius.circular(4.0),
                     topRight: Radius.circular(16.0),
                     bottomRight: Radius.circular(16.0),
                     bottomLeft: Radius.circular(16.0),
                   ),
                 ),
-                child: getMarkdownWidget(context, messageText),
+                child: _buildMessageText(context, messageText),
               ),
       ],
     );

--- a/app/lib/pages/chat/widgets/markdown_message_widget.dart
+++ b/app/lib/pages/chat/widgets/markdown_message_widget.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 
 Widget getMarkdownWidget(BuildContext context, String content) {
-  var style = TextStyle(color: Colors.white, fontSize: 16, height: 1.5);
+  var style = const TextStyle(color: Colors.white, fontSize: 16, height: 1.5);
   return MarkdownBody(
     selectable: false,
     shrinkWrap: true,
@@ -17,7 +17,7 @@ Widget getMarkdownWidget(BuildContext context, String content) {
         color: Colors.white,
       ),
       blockquoteDecoration: BoxDecoration(
-        color: Color(0xFF35343B),
+        color: const Color(0xFF35343B),
         borderRadius: BorderRadius.circular(4),
       ),
       code: style.copyWith(

--- a/app/lib/pages/chat/widgets/user_message.dart
+++ b/app/lib/pages/chat/widgets/user_message.dart
@@ -1,13 +1,28 @@
 import 'package:flutter/material.dart';
 import 'package:omi/backend/schema/message.dart';
 import 'package:omi/pages/chat/widgets/files_handler_widget.dart';
+import 'package:omi/utils/link_utils.dart';
 import 'package:omi/widgets/extensions/string.dart';
-import 'package:omi/utils/other/temp.dart';
+import 'markdown_message_widget.dart';
 
 class HumanMessage extends StatelessWidget {
   final ServerMessage message;
 
   const HumanMessage({super.key, required this.message});
+
+  Widget _buildMessageText(BuildContext context, String text) {
+    if (LinkUtils.containsMarkdown(text)) {
+      return getMarkdownWidget(context, text);
+    }
+
+    return LinkUtils.buildRichText(
+      text,
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: 15,
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -31,21 +46,17 @@ class HumanMessage extends StatelessWidget {
             alignment: WrapAlignment.end,
             children: [
               Container(
-                decoration: BoxDecoration(
-                  color: const Color(0xFF1f1f25),
-                  borderRadius: const BorderRadius.only(
-                    topLeft: Radius.circular(16.0),
-                    topRight: Radius.circular(16.0),
-                    bottomRight: Radius.circular(4.0),
-                    bottomLeft: Radius.circular(16.0),
+                  decoration: const BoxDecoration(
+                    color: Color(0xFF1f1f25),
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(16.0),
+                      topRight: Radius.circular(16.0),
+                      bottomRight: Radius.circular(4.0),
+                      bottomLeft: Radius.circular(16.0),
+                    ),
                   ),
-                ),
-                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
-                child: Text(
-                  message.text.decodeString,
-                  style: const TextStyle(color: Colors.white, fontSize: 16),
-                ),
-              ),
+                  padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                  child: _buildMessageText(context, message.text.decodeString)),
             ],
           ),
         ],

--- a/app/lib/utils/link_utils.dart
+++ b/app/lib/utils/link_utils.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+class LinkUtils {
+  static final urlPattern = RegExp(
+    r'(?:(?:https?|ftp):\/\/|www\.)[^\s/$.?#].[^\s]*',
+    caseSensitive: false,
+  );
+
+  static bool containsMarkdown(String text) {
+    return text.contains('**') || text.contains('##') || text.contains('*') || text.contains('`');
+  }
+
+  static List<TextSpan> buildTextSpans(
+    String text, {
+    TextStyle? defaultStyle,
+    TextStyle? linkStyle,
+  }) {
+    final spans = <TextSpan>[];
+    final defaultTextStyle = defaultStyle ?? const TextStyle();
+    final urlTextStyle = linkStyle ??
+        defaultStyle?.copyWith(
+          color: Colors.blue,
+          decoration: TextDecoration.underline,
+          decorationColor: Colors.blue,
+        ) ??
+        const TextStyle(
+          color: Colors.blue,
+          decoration: TextDecoration.underline,
+          decorationColor: Colors.blue,
+        );
+
+    text.splitMapJoin(
+      urlPattern,
+      onMatch: (match) {
+        final url = match.group(0)!;
+        final displayUrl = url.replaceFirst(RegExp(r'^https?://'), '');
+
+        spans.add(TextSpan(
+          text: displayUrl,
+          style: urlTextStyle,
+          recognizer: TapGestureRecognizer()..onTap = () => launchUrlString(url),
+        ));
+        return '';
+      },
+      onNonMatch: (text) {
+        if (text.isNotEmpty) {
+          spans.add(TextSpan(text: text, style: defaultTextStyle));
+        }
+        return '';
+      },
+    );
+
+    return spans;
+  }
+
+  static Future<void> launchUrlString(String url) async {
+    try {
+      final uri = url.startsWith(RegExp(r'https?://')) ? Uri.parse(url) : Uri.parse('https://$url');
+
+      if (await canLaunchUrl(uri)) {
+        await launchUrl(
+          uri,
+          mode: LaunchMode.externalApplication,
+          webViewConfiguration: const WebViewConfiguration(
+            enableJavaScript: true,
+          ),
+        );
+      } else {
+        debugPrint('Could not launch URL: $url');
+      }
+    } catch (e, stackTrace) {
+      debugPrint('Error launching URL: $e\n$stackTrace');
+    }
+  }
+
+  static Widget buildRichText(
+    String text, {
+    TextStyle? style,
+    TextAlign? textAlign,
+    int? maxLines,
+    TextOverflow? overflow,
+  }) {
+    return RichText(
+      text: TextSpan(
+        children: buildTextSpans(
+          text,
+          defaultStyle: style,
+        ),
+        style: style,
+      ),
+      textAlign: textAlign ?? TextAlign.start,
+      maxLines: maxLines,
+      overflow: overflow ?? TextOverflow.clip,
+    );
+  }
+}


### PR DESCRIPTION
Created LinkUtils utility class with reusable URL handling methods
Removed duplicate URL detection and link handling code
Updated both message components to use the shared utility
Improved URL regex pattern for better matching

Here is Output:
<img width="282" height="407" alt="Screenshot 2025-10-17 at 3 29 42 PM" src="https://github.com/user-attachments/assets/e696ae29-df3e-4973-9b3e-579a2d6040c0" />
