### PR TITLE
feat: Add support for pt-BR in transcription services

### DIFF
--- a/app/lib/providers/home_provider.dart
+++ b/app/lib/providers/home_provider.dart
@@ -30,6 +30,7 @@ class HomeProvider extends ChangeNotifier {
     'Chinese (Mandarin, Simplified)': 'zh',
     'Hindi': 'hi',
     'Portuguese': 'pt',
+    'Portuguese (Brazil)': 'pt-BR',
     'Russian': 'ru',
     'Japanese': 'ja',
     'German': 'de',

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -185,7 +185,8 @@ def get_stt_service_for_language(language: str):
     for m in stt_service_models:
         # Soniox
         if m == 'soniox-stt-rt':
-            if language in soniox_multi_languages:
+            check_lang = 'pt' if language == 'pt-BR' else language
+            if check_lang in soniox_multi_languages:
                 return STTService.soniox, 'multi', 'stt-rt-preview'
         # DeepGram Nova-3
         elif m == 'dg-nova-3':
@@ -425,7 +426,7 @@ async def process_audio_soniox(
         'sample_rate': sample_rate,
         'num_channels': 1,
         'enable_speaker_tags': True,
-        'language_hints': language_hints,
+        'language_hints': [l if l != 'pt-BR' else 'pt' for l in language_hints],
     }
 
     # Add speaker identification if available
@@ -576,6 +577,10 @@ async def process_audio_soniox(
 async def process_audio_speechmatics(stream_transcript, sample_rate: int, language: str, preseconds: int = 0):
     api_key = os.getenv('SPEECHMATICS_API_KEY')
     uri = 'wss://eu2.rt.speechmatics.com/v2'
+
+        # Speechmatics doesn't support pt-BR
+    if language == 'pt-BR':
+        language = 'pt'
 
     request = {
         "message": "StartRecognition",


### PR DESCRIPTION
hey team! I'd like Omi to support pt-BR transcription so:

Added Portuguese (Brazil) (pt-BR) to the language selection menu in home_provider.dart

Updated streaming.py to support pt-BR. Deepgram handles pt-BR natively, while Soniox and Speechmatics now fallback to pt (European Portuguese) as they do not support the Brazilian variant.

Motivation: To enhance the user experience for Brazilian speakers by allowing them to select their native language, while ensuring compatibility across all supported STT providers.