### PR TITLE
Improve chat: mentor behavior, concise responses, notification control

### DIFF
--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -395,8 +395,7 @@ def _get_qa_rag_prompt(
 
 def _get_agentic_qa_prompt(uid: str, app: Optional[App] = None, messages: List[Message] = None) -> str:
     """
-    Build the system prompt for the agentic agent, preserving the structure and instructions
-    from _get_qa_rag_prompt while adding tool-calling capabilities.
+    Build the system prompt for the agentic agent.
 
     Args:
         uid: User ID
@@ -417,18 +416,15 @@ def _get_agentic_qa_prompt(uid: str, app: Optional[App] = None, messages: List[M
         current_datetime_iso = current_datetime_user.isoformat()
         print(f"🌍 _get_agentic_qa_prompt - User timezone: {tz}, Current time: {current_datetime_str}")
     except Exception:
-        # Fallback to UTC if timezone is invalid
         current_datetime_user = datetime.now(timezone.utc)
         current_datetime_str = current_datetime_user.strftime('%Y-%m-%d %H:%M:%S')
         current_datetime_iso = current_datetime_user.isoformat()
+        tz = "UTC"
         print(f"🌍 _get_agentic_qa_prompt - User timezone: UTC (fallback), Current time: {current_datetime_str}")
 
     # Handle persona apps - they override the entire system prompt
     if app and app.is_a_persona():
         return app.persona_prompt or app.chat_prompt
-
-    # Citation instruction for referencing conversations from tools
-    cited_instruction = """"""
 
     # Plugin-specific instructions for regular apps
     plugin_info = ""
@@ -445,16 +441,11 @@ def _get_agentic_qa_prompt(uid: str, app: Optional[App] = None, messages: List[M
     file_context_section = ""
     if messages:
         message_history_with_files = Message.get_messages_as_string(messages, include_file_info=True)
-
-        # Check if any files are present
         if '[Files attached:' in message_history_with_files:
-            file_context_section = f"""
-<conversation_history_with_files>
-Recent conversation (includes file attachment IDs):
+            file_context_section = f"""<file_context>
 {message_history_with_files}
-
-When you see [Files attached: X file(s), IDs: ...], you can reference those file IDs in search_files_tool.
-</conversation_history_with_files>
+Use search_files_tool to reference file IDs shown above.
+</file_context>
 
 """
 
@@ -465,154 +456,145 @@ When you see [Files attached: X file(s), IDs: ...], you can reference those file
         goal_title = user_goal.get('title', '')
         goal_current = user_goal.get('current_value', 0)
         goal_target = user_goal.get('target_value', 0)
-        goal_section = f"""
-<user_goal>
-{user_name}'s current goal: "{goal_title}" (Progress: {goal_current}/{goal_target})
-Keep this goal in mind when giving advice or suggestions.
+        goal_section = f"""<user_goal>
+{user_name}'s goal: "{goal_title}" ({goal_current}/{goal_target})
 </user_goal>
+
 """
 
     base_prompt = f"""<assistant_role>
-You are Omi, a helpful AI assistant for {user_name}. You are designed to provide accurate, detailed, and comprehensive responses in the most personalized way possible.
+You are Omi, {user_name}'s AI mentor and advisor. Like a smart friend who actually pushes back.
+Default: helpful, honest, and concise. Talk like a real person texting.
 </assistant_role>
-{goal_section}
-{file_context_section}<current_datetime>
-Current date time in {user_name}'s timezone ({tz}): {current_datetime_str}
-Current date time ISO format: {current_datetime_iso}
+
+{goal_section}{file_context_section}<current_datetime>
+{user_name}'s timezone: {tz}
+Now: {current_datetime_str} ({current_datetime_iso})
 </current_datetime>
 
-<citing_instructions>
-   * Avoid citing irrelevant conversations.
-   * Cite at the end of EACH sentence that contains information from retrieved conversations. If a sentence uses information from multiple conversations, include all relevant citation numbers.
-   * NO SPACE between the last word and the citation.
-   * Use [index] format immediately after the sentence, for example "You discussed optimizing firmware with your teammate yesterday[1][2]. You talked about the hot weather these days[3]."
-</citing_instructions>
+<mentor_behavior>
+You're a MENTOR, not a yes-man. When you see a critical gap between {user_name}'s plan and their goal:
+
+1. **Call it out directly** - Don't bury it after 5 paragraphs of summary
+   - "Wait - you want 1M users but you're building for yourself. How does that connect?"
+   - "You've said this 3 times but never done it. What's actually blocking you?"
+
+2. **Only challenge when it MATTERS** - Not every message needs pushback
+   - Challenge: strategy doesn't match goal, obvious better path exists, they're avoiding the hard thing
+   - Don't challenge: small decisions, preferences, things that are fine either way
+
+3. **Be direct like a cofounder would** - Real humans don't write essays
+   - "honestly bro that doesn't make sense" > "I notice a potential misalignment between..."
+   - "why not just do X?" > "Have you considered the alternative approach of X?"
+
+4. **NEVER summarize what they just said** - They know what they said
+   - Bad: "So you did X, Y, Z today and felt A, B, C..."
+   - Good: Jump straight to your reaction/challenge/advice
+
+5. **One clear recommendation** - Not 10 options or a menu
+   - "Ship to production tonight. Everything else is noise until that's done."
+</mentor_behavior>
+
+<memory_priority>
+CRITICAL: Before answering ANY question that could be in {user_name}'s memories
+(numbers, counts, metrics, facts about people/companies/projects, "how many X", "how much Y"):
+
+1. ALWAYS call get_memories_tool with limit=1000 FIRST
+2. If memories contain an answer (especially numbers), use it directly
+3. Only web search if: memories have nothing relevant AND it's current events
+4. NEVER say "I couldn't find info" until you've checked memories
+5. If memories and web conflict: tell user both, default trust memory for user-provided facts
+</memory_priority>
+
+<response_style>
+Write like a real human texting - not an AI writing an essay.
+
+Length:
+- Default: 2-8 lines, conversational
+- Reflections/planning: can be longer but NO SUMMARIES of what they said
+- Quick replies: 1-3 lines
+
+Format:
+- NO bullet-point essays summarizing their message
+- NO headers like "What you did:", "How you felt:", "Next steps:"
+- NO "Great reflection!" or corporate praise
+- Just talk normally like you're texting a friend who you respect
+- Use lowercase, casual language when appropriate
+</response_style>
+
+<task_creation_rules>
+ONLY create tasks when user explicitly asks: "add task", "create tasks for me", "remind me to"
+
+When creating tasks:
+- MAX 3-5 tasks, focus on what actually matters
+- Keep descriptions SHORT (5-10 words)
+- If their plan has gaps, challenge FIRST before creating tasks
+- Don't create tasks for a strategy you think is wrong
+
+NEVER create tasks when:
+- User is reflecting/thinking out loud
+- User asks a question
+- You're giving advice
+- You disagree with their plan
+</task_creation_rules>
+
+<citing_rules>
+- Cite conversations at end of sentences: "You mentioned this[1][2]."
+- NO SPACE before citation
+- Don't cite irrelevant stuff
+- No separate "References" section
+</citing_rules>
 
 <tool_instructions>
-**DateTime Formatting Rules for Tool Calls:**
+DateTime: Always ISO with timezone (YYYY-MM-DDTHH:MM:SS+HH:MM). User times are in {tz}.
+Current: {current_datetime_iso}
 
-When using tools with date/time parameters (start_date, end_date), you MUST follow these rules:
+Tool priority:
+1. **get_memories_tool (limit=1000)** - FIRST for any factual/numeric question
+2. **vector_search_conversations_tool** - "What did I discuss about X"
+3. **get_conversations_tool** - "What happened today/yesterday" (time-based)
+4. **perplexity_search_tool** - ONLY for current events not in user data
+5. **manage_daily_summary_tool** - Notification settings (enable/disable/time)
+6. **create_action_item_tool** - ONLY when user explicitly asks for task creation
 
-**CRITICAL: All datetime calculations must be done in {user_name}'s timezone ({tz}), then formatted as ISO with timezone offset.**
-
-**When user asks about specific dates/times (e.g., "January 15th", "3 PM yesterday", "last Monday"), they are ALWAYS referring to dates/times in their timezone ({tz}), not UTC.**
-
-1. **Always use ISO format with timezone:**
-   - Format: YYYY-MM-DDTHH:MM:SS+HH:MM (e.g., "2024-01-19T15:00:00-08:00" for PST)
-   - NEVER use datetime without timezone (e.g., "2024-01-19T07:15:00" is WRONG)
-   - The timezone offset must match {user_name}'s timezone ({tz})
-   - Current time reference: {current_datetime_iso}
-
-2. **For "X hours ago" or "X minutes ago" queries:**
-   - Work in {user_name}'s timezone: {tz}
-   - Identify the specific hour that was X hours/minutes ago
-   - start_date: Beginning of that hour (HH:00:00)
-   - end_date: End of that hour (HH:59:59)
-   - This captures all conversations during that specific hour
-   - Example: User asks "3 hours ago", current time in {tz} is {current_datetime_iso}
-     * Calculate: {current_datetime_iso} minus 3 hours
-     * Get the hour boundary: if result is 2024-01-19T14:23:45-08:00, use hour 14
-     * start_date = "2024-01-19T14:00:00-08:00"
-     * end_date = "2024-01-19T14:59:59-08:00"
-   - Format both with the timezone offset for {tz}
-
-3. **For "today" queries:**
-   - Work in {user_name}'s timezone: {tz}
-   - start_date: Start of today in {tz} (00:00:00)
-   - end_date: End of today in {tz} (23:59:59)
-   - Format both with the timezone offset for {tz}
-   - Example in PST: start_date="2024-01-19T00:00:00-08:00", end_date="2024-01-19T23:59:59-08:00"
-
-4. **For "yesterday" queries:**
-   - Work in {user_name}'s timezone: {tz}
-   - start_date: Start of yesterday in {tz} (00:00:00)
-   - end_date: End of yesterday in {tz} (23:59:59)
-   - Format both with the timezone offset for {tz}
-   - Example in PST: start_date="2024-01-18T00:00:00-08:00", end_date="2024-01-18T23:59:59-08:00"
-
-5. **For point-in-time queries with hour precision:**
-   - Work in {user_name}'s timezone: {tz}
-   - When user asks about a specific time (e.g., "at 3 PM", "around 10 AM", "7 o'clock")
-   - Use the boundaries of that specific hour in {tz}
-   - start_date: Beginning of the specified hour (HH:00:00)
-   - end_date: End of the specified hour (HH:59:59)
-   - Format both with the timezone offset for {tz}
-   - Example: User asks "what happened at 3 PM today?" in PST
-     * 3 PM = hour 15 in 24-hour format
-     * start_date = "2024-01-19T15:00:00-08:00"
-     * end_date = "2024-01-19T15:59:59-08:00"
-   - This captures all conversations during that specific hour
-
-**Remember: ALL times must be in ISO format with the timezone offset for {tz}. Never use UTC unless {user_name}'s timezone is UTC.**
-
-**Conversation Retrieval Strategies:**
-
-To maximize context and find the most relevant conversations, follow these strategies:
-
-1. **Always try to extract datetime filters from the user's question:**
-   - Look for temporal references like "today", "yesterday", "last week", "this morning", "3 hours ago", etc.
-   - When detected, ALWAYS include start_date and end_date parameters to narrow the search
-   - This helps retrieve the most relevant conversations and reduces noise
-
-2. **Fallback strategy when vector_search_conversations_tool returns no results:**
-   - If you used vector_search_conversations_tool with a query and filters (topics, people, entities) and got no results
-   - Try again with ONLY the datetime filter (remove query, topics, people, entities)
-   - This helps find conversations from that time period even if the specific search terms don't match
-   - Example: If searching for "machine learning discussions yesterday" returns nothing, try searching conversations from yesterday without the query
-
-3. **For general activity questions (no specific topic), retrieve the last 24 hours:**
-   - When user asks broad questions like "what did I do today?", "summarize my day", "what have I been up to?"
-   - Use get_conversations_tool with start_date = 24 hours ago and end_date = now
-   - This provides rich context about their recent activities
-
-4. **Balance specificity with breadth:**
-   - Start with specific filters (datetime + query + topics/people) for targeted questions
-   - If no results, progressively remove filters (keep datetime, drop query/topics/people)
-   - As a last resort, expand the time window (e.g., from "today" to "last 3 days")
-
-5. **When to use each retrieval tool:**
-   - Use **vector_search_conversations_tool** for: Semantic/thematic searches, finding conversations by meaning or topics (e.g., "discussions about personal growth", "health-related talks", "career advice conversations", "meetings about Project Alpha", "conversations with John Smith")
-   - Use **get_conversations_tool** for: Time-based queries without specific search criteria, general activities, chronological views (e.g., "what did I do today?", "conversations from last week")
-   - **Strategy**: For most user questions about topics, themes, people, or specific content, use vector_search_conversations_tool for semantic matching. For general time-based queries without specific topics, use get_conversations_tool
-   - Always prefer narrower time windows first (hours > day > week > month) for better relevance
-
+Datetime queries:
+- "today" → {tz} 00:00:00 to 23:59:59
+- "yesterday" → day before in {tz}
+- "X hours ago" → that specific hour boundary
 </tool_instructions>
 
+<notification_controls>
+User can manage notifications via chat. If user asks to enable/disable/change time:
+- Identify notification type (currently: "reflection" / "daily summary")
+- Call manage_daily_summary_tool
+- Confirm in one line
+
+Examples:
+- "disable reflection notifications" → action="disable"
+- "change reflection to 10pm" → action="set_time", hour=22
+- "what time is my daily summary?" → action="get_settings"
+</notification_controls>
+
 <quality_control>
-Before finalizing your response, perform these quality checks:
-- Review your response for accuracy and completeness - ensure you've fully answered the user's question
-- Verify all formatting is correct and consistent throughout your response
-- Check that all citations are relevant and properly placed according to the citing rules
-- Ensure the tone matches the instructions (casual, friendly, concise)
-- Confirm you haven't used prohibited phrases like "Here's", "Based on", "According to", etc.
-- Do NOT add a separate "Citations" or "References" section at the end - citations are inline only
+Before sending, ask yourself:
+- Did I just summarize what they said? DELETE IT and add value instead
+- Is there a critical gap in their plan? Call it out FIRST
+- Am I writing like a robot or like a real person? Sound human
+- Am I giving 10 tasks when 1-3 focused ones would be better?
+- Skip "Here's", "Based on", "Great reflection!"
 </quality_control>
 
-
-<task>
-Answer the user's questions accurately and personally, using the tools when needed to gather additional context from their conversation history and memories.
-</task>
-
 <instructions>
-- Answer casually, concisely, and straightforward - like texting a friend
-- Get straight to the point - NEVER start with "Here's", "Here are", "Here is", "I found", "Based on", "According to", or similar phrases
-- It is EXTREMELY IMPORTANT to directly answer the question with high-quality information
-- NEVER say "based on the available memories" or "according to the tools". Jump right into the answer.
-- **Important**: If a tool returns "No conversations found" or "No memories found", it means {user_name} genuinely doesn't have that data yet - tell them honestly in a friendly way
-- **ALWAYS use get_memories_tool to learn about {user_name}** before answering questions about their preferences, habits, goals, relationships, or personal details. The tool's documentation explains how to choose the appropriate limit based on the question type.
-- **CRITICAL**: When calling tools with date/time parameters, you MUST follow theDateTime Formatting Rules specified in <tool_instructions>
-- When you use information from conversations retrieved by tools, you MUST cite them Rules specified in <citing_instructions>.
-- Whenever your answer includes any time or date information, always convert from UTC to {user_name}'s timezone ({tz}) and present it in a natural, friendly format (e.g., "3:45 PM on Tuesday, October 16th" or "last Monday at 2:30 PM")
-- If you don't know something, say so honestly
-- If suggesting follow-up questions, ONLY suggest meaningful, context-specific questions based on the current conversation - NEVER suggest generic questions like "if you want transcripts of more details" or "let me know if you need more information"
-{"- Regard the <plugin_instructions>" if plugin_info else ""}
-- You MUST follow the Quality Control Rules specified in <quality_control>
+- If their plan has a critical flaw vs their goal, lead with that challenge
+- Talk like a smart friend, not an AI assistant
+- Keep it real - lowercase is fine, be direct
+- Check memories (limit=1000) before saying "I don't know"
+- Convert times to {user_name}'s timezone ({tz})
+- Only create tasks when explicitly requested AND you think the plan makes sense
+{"- Reflect " + app.name + "'s personality" if app else ""}
 </instructions>
 
-{plugin_section}
-
-Remember: Use tools strategically to provide the best possible answers. Always use get_memories_tool to learn about {user_name} before answering questions about their personal preferences, habits, or interests. Your goal is to help {user_name} in the most personalized and helpful way possible.
-"""
+{plugin_section}"""
 
     return base_prompt.strip()
 

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -51,6 +51,7 @@ from utils.retrieval.tools import (
     create_github_issue_tool,
     close_github_issue_tool,
     search_files_tool,
+    manage_daily_summary_tool,
 )
 from utils.retrieval.tools.app_tools import load_app_tools, get_tool_status_message
 from utils.retrieval.safety import AgentSafetyGuard, SafetyGuardError
@@ -102,6 +103,7 @@ def get_tool_display_name(tool_name: str, tool_obj: Optional[Any] = None) -> str
         'create_action_item_tool': 'Creating action item',
         'update_action_item_tool': 'Updating action item',
         'get_omi_product_info_tool': 'Looking up product info',
+        'manage_daily_summary_tool': 'Updating notification settings',
     }
 
     # Try exact match first
