### PR TITLE
Default no filter for short convos

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -280,7 +280,7 @@ class SharedPreferencesUtil {
 
   // Short conversation threshold in seconds - default is 60 (1 minute)
   // Options: 60 (1 min), 120 (2 min), 180 (3 min), 240 (4 min), 300 (5 min)
-  int get shortConversationThreshold => getInt('shortConversationThreshold', defaultValue: 60);
+  int get shortConversationThreshold => getInt('v2/shortConversationThreshold', defaultValue: 0);
 
   set shortConversationThreshold(int value) => saveInt('shortConversationThreshold', value);
 

--- a/app/lib/providers/conversation_provider.dart
+++ b/app/lib/providers/conversation_provider.dart
@@ -18,7 +18,7 @@ class ConversationProvider extends ChangeNotifier {
   bool isLoadingConversations = false;
   bool showDiscardedConversations = false;
   bool showShortConversations = false;
-  int shortConversationThreshold = 60; // in seconds
+  int shortConversationThreshold = 0; // in seconds
   bool showStarredOnly = false; // filter to show only starred conversations
   bool showDailySummaries = false; // filter to show daily summaries instead of conversations
   bool hasDailySummaries = false; // whether user has any daily summaries


### PR DESCRIPTION
this pr defaults to disabling filtering short convos by using the threshold second 0.

**problem:**

filtering short convos with the default 60s forces the convos that might be valuable or might prevent the seamless onboarding experience. one example is the speech profile, which usually takes 30-45 seconds.

there's nothing that acknowledges to users that some short convos are being filtered, which makes users confused, and that's not good.

please review the feature, check the real needs, and fix it, improve the ux, then push again.

thank you.

**deploy steps:**

- [x] deploy mobile app https://codemagic.io/app/66c95e6ec76853c447b8bcbb/build/6959d0e96c27566d249e76f6 https://codemagic.io/app/66c95e6ec76853c447b8bcbb/build/6959d26b6c27566d249e7a43
