### PR TITLE
fix guard ScrollController with positions check

### DIFF
--- a/app/lib/pages/speech_profile/page.dart
+++ b/app/lib/pages/speech_profile/page.dart
@@ -72,6 +72,7 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> with TickerProvid
 
   @override
   void dispose() {
+    _scrollController.dispose();
     _questionAnimationController.dispose();
     super.dispose();
   }
@@ -79,14 +80,16 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> with TickerProvid
   final ScrollController _scrollController = ScrollController();
 
   void scrollDown() async {
-    if (_scrollController.hasClients) {
-      await Future.delayed(const Duration(milliseconds: 250));
-      _scrollController.animateTo(
-        _scrollController.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeOut,
-      );
-    }
+    await Future.delayed(const Duration(milliseconds: 250));
+
+    if (!mounted) return;
+    if (_scrollController.positions.isEmpty) return;
+
+    _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+    );
   }
 
   @override


### PR DESCRIPTION
https://github.com/BasedHardware/omi/blob/ef7ad36e5d2c0e1776efe712bcd1cacdada03d86/app/lib/pages/speech_profile/page.dart#L85

ScrollController had no attached position because the ListView was not built yet, that’s whyu position became invalid

closes #4023 