### PR TITLE
SD card should be off without current leakage

### DIFF
--- a/omi/firmware/omi/src/sd_card.c
+++ b/omi/firmware/omi/src/sd_card.c
@@ -81,7 +81,7 @@ static int sd_enable_power(bool enable)
 
         /* Zephyr didn't handle CS pin in suspend, we handle it manually */
         gpio_pin_configure(DEVICE_DT_GET(DT_NODELABEL(gpio1)), 11, GPIO_DISCONNECTED);
-        gpio_pin_set_dt(&sd_en, 0);
+        ret = gpio_pin_set_dt(&sd_en, 0);
         sd_enabled = false;
     }
     return ret;


### PR DESCRIPTION
Related issue: #3895 

**SD Card Power Management**

there is still potential current leakage through other connected SPI pins (SCK, MISO, MOSI, CS).
 - `SCK, MISO, MOSI` pins are handled by Zephyr API, it will be disconnect when we suspend SPI3 driver.
 - `CS` pin is not handled by Zephyr and it keeps high voltage (active low) usually --> the high voltage made a current leakage on SD card when we turn it off.
 
 
<img width="1179" height="570" alt="image" src="https://github.com/user-attachments/assets/71596f36-586a-4cdd-b3f3-326547e25752" />

This PR will disconnect all SPI pins and turn off the SD card power correctly.

Reduced from 600uA to 27uA (save ~570uA):
<img width="1544" height="587" alt="image" src="https://github.com/user-attachments/assets/41ec37ee-e0a6-45ab-a65f-fa1dac95a481" />

