### PR TITLE
Fix link casing for omiGlass in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Start speaking, you'll see Real-time transcript on [webhook.site ](https://webho
 ## In this repo:
 
 - [omi device](omi) - nRF chips, zephyr, c/c++
-- [omi glass](omiglass) esp32-s3, c/c++
+- [omi glass](omiGlass) esp32-s3, c/c++
 - [omi app](app) - flutter
 - [omi backend](backend) - python, fastapi, firebase, pinecone, redis, deepgram, speechmatic, soniox, openai-compatible apis, langchain, silero vad
 - [SDKs](sdks) - react native, swift, python


### PR DESCRIPTION
Fix link casing for omiGlass in README. The link was broken.