### PR TITLE
fix: Goal widget improvements

### DIFF
--- a/app/lib/backend/http/api/goals.dart
+++ b/app/lib/backend/http/api/goals.dart
@@ -67,8 +67,9 @@ class Goal {
   }
 
   double get progressPercentage {
-    if (targetValue <= minValue) return currentValue > minValue ? 1.0 : 0.0;
-    return ((currentValue - minValue) / (targetValue - minValue)).clamp(0.0, 1.0);
+    // For numeric goals, progress is simply currentValue / targetValue
+    if (targetValue <= 0) return currentValue > 0 ? 1.0 : 0.0;
+    return (currentValue / targetValue).clamp(0.0, 1.0);
   }
 }
 

--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -10,6 +10,7 @@ import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/app.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/backend/schema/message.dart';
+import 'package:uuid/uuid.dart';
 import 'package:omi/gen/assets.gen.dart';
 import 'package:omi/pages/apps/widgets/capability_apps_page.dart';
 import 'package:omi/pages/chat/select_text_screen.dart';
@@ -116,10 +117,25 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin, 
         });
       }
       // Handle auto-message from notification (e.g., daily reflection)
+      // This sends a message FROM Omi AI, not from the user
       if (widget.autoMessage != null && widget.autoMessage!.isNotEmpty && mounted) {
         Future.delayed(const Duration(milliseconds: 500), () {
           if (mounted) {
-            _sendMessageUtil(widget.autoMessage!);
+            final aiMessage = ServerMessage(
+              const Uuid().v4(),
+              DateTime.now(),
+              widget.autoMessage!,
+              MessageSender.ai,
+              MessageType.text,
+              null,
+              false,
+              [],
+              [],
+              [],
+              askForNps: false,
+            );
+            context.read<MessageProvider>().addMessage(aiMessage);
+            scrollToBottom();
           }
         });
       }

--- a/backend/utils/llm/goals.py
+++ b/backend/utils/llm/goals.py
@@ -13,7 +13,7 @@ import database.memories as memories_db
 import database.conversations as conversations_db
 import database.chat as chat_db
 from database.vector_db import query_vectors as vector_search
-from utils.llm.clients import llm_mini
+from utils.llm.clients import llm_mini, llm_medium
 
 
 def _get_goal_context(uid: str, goal_title: str) -> Dict[str, str]:
@@ -215,16 +215,18 @@ USER FACTS:
 
 Give ONE specific, actionable step. Be concrete - mention specific tactics, channels, people, or actions based on their actual context. 
 No generic advice. No motivational fluff. Just the action.
-Max 35 words."""
+Keep it to 2-3 sentences max (around 30-40 words)."""
 
         print(f"[GOAL-ADVICE] Generating advice for '{goal_title}' with {len(context['conversation_context'])} chars conv, {len(context['chat_context'])} chars chat")
         
-        advice = llm_mini.invoke(prompt).content
+        # Use the better model for high-quality advice
+        advice = llm_medium.invoke(prompt).content
         
-        # Clean up the response
+        # Clean up the response - limit by words, not characters
         advice = advice.strip().strip('"').strip("'")
-        if len(advice) > 150:
-            advice = advice[:147] + "..."
+        words = advice.split()
+        if len(words) > 50:  # Limit to ~50 words (about 3-4 lines)
+            advice = ' '.join(words[:50]) + "..."
         
         return advice
         


### PR DESCRIPTION
## Fixes

### 1. Progress scale calculation fixed
- **Problem**: 1/5 showed wrong proportion
- **Fix**: Removed `minValue` from calculation. Now `progressPercentage = currentValue / targetValue`

### 2. Daily reflection message sender
- **Problem**: Reflection sent as user message
- **Fix**: Now sends FROM Omi AI (MessageSender.ai)

### 3. Widget pre-loading
- **Problem**: Widget showed loading spinner every app open
- **Fix**: Loads cached goal/advice instantly, then refreshes in background

### 4. Advice improvements
- **Model**: Now uses `llm_medium` (GPT-4.1) instead of `llm_mini`
- **Length**: Limited to 50 words (~3-4 lines)
- **Display**: Never clips text (overflow: visible)

## Files Changed
- `app/lib/backend/http/api/goals.dart` - Fixed progressPercentage calculation
- `app/lib/pages/chat/page.dart` - Fixed auto-message to send as AI
- `app/lib/pages/conversations/widgets/goal_tracker_widget.dart` - Added caching, pre-loading
- `backend/utils/llm/goals.py` - Use better model, word limit