### PR TITLE
Button delays fix + remove startup led sequence

### DIFF
--- a/omi/firmware/omi/src/lib/core/button.c
+++ b/omi/firmware/omi/src/lib/core/button.c
@@ -12,6 +12,7 @@
 #include <zephyr/pm/device_runtime.h>
 #include <zephyr/sys/poweroff.h>
 
+#include "haptic.h"
 #include "led.h"
 #include "mic.h"
 #include "speaker.h"
@@ -216,10 +217,22 @@ void check_button_level(struct k_work *work_item)
         LOG_INF("single tap detected\n");
         btn_last_event = event;
         notify_tap();
+
+        // Immediate feedback: LED off and haptic
+        led_off();
+        // Set is_off immediately so set_led_state() keeps LEDs off
+        is_off = true;
+
+#ifdef CONFIG_OMI_ENABLE_HAPTIC
+        play_haptic_milli(100);
+        k_msleep(300);
+        haptic_off();
+#endif
+
+        // Delays for stability
         k_msleep(1000);
 
         // // Enter the low power mode
-        is_off = true;
         transport_off();
         k_msleep(300);
         turnoff_all();
@@ -351,16 +364,6 @@ void turnoff_all()
 {
     int rc;
 
-    led_off();
-    k_msleep(100);
-
-    // Play haptic feedback if enabled
-#ifdef CONFIG_OMI_ENABLE_HAPTIC
-    play_haptic_milli(100);
-    k_msleep(300);
-    haptic_off();
-#endif
-
     // Always turn off microphone
     mic_off();
     k_msleep(100);
@@ -381,7 +384,6 @@ void turnoff_all()
         app_sd_off();
     }
     k_msleep(300);
-
 
     // Put the buttons device to sleep if button is enabled
 #ifdef CONFIG_OMI_ENABLE_BUTTON

--- a/omi/firmware/omi/src/main.c
+++ b/omi/firmware/omi/src/main.c
@@ -87,18 +87,17 @@ static void boot_ready_sequence(void)
 
 void set_led_state()
 {
+    // If device is off, turn off all LEDs immediately
+    if (is_off) {
+        led_off();
+        return;
+    }
+
     // Set LED state based on connection and charging status
     if (is_charging) {
         set_led_green(true);
     } else {
         set_led_green(false);
-    }
-
-    // If device is off, turn off all status LEDs except charging indicator
-    if (is_off) {
-        set_led_red(false);
-        set_led_blue(false);
-        return;
     }
 
     if (is_connected) {
@@ -107,7 +106,6 @@ void set_led_state()
         return;
     }
 
-    // Not connected - RED
     if (!is_connected) {
         set_led_red(true);
         set_led_blue(false);
@@ -131,7 +129,8 @@ int main(void)
 
     printk("Starting omi ...\n");
 
-    // Initialize Haptic driver first; this is building up for future of omi turn on sequence - long press to turn on instead of short press
+    // Initialize Haptic driver first; this is building up for future of omi turn on sequence - long press to turn on
+    // instead of short press
 #ifdef CONFIG_OMI_ENABLE_HAPTIC
     ret = haptic_init();
     if (ret) {
@@ -268,9 +267,6 @@ int main(void)
     }
 
     LOG_INF("Device initialized successfully\n");
-
-    // Show ready sequence
-    // boot_ready_sequence();
 
     while (1) {
         monitor_log_metrics();


### PR DESCRIPTION
- there was a delay after clicking button to turn off and seeing led actually get turned off and feeling the haptic - removed this
- removed led startup sequence since it was redundant and provides no value to the user