### PR TITLE
fix: Add speaker_name field to SimpleTranscriptSegment response model

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -621,6 +621,7 @@ class SimpleTranscriptSegment(BaseModel):
     id: Optional[str] = None
     text: str
     speaker_id: Optional[int] = None
+    speaker_name: Optional[str] = None
     start: float
     end: float
 


### PR DESCRIPTION
## Summary
- Fixes missing `speaker_name` field in developer API responses
- The field was being added by `_add_speaker_names_to_segments()` but stripped by Pydantic because it wasn't in the model

## Problem
PR #3962 added `speaker_name` to transcript segments, but the field only appeared in webhooks, not in the developer API (`/v1/dev/user/conversations`). This was because `SimpleTranscriptSegment` Pydantic model didn't include the field.

## Fix
Added `speaker_name: Optional[str] = None` to `SimpleTranscriptSegment` model.