### PR TITLE
fix avoid context access after widget disposal

### DIFF
--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -62,7 +62,7 @@ class _AppShellState extends State<AppShell> {
 
       if (app != null) {
         PlatformManager.instance.mixpanel.track('App Opened From DeepLink', properties: {'appId': app.id});
-          Navigator.of(context).push(MaterialPageRoute(builder: (context) => AppDetailPage(app: app)));
+        Navigator.of(context).push(MaterialPageRoute(builder: (context) => AppDetailPage(app: app)));
       } else {
         debugPrint('App not found: ${uri.pathSegments[1]}');
         AppSnackbar.showSnackbarError('Oops! Looks like the app you are looking for is not available.');
@@ -364,7 +364,6 @@ class _AppShellState extends State<AppShell> {
     initDeepLinks();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-
       final auth = context.read<AuthenticationProvider>();
 
       if (auth.isSignedIn()) {

--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -366,7 +366,6 @@ class _AppShellState extends State<AppShell> {
     initDeepLinks();
 
     WidgetsBinding.instance.addPostFrameCallback((_) async {
-      if (!mounted) return;
 
       final auth = context.read<AuthenticationProvider>();
 
@@ -402,10 +401,7 @@ class _AppShellState extends State<AppShell> {
           await PlatformManager.instance.intercom.loginUnidentifiedUser();
         }
       }
-
-      if (mounted) {
-        PlatformManager.instance.intercom.setUserAttributes();
-      }
+      PlatformManager.instance.intercom.setUserAttributes();
     });
     super.initState();
   }

--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -62,9 +62,7 @@ class _AppShellState extends State<AppShell> {
 
       if (app != null) {
         PlatformManager.instance.mixpanel.track('App Opened From DeepLink', properties: {'appId': app.id});
-        if (mounted) {
           Navigator.of(context).push(MaterialPageRoute(builder: (context) => AppDetailPage(app: app)));
-        }
       } else {
         debugPrint('App not found: ${uri.pathSegments[1]}');
         AppSnackbar.showSnackbarError('Oops! Looks like the app you are looking for is not available.');

--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -371,10 +371,13 @@ class _AppShellState extends State<AppShell> {
       final auth = context.read<AuthenticationProvider>();
 
       if (auth.isSignedIn()) {
-        context.read<HomeProvider>().setupHasSpeakerProfile();
-        context.read<HomeProvider>().setupUserPrimaryLanguage();
-        context.read<UserProvider>().initialize();
-        context.read<PeopleProvider>().initialize();
+        final homeProvider = context.read<HomeProvider>();
+        final userProvider = context.read<UserProvider>();
+        final peopleProvider = context.read<PeopleProvider>();
+        homeProvider.setupHasSpeakerProfile();
+        homeProvider.setupUserPrimaryLanguage();
+        userProvider.initialize();
+        peopleProvider.initialize();
         try {
           await PlatformManager.instance.intercom.loginIdentifiedUser(SharedPreferencesUtil().uid);
         } catch (e) {
@@ -383,12 +386,16 @@ class _AppShellState extends State<AppShell> {
 
         if (!mounted) return;
 
-        context.read<MessageProvider>().setMessagesFromCache();
-        context.read<AppProvider>().setAppsFromCache();
-        context.read<MessageProvider>().refreshMessages();
-        context.read<UsageProvider>().fetchSubscription();
-        context.read<TaskIntegrationProvider>().loadFromBackend();
+        final messageProvider = context.read<MessageProvider>();
+        final appProvider = context.read<AppProvider>();
+        final usageProvider = context.read<UsageProvider>();
+        final taskIntegrationProvider = context.read<TaskIntegrationProvider>();
 
+        messageProvider.setMessagesFromCache();
+        appProvider.setAppsFromCache();
+        messageProvider.refreshMessages();
+        usageProvider.fetchSubscription();
+        taskIntegrationProvider.loadFromBackend();
         NotificationService.instance.saveNotificationToken();
       } else {
         if (!PlatformManager.instance.isAnalyticsSupported) {


### PR DESCRIPTION
https://github.com/BasedHardware/omi/blob/a3678f86a4935cf1c39e683fe06e0d82827d8479/app/lib/core/app_shell.dart#L378-L382

here it tried to use the widget after it was disposed and moved the provider lookup before the async call and added a mounted check

