### PR TITLE
fix provider crash in post frame callback

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -980,8 +980,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                                 ),
                                                 value: [selectedDate],
                                                 onValueChanged: (dates) {
-                                                  if (dates.isNotEmpty && dates[0] != null) {
-                                                    selectedDate = dates[0]!;
+                                                  if (dates.isNotEmpty) {
+                                                    selectedDate = dates[0];
                                                   }
                                                 },
                                               ),


### PR DESCRIPTION
https://github.com/BasedHardware/omi/blob/9a1a3029536edc527d6991e6d2781bcb3df1130e/app/lib/pages/home/page.dart#L459
https://github.com/BasedHardware/omi/blob/9a1a3029536edc527d6991e6d2781bcb3df1130e/app/lib/pages/home/page.dart#L462
https://github.com/BasedHardware/omi/blob/9a1a3029536edc527d6991e6d2781bcb3df1130e/app/lib/pages/home/page.dart#L465

`ctx.read<ConversationProvider>()` was called after await, so the Provider’s inherited element became null and caused the crash

---

also i have removed unnecessary null check

https://github.com/BasedHardware/omi/blob/9a1a3029536edc527d6991e6d2781bcb3df1130e/app/lib/pages/home/page.dart#L979

The operand can't be 'null', so the condition is always 'true'. Remove the condition.
