### PR TITLE
feat: Revamp homepage with Daily Score, Today Tasks, and Goals widgets

### DIFF
--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -7,9 +7,11 @@ import 'package:omi/pages/conversations/widgets/search_result_header_widget.dart
 import 'package:omi/pages/conversations/widgets/search_widget.dart';
 import 'package:omi/pages/conversations/widgets/folder_tabs.dart';
 import 'package:omi/pages/conversations/widgets/daily_summaries_list.dart';
+import 'package:omi/pages/conversations/widgets/daily_score_widget.dart';
+import 'package:omi/pages/conversations/widgets/today_tasks_widget.dart';
+import 'package:omi/pages/conversations/widgets/goals_widget.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/conversation_provider.dart';
-import 'package:omi/providers/developer_mode_provider.dart';
 import 'package:omi/providers/folder_provider.dart';
 import 'package:omi/providers/home_provider.dart';
 import 'package:omi/services/app_review_service.dart';
@@ -20,7 +22,6 @@ import 'package:visibility_detector/visibility_detector.dart';
 
 import 'widgets/empty_conversations.dart';
 import 'widgets/conversations_group_widget.dart';
-import 'widgets/goal_tracker_widget.dart';
 
 class ConversationsPage extends StatefulWidget {
   const ConversationsPage({super.key});
@@ -170,13 +171,14 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
           controller: _scrollController,
           physics: const AlwaysScrollableScrollPhysics(),
           slivers: [
-            // const SliverToBoxAdapter(child: SizedBox(height: 16)), // above capture widget
+            // Header widgets (unchanged)
             const SliverToBoxAdapter(child: SpeechProfileCardWidget()),
             const SliverToBoxAdapter(child: UpdateFirmwareCardWidget()),
             const SliverToBoxAdapter(child: ConversationCaptureWidget()),
+            
+            // Search bar
             Consumer2<HomeProvider, ConversationProvider>(
               builder: (context, homeProvider, convoProvider, _) {
-                // Show search bar if explicitly shown OR if there's an active search query
                 bool shouldShowSearchBar = homeProvider.showConvoSearchBar || convoProvider.previousQuery.isNotEmpty;
                 if (!shouldShowSearchBar) {
                   return const SliverToBoxAdapter(child: SizedBox.shrink());
@@ -184,9 +186,9 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
                 return const SliverToBoxAdapter(
                   child: Column(
                     children: [
-                      SizedBox(height: 12), // above search widget
+                      SizedBox(height: 12),
                       SearchWidget(),
-                      SizedBox(height: 12), //below search widget
+                      SizedBox(height: 12),
                     ],
                   ),
                 );
@@ -194,14 +196,41 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
             ),
             const SliverToBoxAdapter(child: SearchResultHeaderWidget()),
             getProcessingConversationsWidget(convoProvider.processingConversations),
-            // Goal tracker widget - before folders
-            Selector<DeveloperModeProvider, bool>(
-              selector: (context, provider) => provider.showGoalTrackerEnabled,
-              builder: (context, showGoalTrackerEnabled, child) {
-                if (!showGoalTrackerEnabled) return const SliverToBoxAdapter(child: SizedBox.shrink());
-                return const SliverToBoxAdapter(child: GoalTrackerWidget());
-              },
+            
+            // Daily Score Widget
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                child: DailyScoreWidget(),
+              ),
             ),
+            
+            // Today's Tasks (top 3)
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.only(top: 8, bottom: 8),
+                child: TodayTasksWidget(),
+              ),
+            ),
+            
+            // Goals Widget (up to 3 goals)
+            const SliverToBoxAdapter(child: GoalsWidget()),
+            
+            // Conversations section header
+            const SliverToBoxAdapter(
+              child: Padding(
+                padding: EdgeInsets.only(left: 16, top: 16, bottom: 8),
+                child: Text(
+                  'Conversations',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+            
             // Folder tabs
             Consumer2<FolderProvider, ConversationProvider>(
               builder: (context, folderProvider, convoProvider, _) {

--- a/app/lib/pages/conversations/widgets/daily_score_widget.dart
+++ b/app/lib/pages/conversations/widgets/daily_score_widget.dart
@@ -1,0 +1,343 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:omi/providers/action_items_provider.dart';
+import 'package:provider/provider.dart';
+
+/// Daily Score Widget - Shows task completion rate as a 0-5 score
+class DailyScoreWidget extends StatefulWidget {
+  const DailyScoreWidget({super.key});
+
+  @override
+  State<DailyScoreWidget> createState() => _DailyScoreWidgetState();
+}
+
+class _DailyScoreWidgetState extends State<DailyScoreWidget> {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ActionItemsProvider>(
+      builder: (context, provider, child) {
+        // Calculate today's tasks - only tasks due today
+        final now = DateTime.now();
+        final todayStart = DateTime(now.year, now.month, now.day);
+        final todayEnd = todayStart.add(const Duration(days: 1));
+
+        // Get tasks due today only
+        final todayTasks = provider.actionItems.where((item) {
+          if (item.dueAt == null) return false;
+          return item.dueAt!.isAfter(todayStart.subtract(const Duration(days: 1))) && 
+                 item.dueAt!.isBefore(todayEnd);
+        }).toList();
+
+        final totalTasks = todayTasks.length;
+        final completedTasks = todayTasks.where((t) => t.completed).length;
+
+        // Calculate score (0-5)
+        double score;
+        if (totalTasks == 0) {
+          score = 0; // No tasks = 0 score
+        } else {
+          final ratio = completedTasks / totalTasks;
+          // Map 0-1 ratio to 0-5 score
+          score = (ratio * 5).clamp(0.0, 5.0);
+        }
+
+        // Round to nearest 0.5
+        score = (score * 2).roundToDouble() / 2;
+
+        final statusColor = _getStatusColor(score);
+
+        return GestureDetector(
+          onTap: () {
+            HapticFeedback.lightImpact();
+            _showScoreDetails(context, score, completedTasks, totalTasks);
+          },
+          child: Container(
+            margin: const EdgeInsets.only(bottom: 20),
+            padding: const EdgeInsets.all(20),
+            decoration: BoxDecoration(
+              color: const Color(0xFF1A1A1C),
+              borderRadius: BorderRadius.circular(20),
+            ),
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                // Left side: Text content
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'DAILY SCORE',
+                        style: TextStyle(
+                          fontSize: 12,
+                          fontWeight: FontWeight.w600,
+                          letterSpacing: 1.2,
+                          color: Colors.white.withOpacity(0.5),
+                        ),
+                      ),
+                      const SizedBox(height: 6),
+                      Text(
+                        'A score to help you better\nfocus on execution.',
+                        style: TextStyle(
+                          fontSize: 13,
+                          color: Colors.white.withOpacity(0.5),
+                          height: 1.4,
+                        ),
+                      ),
+                      const SizedBox(height: 14),
+                      // "your score >" link
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 8),
+                        decoration: BoxDecoration(
+                          color: Colors.white.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              'Your score',
+                              style: TextStyle(
+                                fontSize: 13,
+                                fontWeight: FontWeight.w500,
+                                color: Colors.white.withOpacity(0.8),
+                              ),
+                            ),
+                            const SizedBox(width: 4),
+                            Icon(
+                              Icons.chevron_right,
+                              size: 16,
+                              color: Colors.white.withOpacity(0.5),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                // Right side: Semicircular gauge
+                SizedBox(
+                  width: 130,
+                  height: 85,
+                  child: Stack(
+                    alignment: Alignment.center,
+                    children: [
+                      // Gauge arc
+                      Positioned(
+                        top: 0,
+                        child: CustomPaint(
+                          size: const Size(130, 75),
+                          painter: _SemicircleGaugePainter(
+                            score: score,
+                            color: statusColor,
+                          ),
+                        ),
+                      ),
+                      // Score text positioned inside the arc - lower and bigger
+                      Positioned(
+                        top: 30,
+                        child: Text(
+                          _formatScore(score),
+                          style: TextStyle(
+                            fontSize: 44,
+                            fontWeight: FontWeight.w500,
+                            color: statusColor,
+                            height: 1,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  String _formatScore(double score) {
+    // Show integer if whole number, otherwise one decimal
+    if (score == score.roundToDouble()) {
+      return score.toInt().toString();
+    }
+    return score.toStringAsFixed(1);
+  }
+
+  Color _getStatusColor(double score) {
+    // When no progress (0), use neutral grey for consistency
+    if (score == 0) return Colors.grey.shade500;
+    if (score >= 4.5) return const Color(0xFFFFD60A); // Gold/Yellow
+    if (score >= 3.5) return const Color(0xFFFFD60A); // Gold/Yellow
+    if (score >= 2.5) return const Color(0xFFF59E0B); // Amber
+    if (score >= 1.5) return const Color(0xFFF97316); // Orange
+    return const Color(0xFFEF4444); // Red
+  }
+
+  void _showScoreDetails(BuildContext context, double score, int completed, int total) {
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => Container(
+        decoration: const BoxDecoration(
+          color: Color(0xFF1A1A1A),
+          borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+        ),
+        padding: const EdgeInsets.all(24),
+        child: SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Container(
+                width: 40,
+                height: 4,
+                margin: const EdgeInsets.only(bottom: 24),
+                decoration: BoxDecoration(
+                  color: Colors.grey.shade700,
+                  borderRadius: BorderRadius.circular(2),
+                ),
+              ),
+              Text(
+                'Daily Score Breakdown',
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 20),
+              _buildDetailRow('Today\'s Score', _formatScore(score), _getStatusColor(score)),
+              const SizedBox(height: 12),
+              _buildDetailRow('Tasks Completed', '$completed / $total', Colors.white70),
+              const SizedBox(height: 12),
+              _buildDetailRow(
+                'Completion Rate',
+                total > 0 ? '${(completed / total * 100).toStringAsFixed(0)}%' : 'N/A',
+                Colors.white70,
+              ),
+              const SizedBox(height: 24),
+              Container(
+                padding: const EdgeInsets.all(16),
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.05),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'How it works',
+                      style: TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w600,
+                        color: Colors.white.withOpacity(0.8),
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Your daily score is based on task completion. Complete your tasks to improve your score!',
+                      style: TextStyle(
+                        fontSize: 13,
+                        color: Colors.white.withOpacity(0.5),
+                        height: 1.4,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: TextButton(
+                  onPressed: () => Navigator.pop(context),
+                  child: const Text(
+                    'Got it',
+                    style: TextStyle(
+                      color: Colors.white70,
+                      fontSize: 15,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDetailRow(String label, String value, Color valueColor) {
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: [
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 14,
+            color: Colors.white.withOpacity(0.5),
+          ),
+        ),
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 16,
+            fontWeight: FontWeight.w600,
+            color: valueColor,
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+/// Custom painter for semicircular gauge (like the design)
+class _SemicircleGaugePainter extends CustomPainter {
+  final double score;
+  final Color color;
+
+  _SemicircleGaugePainter({required this.score, required this.color});
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final center = Offset(size.width / 2, size.height);
+    final radius = size.width / 2 - 6;
+
+    // Background arc (semicircle)
+    final bgPaint = Paint()
+      ..color = Colors.white.withOpacity(0.12)
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 6
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      math.pi, // Start from left
+      math.pi, // Sweep 180 degrees (semicircle)
+      false,
+      bgPaint,
+    );
+
+    // Progress arc
+    final progress = score / 5.0;
+    final progressPaint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 6
+      ..strokeCap = StrokeCap.round;
+
+    canvas.drawArc(
+      Rect.fromCircle(center: center, radius: radius),
+      math.pi, // Start from left
+      math.pi * progress, // Sweep based on progress
+      false,
+      progressPaint,
+    );
+  }
+
+  @override
+  bool shouldRepaint(_SemicircleGaugePainter old) =>
+      old.score != score || old.color != color;
+}

--- a/app/lib/pages/conversations/widgets/goals_widget.dart
+++ b/app/lib/pages/conversations/widgets/goals_widget.dart
@@ -1,0 +1,731 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:omi/backend/http/api/goals.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Multi-goal widget supporting up to 3 goals with minimalistic UI
+class GoalsWidget extends StatefulWidget {
+  const GoalsWidget({super.key});
+
+  @override
+  State<GoalsWidget> createState() => _GoalsWidgetState();
+}
+
+class _GoalsWidgetState extends State<GoalsWidget> with WidgetsBindingObserver {
+  List<Goal> _goals = [];
+  bool _isLoading = true;
+  bool _isExpanded = false;
+  
+  static const String _goalsStorageKey = 'goals_tracker_local_goals';
+  static const String _goalsEmojiKey = 'goals_tracker_emojis';
+  static const int _maxGoals = 3;
+  
+  // Available emojis for goals
+  static const List<String> _availableEmojis = [
+    '🎯', '💪', '📚', '💰', '🏃', '🧘', '💡', '🔥', '⭐', '🚀',
+    '💎', '🏆', '📈', '❤️', '🎨', '🎵', '✈️', '🏠', '🌱', '⏰',
+  ];
+  
+  // Local emoji storage (goalId -> emoji)
+  Map<String, String> _goalEmojis = {};
+  String _selectedEmoji = '🎯';
+
+  final TextEditingController _titleController = TextEditingController();
+  final TextEditingController _currentController = TextEditingController();
+  final TextEditingController _targetController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    _loadGoals();
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(this);
+    _titleController.dispose();
+    _currentController.dispose();
+    _targetController.dispose();
+    super.dispose();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      _loadGoals();
+    }
+  }
+
+  Future<void> _loadGoals() async {
+    try {
+      // Load from local storage first
+      final prefs = await SharedPreferences.getInstance();
+      final goalsJson = prefs.getString(_goalsStorageKey);
+      final emojisJson = prefs.getString(_goalsEmojiKey);
+      
+      // Load emojis
+      if (emojisJson != null) {
+        final Map<String, dynamic> decoded = json.decode(emojisJson);
+        _goalEmojis = decoded.map((k, v) => MapEntry(k, v.toString()));
+      }
+      
+      if (goalsJson != null) {
+        final List<dynamic> decoded = json.decode(goalsJson);
+        final localGoals = decoded.map((e) => Goal.fromJson(e)).toList();
+        if (mounted) {
+          setState(() {
+            _goals = localGoals;
+            _isLoading = false;
+          });
+        }
+      }
+
+      // Try to get from backend
+      final backendGoal = await getCurrentGoal();
+      if (backendGoal != null && mounted) {
+        // Merge backend goal with local goals
+        final existingIndex = _goals.indexWhere((g) => g.id == backendGoal.id);
+        if (existingIndex >= 0) {
+          _goals[existingIndex] = backendGoal;
+        } else if (_goals.isEmpty) {
+          _goals.add(backendGoal);
+        }
+        await _saveGoalsLocally();
+        setState(() => _isLoading = false);
+      } else if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    } catch (e) {
+      debugPrint('[GOALS] Error loading goals: $e');
+      if (mounted) setState(() => _isLoading = false);
+    }
+  }
+
+  Future<void> _saveGoalsLocally() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final goalsJson = json.encode(_goals.map((g) => g.toJson()).toList());
+      await prefs.setString(_goalsStorageKey, goalsJson);
+      // Also save emojis
+      final emojisJson = json.encode(_goalEmojis);
+      await prefs.setString(_goalsEmojiKey, emojisJson);
+    } catch (e) {
+      debugPrint('[GOALS] Error saving goals: $e');
+    }
+  }
+  
+  String _getSmartEmoji(String title) {
+    final lowerTitle = title.toLowerCase();
+    
+    // Keyword to emoji mapping - order matters (more specific first)
+    final Map<List<String>, String> keywordMap = {
+      // Money/Business goals
+      ['revenue', 'money', 'income', 'profit', 'sales', '\$', 'dollar', 'earn']: '💰',
+      ['users', 'customers', 'clients', 'subscribers', 'followers', 'growth', 'million', '1m', '10k', '100k', 'mrr', 'arr']: '🚀',
+      ['startup', 'launch', 'business', 'company']: '🏆',
+      ['invest', 'stock', 'crypto', 'trading']: '📈',
+      
+      // Health/Fitness goals
+      ['workout', 'gym', 'exercise', 'lift', 'muscle', 'strength', 'pushup', 'pullup']: '💪',
+      ['run', 'marathon', 'jog', 'cardio', 'steps', 'walk', 'mile', 'km']: '🏃',
+      ['weight', 'lose', 'fat', 'diet', 'calories', 'kg', 'lbs', 'pounds']: '⚖️',
+      ['meditat', 'mindful', 'yoga', 'breath', 'calm', 'peace', 'zen']: '🧘',
+      ['sleep', 'rest', 'hours']: '😴',
+      ['water', 'hydrat', 'drink']: '💧',
+      ['health', 'wellness', 'healthy']: '❤️',
+      
+      // Learning/Education goals
+      ['read', 'book', 'pages', 'chapter']: '📚',
+      ['learn', 'study', 'course', 'class', 'skill', 'certif']: '🎓',
+      ['code', 'program', 'develop', 'app', 'software', 'tech']: '💻',
+      ['language', 'spanish', 'french', 'chinese', 'english', 'german']: '🗣️',
+      
+      // Creative goals
+      ['write', 'blog', 'article', 'post', 'content', 'words']: '✍️',
+      ['video', 'youtube', 'tiktok', 'film']: '🎬',
+      ['music', 'song', 'piano', 'guitar', 'sing']: '🎵',
+      ['art', 'draw', 'paint', 'design', 'create']: '🎨',
+      ['photo', 'picture', 'camera']: '📸',
+      
+      // Productivity goals  
+      ['task', 'todo', 'complete', 'finish', 'done']: '✅',
+      ['habit', 'daily', 'streak', 'consistent', 'routine']: '🔥',
+      ['time', 'hour', 'minute', 'focus', 'pomodoro', 'productive']: '⏰',
+      ['project', 'ship', 'deliver', 'deadline']: '🎯',
+      
+      // Travel/Lifestyle goals
+      ['travel', 'trip', 'visit', 'country', 'city', 'vacation']: '✈️',
+      ['home', 'house', 'apartment', 'move', 'buy']: '🏠',
+      ['save', 'saving', 'budget', 'emergency fund']: '🏦',
+      
+      // Social/Relationship goals
+      ['friend', 'social', 'network', 'connect', 'meet']: '👥',
+      ['family', 'kids', 'parent']: '👨‍👩‍👧',
+      ['date', 'relationship', 'love']: '💕',
+      
+      // General achievement
+      ['goal', 'target', 'achieve', 'accomplish']: '🎯',
+      ['win', 'first', 'best', 'top', 'champion']: '🏆',
+      ['grow', 'improve', 'better', 'progress']: '🌱',
+      ['star', 'success', 'excellent']: '⭐',
+    };
+    
+    // Check each keyword group
+    for (final entry in keywordMap.entries) {
+      for (final keyword in entry.key) {
+        if (lowerTitle.contains(keyword)) {
+          return entry.value;
+        }
+      }
+    }
+    
+    // Default emoji if no match
+    return '🎯';
+  }
+  
+  String _getGoalEmoji(String goalId) {
+    return _goalEmojis[goalId] ?? '🎯';
+  }
+
+  void _addGoal() {
+    if (_goals.length >= _maxGoals) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('Maximum $_maxGoals goals allowed'),
+          backgroundColor: Colors.orange,
+        ),
+      );
+      return;
+    }
+
+    HapticFeedback.lightImpact();
+    _titleController.clear();
+    _currentController.text = '0';
+    _targetController.text = '100';
+    _selectedEmoji = '🎯'; // Default emoji, will be updated based on title when saved
+
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => _buildGoalEditSheet(null),
+    );
+  }
+
+  void _editGoal(Goal goal) {
+    HapticFeedback.lightImpact();
+    _titleController.text = goal.title;
+    _currentController.text = _rawNum(goal.currentValue);
+    _targetController.text = _rawNum(goal.targetValue);
+    _selectedEmoji = _getGoalEmoji(goal.id); // Load existing emoji
+
+    showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.transparent,
+      isScrollControlled: true,
+      builder: (context) => _buildGoalEditSheet(goal),
+    );
+  }
+
+  Widget _buildGoalEditSheet(Goal? existingGoal) {
+    final isNew = existingGoal == null;
+    
+    return StatefulBuilder(
+      builder: (context, setSheetState) => Padding(
+        padding: EdgeInsets.only(
+          bottom: MediaQuery.of(context).viewInsets.bottom,
+        ),
+        child: Container(
+          decoration: const BoxDecoration(
+            color: Color(0xFF1A1A1A),
+            borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+          ),
+          padding: const EdgeInsets.all(24),
+          child: SafeArea(
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Container(
+                  width: 40,
+                  height: 4,
+                  margin: const EdgeInsets.only(bottom: 20),
+                  decoration: BoxDecoration(
+                    color: Colors.grey.shade700,
+                    borderRadius: BorderRadius.circular(2),
+                  ),
+                ),
+                Text(
+                  isNew ? 'Add Goal' : 'Edit Goal',
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                // Emoji selector - only show when editing (not when creating new)
+                if (!isNew) ...[
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Icon',
+                        style: TextStyle(
+                          color: Colors.white.withOpacity(0.5),
+                          fontSize: 12,
+                        ),
+                      ),
+                      const SizedBox(height: 8),
+                      SizedBox(
+                        height: 44,
+                        child: ListView.builder(
+                          scrollDirection: Axis.horizontal,
+                          itemCount: _availableEmojis.length,
+                          itemBuilder: (context, index) {
+                            final emoji = _availableEmojis[index];
+                            final isSelected = emoji == _selectedEmoji;
+                            return GestureDetector(
+                              onTap: () {
+                                HapticFeedback.selectionClick();
+                                setSheetState(() => _selectedEmoji = emoji);
+                              },
+                              child: Container(
+                                width: 44,
+                                height: 44,
+                                margin: const EdgeInsets.only(right: 8),
+                                decoration: BoxDecoration(
+                                  color: isSelected 
+                                      ? Colors.white.withOpacity(0.15) 
+                                      : Colors.white.withOpacity(0.05),
+                                  borderRadius: BorderRadius.circular(12),
+                                  border: isSelected 
+                                      ? Border.all(color: Colors.white.withOpacity(0.3), width: 2)
+                                      : null,
+                                ),
+                                child: Center(
+                                  child: Text(emoji, style: const TextStyle(fontSize: 22)),
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 16),
+                ],
+                // Title field with label above
+                Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Goal title',
+                      style: TextStyle(
+                        color: Colors.white.withOpacity(0.5),
+                        fontSize: 12,
+                      ),
+                    ),
+                    const SizedBox(height: 8),
+                    TextField(
+                      controller: _titleController,
+                      style: const TextStyle(color: Colors.white, fontSize: 16),
+                      decoration: InputDecoration(
+                        filled: true,
+                        fillColor: Colors.white.withOpacity(0.08),
+                        contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide.none,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              const SizedBox(height: 16),
+              // Current & Target fields with labels above
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Current',
+                          style: TextStyle(
+                            color: Colors.white.withOpacity(0.5),
+                            fontSize: 12,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        TextField(
+                          controller: _currentController,
+                          keyboardType: TextInputType.number,
+                          style: const TextStyle(color: Colors.white, fontSize: 16),
+                          decoration: InputDecoration(
+                            filled: true,
+                            fillColor: Colors.white.withOpacity(0.08),
+                            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide.none,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          'Target',
+                          style: TextStyle(
+                            color: Colors.white.withOpacity(0.5),
+                            fontSize: 12,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        TextField(
+                          controller: _targetController,
+                          keyboardType: TextInputType.number,
+                          style: const TextStyle(color: Colors.white, fontSize: 16),
+                          decoration: InputDecoration(
+                            filled: true,
+                            fillColor: Colors.white.withOpacity(0.08),
+                            contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(12),
+                              borderSide: BorderSide.none,
+                            ),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 24),
+              // Action buttons
+              Row(
+                children: [
+                  if (!isNew) ...[
+                    Expanded(
+                      child: TextButton(
+                        onPressed: () async {
+                          Navigator.pop(context);
+                          await _deleteGoal(existingGoal);
+                        },
+                        style: TextButton.styleFrom(
+                          foregroundColor: Colors.red,
+                          padding: const EdgeInsets.symmetric(vertical: 14),
+                        ),
+                        child: const Text('Delete'),
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                  ],
+                  Expanded(
+                    flex: isNew ? 1 : 2,
+                    child: ElevatedButton(
+                      onPressed: () async {
+                        Navigator.pop(context);
+                        await _saveGoal(existingGoal);
+                      },
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: const Color(0xFF22C55E),
+                        foregroundColor: Colors.white,
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                      ),
+                      child: Text(isNew ? 'Add Goal' : 'Save'),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ),
+    );
+  }
+
+  Future<void> _saveGoal(Goal? existingGoal) async {
+    final title = _titleController.text.trim();
+    if (title.isEmpty) return;
+
+    final current = double.tryParse(_currentController.text) ?? 0;
+    final target = double.tryParse(_targetController.text) ?? 100;
+
+    if (existingGoal != null) {
+      // Update existing goal
+      final updated = Goal(
+        id: existingGoal.id,
+        title: title,
+        goalType: existingGoal.goalType,
+        currentValue: current,
+        targetValue: target,
+        minValue: existingGoal.minValue,
+        maxValue: target,
+        isActive: true,
+        createdAt: existingGoal.createdAt,
+        updatedAt: DateTime.now(),
+      );
+
+      final index = _goals.indexWhere((g) => g.id == existingGoal.id);
+      if (index >= 0) {
+        setState(() {
+          _goals[index] = updated;
+          _goalEmojis[existingGoal.id] = _selectedEmoji; // Save emoji
+        });
+      }
+
+      // Try to sync to backend
+      if (!existingGoal.id.startsWith('local_')) {
+        await updateGoal(existingGoal.id, title: title, currentValue: current, targetValue: target);
+      }
+    } else {
+      // Create new goal
+      final newGoalId = 'local_${DateTime.now().millisecondsSinceEpoch}';
+      final smartEmoji = _getSmartEmoji(title); // Auto-select emoji based on title
+      final newGoal = Goal(
+        id: newGoalId,
+        title: title,
+        goalType: 'numeric',
+        currentValue: current,
+        targetValue: target,
+        minValue: 0,
+        maxValue: target,
+        isActive: true,
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      );
+
+      setState(() {
+        _goals.add(newGoal);
+        _goalEmojis[newGoalId] = smartEmoji; // Save smart emoji for new goal
+      });
+
+      // Try to create on backend
+      final created = await createGoal(
+        title: title,
+        goalType: 'numeric',
+        targetValue: target,
+        currentValue: current,
+      );
+      
+      if (created != null) {
+        final index = _goals.indexWhere((g) => g.id == newGoal.id);
+        if (index >= 0 && mounted) {
+          setState(() {
+            _goals[index] = created;
+            // Move emoji to the new backend id
+            _goalEmojis[created.id] = smartEmoji;
+            _goalEmojis.remove(newGoalId);
+          });
+        }
+      }
+    }
+
+    await _saveGoalsLocally();
+  }
+
+  Future<void> _deleteGoal(Goal goal) async {
+    HapticFeedback.mediumImpact();
+    setState(() {
+      _goals.removeWhere((g) => g.id == goal.id);
+      _goalEmojis.remove(goal.id); // Remove emoji mapping
+    });
+    await _saveGoalsLocally();
+
+    if (!goal.id.startsWith('local_')) {
+      await deleteGoal(goal.id);
+    }
+  }
+
+  String _rawNum(double v) {
+    return v == v.roundToDouble() ? v.toStringAsFixed(0) : v.toStringAsFixed(1);
+  }
+
+  String _formatNum(double v) {
+    if (v >= 1000000) return '${(v / 1000000).toStringAsFixed(1)}M';
+    if (v >= 1000) return '${(v / 1000).toStringAsFixed(1)}K';
+    return _rawNum(v);
+  }
+
+  Color _getColor(double progress) {
+    if (progress >= 0.8) return const Color(0xFF22C55E);
+    if (progress >= 0.6) return const Color(0xFF84CC16);
+    if (progress >= 0.4) return const Color(0xFFFBBF24);
+    if (progress >= 0.2) return const Color(0xFFF97316);
+    return const Color(0xFF6B7280);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_isLoading) {
+      return const SizedBox.shrink();
+    }
+
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.only(top: 16, bottom: 20),
+      decoration: BoxDecoration(
+        border: Border(
+          bottom: BorderSide(
+            color: Colors.white.withOpacity(0.08),
+            width: 1,
+          ),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Header
+          Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text(
+                  'Goals',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 16,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                if (_goals.length < _maxGoals)
+                  GestureDetector(
+                    onTap: _addGoal,
+                    child: Icon(
+                      Icons.add_rounded,
+                      size: 22,
+                      color: Colors.white.withOpacity(0.5),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          // Goals list
+          if (_goals.isEmpty)
+            GestureDetector(
+              onTap: _addGoal,
+              child: Container(
+                padding: const EdgeInsets.symmetric(vertical: 20),
+                child: Center(
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Icon(Icons.add_rounded, size: 18, color: Colors.white.withOpacity(0.4)),
+                      const SizedBox(width: 8),
+                      Text(
+                        'Tap to add a goal',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: Colors.white.withOpacity(0.4),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            )
+          else
+            ..._goals.asMap().entries.map((entry) {
+              final goal = entry.value;
+              final isLast = entry.key == _goals.length - 1;
+              return _buildGoalItem(goal, isLast);
+            }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGoalItem(Goal goal, bool isLast) {
+    final progress = goal.progressPercentage;
+    final color = _getColor(progress);
+    final emoji = _getGoalEmoji(goal.id);
+
+    return GestureDetector(
+      onTap: () => _editGoal(goal),
+      child: Container(
+        margin: EdgeInsets.only(bottom: isLast ? 0 : 12),
+        child: Row(
+          children: [
+            // Emoji icon
+            Container(
+              width: 36,
+              height: 36,
+              margin: const EdgeInsets.only(right: 12),
+              decoration: BoxDecoration(
+                color: Colors.white.withOpacity(0.1),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Center(
+                child: Text(emoji, style: const TextStyle(fontSize: 18)),
+              ),
+            ),
+            // Content
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    goal.title,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                  const SizedBox(height: 6),
+                  // Progress bar
+                  Stack(
+                    children: [
+                      Container(
+                        height: 6,
+                        decoration: BoxDecoration(
+                          color: Colors.white.withOpacity(0.1),
+                          borderRadius: BorderRadius.circular(3),
+                        ),
+                      ),
+                      FractionallySizedBox(
+                        widthFactor: progress.clamp(0.0, 1.0),
+                        child: Container(
+                          height: 6,
+                          decoration: BoxDecoration(
+                            color: color,
+                            borderRadius: BorderRadius.circular(3),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            // Expand icon
+            Padding(
+              padding: const EdgeInsets.only(left: 8),
+              child: Icon(
+                _isExpanded ? Icons.keyboard_arrow_up : Icons.keyboard_arrow_down,
+                size: 20,
+                color: Colors.white.withOpacity(0.3),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/pages/conversations/widgets/today_tasks_widget.dart
+++ b/app/lib/pages/conversations/widgets/today_tasks_widget.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:omi/backend/schema/schema.dart';
+import 'package:omi/providers/action_items_provider.dart';
+import 'package:omi/providers/home_provider.dart';
+import 'package:provider/provider.dart';
+
+/// Widget showing top 3 today's tasks with "Show all ->" button
+class TodayTasksWidget extends StatelessWidget {
+  const TodayTasksWidget({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<ActionItemsProvider>(
+      builder: (context, provider, child) {
+        // Get today's tasks - same logic as action_items_page.dart
+        final now = DateTime.now();
+        final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
+
+        // Get incomplete tasks due today (including overdue) - matches tasks page logic
+        final todayTasks = provider.actionItems.where((item) {
+          if (item.completed) return false;
+          if (item.dueAt == null) return false;
+          // Same as tasks page: dueDate.isBefore(startOfTomorrow)
+          return item.dueAt!.isBefore(startOfTomorrow);
+        }).toList();
+
+        // Take top 3
+        final displayTasks = todayTasks.take(3).toList();
+
+        if (displayTasks.isEmpty && provider.actionItems.isEmpty) {
+          return const SizedBox.shrink();
+        }
+
+        return Container(
+          margin: const EdgeInsets.symmetric(horizontal: 16),
+          padding: const EdgeInsets.only(bottom: 20),
+          decoration: BoxDecoration(
+            border: Border(
+              bottom: BorderSide(
+                color: Colors.white.withOpacity(0.08),
+                width: 1,
+              ),
+            ),
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              // Header with "Today" and "Show all ->"
+              Padding(
+                padding: const EdgeInsets.symmetric(vertical: 8),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    const Text(
+                      'Today',
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    GestureDetector(
+                      onTap: () {
+                        HapticFeedback.lightImpact();
+                        // Navigate to tasks tab
+                        context.read<HomeProvider>().setIndex(1);
+                      },
+                      child: Text(
+                        'Show all →',
+                        style: TextStyle(
+                          color: Colors.white.withOpacity(0.5),
+                          fontSize: 13,
+                          fontWeight: FontWeight.w400,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              // Tasks list
+              if (displayTasks.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 12),
+                  child: Text(
+                    'No tasks for today. Ask Omi for more tasks or create manually.',
+                    style: TextStyle(
+                      color: Colors.white.withOpacity(0.4),
+                      fontSize: 14,
+                    ),
+                  ),
+                )
+              else
+                ...displayTasks.map(
+                  (task) => _TaskItem(task: task, provider: provider),
+                ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _TaskItem extends StatelessWidget {
+  final ActionItemWithMetadata task;
+  final ActionItemsProvider provider;
+
+  const _TaskItem({required this.task, required this.provider});
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Checkbox
+          GestureDetector(
+            onTap: () async {
+              HapticFeedback.lightImpact();
+              await provider.updateActionItemState(task, !task.completed);
+            },
+            child: Container(
+              width: 22,
+              height: 22,
+              margin: const EdgeInsets.only(top: 2, right: 12),
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: task.completed ? Colors.amber : Colors.grey.shade600,
+                  width: 2,
+                ),
+                color: task.completed ? Colors.amber : Colors.transparent,
+              ),
+              child: task.completed
+                  ? const Icon(Icons.check, size: 14, color: Colors.black)
+                  : null,
+            ),
+          ),
+          // Task text
+          Expanded(
+            child: Text(
+              task.description,
+              style: TextStyle(
+                color: task.completed ? Colors.grey.shade600 : Colors.white,
+                fontSize: 15,
+                decoration: task.completed ? TextDecoration.lineThrough : null,
+                height: 1.4,
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
Revamps the Omi mobile app homepage with new widgets for better task tracking and goal management.

## Changes

### Daily Score Widget
- Shows task completion rate as a 0-5 score with semicircular gauge
- Grey color when no tasks, yellow/amber scale based on completion
- Tap to see score details

### Today Tasks Widget  
- Displays top 3 tasks due today (including overdue)
- 'Show all →' button navigates to full tasks page
- Empty state: 'No tasks for today. Ask Omi for more tasks or create manually.'

### Goals Widget (replaces single goal)
- Supports up to 3 goals with minimalistic UI
- **Smart emoji selection** based on goal title keywords:
  - '1m users' → 🚀
  - 'Read books' → 📚
  - 'Run marathon' → 🏃
  - 'Save money' → 💰
  - etc.
- Emoji picker available when editing existing goals
- Progress bars with color coding

### Visual Improvements
- Subtle divider lines between sections (8% white opacity)
- Better spacing/margins for visual separation
- Consistent styling across all widgets

## Testing
- Tested on iOS Simulator (iPhone 16 Pro)
- All widgets render correctly
- Task filtering matches tasks page logic
- Goals persist locally with emoji mappings