### PR TITLE
fix null crash and connection handling

### DIFF
--- a/app/lib/services/wals.dart
+++ b/app/lib/services/wals.dart
@@ -256,10 +256,11 @@ class SDCardWalSync implements IWalSync {
   }
 
   Future<List<Wal>> _getMissingWals() async {
-    if (_device == null) {
+    final device = _device;
+    if (device == null) {
       return [];
     }
-    String deviceId = _device!.id;
+    String deviceId = device.id;
     List<Wal> wals = [];
     var storageFiles = await _getStorageList(deviceId);
     if (storageFiles.isEmpty) {
@@ -284,7 +285,11 @@ class SDCardWalSync implements IWalSync {
 
       // Device model
       var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
-      var pd = await _device!.getDeviceInfo(connection);
+      if (connection == null) {
+        debugPrint("SDCard: No connection for device info");
+        return [];
+      }
+      var pd = await device.getDeviceInfo(connection);
       String deviceModel = pd.modelNumber.isNotEmpty ? pd.modelNumber : "Omi";
 
       wals.add(Wal(
@@ -296,7 +301,7 @@ class SDCardWalSync implements IWalSync {
         storageOffset: storageOffset,
         storageTotalBytes: totalBytes,
         fileNum: 1,
-        device: _device!.id,
+        device: device.id,
         deviceModel: deviceModel,
         totalFrames: seconds * codec.getFramesPerSecond(),
         syncedFrameOffset: 0, // SD card WALs start unsynced
@@ -790,11 +795,12 @@ class FlashPageWalSync implements IWalSync {
   }
 
   Future<List<Wal>> _getMissingWals() async {
-    if (_device == null) return [];
+    final device = _device;
+    if (device == null) return [];
 
-    if (_device!.type != DeviceType.limitless) return [];
+    if (device.type != DeviceType.limitless) return [];
 
-    String deviceId = _device!.id;
+    String deviceId = device.id;
     List<Wal> wals = [];
 
     var storageStatus = await _getStorageStatus(deviceId);
@@ -816,7 +822,11 @@ class FlashPageWalSync implements IWalSync {
 
       // Device model
       var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
-      var pd = await _device!.getDeviceInfo(connection);
+      if (connection == null) {
+        debugPrint("FlashPage: No connection for device info");
+        return [];
+      }
+      var pd = await device.getDeviceInfo(connection);
       String deviceModel = pd.modelNumber.isNotEmpty ? pd.modelNumber : "Limitless";
 
       wals.add(Wal(
@@ -828,7 +838,7 @@ class FlashPageWalSync implements IWalSync {
         storageOffset: _oldestPage,
         storageTotalBytes: _newestPage,
         fileNum: _currentSession,
-        device: _device!.id,
+        device: device.id,
         deviceModel: deviceModel,
         totalFrames: pageCount * framesPerFlashPage,
         syncedFrameOffset: 0,


### PR DESCRIPTION
> Line of code, what is the cause that leads to this fix? Which variable is potentially null?

https://github.com/BasedHardware/omi/blob/94f16e1c96896fdebe95a863ffe885ac95521c35/app/lib/services/wals.dart#L287

https://github.com/BasedHardware/omi/blob/94f16e1c96896fdebe95a863ffe885ac95521c35/app/lib/services/wals.dart#L819

crash occurs because `_device` can become null after await, for example when the device disconnects, but the code still uses `_device!`

closes #3804 
