### PR TITLE
feat: persistent voice recorder across page navigation

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -50,6 +50,7 @@ import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/providers/user_provider.dart';
 import 'package:omi/providers/folder_provider.dart';
+import 'package:omi/providers/voice_recorder_provider.dart';
 import 'package:omi/providers/locale_provider.dart';
 import 'package:omi/services/auth_service.dart';
 import 'package:omi/services/desktop_update_service.dart';
@@ -357,6 +358,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
           ChangeNotifierProvider(create: (context) => CalendarProvider(), lazy: false),
           ChangeNotifierProvider(create: (context) => FolderProvider()),
           ChangeNotifierProvider(create: (context) => LocaleProvider()),
+          ChangeNotifierProvider(create: (context) => VoiceRecorderProvider()),
         ],
         builder: (context, child) {
           return WithForegroundTask(

--- a/app/lib/pages/chat/widgets/voice_recorder_widget.dart
+++ b/app/lib/pages/chat/widgets/voice_recorder_widget.dart
@@ -1,22 +1,10 @@
 import 'dart:async';
 import 'dart:math' as math;
-import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:omi/backend/http/api/messages.dart';
-import 'package:omi/services/services.dart';
-import 'package:omi/utils/alerts/app_snackbar.dart';
-import 'package:omi/utils/file.dart';
-import 'package:permission_handler/permission_handler.dart';
+import 'package:omi/providers/voice_recorder_provider.dart';
+import 'package:provider/provider.dart';
 import 'package:shimmer/shimmer.dart';
-
-enum RecordingState {
-  notRecording,
-  recording,
-  transcribing,
-  transcribeSuccess,
-  transcribeFailed,
-}
 
 class VoiceRecorderWidget extends StatefulWidget {
   final Function(String) onTranscriptReady;
@@ -33,15 +21,7 @@ class VoiceRecorderWidget extends StatefulWidget {
 }
 
 class _VoiceRecorderWidgetState extends State<VoiceRecorderWidget> with SingleTickerProviderStateMixin {
-  RecordingState _state = RecordingState.recording;
-  List<List<int>> _audioChunks = [];
-  String _transcript = '';
-  bool _isProcessing = false;
-
-  // Audio visualization
-  final List<double> _audioLevels = List.generate(20, (_) => 0.1);
   late AnimationController _animationController;
-  Timer? _waveformTimer;
 
   @override
   void initState() {
@@ -51,336 +31,200 @@ class _VoiceRecorderWidgetState extends State<VoiceRecorderWidget> with SingleTi
       duration: const Duration(milliseconds: 1000),
     )..repeat(reverse: true);
 
-    // Setup timer to update the wave visualization every second
-    _waveformTimer = Timer.periodic(const Duration(seconds: 1), (_) {
-      if (_state == RecordingState.recording && mounted) {
-        setState(() {
-          // Just trigger a repaint
-        });
+    // Set up callbacks and start recording
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final provider = context.read<VoiceRecorderProvider>();
+      provider.setCallbacks(
+        onTranscriptReady: widget.onTranscriptReady,
+        onClose: widget.onClose,
+      );
+      
+      // Only start recording if not already recording
+      if (!provider.isRecording) {
+        provider.startRecording();
       }
     });
-
-    _startRecording();
   }
 
   @override
   void dispose() {
     _animationController.dispose();
-    _waveformTimer?.cancel();
-
-    // Make sure to stop recording when widget is disposed
-    if (_state == RecordingState.recording) {
-      // Use a synchronous call to stop recording to avoid any async issues
-      ServiceManager.instance().mic.stop();
-    }
-
+    // Don't stop recording on dispose - let it continue across page navigation
+    // The provider will handle cleanup when close() is called
     super.dispose();
-  }
-
-  Future<void> _startRecording() async {
-    await Permission.microphone.request();
-
-    await ServiceManager.instance().mic.start(onByteReceived: (bytes) {
-      if (_state == RecordingState.recording && mounted) {
-        // Check if widget is still mounted before calling setState
-        if (mounted) {
-          setState(() {
-            _audioChunks.add(bytes.toList());
-
-            // Update audio visualization based on actual audio levels
-            if (bytes.isNotEmpty) {
-              // Calculate RMS (Root Mean Square) for PCM16 audio data
-              double rms = 0;
-
-              // Process bytes as 16-bit samples (2 bytes per sample)
-              for (int i = 0; i < bytes.length - 1; i += 2) {
-                // Convert two bytes to a 16-bit signed integer
-                // PCM16 is little-endian: LSB first, then MSB
-                int sample = bytes[i] | (bytes[i + 1] << 8);
-
-                // Convert to signed value (if high bit is set)
-                if (sample > 32767) {
-                  sample = sample - 65536;
-                }
-
-                // Square the sample and add to sum
-                rms += sample * sample;
-              }
-
-              // Calculate RMS and normalize to 0.0-1.0 range
-              // 32768 is max absolute value for 16-bit audio
-              int sampleCount = bytes.length ~/ 2;
-              if (sampleCount > 0) {
-                rms = math.sqrt(rms / sampleCount) / 32768.0;
-              } else {
-                rms = 0;
-              }
-
-              // Apply non-linear scaling to make quiet sounds more visible
-              // and loud sounds more dramatic
-              final level = math.pow(rms, 0.4).toDouble().clamp(0.1, 1.0);
-
-              // Shift all values left
-              for (int i = 0; i < _audioLevels.length - 1; i++) {
-                _audioLevels[i] = _audioLevels[i + 1];
-              }
-
-              // Add new level at the end
-              _audioLevels[_audioLevels.length - 1] = level;
-
-              // We don't force setState here anymore - the timer will handle updates
-            }
-          });
-        }
-      }
-    }, onRecording: () {
-      debugPrint('Recording started');
-      setState(() {
-        _state = RecordingState.recording;
-        _audioChunks = [];
-        // Reset audio levels
-        for (int i = 0; i < _audioLevels.length; i++) {
-          _audioLevels[i] = 0.1;
-        }
-      });
-    }, onStop: () {
-      debugPrint('Recording stopped');
-    }, onInitializing: () {
-      debugPrint('Initializing');
-    });
-  }
-
-  Future<void> _stopRecording() async {
-    _waveformTimer?.cancel();
-    ServiceManager.instance().mic.stop();
-  }
-
-  Future<void> _processRecording() async {
-    if (_audioChunks.isEmpty) {
-      widget.onClose();
-      return;
-    }
-
-    setState(() {
-      _state = RecordingState.transcribing;
-      _isProcessing = true;
-    });
-
-    await _stopRecording();
-
-    // Flatten audio chunks into a single list
-    List<int> flattenedBytes = [];
-    for (var chunk in _audioChunks) {
-      flattenedBytes.addAll(chunk);
-    }
-
-    // Convert PCM to WAV file
-    final audioFile = await FileUtils.convertPcmToWavFile(
-      Uint8List.fromList(flattenedBytes),
-      16000, // Sample rate
-      1, // Mono channel
-    );
-
-    try {
-      final transcript = await transcribeVoiceMessage(audioFile);
-      if (mounted) {
-        setState(() {
-          _transcript = transcript;
-          _state = RecordingState.transcribeSuccess;
-          _isProcessing = false;
-        });
-        if (transcript.isNotEmpty) {
-          widget.onTranscriptReady(transcript);
-        }
-      }
-    } catch (e) {
-      debugPrint('Error processing recording: $e');
-      if (mounted) {
-        setState(() {
-          _state = RecordingState.transcribeFailed;
-          _isProcessing = false;
-        });
-      }
-      AppSnackbar.showSnackbarError('Failed to transcribe audio');
-    }
-  }
-
-  void _retry() {
-    if (_audioChunks.isEmpty) {
-      _startRecording();
-    } else {
-      // Retry transcription with existing audio data
-      _processRecording();
-    }
   }
 
   @override
   Widget build(BuildContext context) {
-    switch (_state) {
-      case RecordingState.recording:
-        return Container(
-          decoration: BoxDecoration(
-            color: Colors.black,
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Row(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              IconButton(
-                icon: const Icon(Icons.close, color: Colors.white),
-                onPressed: widget.onClose,
-              ),
-              Expanded(
-                child: SizedBox(
-                  height: 40,
-                  child: CustomPaint(
-                    painter: AudioWavePainter(
-                      levels: _audioLevels,
-                      timestamp: DateTime.now(),
-                    ),
-                  ),
-                ),
-              ),
-              GestureDetector(
-                onTap: _processRecording,
-                child: Container(
-                  padding: const EdgeInsets.all(4),
-                  margin: const EdgeInsets.only(top: 10, bottom: 10, right: 6, left: 16),
-                  decoration: const BoxDecoration(
-                    color: Colors.white,
-                    shape: BoxShape.circle,
-                  ),
-                  child: const Icon(
-                    Icons.check,
-                    color: Colors.black,
-                    size: 20.0,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        );
-
-      case RecordingState.transcribing:
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          decoration: BoxDecoration(
-            color: Colors.black,
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              Shimmer.fromColors(
-                baseColor: Color(0xFF35343B),
-                highlightColor: Colors.white,
-                child: const Text(
-                  'Transcribing...',
-                  style: TextStyle(
-                    color: Colors.white,
-                  ),
-                ),
-              ),
-            ],
-          ),
-        );
-
-      case RecordingState.transcribeSuccess:
-        return Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Container(
-              width: double.infinity,
-              padding: const EdgeInsets.all(12),
+    return Consumer<VoiceRecorderProvider>(
+      builder: (context, provider, child) {
+        switch (provider.state) {
+          case VoiceRecorderState.recording:
+            return Container(
               decoration: BoxDecoration(
                 color: Colors.black,
                 borderRadius: BorderRadius.circular(16),
               ),
-              child: Text(
-                _transcript,
-                style: const TextStyle(color: Colors.white),
-              ),
-            ),
-            const SizedBox(height: 8),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.end,
-              children: [
-                IconButton(
-                  icon: const Icon(Icons.close, color: Colors.white),
-                  onPressed: widget.onClose,
-                ),
-                IconButton(
-                  icon: const Icon(Icons.send, color: Colors.white),
-                  onPressed: () => widget.onTranscriptReady(_transcript),
-                ),
-              ],
-            ),
-          ],
-        );
-
-      case RecordingState.transcribeFailed:
-        return Container(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
-          decoration: BoxDecoration(
-            color: Colors.black,
-            borderRadius: BorderRadius.circular(16),
-          ),
-          child: Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              const Text(
-                'Error',
-                style: TextStyle(color: Colors.redAccent, fontSize: 14, fontWeight: FontWeight.w700),
-              ),
-              const SizedBox(width: 16),
-              Expanded(
-                child: SizedBox(
-                  height: 40,
-                  child: CustomPaint(
-                    painter: AudioWavePainter(
-                      levels: _audioLevels,
-                      timestamp: DateTime.now(),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.center,
+                children: [
+                  IconButton(
+                    icon: const Icon(Icons.close, color: Colors.white),
+                    onPressed: provider.close,
+                  ),
+                  Expanded(
+                    child: SizedBox(
+                      height: 40,
+                      child: CustomPaint(
+                        painter: AudioWavePainter(
+                          levels: provider.audioLevels,
+                          timestamp: DateTime.now(),
+                        ),
+                      ),
                     ),
                   ),
-                ),
-              ),
-              Row(
-                children: [
                   GestureDetector(
-                      onTap: _retry,
-                      child: Container(
-                        padding: const EdgeInsets.all(4),
-                        margin: const EdgeInsets.only(left: 10, right: 0, top: 10, bottom: 10),
-                        decoration: const BoxDecoration(
-                          color: Colors.white,
-                          shape: BoxShape.circle,
-                        ),
-                        child: const Icon(
-                          color: Colors.black,
-                          Icons.refresh,
-                          size: 20.0,
-                        ),
-                      )),
-                  GestureDetector(
-                    onTap: widget.onClose,
+                    onTap: provider.processRecording,
                     child: Container(
-                      padding: const EdgeInsets.only(left: 14, right: 0, top: 14, bottom: 14),
-                      child: const Icon(
-                        Icons.close,
+                      padding: const EdgeInsets.all(4),
+                      margin: const EdgeInsets.only(top: 10, bottom: 10, right: 6, left: 16),
+                      decoration: const BoxDecoration(
                         color: Colors.white,
-                        size: 20,
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.check,
+                        color: Colors.black,
+                        size: 20.0,
                       ),
                     ),
                   ),
                 ],
               ),
-            ],
-          ),
-        );
+            );
 
-      default:
-        return const SizedBox.shrink();
-    }
+          case VoiceRecorderState.transcribing:
+            return Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              decoration: BoxDecoration(
+                color: Colors.black,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Shimmer.fromColors(
+                    baseColor: Color(0xFF35343B),
+                    highlightColor: Colors.white,
+                    child: const Text(
+                      'Transcribing...',
+                      style: TextStyle(
+                        color: Colors.white,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+
+          case VoiceRecorderState.transcribeSuccess:
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Container(
+                  width: double.infinity,
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.black,
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Text(
+                    provider.transcript,
+                    style: const TextStyle(color: Colors.white),
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.end,
+                  children: [
+                    IconButton(
+                      icon: const Icon(Icons.close, color: Colors.white),
+                      onPressed: provider.close,
+                    ),
+                    IconButton(
+                      icon: const Icon(Icons.send, color: Colors.white),
+                      onPressed: () => widget.onTranscriptReady(provider.transcript),
+                    ),
+                  ],
+                ),
+              ],
+            );
+
+          case VoiceRecorderState.transcribeFailed:
+            return Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 0),
+              decoration: BoxDecoration(
+                color: Colors.black,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Text(
+                    'Error',
+                    style: TextStyle(color: Colors.redAccent, fontSize: 14, fontWeight: FontWeight.w700),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: SizedBox(
+                      height: 40,
+                      child: CustomPaint(
+                        painter: AudioWavePainter(
+                          levels: provider.audioLevels,
+                          timestamp: DateTime.now(),
+                        ),
+                      ),
+                    ),
+                  ),
+                  Row(
+                    children: [
+                      GestureDetector(
+                          onTap: provider.retry,
+                          child: Container(
+                            padding: const EdgeInsets.all(4),
+                            margin: const EdgeInsets.only(left: 10, right: 0, top: 10, bottom: 10),
+                            decoration: const BoxDecoration(
+                              color: Colors.white,
+                              shape: BoxShape.circle,
+                            ),
+                            child: const Icon(
+                              color: Colors.black,
+                              Icons.refresh,
+                              size: 20.0,
+                            ),
+                          )),
+                      GestureDetector(
+                        onTap: provider.close,
+                        child: Container(
+                          padding: const EdgeInsets.only(left: 14, right: 0, top: 14, bottom: 14),
+                          child: const Icon(
+                            Icons.close,
+                            color: Colors.white,
+                            size: 20,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            );
+
+          default:
+            return const SizedBox.shrink();
+        }
+      },
+    );
   }
 }
 

--- a/app/lib/providers/voice_recorder_provider.dart
+++ b/app/lib/providers/voice_recorder_provider.dart
@@ -1,0 +1,231 @@
+import 'dart:async';
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:omi/backend/http/api/messages.dart';
+import 'package:omi/services/services.dart';
+import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/file.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+enum VoiceRecorderState {
+  idle,
+  recording,
+  transcribing,
+  transcribeSuccess,
+  transcribeFailed,
+}
+
+class VoiceRecorderProvider extends ChangeNotifier {
+  VoiceRecorderState _state = VoiceRecorderState.idle;
+  List<List<int>> _audioChunks = [];
+  String _transcript = '';
+  bool _isProcessing = false;
+
+  // Audio visualization
+  final List<double> _audioLevels = List.generate(20, (_) => 0.1);
+  Timer? _waveformTimer;
+
+  // Callbacks for UI integration
+  Function(String transcript)? _onTranscriptReady;
+  VoidCallback? _onClose;
+
+  VoiceRecorderState get state => _state;
+  String get transcript => _transcript;
+  bool get isProcessing => _isProcessing;
+  List<double> get audioLevels => List.unmodifiable(_audioLevels);
+  bool get isRecording => _state == VoiceRecorderState.recording;
+  bool get isActive => _state != VoiceRecorderState.idle;
+
+  void setCallbacks({
+    Function(String transcript)? onTranscriptReady,
+    VoidCallback? onClose,
+  }) {
+    _onTranscriptReady = onTranscriptReady;
+    _onClose = onClose;
+  }
+
+  void clearCallbacks() {
+    _onTranscriptReady = null;
+    _onClose = null;
+  }
+
+  Future<void> startRecording() async {
+    if (_state == VoiceRecorderState.recording) return;
+
+    _state = VoiceRecorderState.recording;
+    _audioChunks = [];
+    _transcript = '';
+
+    // Reset audio levels
+    for (int i = 0; i < _audioLevels.length; i++) {
+      _audioLevels[i] = 0.1;
+    }
+    notifyListeners();
+
+    await Permission.microphone.request();
+
+    // Setup timer to update the wave visualization every second
+    _waveformTimer = Timer.periodic(const Duration(seconds: 1), (_) {
+      if (_state == VoiceRecorderState.recording) {
+        notifyListeners();
+      }
+    });
+
+    await ServiceManager.instance().mic.start(
+      onByteReceived: (bytes) {
+        if (_state == VoiceRecorderState.recording) {
+          _audioChunks.add(bytes.toList());
+
+          // Update audio visualization based on actual audio levels
+          if (bytes.isNotEmpty) {
+            // Calculate RMS (Root Mean Square) for PCM16 audio data
+            double rms = 0;
+
+            // Process bytes as 16-bit samples (2 bytes per sample)
+            for (int i = 0; i < bytes.length - 1; i += 2) {
+              // Convert two bytes to a 16-bit signed integer
+              // PCM16 is little-endian: LSB first, then MSB
+              int sample = bytes[i] | (bytes[i + 1] << 8);
+
+              // Convert to signed value (if high bit is set)
+              if (sample > 32767) {
+                sample = sample - 65536;
+              }
+
+              // Square the sample and add to sum
+              rms += sample * sample;
+            }
+
+            // Calculate RMS and normalize to 0.0-1.0 range
+            // 32768 is max absolute value for 16-bit audio
+            int sampleCount = bytes.length ~/ 2;
+            if (sampleCount > 0) {
+              rms = math.sqrt(rms / sampleCount) / 32768.0;
+            } else {
+              rms = 0;
+            }
+
+            // Apply non-linear scaling to make quiet sounds more visible
+            // and loud sounds more dramatic
+            final level = math.pow(rms, 0.4).toDouble().clamp(0.1, 1.0);
+
+            // Shift all values left
+            for (int i = 0; i < _audioLevels.length - 1; i++) {
+              _audioLevels[i] = _audioLevels[i + 1];
+            }
+
+            // Add new level at the end
+            _audioLevels[_audioLevels.length - 1] = level;
+          }
+        }
+      },
+      onRecording: () {
+        debugPrint('VoiceRecorderProvider: Recording started');
+        _state = VoiceRecorderState.recording;
+        _audioChunks = [];
+        // Reset audio levels
+        for (int i = 0; i < _audioLevels.length; i++) {
+          _audioLevels[i] = 0.1;
+        }
+        notifyListeners();
+      },
+      onStop: () {
+        debugPrint('VoiceRecorderProvider: Recording stopped');
+      },
+      onInitializing: () {
+        debugPrint('VoiceRecorderProvider: Initializing');
+      },
+    );
+  }
+
+  void stopRecording() {
+    _waveformTimer?.cancel();
+    ServiceManager.instance().mic.stop();
+  }
+
+  Future<void> processRecording() async {
+    if (_audioChunks.isEmpty) {
+      close();
+      return;
+    }
+
+    _state = VoiceRecorderState.transcribing;
+    _isProcessing = true;
+    notifyListeners();
+
+    stopRecording();
+
+    // Flatten audio chunks into a single list
+    List<int> flattenedBytes = [];
+    for (var chunk in _audioChunks) {
+      flattenedBytes.addAll(chunk);
+    }
+
+    // Convert PCM to WAV file
+    final audioFile = await FileUtils.convertPcmToWavFile(
+      Uint8List.fromList(flattenedBytes),
+      16000, // Sample rate
+      1, // Mono channel
+    );
+
+    try {
+      final transcript = await transcribeVoiceMessage(audioFile);
+      _transcript = transcript;
+      _state = VoiceRecorderState.transcribeSuccess;
+      _isProcessing = false;
+      notifyListeners();
+
+      if (transcript.isNotEmpty) {
+        _onTranscriptReady?.call(transcript);
+        // Auto-close after successful transcription
+        close();
+      }
+    } catch (e) {
+      debugPrint('Error processing recording: $e');
+      _state = VoiceRecorderState.transcribeFailed;
+      _isProcessing = false;
+      notifyListeners();
+      AppSnackbar.showSnackbarError('Failed to transcribe audio');
+    }
+  }
+
+  void retry() {
+    if (_audioChunks.isEmpty) {
+      startRecording();
+    } else {
+      // Retry transcription with existing audio data
+      processRecording();
+    }
+  }
+
+  void close() {
+    if (_state == VoiceRecorderState.recording) {
+      stopRecording();
+    }
+    _waveformTimer?.cancel();
+    _state = VoiceRecorderState.idle;
+    _audioChunks = [];
+    _transcript = '';
+    _isProcessing = false;
+    
+    // Reset audio levels
+    for (int i = 0; i < _audioLevels.length; i++) {
+      _audioLevels[i] = 0.1;
+    }
+    
+    notifyListeners();
+    _onClose?.call();
+  }
+
+  @override
+  void dispose() {
+    _waveformTimer?.cancel();
+    if (_state == VoiceRecorderState.recording) {
+      ServiceManager.instance().mic.stop();
+    }
+    super.dispose();
+  }
+}
+


### PR DESCRIPTION
## Summary
When starting speech-to-text recording on the chat page and switching to a different page, recording would stop. This PR fixes that behavior.

## Changes
- Add `VoiceRecorderProvider` for centralized recording state management
- Recording continues when navigating between pages  
- Refactor `voice_recorder_widget` to use provider instead of local state
- Works on both mobile and macOS

## Technical Details
The previous implementation used local widget state which was disposed when navigating away. The new implementation uses a global provider that persists across the widget tree, allowing recording to continue regardless of page navigation.