### PR TITLE
fix: handle null case when uninstalling app

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -252,9 +252,11 @@ class SharedPreferencesUtil {
 
   disableApp(String value) {
     final List<App> apps = appsList;
-    final app = apps.firstWhere((element) => element.id == value);
-    app.enabled = false;
-    appsList = apps;
+    App? app = apps.firstWhereOrNull((element) => element.id == value);
+    if (app != null) {
+      app.enabled = false;
+      appsList = apps;
+    }
   }
 
   String get selectedChatAppId => getString('selectedChatAppId2') ?? 'no_selected';


### PR DESCRIPTION
closes #3241

before:

https://github.com/user-attachments/assets/d00d815c-8419-4c1b-96fb-ec20365fba44

logs:

```
flutter: ----------------FIREBASE CRASHLYTICS----------------
flutter: Bad state: No element
flutter: 
#0      ListBase.firstWhere (dart:collection/list.dart:132:5)
#1      SharedPreferencesUtil.disableApp (package:omi/backend/preferences.dart:255:22)
#2      _AppDetailPageState._toggleApp (package:omi/pages/apps/app_detail/app_detail.dart:1129:13)
#3      _AppDetailPageState.build.<anonymous closure> (package:omi/pages/apps/app_detail/app_detail.dart:576:48)
#4      _AnimatedLoadingButtonState._handleOnPressed (package:omi/widgets/animated_loading_button.dart:38:27)
#5      _InkResponseState.handleTap (package:flutter/src/material/ink_well.dart:1204:21)
#6      GestureRecognizer.invokeCallback (package:flutter/src/gestures/recognizer.dart:345:24)
#7      TapGestureRecognizer.handleTapUp (package:flutter/src/gestures/tap.dart:758:11)
#8      BaseTapGestureRecognizer._checkUp (package:flutter/src/gestures/tap.dart:383:5)
#9      BaseTapGestureRecognizer.acceptGesture (package:flutter/src/gestures/tap.dart:353:7)
#10     GestureArenaManager.sweep (package:flutter/src/gestures/arena.dart:173:27)
#11
```

after:

https://github.com/user-attachments/assets/26ea5c91-e73a-44f4-ba76-4b804876c5df

<img width="1032" height="257" alt="Screenshot 2025-10-18 at 11 15 52 PM" src="https://github.com/user-attachments/assets/44e4e46b-b654-4599-84ee-8ee0920b1cd3" />
