### PR TITLE
Ignore first measurement and remove Moving Agverage filter

### DIFF
--- a/omi/firmware/omi/src/battery.c
+++ b/omi/firmware/omi/src/battery.c
@@ -245,6 +245,7 @@ int battery_get_millivolt(uint16_t *battery_millivolt)
     if (is_first_measurement) {
         LOG_INF("First measurement, skipping to allow voltage to stabilize");
         is_first_measurement = false;
+        k_mutex_unlock(&battery_mut);
         return -EAGAIN; // Skip first measurement to allow voltage to stabilize
     }
 


### PR DESCRIPTION
- The first measurement is very noisy, especially after the device has been powered off for an extended period (around one hour). My assumption is that the `C42` capacitor requires some time to stabilize after power-up.
- No need to apply `MA filter` for milivoltage measurement --> we already have` EMA filter` for battery percentage

Step to preproduce:
1. turn off the device
2. put it for ~1hour
3. turn on the device

<img width="955" height="573" alt="image" src="https://github.com/user-attachments/assets/7201a276-5831-426a-b366-e7c8379899a2" />
