### PR TITLE
Fix: Action item deadline removal and goal tracker improvements

### DIFF
--- a/app/lib/backend/http/api/action_items.dart
+++ b/app/lib/backend/http/api/action_items.dart
@@ -106,6 +106,7 @@ Future<ActionItemWithMetadata?> updateActionItem(
   String? description,
   bool? completed,
   DateTime? dueAt,
+  bool clearDueAt = false, // Flag to explicitly clear due date
   bool? exported,
   DateTime? exportDate,
   String? exportPlatform,
@@ -118,7 +119,10 @@ Future<ActionItemWithMetadata?> updateActionItem(
   if (completed != null) {
     requestBody['completed'] = completed;
   }
-  if (dueAt != null) {
+  // Handle dueAt - send ISO string if set, or null to clear deadline
+  if (clearDueAt) {
+    requestBody['due_at'] = null;
+  } else if (dueAt != null) {
     requestBody['due_at'] = dueAt.toUtc().toIso8601String();
   }
   if (exported != null) {

--- a/app/lib/pages/action_items/widgets/action_item_form_sheet.dart
+++ b/app/lib/pages/action_items/widgets/action_item_form_sheet.dart
@@ -73,7 +73,11 @@ class _ActionItemFormSheetState extends State<ActionItemFormSheet> {
       // Editing existing item
       String newDescription = _textController.text.trim();
       bool descriptionChanged = newDescription != widget.actionItem!.description;
-      bool dueDateChanged = _selectedDueDate != widget.actionItem!.dueAt;
+      // Compare due dates - handle null cases explicitly
+      bool dueDateChanged = (_selectedDueDate == null && widget.actionItem!.dueAt != null) ||
+          (_selectedDueDate != null && widget.actionItem!.dueAt == null) ||
+          (_selectedDueDate != null && widget.actionItem!.dueAt != null && 
+           _selectedDueDate!.millisecondsSinceEpoch != widget.actionItem!.dueAt!.millisecondsSinceEpoch);
       bool completionChanged = _isCompleted != widget.actionItem!.completed;
 
       if (!descriptionChanged && !dueDateChanged && !completionChanged) {

--- a/app/lib/pages/conversations/widgets/goal_tracker_widget.dart
+++ b/app/lib/pages/conversations/widgets/goal_tracker_widget.dart
@@ -81,7 +81,8 @@ class _GoalTrackerWidgetState extends State<GoalTrackerWidget>
 
   Future<void> _loadGoal() async {
     // Only show loading if we don't have any cached data
-    if (_goal == null && mounted) {
+    // But don't show loading for too long - show empty state quickly
+    if (_goal == null && mounted && !_initialLoadDone) {
       setState(() => _isLoading = true);
     }
 

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -237,6 +237,7 @@ class ActionItemsProvider extends ChangeNotifier {
       final updatedItem = await api.updateActionItem(
         item.id,
         dueAt: dueDate,
+        clearDueAt: dueDate == null, // Explicitly clear if null
       );
 
       if (updatedItem != null) {

--- a/app/lib/providers/developer_mode_provider.dart
+++ b/app/lib/providers/developer_mode_provider.dart
@@ -29,7 +29,7 @@ class DeveloperModeProvider extends BaseProvider {
   bool followUpQuestionEnabled = false;
   bool transcriptionDiagnosticEnabled = false;
   bool autoCreateSpeakersEnabled = false;
-  bool showGoalTrackerEnabled = false;
+  bool showGoalTrackerEnabled = true; // Default to true
   bool dailyReflectionEnabled = true;
 
   void onConversationEventsToggled(bool value) {
@@ -101,7 +101,9 @@ class DeveloperModeProvider extends BaseProvider {
     followUpQuestionEnabled = SharedPreferencesUtil().devModeJoanFollowUpEnabled;
     transcriptionDiagnosticEnabled = SharedPreferencesUtil().transcriptionDiagnosticEnabled;
     autoCreateSpeakersEnabled = SharedPreferencesUtil().autoCreateSpeakersEnabled;
-    showGoalTrackerEnabled = SharedPreferencesUtil().showGoalTrackerEnabled;
+    // Goal tracker should be enabled by default
+    final savedValue = SharedPreferencesUtil().showGoalTrackerEnabled;
+    showGoalTrackerEnabled = savedValue; // Use saved value, which defaults to true
     dailyReflectionEnabled = SharedPreferencesUtil().dailyReflectionEnabled;
     conversationEventsToggled = SharedPreferencesUtil().conversationEventsToggled;
     transcriptsToggled = SharedPreferencesUtil().transcriptsToggled;

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -173,7 +173,13 @@ def update_action_item(
             update_data['completed_at'] = datetime.now(timezone.utc)
         else:
             update_data['completed_at'] = None
-    if request.due_at is not None:
+    # Check if due_at was explicitly provided (even if None) to allow clearing
+    # In Pydantic v2, we check model_fields_set to see if field was explicitly set
+    if 'due_at' in request.model_fields_set:
+        # Field was explicitly provided (even if None) - update it
+        update_data['due_at'] = request.due_at
+    elif request.due_at is not None:
+        # Fallback: only update if not None (for backwards compatibility)
         update_data['due_at'] = request.due_at
     if request.exported is not None:
         update_data['exported'] = request.exported


### PR DESCRIPTION
## Changes

### Action Item Deadline Removal Fix
- **Problem**: Clicking the cross icon to remove a deadline didn't actually remove it - the deadline stayed in the task
- **Root Cause**: 
  - Frontend wasn't properly detecting when deadline was cleared (null comparison issue)
  - Backend wasn't handling explicit `null` values for `due_at` field
- **Solution**:
  - Improved deadline comparison logic in `action_item_form_sheet.dart` to explicitly handle null cases
  - Added `clearDueAt` flag to API to explicitly send `null` when clearing deadline
  - Backend now checks `model_fields_set` to detect when `due_at` is explicitly set to `null`

### Goal Tracker Improvements
- **Problem**: Goal tracker sometimes didn't show up even when enabled in settings
- **Solution**:
  - Set goal tracker to be enabled by default (`true`)
  - Improved loading state handling to avoid getting stuck in loading
  - Ensures goal tracker always shows when enabled

## Testing
- ✅ Deadline removal: Click cross icon on task with deadline → deadline is removed and task moves to "no deadline" category
- ✅ Goal tracker: Enabled by default and always visible when enabled

## Files Changed
- `app/lib/pages/action_items/widgets/action_item_form_sheet.dart` - Deadline comparison fix
- `app/lib/backend/http/api/action_items.dart` - Added clearDueAt flag
- `app/lib/providers/action_items_provider.dart` - Use clearDueAt when clearing deadline
- `backend/routers/action_items.py` - Handle explicit null for due_at
- `app/lib/providers/developer_mode_provider.dart` - Goal tracker default to true
- `app/lib/pages/conversations/widgets/goal_tracker_widget.dart` - Loading state fix