### PR TITLE
fix: preserve all goals on app restart (multi-goal persistence)

### DIFF
--- a/app/lib/pages/conversations/widgets/goals_widget.dart
+++ b/app/lib/pages/conversations/widgets/goals_widget.dart
@@ -60,7 +60,7 @@ class _GoalsWidgetState extends State<GoalsWidget> with WidgetsBindingObserver {
 
   Future<void> _loadGoals() async {
     try {
-      // Load from local storage first
+      // Load from local storage first - this is the source of truth for multi-goal
       final prefs = await SharedPreferences.getInstance();
       final goalsJson = prefs.getString(_goalsStorageKey);
       final emojisJson = prefs.getString(_goalsEmojiKey);
@@ -71,29 +71,38 @@ class _GoalsWidgetState extends State<GoalsWidget> with WidgetsBindingObserver {
         _goalEmojis = decoded.map((k, v) => MapEntry(k, v.toString()));
       }
       
+      bool hasLocalGoals = false;
       if (goalsJson != null) {
-        final List<dynamic> decoded = json.decode(goalsJson);
-        final localGoals = decoded.map((e) => Goal.fromJson(e)).toList();
-        if (mounted) {
-          setState(() {
-            _goals = localGoals;
-            _isLoading = false;
-          });
+        try {
+          final List<dynamic> decoded = json.decode(goalsJson);
+          final localGoals = decoded.map((e) => Goal.fromJson(e)).toList();
+          if (localGoals.isNotEmpty) {
+            hasLocalGoals = true;
+            if (mounted) {
+              setState(() {
+                _goals = localGoals;
+                _isLoading = false;
+              });
+            }
+          }
+        } catch (e) {
+          debugPrint('[GOALS] Error parsing local goals: $e');
         }
       }
 
-      // Try to get from backend
-      final backendGoal = await getCurrentGoal();
-      if (backendGoal != null && mounted) {
-        // Merge backend goal with local goals
-        final existingIndex = _goals.indexWhere((g) => g.id == backendGoal.id);
-        if (existingIndex >= 0) {
-          _goals[existingIndex] = backendGoal;
-        } else if (_goals.isEmpty) {
-          _goals.add(backendGoal);
+      // Only try backend if no local goals exist (backward compatibility)
+      // Backend only supports 1 goal, so don't let it overwrite our multi-goal local storage
+      if (!hasLocalGoals) {
+        final backendGoal = await getCurrentGoal();
+        if (backendGoal != null && mounted) {
+          setState(() {
+            _goals = [backendGoal];
+            _isLoading = false;
+          });
+          await _saveGoalsLocally();
+        } else if (mounted) {
+          setState(() => _isLoading = false);
         }
-        await _saveGoalsLocally();
-        setState(() => _isLoading = false);
       } else if (mounted) {
         setState(() => _isLoading = false);
       }


### PR DESCRIPTION
## Problem
Users reported that when they add 3 goals and restart the app, only 1 goal is shown.

## Root Cause
The `_loadGoals()` method in `GoalsWidget` was:
1. Loading goals from local storage (SharedPreferences) - all 3 goals
2. Then calling `getCurrentGoal()` from the backend - which only returns 1 goal
3. The merge logic was potentially overwriting local multi-goal storage

The backend API (`GET /v1/goals`) only supports a **single** goal, but the UI now supports up to 3 goals stored locally.

## Solution
Changed the loading logic to treat local storage as the **source of truth** for multi-goal support:

1. Load goals from local storage first
2. **Only** fetch from backend if no local goals exist (backward compatibility for users who had a single goal before)
3. Don't let the single-goal backend response overwrite local multi-goal storage

## Changes
- `app/lib/pages/conversations/widgets/goals_widget.dart` - Mobile GoalsWidget
- `app/lib/desktop/pages/conversations/widgets/desktop_goals_widget.dart` - Desktop GoalsWidget

Both widgets now have the same fixed `_loadGoals()` logic.