### PR TITLE
fix: ble write handling

### DIFF
--- a/app/lib/services/devices/transports/ble_transport.dart
+++ b/app/lib/services/devices/transports/ble_transport.dart
@@ -208,12 +208,10 @@ class BleTransport extends DeviceTransport {
         } catch (e) {
           if (_isDisconnectionError(e)) {
             debugPrint('Device Disconnected');
-            _updateState(DeviceTransportState.disconnected);
             return;
           }
 
           if (!_bleDevice.isConnected) {
-            _updateState(DeviceTransportState.disconnected);
             return;
           }
 


### PR DESCRIPTION
Android processes only one ble write at once, that’s why it was crashing

fix: added sequential queue, timeout, and busy error handling

closes #3440 
