### PR TITLE
feat: Redesign Tasks page with simplified categories and header controls

### DIFF
--- a/app/lib/desktop/pages/actions/desktop_actions_page.dart
+++ b/app/lib/desktop/pages/actions/desktop_actions_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omi/backend/schema/schema.dart';
@@ -9,9 +8,10 @@ import 'package:omi/utils/responsive/responsive_helper.dart';
 import 'package:provider/provider.dart';
 import 'package:visibility_detector/visibility_detector.dart';
 
-import 'package:omi/ui/organisms/desktop/action_item_desktop.dart';
 import 'package:omi/desktop/pages/actions/widgets/desktop_action_item_form_dialog.dart';
 import 'package:omi/ui/atoms/omi_button.dart';
+
+enum TaskCategory { today, noDeadline, later }
 
 class DesktopActionsPage extends StatefulWidget {
   const DesktopActionsPage({super.key});
@@ -28,22 +28,19 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
   final ScrollController _scrollController = ScrollController();
 
   late AnimationController _fadeController;
-  late AnimationController _slideController;
   late AnimationController _pulseController;
-
   late Animation<double> _fadeAnimation;
-  late Animation<Offset> _slideAnimation;
   late Animation<double> _pulseAnimation;
 
   bool _animationsInitialized = false;
-
-  String? _errorMessage;
-  bool _hasNetworkError = false;
   bool _isReloading = false;
   late FocusNode _focusNode;
 
-  // Tab state: 0 = To Do, 1 = Done, 2 = Snoozed
-  int _selectedTabIndex = 0;
+  // Track indent levels for each task (task id -> indent level 0-3)
+  final Map<String, int> _indentLevels = {};
+
+  // Show completed tasks
+  bool _showCompleted = false;
 
   void _requestFocusIfPossible() {
     if (mounted && _focusNode.canRequestFocus) {
@@ -56,7 +53,6 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     _fadeController.dispose();
-    _slideController.dispose();
     _pulseController.dispose();
     _focusNode.dispose();
     super.dispose();
@@ -73,11 +69,6 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
       vsync: this,
     );
 
-    _slideController = AnimationController(
-      duration: const Duration(milliseconds: 600),
-      vsync: this,
-    );
-
     _pulseController = AnimationController(
       duration: const Duration(milliseconds: 2000),
       vsync: this,
@@ -86,11 +77,6 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
     _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _fadeController, curve: Curves.easeOutCubic),
     );
-
-    _slideAnimation = Tween<Offset>(
-      begin: const Offset(0, 0.3),
-      end: Offset.zero,
-    ).animate(CurvedAnimation(parent: _slideController, curve: Curves.easeOutCubic));
 
     _pulseAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
       CurvedAnimation(parent: _pulseController, curve: Curves.easeInOut),
@@ -107,7 +93,6 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
       }
 
       _fadeController.forward();
-      _slideController.forward();
 
       Future.delayed(const Duration(milliseconds: 100), () {
         _requestFocusIfPossible();
@@ -130,118 +115,203 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
     }
   }
 
