### PR TITLE
use mutex to allow one write at a time

### DIFF
--- a/app/lib/services/devices/transports/ble_transport.dart
+++ b/app/lib/services/devices/transports/ble_transport.dart
@@ -236,6 +236,8 @@ class BleTransport extends DeviceTransport {
     }
     _streamControllers.clear();
 
+    _writeMutexes.clear();
+
     await _connectionStateController.close();
   }
 }


### PR DESCRIPTION
The issue is that checking if the lock is free and acquiring the lock are two separate steps with an await in between. This results in a race condition where another coroutine could acquire the lock while its being set on the first one, making both of them assume they have the lock. The new implementation is atomic and is based off the implementation of the mutex package

https://github.com/hoylen/dart-mutex/blob/master/lib/src/read_write_mutex.dart#L256