### PR TITLE
feat(api): expand /v1/dev/user/memories response with metadata fields

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -96,7 +96,7 @@ class CleanerMemory(BaseModel):
     content: str
     category: MemoryCategory
     visibility: Optional[str] = 'private'
-    tags: List[str]
+    tags: List[str] = []
     created_at: datetime
     updated_at: datetime
     manually_added: bool


### PR DESCRIPTION
Expand CleanerMemory response model to include:
- created_at
- updated_at
- reviewed
- user_review
- manually_added
- edited
- visibility
- scoring
- tags