### PR TITLE
feat(api): Add tags and category update support to memory endpoint

### DIFF
--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -187,18 +187,18 @@ def change_memory_visibility(uid: str, memory_id: str, value: str):
     memory_ref.update({'visibility': value})
 
 
-def update_memory_tags(uid: str, memory_id: str, tags: list):
+def update_memory_fields(uid: str, memory_id: str, data: dict):
+    """Updates specified fields for a memory and sets the updated_at timestamp."""
+    if not data:
+        return
+
     user_ref = db.collection(users_collection).document(uid)
     memories_ref = user_ref.collection(memories_collection)
     memory_ref = memories_ref.document(memory_id)
-    memory_ref.update({'tags': tags, 'updated_at': datetime.now(timezone.utc)})
 
-
-def update_memory_category(uid: str, memory_id: str, category: str):
-    user_ref = db.collection(users_collection).document(uid)
-    memories_ref = user_ref.collection(memories_collection)
-    memory_ref = memories_ref.document(memory_id)
-    memory_ref.update({'category': category, 'updated_at': datetime.now(timezone.utc)})
+    update_payload = data.copy()
+    update_payload['updated_at'] = datetime.now(timezone.utc)
+    memory_ref.update(update_payload)
 
 
 def edit_memory(uid: str, memory_id: str, value: str):

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -338,11 +338,14 @@ def update_memory(
             raise HTTPException(status_code=422, detail="visibility must be 'public' or 'private'")
         memories_db.change_memory_visibility(uid, memory_id, request.visibility)
 
+    update_data = {}
     if request.tags is not None:
-        memories_db.update_memory_tags(uid, memory_id, request.tags)
-
+        update_data['tags'] = request.tags
     if request.category is not None:
-        memories_db.update_memory_category(uid, memory_id, request.category.value)
+        update_data['category'] = request.category.value
+
+    if update_data:
+        memories_db.update_memory_fields(uid, memory_id, update_data)
 
     return memories_db.get_memory(uid, memory_id)
 


### PR DESCRIPTION
## Summary
- Added `tags` and `category` fields to the PATCH `/v1/dev/user/memories/{memory_id}` endpoint
- Added `update_memory_tags()` and `update_memory_category()` database functions

## Changes
- `backend/database/memories.py`: Added two new functions for updating tags and category
- `backend/routers/developer.py`: Extended `UpdateMemoryRequest` model and update endpoint to support tags and category