### PR TITLE
fix: filter out old overdue tasks from today's tasks on homepage

### DIFF
--- a/app/lib/desktop/pages/conversations/widgets/desktop_today_tasks_widget.dart
+++ b/app/lib/desktop/pages/conversations/widgets/desktop_today_tasks_widget.dart
@@ -16,11 +16,15 @@ class DesktopTodayTasksWidget extends StatelessWidget {
         // Get today's tasks - same logic as action_items_page.dart
         final now = DateTime.now();
         final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
+        // Filter out old tasks (older than 7 days) - same as tasks page
+        final sevenDaysAgo = now.subtract(const Duration(days: 7));
 
-        // Get incomplete tasks due today (including overdue)
+        // Get incomplete tasks due today (including recent overdue) - matches tasks page logic
         final todayTasks = provider.actionItems.where((item) {
           if (item.completed) return false;
           if (item.dueAt == null) return false;
+          // Skip very old overdue tasks (older than 7 days)
+          if (item.dueAt!.isBefore(sevenDaysAgo)) return false;
           return item.dueAt!.isBefore(startOfTomorrow);
         }).toList();
 

--- a/app/lib/pages/conversations/widgets/today_tasks_widget.dart
+++ b/app/lib/pages/conversations/widgets/today_tasks_widget.dart
@@ -16,11 +16,15 @@ class TodayTasksWidget extends StatelessWidget {
         // Get today's tasks - same logic as action_items_page.dart
         final now = DateTime.now();
         final startOfTomorrow = DateTime(now.year, now.month, now.day + 1);
+        // Filter out old tasks (older than 7 days) - same as tasks page
+        final sevenDaysAgo = now.subtract(const Duration(days: 7));
 
-        // Get incomplete tasks due today (including overdue) - matches tasks page logic
+        // Get incomplete tasks due today (including recent overdue) - matches tasks page logic
         final todayTasks = provider.actionItems.where((item) {
           if (item.completed) return false;
           if (item.dueAt == null) return false;
+          // Skip very old overdue tasks (older than 7 days)
+          if (item.dueAt!.isBefore(sevenDaysAgo)) return false;
           // Same as tasks page: dueDate.isBefore(startOfTomorrow)
           return item.dueAt!.isBefore(startOfTomorrow);
         }).toList();


### PR DESCRIPTION
## Problem
The TodayTasksWidget on the homepage was showing all overdue tasks, including very old ones that were likely completed or deleted but still showing up due to stale data.

## Solution
Added the same 7-day filter that action_items_page.dart uses:
- Tasks with due dates older than 7 days are now excluded from the 'Today' section on the homepage
- Applied to both mobile and desktop versions

This ensures the homepage only shows recent, relevant tasks.