### PR TITLE
fix desktop filter

### DIFF
--- a/app/lib/desktop/pages/apps/desktop_apps_page.dart
+++ b/app/lib/desktop/pages/apps/desktop_apps_page.dart
@@ -424,7 +424,7 @@ class _DesktopAppsPageState extends State<DesktopAppsPage> with AutomaticKeepAli
               onFilterChanged: () {
                 // Debounce filter operations for better performance
                 _debouncer.run(() {
-                  appProvider.filterApps();
+                  appProvider.applyFilters();
                 });
               },
             ),


### PR DESCRIPTION
closes #3671 

https://github.com/user-attachments/assets/a8fd37c7-7165-468e-8456-67a9188b3799

while recording client side filter stops working, changed to sever side filter
