### PR TITLE
fix: account deletion: clear cache

### DIFF
--- a/app/lib/pages/settings/delete_account.dart
+++ b/app/lib/pages/settings/delete_account.dart
@@ -5,6 +5,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/core/app_shell.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/other/temp.dart';
+import 'package:omi/utils/wal_file_manager.dart';
 import 'package:omi/widgets/dialog.dart';
 import 'package:gradient_borders/gradient_borders.dart';
 
@@ -33,6 +34,7 @@ class _DeleteAccountState extends State<DeleteAccount> {
     MixpanelManager().deleteUser();
     await deleteAccount();
     await FirebaseAuth.instance.signOut();
+    await WalFileManager.clearAll();
     SharedPreferencesUtil().clear();
     setState(() {
       isDeleteing = false;


### PR DESCRIPTION
This pull request makes a small but important improvement to the account deletion flow. After a user deletes their account and signs out, it now also clears all files managed by `WalFileManager` to ensure more thorough cleanup of user data.

* Account deletion flow:
  * Added a call to `WalFileManager.clearAll()` after signing out to clear all WAL-managed files.
  * Imported `omi/utils/wal_file_manager.dart` to support the new cleanup step.