### PR TITLE
fix move wal and backup files to application support dir

### DIFF
--- a/app/lib/utils/wal_file_manager.dart
+++ b/app/lib/utils/wal_file_manager.dart
@@ -13,7 +13,8 @@ class WalFileManager {
   static File? _walBackupFile;
 
   static Future<void> init() async {
-    final directory = await getApplicationSupportDirectory();
+    final directory =
+        Platform.isMacOS ? await getApplicationSupportDirectory() : await getApplicationDocumentsDirectory();
     _walFile = File('${directory.path}/$_walFileName');
     _walBackupFile = File('${directory.path}/$_walBackupFileName');
   }


### PR DESCRIPTION
https://github.com/BasedHardware/omi/blob/81ef150d4c6d56ab7f8dfdb417b124b4257b5c3e/app/lib/utils/wal_file_manager.dart#L74

crash is caused by copying wal file inside the documents dir, and the fix is to move the file to Application Support where macos allows internal write and backup operations

ref: https://stackoverflow.com/questions/66304002/what-is-the-difference-between-getapplicationsupportdirectory-and-getlibrarydire

closes #3940