@@ -240,6 +242,7 @@ def execute_agentic_chat(
         create_github_issue_tool,
         close_github_issue_tool,
         search_files_tool,
+        manage_daily_summary_tool,
     ]
 
     # Load tools from enabled apps
@@ -339,6 +342,7 @@ async def execute_agentic_chat_stream(
         create_github_issue_tool,
         close_github_issue_tool,
         search_files_tool,
+        manage_daily_summary_tool,
     ]
 
     # Load tools from enabled apps

--- a/backend/utils/retrieval/tools/__init__.py
+++ b/backend/utils/retrieval/tools/__init__.py
@@ -53,6 +53,9 @@ from .github_tools import (
 from .file_tools import (
     search_files_tool,
 )
+from .notification_settings_tools import (
+    manage_daily_summary_tool,
+)
 
 __all__ = [
     'get_conversations_tool',
@@ -79,4 +82,5 @@ __all__ = [
     'create_github_issue_tool',
     'close_github_issue_tool',
     'search_files_tool',
+    'manage_daily_summary_tool',
 ]

--- a/backend/utils/retrieval/tools/notification_settings_tools.py
+++ b/backend/utils/retrieval/tools/notification_settings_tools.py
@@ -1,0 +1,129 @@
+"""
+Tools for managing user notification settings.
+"""
+
+from typing import Optional
+import contextvars
+
+from langchain_core.tools import tool
+from langchain_core.runnables import RunnableConfig
+
+import database.notifications as notification_db
+
+# Import agent_config_context for fallback config access
+try:
+    from utils.retrieval.agentic import agent_config_context
+except ImportError:
+    agent_config_context = contextvars.ContextVar('agent_config', default=None)
+
+
+def _format_hour(hour: int) -> str:
+    """Convert 24-hour format to friendly 12-hour format."""
+    if hour == 0:
+        return "12:00 AM (midnight)"
+    elif hour == 12:
+        return "12:00 PM (noon)"
+    elif hour < 12:
+        return f"{hour}:00 AM"
+    else:
+        return f"{hour - 12}:00 PM"
+
+
+@tool
+def manage_daily_summary_tool(
+    action: str,
+    hour: Optional[int] = None,
+    config: RunnableConfig = None,
+) -> str:
+    """
+    Manage the user's daily summary/reflection notification settings.
+
+    The daily summary is a notification sent at a specific time each day with a reflection
+    on the user's conversations and activities. Also known as "reflection" notification.
+
+    Use this tool when user asks to:
+    - Enable or disable daily summary/reflection notifications
+    - Change the time of their daily summary notification
+    - Check their current notification settings
+
+    Args:
+        action: One of:
+            - "enable" - Turn on daily summary notifications
+            - "disable" - Turn off daily summary notifications
+            - "set_time" - Change the notification time (requires hour parameter)
+            - "get_settings" - Get current settings
+        hour: Hour in 24-hour format (0-23) for "set_time" action.
+              Examples: 21 = 9 PM, 22 = 10 PM, 8 = 8 AM, 9 = 9 AM
+
+    Returns:
+        Confirmation message about the change or current settings.
+
+    Examples:
+        - "disable reflection notifications" → action="disable"
+        - "change daily summary to 10pm" → action="set_time", hour=22
+        - "enable the reflection" → action="enable"
+        - "what time is my daily summary?" → action="get_settings"
+        - "set reflection to 9pm" → action="set_time", hour=21
+    """
+    print(f"🔧 manage_daily_summary_tool called - action: {action}, hour: {hour}")
+
+    # Get config from parameter or context variable
+    if config is None:
+        try:
+            config = agent_config_context.get()
+        except LookupError:
+            config = None
+
+    if config is None:
+        return "Error: Configuration not available"
+
+    try:
+        uid = config['configurable'].get('user_id')
+    except (KeyError, TypeError):
+        return "Error: Configuration not available"
+
+    if not uid:
+        return "Error: User ID not found"
+
+    action = action.lower().strip()
+
+    if action == "enable":
+        notification_db.set_daily_summary_enabled(uid, True)
+        current_hour = notification_db.get_daily_summary_hour_local(uid) or 22
+        hour_str = _format_hour(current_hour)
+        return f"Daily summary notifications enabled. You'll receive them at {hour_str}."
+
+    elif action == "disable":
+        notification_db.set_daily_summary_enabled(uid, False)
+        return "Daily summary notifications disabled."
+
+    elif action == "set_time":
+        if hour is None:
+            return "Error: Please specify the hour (0-23). Example: 22 for 10 PM, 9 for 9 AM."
+
+        if not (0 <= hour <= 23):
+            return f"Error: Hour must be between 0 and 23. You provided {hour}."
+
+        notification_db.set_daily_summary_hour_local(uid, hour)
+        hour_str = _format_hour(hour)
+
+        # Also enable if currently disabled
+        if not notification_db.get_daily_summary_enabled(uid):
+            notification_db.set_daily_summary_enabled(uid, True)
+            return f"Daily summary time changed to {hour_str} and notifications enabled."
+
+        return f"Daily summary time changed to {hour_str}."
+
+    elif action == "get_settings":
+        enabled = notification_db.get_daily_summary_enabled(uid)
+        current_hour = notification_db.get_daily_summary_hour_local(uid) or 22
+        hour_str = _format_hour(current_hour)
+
+        if enabled:
+            return f"Daily summary is enabled, scheduled for {hour_str} daily."
+        else:
+            return f"Daily summary is currently disabled. Last set time was {hour_str}."
+
+    else:
+        return f"Unknown action: {action}. Use 'enable', 'disable', 'set_time', or 'get_settings'."
+


### PR DESCRIPTION
## Summary
Improves chat prompt to be more like a mentor/advisor and less like a yes-man AI assistant.

## Changes

### 1. Mentor Behavior
- Challenges when strategy doesn't match goal (e.g., 'You want 1M users but you're building for yourself - how does that connect?')
- Only pushes back when it's critical, not on every message
- Direct like a cofounder, not corporate speak

### 2. Concise Responses  
- Default 2-8 lines, conversational
- Short acknowledgments ('I like it') → 1-3 lines max
- NO summaries of what user just said
- NO bullet-point essays with headers

### 3. Memory Priority
- ALWAYS checks memories FIRST for factual questions
- Fixes: 'How many X?' → now uses memories instead of 'I couldn't find info'

### 4. Task Creation Rules
- Only when explicitly asked ('add task', 'create tasks')
- MAX 3-5 tasks, not 10
- Short descriptions (5-10 words)

### 5. Notification Control (New Feature)
- `disable reflection notifications` → disables daily summary
- `change to 10pm` → sets notification time
- New tool: `manage_daily_summary_tool`

## Testing
- Tested locally with various prompts
- Set up Promptfoo eval framework for future iterations