### PR TITLE
Fix: Web app conversation sorting by date

### DIFF
--- a/web/app/src/components/conversations/ConversationList.tsx
+++ b/web/app/src/components/conversations/ConversationList.tsx
@@ -59,8 +59,13 @@ export function ConversationList({ onConversationClick }: ConversationListProps)
     if (b === 'Today') return 1;
     if (a === 'Yesterday') return -1;
     if (b === 'Yesterday') return 1;
-    // For other dates, parse and compare
-    return new Date(b).getTime() - new Date(a).getTime();
+    // For other dates, use actual conversation timestamps instead of parsing
+    // the date string (which lacks year info and causes incorrect sorting)
+    const convA = groupedConversations[a][0];
+    const convB = groupedConversations[b][0];
+    const dateA = new Date(convA?.started_at || convA?.created_at);
+    const dateB = new Date(convB?.started_at || convB?.created_at);
+    return dateB.getTime() - dateA.getTime();
   });
 
   const isEmpty = !loading && orderedKeys.length === 0;

--- a/web/app/src/components/conversations/ConversationSplitView.tsx
+++ b/web/app/src/components/conversations/ConversationSplitView.tsx
@@ -199,7 +199,13 @@ export function ConversationSplitView() {
     if (b === 'Today') return 1;
     if (a === 'Yesterday') return -1;
     if (b === 'Yesterday') return 1;
-    return new Date(b).getTime() - new Date(a).getTime();
+    // Use actual conversation timestamps instead of parsing the date string
+    // (which lacks year info and causes incorrect sorting)
+    const convA = displayedConversations[a][0];
+    const convB = displayedConversations[b][0];
+    const dateA = new Date(convA?.started_at || convA?.created_at);
+    const dateB = new Date(convB?.started_at || convB?.created_at);
+    return dateB.getTime() - dateA.getTime();
   });
 
   const isLoading = isSearching ? searchLoading : (listLoading || folderSwitching);


### PR DESCRIPTION
## Summary
- Fixes incorrect conversation date group sorting in the web app
- The previous sorting logic parsed formatted date strings (e.g., "Mon, Jan 6") which lack year info, causing incorrect chronological ordering
- Now uses actual conversation timestamps (`started_at`/`created_at`) for accurate sorting

## Test plan
- [ ] Open the web app conversations page
- [ ] Verify conversations are sorted correctly with newest dates at top
- [ ] Check that "Today" and "Yesterday" groups appear before older dates