### PR TITLE
enable deep power down for external flash

### DIFF
--- a/omi/firmware/boards/omi/omi_nrf5340_cpuapp.dts
+++ b/omi/firmware/boards/omi/omi_nrf5340_cpuapp.dts
@@ -224,6 +224,9 @@
 		10 d8 08 81
 		];
 		size = <DT_SIZE_M(16)>;
+		has-dpd;
+		t-enter-dpd = <3000>;
+		t-exit-dpd = <8000>;
 	};
 };
 


### PR DESCRIPTION
This PR enable `Deep Power Down` mode for external flash.
Reduce power consumption in `deepsleep` from `25uA` to `18uA`

<img width="812" height="358" alt="image" src="https://github.com/user-attachments/assets/c1461577-f069-4f6c-846c-26cdda7e5e14" />

<img width="1532" height="560" alt="image" src="https://github.com/user-attachments/assets/81ec1337-17fd-4c2a-94fa-614df790b9bb" />
