### PR TITLE
fix always display speaker names

### DIFF
--- a/app/lib/widgets/transcript.dart
+++ b/app/lib/widgets/transcript.dart
@@ -484,7 +484,12 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
               if (!isUser) ...[
                 // Avatar for other speakers (left side)
                 GestureDetector(
-                  onTap: _toggleShowSpeakerNames,
+                  onTap: data.speakerId == omiSpeakerId
+                      ? null
+                      : () {
+                          widget.editSegment?.call(data.id, data.speakerId);
+                          MixpanelManager().tagSheetOpened();
+                        },
                   child: Column(
                     children: [
                       CircleAvatar(
@@ -650,8 +655,8 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
                                     const SizedBox(height: 4),
                                     _buildTranslationNotice(),
                                   ],
-                                  // Timestamp and provider (only shown when toggled)
-                                  if (_showSpeakerNames && (widget.canDisplaySeconds || data.sttProvider != null)) ...[
+                                  // Timestamp and provider
+                                  if (widget.canDisplaySeconds || data.sttProvider != null) ...[
                                     const SizedBox(height: 4),
                                     Row(
                                       mainAxisAlignment: MainAxisAlignment.end,
@@ -704,7 +709,10 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
                 const SizedBox(width: 8),
                 // Avatar for user (right side)
                 GestureDetector(
-                  onTap: _toggleShowSpeakerNames,
+                  onTap: () {
+                    widget.editSegment?.call(data.id, data.speakerId);
+                    MixpanelManager().tagSheetOpened();
+                  },
                   child: Column(
                     children: [
                       CircleAvatar(


### PR DESCRIPTION
always display speaker names instead of clicking to view

<img width="1206" height="2622" alt="IMG_1678" src="https://github.com/user-attachments/assets/1da89155-9a95-4846-bf6c-d46001f2604c" />
