### PR TITLE
fix remove usage of batch

### DIFF
--- a/app/lib/utils/analytics/mixpanel.dart
+++ b/app/lib/utils/analytics/mixpanel.dart
@@ -28,9 +28,8 @@ class MixpanelManager {
           }
         } else {
           // Use mixpanel_analytics for desktop platforms
-          _mixpanelAnalytics ??= MixpanelAnalytics.batch(
+          _mixpanelAnalytics ??= MixpanelAnalytics(
             token: Env.mixpanelProjectToken!,
-            uploadInterval: const Duration(seconds: 3),
             userId$: Stream.value(_preferences.uid),
             useIp: true,
             verbose: false,


### PR DESCRIPTION
removed usage of `.batch` because it crashes in the `MixpanelAnalytics` queue handling

closes #3569 