### PR TITLE
Fix: Refresh folders on pull-to-refresh

### DIFF
--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -160,8 +160,10 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
         onRefresh: () async {
           HapticFeedback.mediumImpact();
           Provider.of<CaptureProvider>(context, listen: false).refreshInProgressConversations();
-          await convoProvider.getInitialConversations();
-          return;
+          await Future.wait([
+            convoProvider.getInitialConversations(),
+            Provider.of<FolderProvider>(context, listen: false).loadFolders(),
+          ]);
         },
         color: Colors.deepPurpleAccent,
         backgroundColor: Colors.white,


### PR DESCRIPTION
## Summary
- Added folder refresh to the pull-to-refresh handler on the conversations page
- Previously only conversations were refreshed, not folders
- This caused folders created on web to not appear on mobile until app restart

## Test plan
- [ ] Create a folder on web app
- [ ] On mobile, pull down to refresh on the conversations page
- [ ] Verify the new folder appears without needing to restart the app