### PR TITLE
fix chat quote transcription background

### DIFF
--- a/app/lib/pages/chat/widgets/markdown_message_widget.dart
+++ b/app/lib/pages/chat/widgets/markdown_message_widget.dart
@@ -11,6 +11,16 @@ Widget getMarkdownWidget(BuildContext context, String message, {Function(String)
         p: const TextStyle(color: Colors.white, fontSize: 16, height: 1.4),
         a: const TextStyle(color: Colors.blue, decoration: TextDecoration.underline),
         listBullet: const TextStyle(color: Colors.white, fontSize: 16),
+        blockquote: const TextStyle(
+          color: Colors.white,
+          fontSize: 16,
+          height: 1.4,
+          backgroundColor: Colors.transparent,
+        ),
+        blockquoteDecoration: BoxDecoration(
+          color: const Color(0xFF35343B),
+          borderRadius: BorderRadius.circular(4),
+        ),
         code: const TextStyle(
           color: Colors.white,
           backgroundColor: Colors.transparent,


### PR DESCRIPTION
closes #4177

before 

<img width="730" height="599" alt="Screenshot 2026-01-11 at 11 21 42 PM" src="https://github.com/user-attachments/assets/b4b30eed-f55d-4167-a215-302ab19c04c2" />

after 

![IMG_FC11DD090718-1](https://github.com/user-attachments/assets/6ee4235d-de89-4e1a-8277-82fbc596cd5b)
