### PR TITLE
Fix the fal api; using segment level for chat

### DIFF
--- a/backend/utils/chat.py
+++ b/backend/utils/chat.py
@@ -118,7 +118,7 @@ async def process_voice_message_segment_stream(path: str, uid: str) -> AsyncGene
 
     threading.Thread(target=delete_file).start()
 
-    words, language = fal_whisperx(url, 3, 2, True)
+    words = fal_whisperx(audio_url=url, diarize=False, chunk_level="segment")
     transcript_segments: List[TranscriptSegment] = fal_postprocessing(words, 0)
     if not transcript_segments:
         print('failed to get fal segments')

--- a/backend/utils/stt/pre_recorded.py
+++ b/backend/utils/stt/pre_recorded.py
@@ -9,7 +9,12 @@ from utils.other.endpoints import timeit
 
 @timeit
 def fal_whisperx(
-    audio_url: str, speakers_count: int = None, attempts: int = 0, return_language: bool = False
+    audio_url: str,
+    speakers_count: int = None,
+    attempts: int = 0,
+    return_language: bool = False,
+    diarize: bool = True,
+    chunk_level: str = 'word',
 ) -> List[dict]:
     print('fal_whisperx', audio_url, speakers_count, attempts)
 
@@ -19,8 +24,8 @@ def fal_whisperx(
             arguments={
                 "audio_url": audio_url,
                 'task': 'transcribe',
-                'diarize': True,
-                'chunk_level': 'word',
+                'diarize': diarize,
+                'chunk_level': chunk_level,
                 'version': '3',
                 'batch_size': 64,
                 'num_speakers': speakers_count,
@@ -32,7 +37,9 @@ def fal_whisperx(
         if not words:
             raise Exception('No chunks found')
         if return_language:
-            return words, result.get('inferred_languages', ['en'])[0]
+            languages = result.get('inferred_languages', ['en'])
+            language = languages[0] if languages else 'en'
+            return words, language
         return words
     except Exception as e:
         print(e)


### PR DESCRIPTION
**what's included?**
- fal changed the response to not respond to the inferred languages (leave it empty) for requests sometimes; need to support these cases.
- enhance the speed by using the segment level + not diarized for chat

**deploy**
- deploy backend https://github.com/BasedHardware/omi/actions/runs/18610426419

**demo:**

  ```
api-1      | fal_whisperx https://storage.googleapis.com/syncing-local-development//tmp/OAEZL1gRvOQmLLg6E3BzjNpEmtf1_acef48d9-a9cc-4a0d-a04d-d6edfdbf7788.wav?X-Goog-Algorithm=GOOG4-RSA-SHA256&X-Goog-Credential=local-development-joan%40based-hardware-dev.iam.gserviceaccount.com%2F20251018%2Fauto%2Fstorage%2Fgoog4_request&X-Goog-Date=20251018T034114Z&X-Goog-Expires=900&X-Goog-SignedHeaders=host&X-Goog-Signature=13a0e7d1998a9aa4c3ce0f0571fe9bf1fb13f38db65a13c0bfc452defc229ad018299b45b325f23376a58983075c95397ba26ba2d1d72ed67f8ce694b9649530fd2daaca5dfef976466d53d211d72cb6899b36bdde4d3c1e88166c11eeebffdcff952ede84f09b818cdfc1af7a4fbdddc6fd0f786d1417eeb8b3b5c412b7e8f741b9a333c2733d98e57b85d404757aee3b2faf6b4ba669966a6d46ff985c9ac220ddf6d60bb01cd29cb0409864aea0ebe5e6e6322116b4338ef4c00574d03986e8f76f03c02ef988685e6631fcd98904cfa68c15082ea6fd68025dc91699feea05fc44b6970b0609c7f1ad033c3800044905c01935bf942543f93a68d59e26cc 3 2
api-1      | {'text': ' Sorry, can you hear me?', 'chunks': [{'timestamp': [30.01, 30.01], 'text': ' Sorry,', 'speaker': None}, {'timestamp': [30.01, 30.01], 'text': ' can', 'speaker': None}, {'timestamp': [30.01, 30.01], 'text': ' you', 'speaker': None}, {'timestamp': [30.01, 30.01], 'text': ' hear', 'speaker': None}, {'timestamp': [30.01, 30.01], 'text': ' me?', 'speaker': None}], 'inferred_languages': [], 'diarization_segments': []}
api-1      | Processing time of fal_whisperx(): 4.26 seconds.                                                                         api-1      | INFO:     192.168.97.1:36494 - "POST /v2/voice-message/transcribe HTTP/1.1" 200 OK
```