### PR TITLE
fix handle client exception

### DIFF
--- a/app/lib/backend/http/http_pool_manager.dart
+++ b/app/lib/backend/http/http_pool_manager.dart
@@ -70,6 +70,8 @@ class HttpPoolManager {
         lastError = TimeoutException('Request timeout');
       } on SocketException catch (e) {
         lastError = e;
+      } on http.ClientException catch (e) {
+        lastError = e;
       } catch (e) {
         lastError = e;
         rethrow;
@@ -81,7 +83,7 @@ class HttpPoolManager {
     }
 
     if (lastResponse != null) return lastResponse;
-    throw lastError!;
+    throw lastError ?? Exception('Request failed with unknown error');
   }
 
   Future<http.StreamedResponse> sendStreaming(http.BaseRequest request) {


### PR DESCRIPTION
https://github.com/BasedHardware/omi/blob/020ad86d399f4a3b2e29dffe16879050696f53ee/app/lib/backend/http/http_pool_manager.dart#L84

Network request fails with ClientException with SocketException after retries complete and the error is thrown at `throw lastError!;`
