### PR TITLE
Fix home page button interaction blocked by MergeActionBar

### DIFF
--- a/app/lib/pages/conversations/widgets/merge_action_bar.dart
+++ b/app/lib/pages/conversations/widgets/merge_action_bar.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:omi/pages/conversations/widgets/merge_confirmation_dialog.dart';
 import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
 import 'package:provider/provider.dart';
 
 class MergeActionBar extends StatefulWidget {
@@ -81,9 +82,9 @@ class _MergeActionBarState extends State<MergeActionBar> with SingleTickerProvid
                         },
                         child: Container(
                           padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 12),
-                          child: const Text(
-                            'Cancel',
-                            style: TextStyle(
+                          child: Text(
+                            context.l10n.cancel,
+                            style: const TextStyle(
                               color: Color(0xFF8E8E93),
                               fontSize: 17,
                               fontWeight: FontWeight.w500,
@@ -98,7 +99,7 @@ class _MergeActionBarState extends State<MergeActionBar> with SingleTickerProvid
                       AnimatedSwitcher(
                         duration: const Duration(milliseconds: 150),
                         child: Text(
-                          '$count selected',
+                          context.l10n.selectedCount(count),
                           key: ValueKey(count),
                           style: const TextStyle(
                             color: Colors.white,
@@ -130,7 +131,7 @@ class _MergeActionBarState extends State<MergeActionBar> with SingleTickerProvid
                               ),
                               const SizedBox(width: 8),
                               Text(
-                                'Merge',
+                                context.l10n.merge,
                                 style: TextStyle(
                                   color: canMerge ? Colors.white : const Color(0xFF636366),
                                   fontSize: 15,
@@ -168,8 +169,8 @@ class _MergeActionBarState extends State<MergeActionBar> with SingleTickerProvid
           // Show a simple, non-blocking message
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: const Text(
-                'Merging in background. This may take a moment.',
+              content: Text(
+                context.l10n.mergingInBackground,
               ),
               backgroundColor: const Color(0xFF2C2C2E),
               behavior: SnackBarBehavior.floating,
@@ -188,7 +189,7 @@ class _MergeActionBarState extends State<MergeActionBar> with SingleTickerProvid
         } else {
           ScaffoldMessenger.of(context).showSnackBar(
             SnackBar(
-              content: const Text('Failed to start merge'),
+              content: Text(context.l10n.failedToStartMerge),
               backgroundColor: Colors.red.shade700,
               behavior: SnackBarBehavior.floating,
               margin: const EdgeInsets.all(16),


### PR DESCRIPTION
Summary

  Fixes home page button interaction being blocked by the MergeActionBar component.

  Problem: Bottom navigation buttons, record button, and chat button were unresponsive on the home page because the MergeActionBar was intercepting touch events even when not in selection mode.

  Solution: Wrapped the MergeActionBar with IgnorePointer to prevent it from intercepting touch events when not in selection mode, allowing touches to pass through to underlying components.

  Changes

  - Wrapped MergeActionBar with IgnorePointer widget
  - Touch events now pass through when selection mode is inactive

  Test Plan

  - Verify bottom navigation buttons are responsive on home page
  - Verify record button works correctly
  - Verify chat button is tappable
  - Confirm MergeActionBar still works properly when in selection mode
  - Test on both iOS and Android
