### PR TITLE
fix update developer mode initialization

### DIFF
--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -331,7 +331,7 @@ class _MyAppState extends State<MyApp> with WidgetsBindingObserver {
             update: (BuildContext context, app, conversation, ConversationDetailProvider? previous) =>
                 (previous?..setProviders(app, conversation)) ?? ConversationDetailProvider(),
           ),
-          ChangeNotifierProvider(create: (context) => DeveloperModeProvider()),
+          ChangeNotifierProvider(create: (context) => DeveloperModeProvider()..initialize()),
           ChangeNotifierProvider(create: (context) => McpProvider()),
           ChangeNotifierProxyProvider<AppProvider, AddAppProvider>(
             create: (context) => AddAppProvider(),

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -38,7 +38,6 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
   @override
   void initState() {
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      await Provider.of<DeveloperModeProvider>(context, listen: false).initialize();
       context.read<McpProvider>().fetchKeys();
     });
     super.initState();

--- a/app/lib/providers/developer_mode_provider.dart
+++ b/app/lib/providers/developer_mode_provider.dart
@@ -32,14 +32,6 @@ class DeveloperModeProvider extends BaseProvider {
   bool showGoalTrackerEnabled = true; // Default to true
   bool dailyReflectionEnabled = true;
 
-  DeveloperModeProvider() {
-    showGoalTrackerEnabled = SharedPreferencesUtil().showGoalTrackerEnabled;
-    dailyReflectionEnabled = SharedPreferencesUtil().dailyReflectionEnabled;
-    followUpQuestionEnabled = SharedPreferencesUtil().devModeJoanFollowUpEnabled;
-    transcriptionDiagnosticEnabled = SharedPreferencesUtil().transcriptionDiagnosticEnabled;
-    autoCreateSpeakersEnabled = SharedPreferencesUtil().autoCreateSpeakersEnabled;
-  }
-
   void onConversationEventsToggled(bool value) {
     conversationEventsToggled = value;
     if (!value) {
@@ -106,6 +98,11 @@ class DeveloperModeProvider extends BaseProvider {
     webhookOnTranscriptReceived.text = SharedPreferencesUtil().webhookOnTranscriptReceived;
     webhookAudioBytes.text = SharedPreferencesUtil().webhookAudioBytes;
     webhookAudioBytesDelay.text = SharedPreferencesUtil().webhookAudioBytesDelay;
+    followUpQuestionEnabled = SharedPreferencesUtil().devModeJoanFollowUpEnabled;
+    transcriptionDiagnosticEnabled = SharedPreferencesUtil().transcriptionDiagnosticEnabled;
+    autoCreateSpeakersEnabled = SharedPreferencesUtil().autoCreateSpeakersEnabled;
+    showGoalTrackerEnabled = SharedPreferencesUtil().showGoalTrackerEnabled;
+    dailyReflectionEnabled = SharedPreferencesUtil().dailyReflectionEnabled;
     conversationEventsToggled = SharedPreferencesUtil().conversationEventsToggled;
     transcriptsToggled = SharedPreferencesUtil().transcriptsToggled;
     audioBytesToggled = SharedPreferencesUtil().audioBytesToggled;


### PR DESCRIPTION
will fix this crash too when opening developer page

```
flutter: ----------------FIREBASE CRASHLYTICS----------------
flutter: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
flutter: 
#0      State.context.<anonymous closure> (package:flutter/src/widgets/framework.dart:952:9)
#1      State.context (package:flutter/src/widgets/framework.dart:958:6)
#2      _DeveloperSettingsPageState.initState.<anonymous closure> (package:omi/pages/settings/developer.dart:42:7)
```