### PR TITLE
fix: improve 'interesting' vs 'system' memory categorization

### DIFF
--- a/backend/utils/prompts.py
+++ b/backend/utils/prompts.py
@@ -31,70 +31,78 @@ IDENTITY RULES (CRITICAL):
 WORKFLOW:
 1. FIRST: Read the ENTIRE conversation to understand context and identify who is speaking
 2. SECOND: Identify actual names of people mentioned or speaking (use these instead of "Speaker X")
-3. THIRD: Apply the SHAREABILITY TEST to every potential memory
+3. THIRD: Apply the CATEGORIZATION TEST to every potential memory
 4. FOURTH: Filter based on STRICT QUALITY CRITERIA below
-5. FIFTH: Categorize as "interesting" or "system" based on criteria
-6. SIXTH: Ensure memories are concise, specific, and use real names when known
+5. FIFTH: Ensure memories are concise, specific, and use real names when known
 
-THE SHAREABILITY TEST (CRITICAL):
-Before extracting ANY memory, ask: "Would {user_name} actually share this with a friend, colleague, or family member?"
+THE CATEGORIZATION TEST (CRITICAL):
+For EVERY potential memory, ask these questions IN ORDER:
 
-If the answer is "no" or "maybe", DO NOT EXTRACT IT. Only "definitely yes" passes.
+Q1: "Is this wisdom/advice FROM someone else that {user_name} can learn from?"
+    → If YES: This is an INTERESTING memory. Include attribution (who said it).
+    → If NO: Go to Q2.
 
-INTERESTING MEMORIES (The Shareability Standard):
-These are memories that pass the "dinner party test" - things {user_name} would excitedly share with others.
+Q2: "Is this a fact ABOUT {user_name} - their opinions, realizations, network, or actions?"
+    → If YES: This is a SYSTEM memory.
+    → If NO: Probably should NOT be extracted at all.
 
-CRITICAL: Do NOT extract memories that are:
-- Opinions or feelings ("concerned about X", "thinks Y is important", "believes Z")
-- Generic discussions ("discussed X", "talked about Y", "mentioned Z")
-- Obvious facts everyone knows ("X saves time", "Y is important", "Z is useful")
+NEVER put {user_name}'s own realizations or opinions in INTERESTING.
+INTERESTING is ONLY for external wisdom from others that {user_name} can learn from.
 
-INCLUDE interesting memories if they meet AT LEAST ONE of these criteria strongly (ideally multiple):
-1. **Genuinely Surprising or Counter-Intuitive**: Information that challenges common knowledge or expectations
-   ✅ "Pineapple on pizza can cause severe allergic reactions in people with latex allergies"
-   ✅ "9 out of 10 billionaires at the summit got their start by solving unsexy problems like waste management"
-   ❌ "Alex likes pizza" (boring, not shareable)
-   ❌ "Sarah went to a tech conference" (mundane, everyone goes to conferences)
+INTERESTING MEMORIES (External Wisdom You Can Learn From):
+These are actionable advice, frameworks, and strategies FROM OTHER PEOPLE/SOURCES that {user_name} can learn from and apply.
 
-2. **Rare or Exclusive Knowledge**: Information most people don't know or have access to
-   ✅ "The Apollo 11 computer had less processing power than a modern calculator but used revolutionary error-correction algorithms"
-   ✅ "YC's first batch only had 8 startups and met in a room above a pizza shop"
-   ❌ "Python is a popular programming language" (common knowledge)
-   ❌ "Exercise is good for health" (everyone knows this)
+THE KEY QUESTION: "Is this wisdom FROM someone else that {user_name} can learn from?"
+If YES → INTERESTING. If it's about {user_name} themselves → SYSTEM.
 
-3. **Actionable Insights with High Impact**: Information that could meaningfully change behavior or decisions
-   ✅ "Negotiating salary after receiving offer letter can increase compensation by 15-20% on average with minimal risk"
-   ✅ "Writing down 3 things you're grateful for before bed improves sleep quality by 35% according to Stanford research"
-   ❌ "Should drink more water" (vague, low impact)
-   ❌ "Good to network at events" (generic advice)
+CRITICAL REQUIREMENTS FOR INTERESTING MEMORIES:
+1. **Must come from an EXTERNAL source** - not {user_name}'s own realization or opinion
+2. **Should include attribution** - who said it, what company/book/podcast it's from
+3. **Must be actionable** - advice, strategy, or framework that can change behavior
+4. **Format**: "Source: actionable insight" (e.g., "Rockwell: talk to paying customers, 30% will be real usecase")
 
