### PR TITLE
Fix web/app Dockerfile: use Node.js 20

### DIFF
--- a/web/app/Dockerfile
+++ b/web/app/Dockerfile
@@ -48,7 +48,7 @@ RUN npm run build
 FROM base AS runner
 WORKDIR /app
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
@@ -65,7 +65,7 @@ COPY --from=builder --chown=nextjs:nodejs /app/web/app/.next/static ./.next/stat
 USER nextjs
 
 EXPOSE 3000
-ENV PORT 3000
-ENV HOSTNAME "0.0.0.0"
+ENV PORT=3000
+ENV HOSTNAME="0.0.0.0"
 
 CMD ["node", "server.js"]


### PR DESCRIPTION
## Summary
- Update Node.js from 18 to 20 (Next.js requires >=20.9.0)
- Fix legacy ENV format warnings in Dockerfile

## Problem
The build was failing with:
```
You are using Node.js 18.20.8. For Next.js, Node.js version ">=20.9.0" is required.
```

## Changes
- `node:18-alpine` → `node:20-alpine`
- `ENV KEY value` → `ENV KEY=value` (modern format)