+  // Categorize items by deadline
+  Map<TaskCategory, List<ActionItemWithMetadata>> _categorizeItems(List<ActionItemWithMetadata> items) {
+    final now = DateTime.now();
+    final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
+
+    // Filter out old tasks without a future due date (older than 7 days)
+    final sevenDaysAgo = now.subtract(const Duration(days: 7));
+
+    final Map<TaskCategory, List<ActionItemWithMetadata>> categorized = {
+      TaskCategory.noDeadline: [],
+      TaskCategory.today: [],
+      TaskCategory.later: [],
+    };
+
+    for (var item in items) {
+      // Skip completed items unless showing completed
+      if (item.completed && !_showCompleted) continue;
+      if (!item.completed && _showCompleted) continue;
+
+      // Skip old tasks without a future due date (only for non-completed)
+      if (!_showCompleted) {
+        if (item.dueAt != null) {
+          if (item.dueAt!.isBefore(sevenDaysAgo)) continue;
+        } else {
+          if (item.createdAt != null && item.createdAt!.isBefore(sevenDaysAgo)) continue;
+        }
+      }
+
+      if (item.dueAt == null) {
+        categorized[TaskCategory.noDeadline]!.add(item);
+      } else {
+        final dueDate = item.dueAt!;
+        if (dueDate.isBefore(startOfTomorrow)) {
+          categorized[TaskCategory.today]!.add(item);
+        } else {
+          categorized[TaskCategory.later]!.add(item);
+        }
+      }
+    }
+
+    return categorized;
+  }
+
+  String _getCategoryTitle(TaskCategory category) {
+    switch (category) {
+      case TaskCategory.noDeadline:
+        return 'No Deadline';
+      case TaskCategory.today:
+        return 'Today';
+      case TaskCategory.later:
+        return 'Later';
+    }
+  }
+
+  DateTime? _getDefaultDueDateForCategory(TaskCategory category) {
+    final now = DateTime.now();
+    switch (category) {
+      case TaskCategory.noDeadline:
+        return null;
+      case TaskCategory.today:
+        return DateTime(now.year, now.month, now.day, 23, 59);
+      case TaskCategory.later:
+        // Tomorrow
+        return DateTime(now.year, now.month, now.day + 1, 23, 59);
+    }
+  }
+
+  void _updateTaskCategory(ActionItemWithMetadata item, TaskCategory newCategory) {
+    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
+    final newDueDate = _getDefaultDueDateForCategory(newCategory);
+    provider.updateActionItemDueDate(item, newDueDate);
+  }
+
+  int _getIndentLevel(String itemId) {
+    return _indentLevels[itemId] ?? 0;
+  }
+
+  void _incrementIndent(String itemId) {
+    setState(() {
+      final current = _indentLevels[itemId] ?? 0;
+      if (current < 3) {
+        _indentLevels[itemId] = current + 1;
+      }
+    });
+    HapticFeedback.lightImpact();
+  }
+
+  void _decrementIndent(String itemId) {
+    setState(() {
+      final current = _indentLevels[itemId] ?? 0;
+      if (current > 0) {
+        _indentLevels[itemId] = current - 1;
+      }
+    });
+    HapticFeedback.lightImpact();
+  }
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
     return VisibilityDetector(
-        key: const Key('desktop-actions-page'),
-        onVisibilityChanged: (visibilityInfo) {
-          if (visibilityInfo.visibleFraction > 0.1) {
-            WidgetsBinding.instance.addPostFrameCallback((_) => _requestFocusIfPossible());
-          }
+      key: const Key('desktop-actions-page'),
+      onVisibilityChanged: (visibilityInfo) {
+        if (visibilityInfo.visibleFraction > 0.1) {
+          WidgetsBinding.instance.addPostFrameCallback((_) => _requestFocusIfPossible());
+        }
+      },
+      child: CallbackShortcuts(
+        bindings: {
+          const SingleActivator(LogicalKeyboardKey.keyR, meta: true): _handleReload,
         },
-        child: CallbackShortcuts(
-          bindings: {
-            const SingleActivator(LogicalKeyboardKey.keyR, meta: true): _handleReload,
-          },
-          child: Focus(
-            focusNode: _focusNode,
-            autofocus: true,
-            child: GestureDetector(
-              onTap: () {
-                if (!_focusNode.hasFocus) {
-                  _focusNode.requestFocus();
-                }
-              },
-              child: Consumer<ActionItemsProvider>(
-                builder: (context, provider, _) {
-                  // Get categorized items based on new logic
-                  final todoItems = provider.todoItems;
-                  final doneItems = provider.doneItems;
-                  final snoozedItems = provider.snoozedItems;
-                  final allItems = provider.actionItems;
+        child: Focus(
+          focusNode: _focusNode,
+          autofocus: true,
+          child: GestureDetector(
+            onTap: () {
+              if (!_focusNode.hasFocus) {
+                _focusNode.requestFocus();
+              }
+            },
+            child: Consumer<ActionItemsProvider>(
+              builder: (context, provider, _) {
+                final allItems = provider.actionItems;
+                final categorizedItems = _categorizeItems(allItems);
 
-                  // Get current tab items
-                  final currentTabItems = _selectedTabIndex == 0
-                      ? todoItems
-                      : _selectedTabIndex == 1
-                          ? doneItems
-                          : snoozedItems;
-
-                  return Stack(
-                    children: [
+                return Stack(
+                  children: [
+                    Container(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topCenter,
+                          end: Alignment.bottomCenter,
+                          colors: [
+                            ResponsiveHelper.backgroundPrimary,
+                            ResponsiveHelper.backgroundSecondary.withOpacity(0.8),
+                          ],
+                        ),
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: ClipRRect(
+                        borderRadius: BorderRadius.circular(20),
+                        child: Stack(
+                          children: [
+                            _buildAnimatedBackground(),
+                            Container(
+                              decoration: BoxDecoration(
+                                color: Colors.white.withOpacity(0.02),
+                                borderRadius: BorderRadius.circular(20),
+                              ),
+                              child: Column(
+                                children: [
+                                  _buildHeader(),
+                                  Expanded(
+                                    child: _animationsInitialized
+                                        ? FadeTransition(
+                                            opacity: _fadeAnimation,
+                                            child: _buildContent(provider, allItems, categorizedItems),
+                                          )
+                                        : _buildContent(provider, allItems, categorizedItems),
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ),
+                    if (_isReloading)
                       Container(
                         decoration: BoxDecoration(
-                          gradient: LinearGradient(
-                            begin: Alignment.topCenter,
-                            end: Alignment.bottomCenter,
-                            colors: [
-                              ResponsiveHelper.backgroundPrimary,
-                              ResponsiveHelper.backgroundSecondary.withOpacity(0.8),
-                            ],
-                          ),
+                          color: Colors.black54,
                           borderRadius: BorderRadius.circular(20),
                         ),
-                        child: ClipRRect(
-                          borderRadius: BorderRadius.circular(20),
-                          child: Stack(
+                        child: Center(
+                          child: Column(
+                            mainAxisSize: MainAxisSize.min,
                             children: [
-                              _buildAnimatedBackground(),
-                              Container(
-                                decoration: BoxDecoration(
-                                  color: Colors.white.withOpacity(0.02),
-                                  borderRadius: BorderRadius.circular(20),
-                                ),
-                                child: Column(
-                                  children: [
-                                    _buildHeader(todoItems, doneItems, snoozedItems),
-                                    Expanded(
-                                      child: _animationsInitialized
-                                          ? FadeTransition(
-                                              opacity: _fadeAnimation,
-                                              child: SlideTransition(
-                                                position: _slideAnimation,
-                                                child: _buildActionsContent(provider, allItems, currentTabItems),
-                                              ),
-                                            )
-                                          : _buildActionsContent(provider, allItems, currentTabItems),
+                              const CircularProgressIndicator(color: ResponsiveHelper.purplePrimary),
+                              const SizedBox(height: 16),
+                              Text(
+                                'Loading tasks...',
+                                style: ResponsiveHelper(context).bodyLarge.copyWith(
+                                      color: ResponsiveHelper.textPrimary,
                                     ),
-                                  ],
-                                ),
                               ),
                             ],
                           ),
                         ),
                       ),
-                      if (_isReloading)
-                        Container(
-                          decoration: BoxDecoration(
-                            color: Colors.black54,
-                            borderRadius: BorderRadius.circular(20),
-                          ),
-                          child: Center(
-                            child: Column(
-                              mainAxisSize: MainAxisSize.min,
-                              children: [
-                                const CircularProgressIndicator(color: ResponsiveHelper.purplePrimary),
-                                const SizedBox(height: 16),
-                                Text(
-                                  'Loading action items...',
-                                  style: ResponsiveHelper(context).bodyLarge.copyWith(
-                                        color: ResponsiveHelper.textPrimary,
-                                      ),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
-                    ],
-                  );
-                },
-              ),
+                  ],
+                );
+              },
             ),
           ),
-        ));
+        ),
+      ),
+    );
   }
 
   Widget _buildAnimatedBackground() {
@@ -279,116 +349,91 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
     );
   }
 
-  Widget _buildHeader(List<ActionItemWithMetadata> todoItems, List<ActionItemWithMetadata> doneItems,
-      List<ActionItemWithMetadata> snoozedItems) {
+  Widget _buildHeader() {
     return Container(
       padding: const EdgeInsets.all(20),
-      child: Column(
+      child: Row(
         children: [
-          // Title and create button row
-          Row(
-            children: [
-              // Title section
-              const Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
+          const Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
                   children: [
-                    Row(
-                      children: [
-                        Icon(
-                          FontAwesomeIcons.listCheck,
-                          color: ResponsiveHelper.textSecondary,
-                          size: 18,
-                        ),
-                        SizedBox(width: 12),
-                        Text(
-                          'Action Items',
-                          style: TextStyle(
-                            color: ResponsiveHelper.textPrimary,
-                            fontSize: 20,
-                            fontWeight: FontWeight.w600,
-                          ),
-                        ),
-                      ],
+                    Icon(
+                      FontAwesomeIcons.listCheck,
+                      color: ResponsiveHelper.textSecondary,
+                      size: 18,
                     ),
-                    SizedBox(height: 4),
+                    SizedBox(width: 12),
                     Text(
-                      'Tap to edit • Long press to select • Swipe for actions',
+                      'Tasks',
                       style: TextStyle(
-                        color: ResponsiveHelper.textSecondary,
-                        fontSize: 12,
+                        color: ResponsiveHelper.textPrimary,
+                        fontSize: 20,
+                        fontWeight: FontWeight.w600,
                       ),
                     ),
                   ],
                 ),
-              ),
-              // Create button
-              OmiButton(
-                label: 'Create',
-                onPressed: _showCreateActionItemDialog,
-                icon: FontAwesomeIcons.plus,
-              ),
-            ],
+                SizedBox(height: 4),
+                Text(
+                  'Swipe tasks to indent, drag between categories',
+                  style: TextStyle(
+                    color: ResponsiveHelper.textSecondary,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
           ),
-          const SizedBox(height: 16),
-
-          // Segmented Control - Full width like mobile
-          Container(
-            width: double.infinity,
-            decoration: BoxDecoration(
-              color: ResponsiveHelper.backgroundTertiary.withOpacity(0.6),
-              borderRadius: BorderRadius.circular(10),
-            ),
-            padding: const EdgeInsets.all(2),
-            child: CupertinoSlidingSegmentedControl<int>(
-              groupValue: _selectedTabIndex,
-              onValueChanged: (int? value) {
-                if (value != null) {
-                  setState(() {
-                    _selectedTabIndex = value;
-                  });
-                  HapticFeedback.selectionClick();
-
-                  // Track tab change
-                  final tabName = value == 0 ? 'To Do' : (value == 1 ? 'Done' : 'Snoozed');
-                  MixpanelManager().actionItemTabChanged(tabName);
-                }
+          // Show completed toggle
+          MouseRegion(
+            cursor: SystemMouseCursors.click,
+            child: GestureDetector(
+              onTap: () {
+                setState(() {
+                  _showCompleted = !_showCompleted;
+                });
+                HapticFeedback.lightImpact();
               },
-              backgroundColor: Colors.transparent,
-              thumbColor: ResponsiveHelper.backgroundSecondary,
-              padding: const EdgeInsets.all(0),
-              children: {
-                0: _buildTabLabel('To Do', todoItems.length),
-                1: _buildTabLabel('Done', doneItems.length),
-                2: _buildTabLabel('Snoozed', snoozedItems.length),
-              },
+              child: Container(
+                padding: const EdgeInsets.all(8),
+                margin: const EdgeInsets.only(right: 12),
+                decoration: BoxDecoration(
+                  color: _showCompleted
+                      ? ResponsiveHelper.purplePrimary.withOpacity(0.2)
+                      : Colors.transparent,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(
+                  _showCompleted ? Icons.check_circle : Icons.check_circle_outline,
+                  color: _showCompleted ? ResponsiveHelper.purplePrimary : ResponsiveHelper.textSecondary,
+                  size: 20,
+                ),
+              ),
             ),
+          ),
+          OmiButton(
+            label: 'Create',
+            onPressed: () => _showCreateDialog(),
+            icon: FontAwesomeIcons.plus,
           ),
         ],
       ),
     );
   }
 
-  Future<void> _showCreateActionItemDialog() async {
+  Future<void> _showCreateDialog({DateTime? defaultDueDate}) async {
     final result = await showDialog<bool>(
       context: context,
-      builder: (context) => const DesktopActionItemFormDialog(),
+      builder: (context) => DesktopActionItemFormDialog(defaultDueDate: defaultDueDate),
     );
 
     if (result == true) {
-      // Refresh the action items list
       final provider = Provider.of<ActionItemsProvider>(context, listen: false);
       provider.forceRefreshActionItems();
     }
-  }
-
-  void _retryLoadingActionItems() {
-    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
-    setState(() {
-      _hasNetworkError = false;
-      _errorMessage = null;
-    });
-    provider.fetchActionItems(showShimmer: true);
   }
 
   Future<void> _handleReload() async {
@@ -398,7 +443,6 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
       _isReloading = true;
     });
 
-    // Scroll to top
     if (_scrollController.hasClients) {
       _scrollController.animateTo(
         0,
@@ -417,127 +461,33 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
     }
   }
 
-  Widget _buildTabLabel(String label, int count) {
-    final int tabIndex = label == 'To Do' ? 0 : (label == 'Done' ? 1 : 2);
-    final bool isSelected = _selectedTabIndex == tabIndex;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 13,
-              fontWeight: FontWeight.w500,
-              color: isSelected ? ResponsiveHelper.textPrimary : ResponsiveHelper.textSecondary,
-            ),
-          ),
-          if (count > 0) ...[
-            const SizedBox(width: 4),
-            Text(
-              '$count',
-              style: TextStyle(
-                fontSize: 13,
-                fontWeight: FontWeight.w500,
-                color: isSelected ? ResponsiveHelper.textSecondary : ResponsiveHelper.textTertiary,
-              ),
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-
-  Widget _buildActionsContent(
+  Widget _buildContent(
     ActionItemsProvider provider,
     List<ActionItemWithMetadata> allItems,
-    List<ActionItemWithMetadata> currentTabItems,
+    Map<TaskCategory, List<ActionItemWithMetadata>> categorizedItems,
   ) {
-    if (_hasNetworkError && allItems.isEmpty) {
-      return _buildErrorState();
-    }
-
     if (provider.isLoading && allItems.isEmpty) {
-      return _buildModernLoadingState();
+      return _buildLoadingState();
     }
 
-    if (allItems.isEmpty) {
-      return _buildModernEmptyState();
+    if (allItems.isEmpty && !_showCompleted) {
+      return _buildEmptyState();
     }
 
     return CustomScrollView(
       controller: _scrollController,
       slivers: [
-        // Info banner for snoozed tab
-        if (allItems.isNotEmpty && _selectedTabIndex == 2)
+        const SliverPadding(padding: EdgeInsets.only(top: 8)),
+
+        for (final category in TaskCategory.values)
           SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.fromLTRB(20.0, 0, 20.0, 12.0),
-              child: Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: ResponsiveHelper.backgroundTertiary.withOpacity(0.4),
-                  borderRadius: BorderRadius.circular(12),
-                  border: Border.all(
-                    color: ResponsiveHelper.textTertiary.withOpacity(0.3),
-                    width: 1,
-                  ),
-                ),
-                child: const Row(
-                  children: [
-                    Icon(
-                      Icons.info_outline,
-                      size: 16,
-                      color: ResponsiveHelper.textTertiary,
-                    ),
-                    SizedBox(width: 8),
-                    Expanded(
-                      child: Text(
-                        'Old tasks are auto-snoozed after 3 days to keep your To Do list clean. You can still complete or delete them here.',
-                        style: TextStyle(
-                          color: ResponsiveHelper.textSecondary,
-                          fontSize: 12,
-                          height: 1.4,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
+            child: _buildCategorySection(
+              category: category,
+              items: categorizedItems[category] ?? [],
+              provider: provider,
             ),
           ),
 
-        // Current Tab Items
-        if (allItems.isNotEmpty && currentTabItems.isNotEmpty)
-          _buildFlatView(currentTabItems, _selectedTabIndex == 1)
-        else if (allItems.isNotEmpty && currentTabItems.isEmpty)
-          SliverToBoxAdapter(
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 20.0),
-              child: Container(
-                height: 120,
-                decoration: BoxDecoration(
-                  color: ResponsiveHelper.backgroundTertiary.withOpacity(0.4),
-                  borderRadius: BorderRadius.circular(16),
-                ),
-                child: Center(
-                  child: Text(
-                    _getEmptyTabMessage(),
-                    style: const TextStyle(
-                      color: ResponsiveHelper.textSecondary,
-                      fontSize: 14,
-                    ),
-                    textAlign: TextAlign.center,
-                  ),
-                ),
-              ),
-            ),
-          ),
-
-        // Loading indicator for pagination
         if (provider.isFetching)
           SliverToBoxAdapter(
             child: Container(
@@ -550,59 +500,219 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
             ),
           ),
 
-        if (_hasNetworkError && allItems.isNotEmpty)
-          SliverToBoxAdapter(
-            child: Container(
-              margin: const EdgeInsets.fromLTRB(20, 16, 20, 0),
-              padding: const EdgeInsets.all(12),
-              decoration: BoxDecoration(
-                color: Colors.orange.withOpacity(0.1),
-                borderRadius: BorderRadius.circular(8),
-                border: Border.all(
-                  color: Colors.orange.withOpacity(0.3),
-                  width: 1,
-                ),
-              ),
-              child: Row(
-                children: [
-                  Icon(
-                    FontAwesomeIcons.triangleExclamation,
-                    color: Colors.orange[300],
-                    size: 16,
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      _errorMessage ?? 'Some features may not work properly',
-                      style: TextStyle(
-                        color: Colors.orange[300],
-                        fontSize: 13,
-                        fontWeight: FontWeight.w500,
-                      ),
-                    ),
-                  ),
-                  TextButton(
-                    onPressed: _retryLoadingActionItems,
-                    child: Text(
-                      'Retry',
-                      style: TextStyle(
-                        color: Colors.orange[300],
-                        fontSize: 13,
-                        fontWeight: FontWeight.w600,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ),
-          ),
-
         const SliverPadding(padding: EdgeInsets.only(bottom: 20)),
       ],
     );
   }
 
-  Widget _buildModernLoadingState() {
+  Widget _buildCategorySection({
+    required TaskCategory category,
+    required List<ActionItemWithMetadata> items,
+    required ActionItemsProvider provider,
+  }) {
+    final title = _getCategoryTitle(category);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 4),
+      child: DragTarget<ActionItemWithMetadata>(
+        onWillAcceptWithDetails: (details) => true,
+        onAcceptWithDetails: (details) {
+          _updateTaskCategory(details.data, category);
+        },
+        builder: (context, candidateData, rejectedData) {
+          final isHovering = candidateData.isNotEmpty;
+          return AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            decoration: BoxDecoration(
+              color: isHovering ? ResponsiveHelper.backgroundTertiary.withOpacity(0.5) : Colors.transparent,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Header
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(4, 12, 4, 8),
+                  child: Row(
+                    children: [
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          color: ResponsiveHelper.textPrimary,
+                          fontSize: 15,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const Spacer(),
+                      if (items.isNotEmpty)
+                        Text(
+                          '${items.length}',
+                          style: const TextStyle(
+                            color: ResponsiveHelper.textTertiary,
+                            fontSize: 14,
+                          ),
+                        ),
+                    ],
+                  ),
+                ),
+
+                // Task items
+                ...items.map((item) => _buildTaskItem(item, provider)),
+
+                // Spacing after section
+                const SizedBox(height: 8),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildTaskItem(ActionItemWithMetadata item, ActionItemsProvider provider) {
+    final indentLevel = _getIndentLevel(item.id);
+    final indentWidth = indentLevel * 28.0;
+
+    return LongPressDraggable<ActionItemWithMetadata>(
+      data: item,
+      feedback: Material(
+        color: Colors.transparent,
+        child: Container(
+          width: 400,
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: ResponsiveHelper.backgroundSecondary,
+            borderRadius: BorderRadius.circular(12),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.3),
+                blurRadius: 10,
+                offset: const Offset(0, 4),
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              _buildCheckbox(item.completed),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  item.description,
+                  style: const TextStyle(color: ResponsiveHelper.textPrimary, fontSize: 14),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      childWhenDragging: Opacity(
+        opacity: 0.3,
+        child: _buildTaskItemContent(item, provider, indentWidth),
+      ),
+      child: _buildTaskItemContent(item, provider, indentWidth),
+    );
+  }
+
+  Widget _buildTaskItemContent(
+    ActionItemWithMetadata item,
+    ActionItemsProvider provider,
+    double indentWidth,
+  ) {
+    final indentLevel = _getIndentLevel(item.id);
+
+    return MouseRegion(
+      cursor: SystemMouseCursors.click,
+      child: GestureDetector(
+        onHorizontalDragEnd: (details) {
+          if (details.primaryVelocity != null) {
+            if (details.primaryVelocity! > 200) {
+              _incrementIndent(item.id);
+            } else if (details.primaryVelocity! < -200) {
+              _decrementIndent(item.id);
+            }
+          }
+        },
+        child: InkWell(
+          onTap: () => _showEditDialog(item),
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: EdgeInsets.only(left: 4 + indentWidth, right: 4, top: 6, bottom: 6),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                // Indent line
+                if (indentLevel > 0)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 10),
+                    child: Container(
+                      width: 1.5,
+                      height: 20,
+                      decoration: BoxDecoration(
+                        color: ResponsiveHelper.textTertiary,
+                        borderRadius: BorderRadius.circular(1),
+                      ),
+                    ),
+                  ),
+                // Checkbox
+                GestureDetector(
+                  onTap: () async {
+                    await provider.updateActionItemState(item, !item.completed);
+                  },
+                  child: _buildCheckbox(item.completed),
+                ),
+                const SizedBox(width: 12),
+                // Task text
+                Expanded(
+                  child: Text(
+                    item.description,
+                    style: TextStyle(
+                      color: item.completed ? ResponsiveHelper.textTertiary : ResponsiveHelper.textPrimary,
+                      fontSize: 14,
+                      decoration: item.completed ? TextDecoration.lineThrough : null,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildCheckbox(bool isCompleted) {
+    return Container(
+      width: 20,
+      height: 20,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: isCompleted ? Colors.amber : ResponsiveHelper.textTertiary,
+          width: 2,
+        ),
+        color: isCompleted ? Colors.amber : Colors.transparent,
+      ),
+      child: isCompleted
+          ? const Icon(Icons.check, size: 12, color: Colors.black)
+          : null,
+    );
+  }
+
+  Future<void> _showEditDialog(ActionItemWithMetadata item) async {
+    final result = await showDialog<bool>(
+      context: context,
+      builder: (context) => DesktopActionItemFormDialog(actionItem: item),
+    );
+
+    if (result == true) {
+      final provider = Provider.of<ActionItemsProvider>(context, listen: false);
+      provider.forceRefreshActionItems();
+    }
+  }
+
+  Widget _buildLoadingState() {
     return Center(
       child: Container(
         padding: const EdgeInsets.all(20),
@@ -613,58 +723,19 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
             color: Colors.white.withOpacity(0.1),
             width: 1,
           ),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.1),
-              blurRadius: 20,
-              offset: const Offset(0, 10),
-            ),
-          ],
         ),
-        child: Column(
+        child: const Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            _animationsInitialized
-                ? AnimatedBuilder(
-                    animation: _pulseController,
-                    builder: (context, child) {
-                      return Transform.scale(
-                        scale: 1.0 + (_pulseAnimation.value * 0.1),
-                        child: Container(
-                          width: 40,
-                          height: 40,
-                          decoration: BoxDecoration(
-                            color: ResponsiveHelper.purplePrimary,
-                            borderRadius: BorderRadius.circular(20),
-                          ),
-                          child: const CircularProgressIndicator(
-                            valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                            strokeWidth: 2,
-                          ),
-                        ),
-                      );
-                    },
-                  )
-                : Container(
-                    width: 40,
-                    height: 40,
-                    decoration: BoxDecoration(
-                      color: ResponsiveHelper.purplePrimary,
-                      borderRadius: BorderRadius.circular(20),
-                    ),
-                    child: const CircularProgressIndicator(
-                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                      strokeWidth: 2,
-                    ),
-                  ),
-            const SizedBox(height: 16),
-            const Text(
-              'Loading your action items...',
-              textAlign: TextAlign.center,
+            CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(ResponsiveHelper.purplePrimary),
+            ),
+            SizedBox(height: 16),
+            Text(
+              'Loading tasks...',
               style: TextStyle(
                 color: ResponsiveHelper.textSecondary,
                 fontSize: 14,
-                fontWeight: FontWeight.w500,
               ),
             ),
           ],
@@ -673,99 +744,7 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
     );
   }
 
-  Widget _buildModernEmptyState() {
-    Widget content = Container(
-      padding: const EdgeInsets.all(40),
-      margin: const EdgeInsets.all(32),
-      decoration: BoxDecoration(
-        color: ResponsiveHelper.backgroundSecondary.withOpacity(0.6),
-        borderRadius: BorderRadius.circular(24),
-        border: Border.all(
-          color: Colors.white.withOpacity(0.1),
-          width: 1,
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.1),
-            blurRadius: 30,
-            offset: const Offset(0, 15),
-          ),
-        ],
-      ),
-      child: _buildFirstTimeEmptyState(),
-    );
-
-    return Center(
-      child: _animationsInitialized
-          ? FadeTransition(
-              opacity: _fadeAnimation,
-              child: content,
-            )
-          : content,
-    );
-  }
-
-  Widget _buildFirstTimeEmptyState() {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        _animationsInitialized
-            ? AnimatedBuilder(
-                animation: _pulseController,
-                builder: (context, child) {
-                  return Transform.scale(
-                    scale: 1.0 + (_pulseAnimation.value * 0.05),
-                    child: Container(
-                      padding: const EdgeInsets.all(20),
-                      decoration: BoxDecoration(
-                        color: ResponsiveHelper.purplePrimary.withOpacity(0.2),
-                        borderRadius: BorderRadius.circular(20),
-                      ),
-                      child: const Icon(
-                        FontAwesomeIcons.circleCheck,
-                        size: 48,
-                        color: ResponsiveHelper.purplePrimary,
-                      ),
-                    ),
-                  );
-                },
-              )
-            : Container(
-                padding: const EdgeInsets.all(20),
-                decoration: BoxDecoration(
-                  color: ResponsiveHelper.purplePrimary.withOpacity(0.2),
-                  borderRadius: BorderRadius.circular(20),
-                ),
-                child: const Icon(
-                  FontAwesomeIcons.circleCheck,
-                  size: 48,
-                  color: ResponsiveHelper.purplePrimary,
-                ),
-              ),
-        const SizedBox(height: 24),
-        const Text(
-          '✅ No Action Items',
-          style: TextStyle(
-            color: ResponsiveHelper.textPrimary,
-            fontSize: 20,
-            fontWeight: FontWeight.w600,
-          ),
-        ),
-        const SizedBox(height: 8),
-        const Text(
-          'Tasks and to-dos from your conversations will appear here once they are created.',
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            color: ResponsiveHelper.textSecondary,
-            fontSize: 14,
-            height: 1.5,
-          ),
-        ),
-      ],
-    );
-  }
-
-  Widget _buildErrorState() {
+  Widget _buildEmptyState() {
     return Center(
       child: Container(
         padding: const EdgeInsets.all(40),
@@ -774,16 +753,9 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
           color: ResponsiveHelper.backgroundSecondary.withOpacity(0.6),
           borderRadius: BorderRadius.circular(24),
           border: Border.all(
-            color: Colors.red.withOpacity(0.2),
+            color: Colors.white.withOpacity(0.1),
             width: 1,
           ),
-          boxShadow: [
-            BoxShadow(
-              color: Colors.black.withOpacity(0.1),
-              blurRadius: 30,
-              offset: const Offset(0, 15),
-            ),
-          ],
         ),
         child: Column(
           mainAxisSize: MainAxisSize.min,
@@ -791,18 +763,18 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
             Container(
               padding: const EdgeInsets.all(20),
               decoration: BoxDecoration(
-                color: Colors.red.withOpacity(0.1),
+                color: ResponsiveHelper.purplePrimary.withOpacity(0.2),
                 borderRadius: BorderRadius.circular(20),
               ),
               child: const Icon(
-                FontAwesomeIcons.triangleExclamation,
+                FontAwesomeIcons.circleCheck,
                 size: 48,
-                color: Colors.red,
+                color: ResponsiveHelper.purplePrimary,
               ),
             ),
             const SizedBox(height: 24),
             const Text(
-              'Unable to Load Action Items',
+              'No Tasks Yet',
               style: TextStyle(
                 color: ResponsiveHelper.textPrimary,
                 fontSize: 20,
@@ -810,91 +782,17 @@ class DesktopActionsPageState extends State<DesktopActionsPage>
               ),
             ),
             const SizedBox(height: 8),
-            Text(
-              _errorMessage ?? 'Please check your internet connection and try again.',
+            const Text(
+              'Tasks from your conversations will appear here.\nClick Create to add one manually.',
               textAlign: TextAlign.center,
-              style: const TextStyle(
+              style: TextStyle(
                 color: ResponsiveHelper.textSecondary,
                 fontSize: 14,
                 height: 1.5,
               ),
             ),
-            const SizedBox(height: 24),
-            ElevatedButton.icon(
-              onPressed: _retryLoadingActionItems,
-              icon: const Icon(
-                FontAwesomeIcons.arrowRotateRight,
-                size: 16,
-              ),
-              label: const Text('Retry'),
-              style: ElevatedButton.styleFrom(
-                backgroundColor: ResponsiveHelper.purplePrimary,
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-              ),
-            ),
           ],
         ),
-      ),
-    );
-  }
-
-  String _getEmptyTabMessage() {
-    switch (_selectedTabIndex) {
-      case 0: // To Do
-        return '🎉 All caught up!\nNo pending action items';
-      case 1: // Done
-        return 'No completed items yet';
-      case 2: // Snoozed
-        return '✅ No snoozed tasks\n\nOld tasks are auto-snoozed after 3 days to keep your To Do list clean';
-      default:
-        return 'No items';
-    }
-  }
-
-  Widget _buildFlatView(List<ActionItemWithMetadata> items, bool showCompleted) {
-    // For the new tab system, we don't need to filter by completion status
-    // since the provider already returns the correct items for each tab
-    final filteredItems = items;
-
-    return SliverList(
-      delegate: SliverChildBuilderDelegate(
-        (context, index) {
-          final item = filteredItems[index];
-
-          Widget itemWidget = DesktopActionItem(
-            actionItem: item,
-            isSnoozedTab: _selectedTabIndex == 2,
-          );
-
-          return AnimatedContainer(
-            duration: Duration(milliseconds: 300 + (index * 50)),
-            curve: Curves.easeOutCubic,
-            child: _animationsInitialized
-                ? FadeTransition(
-                    opacity: _fadeAnimation,
-                    child: SlideTransition(
-                      position: Tween<Offset>(
-                        begin: Offset(0, 0.1 + (index * 0.02)),
-                        end: Offset.zero,
-                      ).animate(CurvedAnimation(
-                        parent: _slideController,
-                        curve: Interval(
-                          (index * 0.1).clamp(0.0, 0.8),
-                          1.0,
-                          curve: Curves.easeOutCubic,
-                        ),
-                      )),
-                      child: itemWidget,
-                    ),
-                  )
-                : itemWidget,
-          );
-        },
-        childCount: filteredItems.length,
       ),
     );
   }

--- a/app/lib/desktop/pages/actions/widgets/desktop_action_item_form_dialog.dart
+++ b/app/lib/desktop/pages/actions/widgets/desktop_action_item_form_dialog.dart
@@ -15,11 +15,13 @@ import 'package:omi/ui/molecules/omi_confirm_dialog.dart';
 class DesktopActionItemFormDialog extends StatefulWidget {
   final ActionItemWithMetadata? actionItem;
   final String? conversationId;
+  final DateTime? defaultDueDate;
 
   const DesktopActionItemFormDialog({
     super.key,
     this.actionItem,
     this.conversationId,
+    this.defaultDueDate,
   });
 
   @override
@@ -46,6 +48,8 @@ class _DesktopActionItemFormDialogState extends State<DesktopActionItemFormDialo
       _descriptionController.text = widget.actionItem!.description;
       _isCompleted = widget.actionItem!.completed;
       _dueDate = widget.actionItem!.dueAt;
+    } else {
+      _dueDate = widget.defaultDueDate;
     }
 
     if (!_isEditing) {

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -1,20 +1,14 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/services.dart';
-import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
-import 'widgets/action_item_tile_widget.dart';
-import 'widgets/action_item_shimmer_widget.dart';
 import 'widgets/action_item_form_sheet.dart';
-import 'widgets/task_integrations_banner.dart';
 
 import 'package:omi/backend/schema/schema.dart';
 import 'package:omi/providers/action_items_provider.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/services/app_review_service.dart';
-import 'package:omi/backend/preferences.dart';
-import 'package:omi/ui/molecules/omi_confirm_dialog.dart';
-import 'package:omi/utils/l10n_extensions.dart';
+
+enum TaskCategory { today, noDeadline, later }
 
 class ActionItemsPage extends StatefulWidget {
   const ActionItemsPage({super.key});
@@ -27,8 +21,8 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
   final ScrollController _scrollController = ScrollController();
   final AppReviewService _appReviewService = AppReviewService();
 
-  // Tab state: 0 = To Do, 1 = Done, 2 = snoozed
-  int _selectedTabIndex = 0;
+  // Track indent levels for each task (task id -> indent level 0-3)
+  final Map<String, int> _indentLevels = {};
 
   @override
   bool get wantKeepAlive => true;
@@ -54,9 +48,17 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     super.dispose();
   }
 
-  // checks if it's the first action item completed
-  Future<void> _onActionItemCompleted({bool isSnoozed = false}) async {
-    MixpanelManager().actionItemCompleted(fromTab: isSnoozed ? 'Snoozed' : 'To Do');
+  void _onScroll() {
+    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
+    if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent - 200) {
+      if (!provider.isFetching && provider.hasMore) {
+        provider.loadMoreActionItems();
+      }
+    }
+  }
+
+  Future<void> _onActionItemCompleted() async {
+    MixpanelManager().actionItemCompleted(fromTab: 'Tasks');
 
     final hasCompletedFirst = await _appReviewService.hasCompletedFirstActionItem();
 
@@ -69,43 +71,110 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     }
   }
 
-  void _onScroll() {
-    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
-    if (_scrollController.position.pixels >= _scrollController.position.maxScrollExtent - 200) {
-      if (!provider.isFetching && provider.hasMore) {
-        provider.loadMoreActionItems();
-      }
-    }
-  }
-
-  void scrollToTop() {
-    if (_scrollController.hasClients) {
-      _scrollController.animateTo(
-        0.0,
-        duration: const Duration(milliseconds: 500),
-        curve: Curves.easeOutCubic,
-      );
-    }
-  }
-
-  void _showCreateActionItemSheet() {
+  void _showCreateActionItemSheet({DateTime? defaultDueDate}) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
-      builder: (context) => const ActionItemFormSheet(),
+      builder: (context) => ActionItemFormSheet(defaultDueDate: defaultDueDate),
     );
   }
 
-  void _onTabChanged(int value) {
-    setState(() {
-      _selectedTabIndex = value;
-    });
-    HapticFeedback.selectionClick();
+  // Categorize items by deadline
+  Map<TaskCategory, List<ActionItemWithMetadata>> _categorizeItems(List<ActionItemWithMetadata> items, bool showCompleted) {
+    final now = DateTime.now();
+    final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
 
-    // Track tab change
-    final tabName = value == 0 ? 'To Do' : (value == 1 ? 'Done' : 'Old');
-    MixpanelManager().actionItemTabChanged(tabName);
+    // Filter out old tasks without a future due date (older than 7 days)
+    final sevenDaysAgo = now.subtract(const Duration(days: 7));
+
+    final Map<TaskCategory, List<ActionItemWithMetadata>> categorized = {
+      TaskCategory.today: [],
+      TaskCategory.noDeadline: [],
+      TaskCategory.later: [],
+    };
+
+    for (var item in items) {
+      // Skip completed items unless showing completed
+      if (item.completed && !showCompleted) continue;
+      if (!item.completed && showCompleted) continue;
+
+      // Skip old tasks without a future due date (only for non-completed)
+      if (!showCompleted) {
+        if (item.dueAt != null) {
+          if (item.dueAt!.isBefore(sevenDaysAgo)) continue;
+        } else {
+          if (item.createdAt != null && item.createdAt!.isBefore(sevenDaysAgo)) continue;
+        }
+      }
+
+      if (item.dueAt == null) {
+        categorized[TaskCategory.noDeadline]!.add(item);
+      } else {
+        final dueDate = item.dueAt!;
+        if (dueDate.isBefore(startOfTomorrow)) {
+          categorized[TaskCategory.today]!.add(item);
+        } else {
+          categorized[TaskCategory.later]!.add(item);
+        }
+      }
+    }
+
+    return categorized;
+  }
+
+  String _getCategoryTitle(TaskCategory category) {
+    switch (category) {
+      case TaskCategory.noDeadline:
+        return 'No Deadline';
+      case TaskCategory.today:
+        return 'Today';
+      case TaskCategory.later:
+        return 'Later';
+    }
+  }
+
+  DateTime? _getDefaultDueDateForCategory(TaskCategory category) {
+    final now = DateTime.now();
+    switch (category) {
+      case TaskCategory.noDeadline:
+        return null;
+      case TaskCategory.today:
+        return DateTime(now.year, now.month, now.day, 23, 59);
+      case TaskCategory.later:
+        // Tomorrow
+        return DateTime(now.year, now.month, now.day + 1, 23, 59);
+    }
+  }
+
+  void _updateTaskCategory(ActionItemWithMetadata item, TaskCategory newCategory) {
+    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
+    final newDueDate = _getDefaultDueDateForCategory(newCategory);
+    provider.updateActionItemDueDate(item, newDueDate);
+  }
+
+  int _getIndentLevel(String itemId) {
+    return _indentLevels[itemId] ?? 0;
+  }
+
+  void _incrementIndent(String itemId) {
+    setState(() {
+      final current = _indentLevels[itemId] ?? 0;
+      if (current < 3) {
+        _indentLevels[itemId] = current + 1;
+      }
+    });
+    HapticFeedback.lightImpact();
+  }
+
+  void _decrementIndent(String itemId) {
+    setState(() {
+      final current = _indentLevels[itemId] ?? 0;
+      if (current > 0) {
+        _indentLevels[itemId] = current - 1;
+      }
+    });
+    HapticFeedback.lightImpact();
   }
 
   @override
@@ -114,36 +183,20 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
 
     return Consumer<ActionItemsProvider>(
       builder: (context, provider, child) {
-        // Get categorized items based on tab
-        final todoItems = provider.todoItems;
-        final doneItems = provider.doneItems;
-        final snoozedItems = provider.snoozedItems;
-
-        // Get current tab items
-        final currentTabItems = _selectedTabIndex == 0
-            ? todoItems
-            : _selectedTabIndex == 1
-                ? doneItems
-                : snoozedItems;
+        final showCompleted = provider.showCompletedView;
+        final categorizedItems = _categorizeItems(provider.actionItems, showCompleted);
 
         return Scaffold(
           backgroundColor: Theme.of(context).colorScheme.primary,
-          appBar: provider.isSelectionMode ? _buildSelectionAppBar(provider, currentTabItems) : null,
-          floatingActionButton: provider.isSelectionMode
-              ? null
-              : Padding(
-                  padding: const EdgeInsets.only(bottom: 60.0),
-                  child: FloatingActionButton(
-                    heroTag: 'action_items_fab',
-                    onPressed: _showCreateActionItemSheet,
-                    backgroundColor: Colors.deepPurpleAccent,
-                    tooltip: context.l10n.createActionItemTooltip,
-                    child: const Icon(
-                      Icons.add,
-                      color: Colors.white,
-                    ),
-                  ),
-                ),
+          floatingActionButton: Padding(
+            padding: const EdgeInsets.only(bottom: 60.0),
+            child: FloatingActionButton(
+              heroTag: 'action_items_fab',
+              onPressed: () => _showCreateActionItemSheet(),
+              backgroundColor: Colors.deepPurpleAccent,
+              child: const Icon(Icons.add, color: Colors.white),
+            ),
+          ),
           body: RefreshIndicator(
             onRefresh: () async {
               HapticFeedback.mediumImpact();
@@ -151,684 +204,301 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
             },
             color: Colors.deepPurpleAccent,
             backgroundColor: Colors.white,
-            child: CustomScrollView(
-              controller: _scrollController,
-              physics: const AlwaysScrollableScrollPhysics(),
-              slivers: [
-                // Main Content
-                if (provider.isLoading && provider.actionItems.isEmpty) ...[
-                  // Header shimmer
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(16.0, 24.0, 16.0, 16.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Text(
-                                context.l10n.actionItemsTitle,
-                                style: const TextStyle(
-                                  color: Colors.white,
-                                  fontSize: 20,
-                                  fontWeight: FontWeight.w600,
-                                ),
-                              ),
-                              Container(
-                                width: 32,
-                                height: 32,
-                                decoration: BoxDecoration(
-                                  color: Colors.grey[800]?.withOpacity(0.5),
-                                  borderRadius: BorderRadius.circular(8),
-                                ),
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 8),
-                          Text(
-                            context.l10n.actionItemsDescription,
-                            style: TextStyle(
-                              color: Colors.grey.shade500,
-                              fontSize: 12,
-                            ),
-                          ),
-                        ],
-                      ),
-                    ),
-                  ),
-                  // Shimmer list
-                  const ActionItemsShimmerList(),
-                ] else if (provider.actionItems.isEmpty)
-                  SliverFillRemaining(
-                    child: _buildSmartEmptyState(provider),
-                  )
-                else
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          // Task Integrations Banner
-                          const TaskIntegrationsBanner(),
-
-                          // Segmented Control - Full width like action items
-                          Container(
-                            width: double.infinity,
-                            decoration: BoxDecoration(
-                              color: const Color(0xFF1C1C1E),
-                              borderRadius: BorderRadius.circular(16),
-                            ),
-                            padding: const EdgeInsets.all(4),
-                            child: LayoutBuilder(
-                              builder: (context, constraints) {
-                                final tabWidth = constraints.maxWidth / 3;
-                                return Stack(
-                                  children: [
-                                    // Animated sliding background
-                                    AnimatedPositioned(
-                                      duration: const Duration(milliseconds: 200),
-                                      curve: Curves.easeInOut,
-                                      left: _selectedTabIndex * tabWidth,
-                                      top: 0,
-                                      bottom: 0,
-                                      width: tabWidth,
-                                      child: Container(
-                                        decoration: BoxDecoration(
-                                          color: const Color(0xFF2C2C2E),
-                                          borderRadius: BorderRadius.circular(12),
-                                        ),
-                                      ),
-                                    ),
-                                    // Tab buttons
-                                    Row(
-                                      children: [
-                                        Expanded(
-                                          child: GestureDetector(
-                                            onTap: () => _onTabChanged(0),
-                                            behavior: HitTestBehavior.opaque,
-                                            child: _buildTabLabel(context.l10n.tabToDo, todoItems.length),
-                                          ),
-                                        ),
-                                        Expanded(
-                                          child: GestureDetector(
-                                            onTap: () => _onTabChanged(1),
-                                            behavior: HitTestBehavior.opaque,
-                                            child: _buildTabLabel(context.l10n.tabDone, doneItems.length),
-                                          ),
-                                        ),
-                                        Expanded(
-                                          child: GestureDetector(
-                                            onTap: () => _onTabChanged(2),
-                                            behavior: HitTestBehavior.opaque,
-                                            child: _buildTabLabel(context.l10n.tabOld, snoozedItems.length),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ],
-                                );
-                              },
-                            ),
-                          ),
-                          const SizedBox(height: 16),
-                        ],
-                      ),
-                    ),
-                  ),
-
-                // Current Tab Items
-                if (provider.actionItems.isNotEmpty && currentTabItems.isNotEmpty)
-                  _buildTabItems(currentTabItems, provider)
-                else if (provider.actionItems.isNotEmpty && currentTabItems.isEmpty)
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: Container(
-                        height: 120,
-                        decoration: BoxDecoration(
-                          color: const Color(0xFF1F1F25),
-                          borderRadius: BorderRadius.circular(16),
-                        ),
-                        child: Center(
-                          child: Text(
-                            _getEmptyTabMessage(),
-                            style: TextStyle(
-                              color: Colors.grey.shade400,
-                              fontSize: 14,
-                            ),
-                            textAlign: TextAlign.center,
-                          ),
-                        ),
-                      ),
-                    ),
-                  ),
-
-                // Loading shimmer for pagination
-                if (provider.isFetching || provider.isLoading)
-                  SliverToBoxAdapter(
-                    child: Padding(
-                      padding: const EdgeInsets.all(16),
-                      child: Column(
-                        children: List.generate(
-                            3,
-                            (index) => const Padding(
-                                  padding: EdgeInsets.symmetric(vertical: 4),
-                                  child: ActionItemShimmerWidget(),
-                                )),
-                      ),
-                    ),
-                  ),
-
-                const SliverPadding(padding: EdgeInsets.only(bottom: 100)),
-              ],
-            ),
+            child: provider.isLoading && provider.actionItems.isEmpty
+                ? _buildLoadingState()
+                : provider.actionItems.isEmpty && !showCompleted
+                    ? _buildEmptyState()
+                    : _buildTasksList(categorizedItems, provider),
           ),
         );
       },
     );
   }
 
-  Widget _buildTabItems(List<ActionItemWithMetadata> items, ActionItemsProvider provider) {
-    return SliverList(
-      delegate: SliverChildBuilderDelegate(
-        (context, index) {
-          if (index < items.length) {
-            final item = items[index];
-            return Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: _buildDismissibleActionItem(
-                item: item,
-                provider: provider,
-              ),
-            );
-          }
-          return null;
-        },
-        childCount: items.length,
-      ),
+  Widget _buildLoadingState() {
+    return const Center(
+      child: CircularProgressIndicator(color: Colors.deepPurpleAccent),
     );
   }
 
-  String _getEmptyTabMessage() {
-    switch (_selectedTabIndex) {
-      case 0: // To Do
-        return context.l10n.emptyTodoMessage;
-      case 1: // Done
-        return context.l10n.emptyDoneMessage;
-      case 2: // Old
-        return context.l10n.emptyOldMessage;
-      default:
-        return context.l10n.noItems;
-    }
-  }
-
-  Widget _buildDismissibleActionItem({
-    required ActionItemWithMetadata item,
-    required ActionItemsProvider provider,
-  }) {
-    return Dismissible(
-      key: Key(item.id),
-      // Swipe right background - Mark as completed
-      background: provider.isSelectionMode
-          ? null
-          : Container(
-              margin: const EdgeInsets.symmetric(vertical: 2),
-              decoration: BoxDecoration(
-                color: item.completed ? Colors.orange : Colors.green,
-                borderRadius: BorderRadius.circular(16),
-              ),
-              alignment: Alignment.centerLeft,
-              padding: const EdgeInsets.only(left: 20),
-              child: Icon(
-                item.completed ? Icons.undo : Icons.check,
-                color: Colors.white,
-                size: 24,
-              ),
-            ),
-      // Swipe left background - Delete
-      secondaryBackground: provider.isSelectionMode
-          ? null
-          : Container(
-              margin: const EdgeInsets.symmetric(vertical: 2),
-              decoration: BoxDecoration(
-                color: Colors.red,
-                borderRadius: BorderRadius.circular(16),
-              ),
-              alignment: Alignment.centerRight,
-              padding: const EdgeInsets.only(right: 20),
-              child: const Icon(
-                Icons.delete,
-                color: Colors.white,
-                size: 24,
-              ),
-            ),
-      confirmDismiss: (direction) async {
-        // Disable swipe gestures when in selection mode
-        if (provider.isSelectionMode) {
-          return false;
-        }
-
-        if (direction == DismissDirection.startToEnd) {
-          // Swipe right - Toggle completion
-          await provider.updateActionItemState(item, !item.completed);
-
-          // Show feedback
-          if (mounted) {
-            ScaffoldMessenger.of(context).showSnackBar(
-              SnackBar(
-                content:
-                    Text(item.completed ? context.l10n.actionItemMarkedIncomplete : context.l10n.actionItemCompleted),
-                backgroundColor: item.completed ? Colors.orange : Colors.green,
-                duration: const Duration(seconds: 2),
-              ),
-            );
-          }
-          return false;
-        } else {
-          // Swipe left - Show delete confirmation
-          await _deleteActionItem(item, provider);
-          return false;
-        }
-      },
-      onDismissed: (direction) async {
-        // Only called for delete action (swipe left)
-        if (direction == DismissDirection.endToStart) {
-          await _deleteActionItem(item, provider);
-        }
-      },
-      child: ActionItemTileWidget(
-        actionItem: item,
-        onToggle: (newState) {
-          provider.updateActionItemState(item, newState);
-          if (newState) {
-            _onActionItemCompleted(isSnoozed: _selectedTabIndex == 2);
-          }
-        },
-        onRefresh: () => provider.fetchActionItems(),
-        isSelectionMode: provider.isSelectionMode,
-        isSelected: provider.isItemSelected(item.id),
-        onLongPress: () => _handleItemLongPress(item, provider),
-        onSelectionToggle: () => provider.toggleItemSelection(item.id),
-        isSnoozedTab: _selectedTabIndex == 2,
-      ),
-    );
-  }
-
-  void _handleItemLongPress(ActionItemWithMetadata item, ActionItemsProvider provider) {
-    if (!provider.isSelectionMode) {
-      // Enter selection mode and select the long-pressed item
-      provider.startSelection();
-      provider.selectItem(item.id);
-      HapticFeedback.mediumImpact();
-    }
-  }
-
-  PreferredSizeWidget _buildSelectionAppBar(
-      ActionItemsProvider provider, List<ActionItemWithMetadata> currentTabItems) {
-    return AppBar(
-      backgroundColor: Colors.black.withValues(alpha: 0.05),
-      elevation: 0,
-      foregroundColor: Colors.white,
-      leading: IconButton(
-        icon: const Icon(Icons.close, size: 20),
-        onPressed: () => provider.endSelection(),
-        padding: EdgeInsets.zero,
-        constraints: const BoxConstraints(),
-      ),
-      title: Text(
-        '${provider.selectedCount} selected',
-        style: const TextStyle(
-          fontSize: 16,
-          fontWeight: FontWeight.w500,
-        ),
-      ),
-      actions: [
-        if (provider.selectedCount < currentTabItems.length)
-          IconButton(
-            icon: const FaIcon(FontAwesomeIcons.squareCheck, size: 18),
-            tooltip: context.l10n.selectAll,
-            onPressed: () => provider.selectAllItemsFromTab(_selectedTabIndex),
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-          ),
-        if (provider.hasSelection)
-          IconButton(
-            icon: const FaIcon(FontAwesomeIcons.trash, size: 20),
-            tooltip: context.l10n.deleteSelected,
-            onPressed: () => _deleteSelectedItems(provider),
-            padding: const EdgeInsets.symmetric(horizontal: 8),
-          ),
-      ],
-    );
-  }
-
-  Future<void> _deleteSelectedItems(ActionItemsProvider provider) async {
-    final selectedCount = provider.selectedCount;
-    if (selectedCount == 0) return;
-
-    final prefs = SharedPreferencesUtil();
-
-    // Check if user has opted out of delete confirmations
-    if (!prefs.showActionItemDeleteConfirmation) {
-      // Skip confirmation and proceed with bulk deletion
-      await _performBulkDelete(provider);
-      return;
-    }
-
-    // Show confirmation dialog for bulk delete
-    final result = await OmiConfirmDialog.showWithSkipOption(
-      context,
-      title: context.l10n.deleteSelectedItemsTitle,
-      message: context.l10n.deleteSelectedItemsMessage(selectedCount, selectedCount > 1 ? 's' : ''),
-    );
-
-    if (result != null && result.confirmed) {
-      // Update preference if user chose to skip future confirmations
-      if (result.skipFutureConfirmations) {
-        prefs.showActionItemDeleteConfirmation = false;
-      }
-
-      await _performBulkDelete(provider);
-    }
-  }
-
-  Future<void> _performBulkDelete(ActionItemsProvider provider) async {
-    final selectedCount = provider.selectedCount;
-
-    try {
-      final success = await provider.deleteSelectedItems();
-
-      if (mounted && success) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.itemsDeletedResult(selectedCount, selectedCount > 1 ? 's' : '')),
-            backgroundColor: Colors.green,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      } else if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.failedToDeleteSomeItems),
-            backgroundColor: Colors.red,
-          ),
-        );
-      }
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.failedToDeleteItems),
-            backgroundColor: Colors.red,
-          ),
-        );
-      }
-    }
-  }
-
-  Future<void> _deleteActionItem(ActionItemWithMetadata item, ActionItemsProvider provider) async {
-    final prefs = SharedPreferencesUtil();
-
-    // Check if user has opted out of delete confirmations
-    if (!prefs.showActionItemDeleteConfirmation) {
-      // Skip confirmation and proceed with deletion
-      await _performDeleteActionItem(item, provider);
-      return;
-    }
-
-    final result = await OmiConfirmDialog.showWithSkipOption(
-      context,
-      title: context.l10n.deleteActionItemTitle,
-      message: context.l10n.deleteActionItemMessage,
-    );
-
-    if (result?.confirmed == true) {
-      // Update preference if user chose to skip future confirmations
-      if (result!.skipFutureConfirmations) {
-        prefs.showActionItemDeleteConfirmation = false;
-      }
-
-      await _performDeleteActionItem(item, provider);
-    }
-  }
-
-  Future<void> _performDeleteActionItem(ActionItemWithMetadata item, ActionItemsProvider provider) async {
-    final success = await provider.deleteActionItem(item);
-
-    if (mounted) {
-      if (success) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.actionItemDeletedResult(item.description)),
-            backgroundColor: Colors.green,
-            duration: const Duration(seconds: 3),
-          ),
-        );
-      } else {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(context.l10n.failedToDeleteItem),
-            backgroundColor: Colors.red,
-          ),
-        );
-      }
-    }
-  }
-
-  Widget _buildSmartEmptyState(ActionItemsProvider provider) {
+  Widget _buildEmptyState() {
     return Center(
-      child: Container(
-        constraints: const BoxConstraints(maxWidth: 400),
-        padding: const EdgeInsets.all(32.0),
-        child: _buildFirstTimeEmptyState(),
-      ),
-    );
-  }
-
-  Widget _buildTabLabel(String label, int count) {
-    final int tabIndex = label == 'To Do' ? 0 : (label == 'Done' ? 1 : (label == 'Old' ? 2 : 2));
-    final bool isSelected = _selectedTabIndex == tabIndex;
-
-    return Container(
-      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 8),
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          Text(
-            label,
-            style: TextStyle(
-              fontSize: 14,
-              fontWeight: FontWeight.w500,
-              color: isSelected ? Colors.white : Colors.grey[500],
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                color: Colors.deepPurpleAccent.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(24),
+              ),
+              child: Icon(
+                Icons.check_circle_outline,
+                size: 40,
+                color: Colors.deepPurpleAccent.withOpacity(0.6),
+              ),
             ),
-          ),
-          if (count > 0) ...[
-            const SizedBox(width: 4),
-            Text(
-              '$count',
+            const SizedBox(height: 24),
+            const Text(
+              'No Tasks Yet',
               style: TextStyle(
-                fontSize: 12,
-                fontWeight: FontWeight.w500,
-                color: isSelected ? Colors.grey[400] : Colors.grey[600],
+                color: Colors.white,
+                fontSize: 24,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 12),
+            Text(
+              'Tasks from your conversations will appear here.\nTap + to create one manually.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.grey[400],
+                fontSize: 16,
+                height: 1.5,
               ),
             ),
           ],
-        ],
+        ),
       ),
     );
   }
 
-  Widget _buildFirstTimeEmptyState() {
-    return Column(
-      mainAxisAlignment: MainAxisAlignment.center,
-      children: [
-        Container(
-          width: 96,
-          height: 96,
-          decoration: BoxDecoration(
-            gradient: LinearGradient(
-              colors: [
-                const Color(0xFF8B5CF6).withOpacity(0.1),
-                const Color(0xFFA855F7).withOpacity(0.05),
-              ],
-              begin: Alignment.topLeft,
-              end: Alignment.bottomRight,
-            ),
-            borderRadius: BorderRadius.circular(32),
-            border: Border.all(
-              color: const Color(0xFF8B5CF6).withOpacity(0.2),
-              width: 1,
+  Widget _buildTasksList(
+    Map<TaskCategory, List<ActionItemWithMetadata>> categorizedItems,
+    ActionItemsProvider provider,
+  ) {
+    return CustomScrollView(
+      controller: _scrollController,
+      physics: const AlwaysScrollableScrollPhysics(),
+      slivers: [
+        const SliverPadding(padding: EdgeInsets.only(top: 12)),
+
+        // Build each category section
+        for (final category in TaskCategory.values)
+          SliverToBoxAdapter(
+            child: _buildCategorySection(
+              category: category,
+              items: categorizedItems[category] ?? [],
+              provider: provider,
             ),
           ),
-          child: Stack(
-            alignment: Alignment.center,
-            children: [
-              Icon(
-                Icons.assignment_outlined,
-                size: 40,
-                color: const Color(0xFF8B5CF6).withOpacity(0.6),
-              ),
-              Positioned(
-                right: 24,
-                bottom: 24,
-                child: Container(
-                  width: 20,
-                  height: 20,
-                  decoration: const BoxDecoration(
-                    color: Color(0xFF10B981),
-                    shape: BoxShape.circle,
-                  ),
-                  child: const Icon(
-                    Icons.check,
-                    size: 12,
-                    color: Colors.white,
+
+        // Bottom padding
+        const SliverPadding(padding: EdgeInsets.only(bottom: 100)),
+      ],
+    );
+  }
+
+  Widget _buildCategorySection({
+    required TaskCategory category,
+    required List<ActionItemWithMetadata> items,
+    required ActionItemsProvider provider,
+  }) {
+    final title = _getCategoryTitle(category);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+      child: DragTarget<ActionItemWithMetadata>(
+        onWillAcceptWithDetails: (details) => true,
+        onAcceptWithDetails: (details) {
+          _updateTaskCategory(details.data, category);
+        },
+        builder: (context, candidateData, rejectedData) {
+          final isHovering = candidateData.isNotEmpty;
+          return AnimatedContainer(
+            duration: const Duration(milliseconds: 200),
+            decoration: BoxDecoration(
+              color: isHovering ? const Color(0xFF252528) : Colors.transparent,
+              borderRadius: BorderRadius.circular(12),
+            ),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Header
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(4, 12, 4, 8),
+                  child: Row(
+                    children: [
+                      Text(
+                        title,
+                        style: const TextStyle(
+                          color: Colors.white,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      const Spacer(),
+                      if (items.isNotEmpty)
+                        Text(
+                          '${items.length}',
+                          style: TextStyle(
+                            color: Colors.grey[600],
+                            fontSize: 14,
+                          ),
+                        ),
+                    ],
                   ),
                 ),
-              ),
-            ],
-          ),
-        ),
 
-        const SizedBox(height: 28),
+                // Task items
+                ...items.map((item) => _buildTaskItem(item, provider)),
 
-        // Welcome heading
-        Text(
-          context.l10n.welcomeActionItemsTitle,
-          style: const TextStyle(
-            color: Color(0xFFFFFFFF),
-            fontSize: 28,
-            fontWeight: FontWeight.w700,
-            letterSpacing: -0.8,
-          ),
-          textAlign: TextAlign.center,
-        ),
+                // Spacing after section
+                const SizedBox(height: 8),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
 
-        const SizedBox(height: 16),
+  Widget _buildTaskItem(ActionItemWithMetadata item, ActionItemsProvider provider) {
+    final indentLevel = _getIndentLevel(item.id);
+    final indentWidth = indentLevel * 28.0;
 
-        // Educational description
-        Text(
-          context.l10n.welcomeActionItemsDescription,
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            color: Color(0xFFB0B0B0),
-            fontSize: 16,
-            height: 1.6,
-            fontWeight: FontWeight.w400,
-          ),
-        ),
-
-        const SizedBox(height: 32),
-
-        // Subtle feature hints
-        Container(
-          padding: const EdgeInsets.all(20),
-          decoration: BoxDecoration(
-            color: const Color(0xFF1A1A1A),
-            borderRadius: BorderRadius.circular(16),
-            border: Border.all(
-              color: const Color(0xFF2A2A2A),
-              width: 1,
+    return GestureDetector(
+      onHorizontalDragEnd: (details) {
+        // Swipe right to increase indent, left to decrease
+        if (details.primaryVelocity != null) {
+          if (details.primaryVelocity! > 200) {
+            _incrementIndent(item.id);
+          } else if (details.primaryVelocity! < -200) {
+            _decrementIndent(item.id);
+          }
+        }
+      },
+      child: LongPressDraggable<ActionItemWithMetadata>(
+        data: item,
+        feedback: Material(
+          color: Colors.transparent,
+          child: Container(
+            width: MediaQuery.of(context).size.width - 64,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+            decoration: BoxDecoration(
+              color: const Color(0xFF2C2C2E),
+              borderRadius: BorderRadius.circular(12),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.3),
+                  blurRadius: 10,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Row(
+              children: [
+                _buildCheckbox(item.completed),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    item.description,
+                    style: const TextStyle(color: Colors.white, fontSize: 15),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
             ),
           ),
-          child: Column(
-            children: [
-              Row(
-                children: [
-                  Container(
-                    width: 6,
-                    height: 6,
-                    decoration: const BoxDecoration(
-                      color: Color(0xFF8B5CF6),
-                      shape: BoxShape.circle,
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      context.l10n.autoExtractionFeature,
-                      style: TextStyle(
-                        color: Color(0xFFE5E5E5),
-                        fontSize: 14,
-                        height: 1.4,
+        ),
+        childWhenDragging: Opacity(
+          opacity: 0.3,
+          child: _buildTaskItemContent(item, provider, indentWidth),
+        ),
+        child: _buildTaskItemContent(item, provider, indentWidth),
+      ),
+    );
+  }
+
+  Widget _buildTaskItemContent(
+    ActionItemWithMetadata item,
+    ActionItemsProvider provider,
+    double indentWidth,
+  ) {
+    final indentLevel = _getIndentLevel(item.id);
+
+    return GestureDetector(
+      onTap: () => _showEditSheet(item),
+      child: Container(
+        margin: const EdgeInsets.symmetric(vertical: 1),
+        child: Dismissible(
+          key: Key('${item.id}_dismiss'),
+          direction: DismissDirection.none, // Disable dismiss, use swipe for indent
+          child: Padding(
+            padding: EdgeInsets.only(left: 4 + indentWidth, right: 4, top: 6, bottom: 6),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                // Indent line
+                if (indentLevel > 0)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 10),
+                    child: Container(
+                      width: 1.5,
+                      height: 20,
+                      decoration: BoxDecoration(
+                        color: Colors.grey[700],
+                        borderRadius: BorderRadius.circular(1),
                       ),
                     ),
                   ),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: [
-                  Container(
-                    width: 6,
-                    height: 6,
-                    decoration: const BoxDecoration(
-                      color: Color(0xFF8B5CF6),
-                      shape: BoxShape.circle,
+                // Checkbox
+                GestureDetector(
+                  onTap: () async {
+                    HapticFeedback.lightImpact();
+                    await provider.updateActionItemState(item, !item.completed);
+                    if (!item.completed) _onActionItemCompleted();
+                  },
+                  child: _buildCheckbox(item.completed),
+                ),
+                const SizedBox(width: 12),
+                // Task text
+                Expanded(
+                  child: Text(
+                    item.description,
+                    style: TextStyle(
+                      color: item.completed ? Colors.grey[600] : Colors.white,
+                      fontSize: 15,
+                      decoration: item.completed ? TextDecoration.lineThrough : null,
                     ),
                   ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      context.l10n.editSwipeFeature,
-                      style: TextStyle(
-                        color: Color(0xFFE5E5E5),
-                        fontSize: 14,
-                        height: 1.4,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-              const SizedBox(height: 12),
-              Row(
-                children: [
-                  Container(
-                    width: 6,
-                    height: 6,
-                    decoration: const BoxDecoration(
-                      color: Color(0xFF8B5CF6),
-                      shape: BoxShape.circle,
-                    ),
-                  ),
-                  const SizedBox(width: 12),
-                  const Expanded(
-                    child: Text(
-                      'Filter and organize by date ranges',
-                      style: TextStyle(
-                        color: Color(0xFFE5E5E5),
-                        fontSize: 14,
-                        height: 1.4,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
-            ],
+                ),
+              ],
+            ),
           ),
         ),
-      ],
+      ),
+    );
+  }
+
+  Widget _buildCheckbox(bool isCompleted) {
+    return Container(
+      width: 22,
+      height: 22,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: isCompleted ? Colors.amber : Colors.grey[600]!,
+          width: 2,
+        ),
+        color: isCompleted ? Colors.amber : Colors.transparent,
+      ),
+      child: isCompleted
+          ? const Icon(Icons.check, size: 14, color: Colors.black)
+          : null,
+    );
+  }
+
+  void _showEditSheet(ActionItemWithMetadata item) {
+    showModalBottomSheet(
+      context: context,
+      isScrollControlled: true,
+      backgroundColor: Colors.transparent,
+      builder: (context) => ActionItemFormSheet(actionItem: item),
     );
   }
 }

--- a/app/lib/pages/action_items/widgets/action_item_form_sheet.dart
+++ b/app/lib/pages/action_items/widgets/action_item_form_sheet.dart
@@ -14,8 +14,9 @@ import 'package:omi/utils/l10n_extensions.dart';
 class ActionItemFormSheet extends StatefulWidget {
   final ActionItemWithMetadata? actionItem; // null for create, non-null for edit
   final VoidCallback? onRefresh;
+  final DateTime? defaultDueDate; // Default due date for new items
 
-  const ActionItemFormSheet({super.key, this.actionItem, this.onRefresh});
+  const ActionItemFormSheet({super.key, this.actionItem, this.onRefresh, this.defaultDueDate});
 
   bool get isEditing => actionItem != null;
 
@@ -43,7 +44,7 @@ class _ActionItemFormSheetState extends State<ActionItemFormSheet> {
     } else {
       _textController = TextEditingController();
       _isCompleted = false;
-      _selectedDueDate = null;
+      _selectedDueDate = widget.defaultDueDate;
     }
   }
 

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -19,7 +19,9 @@ import 'package:omi/pages/conversations/conversations_page.dart';
 import 'package:omi/pages/memories/page.dart';
 import 'package:omi/pages/settings/data_privacy_page.dart';
 import 'package:omi/pages/settings/settings_drawer.dart';
+import 'package:omi/pages/settings/task_integrations_page.dart';
 import 'package:omi/pages/settings/wrapped_2025_page.dart';
+import 'package:omi/providers/action_items_provider.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/connectivity_provider.dart';
@@ -964,6 +966,69 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                 },
                               );
                             }
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                    ],
+                  );
+                },
+              ),
+              // Action items page buttons - export and completed toggle
+              Consumer2<HomeProvider, ActionItemsProvider>(
+                builder: (context, homeProvider, actionItemsProvider, _) {
+                  if (homeProvider.selectedIndex != 1) {
+                    return const SizedBox.shrink();
+                  }
+                  final showCompleted = actionItemsProvider.showCompletedView;
+                  return Row(
+                    children: [
+                      // Export button
+                      Container(
+                        width: 36,
+                        height: 36,
+                        decoration: const BoxDecoration(
+                          color: Color(0xFF1F1F25),
+                          shape: BoxShape.circle,
+                        ),
+                        child: IconButton(
+                          padding: EdgeInsets.zero,
+                          icon: const Icon(
+                            Icons.ios_share,
+                            size: 18,
+                            color: Colors.white70,
+                          ),
+                          onPressed: () {
+                            HapticFeedback.mediumImpact();
+                            Navigator.of(context).push(
+                              MaterialPageRoute(
+                                builder: (context) => const TaskIntegrationsPage(),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      // Completed toggle
+                      Container(
+                        width: 36,
+                        height: 36,
+                        decoration: BoxDecoration(
+                          color: showCompleted
+                              ? Colors.deepPurple.withValues(alpha: 0.5)
+                              : const Color(0xFF1F1F25),
+                          shape: BoxShape.circle,
+                        ),
+                        child: IconButton(
+                          padding: EdgeInsets.zero,
+                          icon: Icon(
+                            showCompleted ? Icons.check_circle : Icons.check_circle_outline,
+                            size: 18,
+                            color: showCompleted ? Colors.white : Colors.white70,
+                          ),
+                          onPressed: () {
+                            HapticFeedback.mediumImpact();
+                            actionItemsProvider.toggleShowCompletedView();
                           },
                         ),
                       ),

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -14,6 +14,9 @@ class ActionItemsProvider extends ChangeNotifier {
 
   bool _includeCompleted = true;
 
+  // UI filter: show completed tasks view
+  bool _showCompletedView = false;
+
   // Date range filter
   DateTime? _startDate;
   DateTime? _endDate;
@@ -33,6 +36,7 @@ class ActionItemsProvider extends ChangeNotifier {
   bool get isFetching => _isFetching;
   bool get hasMore => _hasMore;
   bool get includeCompleted => _includeCompleted;
+  bool get showCompletedView => _showCompletedView;
   DateTime? get startDate => _startDate;
   DateTime? get endDate => _endDate;
   bool get hasActiveFilter => _startDate != null || _endDate != null;
@@ -342,6 +346,11 @@ class ActionItemsProvider extends ChangeNotifier {
     _includeCompleted = !_includeCompleted;
     fetchActionItems(showShimmer: true);
     // TODO: Add analytics for completed action items toggle
+  }
+
+  void toggleShowCompletedView() {
+    _showCompletedView = !_showCompletedView;
+    notifyListeners();
   }
 
   void setDateRangeFilter(DateTime? startDate, DateTime? endDate) {


### PR DESCRIPTION
## Summary
- Simplified task categories from 5 (No Deadline, Today, This Month, This Quarter, This Year) to 3: **Today**, **No Deadline**, **Later**
- Added drag-and-drop between categories that automatically updates task deadlines
- Added swipe left/right gesture to indent tasks (cascade like Apple Notes/Notion)
- Moved export and completed toggle buttons to header bar for cleaner UI
- Removed banner and tabs UI for a cleaner single-page layout
- Added 7-day filter to hide old uncompleted tasks automatically
- Synced all changes to desktop version

## Test plan
- [ ] Verify tasks display in correct categories based on due date
- [ ] Test drag-and-drop between categories updates deadline
- [ ] Test swipe left/right indents tasks properly
- [ ] Verify export button opens Task Integrations page
- [ ] Test completed toggle shows/hides completed tasks
- [ ] Test on desktop version

🤖 Generated with [Claude Code](https://claude.com/claude-code)