### PR TITLE
omi chat: citing instructions, quality control, more accurate time extraction on the point-in-time query

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -313,6 +313,21 @@ class Conversation(BaseModel):
             conversation_str = (
                 f"Conversation #{i + 1}\n"
                 f"{formatted_date} ({str(conversation.structured.category.value).capitalize()})\n"
+            )
+
+            # Add started_at and finished_at if available
+            if conversation.started_at:
+                formatted_started = (
+                    conversation.started_at.astimezone(timezone.utc).strftime("%d %b %Y at %H:%M") + " UTC"
+                )
+                conversation_str += f"Started: {formatted_started}\n"
+            if conversation.finished_at:
+                formatted_finished = (
+                    conversation.finished_at.astimezone(timezone.utc).strftime("%d %b %Y at %H:%M") + " UTC"
+                )
+                conversation_str += f"Finished: {formatted_finished}\n"
+
+            conversation_str += (
                 f"{str(conversation.structured.title).capitalize()}\n"
                 f"{str(conversation.structured.overview).capitalize()}\n"
             )

--- a/backend/scripts/chat/stream_test.py
+++ b/backend/scripts/chat/stream_test.py
@@ -23,7 +23,7 @@ import routers.chat as chat_routers
 
 
 async def test_stream():
-    uid = "eLC***"
+    uid = "GPW9***"
     response = chat_routers.send_message(
         # data=chat_models.SendMessageRequest(
         #    text="Did i discuss anything abt yacht party recently? If yes do you think that partnership makes sense for us",
@@ -51,10 +51,16 @@ async def test_stream():
         # ),
         # uid=uid,
         # data=chat_models.SendMessageRequest(
-        #     text="summarise my week",
+        #     text="summarise my month",
         #     file_ids=[],  # ['x']
         # ),
         # uid=uid,
+        # data=chat_models.SendMessageRequest(
+        #     text="what did i discuss in the last 3 hours ago",
+        #     file_ids=[],  # ['x']
+        # ),
+        # uid=uid,
+        #
         ### MEMORIES TOOLS
         #
         # data=chat_models.SendMessageRequest(
@@ -92,11 +98,22 @@ async def test_stream():
         #
         # OMI docs
         #
-        data=chat_models.SendMessageRequest(
-            text="how to flash the omi consumer cv1 firmware ?",
-            file_ids=[],  # ['x']
-        ),
-        uid=uid,
+        # data=chat_models.SendMessageRequest(
+        #    text="how to flash the omi consumer cv1 firmware ?",
+        #    file_ids=[],  # ['x']
+        # ),
+        # uid=uid,
+        ## testing
+        # data=chat_models.SendMessageRequest(
+        #     text="what did i discuss 3 hours ago",
+        #     file_ids=[],  # ['x']
+        # ),
+        # uid=uid,
+        # data=chat_models.SendMessageRequest(
+        #     text="what did i discuss in the last 3 hours ago",
+        #     file_ids=[],  # ['x']
+        # ),
+        # uid=uid,
     )
 
     # Read the stream


### PR DESCRIPTION
add support for citing instructions, quality control, and more accurate time extraction on the point-in-time query for omi chat

**deploy:**

- [x] deploy backend https://github.com/BasedHardware/omi/actions/runs/18628934015


**known issues:**

- llm caching might help an instance's response to reduce costs but could result in not calling tools -> lost the citation.