### PR TITLE
fix stop reporting socket errors as crashes

### DIFF
--- a/app/lib/services/sockets/pure_socket.dart
+++ b/app/lib/services/sockets/pure_socket.dart
@@ -203,6 +203,9 @@ class PureSocket implements IPureSocket {
     });
 
     _listener?.onError(err, trace);
+    if (err is! SocketException && err is! WebSocketChannelException) {
+      PlatformManager.instance.crashReporter.reportCrash(err, trace);
+    }
   }
 
   @override

--- a/app/lib/services/sockets/pure_socket.dart
+++ b/app/lib/services/sockets/pure_socket.dart
@@ -203,7 +203,6 @@ class PureSocket implements IPureSocket {
     });
 
     _listener?.onError(err, trace);
-    PlatformManager.instance.crashReporter.reportCrash(err, trace);
   }
 
   @override


### PR DESCRIPTION
socket disconnect errors commonly occur during network changes or server restarts and are expected behavior. This change prevents treating them as crashes, reducing crashlytics noise

closes #3147 