### PR TITLE
fix: Use user profile name instead of hardcoded 'User' for speaker_name

### DIFF
--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -696,6 +696,9 @@ class CreateConversationFromTranscriptRequest(BaseModel):
 
 def _add_speaker_names_to_segments(uid, conversations: list):
     """Add speaker_name to transcript segments based on person_id mappings."""
+    user_profile = users_db.get_user_profile(uid)
+    user_name = user_profile.get('name') or 'User'
+
     all_person_ids = set()
     for conv in conversations:
         for seg in conv.get('transcript_segments', []):
@@ -710,7 +713,7 @@ def _add_speaker_names_to_segments(uid, conversations: list):
     for conv in conversations:
         for seg in conv.get('transcript_segments', []):
             if seg.get('is_user'):
-                seg['speaker_name'] = 'User'
+                seg['speaker_name'] = user_name
             elif seg.get('person_id') and seg['person_id'] in people_map:
                 seg['speaker_name'] = people_map[seg['person_id']]
             else:

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -109,6 +109,9 @@ class SimpleTranscriptSegment(BaseModel):
 
 def _add_speaker_names_to_segments(uid, conversations: list):
     """Add speaker_name to transcript segments based on person_id mappings."""
+    user_profile = users_db.get_user_profile(uid)
+    user_name = user_profile.get('name') or 'User'
+
     all_person_ids = set()
     for conv in conversations:
         for seg in conv.get('transcript_segments', []):
@@ -123,7 +126,7 @@ def _add_speaker_names_to_segments(uid, conversations: list):
     for conv in conversations:
         for seg in conv.get('transcript_segments', []):
             if seg.get('is_user'):
-                seg['speaker_name'] = 'User'
+                seg['speaker_name'] = user_name
             elif seg.get('person_id') and seg['person_id'] in people_map:
                 seg['speaker_name'] = people_map[seg['person_id']]
             else:

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -38,6 +38,9 @@ def _add_speaker_names_to_payload(uid, payload: dict):
     if not segments:
         return
 
+    user_profile = users_db.get_user_profile(uid)
+    user_name = user_profile.get('name') or 'User'
+
     person_ids = [seg.get('person_id') for seg in segments if seg.get('person_id')]
     people_map = {}
     if person_ids:
@@ -46,7 +49,7 @@ def _add_speaker_names_to_payload(uid, payload: dict):
 
     for seg in segments:
         if seg.get('is_user'):
-            seg['speaker_name'] = 'User'
+            seg['speaker_name'] = user_name
         elif seg.get('person_id') and seg['person_id'] in people_map:
             seg['speaker_name'] = people_map[seg['person_id']]
         else:


### PR DESCRIPTION
## Summary
When `is_user: true`, the `speaker_name` was hardcoded to `"User"` instead of using the user's actual profile name.

## Fix
Fetch the user's name from their profile via `get_user_profile(uid)` and use it for `is_user` segments. Falls back to `"User"` if no name is set.

## Files Changed
- `backend/routers/developer.py`
- `backend/routers/mcp.py`
- `backend/utils/webhooks.py`