### PR TITLE
fix - task & memories page

### DIFF
--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -275,7 +275,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
         return Scaffold(
           backgroundColor: Theme.of(context).colorScheme.primary,
           floatingActionButton: Padding(
-            padding: const EdgeInsets.only(bottom: 60.0),
+            padding: const EdgeInsets.only(bottom: 100.0),
             child: FloatingActionButton(
               heroTag: 'action_items_fab',
               onPressed: () => _showCreateActionItemSheet(),
@@ -292,7 +292,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
             backgroundColor: Colors.white,
             child: provider.isLoading && provider.actionItems.isEmpty
                 ? _buildLoadingState()
-                : provider.actionItems.isEmpty && !showCompleted
+                : categorizedItems.values.every((l) => l.isEmpty)
                     ? _buildEmptyState()
                     : _buildTasksList(categorizedItems, provider),
           ),

--- a/app/lib/pages/memories/page.dart
+++ b/app/lib/pages/memories/page.dart
@@ -154,7 +154,7 @@ class MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClien
           child: Scaffold(
             backgroundColor: Theme.of(context).colorScheme.primary,
             floatingActionButton: Padding(
-              padding: const EdgeInsets.only(bottom: 60.0),
+              padding: const EdgeInsets.only(bottom: 100.0),
               child: FloatingActionButton(
                 heroTag: 'memories_fab',
                 onPressed: () {


### PR DESCRIPTION

<img width="1079" height="744" alt="image" src="https://github.com/user-attachments/assets/cc0b7c29-04ae-4364-a703-acc9223d24d8" />

<img width="1071" height="803" alt="image" src="https://github.com/user-attachments/assets/93a80809-1e27-4b2e-922f-4159d7befe14" />


This pull request updates the UI for both the Action Items and Memories pages by adjusting the placement of floating action buttons and improving the logic for displaying empty states. The changes enhance the user experience by providing more consistent spacing and more accurate empty state detection.

UI/UX Improvements:

* Increased the bottom padding for the floating action button from 60.0 to 100.0 on both the `ActionItemsPage` and `MemoriesPage`, ensuring the button does not overlap with other UI elements and is more accessible. [[1]](diffhunk://#diff-b902e2dcd4a443f23c98f0d55a4b0093bafd2e3ae5c025f3ec95266a61c8ddaeL278-R278) [[2]](diffhunk://#diff-f6acf047a101c895c2c54e6934e24fa98621aa1d8484193114e48950f249f548L157-R157)

Logic Improvements:

* Updated the empty state logic on the `ActionItemsPage` to check if all categories are empty using `categorizedItems.values.every((l) => l.isEmpty)`, rather than only checking if the main list is empty and completed items are hidden. This provides a more accurate representation of when to show the empty state.