### PR TITLE
Revert "allow long writes with response on ble"

### DIFF
--- a/app/lib/services/devices/transports/ble_transport.dart
+++ b/app/lib/services/devices/transports/ble_transport.dart
@@ -197,17 +197,11 @@ class BleTransport extends DeviceTransport {
         }
 
         try {
-          // Long writes (data > MTU-3) require withResponse on iOS/Android
-          // Use writeWithoutResponse only if data fits in a single packet and characteristic supports it
-          final mtuThreshold = _bleDevice.mtuNow - 3;
-          final needsLongWrite = data.length > mtuThreshold;
-          final useWithoutResponse = !needsLongWrite && characteristic.properties.writeWithoutResponse;
-
           await characteristic
               .write(
                 data,
-                withoutResponse: useWithoutResponse,
-                allowLongWrite: needsLongWrite,
+                withoutResponse: characteristic.properties.writeWithoutResponse,
+                allowLongWrite: true,
               )
               .timeout(const Duration(seconds: 2));
           return;


### PR DESCRIPTION
Reverts BasedHardware/omi#3723

Needs more testing to cover all the cases. Currently doesn't work correctly when pairing first time