### PR TITLE
docs: add DeepWiki badge to README for LLM-powered documentation search

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ transcriptions of meetings, chats, and voice memos wherever you are.
 [![Discord Follow](https://img.shields.io/discord/1192313062041067520?label=Discord)](http://discord.omi.me) &ensp;&ensp;&ensp;
 [![Twitter Follow](https://img.shields.io/twitter/follow/kodjima33)](https://x.com/kodjima33) &ensp;&ensp;&ensp;
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)&ensp;&ensp;&ensp;
-[![GitHub Repo stars](https://img.shields.io/github/stars/BasedHardware/Omi)](https://github.com/BasedHardware/Omi)
+[![GitHub Repo stars](https://img.shields.io/github/stars/BasedHardware/Omi)](https://github.com/BasedHardware/Omi)&ensp;&ensp;&ensp;
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/BasedHardware/omi)
 
 <h3>
 


### PR DESCRIPTION
## Summary

Add a DeepWiki badge to the README to enable LLM-powered documentation search and automatic index updates.

## Background

### The Challenge with Omi's Monorepo Structure

The Omi repository is a **monorepo** containing diverse codebases:
- App code (Flutter)
- Backend code (Python/FastAPI)
- Kubernetes infrastructure code
- OmiGlass code
- MCP code
- And more...

While being open-source is great, **finding specific code locations and understanding specifications across this large codebase can be challenging** for contributors.

### How DeepWiki Helps

[DeepWiki](https://deepwiki.com) provides an AI-powered documentation layer for any GitHub repository:
- Query the repository through DeepWiki's website or MCP server
- Ask questions about the codebase using LLM agents
- Get answers about specifications, code structure, and implementation details

I personally used DeepWiki when contributing to Omi ([#3814](https://github.com/BasedHardware/Omi/pull/3814) - merged last week), and it was very helpful for investigating the current specifications and understanding the codebase.

### Why Add the Badge

- By default, DeepWiki does **not** automatically update its index
- **Adding a badge to the README enables automatic index updates**
- This makes it easier to:
  - Quickly look up Omi specifications
  - Lower the barrier for new contributors
  - Keep documentation in sync with the latest code

## Changes

- Added DeepWiki badge to the existing badge row in README.md
- Badge links to: https://deepwiki.com/BasedHardware/omi