-4. **Remarkable Stories or Anecdotes**: Narratives with memorable details or unexpected outcomes
-   ✅ "{user_name}'s mentor got their first customer by cold-calling 1000 people in 2 weeks and was rejected 997 times"
-   ✅ "Airbnb was rejected by 7 investors in a single day, then changed their pitch and raised $600k the next week"
-   ❌ "Had a good meeting with the team" (forgettable)
-   ❌ "Caught up with an old friend" (not remarkable)
+EXAMPLES OF GOOD INTERESTING MEMORIES:
+✅ "Rockwell: talk to paying customers, 30% will be a real usecase"
+✅ "Julian: ask everyone around for refs, keep pushing until they decline"
+✅ "James: hired 20 people by outbound, used advisors then asked for recs"
+✅ "Raspberry Pi: 1m sales in 1.5 years, licensed design to factories (best decision)"
+✅ "Apple: Jobs found advertising agency by figuring out who did it well for Intel"
+✅ "Hormozi on influencers: first influencers I know, second ask my network, third influencers I follow"
+✅ "YC advice: find competitors of your most successful customers"
+✅ "Keshav: get advisors in companies you want to target (ex-CEOs work well)"
 
-5. **Unique Personal Insights or Discoveries**: Realizations that reveal something deep or meaningful
-   ✅ "{user_name} realized they've been avoiding difficult conversations for 5 years, leading to chronic stress"
-   ✅ "{user_name} discovered their most productive hours are 5-7am, not evening as they assumed"
-   ❌ "Feeling stressed about work" (common, not insightful)
-   ❌ "Prefers working in the morning" (preference, not discovery)
+EXAMPLES OF WHAT IS NOT INTERESTING (should be SYSTEM or excluded):
+❌ "{user_name} realized multiple cofounders are essential" (user's OWN realization → SYSTEM)
+❌ "{user_name} advises making 20 Instagram posts" (user's OWN advice → SYSTEM)
+❌ "{user_name}'s cofounder Araf built apps at age 14" (fact about user's network → SYSTEM)
+❌ "{user_name} builds open source AI wearables" (fact ABOUT user → SYSTEM)
+❌ "{user_name} discovered their productive hours are 5-7am" (user's OWN discovery → SYSTEM)
+❌ "9 out of 10 billionaires solve unsexy problems" (no attribution, too generic)
+❌ "Exercise is good for health" (common knowledge, no source)
 
-SYSTEM MEMORIES (Useful Context, Not Shareable):
-These are factual details useful for context but NOT interesting enough to share with others.
+SYSTEM MEMORIES (Facts About the User):
+These are facts ABOUT {user_name} - their preferences, opinions, realizations, network, projects, and actions.
+
+THE KEY QUESTION: "Is this a fact ABOUT {user_name} or their world?"
+If YES → SYSTEM.
 
 INCLUDE system memories for:
-• Concrete plans, decisions, or commitments made
-• Important preferences or specific requirements stated
-• Logistical details that may be referenced later
+• {user_name}'s own opinions, realizations, and discoveries
+• {user_name}'s preferences and requirements
+• Facts about {user_name}'s network (who they know, relationships)
+• {user_name}'s projects, work, and achievements
+• {user_name}'s own advice or tips they give to others
+• Concrete plans, decisions, or commitments {user_name} made
 • Relationship context (who knows who, what roles people have)
-• Specific facts about {user_name}'s work, projects, or life
 
 Examples:
-✅ "{user_name} and Jamie are working on the Q4 budget presentation"
+✅ "{user_name} realized multiple cofounders are essential after Omi project delays"
+✅ "{user_name}'s cofounder Araf built apps with hundreds of thousands of users at age 14"
+✅ "{user_name} advises making 20 Instagram posts showing product use for viral success"
 ✅ "{user_name} prefers dark roast coffee with oat milk, no sugar"
 ✅ "{user_name}'s colleague David is the lead engineer on the authentication system"
-✅ "Rachel is the project lead for the client presentation"
+✅ "{user_name} builds open source AI wearables to keep user data private"
+✅ "{user_name} discovered their most productive hours are 5-7am"
 ❌ "Had coffee this morning" (too trivial)
 ❌ "Talked about the weather" (no value)
 ❌ "Meeting with Jamie on Thursday" (temporal, not timeless)
@@ -230,9 +238,17 @@ CRITICAL - Date and Time Handling:
   ❌ "Meeting scheduled for January 15th" (temporal, not a memory)
 
 Examples of GOOD memory format:
-✅ "{user_name} learned that honey never spoils; 3000-year-old honey found in Egyptian tombs was still edible"
-✅ "Jamie (CTO) mentioned 90% of bugs come from async race conditions in their codebase"
-✅ "{user_name} discovered writing for 10 min daily reduced anxiety by 40% in 3 weeks"
+
+INTERESTING (external wisdom with attribution):
+✅ "Rockwell: talk to paying customers, 30% will be a real usecase"
+✅ "Julian: ask everyone around for refs, keep pushing until they decline"
+✅ "Raspberry Pi: licensed design to factories, 1m sales in 1.5 years"
+✅ "Jamie (CTO): 90% of bugs come from async race conditions in their codebase"
+
+SYSTEM (facts about the user):
+✅ "{user_name} realized writing for 10 min daily reduced their anxiety significantly"
+✅ "{user_name}'s cofounder built apps with hundreds of thousands of users at age 14"
+✅ "{user_name} prefers morning meetings and avoids calls after 4pm"
 
 Examples of BAD memory format:
 ❌ "Speaker 0 learned something interesting about that thing we discussed" (vague, uses Speaker X)
@@ -291,33 +307,44 @@ For EACH memory you're about to extract, verify it does NOT match these patterns
 
 If a memory matches ANY of the above patterns, REMOVE it from your output.
 
+CATEGORIZATION DECISION TREE (CRITICAL - Apply to EVERY memory):
+1. "Is this wisdom/advice FROM someone else that {user_name} can learn from?"
+   → YES: Consider for INTERESTING (must have attribution)
+   → NO: Go to step 2
+
+2. "Is this a fact ABOUT {user_name}, their opinions, realizations, or network?"
+   → YES: Consider for SYSTEM
+   → NO: Probably should NOT be extracted
+
 FINAL CHECK - For each INTERESTING memory, ask yourself:
-1. "If I told this to a stranger at a party, would they find it interesting?" (If no → DELETE)
-2. "Does this contain specific numbers, names, or surprising details?" (If no → DELETE)
-3. "Is this something everyone already knows?" (If yes → DELETE)
-4. "Would this make someone say 'Wow, I didn't know that!'?" (If no → DELETE)
+1. "Does this have clear attribution (who said it, what source)?" (If no → move to SYSTEM or DELETE)
+2. "Is this actionable advice/strategy that can change behavior?" (If no → DELETE or move to SYSTEM)
+3. "Would {user_name} want to reference this advice later?" (If no → DELETE)
+4. "Is this formatted as 'Source: insight'?" (If no → reformat or DELETE)
 
 For SYSTEM memories, ask:
 1. "Is this specific enough to be useful later?" (If no → DELETE)
-2. "Would this help understand context in the future?" (If no → DELETE)
+2. "Would this help understand context about {user_name} in the future?" (If no → DELETE)
 3. "Does this contain a date/time reference like 'Thursday', 'next week', etc.?" (If yes → DELETE or make timeless)
 4. "Will this memory still make sense in 6 months?" (If no → DELETE)
 
 OUTPUT LIMITS (These are MAXIMUMS, not targets):
 • Extract AT MOST 2 interesting memories (most conversations will have 0-1)
 • Extract AT MOST 2 system memories (most conversations will have 0-2)
-• Interesting memories are RARE - only extract if they truly pass the shareability test
+• INTERESTING memories are RARE - they require EXTERNAL wisdom with ATTRIBUTION
+• If someone in the conversation shares advice/strategy, that's INTERESTING (with their name)
+• If {user_name} shares their own opinion/realization, that's SYSTEM (not interesting)
 • Many conversations will result in 0 interesting memories and 0-2 system memories - this is NORMAL and EXPECTED
 • Better to extract 0 memories than to include low-quality ones
 • When in doubt, DON'T extract - be conservative and selective
-• Think: "Would someone actually want to remember this?"
 • DEFAULT TO EMPTY LIST - only extract if memories are truly exceptional
 
 QUALITY OVER QUANTITY:
 • Most conversations have 0 interesting memories - this is completely fine
-• If ambiguous whether something is interesting or system, categorize as system
+• INTERESTING memories are RARE - they require external wisdom with clear attribution
+• If the wisdom comes from {user_name} themselves, it's SYSTEM, not INTERESTING
+• If ambiguous whether something is interesting or system, categorize as SYSTEM
 • Better to have an empty list than to flood with mediocre memories
-• Apply the shareability test rigorously
 • Only extract system memories if they're genuinely useful for future context
 • When uncertain, choose: EMPTY LIST over low-quality memories
 


### PR DESCRIPTION
## Summary
Fixes the memory categorization to properly distinguish between:
- **Interesting memories**: External wisdom/advice FROM others (with attribution) - actionable insights that can change behavior
- **System memories**: Facts ABOUT the user - preferences, opinions, realizations, network, projects

## Problem
Previously, memories like "Nik realized multiple cofounders are essential" were incorrectly categorized as "interesting" when they should be "system" since they're facts about the user, not external wisdom the user can learn from.

## Changes
- Redefine 'interesting' memories as external wisdom with attribution (format: "Source: insight")
- Redefine 'system' memories as facts ABOUT the user
- Add explicit categorization decision tree to guide LLM
- Update all examples to match new format
- Add clear Q1/Q2 categorization test

## Examples of Correct Categorization

**INTERESTING** (external wisdom):
- "Rockwell: talk to paying customers, 30% will be a real usecase"
- "Julian: ask everyone around for refs, keep pushing until they decline"

**SYSTEM** (facts about user):
- "Nik realized multiple cofounders are essential after Omi project delays"
- "Nik advises making 20 Instagram posts showing product use"