### PR TITLE
fix: use push instead of pushReplacement for notification navigation

### DIFF
--- a/app/lib/services/notifications.dart
+++ b/app/lib/services/notifications.dart
@@ -70,13 +70,12 @@ class NotificationUtil {
       return;
     }
 
-    // Check if this is a daily reflection notification
     String? autoMessage;
     if (DailyReflectionNotification.isReflectionPayload(payload)) {
       autoMessage = DailyReflectionNotification.reflectionMessage;
     }
 
-    MyApp.navigatorKey.currentState?.pushReplacement(
+    MyApp.navigatorKey.currentState?.push(
       MaterialPageRoute(
         builder: (context) => HomePageWrapper(
           navigateToRoute: navigateTo,


### PR DESCRIPTION
Fixes #4057

Changed navigation method from pushReplacement to push when handling notification taps. pushReplacement was destroying the navigation stack, preventing proper deep-linking to daily recap pages. Using push preserves the stack and allows correct navigation to the intended destination.