### PR TITLE
Add support for 21 languages for the app’s interface. Clarify Settings > Profile > Language

### DIFF
--- a/app/lib/gen/assets.gen.dart
+++ b/app/lib/gen/assets.gen.dart
@@ -13,7 +13,8 @@ class $AssetsCompetitorLogosGen {
   const $AssetsCompetitorLogosGen();
 
   /// File path: assets/competitor-logos/limitless-logo.jpg
-  AssetGenImage get limitlessLogo => const AssetGenImage('assets/competitor-logos/limitless-logo.jpg');
+  AssetGenImage get limitlessLogo =>
+      const AssetGenImage('assets/competitor-logos/limitless-logo.jpg');
 
   /// List of all assets
   List<AssetGenImage> get values => [limitlessLogo];
@@ -33,16 +34,19 @@ class $AssetsFontsGen {
   const $AssetsFontsGen();
 
   /// File path: assets/fonts/SFPRODISPLAYBLACKITALIC.OTF
-  String get sfprodisplayblackitalic => 'assets/fonts/SFPRODISPLAYBLACKITALIC.OTF';
+  String get sfprodisplayblackitalic =>
+      'assets/fonts/SFPRODISPLAYBLACKITALIC.OTF';
 
   /// File path: assets/fonts/SFPRODISPLAYBOLD.OTF
   String get sfprodisplaybold => 'assets/fonts/SFPRODISPLAYBOLD.OTF';
 
   /// File path: assets/fonts/SFPRODISPLAYHEAVYITALIC.OTF
-  String get sfprodisplayheavyitalic => 'assets/fonts/SFPRODISPLAYHEAVYITALIC.OTF';
+  String get sfprodisplayheavyitalic =>
+      'assets/fonts/SFPRODISPLAYHEAVYITALIC.OTF';
 
   /// File path: assets/fonts/SFPRODISPLAYLIGHTITALIC.OTF
-  String get sfprodisplaylightitalic => 'assets/fonts/SFPRODISPLAYLIGHTITALIC.OTF';
+  String get sfprodisplaylightitalic =>
+      'assets/fonts/SFPRODISPLAYLIGHTITALIC.OTF';
 
   /// File path: assets/fonts/SFPRODISPLAYMEDIUM.OTF
   String get sfprodisplaymedium => 'assets/fonts/SFPRODISPLAYMEDIUM.OTF';
@@ -51,22 +55,24 @@ class $AssetsFontsGen {
   String get sfprodisplayregular => 'assets/fonts/SFPRODISPLAYREGULAR.OTF';
 
   /// File path: assets/fonts/SFPRODISPLAYSEMIBOLDITALIC.OTF
-  String get sfprodisplaysemibolditalic => 'assets/fonts/SFPRODISPLAYSEMIBOLDITALIC.OTF';
+  String get sfprodisplaysemibolditalic =>
+      'assets/fonts/SFPRODISPLAYSEMIBOLDITALIC.OTF';
 
   /// File path: assets/fonts/SFPRODISPLAYTHINITALIC.OTF
-  String get sfprodisplaythinitalic => 'assets/fonts/SFPRODISPLAYTHINITALIC.OTF';
+  String get sfprodisplaythinitalic =>
+      'assets/fonts/SFPRODISPLAYTHINITALIC.OTF';
 
   /// List of all assets
   List<String> get values => [
-        sfprodisplayblackitalic,
-        sfprodisplaybold,
-        sfprodisplayheavyitalic,
-        sfprodisplaylightitalic,
-        sfprodisplaymedium,
-        sfprodisplayregular,
-        sfprodisplaysemibolditalic,
-        sfprodisplaythinitalic,
-      ];
+    sfprodisplayblackitalic,
+    sfprodisplaybold,
+    sfprodisplayheavyitalic,
+    sfprodisplaylightitalic,
+    sfprodisplaymedium,
+    sfprodisplayregular,
+    sfprodisplaysemibolditalic,
+    sfprodisplaythinitalic,
+  ];
 }
 
 class $AssetsImagesGen {
@@ -88,34 +94,42 @@ class $AssetsImagesGen {
   String get a5 => 'assets/images/5.mov';
 
   /// File path: assets/images/Logo Text White.png
-  AssetGenImage get logoTextWhite => const AssetGenImage('assets/images/Logo Text White.png');
+  AssetGenImage get logoTextWhite =>
+      const AssetGenImage('assets/images/Logo Text White.png');
 
   /// File path: assets/images/ai_magic.svg
   String get aiMagic => 'assets/images/ai_magic.svg';
 
   /// File path: assets/images/app_launcher_icon.png
-  AssetGenImage get appLauncherIcon => const AssetGenImage('assets/images/app_launcher_icon.png');
+  AssetGenImage get appLauncherIcon =>
+      const AssetGenImage('assets/images/app_launcher_icon.png');
 
   /// File path: assets/images/apple-reminders-logo.png
-  AssetGenImage get appleRemindersLogo => const AssetGenImage('assets/images/apple-reminders-logo.png');
+  AssetGenImage get appleRemindersLogo =>
+      const AssetGenImage('assets/images/apple-reminders-logo.png');
 
   /// File path: assets/images/apple_logo.png
-  AssetGenImage get appleLogo => const AssetGenImage('assets/images/apple_logo.png');
+  AssetGenImage get appleLogo =>
+      const AssetGenImage('assets/images/apple_logo.png');
 
   /// File path: assets/images/apple_watch.png
-  AssetGenImage get appleWatch => const AssetGenImage('assets/images/apple_watch.png');
+  AssetGenImage get appleWatch =>
+      const AssetGenImage('assets/images/apple_watch.png');
 
   /// File path: assets/images/background.png
-  AssetGenImage get background => const AssetGenImage('assets/images/background.png');
+  AssetGenImage get background =>
+      const AssetGenImage('assets/images/background.png');
 
   /// File path: assets/images/bee_device.webp
-  AssetGenImage get beeDevice => const AssetGenImage('assets/images/bee_device.webp');
+  AssetGenImage get beeDevice =>
+      const AssetGenImage('assets/images/bee_device.webp');
 
   /// File path: assets/images/blob.webp
   AssetGenImage get blob => const AssetGenImage('assets/images/blob.webp');
 
   /// File path: assets/images/calendar_logo.png
-  AssetGenImage get calendarLogo => const AssetGenImage('assets/images/calendar_logo.png');
+  AssetGenImage get calendarLogo =>
+      const AssetGenImage('assets/images/calendar_logo.png');
 
   /// File path: assets/images/checkbox.svg
   String get checkbox => 'assets/images/checkbox.svg';
@@ -124,28 +138,35 @@ class $AssetsImagesGen {
   AssetGenImage get clone => const AssetGenImage('assets/images/clone.png');
 
   /// File path: assets/images/email_logo.png
-  AssetGenImage get emailLogo => const AssetGenImage('assets/images/email_logo.png');
+  AssetGenImage get emailLogo =>
+      const AssetGenImage('assets/images/email_logo.png');
 
   /// File path: assets/images/emotional_feedback_1.png
-  AssetGenImage get emotionalFeedback1 => const AssetGenImage('assets/images/emotional_feedback_1.png');
+  AssetGenImage get emotionalFeedback1 =>
+      const AssetGenImage('assets/images/emotional_feedback_1.png');
 
   /// File path: assets/images/facebook_logo.png
-  AssetGenImage get facebookLogo => const AssetGenImage('assets/images/facebook_logo.png');
+  AssetGenImage get facebookLogo =>
+      const AssetGenImage('assets/images/facebook_logo.png');
 
   /// File path: assets/images/fieldy.webp
   AssetGenImage get fieldy => const AssetGenImage('assets/images/fieldy.webp');
 
   /// File path: assets/images/friend-pendant.webp
-  AssetGenImage get friendPendant => const AssetGenImage('assets/images/friend-pendant.webp');
+  AssetGenImage get friendPendant =>
+      const AssetGenImage('assets/images/friend-pendant.webp');
 
   /// File path: assets/images/google_logo.png
-  AssetGenImage get googleLogo => const AssetGenImage('assets/images/google_logo.png');
+  AssetGenImage get googleLogo =>
+      const AssetGenImage('assets/images/google_logo.png');
 
   /// File path: assets/images/gradient_card.png
-  AssetGenImage get gradientCard => const AssetGenImage('assets/images/gradient_card.png');
+  AssetGenImage get gradientCard =>
+      const AssetGenImage('assets/images/gradient_card.png');
 
   /// File path: assets/images/herologo.png
-  AssetGenImage get herologo => const AssetGenImage('assets/images/herologo.png');
+  AssetGenImage get herologo =>
+      const AssetGenImage('assets/images/herologo.png');
 
   /// File path: assets/images/ic_chart.svg
   String get icChart => 'assets/images/ic_chart.svg';
@@ -169,103 +190,132 @@ class $AssetsImagesGen {
   String get imessageLogo => 'assets/images/imessage_logo.svg';
 
   /// File path: assets/images/instagram_logo.png
-  AssetGenImage get instagramLogo => const AssetGenImage('assets/images/instagram_logo.png');
+  AssetGenImage get instagramLogo =>
+      const AssetGenImage('assets/images/instagram_logo.png');
 
   /// File path: assets/images/instruction_1.png
-  AssetGenImage get instruction1 => const AssetGenImage('assets/images/instruction_1.png');
+  AssetGenImage get instruction1 =>
+      const AssetGenImage('assets/images/instruction_1.png');
 
   /// File path: assets/images/instruction_2.png
-  AssetGenImage get instruction2 => const AssetGenImage('assets/images/instruction_2.png');
+  AssetGenImage get instruction2 =>
+      const AssetGenImage('assets/images/instruction_2.png');
 
   /// File path: assets/images/instruction_3.png
-  AssetGenImage get instruction3 => const AssetGenImage('assets/images/instruction_3.png');
+  AssetGenImage get instruction3 =>
+      const AssetGenImage('assets/images/instruction_3.png');
 
   /// File path: assets/images/limitless.png
-  AssetGenImage get limitless => const AssetGenImage('assets/images/limitless.png');
+  AssetGenImage get limitless =>
+      const AssetGenImage('assets/images/limitless.png');
 
   /// File path: assets/images/link_icon.svg
   String get linkIcon => 'assets/images/link_icon.svg';
 
   /// File path: assets/images/linkedin_logo.png
-  AssetGenImage get linkedinLogo => const AssetGenImage('assets/images/linkedin_logo.png');
+  AssetGenImage get linkedinLogo =>
+      const AssetGenImage('assets/images/linkedin_logo.png');
 
   /// File path: assets/images/logo_transparent.png
-  AssetGenImage get logoTransparent => const AssetGenImage('assets/images/logo_transparent.png');
+  AssetGenImage get logoTransparent =>
+      const AssetGenImage('assets/images/logo_transparent.png');
 
   /// File path: assets/images/logo_transparent_v2.png
-  AssetGenImage get logoTransparentV2 => const AssetGenImage('assets/images/logo_transparent_v2.png');
+  AssetGenImage get logoTransparentV2 =>
+      const AssetGenImage('assets/images/logo_transparent_v2.png');
 
   /// File path: assets/images/neo_one.webp
   AssetGenImage get neoOne => const AssetGenImage('assets/images/neo_one.webp');
 
   /// File path: assets/images/new_background.png
-  AssetGenImage get newBackground => const AssetGenImage('assets/images/new_background.png');
+  AssetGenImage get newBackground =>
+      const AssetGenImage('assets/images/new_background.png');
 
   /// File path: assets/images/notion_logo.png
-  AssetGenImage get notionLogo => const AssetGenImage('assets/images/notion_logo.png');
+  AssetGenImage get notionLogo =>
+      const AssetGenImage('assets/images/notion_logo.png');
 
   /// File path: assets/images/omi-devkit-without-rope.png
-  AssetGenImage get omiDevkitWithoutRope => const AssetGenImage('assets/images/omi-devkit-without-rope.png');
+  AssetGenImage get omiDevkitWithoutRope =>
+      const AssetGenImage('assets/images/omi-devkit-without-rope.png');
 
   /// File path: assets/images/omi-glass.png
-  AssetGenImage get omiGlass => const AssetGenImage('assets/images/omi-glass.png');
+  AssetGenImage get omiGlass =>
+      const AssetGenImage('assets/images/omi-glass.png');
 
   /// File path: assets/images/omi-with-rope-no-padding.webp
-  AssetGenImage get omiWithRopeNoPadding => const AssetGenImage('assets/images/omi-with-rope-no-padding.webp');
+  AssetGenImage get omiWithRopeNoPadding =>
+      const AssetGenImage('assets/images/omi-with-rope-no-padding.webp');
 
   /// File path: assets/images/omi-with-rope.webp
-  AssetGenImage get omiWithRope => const AssetGenImage('assets/images/omi-with-rope.webp');
+  AssetGenImage get omiWithRope =>
+      const AssetGenImage('assets/images/omi-with-rope.webp');
 
   /// File path: assets/images/omi-without-rope-turned-off.webp
-  AssetGenImage get omiWithoutRopeTurnedOff => const AssetGenImage('assets/images/omi-without-rope-turned-off.webp');
+  AssetGenImage get omiWithoutRopeTurnedOff =>
+      const AssetGenImage('assets/images/omi-without-rope-turned-off.webp');
 
   /// File path: assets/images/omi-without-rope.webp
-  AssetGenImage get omiWithoutRope => const AssetGenImage('assets/images/omi-without-rope.webp');
+  AssetGenImage get omiWithoutRope =>
+      const AssetGenImage('assets/images/omi-without-rope.webp');
 
   /// File path: assets/images/onboarding-bg-1.webp
-  AssetGenImage get onboardingBg1 => const AssetGenImage('assets/images/onboarding-bg-1.webp');
+  AssetGenImage get onboardingBg1 =>
+      const AssetGenImage('assets/images/onboarding-bg-1.webp');
 
   /// File path: assets/images/onboarding-bg-2.webp
-  AssetGenImage get onboardingBg2 => const AssetGenImage('assets/images/onboarding-bg-2.webp');
+  AssetGenImage get onboardingBg2 =>
+      const AssetGenImage('assets/images/onboarding-bg-2.webp');
 
   /// File path: assets/images/onboarding-bg-3.webp
-  AssetGenImage get onboardingBg3 => const AssetGenImage('assets/images/onboarding-bg-3.webp');
+  AssetGenImage get onboardingBg3 =>
+      const AssetGenImage('assets/images/onboarding-bg-3.webp');
 
   /// File path: assets/images/onboarding-bg-4.webp
-  AssetGenImage get onboardingBg4 => const AssetGenImage('assets/images/onboarding-bg-4.webp');
+  AssetGenImage get onboardingBg4 =>
+      const AssetGenImage('assets/images/onboarding-bg-4.webp');
 
   /// File path: assets/images/onboarding-bg-5-1.webp
-  AssetGenImage get onboardingBg51 => const AssetGenImage('assets/images/onboarding-bg-5-1.webp');
+  AssetGenImage get onboardingBg51 =>
+      const AssetGenImage('assets/images/onboarding-bg-5-1.webp');
 
   /// File path: assets/images/onboarding-bg-5-2.webp
-  AssetGenImage get onboardingBg52 => const AssetGenImage('assets/images/onboarding-bg-5-2.webp');
+  AssetGenImage get onboardingBg52 =>
+      const AssetGenImage('assets/images/onboarding-bg-5-2.webp');
 
   /// File path: assets/images/onboarding-bg-6.webp
-  AssetGenImage get onboardingBg6 => const AssetGenImage('assets/images/onboarding-bg-6.webp');
+  AssetGenImage get onboardingBg6 =>
+      const AssetGenImage('assets/images/onboarding-bg-6.webp');
 
   /// File path: assets/images/onboarding.mp4
   String get onboarding => 'assets/images/onboarding.mp4';
 
   /// File path: assets/images/plaud_note_pin.webp
-  AssetGenImage get plaudNotePin => const AssetGenImage('assets/images/plaud_note_pin.webp');
+  AssetGenImage get plaudNotePin =>
+      const AssetGenImage('assets/images/plaud_note_pin.webp');
 
   /// File path: assets/images/recording_green_circle_icon.png
-  AssetGenImage get recordingGreenCircleIcon => const AssetGenImage('assets/images/recording_green_circle_icon.png');
+  AssetGenImage get recordingGreenCircleIcon =>
+      const AssetGenImage('assets/images/recording_green_circle_icon.png');
 
   /// File path: assets/images/slack_logo.png
-  AssetGenImage get slackLogo => const AssetGenImage('assets/images/slack_logo.png');
+  AssetGenImage get slackLogo =>
+      const AssetGenImage('assets/images/slack_logo.png');
 
   /// File path: assets/images/speaker_0_icon.png
-  AssetGenImage get speaker0Icon => const AssetGenImage('assets/images/speaker_0_icon.png');
+  AssetGenImage get speaker0Icon =>
+      const AssetGenImage('assets/images/speaker_0_icon.png');
 
   /// File path: assets/images/speaker_1_icon.png
-  AssetGenImage get speaker1Icon => const AssetGenImage('assets/images/speaker_1_icon.png');
+  AssetGenImage get speaker1Icon =>
+      const AssetGenImage('assets/images/speaker_1_icon.png');
 
   /// File path: assets/images/splash.png
   AssetGenImage get splash => const AssetGenImage('assets/images/splash.png');
 
   /// File path: assets/images/splash_icon.png
-  AssetGenImage get splashIcon => const AssetGenImage('assets/images/splash_icon.png');
+  AssetGenImage get splashIcon =>
+      const AssetGenImage('assets/images/splash_icon.png');
 
   /// File path: assets/images/stars.png
   AssetGenImage get stars => const AssetGenImage('assets/images/stars.png');
@@ -274,161 +324,178 @@ class $AssetsImagesGen {
   String get stripeLogo => 'assets/images/stripe_logo.svg';
 
   /// File path: assets/images/telegram_logo.png
-  AssetGenImage get telegramLogo => const AssetGenImage('assets/images/telegram_logo.png');
+  AssetGenImage get telegramLogo =>
+      const AssetGenImage('assets/images/telegram_logo.png');
 
   /// File path: assets/images/whatsapp_logo.png
-  AssetGenImage get whatsappLogo => const AssetGenImage('assets/images/whatsapp_logo.png');
+  AssetGenImage get whatsappLogo =>
+      const AssetGenImage('assets/images/whatsapp_logo.png');
 
   /// File path: assets/images/x_logo.png
   AssetGenImage get xLogo => const AssetGenImage('assets/images/x_logo.png');
 
   /// File path: assets/images/x_logo_mini.png
-  AssetGenImage get xLogoMini => const AssetGenImage('assets/images/x_logo_mini.png');
+  AssetGenImage get xLogoMini =>
+      const AssetGenImage('assets/images/x_logo_mini.png');
 
   /// File path: assets/images/youtube_logo.png
-  AssetGenImage get youtubeLogo => const AssetGenImage('assets/images/youtube_logo.png');
+  AssetGenImage get youtubeLogo =>
+      const AssetGenImage('assets/images/youtube_logo.png');
 
   /// List of all assets
   List<dynamic> get values => [
-        a1,
-        a2,
-        a3,
-        a4,
-        a5,
-        logoTextWhite,
-        aiMagic,
-        appLauncherIcon,
-        appleRemindersLogo,
-        appleLogo,
-        appleWatch,
-        background,
-        beeDevice,
-        blob,
-        calendarLogo,
-        checkbox,
-        clone,
-        emailLogo,
-        emotionalFeedback1,
-        facebookLogo,
-        fieldy,
-        friendPendant,
-        googleLogo,
-        gradientCard,
-        herologo,
-        icChart,
-        icCloneChat,
-        icClonePlus,
-        icDollar,
-        icPersonaProfile,
-        icSettingPersona,
-        imessageLogo,
-        instagramLogo,
-        instruction1,
-        instruction2,
-        instruction3,
-        limitless,
-        linkIcon,
-        linkedinLogo,
-        logoTransparent,
-        logoTransparentV2,
-        neoOne,
-        newBackground,
-        notionLogo,
-        omiDevkitWithoutRope,
-        omiGlass,
-        omiWithRopeNoPadding,
-        omiWithRope,
-        omiWithoutRopeTurnedOff,
-        omiWithoutRope,
-        onboardingBg1,
-        onboardingBg2,
-        onboardingBg3,
-        onboardingBg4,
-        onboardingBg51,
-        onboardingBg52,
-        onboardingBg6,
-        onboarding,
-        plaudNotePin,
-        recordingGreenCircleIcon,
-        slackLogo,
-        speaker0Icon,
-        speaker1Icon,
-        splash,
-        splashIcon,
-        stars,
-        stripeLogo,
-        telegramLogo,
-        whatsappLogo,
-        xLogo,
-        xLogoMini,
-        youtubeLogo,
-      ];
+    a1,
+    a2,
+    a3,
+    a4,
+    a5,
+    logoTextWhite,
+    aiMagic,
+    appLauncherIcon,
+    appleRemindersLogo,
+    appleLogo,
+    appleWatch,
+    background,
+    beeDevice,
+    blob,
+    calendarLogo,
+    checkbox,
+    clone,
+    emailLogo,
+    emotionalFeedback1,
+    facebookLogo,
+    fieldy,
+    friendPendant,
+    googleLogo,
+    gradientCard,
+    herologo,
+    icChart,
+    icCloneChat,
+    icClonePlus,
+    icDollar,
+    icPersonaProfile,
+    icSettingPersona,
+    imessageLogo,
+    instagramLogo,
+    instruction1,
+    instruction2,
+    instruction3,
+    limitless,
+    linkIcon,
+    linkedinLogo,
+    logoTransparent,
+    logoTransparentV2,
+    neoOne,
+    newBackground,
+    notionLogo,
+    omiDevkitWithoutRope,
+    omiGlass,
+    omiWithRopeNoPadding,
+    omiWithRope,
+    omiWithoutRopeTurnedOff,
+    omiWithoutRope,
+    onboardingBg1,
+    onboardingBg2,
+    onboardingBg3,
+    onboardingBg4,
+    onboardingBg51,
+    onboardingBg52,
+    onboardingBg6,
+    onboarding,
+    plaudNotePin,
+    recordingGreenCircleIcon,
+    slackLogo,
+    speaker0Icon,
+    speaker1Icon,
+    splash,
+    splashIcon,
+    stars,
+    stripeLogo,
+    telegramLogo,
+    whatsappLogo,
+    xLogo,
+    xLogoMini,
+    youtubeLogo,
+  ];
 }
 
 class $AssetsIntegrationAppLogosGen {
   const $AssetsIntegrationAppLogosGen();
 
   /// File path: assets/integration_app_logos/asana-logo.png
-  AssetGenImage get asanaLogo => const AssetGenImage('assets/integration_app_logos/asana-logo.png');
+  AssetGenImage get asanaLogo =>
+      const AssetGenImage('assets/integration_app_logos/asana-logo.png');
 
   /// File path: assets/integration_app_logos/clickup-logo.png
-  AssetGenImage get clickupLogo => const AssetGenImage('assets/integration_app_logos/clickup-logo.png');
+  AssetGenImage get clickupLogo =>
+      const AssetGenImage('assets/integration_app_logos/clickup-logo.png');
 
   /// File path: assets/integration_app_logos/github-logo.png
-  AssetGenImage get githubLogo => const AssetGenImage('assets/integration_app_logos/github-logo.png');
+  AssetGenImage get githubLogo =>
+      const AssetGenImage('assets/integration_app_logos/github-logo.png');
 
   /// File path: assets/integration_app_logos/gmail-logo.jpeg
-  AssetGenImage get gmailLogo => const AssetGenImage('assets/integration_app_logos/gmail-logo.jpeg');
+  AssetGenImage get gmailLogo =>
+      const AssetGenImage('assets/integration_app_logos/gmail-logo.jpeg');
 
   /// File path: assets/integration_app_logos/google-calendar.png
-  AssetGenImage get googleCalendar => const AssetGenImage('assets/integration_app_logos/google-calendar.png');
+  AssetGenImage get googleCalendar =>
+      const AssetGenImage('assets/integration_app_logos/google-calendar.png');
 
   /// File path: assets/integration_app_logos/google-tasks-logo.png
-  AssetGenImage get googleTasksLogo => const AssetGenImage('assets/integration_app_logos/google-tasks-logo.png');
+  AssetGenImage get googleTasksLogo =>
+      const AssetGenImage('assets/integration_app_logos/google-tasks-logo.png');
 
   /// File path: assets/integration_app_logos/monday-logo.jpeg
-  AssetGenImage get mondayLogo => const AssetGenImage('assets/integration_app_logos/monday-logo.jpeg');
+  AssetGenImage get mondayLogo =>
+      const AssetGenImage('assets/integration_app_logos/monday-logo.jpeg');
 
   /// File path: assets/integration_app_logos/notion-logo.png
-  AssetGenImage get notionLogo => const AssetGenImage('assets/integration_app_logos/notion-logo.png');
+  AssetGenImage get notionLogo =>
+      const AssetGenImage('assets/integration_app_logos/notion-logo.png');
 
   /// File path: assets/integration_app_logos/todoist-logo.webp
-  AssetGenImage get todoistLogo => const AssetGenImage('assets/integration_app_logos/todoist-logo.webp');
+  AssetGenImage get todoistLogo =>
+      const AssetGenImage('assets/integration_app_logos/todoist-logo.webp');
 
   /// File path: assets/integration_app_logos/trello-logo.png
-  AssetGenImage get trelloLogo => const AssetGenImage('assets/integration_app_logos/trello-logo.png');
+  AssetGenImage get trelloLogo =>
+      const AssetGenImage('assets/integration_app_logos/trello-logo.png');
 
   /// File path: assets/integration_app_logos/whoop.png
-  AssetGenImage get whoop => const AssetGenImage('assets/integration_app_logos/whoop.png');
+  AssetGenImage get whoop =>
+      const AssetGenImage('assets/integration_app_logos/whoop.png');
 
   /// File path: assets/integration_app_logos/x-logo.avif
   String get xLogo => 'assets/integration_app_logos/x-logo.avif';
 
   /// List of all assets
   List<dynamic> get values => [
-        asanaLogo,
-        clickupLogo,
-        githubLogo,
-        gmailLogo,
-        googleCalendar,
-        googleTasksLogo,
-        mondayLogo,
-        notionLogo,
-        todoistLogo,
-        trelloLogo,
-        whoop,
-        xLogo,
-      ];
+    asanaLogo,
+    clickupLogo,
+    githubLogo,
+    gmailLogo,
+    googleCalendar,
+    googleTasksLogo,
+    mondayLogo,
+    notionLogo,
+    todoistLogo,
+    trelloLogo,
+    whoop,
+    xLogo,
+  ];
 }
 
 class Assets {
   const Assets._();
 
-  static const $AssetsCompetitorLogosGen competitorLogos = $AssetsCompetitorLogosGen();
+  static const $AssetsCompetitorLogosGen competitorLogos =
+      $AssetsCompetitorLogosGen();
   static const $AssetsDeviceAssetsGen deviceAssets = $AssetsDeviceAssetsGen();
   static const $AssetsFontsGen fonts = $AssetsFontsGen();
   static const $AssetsImagesGen images = $AssetsImagesGen();
-  static const $AssetsIntegrationAppLogosGen integrationAppLogos = $AssetsIntegrationAppLogosGen();
+  static const $AssetsIntegrationAppLogosGen integrationAppLogos =
+      $AssetsIntegrationAppLogosGen();
   static const String shorebird = 'shorebird.yaml';
 
   /// List of all assets

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "ar",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "المحادثة",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "النص المكتوب",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "المهام",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "حذف المحادثة؟",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "هل أنت متأكد من رغبتك في حذف هذه المحادثة؟ لا يمكن التراجع عن هذا الإجراء.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "تأكيد",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "إلغاء",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "حسناً",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "حذف",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "إضافة",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "تحديث",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "حفظ",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "تعديل",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "إغلاق",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "مسح",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "نسخ النص المكتوب",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "نسخ الملخص",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "اختبار الأمر",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "إعادة معالجة المحادثة",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "حذف المحادثة",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "تم نسخ المحتوى إلى الحافظة",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "فشل تحديث حالة التمييز بنجمة.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "تعذرت مشاركة رابط المحادثة.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "خطأ أثناء معالجة المحادثة. يرجى المحاولة مرة أخرى لاحقاً.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "يرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "تعذر حذف المحادثة",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "حدث خطأ ما! يرجى المحاولة مرة أخرى لاحقاً.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "نسخ رسالة الخطأ",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "تم نسخ رسالة الخطأ إلى الحافظة",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "المتبقي",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "جاري التحميل...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "جاري تحميل المدة...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} ثانية",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "الأشخاص",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "إضافة شخص جديد",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "تعديل الشخص",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "أنشئ شخصاً جديداً ودرب Omi على التعرف على صوته أيضاً!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "ملف الصوت",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "عينة {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "الإعدادات",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "اللغة",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "اختر اللغة",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "جاري الحذف...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "يرجى إكمال المصادقة في متصفحك. بعد الانتهاء، ارجع إلى التطبيق.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "فشل بدء المصادقة",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "بدأ الاستيراد! سيتم إشعارك عند اكتماله.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "فشل بدء الاستيراد. يرجى المحاولة مرة أخرى.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "تعذر الوصول إلى الملف المحدد",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "اسأل Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "تم",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "غير متصل",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "جاري البحث",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "توصيل جهاز",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "لقد وصلت إلى الحد الشهري.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "التحقق من الاستخدام",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "مزامنة التسجيلات",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "التسجيلات المراد مزامنتها",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "كل شيء محدث",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "مزامنة",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "القلادة محدثة",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "جميع التسجيلات متزامنة",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "المزامنة قيد التنفيذ",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "جاهز للمزامنة",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "اضغط على مزامنة للبدء",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "القلادة غير متصلة. قم بالتوصيل للمزامنة.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "كل شيء متزامن بالفعل.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "لديك تسجيلات لم تتم مزامنتها بعد.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "سنستمر في مزامنة تسجيلاتك في الخلفية.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "لا توجد محادثات بعد.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "لا توجد محادثات مميزة بنجمة بعد.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "لتمييز محادثة بنجمة، افتحها واضغط على أيقونة النجمة في الرأس.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "بحث في المحادثات",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} محدد",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "دمج",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "دمج المحادثات",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "سيؤدي هذا إلى دمج {count} محادثة في واحدة. سيتم دمج وإعادة إنشاء جميع المحتويات.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "جاري الدمج في الخلفية. قد يستغرق هذا لحظة.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "فشل بدء الدمج",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "اسأل أي شيء",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "لا توجد رسائل بعد!\nلماذا لا تبدأ محادثة؟",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "جاري حذف رسائلك من ذاكرة Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "تم نسخ الرسالة إلى الحافظة.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "لا يمكنك الإبلاغ عن رسائلك الخاصة.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "الإبلاغ عن رسالة",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "هل أنت متأكد من رغبتك في الإبلاغ عن هذه الرسالة؟",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "تم الإبلاغ عن الرسالة بنجاح.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "شكراً لك على ملاحظاتك!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "مسح المحادثة؟",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "هل أنت متأكد من رغبتك في مسح المحادثة؟ لا يمكن التراجع عن هذا الإجراء.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "يمكنك تحميل 4 ملفات فقط في كل مرة",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "الدردشة مع Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "التطبيقات",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "لم يتم العثور على تطبيقات",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "حاول تعديل البحث أو الفلاتر",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "أنشئ تطبيقك الخاص",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "أنشئ وشارك تطبيقك المخصص",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "بحث في أكثر من 1500 تطبيق",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "تطبيقاتي",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "التطبيقات المثبتة",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "تعذر جلب التطبيقات :(\n\nيرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "عن Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "سياسة الخصوصية",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "زيارة الموقع",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "مساعدة أو استفسارات؟",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "انضم إلى المجتمع!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "أكثر من 8000 عضو وما زال العدد في ازدياد.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "حذف الحساب",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "هل أنت متأكد من رغبتك في حذف حسابك؟",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "لا يمكن التراجع عن هذا.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "سيتم حذف جميع ذكرياتك ومحادثاتك بشكل دائم.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "سيتم فصل تطبيقاتك وتكاملاتك فوراً.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "يمكنك تصدير بياناتك قبل حذف حسابك، ولكن بمجرد الحذف، لا يمكن استردادها.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "أدرك أن حذف حسابي دائم وأن جميع البيانات، بما في ذلك الذكريات والمحادثات، ستُفقد ولا يمكن استردادها.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "هل أنت متأكد؟",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "هذا الإجراء لا رجعة فيه وسيحذف حسابك وجميع البيانات المرتبطة به نهائياً. هل أنت متأكد من رغبتك في المتابعة؟",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "احذف الآن",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "العودة",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "حدد المربع لتأكيد فهمك أن حذف حسابك دائم ولا رجعة فيه.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "الملف الشخصي",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "الاسم",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "البريد الإلكتروني",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "المفردات المخصصة",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "التعرف على الآخرين",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "طرق الدفع",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "عرض المحادثة",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "البيانات والخصوصية",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "معرف المستخدم",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "غير محدد",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "تم نسخ معرف المستخدم إلى الحافظة",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "افتراضي النظام",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "الخطة والاستخدام",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "المزامنة دون اتصال",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "إعدادات الجهاز",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "أدوات الدردشة",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "ملاحظات / خطأ",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "مركز المساعدة",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "إعدادات المطور",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "احصل على Omi لنظام Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "برنامج الإحالة",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "تسجيل الخروج",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "تم نسخ تفاصيل التطبيق والجهاز",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "ملخص 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "خصوصيتك، تحكمك",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "في Omi، نحن ملتزمون بحماية خصوصيتك. تتيح لك هذه الصفحة التحكم في كيفية تخزين بياناتك واستخدامها.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "اعرف المزيد...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "مستوى حماية البيانات",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "بياناتك محمية افتراضياً بتشفير قوي. راجع إعداداتك وخيارات الخصوصية المستقبلية أدناه.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "وصول التطبيقات",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "يمكن للتطبيقات التالية الوصول إلى بياناتك. اضغط على تطبيق لإدارة أذوناته.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "لا توجد تطبيقات مثبتة لها وصول خارجي إلى بياناتك.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "اسم الجهاز",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "معرف الجهاز",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "البرنامج الثابت",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "مزامنة بطاقة SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "مراجعة الأجهزة",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "رقم الطراز",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "الشركة المصنعة",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "نقرة مزدوجة",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "سطوع LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "تضخيم الميكروفون",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "قطع الاتصال",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "نسيان الجهاز",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "مشاكل الشحن",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "قطع اتصال الجهاز",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "إلغاء إقران الجهاز",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "إلغاء الإقران ونسيان الجهاز",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "تم قطع اتصال Omi الخاص بك 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "تم إلغاء إقران الجهاز. انتقل إلى الإعدادات > البلوتوث وانسَ الجهاز لإكمال إلغاء الإقران.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "إلغاء إقران الجهاز",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "سيؤدي هذا إلى إلغاء إقران الجهاز بحيث يمكن توصيله بهاتف آخر. ستحتاج إلى الذهاب إلى الإعدادات > البلوتوث ونسيان الجهاز لإكمال العملية.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "الجهاز غير متصل",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "قم بتوصيل جهاز Omi الخاص بك للوصول\nإلى إعدادات الجهاز والتخصيص",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "معلومات الجهاز",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "التخصيص",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "الأجهزة",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "لم يتم اكتشاف V2",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "نرى أن لديك جهاز V1 أو أن جهازك غير متصل. وظيفة بطاقة SD متاحة فقط لأجهزة V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "إنهاء المحادثة",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "إيقاف مؤقت/استئناف",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "تمييز المحادثة بنجمة",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "إجراء النقر المزدوج",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "إنهاء ومعالجة المحادثة",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "إيقاف مؤقت/استئناف التسجيل",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "تمييز المحادثة الجارية بنجمة",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "متوقف",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "الحد الأقصى",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "كتم",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "هادئ",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "عادي",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "عالي",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "الميكروفون مكتوم",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "هادئ جداً - للبيئات الصاخبة",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "هادئ - للضوضاء المعتدلة",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "متعادل - تسجيل متوازن",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "معزز قليلاً - للاستخدام العادي",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "معزز - للبيئات الهادئة",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "عالي - للأصوات البعيدة أو الناعمة",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "عالي جداً - للمصادر الهادئة جداً",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "الحد الأقصى - استخدم بحذر",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "إعدادات المطور",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "جاري الحفظ...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "قم بتكوين شخصية الذكاء الاصطناعي الخاصة بك",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "تجريبي",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "النسخ الصوتي",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "قم بتكوين موفر STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "انتهاء مهلة المحادثة",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "حدد متى تنتهي المحادثات تلقائياً",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "استيراد البيانات",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "استيراد البيانات من مصادر أخرى",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "تصحيح الأخطاء والتشخيصات",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "رابط نقطة النهاية",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "لا توجد مفاتيح API بعد",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "أنشئ مفتاحاً للبدء",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "إنشاء مفتاح",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "المستندات",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "رؤى Omi الخاصة بك",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "اليوم",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "هذا الشهر",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "هذا العام",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "كل الأوقات",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "لا يوجد نشاط بعد",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "ابدأ محادثة مع Omi\nلرؤية رؤى استخدامك هنا.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "الاستماع",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "إجمالي الوقت الذي استمع فيه Omi بنشاط.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "الفهم",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "الكلمات المفهومة من محادثاتك.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "التوفير",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "المهام والملاحظات الملتقطة تلقائياً.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "التذكر",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "الحقائق والتفاصيل المحفوظة من أجلك.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "خطة غير محدودة",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "إدارة الخطة",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "ستنتهي خطتك في {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "تتجدد خطتك في {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "خطة مجانية",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} من {limit} دقيقة مستخدمة",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "ترقية",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "الترقية إلى غير محدود",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "تتضمن خطتك {limit} دقيقة مجانية شهرياً. قم بالترقية للحصول على دقائق غير محدودة.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "مشاركة إحصائيات Omi الخاصة بي! (omi.me - مساعدك الذكي الدائم)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "اليوم، قام omi بـ:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "هذا الشهر، قام omi بـ:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "هذا العام، قام omi بـ:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "حتى الآن، قام omi بـ:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 استمع لمدة {minutes} دقيقة",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 فهم {words} كلمة",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ قدم {count} رؤية",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 تذكر {count} ذكرى",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "سجلات التصحيح",
+  "debugLogsAutoDelete": "يتم الحذف التلقائي بعد 3 أيام.",
+  "debugLogsDesc": "يساعد في تشخيص المشاكل",
+  "noLogFilesFound": "لم يتم العثور على ملفات سجل.",
+  "omiDebugLog": "سجل تصحيح Omi",
+  "logShared": "تمت مشاركة السجل",
+  "selectLogFile": "حدد ملف السجل",
+  "shareLogs": "مشاركة السجلات",
+  "debugLogCleared": "تم مسح سجل التصحيح",
+  "exportStarted": "بدأ التصدير. قد يستغرق هذا بضع ثوان...",
+  "exportAllData": "تصدير جميع البيانات",
+  "exportDataDesc": "تصدير المحادثات إلى ملف JSON",
+  "exportedConversations": "المحادثات المصدرة من Omi",
+  "exportShared": "تمت مشاركة التصدير",
+  "deleteKnowledgeGraphTitle": "حذف رسم المعرفة؟",
+  "deleteKnowledgeGraphMessage": "سيؤدي هذا إلى حذف جميع بيانات رسم المعرفة المشتقة (العقد والاتصالات). ستبقى ذكرياتك الأصلية آمنة. سيتم إعادة بناء الرسم بمرور الوقت أو عند الطلب التالي.",
+  "knowledgeGraphDeleted": "تم حذف رسم المعرفة بنجاح",
+  "deleteGraphFailed": "فشل حذف الرسم: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "حذف رسم المعرفة",
+  "deleteKnowledgeGraphDesc": "مسح جميع العقد والاتصالات",
+  "mcp": "MCP",
+  "mcpServer": "خادم MCP",
+  "mcpServerDesc": "ربط مساعدي الذكاء الاصطناعي ببياناتك",
+  "serverUrl": "رابط الخادم",
+  "urlCopied": "تم نسخ الرابط",
+  "apiKeyAuth": "مصادقة مفتاح API",
+  "header": "الترويسة",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "معرف العميل",
+  "clientSecret": "سر العميل",
+  "useMcpApiKey": "استخدم مفتاح MCP API الخاص بك",
+  "webhooks": "Webhooks",
+  "conversationEvents": "أحداث المحادثة",
+  "newConversationCreated": "تم إنشاء محادثة جديدة",
+  "realtimeTranscript": "نص مباشر",
+  "transcriptReceived": "تم استلام النص",
+  "audioBytes": "بايتات الصوت",
+  "audioDataReceived": "تم استلام بيانات الصوت",
+  "intervalSeconds": "الفاصل الزمني (بالثواني)",
+  "daySummary": "ملخص اليوم",
+  "summaryGenerated": "تم إنشاء الملخص",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "أضف إلى claude_desktop_config.json",
+  "copyConfig": "نسخ التكوين",
+  "configCopied": "تم نسخ التكوين إلى الحافظة",
+  "listeningMins": "الاستماع (دقائق)",
+  "understandingWords": "الفهم (كلمات)",
+  "insights": "رؤى",
+  "memories": "ذكريات",
+  "minsUsedThisMonth": "{used} من {limit} دقيقة مستخدمة هذا الشهر",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} من {limit} كلمة مستخدمة هذا الشهر",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} من {limit} رؤية تم اكتسابها هذا الشهر",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} من {limit} ذكرى تم إنشاؤها هذا الشهر",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "الرؤية",
+  "visibilitySubtitle": "تحكم في المحادثات التي تظهر في قائمتك",
+  "showShortConversations": "إظهار المحادثات القصيرة",
+  "showShortConversationsDesc": "عرض المحادثات الأقصر من الحد الأدنى",
+  "showDiscardedConversations": "إظهار المحادثات المهملة",
+  "showDiscardedConversationsDesc": "تضمين المحادثات المميزة كمهملة",
+  "shortConversationThreshold": "حد المحادثة القصيرة",
+  "shortConversationThresholdSubtitle": "سيتم إخفاء المحادثات الأقصر من هذا ما لم يتم تمكينها أعلاه",
+  "durationThreshold": "حد المدة",
+  "durationThresholdDesc": "إخفاء المحادثات الأقصر من هذا",
+  "minLabel": "{count} دقيقة",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "المفردات المخصصة",
+  "addWords": "إضافة كلمات",
+  "addWordsDesc": "أسماء أو مصطلحات أو كلمات غير شائعة",
+  "vocabularyHint": "Omi، Callie، OpenAI",
+  "connect": "اتصال",
+  "comingSoon": "قريباً",
+  "chatToolsFooter": "قم بتوصيل تطبيقاتك لعرض البيانات والمقاييس في الدردشة.",
+  "completeAuthInBrowser": "يرجى إكمال المصادقة في متصفحك. بعد الانتهاء، ارجع إلى التطبيق.",
+  "failedToStartAuth": "فشل بدء مصادقة {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "قطع الاتصال بـ {appName}؟",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "هل أنت متأكد من رغبتك في قطع الاتصال بـ {appName}؟ يمكنك إعادة الاتصال في أي وقت.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "تم قطع الاتصال بـ {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "فشل قطع الاتصال",
+  "connectTo": "الاتصال بـ {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "ستحتاج إلى تفويض Omi للوصول إلى بيانات {appName} الخاصة بك. سيتم فتح متصفحك للمصادقة.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "متابعة",
+  "languageTitle": "اللغة",
+  "primaryLanguage": "اللغة الأساسية",
+  "automaticTranslation": "الترجمة التلقائية",
+  "detectLanguages": "اكتشاف أكثر من 10 لغات",
+  "authorizeSavingRecordings": "التفويض بحفظ التسجيلات",
+  "thanksForAuthorizing": "شكراً على التفويض!",
+  "needYourPermission": "نحتاج إذنك",
+  "alreadyGavePermission": "لقد منحتنا بالفعل إذناً بحفظ تسجيلاتك. إليك تذكير بسبب حاجتنا إليه:",
+  "wouldLikePermission": "نود الحصول على إذنك لحفظ تسجيلاتك الصوتية. إليك السبب:",
+  "improveSpeechProfile": "تحسين ملف الصوت الخاص بك",
+  "improveSpeechProfileDesc": "نستخدم التسجيلات لمواصلة تدريب وتحسين ملف الصوت الشخصي الخاص بك.",
+  "trainFamilyProfiles": "تدريب ملفات تعريف الأصدقاء والعائلة",
+  "trainFamilyProfilesDesc": "تساعدنا تسجيلاتك في التعرف على أصدقائك وعائلتك وإنشاء ملفات تعريف لهم.",
+  "enhanceTranscriptAccuracy": "تحسين دقة النص المكتوب",
+  "enhanceTranscriptAccuracyDesc": "مع تحسن نموذجنا، يمكننا توفير نتائج نسخ أفضل لتسجيلاتك.",
+  "legalNotice": "إشعار قانوني: قد تختلف قانونية تسجيل وتخزين البيانات الصوتية اعتماداً على موقعك وكيفية استخدامك لهذه الميزة. من مسؤوليتك ضمان الامتثال للقوانين واللوائح المحلية.",
+  "alreadyAuthorized": "تم التفويض بالفعل",
+  "authorize": "تفويض",
+  "revokeAuthorization": "إلغاء التفويض",
+  "authorizationSuccessful": "التفويض ناجح!",
+  "failedToAuthorize": "فشل التفويض. يرجى المحاولة مرة أخرى.",
+  "authorizationRevoked": "تم إلغاء التفويض.",
+  "recordingsDeleted": "تم حذف التسجيلات.",
+  "failedToRevoke": "فشل إلغاء التفويض. يرجى المحاولة مرة أخرى.",
+  "permissionRevokedTitle": "تم إلغاء الإذن",
+  "permissionRevokedMessage": "هل تريد منا حذف جميع تسجيلاتك الحالية أيضاً؟",
+  "yes": "نعم",
+  "editName": "تعديل الاسم",
+  "howShouldOmiCallYou": "كيف يجب على Omi أن يناديك؟",
+  "enterYourName": "أدخل اسمك",
+  "nameCannotBeEmpty": "لا يمكن أن يكون الاسم فارغاً",
+  "nameUpdatedSuccessfully": "تم تحديث الاسم بنجاح!",
+  "calendarSettings": "إعدادات التقويم",
+  "calendarProviders": "موفرو التقويم",
+  "macOsCalendar": "تقويم macOS",
+  "connectMacOsCalendar": "قم بتوصيل تقويم macOS المحلي الخاص بك",
+  "googleCalendar": "تقويم Google",
+  "syncGoogleAccount": "المزامنة مع حساب Google الخاص بك",
+  "showMeetingsMenuBar": "إظهار الاجتماعات القادمة في شريط القوائم",
+  "showMeetingsMenuBarDesc": "عرض اجتماعك التالي والوقت حتى يبدأ في شريط قوائم macOS",
+  "showEventsNoParticipants": "إظهار الأحداث بدون مشاركين",
+  "showEventsNoParticipantsDesc": "عند التمكين، يعرض القادم الأحداث بدون مشاركين أو رابط فيديو.",
+  "yourMeetings": "اجتماعاتك",
+  "refresh": "تحديث",
+  "noUpcomingMeetings": "لم يتم العثور على اجتماعات قادمة",
+  "checkingNextDays": "التحقق من الـ 30 يوماً القادمة",
+  "tomorrow": "غداً",
+  "googleCalendarComingSoon": "تكامل تقويم Google قريباً!",
+  "connectedAsUser": "متصل كمستخدم: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "مساحة العمل الافتراضية",
+  "tasksCreatedInWorkspace": "سيتم إنشاء المهام في مساحة العمل هذه",
+  "defaultProjectOptional": "المشروع الافتراضي (اختياري)",
+  "leaveUnselectedTasks": "اترك غير محدد لإنشاء مهام بدون مشروع",
+  "noProjectsInWorkspace": "لم يتم العثور على مشاريع في مساحة العمل هذه",
+  "conversationTimeoutDesc": "اختر المدة التي يجب الانتظار فيها في صمت قبل إنهاء المحادثة تلقائياً:",
+  "timeout2Minutes": "دقيقتان",
+  "timeout2MinutesDesc": "إنهاء المحادثة بعد دقيقتين من الصمت",
+  "timeout5Minutes": "5 دقائق",
+  "timeout5MinutesDesc": "إنهاء المحادثة بعد 5 دقائق من الصمت",
+  "timeout10Minutes": "10 دقائق",
+  "timeout10MinutesDesc": "إنهاء المحادثة بعد 10 دقائق من الصمت",
+  "timeout30Minutes": "30 دقيقة",
+  "timeout30MinutesDesc": "إنهاء المحادثة بعد 30 دقيقة من الصمت",
+  "timeout4Hours": "4 ساعات",
+  "timeout4HoursDesc": "إنهاء المحادثة بعد 4 ساعات من الصمت",
+  "conversationEndAfterHours": "ستنتهي المحادثات الآن بعد 4 ساعات من الصمت",
+  "conversationEndAfterMinutes": "ستنتهي المحادثات الآن بعد {minutes} دقيقة من الصمت",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "أخبرنا بلغتك الأساسية",
+  "languageForTranscription": "حدد لغتك للحصول على نسخ أكثر دقة وتجربة شخصية.",
+  "singleLanguageModeInfo": "وضع اللغة الواحدة ممكّن. الترجمة معطلة لدقة أعلى.",
+  "searchLanguageHint": "بحث عن اللغة بالاسم أو الرمز",
+  "noLanguagesFound": "لم يتم العثور على لغات",
+  "skip": "تخطي",
+  "languageSetTo": "تم تعيين اللغة إلى {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "فشل تعيين اللغة",
+  "appSettings": "إعدادات {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "قطع الاتصال بـ {appName}؟",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "سيؤدي هذا إلى حذف مصادقة {appName} الخاصة بك. ستحتاج إلى إعادة الاتصال لاستخدامه مرة أخرى.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "متصل بـ {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "الحساب",
+  "actionItemsSyncedTo": "سيتم مزامنة مهامك مع حساب {appName} الخاص بك",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "المساحة الافتراضية",
+  "selectSpaceInWorkspace": "حدد مساحة في مساحة العمل الخاصة بك",
+  "noSpacesInWorkspace": "لم يتم العثور على مساحات في مساحة العمل هذه",
+  "defaultList": "القائمة الافتراضية",
+  "tasksAddedToList": "سيتم إضافة المهام إلى هذه القائمة",
+  "noListsInSpace": "لم يتم العثور على قوائم في هذه المساحة",
+  "failedToLoadRepos": "فشل تحميل المستودعات: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "تم حفظ المستودع الافتراضي",
+  "failedToSaveDefaultRepo": "فشل حفظ المستودع الافتراضي",
+  "defaultRepository": "المستودع الافتراضي",
+  "selectDefaultRepoDesc": "حدد مستودعاً افتراضياً لإنشاء المشكلات. لا يزال بإمكانك تحديد مستودع مختلف عند إنشاء المشكلات.",
+  "noReposFound": "لم يتم العثور على مستودعات",
+  "private": "خاص",
+  "updatedDate": "تم التحديث {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "أمس",
+  "daysAgo": "منذ {count} أيام",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "منذ أسبوع",
+  "weeksAgo": "منذ {count} أسابيع",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "منذ شهر",
+  "monthsAgo": "منذ {count} أشهر",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "سيتم إنشاء المشكلات في مستودعك الافتراضي",
+  "taskIntegrations": "تكاملات المهام",
+  "configureSettings": "تكوين الإعدادات",
+  "completeAuthBrowser": "يرجى إكمال المصادقة في متصفحك. بعد الانتهاء، ارجع إلى التطبيق.",
+  "failedToStartAppAuth": "فشل بدء مصادقة {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "الاتصال بـ {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "ستحتاج إلى تفويض Omi لإنشاء مهام في حساب {appName} الخاص بك. سيتم فتح متصفحك للمصادقة.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "متابعة",
+  "appIntegration": "تكامل {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "التكامل مع {appName} قريباً! نعمل بجد لنوفر لك المزيد من خيارات إدارة المهام.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "فهمت",
+  "tasksExportedOneApp": "يمكن تصدير المهام إلى تطبيق واحد في كل مرة.",
+  "completeYourUpgrade": "أكمل ترقيتك",
+  "importConfiguration": "استيراد التكوين",
+  "exportConfiguration": "تصدير التكوين",
+  "bringYourOwn": "احضر الخاص بك",
+  "payYourSttProvider": "استخدم omi بحرية. أنت تدفع فقط لموفر STT الخاص بك مباشرة.",
+  "freeMinutesMonth": "1,200 دقيقة مجانية شهرياً متضمنة. غير محدود مع ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "المضيف مطلوب",
+  "validPortRequired": "المنفذ الصحيح مطلوب",
+  "validWebsocketUrlRequired": "رابط WebSocket صحيح مطلوب (wss://)",
+  "apiUrlRequired": "رابط API مطلوب",
+  "apiKeyRequired": "مفتاح API مطلوب",
+  "invalidJsonConfig": "تكوين JSON غير صالح",
+  "errorSaving": "خطأ في الحفظ: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "تم نسخ التكوين إلى الحافظة",
+  "pasteJsonConfig": "الصق تكوين JSON الخاص بك أدناه:",
+  "addApiKeyAfterImport": "ستحتاج إلى إضافة مفتاح API الخاص بك بعد الاستيراد",
+  "paste": "لصق",
+  "import": "استيراد",
+  "invalidProviderInConfig": "موفر غير صالح في التكوين",
+  "importedConfig": "تم استيراد تكوين {providerName}",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON غير صالح: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "الموفر",
+  "live": "مباشر",
+  "onDevice": "على الجهاز",
+  "apiUrl": "رابط API",
+  "enterSttHttpEndpoint": "أدخل نقطة نهاية STT HTTP الخاصة بك",
+  "websocketUrl": "رابط WebSocket",
+  "enterLiveSttWebsocket": "أدخل نقطة نهاية WebSocket STT المباشرة",
+  "apiKey": "مفتاح API",
+  "enterApiKey": "أدخل مفتاح API الخاص بك",
+  "storedLocallyNeverShared": "يُخزن محلياً، ولا يُشارك أبداً",
+  "host": "المضيف",
+  "port": "المنفذ",
+  "advanced": "متقدم",
+  "configuration": "التكوين",
+  "requestConfiguration": "تكوين الطلب",
+  "responseSchema": "مخطط الاستجابة",
+  "modified": "معدل",
+  "resetRequestConfig": "إعادة تعيين تكوين الطلب إلى الافتراضي",
+  "logs": "السجلات",
+  "logsCopied": "تم نسخ السجلات",
+  "noLogsYet": "لا توجد سجلات بعد. ابدأ التسجيل لرؤية نشاط STT المخصص.",
+  "deviceUsesCodec": "{deviceName} يستخدم {codecReason}. سيتم استخدام Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "نسخ Omi",
+  "bestInClassTranscription": "أفضل نسخ في فئته بدون إعداد",
+  "instantSpeakerLabels": "تسميات المتحدثين الفورية",
+  "languageTranslation": "ترجمة أكثر من 100 لغة",
+  "optimizedForConversation": "محسّن للمحادثة",
+  "autoLanguageDetection": "اكتشاف اللغة التلقائي",
+  "highAccuracy": "دقة عالية",
+  "privacyFirst": "الخصوصية أولاً",
+  "saveChanges": "حفظ التغييرات",
+  "resetToDefault": "إعادة التعيين إلى الافتراضي",
+  "viewTemplate": "عرض النموذج",
+  "trySomethingLike": "جرب شيئاً مثل...",
+  "tryIt": "جربه",
+  "creatingPlan": "إنشاء خطة",
+  "developingLogic": "تطوير المنطق",
+  "designingApp": "تصميم التطبيق",
+  "generatingIconStep": "إنشاء أيقونة",
+  "finalTouches": "اللمسات الأخيرة",
+  "processing": "جاري المعالجة...",
+  "features": "الميزات",
+  "creatingYourApp": "جاري إنشاء تطبيقك...",
+  "generatingIcon": "جاري إنشاء الأيقونة...",
+  "whatShouldWeMake": "ماذا يجب أن نصنع؟",
+  "appName": "اسم التطبيق",
+  "description": "الوصف",
+  "publicLabel": "عام",
+  "privateLabel": "خاص",
+  "free": "مجاني",
+  "perMonth": "/ شهرياً",
+  "tailoredConversationSummaries": "ملخصات محادثة مخصصة",
+  "customChatbotPersonality": "شخصية chatbot مخصصة",
+  "makePublic": "جعله عاماً",
+  "anyoneCanDiscover": "يمكن لأي شخص اكتشاف تطبيقك",
+  "onlyYouCanUse": "أنت فقط يمكنك استخدام هذا التطبيق",
+  "paidApp": "تطبيق مدفوع",
+  "usersPayToUse": "يدفع المستخدمون لاستخدام تطبيقك",
+  "freeForEveryone": "مجاني للجميع",
+  "perMonthLabel": "/ شهرياً",
+  "creating": "جاري الإنشاء...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "إنشاء تطبيق",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "جاري البحث عن الأجهزة...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{جهاز} other{أجهزة}} تم العثور عليها بالقرب منك",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "نجح الإقران",
+  "errorConnectingAppleWatch": "خطأ في الاتصال بـ Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "لا تظهر مرة أخرى",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "أفهم",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "تمكين البلوتوث",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "يحتاج Omi إلى البلوتوث للاتصال بجهازك القابل للارتداء. يرجى تمكين البلوتوث والمحاولة مرة أخرى.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "الاتصال بالدعم؟",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "الاتصال لاحقاً",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "منح الأذونات",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "النشاط في الخلفية",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "دع Omi يعمل في الخلفية لاستقرار أفضل",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "الوصول إلى الموقع",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "تمكين الموقع في الخلفية للحصول على التجربة الكاملة",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "الإشعارات",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "تمكين الإشعارات للبقاء على اطلاع",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "خدمة الموقع معطلة",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "خدمة الموقع معطلة. يرجى الذهاب إلى الإعدادات > الخصوصية والأمان > خدمات الموقع وتمكينها",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "تم رفض الوصول إلى الموقع في الخلفية",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "يرجى الذهاب إلى إعدادات الجهاز وتعيين إذن الموقع إلى \"السماح دائماً\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "تحب Omi؟",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "ساعدنا في الوصول إلى المزيد من الأشخاص من خلال ترك تقييم في App Store. ملاحظاتك تعني لنا الكثير!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "ساعدنا في الوصول إلى المزيد من الأشخاص من خلال ترك تقييم في Google Play Store. ملاحظاتك تعني لنا الكثير!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "التقييم على App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "التقييم على Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "ربما لاحقاً",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "يحتاج Omi إلى تعلم أهدافك وصوتك. ستتمكن من تعديله لاحقاً.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "ابدأ",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "تم كل شيء!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "استمر، أنت تقوم بعمل رائع",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "تخطي هذا السؤال",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "تخطي الآن",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "خطأ في الاتصال",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "فشل الاتصال بالخادم. يرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "تم اكتشاف تسجيل غير صالح",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "يبدو أن هناك عدة متحدثين في التسجيل. يرجى التأكد من أنك في موقع هادئ والمحاولة مرة أخرى.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "لا يوجد كلام كافٍ مكتشف. يرجى التحدث أكثر والمحاولة مرة أخرى.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "يرجى التأكد من التحدث لمدة 5 ثوانٍ على الأقل وليس أكثر من 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "هل أنت هناك؟",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "لم نتمكن من اكتشاف أي كلام. يرجى التأكد من التحدث لمدة 10 ثوانٍ على الأقل وليس أكثر من 3 دقائق.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "فُقد الاتصال",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "تم انقطاع الاتصال. يرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "حاول مرة أخرى",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "توصيل Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "متابعة بدون جهاز",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "الأذونات مطلوبة",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "يحتاج هذا التطبيق إلى أذونات البلوتوث والموقع للعمل بشكل صحيح. يرجى تمكينها في الإعدادات.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "فتح الإعدادات",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "تريد أن يُناديك باسم آخر؟",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "ما اسمك؟",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "تحدث. انسخ. لخص.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "تسجيل الدخول باستخدام Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "تسجيل الدخول باستخدام Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "بالمتابعة، فإنك توافق على ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "شروط الاستخدام",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – رفيقك الذكي",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "احتفظ بكل لحظة. احصل على ملخصات مدعومة بالذكاء الاصطناعي.\nلا تدون ملاحظات بعد الآن.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "إعداد Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "تم طلب الإذن!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "إذن الميكروفون",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "تم منح الإذن! الآن:\n\nافتح تطبيق Omi على ساعتك واضغط على \"متابعة\" أدناه",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "نحتاج إذن الميكروفون.\n\n1. اضغط على \"منح الإذن\"\n2. اسمح على iPhone الخاص بك\n3. سيُغلق تطبيق الساعة\n4. أعد فتحه واضغط على \"متابعة\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "منح الإذن",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "تحتاج مساعدة؟",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "استكشاف الأخطاء وإصلاحها:\n\n1. تأكد من تثبيت Omi على ساعتك\n2. افتح تطبيق Omi على ساعتك\n3. ابحث عن نافذة الإذن المنبثقة\n4. اضغط على \"السماح\" عند المطالبة\n5. سيغلق التطبيق على ساعتك - أعد فتحه\n6. ارجع واضغط على \"متابعة\" على iPhone الخاص بك",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "بدأ التسجيل بنجاح!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "لم يتم منح الإذن بعد. يرجى التأكد من أنك سمحت بالوصول إلى الميكروفون وأعدت فتح التطبيق على ساعتك.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "خطأ في طلب الإذن: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "خطأ في بدء التسجيل: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "حدد لغتك الأساسية",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "حدد لغتك للحصول على نسخ أكثر دقة وتجربة شخصية",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "ما هي لغتك الأساسية؟",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "حدد لغتك",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "رحلة نموك الشخصية مع الذكاء الاصطناعي الذي يستمع إلى كل كلمة تقولها.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "المهام",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "اضغط للتعديل • اضغط مطولاً للتحديد • اسحب للإجراءات",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "للقيام به",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "تم",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "قديم",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 كل شيء محدث!\nلا توجد مهام معلقة",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "لا توجد عناصر مكتملة بعد",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ لا توجد مهام قديمة",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "لا توجد عناصر",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "تم وضع علامة على المهمة كغير مكتملة",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "تم إنجاز المهمة",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "حذف المهمة",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "هل أنت متأكد من رغبتك في حذف هذه المهمة؟",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "حذف العناصر المحددة",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "هل أنت متأكد من رغبتك في حذف {count} مهمة محددة{s}؟",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "تم حذف المهمة \"{description}\"",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "تم حذف {count} مهمة{s}",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "فشل حذف المهمة",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "فشل حذف المهام",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "فشل حذف بعض المهام",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "جاهز للمهام",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "سيستخرج الذكاء الاصطناعي الخاص بك المهام والأعمال تلقائياً من محادثاتك. ستظهر هنا عند إنشائها.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "يتم استخراجها تلقائياً من المحادثات",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "اضغط للتعديل، اسحب للإكمال أو الحذف",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} محدد",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "تحديد الكل",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "حذف المحدد",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "بحث في {count} ذكرى",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "تم حذف الذكرى.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "تراجع",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "لا توجد ذكريات بعد",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "لا توجد ذكريات مستخرجة تلقائياً بعد",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "لا توجد ذكريات يدوية بعد",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "لا توجد ذكريات في هذه الفئات",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "لم يتم العثور على ذكريات",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "أضف ذكرتك الأولى",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "مسح ذاكرة Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "هل أنت متأكد من رغبتك في مسح ذاكرة Omi؟ لا يمكن التراجع عن هذا الإجراء.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "مسح الذاكرة",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "تم مسح ذاكرة Omi عنك",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "لا توجد ذكريات لحذفها",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "إنشاء ذكرى جديدة",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "إنشاء مهمة جديدة",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "إدارة الذاكرة",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "تصفية الذكريات",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "لديك {count} ذكرى إجمالية",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "ذكريات عامة",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "ذكريات خاصة",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "جعل جميع الذكريات خاصة",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "جعل جميع الذكريات عامة",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "حذف جميع الذكريات",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "جميع الذكريات خاصة الآن",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "جميع الذكريات عامة الآن",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "ذكرى جديدة",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "تعديل الذكرى",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "أحب تناول الآيس كريم...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "فشل الحفظ. يرجى التحقق من اتصالك.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "حفظ الذكرى",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "إعادة المحاولة",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "إنشاء مهمة",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "تعديل المهمة",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "ما الذي يجب القيام به؟",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "لا يمكن أن يكون وصف المهمة فارغاً.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "تم تحديث المهمة",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "فشل تحديث المهمة",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "تم إنشاء المهمة",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "فشل إنشاء المهمة",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "تاريخ الاستحقاق",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "الوقت",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "إضافة تاريخ استحقاق",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "اضغط على تم للحفظ",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "اضغط على تم للإنشاء",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "الكل",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "عنك",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "رؤى",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "يدوي",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "مكتمل",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "وضع علامة كمكتمل",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "تم حذف المهمة",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "فشل حذف المهمة",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "حذف المهمة",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "هل أنت متأكد من رغبتك في حذف هذه المهمة؟",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "لغة التطبيق",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "واجهة التطبيق",
+  "speechTranscriptionSectionTitle": "الكلام والنسخ",
+  "languageSettingsHelperText": "لغة التطبيق تغير القوائم والأزرار. لغة الكلام تؤثر على كيفية نسخ تسجيلاتك."
+}

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "bg",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Разговор",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Транскрипт",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Задачи",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Изтриване на разговор?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Сигурни ли сте, че искате да изтриете този разговор? Това действие не може да бъде отменено.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Потвърди",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Отказ",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "ОК",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Изтрий",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Добави",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Актуализирай",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Запази",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Редактирай",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Затвори",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Изчисти",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Копирай транскрипт",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Копирай резюме",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Тествай подсказка",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Преработи разговор",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Изтрий разговор",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Съдържанието е копирано в клипборда",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Неуспешна актуализация на статуса с отметка.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "URL адресът на разговора не можа да бъде споделен.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Грешка при обработка на разговора. Моля, опитайте отново по-късно.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Моля, проверете интернет връзката си и опитайте отново.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Невъзможно изтриване на разговор",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Нещо се обърка! Моля, опитайте отново по-късно.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Копирай съобщение за грешка",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Съобщението за грешка е копирано в клипборда",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Остават",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Зареждане...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Зареждане на продължителност...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} секунди",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Хора",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Добави нов човек",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Редактирай човек",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Създайте нов човек и обучете Omi да разпознава и тяхната реч!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Гласов профил",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Образец {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Настройки",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Език",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Изберете език",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Изтриване...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Неуспешно стартиране на удостоверяване",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Импортирането започна! Ще получите известие, когато приключи.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Неуспешно стартиране на импортиране. Моля, опитайте отново.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Не можа да се получи достъп до избрания файл",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Попитай Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Готово",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Прекъснато",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Търсене",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Свържи устройство",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Достигнахте месечния си лимит.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Провери използване",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Синхронизиране на записи",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Записи за синхронизиране",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Всичко е актуално",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Синхронизирай",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Медальонът е актуален",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Всички записи са синхронизирани",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Синхронизацията е в ход",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Готово за синхронизация",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Натиснете Синхронизирай за начало",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Медальонът не е свързан. Свържете за синхронизация.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Всичко вече е синхронизирано.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Имате записи, които все още не са синхронизирани.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Ще продължим да синхронизираме записите ви във фонов режим.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Все още няма разговори.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Все още няма отбелязани разговори.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "За да отбележите разговор, отворете го и натиснете иконката със звезда в заглавието.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Търсене на разговори",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} избрани",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Обедини",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Обедини разговори",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Това ще комбинира {count} разговора в един. Всичко съдържание ще бъде обединено и регенерирано.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Обединяване във фонов режим. Това може да отнеме момент.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Неуспешно стартиране на обединяване",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Попитайте каквото и да е",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Все още няма съобщения!\nЗащо не започнете разговор?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Изтриване на съобщенията ви от паметта на Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Съобщението е копирано в клипборда.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Не можете да докладвате собствените си съобщения.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Докладвай съобщение",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Сигурни ли сте, че искате да докладвате това съобщение?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Съобщението е докладвано успешно.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Благодарим за обратната връзка!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Изчисти чат?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Сигурни ли сте, че искате да изчистите чата? Това действие не може да бъде отменено.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Можете да качите само 4 файла наведнъж",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Чат с Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Приложения",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Не са намерени приложения",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Опитайте да коригирате търсенето или филтрите си",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Създайте свое приложение",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Създайте и споделете персонализирано приложение",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Търсене в над 1500 приложения",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Моите приложения",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Инсталирани приложения",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Не могат да се заредят приложенията :(\n\nМоля, проверете интернет връзката си и опитайте отново.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Относно Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Политика за поверителност",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Посетете уебсайта",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Помощ или запитвания?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Присъединете се към общността!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ членове и продължават да се увеличават.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Изтриване на акаунт",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Сигурни ли сте, че искате да изтриете акаунта си?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Това не може да бъде отменено.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Всички ваши спомени и разговори ще бъдат изтрити завинаги.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Вашите приложения и интеграции ще бъдат прекратени незабавно.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Можете да експортирате данните си преди да изтриете акаунта си, но след като бъде изтрит, не може да бъде възстановен.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Разбирам, че изтриването на акаунта ми е постоянно и всички данни, включително спомени и разговори, ще бъдат загубени и не могат да бъдат възстановени.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Сигурни ли сте?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Това действие е необратимо и ще изтрие завинаги вашия акаунт и всички свързани данни. Сигурни ли сте, че искате да продължите?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Изтрий сега",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Назад",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Отметнете квадратчето, за да потвърдите, че разбирате, че изтриването на акаунта ви е постоянно и необратимо.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Профил",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Име",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Имейл",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Персонализиран речник",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Идентифициране на други",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Методи на плащане",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Показване на разговор",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Данни и поверителност",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID на потребител",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Не е зададено",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID на потребителя е копиран в клипборда",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "По подразбиране на системата",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "План и използване",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Офлайн синхронизация",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Настройки на устройството",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Инструменти за чат",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Обратна връзка / Грешка",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Център за помощ",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Настройки за разработчици",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Вземете Omi за Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Програма за препоръки",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Излез",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Детайлите за приложението и устройството са копирани",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Вашата поверителност, вашият контрол",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "В Omi сме ангажирани със защитата на вашата поверителност. Тази страница ви позволява да контролирате как вашите данни се съхраняват и използват.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Научете повече...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Ниво на защита на данните",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Вашите данни са защитени по подразбиране със силно криптиране. Прегледайте настройките си и бъдещите опции за поверителност по-долу.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Достъп до приложение",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Следните приложения могат да имат достъп до вашите данни. Докоснете приложение, за да управлявате неговите разрешения.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Няма инсталирани приложения с външен достъп до вашите данни.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Име на устройство",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID на устройство",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Фърмуер",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Синхронизация на SD карта",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Хардуерна ревизия",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Модел номер",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Производител",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Двойно докосване",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Яркост на LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Усилване на микрофон",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Прекъсни",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Забрави устройство",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Проблеми със зареждането",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Прекъсни устройство",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Разедини устройство",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Разедини и забрави устройство",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Вашият Omi беше прекъснат 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Устройството е разединено. Отидете в Настройки > Bluetooth и забравете устройството, за да завършите разединяването.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Разедини устройство",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Това ще разедини устройството, така че да може да бъде свързано с друг телефон. Ще трябва да отидете в Настройки > Bluetooth и да забравите устройството, за да завършите процеса.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Устройството не е свързано",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Свържете вашето Omi устройство за достъп\nдо настройките на устройството и персонализация",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Информация за устройството",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Персонализация",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Хардуер",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 не е открит",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Виждаме, че имате V1 устройство или устройството ви не е свързано. Функционалността на SD картата е налична само за V2 устройства.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Край на разговор",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Пауза/Възобнови",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Отбележи разговор",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Действие при двойно докосване",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Край и обработка на разговор",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Пауза/Възобнови записването",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Отбележи текущ разговор",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Изключено",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Макс",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Заглуши",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Тихо",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Нормално",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Високо",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Микрофонът е заглушен",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Много тихо - за шумни среди",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Тихо - за умерен шум",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Неутрално - балансирано записване",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Леко засилено - нормално използване",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Засилено - за тихи среди",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Високо - за далечни или тихи гласове",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Много високо - за много тихи източници",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Максимално - използвайте с внимание",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Настройки за разработчици",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Запазване...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Конфигурирайте вашата AI персона",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "БЕТА",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Транскрипция",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Конфигурирай STT доставчик",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Изчакване на разговор",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Задайте кога разговорите приключват автоматично",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Импортирай данни",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Импортирайте данни от други източници",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Отстраняване на грешки и диагностика",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL на крайна точка",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Все още няма API ключове",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Създайте ключ, за да започнете",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Създай ключ",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Документация",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Вашите Omi прозрения",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Днес",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Този месец",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Тази година",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Цялото време",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Все още няма дейност",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Започнете разговор с Omi,\nза да видите прозренията си за използване тук.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Слушане",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Общо време, през което Omi активно е слушал.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Разбиране",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Думи, разбрани от вашите разговори.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Предоставяне",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Задачи и бележки, автоматично записани.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Запомняне",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Факти и детайли, запомнени за вас.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Неограничен план",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Управлявай план",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Вашият план ще бъде анулиран на {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Вашият план се подновява на {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Безплатен план",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} от {limit} мин използвани",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Надстрой",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Надстрой до неограничен",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Вашият план включва {limit} безплатни минути на месец. Надстройте за неограничен достъп.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Споделям моите Omi статистики! (omi.me - вашият винаги включен AI асистент)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Днес omi има:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Този месец omi има:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Тази година omi има:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Досега omi има:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Слушал {minutes} минути",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Разбрал {words} думи",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Предоставил {count} прозрения",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Запомнил {count} спомена",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Дневници за отстраняване на грешки",
+  "debugLogsAutoDelete": "Автоматично се изтриват след 3 дни.",
+  "debugLogsDesc": "Помага за диагностициране на проблеми",
+  "noLogFilesFound": "Не са намерени файлове с дневници.",
+  "omiDebugLog": "Omi дневник за отстраняване на грешки",
+  "logShared": "Дневникът е споделен",
+  "selectLogFile": "Изберете файл с дневник",
+  "shareLogs": "Споделете дневници",
+  "debugLogCleared": "Дневникът за отстраняване на грешки е изчистен",
+  "exportStarted": "Експортирането започна. Може да отнеме няколко секунди...",
+  "exportAllData": "Експортирай всички данни",
+  "exportDataDesc": "Експортирайте разговори в JSON файл",
+  "exportedConversations": "Експортирани разговори от Omi",
+  "exportShared": "Експортът е споделен",
+  "deleteKnowledgeGraphTitle": "Изтриване на граф на знанията?",
+  "deleteKnowledgeGraphMessage": "Това ще изтрие всички производни данни от графа на знанията (възли и връзки). Вашите оригинални спомени ще останат в безопасност. Графът ще бъде възстановен с течение на времето или при следващо запитване.",
+  "knowledgeGraphDeleted": "Графът на знанията е изтрит успешно",
+  "deleteGraphFailed": "Неуспешно изтриване на граф: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Изтрий граф на знанията",
+  "deleteKnowledgeGraphDesc": "Изчисти всички възли и връзки",
+  "mcp": "MCP",
+  "mcpServer": "MCP сървър",
+  "mcpServerDesc": "Свържете AI асистенти с вашите данни",
+  "serverUrl": "URL на сървър",
+  "urlCopied": "URL е копиран",
+  "apiKeyAuth": "Удостоверяване с API ключ",
+  "header": "Заглавка",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "ID на клиент",
+  "clientSecret": "Тайна на клиент",
+  "useMcpApiKey": "Използвайте вашия MCP API ключ",
+  "webhooks": "Webhooks",
+  "conversationEvents": "События на разговор",
+  "newConversationCreated": "Създаден нов разговор",
+  "realtimeTranscript": "Транскрипт в реално време",
+  "transcriptReceived": "Получен транскрипт",
+  "audioBytes": "Аудио байтове",
+  "audioDataReceived": "Получени аудио данни",
+  "intervalSeconds": "Интервал (секунди)",
+  "daySummary": "Дневно резюме",
+  "summaryGenerated": "Генерирано резюме",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Добавете към claude_desktop_config.json",
+  "copyConfig": "Копирай конфигурация",
+  "configCopied": "Конфигурацията е копирана в клипборда",
+  "listeningMins": "Слушане (мин)",
+  "understandingWords": "Разбиране (думи)",
+  "insights": "Прозрения",
+  "memories": "Спомени",
+  "minsUsedThisMonth": "{used} от {limit} мин използвани този месец",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} от {limit} думи използвани този месец",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} от {limit} прозрения получени този месец",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} от {limit} спомена създадени този месец",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Видимост",
+  "visibilitySubtitle": "Контролирайте кои разговори се появяват във вашия списък",
+  "showShortConversations": "Показвай кратки разговори",
+  "showShortConversationsDesc": "Показвай разговори по-къси от прага",
+  "showDiscardedConversations": "Показвай изхвърлени разговори",
+  "showDiscardedConversationsDesc": "Включи разговори, маркирани като изхвърлени",
+  "shortConversationThreshold": "Праг за кратък разговор",
+  "shortConversationThresholdSubtitle": "Разговорите по-къси от това ще бъдат скрити, освен ако не са активирани по-горе",
+  "durationThreshold": "Праг на продължителност",
+  "durationThresholdDesc": "Скривай разговори по-къси от това",
+  "minLabel": "{count} мин",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Персонализиран речник",
+  "addWords": "Добавете думи",
+  "addWordsDesc": "Имена, термини или необичайни думи",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Свържи",
+  "comingSoon": "Скоро",
+  "chatToolsFooter": "Свържете вашите приложения, за да виждате данни и метрики в чата.",
+  "completeAuthInBrowser": "Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.",
+  "failedToStartAuth": "Неуспешно стартиране на {appName} удостоверяване",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Прекъсни връзката с {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Сигурни ли сте, че искате да прекъснете връзката с {appName}? Можете да се свържете отново по всяко време.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Прекъсната връзка с {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Неуспешно прекъсване на връзката",
+  "connectTo": "Свържи се с {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Ще трябва да упълномощите Omi за достъп до вашите {appName} данни. Това ще отвори браузъра ви за удостоверяване.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Продължи",
+  "languageTitle": "Език",
+  "primaryLanguage": "Основен език",
+  "automaticTranslation": "Автоматичен превод",
+  "detectLanguages": "Разпознавай 10+ езика",
+  "authorizeSavingRecordings": "Разрешете запазване на записи",
+  "thanksForAuthorizing": "Благодарим, че разрешихте!",
+  "needYourPermission": "Нуждаем се от вашето разрешение",
+  "alreadyGavePermission": "Вече сте ни дали разрешение да запазваме вашите записи. Ето напомняне защо го нуждаем:",
+  "wouldLikePermission": "Бихме искали вашето разрешение да запазваме вашите гласови записи. Ето защо:",
+  "improveSpeechProfile": "Подобрете вашия гласов профил",
+  "improveSpeechProfileDesc": "Използваме записи, за да обучим и подобрим вашия личен гласов профил.",
+  "trainFamilyProfiles": "Обучете профили за приятели и семейство",
+  "trainFamilyProfilesDesc": "Вашите записи ни помагат да разпознаем и създадем профили за вашите приятели и семейство.",
+  "enhanceTranscriptAccuracy": "Подобрете точността на транскрипта",
+  "enhanceTranscriptAccuracyDesc": "С подобряването на нашия модел, можем да предоставим по-добри резултати от транскрипцията за вашите записи.",
+  "legalNotice": "Юридическо уведомление: Законността на записването и съхраняването на гласови данни може да варира в зависимост от вашето местоположение и как използвате тази функция. Вие сте отговорни за спазването на местните закони и разпоредби.",
+  "alreadyAuthorized": "Вече разрешено",
+  "authorize": "Разреши",
+  "revokeAuthorization": "Оттегли разрешение",
+  "authorizationSuccessful": "Разрешението е успешно!",
+  "failedToAuthorize": "Неуспешно разрешаване. Моля, опитайте отново.",
+  "authorizationRevoked": "Разрешението е оттеглено.",
+  "recordingsDeleted": "Записите са изтрити.",
+  "failedToRevoke": "Неуспешно оттегляне на разрешение. Моля, опитайте отново.",
+  "permissionRevokedTitle": "Разрешението е оттеглено",
+  "permissionRevokedMessage": "Искате ли да премахнем и всички ваши съществуващи записи?",
+  "yes": "Да",
+  "editName": "Редактирай име",
+  "howShouldOmiCallYou": "Как Omi да ви нарича?",
+  "enterYourName": "Въведете вашето име",
+  "nameCannotBeEmpty": "Името не може да бъде празно",
+  "nameUpdatedSuccessfully": "Името е актуализирано успешно!",
+  "calendarSettings": "Настройки на календар",
+  "calendarProviders": "Доставчици на календар",
+  "macOsCalendar": "macOS Календар",
+  "connectMacOsCalendar": "Свържете вашия локален macOS календар",
+  "googleCalendar": "Google Календар",
+  "syncGoogleAccount": "Синхронизирай с вашия Google акаунт",
+  "showMeetingsMenuBar": "Показвай предстоящи срещи в лентата с менюта",
+  "showMeetingsMenuBarDesc": "Показвай следващата ви среща и време до нея в macOS лентата с менюта",
+  "showEventsNoParticipants": "Показвай събития без участници",
+  "showEventsNoParticipantsDesc": "Когато е активирано, показва събития без участници или видео връзка.",
+  "yourMeetings": "Вашите срещи",
+  "refresh": "Обнови",
+  "noUpcomingMeetings": "Няма намерени предстоящи срещи",
+  "checkingNextDays": "Проверка на следващите 30 дни",
+  "tomorrow": "Утре",
+  "googleCalendarComingSoon": "Google Календар интеграция скоро!",
+  "connectedAsUser": "Свързан като потребител: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Работно пространство по подразбиране",
+  "tasksCreatedInWorkspace": "Задачите ще бъдат създадени в това работно пространство",
+  "defaultProjectOptional": "Проект по подразбиране (Незадължително)",
+  "leaveUnselectedTasks": "Оставете неизбрано, за да създавате задачи без проект",
+  "noProjectsInWorkspace": "Няма намерени проекти в това работно пространство",
+  "conversationTimeoutDesc": "Изберете колко дълго да се чака в тишина преди автоматично приключване на разговор:",
+  "timeout2Minutes": "2 минути",
+  "timeout2MinutesDesc": "Приключи разговор след 2 минути тишина",
+  "timeout5Minutes": "5 минути",
+  "timeout5MinutesDesc": "Приключи разговор след 5 минути тишина",
+  "timeout10Minutes": "10 минути",
+  "timeout10MinutesDesc": "Приключи разговор след 10 минути тишина",
+  "timeout30Minutes": "30 минути",
+  "timeout30MinutesDesc": "Приключи разговор след 30 минути тишина",
+  "timeout4Hours": "4 часа",
+  "timeout4HoursDesc": "Приключи разговор след 4 часа тишина",
+  "conversationEndAfterHours": "Разговорите сега ще приключват след 4 часа тишина",
+  "conversationEndAfterMinutes": "Разговорите сега ще приключват след {minutes} минута(и) тишина",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Кажете ни вашия основен език",
+  "languageForTranscription": "Задайте вашия език за по-точни транскрипции и персонализирано изживяване.",
+  "singleLanguageModeInfo": "Режимът с един език е активиран. Преводът е деактивиран за по-висока точност.",
+  "searchLanguageHint": "Търсете език по име или код",
+  "noLanguagesFound": "Не са намерени езици",
+  "skip": "Пропусни",
+  "languageSetTo": "Езикът е зададен на {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Неуспешно задаване на език",
+  "appSettings": "{appName} Настройки",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Прекъсни връзката с {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Това ще премахне вашето {appName} удостоверяване. Ще трябва да се свържете отново, за да го използвате.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Свързан с {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Акаунт",
+  "actionItemsSyncedTo": "Вашите задачи ще бъдат синхронизирани с вашия {appName} акаунт",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Пространство по подразбиране",
+  "selectSpaceInWorkspace": "Изберете пространство във вашето работно пространство",
+  "noSpacesInWorkspace": "Няма намерени пространства в това работно пространство",
+  "defaultList": "Списък по подразбиране",
+  "tasksAddedToList": "Задачите ще бъдат добавени в този списък",
+  "noListsInSpace": "Няма намерени списъци в това пространство",
+  "failedToLoadRepos": "Неуспешно зареждане на хранилища: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Хранилището по подразбиране е запазено",
+  "failedToSaveDefaultRepo": "Неуспешно запазване на хранилище по подразбиране",
+  "defaultRepository": "Хранилище по подразбиране",
+  "selectDefaultRepoDesc": "Изберете хранилище по подразбиране за създаване на проблеми. Все още можете да посочите различно хранилище при създаване на проблеми.",
+  "noReposFound": "Не са намерени хранилища",
+  "private": "Частно",
+  "updatedDate": "Актуализиран {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "вчера",
+  "daysAgo": "преди {count} дни",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "преди 1 седмица",
+  "weeksAgo": "преди {count} седмици",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "преди 1 месец",
+  "monthsAgo": "преди {count} месеца",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Проблемите ще бъдат създадени във вашето хранилище по подразбиране",
+  "taskIntegrations": "Интеграции на задачи",
+  "configureSettings": "Конфигурирай настройки",
+  "completeAuthBrowser": "Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.",
+  "failedToStartAppAuth": "Неуспешно стартиране на {appName} удостоверяване",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Свържи се с {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Ще трябва да упълномощите Omi за създаване на задачи в вашия {appName} акаунт. Това ще отвори браузъра ви за удостоверяване.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Продължи",
+  "appIntegration": "{appName} Интеграция",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Интеграцията с {appName} идва скоро! Работим усилено, за да ви предоставим повече опции за управление на задачи.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Разбрах",
+  "tasksExportedOneApp": "Задачите могат да бъдат експортирани в едно приложение наведнъж.",
+  "completeYourUpgrade": "Завършете вашата надстройка",
+  "importConfiguration": "Импортирай конфигурация",
+  "exportConfiguration": "Експортирай конфигурация",
+  "bringYourOwn": "Донесете свой собствен",
+  "payYourSttProvider": "Използвайте omi свободно. Плащате само на вашия STT доставчик директно.",
+  "freeMinutesMonth": "1 200 безплатни минути/месец включени. Неограничено с ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Хостът е задължителен",
+  "validPortRequired": "Валиден порт е задължителен",
+  "validWebsocketUrlRequired": "Валиден WebSocket URL е задължителен (wss://)",
+  "apiUrlRequired": "API URL е задължителен",
+  "apiKeyRequired": "API ключ е задължителен",
+  "invalidJsonConfig": "Невалидна JSON конфигурация",
+  "errorSaving": "Грешка при запазване: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Конфигурацията е копирана в клипборда",
+  "pasteJsonConfig": "Поставете вашата JSON конфигурация по-долу:",
+  "addApiKeyAfterImport": "Ще трябва да добавите собствен API ключ след импортиране",
+  "paste": "Постави",
+  "import": "Импортирай",
+  "invalidProviderInConfig": "Невалиден доставчик в конфигурацията",
+  "importedConfig": "Импортирана {providerName} конфигурация",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Невалиден JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Доставчик",
+  "live": "На живо",
+  "onDevice": "На устройството",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "Въведете вашата STT HTTP крайна точка",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "Въведете вашата STT WebSocket крайна точка на живо",
+  "apiKey": "API ключ",
+  "enterApiKey": "Въведете вашия API ключ",
+  "storedLocallyNeverShared": "Съхранено локално, никога не се споделя",
+  "host": "Хост",
+  "port": "Порт",
+  "advanced": "Разширени",
+  "configuration": "Конфигурация",
+  "requestConfiguration": "Конфигурация на заявка",
+  "responseSchema": "Схема на отговор",
+  "modified": "Модифициран",
+  "resetRequestConfig": "Нулирай конфигурацията на заявката по подразбиране",
+  "logs": "Дневници",
+  "logsCopied": "Дневниците са копирани",
+  "noLogsYet": "Все още няма дневници. Започнете записване, за да видите активността на персонализирания STT.",
+  "deviceUsesCodec": "{deviceName} използва {codecReason}. Ще се използва Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi транскрипция",
+  "bestInClassTranscription": "Най-добра транскрипция в класа си без настройки",
+  "instantSpeakerLabels": "Моментални етикети на говорител",
+  "languageTranslation": "Превод на 100+ езика",
+  "optimizedForConversation": "Оптимизирано за разговор",
+  "autoLanguageDetection": "Автоматично разпознаване на език",
+  "highAccuracy": "Висока точност",
+  "privacyFirst": "Поверителност на първо място",
+  "saveChanges": "Запази промени",
+  "resetToDefault": "Нулирай по подразбиране",
+  "viewTemplate": "Виж шаблон",
+  "trySomethingLike": "Опитайте нещо като...",
+  "tryIt": "Опитай го",
+  "creatingPlan": "Създаване на план",
+  "developingLogic": "Разработване на логика",
+  "designingApp": "Дизайниране на приложение",
+  "generatingIconStep": "Генериране на икона",
+  "finalTouches": "Финални щрихи",
+  "processing": "Обработка...",
+  "features": "Функции",
+  "creatingYourApp": "Създаване на вашето приложение...",
+  "generatingIcon": "Генериране на икона...",
+  "whatShouldWeMake": "Какво да направим?",
+  "appName": "Име на приложение",
+  "description": "Описание",
+  "publicLabel": "Публично",
+  "privateLabel": "Частно",
+  "free": "Безплатно",
+  "perMonth": "/ Месец",
+  "tailoredConversationSummaries": "Персонализирани резюмета на разговори",
+  "customChatbotPersonality": "Персонализирана личност на чатбот",
+  "makePublic": "Направи публично",
+  "anyoneCanDiscover": "Всеки може да открие вашето приложение",
+  "onlyYouCanUse": "Само вие можете да използвате това приложение",
+  "paidApp": "Платено приложение",
+  "usersPayToUse": "Потребителите плащат, за да използват вашето приложение",
+  "freeForEveryone": "Безплатно за всички",
+  "perMonthLabel": "/ месец",
+  "creating": "Създаване...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Създай приложение",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Търсене на устройства...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{УСТРОЙСТВО} other{УСТРОЙСТВА}} НАМЕРЕНИ НАБЛИЗО",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "СДВОЯВАНЕТО Е УСПЕШНО",
+  "errorConnectingAppleWatch": "Грешка при свързване с Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Не го показвай отново",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Разбирам",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Активирай Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi се нуждае от Bluetooth, за да се свърже с вашето носимо устройство. Моля, активирайте Bluetooth и опитайте отново.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Свържете се с поддръжката?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Свържи по-късно",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Дайте разрешения",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Фонова активност",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Позволете на Omi да работи на заден план за по-добра стабилност",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Достъп до местоположение",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Активирайте фоново местоположение за пълното изживяване",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Известия",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Активирайте известия, за да сте информирани",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Услугата за местоположение е деактивирана",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Услугата за местоположение е деактивирана. Моля, отидете в Настройки > Поверителност и сигурност > Услуги за местоположение и я активирайте",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Отказан достъп до фоново местоположение",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Моля, отидете в настройките на устройството и задайте разрешението за местоположение на \"Винаги разрешавай\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Обичате ли Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Помогнете ни да достигнем до повече хора, като оставите отзив в App Store. Вашата обратна връзка е много важна за нас!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Помогнете ни да достигнем до повече хора, като оставите отзив в Google Play Store. Вашата обратна връзка е много важна за нас!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Оценете в App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Оценете в Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Може би по-късно",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi трябва да научи вашите цели и вашия глас. Ще можете да го промените по-късно.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Започнете",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Готово!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Продължавайте, справяте се страхотно",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Пропусни този въпрос",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Пропусни засега",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Грешка в връзката",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Неуспешна връзка със сървъра. Моля, проверете интернет връзката си и опитайте отново.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Открит е невалиден запис",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Изглежда има множество говорители в записа. Моля, уверете се, че сте на тихо място и опитайте отново.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Не е открита достатъчно реч. Моля, говорете повече и опитайте отново.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Моля, уверете се, че говорите поне 5 секунди и не повече от 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Там ли сте?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Не можахме да открием реч. Моля, уверете се, че говорите поне 10 секунди и не повече от 3 минути.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Връзката е изгубена",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Връзката беше прекъсната. Моля, проверете интернет връзката си и опитайте отново.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Опитай отново",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Свържи Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Продължи без устройство",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Изискват се разрешения",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Това приложение се нуждае от разрешения за Bluetooth и местоположение, за да функционира правилно. Моля, активирайте ги в настройките.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Отвори настройки",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Искате ли различно име?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Как се казвате?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Говорете. Транскрибирайте. Обобщавайте.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Влезте с Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Влезте с Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Като продължавате, вие се съгласявате с нашата ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Условия за ползване",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Вашият AI спътник",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Уловете всеки момент. Получавайте резюмета с\nAI. Никога повече бележки.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Настройка на Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Разрешение заявено!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Разрешение за микрофон",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Разрешението е дадено! Сега:\n\nОтворете приложението Omi на часовника си и натиснете \"Продължи\" по-долу",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Нуждаем се от разрешение за микрофон.\n\n1. Натиснете \"Дайте разрешение\"\n2. Разрешете на вашия iPhone\n3. Приложението на часовника ще се затвори\n4. Отворете отново и натиснете \"Продължи\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Дайте разрешение",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Нужда от помощ?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Отстраняване на проблеми:\n\n1. Уверете се, че Omi е инсталиран на часовника ви\n2. Отворете приложението Omi на часовника си\n3. Потърсете изскачащия прозорец за разрешение\n4. Натиснете \"Разреши\" когато бъдете подканени\n5. Приложението на часовника ще се затвори - отворете го отново\n6. Върнете се и натиснете \"Продължи\" на вашия iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Записването започна успешно!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Разрешението все още не е дадено. Моля, уверете се, че сте разрешили достъп до микрофона и сте отворили отново приложението на часовника си.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Грешка при заявяване на разрешение: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Грешка при стартиране на записване: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Изберете вашия основен език",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Задайте вашия език за по-точни транскрипции и персонализирано изживяване",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Кой е вашият основен език?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Изберете вашия език",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Вашето пътешествие на личностен растеж с AI, който слуша всяка ваша дума.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Задачи",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Докоснете за редактиране • Натиснете дълго за избор • Плъзнете за действия",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "За изпълнение",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Готово",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Стари",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Всичко е актуално!\nНяма чакащи задачи",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Все още няма завършени елементи",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Няма стари задачи",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Няма елементи",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Задачата е маркирана като незавършена",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Задачата е завършена",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Изтриване на задача",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Сигурни ли сте, че искате да изтриете тази задача?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Изтриване на избраните елементи",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Сигурни ли сте, че искате да изтриете {count} избрана(и) задача(и){s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Задачата \"{description}\" е изтрита",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} задача(и){s} изтрити",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Неуспешно изтриване на задача",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Неуспешно изтриване на елементи",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Неуспешно изтриване на някои елементи",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Готови за задачи",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Вашият AI автоматично ще извлича задачи и дейности от вашите разговори. Те ще се появят тук, когато бъдат създадени.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Автоматично извлечени от разговори",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Докоснете за редактиране, плъзнете за завършване или изтриване",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} избрани",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Избери всички",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Изтрий избраните",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Търсене в {count} спомени",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Споменът е изтрит.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Отмени",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Все още няма спомени",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Все още няма автоматично извлечени спомени",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Все още няма ръчно добавени спомени",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Няма спомени в тези категории",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Не са намерени спомени",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Добавете вашия първи спомен",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Изчистване на паметта на Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Сигурни ли сте, че искате да изчистите паметта на Omi? Това действие не може да бъде отменено.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Изчисти паметта",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Паметта на Omi за вас е изчистена",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Няма спомени за изтриване",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Създай нов спомен",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Създай нова задача",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Управление на паметта",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Филтриране на спомени",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Имате общо {count} спомена",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Публични спомени",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Частни спомени",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Направи всички спомени частни",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Направи всички спомени публични",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Изтрий всички спомени",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Всички спомени сега са частни",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Всички спомени сега са публични",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Нов спомен",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Редактирай спомен",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Обичам да ям сладолед...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Неуспешно запазване. Моля, проверете връзката си.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Запази спомен",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Опитай отново",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Създай задача",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Редактирай задача",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Какво трябва да се направи?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Описанието на задачата не може да бъде празно.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Задачата е актуализирана",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Неуспешна актуализация на задачата",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Задачата е създадена",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Неуспешно създаване на задача",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Краен срок",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Час",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Добави краен срок",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Натиснете готово за запазване",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Натиснете готово за създаване",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Всички",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "За вас",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Прозрения",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Ръчно",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Завършено",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Маркирай като завършено",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Задачата е изтрита",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Неуспешно изтриване на задача",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Изтриване на задача",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Сигурни ли сте, че искате да изтриете тази задача?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Език на приложението",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ИНТЕРФЕЙС НА ПРИЛОЖЕНИЕТО",
+  "speechTranscriptionSectionTitle": "РЕЧ И ТРАНСКРИПЦИЯ",
+  "languageSettingsHelperText": "Езикът на приложението променя менютата и бутоните. Езикът на речта влияе на начина, по който се транскрибират вашите записи."
+}

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "ca",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Conversa",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transcripció",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Tasques",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Eliminar conversa?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Esteu segur que voleu eliminar aquesta conversa? Aquesta acció no es pot desfer.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Confirmar",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Cancel·lar",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "D'acord",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Eliminar",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Afegir",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Actualitzar",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Desar",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Editar",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Tancar",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Netejar",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Copiar transcripció",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Copiar resum",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Provar indicació",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Reprocessar conversa",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Eliminar conversa",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Contingut copiat al porta-retalls",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "No s'ha pogut actualitzar l'estat de destacat.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "No s'ha pogut compartir l'URL de la conversa.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Error en processar la conversa. Torneu-ho a provar més tard.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Comproveu la vostra connexió a internet i torneu-ho a provar.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "No es pot eliminar la conversa",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Alguna cosa ha anat malament! Torneu-ho a provar més tard.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Copiar missatge d'error",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Missatge d'error copiat al porta-retalls",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Restants",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Carregant...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Carregant durada...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} segons",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Persones",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Afegir nova persona",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Editar persona",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Creeu una nova persona i ensenyeu a Omi a reconèixer la seva veu també!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Perfil de veu",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Mostra {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Configuració",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Idioma",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Seleccionar idioma",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Eliminant...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Completeu l'autenticació al vostre navegador. Un cop fet, torneu a l'aplicació.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "No s'ha pogut iniciar l'autenticació",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Importació iniciada! Se us notificarà quan estigui completa.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "No s'ha pogut iniciar la importació. Torneu-ho a provar.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "No s'ha pogut accedir al fitxer seleccionat",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Preguntar a Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Fet",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Desconnectat",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Cercant",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Connectar dispositiu",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Heu arribat al vostre límit mensual.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Comprovar ús",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Sincronitzant enregistraments",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Enregistraments per sincronitzar",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Tot al dia",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Sincronitzar",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "El penjoll està actualitzat",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Tots els enregistraments estan sincronitzats",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Sincronització en curs",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Llest per sincronitzar",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Toqueu Sincronitzar per començar",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Penjoll no connectat. Connecteu-lo per sincronitzar.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Tot està ja sincronitzat.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Teniu enregistraments que encara no s'han sincronitzat.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Continuarem sincronitzant els vostres enregistraments en segon pla.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Encara no hi ha converses.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Encara no hi ha converses destacades.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Per destacar una conversa, obriu-la i toqueu la icona d'estrella a la capçalera.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Cercar converses",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} seleccionats",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Fusionar",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Fusionar converses",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Això combinarà {count} converses en una. Tot el contingut es fusionarà i regenerarà.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Fusionant en segon pla. Això pot trigar una mica.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "No s'ha pogut iniciar la fusió",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Pregunta qualsevol cosa",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Encara no hi ha missatges!\nPer què no comenceu una conversa?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Eliminant els vostres missatges de la memòria d'Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Missatge copiat al porta-retalls.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "No podeu denunciar els vostres propis missatges.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Denunciar missatge",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Esteu segur que voleu denunciar aquest missatge?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Missatge denunciat correctament.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Gràcies pels vostres comentaris!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Netejar xat?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Esteu segur que voleu netejar el xat? Aquesta acció no es pot desfer.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Només podeu pujar 4 fitxers alhora",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Xatejar amb Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Aplicacions",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "No s'han trobat aplicacions",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Proveu d'ajustar la cerca o els filtres",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Creeu la vostra pròpia aplicació",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Construïu i compartiu la vostra aplicació personalitzada",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Cercar més de 1500 aplicacions",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Les meves aplicacions",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Aplicacions instal·lades",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "No s'han pogut obtenir les aplicacions :(\n\nComproveu la vostra connexió a internet i torneu-ho a provar.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Sobre Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Política de privadesa",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Visitar lloc web",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Ajuda o consultes?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Uniu-vos a la comunitat!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "Més de 8000 membres i sumant.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Eliminar compte",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Esteu segur que voleu eliminar el vostre compte?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Això no es pot desfer.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Tots els vostres records i converses s'eliminaran permanentment.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Les vostres aplicacions i integracions es desconnectaran immediatament.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Podeu exportar les vostres dades abans d'eliminar el compte, però un cop eliminat, no es pot recuperar.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Entenc que eliminar el meu compte és permanent i totes les dades, incloent records i converses, es perdran i no es poden recuperar.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Esteu segur?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Aquesta acció és irreversible i eliminarà permanentment el vostre compte i totes les dades associades. Esteu segur que voleu continuar?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Eliminar ara",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Tornar",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Marqueu la casella per confirmar que enteneu que eliminar el vostre compte és permanent i irreversible.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Perfil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Nom",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Correu electrònic",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Vocabulari personalitzat",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identificar altres",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Mètodes de pagament",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Visualització de converses",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Dades i privadesa",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID d'usuari",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "No establert",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID d'usuari copiat al porta-retalls",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Per defecte del sistema",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Pla i ús",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Sincronització fora de línia",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Configuració del dispositiu",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Eines de xat",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Comentaris / Error",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Centre d'ajuda",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Configuració de desenvolupador",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Obtenir Omi per a Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Programa de recomanacions",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Tancar sessió",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Detalls de l'aplicació i el dispositiu copiats",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Resum 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "La vostra privadesa, el vostre control",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "A Omi, estem compromesos a protegir la vostra privadesa. Aquesta pàgina us permet controlar com s'emmagatzemen i utilitzen les vostres dades.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Més informació...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Nivell de protecció de dades",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Les vostres dades estan protegides per defecte amb un xifratge fort. Reviseu la vostra configuració i opcions futures de privadesa a continuació.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Accés d'aplicacions",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Les següents aplicacions poden accedir a les vostres dades. Toqueu una aplicació per gestionar els seus permisos.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Cap aplicació instal·lada té accés extern a les vostres dades.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Nom del dispositiu",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID del dispositiu",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmware",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Sincronització de targeta SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Revisió de maquinari",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Número de model",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Fabricant",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Doble toc",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Brillantor LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Guany del micròfon",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Desconnectar",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Oblidar dispositiu",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Problemes de càrrega",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Desconnectar dispositiu",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Desvincular dispositiu",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Desvincular i oblidar dispositiu",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "El vostre Omi s'ha desconnectat 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Dispositiu desvinculat. Aneu a Configuració > Bluetooth i oblideu el dispositiu per completar la desvinculació.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Desvincular dispositiu",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Això desvin cularà el dispositiu perquè es pugui connectar a un altre telèfon. Haureu d'anar a Configuració > Bluetooth i oblidar el dispositiu per completar el procés.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Dispositiu no connectat",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Connecteu el vostre dispositiu Omi per accedir\na la configuració i personalització del dispositiu",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Informació del dispositiu",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Personalització",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Maquinari",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 no detectat",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Veiem que teniu un dispositiu V1 o que el vostre dispositiu no està connectat. La funcionalitat de targeta SD només està disponible per a dispositius V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Finalitzar conversa",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pausar/Reprendre",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Destacar conversa",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Acció de doble toc",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Finalitzar i processar conversa",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pausar/Reprendre enregistrament",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Destacar conversa en curs",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Apagat",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Màxim",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Silenciar",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Silenciós",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normal",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Alt",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "El micròfon està silenciat",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Molt silenciós - per entorns sorollosos",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Silenciós - per soroll moderat",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutre - enregistrament equilibrat",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Lleugerament potenciat - ús normal",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Potenciat - per entorns silenciosos",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Alt - per veus distants o suaus",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Molt alt - per fonts molt silencioses",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Màxim - utilitzeu amb precaució",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Configuració de desenvolupador",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Desant...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Configureu la vostra personalitat d'IA",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transcripció",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Configurar proveïdor STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Temps d'espera de conversa",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Establir quan finalitzen automàticament les converses",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importar dades",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importar dades d'altres fonts",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Depuració i diagnòstics",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL del punt final",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Encara no hi ha claus API",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Creeu una clau per començar",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Crear clau",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Documentació",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Les vostres estadístiques d'Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Avui",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Aquest mes",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Enguany",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Des de sempre",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Encara no hi ha activitat",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Comenceu una conversa amb Omi\nper veure les vostres estadístiques d'ús aquí.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Escoltant",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Temps total que Omi ha estat escoltant activament.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Entenent",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Paraules enteses de les vostres converses.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Proporcionant",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Tasques i notes capturades automàticament.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Recordant",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fets i detalls recordats per a vosaltres.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Pla il·limitat",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Gestionar pla",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "El vostre pla es cancel·larà el {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "El vostre pla es renova el {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Pla gratuït",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} de {limit} min utilitzats",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Actualitzar",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Actualitzar a il·limitat",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "El vostre pla inclou {limit} minuts gratuïts al mes. Actualitzeu per tenir-ne il·limitats.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Compartint les meves estadístiques d'Omi! (omi.me - el vostre assistent d'IA sempre actiu)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Avui, omi ha:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Aquest mes, omi ha:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Enguany, omi ha:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Fins ara, omi ha:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Escoltat durant {minutes} minuts",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Entès {words} paraules",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Proporcionat {count} informacions",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Recordat {count} records",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Registres de depuració",
+  "debugLogsAutoDelete": "S'eliminen automàticament després de 3 dies.",
+  "debugLogsDesc": "Ajuda a diagnosticar problemes",
+  "noLogFilesFound": "No s'han trobat fitxers de registre.",
+  "omiDebugLog": "Registre de depuració d'Omi",
+  "logShared": "Registre compartit",
+  "selectLogFile": "Seleccionar fitxer de registre",
+  "shareLogs": "Compartir registres",
+  "debugLogCleared": "Registre de depuració netejat",
+  "exportStarted": "Exportació iniciada. Això pot trigar uns segons...",
+  "exportAllData": "Exportar totes les dades",
+  "exportDataDesc": "Exportar converses a un fitxer JSON",
+  "exportedConversations": "Converses exportades d'Omi",
+  "exportShared": "Exportació compartida",
+  "deleteKnowledgeGraphTitle": "Eliminar graf de coneixement?",
+  "deleteKnowledgeGraphMessage": "Això eliminarà totes les dades derivades del graf de coneixement (nodes i connexions). Els vostres records originals restaran segurs. El graf es reconstruirà amb el temps o a la propera sol·licitud.",
+  "knowledgeGraphDeleted": "Graf de coneixement eliminat correctament",
+  "deleteGraphFailed": "No s'ha pogut eliminar el graf: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Eliminar graf de coneixement",
+  "deleteKnowledgeGraphDesc": "Esborrar tots els nodes i connexions",
+  "mcp": "MCP",
+  "mcpServer": "Servidor MCP",
+  "mcpServerDesc": "Connectar assistents d'IA a les vostres dades",
+  "serverUrl": "URL del servidor",
+  "urlCopied": "URL copiada",
+  "apiKeyAuth": "Autenticació amb clau API",
+  "header": "Capçalera",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "ID de client",
+  "clientSecret": "Secret de client",
+  "useMcpApiKey": "Utilitzeu la vostra clau API MCP",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Esdeveniments de conversa",
+  "newConversationCreated": "Nova conversa creada",
+  "realtimeTranscript": "Transcripció en temps real",
+  "transcriptReceived": "Transcripció rebuda",
+  "audioBytes": "Bytes d'àudio",
+  "audioDataReceived": "Dades d'àudio rebudes",
+  "intervalSeconds": "Interval (segons)",
+  "daySummary": "Resum del dia",
+  "summaryGenerated": "Resum generat",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Afegir a claude_desktop_config.json",
+  "copyConfig": "Copiar configuració",
+  "configCopied": "Configuració copiada al porta-retalls",
+  "listeningMins": "Escoltant (min)",
+  "understandingWords": "Entenent (paraules)",
+  "insights": "Informacions",
+  "memories": "Records",
+  "minsUsedThisMonth": "{used} de {limit} min utilitzats aquest mes",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} de {limit} paraules utilitzades aquest mes",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} de {limit} informacions obtingudes aquest mes",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} de {limit} records creats aquest mes",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Visibilitat",
+  "visibilitySubtitle": "Controleu quines converses apareixen a la vostra llista",
+  "showShortConversations": "Mostrar converses curtes",
+  "showShortConversationsDesc": "Mostrar converses més curtes que el llindar",
+  "showDiscardedConversations": "Mostrar converses descartades",
+  "showDiscardedConversationsDesc": "Incloure converses marcades com a descartades",
+  "shortConversationThreshold": "Llindar de conversa curta",
+  "shortConversationThresholdSubtitle": "Les converses més curtes que això s'amagaran tret que s'activi a dalt",
+  "durationThreshold": "Llindar de durada",
+  "durationThresholdDesc": "Amagar converses més curtes que això",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Vocabulari personalitzat",
+  "addWords": "Afegir paraules",
+  "addWordsDesc": "Noms, termes o paraules poc comunes",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Connectar",
+  "comingSoon": "Properament",
+  "chatToolsFooter": "Connecteu les vostres aplicacions per veure dades i estadístiques al xat.",
+  "completeAuthInBrowser": "Completeu l'autenticació al vostre navegador. Un cop fet, torneu a l'aplicació.",
+  "failedToStartAuth": "No s'ha pogut iniciar l'autenticació de {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Desconnectar {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Esteu segur que voleu desconnectar-vos de {appName}? Podeu reconnectar en qualsevol moment.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Desconnectat de {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "No s'ha pogut desconnectar",
+  "connectTo": "Connectar a {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Haureu d'autoritzar Omi per accedir a les vostres dades de {appName}. Això obrirà el vostre navegador per a l'autenticació.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Continuar",
+  "languageTitle": "Idioma",
+  "primaryLanguage": "Idioma principal",
+  "automaticTranslation": "Traducció automàtica",
+  "detectLanguages": "Detectar més de 10 idiomes",
+  "authorizeSavingRecordings": "Autoritzar desar enregistraments",
+  "thanksForAuthorizing": "Gràcies per autoritzar!",
+  "needYourPermission": "Necessitem el vostre permís",
+  "alreadyGavePermission": "Ja ens heu donat permís per desar els vostres enregistraments. Aquí teniu un recordatori de per què ho necessitem:",
+  "wouldLikePermission": "Ens agradaria el vostre permís per desar els vostres enregistraments de veu. Aquesta és la raó:",
+  "improveSpeechProfile": "Millorar el vostre perfil de veu",
+  "improveSpeechProfileDesc": "Utilitzem els enregistraments per entrenar i millorar el vostre perfil de veu personal.",
+  "trainFamilyProfiles": "Entrenar perfils d'amics i família",
+  "trainFamilyProfilesDesc": "Els vostres enregistraments ens ajuden a reconèixer i crear perfils per als vostres amics i família.",
+  "enhanceTranscriptAccuracy": "Millorar la precisió de transcripció",
+  "enhanceTranscriptAccuracyDesc": "A mesura que el nostre model millora, podem proporcionar millors resultats de transcripció per als vostres enregistraments.",
+  "legalNotice": "Avís legal: La legalitat d'enregistrar i emmagatzemar dades de veu pot variar segons la vostra ubicació i com utilitzeu aquesta funció. És la vostra responsabilitat assegurar el compliment de les lleis i regulacions locals.",
+  "alreadyAuthorized": "Ja autoritzat",
+  "authorize": "Autoritzar",
+  "revokeAuthorization": "Revocar autorització",
+  "authorizationSuccessful": "Autorització correcta!",
+  "failedToAuthorize": "No s'ha pogut autoritzar. Torneu-ho a provar.",
+  "authorizationRevoked": "Autorització revocada.",
+  "recordingsDeleted": "Enregistraments eliminats.",
+  "failedToRevoke": "No s'ha pogut revocar l'autorització. Torneu-ho a provar.",
+  "permissionRevokedTitle": "Permís revocat",
+  "permissionRevokedMessage": "Voleu que eliminem també tots els vostres enregistraments existents?",
+  "yes": "Sí",
+  "editName": "Editar nom",
+  "howShouldOmiCallYou": "Com hauria d'anomenar-vos Omi?",
+  "enterYourName": "Introduïu el vostre nom",
+  "nameCannotBeEmpty": "El nom no pot estar buit",
+  "nameUpdatedSuccessfully": "Nom actualitzat correctament!",
+  "calendarSettings": "Configuració del calendari",
+  "calendarProviders": "Proveïdors de calendari",
+  "macOsCalendar": "Calendari de macOS",
+  "connectMacOsCalendar": "Connectar el vostre calendari local de macOS",
+  "googleCalendar": "Google Calendar",
+  "syncGoogleAccount": "Sincronitzar amb el vostre compte de Google",
+  "showMeetingsMenuBar": "Mostrar reunions properes a la barra de menú",
+  "showMeetingsMenuBarDesc": "Mostrar la vostra propera reunió i el temps fins que comenci a la barra de menú de macOS",
+  "showEventsNoParticipants": "Mostrar esdeveniments sense participants",
+  "showEventsNoParticipantsDesc": "Quan s'activa, Properament mostra esdeveniments sense participants o enllaç de vídeo.",
+  "yourMeetings": "Les vostres reunions",
+  "refresh": "Actualitzar",
+  "noUpcomingMeetings": "No s'han trobat reunions properes",
+  "checkingNextDays": "Comprovant els propers 30 dies",
+  "tomorrow": "Demà",
+  "googleCalendarComingSoon": "Integració de Google Calendar properament!",
+  "connectedAsUser": "Connectat com a usuari: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Espai de treball per defecte",
+  "tasksCreatedInWorkspace": "Les tasques es crearan en aquest espai de treball",
+  "defaultProjectOptional": "Projecte per defecte (opcional)",
+  "leaveUnselectedTasks": "Deixeu sense seleccionar per crear tasques sense projecte",
+  "noProjectsInWorkspace": "No s'han trobat projectes en aquest espai de treball",
+  "conversationTimeoutDesc": "Trieu quant temps esperar en silenci abans de finalitzar automàticament una conversa:",
+  "timeout2Minutes": "2 minuts",
+  "timeout2MinutesDesc": "Finalitzar conversa després de 2 minuts de silenci",
+  "timeout5Minutes": "5 minuts",
+  "timeout5MinutesDesc": "Finalitzar conversa després de 5 minuts de silenci",
+  "timeout10Minutes": "10 minuts",
+  "timeout10MinutesDesc": "Finalitzar conversa després de 10 minuts de silenci",
+  "timeout30Minutes": "30 minuts",
+  "timeout30MinutesDesc": "Finalitzar conversa després de 30 minuts de silenci",
+  "timeout4Hours": "4 hores",
+  "timeout4HoursDesc": "Finalitzar conversa després de 4 hores de silenci",
+  "conversationEndAfterHours": "Les converses ara finalitzaran després de 4 hores de silenci",
+  "conversationEndAfterMinutes": "Les converses ara finalitzaran després de {minutes} minut(s) de silenci",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Digueu-nos el vostre idioma principal",
+  "languageForTranscription": "Establiu el vostre idioma per a transcripcions més precises i una experiència personalitzada.",
+  "singleLanguageModeInfo": "El mode d'idioma únic està activat. La traducció està desactivada per a una major precisió.",
+  "searchLanguageHint": "Cercar idioma per nom o codi",
+  "noLanguagesFound": "No s'han trobat idiomes",
+  "skip": "Ometre",
+  "languageSetTo": "Idioma establert a {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "No s'ha pogut establir l'idioma",
+  "appSettings": "Configuració de {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Desconnectar de {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Això eliminarà la vostra autenticació de {appName}. Haureu de reconnectar per utilitzar-la de nou.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Connectat a {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Compte",
+  "actionItemsSyncedTo": "Les vostres tasques es sincronitzaran amb el vostre compte de {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Espai per defecte",
+  "selectSpaceInWorkspace": "Seleccioneu un espai al vostre espai de treball",
+  "noSpacesInWorkspace": "No s'han trobat espais en aquest espai de treball",
+  "defaultList": "Llista per defecte",
+  "tasksAddedToList": "Les tasques s'afegiran a aquesta llista",
+  "noListsInSpace": "No s'han trobat llistes en aquest espai",
+  "failedToLoadRepos": "No s'han pogut carregar els repositoris: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Repositori per defecte desat",
+  "failedToSaveDefaultRepo": "No s'ha pogut desar el repositori per defecte",
+  "defaultRepository": "Repositori per defecte",
+  "selectDefaultRepoDesc": "Seleccioneu un repositori per defecte per crear incidències. Encara podeu especificar un repositori diferent quan creeu incidències.",
+  "noReposFound": "No s'han trobat repositoris",
+  "private": "Privat",
+  "updatedDate": "Actualitzat {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "ahir",
+  "daysAgo": "fa {count} dies",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "fa 1 setmana",
+  "weeksAgo": "fa {count} setmanes",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "fa 1 mes",
+  "monthsAgo": "fa {count} mesos",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Les incidències es crearan al vostre repositori per defecte",
+  "taskIntegrations": "Integracions de tasques",
+  "configureSettings": "Configurar opcions",
+  "completeAuthBrowser": "Completeu l'autenticació al vostre navegador. Un cop fet, torneu a l'aplicació.",
+  "failedToStartAppAuth": "No s'ha pogut iniciar l'autenticació de {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Connectar a {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Haureu d'autoritzar Omi per crear tasques al vostre compte de {appName}. Això obrirà el vostre navegador per a l'autenticació.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Continuar",
+  "appIntegration": "Integració de {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "La integració amb {appName} arribarà aviat! Estem treballant dur per oferir-vos més opcions de gestió de tasques.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Entès",
+  "tasksExportedOneApp": "Les tasques es poden exportar a una aplicació alhora.",
+  "completeYourUpgrade": "Completeu la vostra actualització",
+  "importConfiguration": "Importar configuració",
+  "exportConfiguration": "Exportar configuració",
+  "bringYourOwn": "Utilitzeu el vostre propi",
+  "payYourSttProvider": "Utilitzeu omi lliurement. Només pagueu directament al vostre proveïdor STT.",
+  "freeMinutesMonth": "1.200 minuts gratuïts/mes inclosos. Il·limitat amb ",
+  "omiUnlimited": "Omi Il·limitat",
+  "hostRequired": "Cal un amfitrió",
+  "validPortRequired": "Cal un port vàlid",
+  "validWebsocketUrlRequired": "Cal un URL WebSocket vàlid (wss://)",
+  "apiUrlRequired": "Cal un URL API",
+  "apiKeyRequired": "Cal una clau API",
+  "invalidJsonConfig": "Configuració JSON no vàlida",
+  "errorSaving": "Error en desar: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Configuració copiada al porta-retalls",
+  "pasteJsonConfig": "Enganxeu la vostra configuració JSON a continuació:",
+  "addApiKeyAfterImport": "Haureu d'afegir la vostra pròpia clau API després d'importar",
+  "paste": "Enganxar",
+  "import": "Importar",
+  "invalidProviderInConfig": "Proveïdor no vàlid a la configuració",
+  "importedConfig": "Configuració de {providerName} importada",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON no vàlid: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Proveïdor",
+  "live": "En directe",
+  "onDevice": "Al dispositiu",
+  "apiUrl": "URL de l'API",
+  "enterSttHttpEndpoint": "Introduïu el vostre punt final HTTP STT",
+  "websocketUrl": "URL de WebSocket",
+  "enterLiveSttWebsocket": "Introduïu el vostre punt final WebSocket STT en directe",
+  "apiKey": "Clau API",
+  "enterApiKey": "Introduïu la vostra clau API",
+  "storedLocallyNeverShared": "Emmagatzemat localment, mai compartit",
+  "host": "Amfitrió",
+  "port": "Port",
+  "advanced": "Avançat",
+  "configuration": "Configuració",
+  "requestConfiguration": "Configuració de sol·licitud",
+  "responseSchema": "Esquema de resposta",
+  "modified": "Modificat",
+  "resetRequestConfig": "Restablir configuració de sol·licitud per defecte",
+  "logs": "Registres",
+  "logsCopied": "Registres copiats",
+  "noLogsYet": "Encara no hi ha registres. Comenceu a enregistrar per veure l'activitat STT personalitzada.",
+  "deviceUsesCodec": "{deviceName} utilitza {codecReason}. S'utilitzarà Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Transcripció d'Omi",
+  "bestInClassTranscription": "Transcripció de millor qualitat sense configuració",
+  "instantSpeakerLabels": "Etiquetes d'interlocutor instantànies",
+  "languageTranslation": "Traducció de més de 100 idiomes",
+  "optimizedForConversation": "Optimitzat per a converses",
+  "autoLanguageDetection": "Detecció automàtica d'idioma",
+  "highAccuracy": "Alta precisió",
+  "privacyFirst": "Privadesa primer",
+  "saveChanges": "Desar canvis",
+  "resetToDefault": "Restablir per defecte",
+  "viewTemplate": "Veure plantilla",
+  "trySomethingLike": "Proveu quelcom com...",
+  "tryIt": "Provar-ho",
+  "creatingPlan": "Creant pla",
+  "developingLogic": "Desenvolupant lògica",
+  "designingApp": "Dissenyant aplicació",
+  "generatingIconStep": "Generant icona",
+  "finalTouches": "Tocs finals",
+  "processing": "Processant...",
+  "features": "Funcionalitats",
+  "creatingYourApp": "Creant la vostra aplicació...",
+  "generatingIcon": "Generant icona...",
+  "whatShouldWeMake": "Què hauríem de fer?",
+  "appName": "Nom de l'aplicació",
+  "description": "Descripció",
+  "publicLabel": "Pública",
+  "privateLabel": "Privada",
+  "free": "Gratuïta",
+  "perMonth": "/ Mes",
+  "tailoredConversationSummaries": "Resums de converses personalitzats",
+  "customChatbotPersonality": "Personalitat de xatbot personalitzada",
+  "makePublic": "Fer pública",
+  "anyoneCanDiscover": "Qualsevol pot descobrir la vostra aplicació",
+  "onlyYouCanUse": "Només vós podeu utilitzar aquesta aplicació",
+  "paidApp": "Aplicació de pagament",
+  "usersPayToUse": "Els usuaris paguen per utilitzar la vostra aplicació",
+  "freeForEveryone": "Gratuïta per a tothom",
+  "perMonthLabel": "/ mes",
+  "creating": "Creant...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Crear aplicació",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Cercant dispositius...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{DISPOSITIU} other{DISPOSITIUS}} TROBATS A PROP",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "VINCULACIÓ CORRECTA",
+  "errorConnectingAppleWatch": "Error en connectar amb l'Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "No ho tornis a mostrar",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Ho entenc",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Activar Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi necessita Bluetooth per connectar-se al vostre dispositiu portàtil. Activeu Bluetooth i torneu-ho a provar.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Contactar amb suport?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Connectar més tard",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Atorgar permisos",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Activitat en segon pla",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Deixeu que Omi s'executi en segon pla per a una millor estabilitat",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Accés a la ubicació",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Activeu la ubicació en segon pla per a l'experiència completa",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Notificacions",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Activeu les notificacions per mantenir-vos informat",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Servei d'ubicació desactivat",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "El servei d'ubicació està desactivat. Aneu a Configuració > Privadesa i seguretat > Serveis d'ubicació i activeu-lo",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Accés a la ubicació en segon pla denegat",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Aneu a la configuració del dispositiu i establiu el permís d'ubicació a \"Permetre sempre\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "T'agrada Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Ajudeu-nos a arribar a més gent deixant una ressenya a l'App Store. Els vostres comentaris són molt importants per a nosaltres!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Ajudeu-nos a arribar a més gent deixant una ressenya a Google Play Store. Els vostres comentaris són molt importants per a nosaltres!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Valorar a l'App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Valorar a Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Potser més tard",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi necessita aprendre els vostres objectius i la vostra veu. Podreu modificar-ho més tard.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Començar",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Tot fet!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Continueu, ho esteu fent molt bé",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Ometre aquesta pregunta",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Ometre ara",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Error de connexió",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "No s'ha pogut connectar amb el servidor. Comproveu la vostra connexió a internet i torneu-ho a provar.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "S'ha detectat un enregistrament no vàlid",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Sembla que hi ha diversos parlants a l'enregistrament. Assegureu-vos que esteu en un lloc tranquil i torneu-ho a provar.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "No s'ha detectat prou veu. Parleu més i torneu-ho a provar.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Assegureu-vos de parlar durant almenys 5 segons i no més de 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Hi sou?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "No hem pogut detectar cap veu. Assegureu-vos de parlar durant almenys 10 segons i no més de 3 minuts.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Connexió perduda",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "La connexió s'ha interromput. Comproveu la vostra connexió a internet i torneu-ho a provar.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Tornar a provar",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Connectar Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Continuar sense dispositiu",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Permisos necessaris",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Aquesta aplicació necessita permisos de Bluetooth i ubicació per funcionar correctament. Activeu-los a la configuració.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Obrir configuració",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Voleu que us anomeni d'una altra manera?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Com us dieu?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Parlar. Transcriure. Resumir.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Iniciar sessió amb Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Iniciar sessió amb Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "En continuar, accepteu la nostra ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Condicions d'ús",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – El vostre company d'IA",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Captureu cada moment. Obteniu resums\nimpulsats per IA. No prengueu més notes.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Configuració de l'Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Permís sol·licitat!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Permís del micròfon",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Permís atorgat! Ara:\n\nObriu l'aplicació Omi al vostre rellotge i toqueu \"Continuar\" a continuació",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Necessitem permís del micròfon.\n\n1. Toqueu \"Atorgar permís\"\n2. Permeteu al vostre iPhone\n3. L'aplicació del rellotge es tancarà\n4. Torneu a obrir-la i toqueu \"Continuar\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Atorgar permís",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Necessiteu ajuda?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Resolució de problemes:\n\n1. Assegureu-vos que Omi està instal·lat al vostre rellotge\n2. Obriu l'aplicació Omi al vostre rellotge\n3. Busqueu la finestra emergent de permisos\n4. Toqueu \"Permetre\" quan se us demani\n5. L'aplicació al vostre rellotge es tancarà - torneu a obrir-la\n6. Torneu i toqueu \"Continuar\" al vostre iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Enregistrament iniciat correctament!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Permís encara no atorgat. Assegureu-vos que heu permès l'accés al micròfon i heu tornat a obrir l'aplicació al vostre rellotge.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Error en sol·licitar permís: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Error en iniciar l'enregistrament: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Seleccioneu el vostre idioma principal",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Establiu el vostre idioma per a transcripcions més precises i una experiència personalitzada",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Quin és el vostre idioma principal?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Seleccioneu el vostre idioma",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "El vostre viatge de creixement personal amb IA que escolta cada paraula vostra.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Tasques",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Toqueu per editar • Manteniu per seleccionar • Llisqueu per a accions",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Per fer",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Fet",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Antic",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Tot al dia!\nNo hi ha tasques pendents",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Encara no hi ha elements completats",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ No hi ha tasques antigues",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "No hi ha elements",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Tasca marcada com a incompleta",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Tasca completada",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Eliminar tasca",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Esteu segur que voleu eliminar aquesta tasca?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Eliminar elements seleccionats",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Esteu segur que voleu eliminar {count} tasca{s} seleccionada{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Tasca \"{description}\" eliminada",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} tasca{s} eliminada{s}",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "No s'ha pogut eliminar la tasca",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "No s'han pogut eliminar els elements",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "No s'han pogut eliminar alguns elements",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Llest per a les tasques",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "La vostra IA extraurà automàticament tasques de les vostres converses. Apareixeran aquí quan es creïn.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Extret automàticament de converses",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Toqueu per editar, llisqueu per completar o eliminar",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} seleccionats",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Seleccionar tot",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Eliminar seleccionats",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Cercar {count} records",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Record eliminat.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Desfer",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Encara no hi ha records",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Encara no hi ha records extrets automàticament",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Encara no hi ha records manuals",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "No hi ha records en aquestes categories",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "No s'han trobat records",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Afegiu el vostre primer record",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Esborrar la memòria d'Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Esteu segur que voleu esborrar la memòria d'Omi? Aquesta acció no es pot desfer.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Esborrar memòria",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "La memòria d'Omi sobre vós s'ha esborrat",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "No hi ha records per eliminar",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Crear nou record",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Crear nova tasca",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Gestió de records",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtrar records",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Teniu {count} records en total",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Records públics",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Records privats",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Fer tots els records privats",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Fer tots els records públics",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Eliminar tots els records",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Tots els records són ara privats",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Tots els records són ara públics",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Nou record",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Editar record",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "M'agrada menjar gelat...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "No s'ha pogut desar. Comproveu la vostra connexió.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Desar record",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Tornar a provar",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Crear tasca",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Editar tasca",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Què cal fer?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "La descripció de la tasca no pot estar buida.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Tasca actualitzada",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "No s'ha pogut actualitzar la tasca",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Tasca creada",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "No s'ha pogut crear la tasca",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Data de venciment",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Hora",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Afegir data de venciment",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Premeu fet per desar",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Premeu fet per crear",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Tot",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Sobre vós",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Informacions",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manual",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Completat",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Marcar com a complet",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Tasca eliminada",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "No s'ha pogut eliminar la tasca",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Eliminar tasca",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Esteu segur que voleu eliminar aquesta tasca?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Idioma de l'aplicació",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "INTERFÍCIE DE L'APLICACIÓ",
+  "speechTranscriptionSectionTitle": "VEU I TRANSCRIPCIÓ",
+  "languageSettingsHelperText": "L'idioma de l'aplicació canvia els menús i els botons. L'idioma de la veu afecta com es transcriuen les teves gravacions."
+}

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "cs",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Konverzace",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Přepis",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Úkoly",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Smazat konverzaci?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Opravdu chcete smazat tuto konverzaci? Tuto akci nelze vrátit zpět.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Potvrdit",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Zrušit",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Smazat",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Přidat",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Aktualizovat",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Uložit",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Upravit",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Zavřít",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Vymazat",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopírovat přepis",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopírovat shrnutí",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Testovat výzvu",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Znovu zpracovat konverzaci",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Smazat konverzaci",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Obsah zkopírován do schránky",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Nepodařilo se aktualizovat stav oblíbených.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "URL konverzace nelze sdílet.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Chyba při zpracování konverzace. Zkuste to prosím později.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Zkontrolujte prosím připojení k internetu a zkuste to znovu.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Nelze smazat konverzaci",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Něco se pokazilo! Zkuste to prosím později.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopírovat chybovou zprávu",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Chybová zpráva zkopírována do schránky",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Zbývá",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Načítání...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Načítání délky...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekund",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Lidé",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Přidat novou osobu",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Upravit osobu",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Vytvořte novou osobu a naučte Omi rozpoznat i její řeč!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Hlasový profil",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Vzorek {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Nastavení",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Jazyk",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Vybrat jazyk",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Mazání...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Nepodařilo se spustit ověření",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import byl zahájen! Budete informováni, až bude dokončen.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Nepodařilo se spustit import. Zkuste to prosím znovu.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "K vybranému souboru se nepodařilo získat přístup",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Zeptat se Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Hotovo",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Odpojeno",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Vyhledávání",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Připojit zařízení",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Dosáhli jste měsíčního limitu.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Zkontrolovat využití",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Synchronizace nahrávek",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Nahrávky k synchronizaci",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Vše je aktuální",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Synchronizovat",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Přívěsek je aktuální",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Všechny nahrávky jsou synchronizovány",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Probíhá synchronizace",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Připraveno k synchronizaci",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Klepněte na Synchronizovat",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Přívěsek není připojen. Připojte jej pro synchronizaci.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Vše je již synchronizováno.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Máte nahrávky, které ještě nejsou synchronizovány.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Budeme pokračovat v synchronizaci vašich nahrávek na pozadí.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Zatím žádné konverzace.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Zatím žádné oblíbené konverzace.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Chcete-li konverzaci označit hvězdičkou, otevřete ji a klepněte na ikonu hvězdičky v záhlaví.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Hledat konverzace",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "Vybráno: {count}",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Sloučit",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Sloučit konverzace",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Tím se spojí {count} konverzací do jedné. Veškerý obsah bude sloučen a znovu vygenerován.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Slučování na pozadí. Může to chvíli trvat.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Nepodařilo se spustit sloučení",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Zeptejte se na cokoliv",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Zatím žádné zprávy!\nProč nezačít konverzaci?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Mazání vašich zpráv z paměti Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Zpráva zkopírována do schránky.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Nemůžete nahlásit vlastní zprávy.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Nahlásit zprávu",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Opravdu chcete nahlásit tuto zprávu?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Zpráva úspěšně nahlášena.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Děkujeme za vaši zpětnou vazbu!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Vymazat chat?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Opravdu chcete vymazat chat? Tuto akci nelze vrátit zpět.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Najednou můžete nahrát pouze 4 soubory",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Chat s Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Aplikace",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Nenalezeny žádné aplikace",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Zkuste upravit vyhledávání nebo filtry",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Vytvořte vlastní aplikaci",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Vytvořte a sdílejte vlastní aplikaci",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Hledat v 1500+ aplikacích",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Moje aplikace",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Nainstalované aplikace",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Nelze načíst aplikace :(\n\nZkontrolujte prosím připojení k internetu a zkuste to znovu.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "O aplikaci Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Zásadami ochrany osobních údajů",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Navštívit webové stránky",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Pomoc nebo dotazy?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Připojte se ke komunitě!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ členů a stále přibývá.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Smazat účet",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Opravdu chcete smazat svůj účet?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Toto nelze vrátit zpět.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Všechny vaše vzpomínky a konverzace budou trvale smazány.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Vaše aplikace a integrace budou okamžitě odpojeny.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Před smazáním účtu si můžete exportovat data, ale po smazání je nelze obnovit.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Rozumím tomu, že smazání mého účtu je trvalé a všechna data včetně vzpomínek a konverzací budou ztracena a nelze je obnovit.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Jste si jisti?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Tato akce je nevratná a trvale smaže váš účet a všechna související data. Opravdu chcete pokračovat?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Smazat nyní",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Zpět",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Zaškrtněte políčko pro potvrzení, že rozumíte tomu, že smazání účtu je trvalé a nevratné.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Jméno",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-mail",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Vlastní slovník",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identifikace ostatních",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Platební metody",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Zobrazení konverzace",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Data a soukromí",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID uživatele",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Nenastaveno",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID uživatele zkopírováno do schránky",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Výchozí systém",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plán a využití",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Offline synchronizace",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Nastavení zařízení",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Nástroje chatu",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Zpětná vazba / Chyba",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Centrum nápovědy",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Nastavení pro vývojáře",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Získat Omi pro Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Doporučovací program",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Odhlásit se",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Podrobnosti o aplikaci a zařízení zkopírovány",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Vaše soukromí, vaše kontrola",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "V Omi se zavazujeme chránit vaše soukromí. Tato stránka vám umožňuje kontrolovat, jak jsou vaše data ukládána a používána.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Dozvědět se více...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Úroveň ochrany dat",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Vaše data jsou standardně zabezpečena silným šifrováním. Níže si prohlédněte svá nastavení a budoucí možnosti ochrany soukromí.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Přístup aplikací",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Následující aplikace mají přístup k vašim datům. Klepnutím na aplikaci spravujete její oprávnění.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Žádné nainstalované aplikace nemají externí přístup k vašim datům.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Název zařízení",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID zařízení",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmware",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Synchronizace SD karty",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Revize hardwaru",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Číslo modelu",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Výrobce",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dvojité klepnutí",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Jas LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Zesílení mikrofonu",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Odpojit",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Zapomenout zařízení",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Problémy s nabíjením",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Odpojit zařízení",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Zrušit párování zařízení",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Zrušit párování a zapomenout zařízení",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Vaše Omi bylo odpojeno 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Párování zařízení zrušeno. Přejděte do Nastavení > Bluetooth a zapomeňte zařízení pro dokončení zrušení párování.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Zrušit párování zařízení",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Tím se zruší párování zařízení, aby mohlo být připojeno k jinému telefonu. Budete muset přejít do Nastavení > Bluetooth a zapomenout zařízení pro dokončení procesu.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Zařízení není připojeno",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Připojte své zařízení Omi pro přístup\nk nastavením a přizpůsobení zařízení",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Informace o zařízení",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Přizpůsobení",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Hardware",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 nedetekováno",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Vidíme, že máte buď zařízení V1, nebo vaše zařízení není připojeno. Funkce SD karty je dostupná pouze pro zařízení V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Ukončit konverzaci",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pozastavit/Obnovit",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Označit konverzaci hvězdičkou",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Akce dvojitého klepnutí",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Ukončit a zpracovat konverzaci",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pozastavit/Obnovit nahrávání",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Označit probíhající konverzaci hvězdičkou",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Vypnuto",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maximum",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Ztlumit",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Tiché",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normální",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Vysoké",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon je ztlumený",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Velmi tiché - pro hlučná prostředí",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Tiché - pro mírný hluk",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutrální - vyvážené nahrávání",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Mírně zesílené - běžné použití",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Zesílené - pro tichá prostředí",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Vysoké - pro vzdálené nebo tiché hlasy",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Velmi vysoké - pro velmi tiché zdroje",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maximum - používejte opatrně",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Nastavení pro vývojáře",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Ukládání...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Nakonfigurujte svou AI personu",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Přepis",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Nakonfigurovat poskytovatele STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Časový limit konverzace",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Nastavit, kdy konverzace automaticky skončí",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importovat data",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importovat data z jiných zdrojů",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Ladění a diagnostika",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL koncového bodu",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Zatím žádné API klíče",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Vytvořte klíč pro začátek",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Vytvořit klíč",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentace",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Vaše přehledy Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Dnes",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Tento měsíc",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Letos",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Vždy",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Zatím žádná aktivita",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Začněte konverzaci s Omi,\nabyste zde viděli své přehledy využití.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Naslouchání",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Celková doba, po kterou Omi aktivně naslouchalo.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Porozumění",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Slova pochopená z vašich konverzací.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Poskytování",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Úkoly a poznámky automaticky zachycené.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Zapamatování",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakta a detaily zapamatované pro vás.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Neomezený plán",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Spravovat plán",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Váš plán bude zrušen dne {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Váš plán se obnoví dne {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Bezplatný plán",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "Využito {used} z {limit} min",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Upgradovat",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Upgradovat na neomezený",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Váš plán zahrnuje {limit} bezplatných minut měsíčně. Upgradujte pro neomezený přístup.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Sdílím své statistiky Omi! (omi.me - váš AI asistent, který je vždy online)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Dnes Omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Tento měsíc Omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Letos Omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Dosud Omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Naslouchalo {minutes} minut",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Porozumělo {words} slovům",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Poskytlo {count} přehledů",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Zapamatovalo si {count} vzpomínek",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Protokoly ladění",
+  "debugLogsAutoDelete": "Automaticky se smažou po 3 dnech.",
+  "debugLogsDesc": "Pomáhá diagnostikovat problémy",
+  "noLogFilesFound": "Nenalezeny žádné soubory protokolu.",
+  "omiDebugLog": "Protokol ladění Omi",
+  "logShared": "Protokol sdílen",
+  "selectLogFile": "Vybrat soubor protokolu",
+  "shareLogs": "Sdílet protokoly",
+  "debugLogCleared": "Protokol ladění vymazán",
+  "exportStarted": "Export zahájen. Může to trvat několik sekund...",
+  "exportAllData": "Exportovat všechna data",
+  "exportDataDesc": "Exportovat konverzace do souboru JSON",
+  "exportedConversations": "Exportované konverzace z Omi",
+  "exportShared": "Export sdílen",
+  "deleteKnowledgeGraphTitle": "Smazat graf znalostí?",
+  "deleteKnowledgeGraphMessage": "Tím se smažou všechna odvozená data grafu znalostí (uzly a spojení). Vaše původní vzpomínky zůstanou v bezpečí. Graf bude v průběhu času znovu vytvořen nebo při dalším požadavku.",
+  "knowledgeGraphDeleted": "Graf znalostí úspěšně smazán",
+  "deleteGraphFailed": "Smazání grafu se nezdařilo: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Smazat graf znalostí",
+  "deleteKnowledgeGraphDesc": "Vymazat všechny uzly a spojení",
+  "mcp": "MCP",
+  "mcpServer": "Server MCP",
+  "mcpServerDesc": "Připojit AI asistenty k vašim datům",
+  "serverUrl": "URL serveru",
+  "urlCopied": "URL zkopírována",
+  "apiKeyAuth": "Ověření API klíčem",
+  "header": "Záhlaví",
+  "authorizationBearer": "Authorization: Bearer <klíč>",
+  "oauth": "OAuth",
+  "clientId": "ID klienta",
+  "clientSecret": "Tajný klíč klienta",
+  "useMcpApiKey": "Použijte svůj MCP API klíč",
+  "webhooks": "Webhooky",
+  "conversationEvents": "Události konverzace",
+  "newConversationCreated": "Vytvořena nová konverzace",
+  "realtimeTranscript": "Přepis v reálném čase",
+  "transcriptReceived": "Přepis přijat",
+  "audioBytes": "Audio bajty",
+  "audioDataReceived": "Audio data přijata",
+  "intervalSeconds": "Interval (sekundy)",
+  "daySummary": "Denní souhrn",
+  "summaryGenerated": "Souhrn vygenerován",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Přidat do claude_desktop_config.json",
+  "copyConfig": "Kopírovat konfiguraci",
+  "configCopied": "Konfigurace zkopírována do schránky",
+  "listeningMins": "Naslouchání (min)",
+  "understandingWords": "Porozumění (slova)",
+  "insights": "Přehledy",
+  "memories": "Vzpomínky",
+  "minsUsedThisMonth": "Tento měsíc využito {used} z {limit} min",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "Tento měsíc pochopeno {used} z {limit} slov",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "Tento měsíc získáno {used} z {limit} přehledů",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "Tento měsíc vytvořeno {used} z {limit} vzpomínek",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Viditelnost",
+  "visibilitySubtitle": "Kontrolujte, které konverzace se zobrazují ve vašem seznamu",
+  "showShortConversations": "Zobrazit krátké konverzace",
+  "showShortConversationsDesc": "Zobrazit konverzace kratší než prahová hodnota",
+  "showDiscardedConversations": "Zobrazit zahozené konverzace",
+  "showDiscardedConversationsDesc": "Zahrnout konverzace označené jako zahozené",
+  "shortConversationThreshold": "Prahová hodnota krátkých konverzací",
+  "shortConversationThresholdSubtitle": "Konverzace kratší než tato hodnota budou skryty, pokud nejsou výše povoleny",
+  "durationThreshold": "Prahová hodnota trvání",
+  "durationThresholdDesc": "Skrýt konverzace kratší než tato hodnota",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Vlastní slovník",
+  "addWords": "Přidat slova",
+  "addWordsDesc": "Jména, výrazy nebo neobvyklá slova",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Připojit",
+  "comingSoon": "Již brzy",
+  "chatToolsFooter": "Připojte své aplikace k zobrazení dat a metrik v chatu.",
+  "completeAuthInBrowser": "Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.",
+  "failedToStartAuth": "Nepodařilo se spustit ověření {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Odpojit {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Opravdu chcete odpojit od {appName}? Můžete se kdykoli znovu připojit.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Odpojeno od {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Nepodařilo se odpojit",
+  "connectTo": "Připojit k {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Budete muset autorizovat Omi pro přístup k vašim datům {appName}. Tím se otevře váš prohlížeč pro ověření.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Pokračovat",
+  "languageTitle": "Jazyk",
+  "primaryLanguage": "Primární jazyk",
+  "automaticTranslation": "Automatický překlad",
+  "detectLanguages": "Detekovat 10+ jazyků",
+  "authorizeSavingRecordings": "Autorizovat ukládání nahrávek",
+  "thanksForAuthorizing": "Děkujeme za autorizaci!",
+  "needYourPermission": "Potřebujeme vaše povolení",
+  "alreadyGavePermission": "Již jste nám dali povolení k ukládání vašich nahrávek. Zde je připomenutí, proč to potřebujeme:",
+  "wouldLikePermission": "Rádi bychom vaše povolení k ukládání vašich hlasových nahrávek. Zde je proč:",
+  "improveSpeechProfile": "Vylepšit váš hlasový profil",
+  "improveSpeechProfileDesc": "Nahrávky používáme k dalšímu trénování a vylepšování vašeho osobního hlasového profilu.",
+  "trainFamilyProfiles": "Trénovat profily pro přátele a rodinu",
+  "trainFamilyProfilesDesc": "Vaše nahrávky nám pomáhají rozpoznat a vytvářet profily pro vaše přátele a rodinu.",
+  "enhanceTranscriptAccuracy": "Zvýšit přesnost přepisu",
+  "enhanceTranscriptAccuracyDesc": "S vylepšením našeho modelu můžeme pro vaše nahrávky poskytovat lepší výsledky přepisu.",
+  "legalNotice": "Právní upozornění: Legálnost nahrávání a ukládání hlasových dat se může lišit v závislosti na vaší lokalitě a způsobu použití této funkce. Je vaší odpovědností zajistit dodržování místních zákonů a předpisů.",
+  "alreadyAuthorized": "Již autorizováno",
+  "authorize": "Autorizovat",
+  "revokeAuthorization": "Zrušit autorizaci",
+  "authorizationSuccessful": "Autorizace úspěšná!",
+  "failedToAuthorize": "Autorizace se nezdařila. Zkuste to prosím znovu.",
+  "authorizationRevoked": "Autorizace zrušena.",
+  "recordingsDeleted": "Nahrávky smazány.",
+  "failedToRevoke": "Zrušení autorizace se nezdařilo. Zkuste to prosím znovu.",
+  "permissionRevokedTitle": "Povolení zrušeno",
+  "permissionRevokedMessage": "Chcete, abychom odstranili také všechny vaše existující nahrávky?",
+  "yes": "Ano",
+  "editName": "Upravit jméno",
+  "howShouldOmiCallYou": "Jak vás má Omi oslovovat?",
+  "enterYourName": "Zadejte své jméno",
+  "nameCannotBeEmpty": "Jméno nemůže být prázdné",
+  "nameUpdatedSuccessfully": "Jméno úspěšně aktualizováno!",
+  "calendarSettings": "Nastavení kalendáře",
+  "calendarProviders": "Poskytovatelé kalendáře",
+  "macOsCalendar": "Kalendář macOS",
+  "connectMacOsCalendar": "Připojit váš místní kalendář macOS",
+  "googleCalendar": "Kalendář Google",
+  "syncGoogleAccount": "Synchronizovat s vaším účtem Google",
+  "showMeetingsMenuBar": "Zobrazit nadcházející schůzky v menu baru",
+  "showMeetingsMenuBarDesc": "Zobrazit vaši další schůzku a čas do jejího začátku v menu baru macOS",
+  "showEventsNoParticipants": "Zobrazit události bez účastníků",
+  "showEventsNoParticipantsDesc": "Pokud je povoleno, Již brzy zobrazuje události bez účastníků nebo video odkazu.",
+  "yourMeetings": "Vaše schůzky",
+  "refresh": "Obnovit",
+  "noUpcomingMeetings": "Nenalezeny žádné nadcházející schůzky",
+  "checkingNextDays": "Kontrola dalších 30 dnů",
+  "tomorrow": "Zítra",
+  "googleCalendarComingSoon": "Integrace s Kalendářem Google již brzy!",
+  "connectedAsUser": "Připojeno jako uživatel: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Výchozí pracovní prostor",
+  "tasksCreatedInWorkspace": "Úkoly budou vytvořeny v tomto pracovním prostoru",
+  "defaultProjectOptional": "Výchozí projekt (volitelné)",
+  "leaveUnselectedTasks": "Ponechte nevybrané pro vytváření úkolů bez projektu",
+  "noProjectsInWorkspace": "V tomto pracovním prostoru nebyly nalezeny žádné projekty",
+  "conversationTimeoutDesc": "Vyberte, jak dlouho čekat v tichosti před automatickým ukončením konverzace:",
+  "timeout2Minutes": "2 minuty",
+  "timeout2MinutesDesc": "Ukončit konverzaci po 2 minutách ticha",
+  "timeout5Minutes": "5 minut",
+  "timeout5MinutesDesc": "Ukončit konverzaci po 5 minutách ticha",
+  "timeout10Minutes": "10 minut",
+  "timeout10MinutesDesc": "Ukončit konverzaci po 10 minutách ticha",
+  "timeout30Minutes": "30 minut",
+  "timeout30MinutesDesc": "Ukončit konverzaci po 30 minutách ticha",
+  "timeout4Hours": "4 hodiny",
+  "timeout4HoursDesc": "Ukončit konverzaci po 4 hodinách ticha",
+  "conversationEndAfterHours": "Konverzace nyní skončí po 4 hodinách ticha",
+  "conversationEndAfterMinutes": "Konverzace nyní skončí po {minutes} minutě/minutách ticha",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Řekněte nám svůj primární jazyk",
+  "languageForTranscription": "Nastavte svůj jazyk pro ostřejší přepisy a personalizovaný zážitek.",
+  "singleLanguageModeInfo": "Režim jednoho jazyka je povolen. Překlad je zakázán pro vyšší přesnost.",
+  "searchLanguageHint": "Hledat jazyk podle názvu nebo kódu",
+  "noLanguagesFound": "Nenalezeny žádné jazyky",
+  "skip": "Přeskočit",
+  "languageSetTo": "Jazyk nastaven na {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Nastavení jazyka se nezdařilo",
+  "appSettings": "Nastavení {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Odpojit od {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Tím se odstraní vaše ověření {appName}. Pro opětovné použití se budete muset znovu připojit.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Připojeno k {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Účet",
+  "actionItemsSyncedTo": "Vaše úkoly budou synchronizovány s vaším účtem {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Výchozí prostor",
+  "selectSpaceInWorkspace": "Vyberte prostor ve vašem pracovním prostoru",
+  "noSpacesInWorkspace": "V tomto pracovním prostoru nebyly nalezeny žádné prostory",
+  "defaultList": "Výchozí seznam",
+  "tasksAddedToList": "Úkoly budou přidány do tohoto seznamu",
+  "noListsInSpace": "V tomto prostoru nebyly nalezeny žádné seznamy",
+  "failedToLoadRepos": "Načtení repozitářů se nezdařilo: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Výchozí repozitář uložen",
+  "failedToSaveDefaultRepo": "Uložení výchozího repozitáře se nezdařilo",
+  "defaultRepository": "Výchozí repozitář",
+  "selectDefaultRepoDesc": "Vyberte výchozí repozitář pro vytváření problémů. Při vytváření problémů můžete stále specifikovat jiný repozitář.",
+  "noReposFound": "Nenalezeny žádné repozitáře",
+  "private": "Soukromé",
+  "updatedDate": "Aktualizováno {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "včera",
+  "daysAgo": "před {count} dny",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "před 1 týdnem",
+  "weeksAgo": "před {count} týdny",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "před 1 měsícem",
+  "monthsAgo": "před {count} měsíci",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Problémy budou vytvořeny ve vašem výchozím repozitáři",
+  "taskIntegrations": "Integrace úkolů",
+  "configureSettings": "Nakonfigurovat nastavení",
+  "completeAuthBrowser": "Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.",
+  "failedToStartAppAuth": "Spuštění ověření {appName} se nezdařilo",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Připojit k {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Budete muset autorizovat Omi k vytváření úkolů ve vašem účtu {appName}. Tím se otevře váš prohlížeč pro ověření.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Pokračovat",
+  "appIntegration": "Integrace {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integrace s {appName} již brzy! Usilovně pracujeme na tom, abychom vám přinesli více možností správy úkolů.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Rozumím",
+  "tasksExportedOneApp": "Úkoly lze exportovat do jedné aplikace najednou.",
+  "completeYourUpgrade": "Dokončete svůj upgrade",
+  "importConfiguration": "Importovat konfiguraci",
+  "exportConfiguration": "Exportovat konfiguraci",
+  "bringYourOwn": "Přineste si vlastní",
+  "payYourSttProvider": "Používejte Omi zdarma. Platíte pouze svému poskytovateli STT přímo.",
+  "freeMinutesMonth": "1 200 bezplatných minut měsíčně. Neomezené s ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Host je povinný",
+  "validPortRequired": "Je vyžadován platný port",
+  "validWebsocketUrlRequired": "Je vyžadována platná URL WebSocket (wss://)",
+  "apiUrlRequired": "URL API je povinná",
+  "apiKeyRequired": "API klíč je povinný",
+  "invalidJsonConfig": "Neplatná konfigurace JSON",
+  "errorSaving": "Chyba při ukládání: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfigurace zkopírována do schránky",
+  "pasteJsonConfig": "Vložte níže svou konfiguraci JSON:",
+  "addApiKeyAfterImport": "Po importu budete muset přidat svůj vlastní API klíč",
+  "paste": "Vložit",
+  "import": "Importovat",
+  "invalidProviderInConfig": "Neplatný poskytovatel v konfiguraci",
+  "importedConfig": "Importována konfigurace {providerName}",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Neplatný JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Poskytovatel",
+  "live": "Živě",
+  "onDevice": "Na zařízení",
+  "apiUrl": "URL API",
+  "enterSttHttpEndpoint": "Zadejte koncový bod HTTP vašeho STT",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Zadejte WebSocket koncový bod vašeho živého STT",
+  "apiKey": "API klíč",
+  "enterApiKey": "Zadejte svůj API klíč",
+  "storedLocallyNeverShared": "Uloženo lokálně, nikdy nesdíleno",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Pokročilé",
+  "configuration": "Konfigurace",
+  "requestConfiguration": "Konfigurace požadavku",
+  "responseSchema": "Schéma odpovědi",
+  "modified": "Upraveno",
+  "resetRequestConfig": "Obnovit výchozí konfiguraci požadavku",
+  "logs": "Protokoly",
+  "logsCopied": "Protokoly zkopírovány",
+  "noLogsYet": "Zatím žádné protokoly. Začněte nahrávat, abyste viděli aktivitu vlastního STT.",
+  "deviceUsesCodec": "{deviceName} používá {codecReason}. Bude použito Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Přepis Omi",
+  "bestInClassTranscription": "Nejlepší přepis ve své třídě bez nutnosti nastavení",
+  "instantSpeakerLabels": "Okamžité štítky mluvčích",
+  "languageTranslation": "Překlad 100+ jazyků",
+  "optimizedForConversation": "Optimalizováno pro konverzaci",
+  "autoLanguageDetection": "Automatická detekce jazyka",
+  "highAccuracy": "Vysoká přesnost",
+  "privacyFirst": "Soukromí na prvním místě",
+  "saveChanges": "Uložit změny",
+  "resetToDefault": "Obnovit na výchozí",
+  "viewTemplate": "Zobrazit šablonu",
+  "trySomethingLike": "Zkuste něco jako...",
+  "tryIt": "Vyzkoušejte to",
+  "creatingPlan": "Vytváření plánu",
+  "developingLogic": "Vývoj logiky",
+  "designingApp": "Navrhování aplikace",
+  "generatingIconStep": "Generování ikony",
+  "finalTouches": "Závěrečné úpravy",
+  "processing": "Zpracování...",
+  "features": "Funkce",
+  "creatingYourApp": "Vytváření vaší aplikace...",
+  "generatingIcon": "Generování ikony...",
+  "whatShouldWeMake": "Co bychom měli vytvořit?",
+  "appName": "Název aplikace",
+  "description": "Popis",
+  "publicLabel": "Veřejné",
+  "privateLabel": "Soukromé",
+  "free": "Zdarma",
+  "perMonth": "/ Měsíc",
+  "tailoredConversationSummaries": "Přizpůsobená shrnutí konverzací",
+  "customChatbotPersonality": "Vlastní osobnost chatbota",
+  "makePublic": "Zveřejnit",
+  "anyoneCanDiscover": "Kdokoli může objevit vaši aplikaci",
+  "onlyYouCanUse": "Pouze vy můžete používat tuto aplikaci",
+  "paidApp": "Placená aplikace",
+  "usersPayToUse": "Uživatelé platí za použití vaší aplikace",
+  "freeForEveryone": "Zdarma pro všechny",
+  "perMonthLabel": "/ měsíc",
+  "creating": "Vytváření...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Vytvořit aplikaci",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Hledání zařízení...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{ZAŘÍZENÍ} other{ZAŘÍZENÍ}} NALEZENO V BLÍZKOSTI",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PÁROVÁNÍ ÚSPĚŠNÉ",
+  "errorConnectingAppleWatch": "Chyba při připojování k Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Už nezobrazovat",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Rozumím",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Povolit Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi potřebuje Bluetooth pro připojení k vašemu nositelného zařízení. Povolte prosím Bluetooth a zkuste to znovu.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Kontaktovat podporu?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Připojit později",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Udělit oprávnění",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Aktivita na pozadí",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Umožněte Omi běžet na pozadí pro lepší stabilitu",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Přístup k poloze",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Povolte polohu na pozadí pro plný zážitek",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Oznámení",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Povolte oznámení, abyste byli informováni",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Služba určování polohy zakázána",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Služba určování polohy je zakázána. Přejděte do Nastavení > Soukromí a zabezpečení > Služby určování polohy a povolte ji",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Přístup k poloze na pozadí odepřen",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Přejděte do nastavení zařízení a nastavte oprávnění k poloze na \"Vždy povolit\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Líbí se vám Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Pomozte nám oslovit více lidí tím, že zanecháte hodnocení v App Store. Vaše zpětná vazba pro nás hodně znamená!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Pomozte nám oslovit více lidí tím, že zanecháte hodnocení v Obchodě Google Play. Vaše zpětná vazba pro nás hodně znamená!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Ohodnotit v App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Ohodnotit v Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Možná později",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi potřebuje poznat vaše cíle a váš hlas. Později to budete moci upravit.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Začít",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Vše hotovo!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Pokračujte dál, jde vám to skvěle",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Přeskočit tuto otázku",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Zatím přeskočit",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Chyba připojení",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Nepodařilo se připojit k serveru. Zkontrolujte prosím připojení k internetu a zkuste to znovu.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Detekována neplatná nahrávka",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Zdá se, že v nahrávce je více mluvčích. Ujistěte se prosím, že jste na tichém místě, a zkuste to znovu.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Není detekován dostatek řeči. Mluvte prosím více a zkuste to znovu.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Ujistěte se prosím, že mluvíte alespoň 5 sekund a ne více než 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Jste tam?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Nemohli jsme detekovat žádnou řeč. Ujistěte se prosím, že mluvíte alespoň 10 sekund a ne více než 3 minuty.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Spojení ztraceno",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Spojení bylo přerušeno. Zkontrolujte prosím připojení k internetu a zkuste to znovu.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Zkusit znovu",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Připojit Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Pokračovat bez zařízení",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Vyžadována oprávnění",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Tato aplikace potřebuje oprávnění Bluetooth a Poloha, aby fungovala správně. Povolte je prosím v nastavení.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Otevřít nastavení",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Chcete jiné jméno?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Jak se jmenujete?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Mluvte. Přepisujte. Shrňte.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Přihlásit se přes Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Přihlásit se přes Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Pokračováním souhlasíte s našimi ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Podmínkami použití",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Váš AI společník",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Zachyťte každý okamžik. Získejte souhrny\npodporované AI. Už nikdy si nedělejte poznámky.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Nastavení Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Oprávnění požadováno!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Oprávnění k mikrofonu",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Oprávnění uděleno! Nyní:\n\nOtevřete aplikaci Omi na hodinkách a klepněte níže na \"Pokračovat\"",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Potřebujeme oprávnění k mikrofonu.\n\n1. Klepněte na \"Udělit oprávnění\"\n2. Povolte na svém iPhone\n3. Aplikace na hodinkách se zavře\n4. Znovu otevřete a klepněte na \"Pokračovat\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Udělit oprávnění",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Potřebujete pomoc?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Řešení problémů:\n\n1. Ujistěte se, že Omi je nainstalováno na vašich hodinkách\n2. Otevřete aplikaci Omi na hodinkách\n3. Hledejte vyskakovací okno s oprávněním\n4. Klepněte na \"Povolit\", když budete vyzváni\n5. Aplikace na hodinkách se zavře - znovu ji otevřete\n6. Vraťte se a klepněte na \"Pokračovat\" na svém iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Nahrávání úspěšně zahájeno!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Oprávnění ještě nebylo uděleno. Ujistěte se prosím, že jste povolili přístup k mikrofonu a znovu otevřeli aplikaci na hodinkách.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Chyba při žádosti o oprávnění: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Chyba při zahájení nahrávání: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Vyberte svůj primární jazyk",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Nastavte svůj jazyk pro ostřejší přepisy a personalizovaný zážitek",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Jaký je váš primární jazyk?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Vyberte svůj jazyk",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Vaše cesta osobního růstu s AI, které naslouchá každému vašemu slovu.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Úkoly",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Klepněte pro úpravu • Dlouze stiskněte pro výběr • Přejeďte pro akce",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "K provedení",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Hotovo",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Staré",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Vše máte hotové!\nŽádné nevyřízené úkoly",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Zatím žádné dokončené položky",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Žádné staré úkoly",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Žádné položky",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Úkol označen jako nedokončený",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Úkol dokončen",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Smazat úkol",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Opravdu chcete smazat tento úkol?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Smazat vybrané položky",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Opravdu chcete smazat {count} vybraný/vybrané/vybraných úkol{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Úkol \"{description}\" smazán",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "Smazáno {count} úkol{s}",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Smazání úkolu se nezdařilo",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Smazání položek se nezdařilo",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Smazání některých položek se nezdařilo",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Připraveno na úkoly",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Vaše AI automaticky extrahuje úkoly a to-dos z vašich konverzací. Objeví se zde, když budou vytvořeny.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automaticky extrahováno z konverzací",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Klepněte pro úpravu, přejeďte pro dokončení nebo smazání",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "Vybráno: {count}",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Vybrat vše",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Smazat vybrané",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Hledat ve {count} vzpomínkách",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Vzpomínka smazána.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Vrátit zpět",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Zatím žádné vzpomínky",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Zatím žádné automaticky extrahované vzpomínky",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Zatím žádné manuální vzpomínky",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Žádné vzpomínky v těchto kategoriích",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Nenalezeny žádné vzpomínky",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Přidat první vzpomínku",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Vymazat paměť Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Opravdu chcete vymazat paměť Omi? Tuto akci nelze vrátit zpět.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Vymazat paměť",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Paměť Omi o vás byla vymazána",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Žádné vzpomínky ke smazání",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Vytvořit novou vzpomínku",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Vytvořit nový úkol",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Správa vzpomínek",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtrovat vzpomínky",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Máte celkem {count} vzpomínek",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Veřejné vzpomínky",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Soukromé vzpomínky",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Nastavit všechny vzpomínky jako soukromé",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Nastavit všechny vzpomínky jako veřejné",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Smazat všechny vzpomínky",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Všechny vzpomínky jsou nyní soukromé",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Všechny vzpomínky jsou nyní veřejné",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Nová vzpomínka",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Upravit vzpomínku",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Rád/a jím zmrzlinu...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Uložení se nezdařilo. Zkontrolujte prosím připojení.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Uložit vzpomínku",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Zkusit znovu",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Vytvořit úkol",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Upravit úkol",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Co je třeba udělat?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Popis úkolu nemůže být prázdný.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Úkol aktualizován",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Aktualizace úkolu se nezdařila",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Úkol vytvořen",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Vytvoření úkolu se nezdařilo",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Termín dokončení",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Čas",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Přidat termín dokončení",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Stiskněte hotovo pro uložení",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Stiskněte hotovo pro vytvoření",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Vše",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "O vás",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Přehledy",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuální",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Dokončeno",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Označit jako dokončené",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Úkol smazán",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Smazání úkolu se nezdařilo",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Smazat úkol",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Opravdu chcete smazat tento úkol?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Jazyk aplikace",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ROZHRANÍ APLIKACE",
+  "speechTranscriptionSectionTitle": "ŘEČ A PŘEPIS",
+  "languageSettingsHelperText": "Jazyk aplikace mění nabídky a tlačítka. Jazyk řeči ovlivňuje, jak jsou vaše nahrávky přepisovány."
+}

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "da",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Samtale",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Udskrift",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Handlingspunkter",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Slet samtale?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Er du sikker på, at du vil slette denne samtale? Denne handling kan ikke fortrydes.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Bekræft",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Cancel",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Delete",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Tilføj",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Opdater",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Gem",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Rediger",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Luk",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Ryd",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopier udskrift",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopier sammenfatning",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Test prompt",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Genbehandl samtale",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Slet samtale",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Indhold kopieret til udklipsholder",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Kunne ikke opdatere stjerne-status.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Samtale-URL kunne ikke deles.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Fejl under behandling af samtale. Prøv venligst igen senere.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Tjek venligst din internetforbindelse og prøv igen.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Kan ikke slette samtale",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Noget gik galt! Prøv venligst igen senere.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopier fejlbesked",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Fejlbesked kopieret til udklipsholder",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Resterende",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Indlæser...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Indlæser varighed...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekunder",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Personer",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Tilføj ny person",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Rediger person",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Opret en ny person og træn Omi til at genkende deres tale også!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Taleprofil",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Prøve {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Indstillinger",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Sprog",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Vælg sprog",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Sletter...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Fuldfør venligst godkendelse i din browser. Når det er færdigt, vend tilbage til appen.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Kunne ikke starte godkendelse",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import startet! Du får besked når den er færdig.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Kunne ikke starte import. Prøv venligst igen.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Kunne ikke få adgang til den valgte fil",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Spørg Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Done",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Frakoblet",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Søger",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Tilslut enhed",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Du har nået din månedlige grænse.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Tjek forbrug",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Synkroniserer optagelser",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Optagelser til synkronisering",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Alt er opdateret",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Synkroniser",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Vedhæng er opdateret",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Alle optagelser er synkroniseret",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Synkronisering i gang",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Klar til synkronisering",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Tryk på Synkroniser for at starte",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Vedhæng ikke tilsluttet. Tilslut for at synkronisere.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Alt er allerede synkroniseret.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Du har optagelser, der ikke er synkroniseret endnu.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Vi fortsætter med at synkronisere dine optagelser i baggrunden.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Ingen samtaler endnu.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Ingen stjernemarkerede samtaler endnu.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "For at stjernemarkere en samtale skal du åbne den og trykke på stjerneikonet i overskriften.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Søg samtaler",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} valgt",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Flet",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Flet samtaler",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Dette vil kombinere {count} samtaler til én. Alt indhold vil blive flettet og regenereret.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Fletter i baggrunden. Dette kan tage et øjeblik.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Kunne ikke starte fletning",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Spørg om hvad som helst",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Ingen beskeder endnu!\nHvorfor starter du ikke en samtale?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Sletter dine beskeder fra Omis hukommelse...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Besked kopieret til udklipsholder.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Du kan ikke rapportere dine egne beskeder.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Rapporter besked",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Er du sikker på, at du vil rapportere denne besked?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Besked rapporteret.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Tak for din feedback!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Ryd chat?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Er du sikker på, at du vil rydde chatten? Denne handling kan ikke fortrydes.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Du kan kun uploade 4 filer ad gangen",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Chat med Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Apps",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Ingen apps fundet",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Prøv at justere din søgning eller filtre",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Opret din egen app",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Byg og del din tilpassede app",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Søg i 1500+ apps",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Mine apps",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Installerede apps",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Kan ikke hente apps :(\n\nTjek venligst din internetforbindelse og prøv igen.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Om Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Privacy Policy",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Besøg hjemmeside",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Hjælp eller forespørgsler?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Bliv en del af fællesskabet!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ medlemmer og tæller.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Slet konto",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Er du sikker på, at du vil slette din konto?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Dette kan ikke fortrydes.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Alle dine minder og samtaler vil blive permanent slettet.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Dine apps og integrationer vil blive afbrudt øjeblikkeligt.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Du kan eksportere dine data før du sletter din konto, men når den er slettet, kan den ikke gendannes.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Jeg forstår, at sletning af min konto er permanent, og at alle data, inklusive minder og samtaler, vil gå tabt og ikke kan gendannes.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Er du sikker?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Denne handling er irreversibel og vil permanent slette din konto og alle tilknyttede data. Er du sikker på, at du vil fortsætte?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Slet nu",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Gå tilbage",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Marker afkrydsningsfeltet for at bekræfte, at du forstår, at sletning af din konto er permanent og irreversibel.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Navn",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-mail",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Brugerdefineret ordforråd",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identifikation af andre",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Betalingsmetoder",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Samtalevisning",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Data og privatliv",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Bruger-ID",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Ikke angivet",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Bruger-ID kopieret til udklipsholder",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Systemstandard",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plan og forbrug",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Offline synkronisering",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Enhedsindstillinger",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Chatværktøjer",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Feedback / Fejl",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Hjælpecenter",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Udviklerindstillinger",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Få Omi til Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Henvisningsprogram",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Log ud",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "App- og enhedsdetaljer kopieret",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Opsamling 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Dit privatliv, din kontrol",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Hos Omi er vi forpligtede til at beskytte dit privatliv. Denne side giver dig mulighed for at styre, hvordan dine data gemmes og bruges.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Læs mere...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Databeskyttelsesniveau",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Dine data er som standard sikret med stærk kryptering. Gennemgå dine indstillinger og fremtidige privatlivsindstillinger nedenfor.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "App-adgang",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Følgende apps kan få adgang til dine data. Tryk på en app for at administrere dens tilladelser.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Ingen installerede apps har ekstern adgang til dine data.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Enhedsnavn",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Enheds-ID",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmware",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD-kort synkronisering",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Hardware-revision",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Modelnummer",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Producent",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dobbelttryk",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED-lysstyrke",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Mikrofonforstærkning",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Afbryd",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Glem enhed",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Opladningsproblemer",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Afbryd enhed",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Afpar enhed",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Afpar og glem enhed",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Din Omi er blevet afbrudt 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Enhed afparret. Gå til Indstillinger > Bluetooth og glem enheden for at fuldføre afparringen.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Afpar enhed",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Dette vil afparre enheden, så den kan tilsluttes en anden telefon. Du skal gå til Indstillinger > Bluetooth og glemme enheden for at fuldføre processen.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Enhed ikke tilsluttet",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Tilslut din Omi-enhed for at få adgang til\nenhedsindstillinger og tilpasning",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Enhedsinformation",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Tilpasning",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Hardware",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 ikke opdaget",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Vi kan se, at du enten har en V1-enhed, eller at din enhed ikke er tilsluttet. SD-kort-funktionalitet er kun tilgængelig for V2-enheder.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Afslut samtale",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pause/Genoptag",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Stjernemarkér samtale",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Dobbelttryk-handling",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Afslut og behandl samtale",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pause/Genoptag optagelse",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Stjernemarkér igangværende samtale",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Fra",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maks",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Lydløs",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Stille",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normal",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Høj",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon er lydløs",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Meget stille - til høje omgivelser",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Stille - til moderat støj",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutral - afbalanceret optagelse",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Let forstærket - normal brug",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Forstærket - til stille omgivelser",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Høj - til fjerne eller bløde stemmer",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Meget høj - til meget stille kilder",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimum - brug med forsigtighed",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Udviklerindstillinger",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Saving...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Konfigurer din AI-persona",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transcription",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Konfigurer STT-udbyder",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Samtale timeout",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Indstil hvornår samtaler automatisk afsluttes",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importer data",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importer data fra andre kilder",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Debug og diagnostik",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Endpoint URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Ingen API-nøgler endnu",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Opret en nøgle for at komme i gang",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Opret nøgle",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentation",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Dine Omi-indsigter",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "I dag",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Denne måned",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Dette år",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Altid",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Ingen aktivitet endnu",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Start en samtale med Omi\nfor at se dine forbrugsindsigter her.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Lytter",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Samlet tid Omi har lyttet aktivt.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Forstår",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Ord forstået fra dine samtaler.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Leverer",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Handlingspunkter og notater automatisk registreret.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Husker",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakta og detaljer husket for dig.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Ubegrænset plan",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Administrer plan",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Din plan annulleres den {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Din plan fornyes den {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Gratis plan",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} af {limit} min brugt",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Opgrader",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Opgrader til ubegrænset",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Din plan inkluderer {limit} gratis minutter om måneden. Opgrader for at få ubegrænset.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Deler mine Omi-statistikker! (omi.me - din altid-aktive AI-assistent)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "I dag har omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Denne måned har omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Dette år har omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Indtil videre har omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Lyttet i {minutes} minutter",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Forstået {words} ord",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Leveret {count} indsigter",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Husket {count} minder",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Debug-logfiler",
+  "debugLogsAutoDelete": "Slettes automatisk efter 3 dage.",
+  "debugLogsDesc": "Hjælper med at diagnosticere problemer",
+  "noLogFilesFound": "Ingen logfiler fundet.",
+  "omiDebugLog": "Omi debug-log",
+  "logShared": "Log delt",
+  "selectLogFile": "Vælg logfil",
+  "shareLogs": "Del logfiler",
+  "debugLogCleared": "Debug-log ryddet",
+  "exportStarted": "Eksport startet. Dette kan tage et par sekunder...",
+  "exportAllData": "Eksporter alle data",
+  "exportDataDesc": "Eksporter samtaler til en JSON-fil",
+  "exportedConversations": "Eksporterede samtaler fra Omi",
+  "exportShared": "Eksport delt",
+  "deleteKnowledgeGraphTitle": "Slet videngraf?",
+  "deleteKnowledgeGraphMessage": "Dette vil slette alle afledte videngraf-data (noder og forbindelser). Dine originale minder forbliver sikre. Grafen vil blive genopbygget over tid eller ved næste anmodning.",
+  "knowledgeGraphDeleted": "Videngraf slettet",
+  "deleteGraphFailed": "Kunne ikke slette graf: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Slet videngraf",
+  "deleteKnowledgeGraphDesc": "Ryd alle noder og forbindelser",
+  "mcp": "MCP",
+  "mcpServer": "MCP-server",
+  "mcpServerDesc": "Forbind AI-assistenter til dine data",
+  "serverUrl": "Server-URL",
+  "urlCopied": "URL kopieret",
+  "apiKeyAuth": "API-nøglegodkendelse",
+  "header": "Header",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Klient-ID",
+  "clientSecret": "Klient-hemmelighed",
+  "useMcpApiKey": "Brug din MCP API-nøgle",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Samtalehændelser",
+  "newConversationCreated": "Ny samtale oprettet",
+  "realtimeTranscript": "Realtids-udskrift",
+  "transcriptReceived": "Udskrift modtaget",
+  "audioBytes": "Lyd-bytes",
+  "audioDataReceived": "Lyddata modtaget",
+  "intervalSeconds": "Interval (sekunder)",
+  "daySummary": "Dagsammenfatning",
+  "summaryGenerated": "Sammenfatning genereret",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Tilføj til claude_desktop_config.json",
+  "copyConfig": "Kopier konfiguration",
+  "configCopied": "Konfiguration kopieret til udklipsholder",
+  "listeningMins": "Lytning (min)",
+  "understandingWords": "Forståelse (ord)",
+  "insights": "Indsigter",
+  "memories": "Minder",
+  "minsUsedThisMonth": "{used} af {limit} min brugt denne måned",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} af {limit} ord brugt denne måned",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} af {limit} indsigter opnået denne måned",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} af {limit} minder oprettet denne måned",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Synlighed",
+  "visibilitySubtitle": "Styr hvilke samtaler der vises i din liste",
+  "showShortConversations": "Vis korte samtaler",
+  "showShortConversationsDesc": "Vis samtaler kortere end tærsklen",
+  "showDiscardedConversations": "Vis kasserede samtaler",
+  "showDiscardedConversationsDesc": "Inkluder samtaler markeret som kasseret",
+  "shortConversationThreshold": "Kort samtale-tærskel",
+  "shortConversationThresholdSubtitle": "Samtaler kortere end denne vil blive skjult, medmindre aktiveret ovenfor",
+  "durationThreshold": "Varighedstærskel",
+  "durationThresholdDesc": "Skjul samtaler kortere end denne",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Brugerdefineret ordforråd",
+  "addWords": "Tilføj ord",
+  "addWordsDesc": "Navne, termer eller usædvanlige ord",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Connect",
+  "comingSoon": "Kommer snart",
+  "chatToolsFooter": "Forbind dine apps for at se data og målinger i chat.",
+  "completeAuthInBrowser": "Fuldfør venligst godkendelse i din browser. Når det er færdigt, vend tilbage til appen.",
+  "failedToStartAuth": "Kunne ikke starte {appName}-godkendelse",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Afbryd {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Er du sikker på, at du vil afbryde forbindelsen til {appName}? Du kan genoprette forbindelsen når som helst.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Afbrudt fra {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Kunne ikke afbryde",
+  "connectTo": "Tilslut til {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Du skal give Omi tilladelse til at få adgang til dine {appName}-data. Dette åbner din browser til godkendelse.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Fortsæt",
+  "languageTitle": "Sprog",
+  "primaryLanguage": "Primært sprog",
+  "automaticTranslation": "Automatisk oversættelse",
+  "detectLanguages": "Registrer 10+ sprog",
+  "authorizeSavingRecordings": "Godkend lagring af optagelser",
+  "thanksForAuthorizing": "Tak for godkendelsen!",
+  "needYourPermission": "Vi har brug for din tilladelse",
+  "alreadyGavePermission": "Du har allerede givet os tilladelse til at gemme dine optagelser. Her er en påmindelse om, hvorfor vi har brug for det:",
+  "wouldLikePermission": "Vi vil gerne have din tilladelse til at gemme dine stemmeoptagelser. Her er hvorfor:",
+  "improveSpeechProfile": "Forbedr din taleprofil",
+  "improveSpeechProfileDesc": "Vi bruger optagelser til yderligere at træne og forbedre din personlige taleprofil.",
+  "trainFamilyProfiles": "Træn profiler for venner og familie",
+  "trainFamilyProfilesDesc": "Dine optagelser hjælper os med at genkende og oprette profiler for dine venner og familie.",
+  "enhanceTranscriptAccuracy": "Forbedr udskriftspræcision",
+  "enhanceTranscriptAccuracyDesc": "Efterhånden som vores model forbedres, kan vi levere bedre transskriptionsresultater for dine optagelser.",
+  "legalNotice": "Juridisk meddelelse: Lovligheden af at optage og gemme stemmedata kan variere afhængigt af din placering og hvordan du bruger denne funktion. Det er dit ansvar at sikre overholdelse af lokale love og regler.",
+  "alreadyAuthorized": "Allerede godkendt",
+  "authorize": "Godkend",
+  "revokeAuthorization": "Tilbagekald godkendelse",
+  "authorizationSuccessful": "Godkendelse vellykket!",
+  "failedToAuthorize": "Kunne ikke godkende. Prøv venligst igen.",
+  "authorizationRevoked": "Godkendelse tilbagekaldt.",
+  "recordingsDeleted": "Optagelser slettet.",
+  "failedToRevoke": "Kunne ikke tilbagekalde godkendelse. Prøv venligst igen.",
+  "permissionRevokedTitle": "Tilladelse tilbagekaldt",
+  "permissionRevokedMessage": "Vil du have os til også at fjerne alle dine eksisterende optagelser?",
+  "yes": "Ja",
+  "editName": "Rediger navn",
+  "howShouldOmiCallYou": "Hvad skal Omi kalde dig?",
+  "enterYourName": "Enter your name",
+  "nameCannotBeEmpty": "Navn kan ikke være tomt",
+  "nameUpdatedSuccessfully": "Navn opdateret!",
+  "calendarSettings": "Kalenderindstillinger",
+  "calendarProviders": "Kalenderudbydere",
+  "macOsCalendar": "macOS-kalender",
+  "connectMacOsCalendar": "Tilslut din lokale macOS-kalender",
+  "googleCalendar": "Google Calendar",
+  "syncGoogleAccount": "Synkroniser med din Google-konto",
+  "showMeetingsMenuBar": "Vis kommende møder i menulinjen",
+  "showMeetingsMenuBarDesc": "Vis dit næste møde og tid indtil det starter i macOS-menulinjen",
+  "showEventsNoParticipants": "Vis begivenheder uden deltagere",
+  "showEventsNoParticipantsDesc": "Når aktiveret, viser Kommende begivenheder uden deltagere eller videolink.",
+  "yourMeetings": "Dine møder",
+  "refresh": "Opdater",
+  "noUpcomingMeetings": "Ingen kommende møder fundet",
+  "checkingNextDays": "Tjekker de næste 30 dage",
+  "tomorrow": "I morgen",
+  "googleCalendarComingSoon": "Google Calendar-integration kommer snart!",
+  "connectedAsUser": "Tilsluttet som bruger: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Standard arbejdsområde",
+  "tasksCreatedInWorkspace": "Opgaver oprettes i dette arbejdsområde",
+  "defaultProjectOptional": "Standardprojekt (valgfrit)",
+  "leaveUnselectedTasks": "Lad være uvalgt for at oprette opgaver uden projekt",
+  "noProjectsInWorkspace": "Ingen projekter fundet i dette arbejdsområde",
+  "conversationTimeoutDesc": "Vælg hvor længe der skal ventes i stilhed før automatisk afslutning af samtale:",
+  "timeout2Minutes": "2 minutter",
+  "timeout2MinutesDesc": "Afslut samtale efter 2 minutters stilhed",
+  "timeout5Minutes": "5 minutter",
+  "timeout5MinutesDesc": "Afslut samtale efter 5 minutters stilhed",
+  "timeout10Minutes": "10 minutter",
+  "timeout10MinutesDesc": "Afslut samtale efter 10 minutters stilhed",
+  "timeout30Minutes": "30 minutter",
+  "timeout30MinutesDesc": "Afslut samtale efter 30 minutters stilhed",
+  "timeout4Hours": "4 timer",
+  "timeout4HoursDesc": "Afslut samtale efter 4 timers stilhed",
+  "conversationEndAfterHours": "Samtaler afsluttes nu efter 4 timers stilhed",
+  "conversationEndAfterMinutes": "Samtaler afsluttes nu efter {minutes} minut(ter) i stilhed",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Fortæl os dit primære sprog",
+  "languageForTranscription": "Indstil dit sprog for skarpere transskriptioner og en personlig oplevelse.",
+  "singleLanguageModeInfo": "Enkeltsprogs-tilstand er aktiveret. Oversættelse er deaktiveret for højere nøjagtighed.",
+  "searchLanguageHint": "Search language by name or code",
+  "noLanguagesFound": "No languages found",
+  "skip": "Spring over",
+  "languageSetTo": "Sprog indstillet til {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Kunne ikke indstille sprog",
+  "appSettings": "{appName} Settings",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Disconnect from {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "This will remove your {appName} authentication. You'll need to reconnect to use it again.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Connected to {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Account",
+  "actionItemsSyncedTo": "Your action items will be synced to your {appName} account",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Default Space",
+  "selectSpaceInWorkspace": "Select a space in your workspace",
+  "noSpacesInWorkspace": "No spaces found in this workspace",
+  "defaultList": "Default List",
+  "tasksAddedToList": "Tasks will be added to this list",
+  "noListsInSpace": "No lists found in this space",
+  "failedToLoadRepos": "Failed to load repositories: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Default repository saved",
+  "failedToSaveDefaultRepo": "Failed to save default repository",
+  "defaultRepository": "Default Repository",
+  "selectDefaultRepoDesc": "Select a default repository for creating issues. You can still specify a different repository when creating issues.",
+  "noReposFound": "No repositories found",
+  "private": "Private",
+  "updatedDate": "Updated {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "yesterday",
+  "daysAgo": "{count} days ago",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 week ago",
+  "weeksAgo": "{count} weeks ago",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 month ago",
+  "monthsAgo": "{count} months ago",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Issues will be created in your default repository",
+  "taskIntegrations": "Task Integrations",
+  "configureSettings": "Configure Settings",
+  "completeAuthBrowser": "Please complete authentication in your browser. Once done, return to the app.",
+  "failedToStartAppAuth": "Failed to start {appName} authentication",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Connect to {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "You'll need to authorize Omi to create tasks in your {appName} account. This will open your browser for authentication.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Continue",
+  "appIntegration": "{appName} Integration",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integration with {appName} is coming soon! We're working hard to bring you more task management options.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Got it",
+  "tasksExportedOneApp": "Tasks can be exported to one app at a time.",
+  "completeYourUpgrade": "Complete Your Upgrade",
+  "importConfiguration": "Import Configuration",
+  "exportConfiguration": "Export configuration",
+  "bringYourOwn": "Bring your own",
+  "payYourSttProvider": "Freely use omi. You only pay your STT provider directly.",
+  "freeMinutesMonth": "1,200 free minutes/month included. Unlimited with ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Host is required",
+  "validPortRequired": "Valid port is required",
+  "validWebsocketUrlRequired": "Valid WebSocket URL is required (wss://)",
+  "apiUrlRequired": "API URL is required",
+  "apiKeyRequired": "API key is required",
+  "invalidJsonConfig": "Invalid JSON configuration",
+  "errorSaving": "Error saving: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Configuration copied to clipboard",
+  "pasteJsonConfig": "Paste your JSON configuration below:",
+  "addApiKeyAfterImport": "You'll need to add your own API key after importing",
+  "paste": "Paste",
+  "import": "Import",
+  "invalidProviderInConfig": "Invalid provider in configuration",
+  "importedConfig": "Imported {providerName} configuration",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Invalid JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Provider",
+  "live": "Live",
+  "onDevice": "On Device",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "Enter your STT HTTP endpoint",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "Enter your live STT WebSocket endpoint",
+  "apiKey": "API Key",
+  "enterApiKey": "Enter your API key",
+  "storedLocallyNeverShared": "Stored locally, never shared",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Advanced",
+  "configuration": "Configuration",
+  "requestConfiguration": "Request Configuration",
+  "responseSchema": "Response Schema",
+  "modified": "Modified",
+  "resetRequestConfig": "Reset request config to default",
+  "logs": "Logs",
+  "logsCopied": "Logs copied",
+  "noLogsYet": "No logs yet. Start recording to see custom STT activity.",
+  "deviceUsesCodec": "{deviceName} uses {codecReason}. Omi will be used.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi Transcription",
+  "bestInClassTranscription": "Best in class transcription with zero setup",
+  "instantSpeakerLabels": "Instant speaker labels",
+  "languageTranslation": "100+ language translation",
+  "optimizedForConversation": "Optimized for conversation",
+  "autoLanguageDetection": "Auto language detection",
+  "highAccuracy": "High accuracy",
+  "privacyFirst": "Privacy first",
+  "saveChanges": "Save Changes",
+  "resetToDefault": "Reset to Default",
+  "viewTemplate": "View Template",
+  "trySomethingLike": "Try something like...",
+  "tryIt": "Try it",
+  "creatingPlan": "Creating plan",
+  "developingLogic": "Developing logic",
+  "designingApp": "Designing app",
+  "generatingIconStep": "Generating icon",
+  "finalTouches": "Final touches",
+  "processing": "Processing...",
+  "features": "Features",
+  "creatingYourApp": "Creating your app...",
+  "generatingIcon": "Generating icon...",
+  "whatShouldWeMake": "What should we make?",
+  "appName": "App Name",
+  "description": "Description",
+  "publicLabel": "Public",
+  "privateLabel": "Private",
+  "free": "Free",
+  "perMonth": "/ Month",
+  "tailoredConversationSummaries": "Tailored Conversation Summaries",
+  "customChatbotPersonality": "Custom Chatbot Personality",
+  "makePublic": "Make public",
+  "anyoneCanDiscover": "Anyone can discover your app",
+  "onlyYouCanUse": "Only you can use this app",
+  "paidApp": "Paid app",
+  "usersPayToUse": "Users pay to use your app",
+  "freeForEveryone": "Free for everyone",
+  "perMonthLabel": "/ month",
+  "creating": "Creating...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Create App",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Searching for devices...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{DEVICE} other{DEVICES}} FOUND NEARBY",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PAIRING SUCCESSFUL",
+  "errorConnectingAppleWatch": "Error connecting to Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Don't show it again",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "I Understand",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Enable Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi needs Bluetooth to connect to your wearable. Please enable Bluetooth and try again.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Contact Support?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Connect Later",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Grant permissions",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Background activity",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Let Omi run in the background for better stability",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Location access",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Enable background location for the full experience",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Notifications",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Enable notifications to stay informed",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Location Service Disabled",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Location Service is Disabled. Please go to Settings > Privacy & Security > Location Services and enable it",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Background Location Access Denied",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Please go to device settings and set location permission to \"Always Allow\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Loving Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Help us reach more people by leaving a review in the App Store. Your feedback means the world to us!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Help us reach more people by leaving a review in the Google Play Store. Your feedback means the world to us!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Rate on App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Rate on Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Maybe later",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi needs to learn your goals and your voice. You'll be able to modify it later.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Get Started",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "All done!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Keep going, you are doing great",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Skip this question",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Skip for now",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Connection Error",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Failed to connect to the server. Please check your internet connection and try again.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Invalid recording detected",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "There is not enough speech detected. Please speak more and try again.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Please make sure you speak for at least 5 seconds and not more than 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Are you there?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "We could not detect any speech. Please make sure to speak for at least 10 seconds and not more than 3 minutes.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Connection Lost",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "The connection was interrupted. Please check your internet connection and try again.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Try Again",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Connect Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Continue Without Device",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Permissions Required",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "This app needs Bluetooth and Location permissions to function properly. Please enable them in the settings.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Open Settings",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Want to go by something else?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "What's your name?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Speak. Transcribe. Summarize.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Sign in with Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Sign in with Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "By continuing, you agree to our ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Terms of Use",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Your AI Companion",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Capture every moment. Get AI-powered\nsummaries. Never take notes again.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch Setup",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Permission Requested!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Microphone Permission",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Permission granted! Now:\n\nOpen the Omi app on your watch and tap \"Continue\" below",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "We need microphone permission.\n\n1. Tap \"Grant Permission\"\n2. Allow on your iPhone\n3. Watch app will close\n4. Reopen and tap \"Continue\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Grant Permission",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Need Help?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Troubleshooting:\n\n1. Ensure Omi is installed on your watch\n2. Open the Omi app on your watch\n3. Look for the permission popup\n4. Tap \"Allow\" when prompted\n5. App on your watch will close - reopen it\n6. Come back and tap \"Continue\" on your iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Recording started successfully!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Permission not granted yet. Please make sure you allowed microphone access and reopened the app on your watch.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Error requesting permission: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Error starting recording: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Select your primary language",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Set your language for sharper transcriptions and a personalized experience",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "What's your primary language?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Select your language",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Your personal growth journey with AI that listens to your every word.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "To-Do's",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Tap to edit • Long press to select • Swipe for actions",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "To Do",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Done",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Old",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 All caught up!\nNo pending action items",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "No completed items yet",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ No old tasks",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "No items",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Action item marked as incomplete",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Action item completed",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Delete Action Item",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Are you sure you want to delete this action item?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Delete Selected Items",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Are you sure you want to delete {count} selected action item{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Action item \"{description}\" deleted",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} action item{s} deleted",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Failed to delete action item",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Failed to delete items",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Failed to delete some items",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Ready for Action Items",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Your AI will automatically extract tasks and to-dos from your conversations. They'll appear here when created.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automatically extracted from conversations",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Tap to edit, swipe to complete or delete",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} selected",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Select all",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Delete selected",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Search {count} Memories",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Memory Deleted.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Undo",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "No memories yet",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "No auto-extracted memories yet",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "No manual memories yet",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "No memories in these categories",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "No memories found",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Add your first memory",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Clear Omi's Memory",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Are you sure you want to clear Omi's memory? This action cannot be undone.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Clear Memory",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omi's memory about you has been cleared",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "No memories to delete",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Create new memory",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Create new action item",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Memory Management",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filter Memories",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "You have {count} total memories",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Public memories",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Private memories",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Make All Memories Private",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Make All Memories Public",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Delete All Memories",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "All memories are now private",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "All memories are now public",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "New Memory",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Edit Memory",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "I like to eat ice cream...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Failed to save. Please check your connection.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Save Memory",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Retry",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Create Action Item",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Edit Action Item",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "What needs to be done?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Action item description cannot be empty.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Action item updated",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Failed to update action item",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Action item created",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Failed to create action item",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Due Date",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Time",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Add due date",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Press done to save",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Press done to create",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "All",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "About You",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Insights",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manual",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Completed",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Mark complete",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Action item deleted",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Failed to delete action item",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Delete Action Item",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Are you sure you want to delete this action item?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "App Language",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "APP-GRÆNSEFLADE",
+  "speechTranscriptionSectionTitle": "TALE OG TRANSSKRIPTION",
+  "languageSettingsHelperText": "App-sprog ændrer menuer og knapper. Talesprog påvirker, hvordan dine optagelser transskriberes."
+}

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -90,7 +90,9 @@
   "selectedCount": "{count} ausgewählt",
   "@selectedCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "merge": "Zusammenführen",
@@ -98,7 +100,9 @@
   "mergeConversationsMessage": "Dies wird {count} Unterhaltungen zu einer zusammenfassen. Alle Inhalte werden zusammengeführt und neu generiert.",
   "@mergeConversationsMessage": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "mergingInBackground": "Zusammenführung im Hintergrund. Dies kann einen Moment dauern.",
@@ -106,7 +110,7 @@
   "askAnything": "Frag irgendetwas",
   "noMessagesYet": "Noch keine Nachrichten!\nWarum starten Sie keine Unterhaltung?",
   "deletingMessages": "Lösche Ihre Nachrichten aus Omis Gedächtnis...",
-  "messageCopied": "Nachricht in die Zwischenablage kopiert.",  
+  "messageCopied": "Nachricht in die Zwischenablage kopiert.",
   "cannotReportOwnMessage": "Sie können Ihre eigenen Nachrichten nicht melden.",
   "reportMessage": "Nachricht melden",
   "reportMessageConfirm": "Sind Sie sicher, dass Sie diese Nachricht melden möchten?",
@@ -408,7 +412,6 @@
   "defaultProjectOptional": "Standardprojekt (Optional)",
   "leaveUnselectedTasks": "Unmarkiert lassen, um Aufgaben ohne Projekt zu erstellen",
   "noProjectsInWorkspace": "Keine Projekte in diesem Arbeitsbereich gefunden",
-  "conversationTimeout": "Unterhaltungs-Timeout",
   "conversationTimeoutDesc": "Wählen Sie, wie lange bei Stille gewartet werden soll, bevor eine Unterhaltung automatisch beendet wird:",
   "timeout2Minutes": "2 Minuten",
   "timeout2MinutesDesc": "Unterhaltung nach 2 Minuten Stille beenden",
@@ -461,15 +464,14 @@
   "configureSettings": "Einstellungen konfigurieren",
   "completeAuthBrowser": "Bitte schließen Sie die Authentifizierung in Ihrem Browser ab. Kehren Sie danach zur App zurück.",
   "failedToStartAppAuth": "Authentifizierung für {appName} konnte nicht gestartet werden",
-  "connectToAppTitle": "Verbinden mit {appName}",
-  "authorizeOmiForTasks": "Sie müssen Omi autorisieren, Aufgaben in Ihrem {appName}-Konto zu erstellen. Dies öffnet Ihren Browser für die Authentifizierung.",
+  "connectToAppTitle": "Mit {appName} verbinden",
+  "authorizeOmiForTasks": "Sie müssen Omi autorisieren, Aufgaben in Ihrem {appName}-Konto zu erstellen. Dies öffnet Ihren Browser zur Authentifizierung.",
   "continueButton": "Weiter",
   "appIntegration": "{appName}-Integration",
   "integrationComingSoon": "Integration mit {appName} kommt bald! Wir arbeiten hart daran, Ihnen mehr Aufgabenmanagement-Optionen zu bieten.",
   "gotIt": "Verstanden",
   "tasksExportedOneApp": "Aufgaben können jeweils nur in eine App exportiert werden.",
   "completeYourUpgrade": "Vervollständigen Sie Ihr Upgrade",
-  "transcription": "Transkription",
   "importConfiguration": "Konfiguration importieren",
   "exportConfiguration": "Konfiguration exportieren",
   "bringYourOwn": "Bring Your Own",
@@ -702,6 +704,8 @@
   "pressDoneToCreate": "Drücken Sie Fertig zum Erstellen",
   "filterAll": "Alle",
   "filterAuto": "Automatisch",
+  "filterInteresting": "Einblicke",
+  "filterSystem": "Über Sie",
   "filterManual": "Manuell",
   "completed": "Erledigt",
   "markComplete": "Als erledigt markieren",
@@ -710,8 +714,6 @@
   "deleteActionItemConfirmTitle": "Aufgabe löschen",
   "deleteActionItemConfirmMessage": "Sind Sie sicher, dass Sie diese Aufgabe löschen möchten?",
   "appLanguage": "App-Sprache",
-  "completeAuthBrowser": "Bitte schließen Sie die Authentifizierung in Ihrem Browser ab. Kehren Sie danach zur App zurück.",
-  "failedToStartAppAuth": "Authentifizierung für {appName} konnte nicht gestartet werden",
   "@failedToStartAppAuth": {
     "placeholders": {
       "appName": {
@@ -719,7 +721,6 @@
       }
     }
   },
-  "connectToAppTitle": "Mit {appName} verbinden",
   "@connectToAppTitle": {
     "placeholders": {
       "appName": {
@@ -727,7 +728,6 @@
       }
     }
   },
-  "authorizeOmiForTasks": "Sie müssen Omi autorisieren, Aufgaben in Ihrem {appName}-Konto zu erstellen. Dies öffnet Ihren Browser zur Authentifizierung.",
   "@authorizeOmiForTasks": {
     "placeholders": {
       "appName": {
@@ -735,5 +735,7 @@
       }
     }
   },
-  "continueButton": "Weiter"
+  "appInterfaceSectionTitle": "APP-OBERFLÄCHE",
+  "speechTranscriptionSectionTitle": "SPRACHE UND TRANSKRIPTION",
+  "languageSettingsHelperText": "Die App-Sprache ändert Menüs und Schaltflächen. Die Sprachsprache beeinflusst, wie Ihre Aufnahmen transkribiert werden."
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "el",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Συνομιλία",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Απομαγνητοφώνηση",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Ενέργειες",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Διαγραφή Συνομιλίας;",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Επιβεβαίωση",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Ακύρωση",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Εντάξει",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Διαγραφή",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Προσθήκη",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Ενημέρωση",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Αποθήκευση",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Επεξεργασία",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Κλείσιμο",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Εκκαθάριση",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Αντιγραφή Απομαγνητοφώνησης",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Αντιγραφή Περίληψης",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Δοκιμή Εντολής",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Επανεπεξεργασία Συνομιλίας",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Διαγραφή Συνομιλίας",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Το περιεχόμενο αντιγράφηκε στο πρόχειρο",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Αποτυχία ενημέρωσης της κατάστασης αγαπημένων.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Δεν ήταν δυνατή η κοινοποίηση του URL της συνομιλίας.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Σφάλμα κατά την επεξεργασία της συνομιλίας. Παρακαλώ δοκιμάστε ξανά αργότερα.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Αδυναμία Διαγραφής Συνομιλίας",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Κάτι πήγε στραβά! Παρακαλώ δοκιμάστε ξανά αργότερα.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Αντιγραφή μηνύματος σφάλματος",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Το μήνυμα σφάλματος αντιγράφηκε στο πρόχειρο",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Υπολειπόμενα",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Φόρτωση...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Φόρτωση διάρκειας...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} δευτερόλεπτα",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Άτομα",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Προσθήκη Νέου Ατόμου",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Επεξεργασία Ατόμου",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Δημιουργήστε ένα νέο άτομο και εκπαιδεύστε το Omi να αναγνωρίζει και την ομιλία του!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Προφίλ Ομιλίας",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Δείγμα {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Ρυθμίσεις",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Γλώσσα",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Επιλογή Γλώσσας",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Διαγραφή...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Αποτυχία έναρξης πιστοποίησης",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Η εισαγωγή ξεκίνησε! Θα ειδοποιηθείτε όταν ολοκληρωθεί.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Αποτυχία έναρξης εισαγωγής. Παρακαλώ δοκιμάστε ξανά.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Δεν ήταν δυνατή η πρόσβαση στο επιλεγμένο αρχείο",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Ρωτήστε το Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Τέλος",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Αποσυνδέθηκε",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Αναζήτηση",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Σύνδεση Συσκευής",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Φτάσατε το μηνιαίο όριό σας.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Έλεγχος Χρήσης",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Συγχρονισμός ηχογραφήσεων",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Ηχογραφήσεις για συγχρονισμό",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Όλα ενημερωμένα",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Συγχρονισμός",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Το περιδέραιο είναι ενημερωμένο",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Όλες οι ηχογραφήσεις συγχρονίστηκαν",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Συγχρονισμός σε εξέλιξη",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Έτοιμο για συγχρονισμό",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Πατήστε Συγχρονισμός για έναρξη",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Το περιδέραιο δεν είναι συνδεδεμένο. Συνδεθείτε για συγχρονισμό.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Όλα είναι ήδη συγχρονισμένα.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Έχετε ηχογραφήσεις που δεν έχουν συγχρονιστεί ακόμα.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Θα συνεχίσουμε να συγχρονίζουμε τις ηχογραφήσεις σας στο παρασκήνιο.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Δεν υπάρχουν συνομιλίες ακόμα.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Δεν υπάρχουν αγαπημένες συνομιλίες ακόμα.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Για να προσθέσετε μια συνομιλία στα αγαπημένα, ανοίξτε τη και πατήστε το εικονίδιο αστεριού στην κεφαλίδα.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Αναζήτηση Συνομιλιών",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} επιλεγμένα",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Συγχώνευση",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Συγχώνευση Συνομιλιών",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Αυτό θα συνδυάσει {count} συνομιλίες σε μία. Όλο το περιεχόμενο θα συγχωνευτεί και θα αναδημιουργηθεί.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Συγχώνευση στο παρασκήνιο. Μπορεί να πάρει λίγο χρόνο.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Αποτυχία έναρξης συγχώνευσης",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Ρωτήστε οτιδήποτε",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Δεν υπάρχουν μηνύματα ακόμα!\nΓιατί δεν ξεκινάτε μια συνομιλία;",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Διαγραφή των μηνυμάτων σας από τη μνήμη του Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Το μήνυμα αντιγράφηκε στο πρόχειρο.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Δεν μπορείτε να αναφέρετε τα δικά σας μηνύματα.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Αναφορά Μηνύματος",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Είστε βέβαιοι ότι θέλετε να αναφέρετε αυτό το μήνυμα;",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Το μήνυμα αναφέρθηκε επιτυχώς.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Ευχαριστούμε για τα σχόλιά σας!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Εκκαθάριση Συνομιλίας;",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Είστε βέβαιοι ότι θέλετε να εκκαθαρίσετε τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Μπορείτε να ανεβάσετε μόνο 4 αρχεία τη φορά",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Συνομιλία με το Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Εφαρμογές",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Δεν βρέθηκαν εφαρμογές",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Δοκιμάστε να προσαρμόσετε την αναζήτηση ή τα φίλτρα σας",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Δημιουργήστε τη Δική σας Εφαρμογή",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Δημιουργήστε και μοιραστείτε την προσαρμοσμένη εφαρμογή σας",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Αναζήτηση 1500+ Εφαρμογών",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Οι Εφαρμογές μου",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Εγκατεστημένες Εφαρμογές",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Αδυναμία λήψης εφαρμογών :(\n\nΠαρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Σχετικά με το Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Πολιτική Απορρήτου",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Επισκεφτείτε τον Ιστότοπο",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Βοήθεια ή Ερωτήσεις;",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Γίνετε μέλος της κοινότητας!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ μέλη και συνεχίζουν.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Διαγραφή Λογαριασμού",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Είστε βέβαιοι ότι θέλετε να διαγράψετε τον λογαριασμό σας;",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Αυτό δεν μπορεί να αναιρεθεί.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Όλες οι αναμνήσεις και οι συνομιλίες σας θα διαγραφούν μόνιμα.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Οι Εφαρμογές και οι Ενσωματώσεις σας θα αποσυνδεθούν αμέσως.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Μπορείτε να εξάγετε τα δεδομένα σας πριν διαγράψετε τον λογαριασμό σας, αλλά μόλις διαγραφεί, δεν μπορεί να ανακτηθεί.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Κατανοώ ότι η διαγραφή του λογαριασμού μου είναι μόνιμη και όλα τα δεδομένα, συμπεριλαμβανομένων των αναμνήσεων και των συνομιλιών, θα χαθούν και δεν μπορούν να ανακτηθούν.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Είστε βέβαιοι;",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Αυτή η ενέργεια είναι μη αναστρέψιμη και θα διαγράψει μόνιμα τον λογαριασμό σας και όλα τα σχετικά δεδομένα. Είστε βέβαιοι ότι θέλετε να συνεχίσετε;",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Διαγραφή Τώρα",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Επιστροφή",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Επιλέξτε το πλαίσιο για να επιβεβαιώσετε ότι κατανοείτε ότι η διαγραφή του λογαριασμού σας είναι μόνιμη και μη αναστρέψιμη.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Προφίλ",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Όνομα",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Email",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Προσαρμοσμένο Λεξιλόγιο",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Αναγνώριση Άλλων",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Μέθοδοι Πληρωμής",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Εμφάνιση Συνομιλίας",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Δεδομένα & Απόρρητο",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Αναγνωριστικό Χρήστη",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Δεν έχει οριστεί",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Το αναγνωριστικό χρήστη αντιγράφηκε στο πρόχειρο",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Προεπιλογή Συστήματος",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Πρόγραμμα & Χρήση",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Συγχρονισμός Εκτός Σύνδεσης",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Ρυθμίσεις Συσκευής",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Εργαλεία Συνομιλίας",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Σχόλια / Σφάλμα",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Κέντρο Βοήθειας",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Ρυθμίσεις Προγραμματιστή",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Αποκτήστε το Omi για Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Πρόγραμμα Παραπομπών",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Αποσύνδεση",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Τα στοιχεία εφαρμογής και συσκευής αντιγράφηκαν",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Το Απόρρητό σας, ο Έλεγχός σας",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Στο Omi, δεσμευόμαστε να προστατεύουμε το απόρρητό σας. Αυτή η σελίδα σας επιτρέπει να ελέγχετε πώς αποθηκεύονται και χρησιμοποιούνται τα δεδομένα σας.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Μάθετε περισσότερα...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Επίπεδο Προστασίας Δεδομένων",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Τα δεδομένα σας είναι ασφαλισμένα από προεπιλογή με ισχυρή κρυπτογράφηση. Ελέγξτε τις ρυθμίσεις σας και τις μελλοντικές επιλογές απορρήτου παρακάτω.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Πρόσβαση Εφαρμογών",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Οι παρακάτω εφαρμογές μπορούν να έχουν πρόσβαση στα δεδομένα σας. Πατήστε σε μια εφαρμογή για να διαχειριστείτε τα δικαιώματά της.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Καμία εγκατεστημένη εφαρμογή δεν έχει εξωτερική πρόσβαση στα δεδομένα σας.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Όνομα Συσκευής",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Αναγνωριστικό Συσκευής",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Λογισμικό",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Συγχρονισμός Κάρτας SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Αναθεώρηση Υλικού",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Αριθμός Μοντέλου",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Κατασκευαστής",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Διπλό Πάτημα",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Φωτεινότητα LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Ενίσχυση Μικροφώνου",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Αποσύνδεση",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Διαγραφή Συσκευής",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Προβλήματα Φόρτισης",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Αποσύνδεση Συσκευής",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Κατάργηση Σύζευξης Συσκευής",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Κατάργηση Σύζευξης και Διαγραφή Συσκευής",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Το Omi σας έχει αποσυνδεθεί 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Η σύζευξη της συσκευής καταργήθηκε. Μεταβείτε στις Ρυθμίσεις > Bluetooth και διαγράψτε τη συσκευή για να ολοκληρώσετε την κατάργηση της σύζευξης.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Κατάργηση Σύζευξης Συσκευής",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Αυτό θα καταργήσει τη σύζευξη της συσκευής ώστε να μπορεί να συνδεθεί σε άλλο τηλέφωνο. Θα χρειαστεί να μεταβείτε στις Ρυθμίσεις > Bluetooth και να διαγράψετε τη συσκευή για να ολοκληρώσετε τη διαδικασία.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Η Συσκευή Δεν Είναι Συνδεδεμένη",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Συνδέστε τη συσκευή Omi για να αποκτήσετε πρόσβαση\nστις ρυθμίσεις και την προσαρμογή της συσκευής",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Πληροφορίες Συσκευής",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Προσαρμογή",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Υλικό",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "Δεν ανιχνεύτηκε V2",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Βλέπουμε ότι είτε έχετε συσκευή V1 είτε η συσκευή σας δεν είναι συνδεδεμένη. Η λειτουργικότητα κάρτας SD είναι διαθέσιμη μόνο για συσκευές V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Τερματισμός Συνομιλίας",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Παύση/Συνέχιση",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Αγαπημένη Συνομιλία",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Ενέργεια Διπλού Πατήματος",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Τερματισμός & Επεξεργασία Συνομιλίας",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Παύση/Συνέχιση Εγγραφής",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Αγαπημένη Τρέχουσα Συνομιλία",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Ανενεργό",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Μέγιστο",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Σίγαση",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Ήσυχο",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Κανονικό",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Υψηλό",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Το μικρόφωνο είναι σε σίγαση",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Πολύ ήσυχο - για θορυβώδη περιβάλλοντα",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Ήσυχο - για μέτριο θόρυβο",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Ουδέτερο - ισορροπημένη εγγραφή",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Ελαφρώς ενισχυμένο - κανονική χρήση",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Ενισχυμένο - για ήσυχα περιβάλλοντα",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Υψηλό - για απομακρυσμένες ή απαλές φωνές",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Πολύ υψηλό - για πολύ ήσυχες πηγές",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Μέγιστο - χρησιμοποιήστε με προσοχή",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Ρυθμίσεις Προγραμματιστή",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Αποθήκευση...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Διαμορφώστε την προσωπικότητα του AI σας",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Απομαγνητοφώνηση",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Διαμόρφωση παρόχου STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Λήξη Χρόνου Συνομιλίας",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Ορίστε πότε τελειώνουν αυτόματα οι συνομιλίες",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Εισαγωγή Δεδομένων",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Εισαγωγή δεδομένων από άλλες πηγές",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Εντοπισμός Σφαλμάτων & Διαγνωστικά",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL Τελικού Σημείου",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Δεν υπάρχουν κλειδιά API ακόμα",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Δημιουργήστε ένα κλειδί για να ξεκινήσετε",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Δημιουργία Κλειδιού",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Τεκμηρίωση",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Οι Πληροφορίες σας στο Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Σήμερα",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Αυτόν τον Μήνα",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Φέτος",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Συνολικά",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Καμία Δραστηριότητα Ακόμα",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Ξεκινήστε μια συνομιλία με το Omi\nγια να δείτε τις πληροφορίες χρήσης σας εδώ.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Ακρόαση",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Συνολικός χρόνος που το Omi έχει ακούσει ενεργά.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Κατανόηση",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Λέξεις που κατανοήθηκαν από τις συνομιλίες σας.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Παροχή",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Ενέργειες και σημειώσεις που καταγράφονται αυτόματα.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Απομνημόνευση",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Γεγονότα και λεπτομέρειες που απομνημονεύονται για εσάς.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Απεριόριστο Πρόγραμμα",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Διαχείριση Προγράμματος",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Το πρόγραμμά σας θα ακυρωθεί στις {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Το πρόγραμμά σας ανανεώνεται στις {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Δωρεάν Πρόγραμμα",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} από {limit} λεπτά χρησιμοποιήθηκαν",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Αναβάθμιση",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Αναβάθμιση σε Απεριόριστο",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Το πρόγραμμά σας περιλαμβάνει {limit} δωρεάν λεπτά ανά μήνα. Αναβαθμίστε για απεριόριστη χρήση.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Μοιράζομαι τα στατιστικά μου στο Omi! (omi.me - ο πάντα ενεργός βοηθός AI σας)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Σήμερα, το omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Αυτόν τον μήνα, το omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Φέτος, το omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Μέχρι τώρα, το omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Άκουσε για {minutes} λεπτά",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Κατανόησε {words} λέξεις",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Παρείχε {count} πληροφορίες",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Απομνημόνευσε {count} αναμνήσεις",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Αρχεία Εντοπισμού Σφαλμάτων",
+  "debugLogsAutoDelete": "Αυτόματη διαγραφή μετά από 3 ημέρες.",
+  "debugLogsDesc": "Βοηθά στη διάγνωση προβλημάτων",
+  "noLogFilesFound": "Δεν βρέθηκαν αρχεία καταγραφής.",
+  "omiDebugLog": "Αρχείο εντοπισμού σφαλμάτων Omi",
+  "logShared": "Το αρχείο καταγραφής κοινοποιήθηκε",
+  "selectLogFile": "Επιλογή Αρχείου Καταγραφής",
+  "shareLogs": "Κοινοποίηση Αρχείων Καταγραφής",
+  "debugLogCleared": "Το αρχείο εντοπισμού σφαλμάτων εκκαθαρίστηκε",
+  "exportStarted": "Η εξαγωγή ξεκίνησε. Μπορεί να διαρκέσει μερικά δευτερόλεπτα...",
+  "exportAllData": "Εξαγωγή Όλων των Δεδομένων",
+  "exportDataDesc": "Εξαγωγή συνομιλιών σε αρχείο JSON",
+  "exportedConversations": "Εξαγωγή Συνομιλιών από το Omi",
+  "exportShared": "Η εξαγωγή κοινοποιήθηκε",
+  "deleteKnowledgeGraphTitle": "Διαγραφή Γραφήματος Γνώσης;",
+  "deleteKnowledgeGraphMessage": "Αυτό θα διαγράψει όλα τα παράγωγα δεδομένα του γραφήματος γνώσης (κόμβοι και συνδέσεις). Οι αρχικές αναμνήσεις σας θα παραμείνουν ασφαλείς. Το γράφημα θα ξαναδημιουργηθεί με το χρόνο ή στο επόμενο αίτημα.",
+  "knowledgeGraphDeleted": "Το Γράφημα Γνώσης διαγράφηκε επιτυχώς",
+  "deleteGraphFailed": "Αποτυχία διαγραφής γραφήματος: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Διαγραφή Γραφήματος Γνώσης",
+  "deleteKnowledgeGraphDesc": "Εκκαθάριση όλων των κόμβων και των συνδέσεων",
+  "mcp": "MCP",
+  "mcpServer": "Διακομιστής MCP",
+  "mcpServerDesc": "Συνδέστε βοηθούς AI στα δεδομένα σας",
+  "serverUrl": "URL Διακομιστή",
+  "urlCopied": "Το URL αντιγράφηκε",
+  "apiKeyAuth": "Πιστοποίηση Κλειδιού API",
+  "header": "Κεφαλίδα",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Αναγνωριστικό Πελάτη",
+  "clientSecret": "Μυστικό Πελάτη",
+  "useMcpApiKey": "Χρησιμοποιήστε το κλειδί MCP API σας",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Συμβάντα Συνομιλίας",
+  "newConversationCreated": "Δημιουργήθηκε νέα συνομιλία",
+  "realtimeTranscript": "Απομαγνητοφώνηση σε Πραγματικό Χρόνο",
+  "transcriptReceived": "Λήφθηκε απομαγνητοφώνηση",
+  "audioBytes": "Bytes Ήχου",
+  "audioDataReceived": "Λήφθηκαν δεδομένα ήχου",
+  "intervalSeconds": "Διάστημα (δευτερόλεπτα)",
+  "daySummary": "Περίληψη Ημέρας",
+  "summaryGenerated": "Δημιουργήθηκε περίληψη",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Προσθήκη στο claude_desktop_config.json",
+  "copyConfig": "Αντιγραφή Διαμόρφωσης",
+  "configCopied": "Η διαμόρφωση αντιγράφηκε στο πρόχειρο",
+  "listeningMins": "Ακρόαση (λεπτά)",
+  "understandingWords": "Κατανόηση (λέξεις)",
+  "insights": "Πληροφορίες",
+  "memories": "Αναμνήσεις",
+  "minsUsedThisMonth": "{used} από {limit} λεπτά χρησιμοποιήθηκαν αυτόν τον μήνα",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} από {limit} λέξεις χρησιμοποιήθηκαν αυτόν τον μήνα",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} από {limit} πληροφορίες αποκτήθηκαν αυτόν τον μήνα",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} από {limit} αναμνήσεις δημιουργήθηκαν αυτόν τον μήνα",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Ορατότητα",
+  "visibilitySubtitle": "Ελέγξτε ποιες συνομιλίες εμφανίζονται στη λίστα σας",
+  "showShortConversations": "Εμφάνιση Σύντομων Συνομιλιών",
+  "showShortConversationsDesc": "Εμφάνιση συνομιλιών συντομότερων από το όριο",
+  "showDiscardedConversations": "Εμφάνιση Απορριφθεισών Συνομιλιών",
+  "showDiscardedConversationsDesc": "Συμπερίληψη συνομιλιών που επισημάνθηκαν ως απορριφθείσες",
+  "shortConversationThreshold": "Όριο Σύντομης Συνομιλίας",
+  "shortConversationThresholdSubtitle": "Οι συνομιλίες συντομότερες από αυτό θα αποκρύπτονται εκτός αν ενεργοποιηθούν παραπάνω",
+  "durationThreshold": "Όριο Διάρκειας",
+  "durationThresholdDesc": "Απόκρυψη συνομιλιών συντομότερων από αυτό",
+  "minLabel": "{count} λεπτά",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Προσαρμοσμένο Λεξιλόγιο",
+  "addWords": "Προσθήκη Λέξεων",
+  "addWordsDesc": "Ονόματα, όροι ή ασυνήθιστες λέξεις",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Σύνδεση",
+  "comingSoon": "Σύντομα Διαθέσιμο",
+  "chatToolsFooter": "Συνδέστε τις εφαρμογές σας για να δείτε δεδομένα και μετρήσεις στη συνομιλία.",
+  "completeAuthInBrowser": "Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.",
+  "failedToStartAuth": "Αποτυχία έναρξης πιστοποίησης {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Αποσύνδεση από {appName};",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Είστε βέβαιοι ότι θέλετε να αποσυνδεθείτε από το {appName}; Μπορείτε να επανασυνδεθείτε ανά πάσα στιγμή.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Αποσυνδέθηκε από {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Αποτυχία αποσύνδεσης",
+  "connectTo": "Σύνδεση με {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Θα χρειαστεί να εξουσιοδοτήσετε το Omi να έχει πρόσβαση στα δεδομένα σας στο {appName}. Αυτό θα ανοίξει το πρόγραμμα περιήγησής σας για πιστοποίηση.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Συνέχεια",
+  "languageTitle": "Γλώσσα",
+  "primaryLanguage": "Κύρια Γλώσσα",
+  "automaticTranslation": "Αυτόματη Μετάφραση",
+  "detectLanguages": "Ανίχνευση 10+ γλωσσών",
+  "authorizeSavingRecordings": "Εξουσιοδότηση Αποθήκευσης Εγγραφών",
+  "thanksForAuthorizing": "Ευχαριστούμε για την εξουσιοδότηση!",
+  "needYourPermission": "Χρειαζόμαστε την άδειά σας",
+  "alreadyGavePermission": "Έχετε ήδη δώσει την άδειά σας για αποθήκευση των εγγραφών σας. Ορίστε μια υπενθύμιση γιατί το χρειαζόμαστε:",
+  "wouldLikePermission": "Θα θέλαμε την άδειά σας για αποθήκευση των φωνητικών σας εγγραφών. Εδώ είναι γιατί:",
+  "improveSpeechProfile": "Βελτίωση του Προφίλ Ομιλίας σας",
+  "improveSpeechProfileDesc": "Χρησιμοποιούμε τις εγγραφές για περαιτέρω εκπαίδευση και βελτίωση του προσωπικού σας προφίλ ομιλίας.",
+  "trainFamilyProfiles": "Εκπαίδευση Προφίλ για Φίλους και Οικογένεια",
+  "trainFamilyProfilesDesc": "Οι εγγραφές σας μας βοηθούν να αναγνωρίζουμε και να δημιουργούμε προφίλ για τους φίλους και την οικογένειά σας.",
+  "enhanceTranscriptAccuracy": "Βελτίωση της Ακρίβειας Απομαγνητοφώνησης",
+  "enhanceTranscriptAccuracyDesc": "Καθώς το μοντέλο μας βελτιώνεται, μπορούμε να παρέχουμε καλύτερα αποτελέσματα απομαγνητοφώνησης για τις εγγραφές σας.",
+  "legalNotice": "Νομική Ειδοποίηση: Η νομιμότητα της εγγραφής και αποθήκευσης φωνητικών δεδομένων μπορεί να διαφέρει ανάλογα με την τοποθεσία σας και τον τρόπο χρήσης αυτής της λειτουργίας. Είναι δική σας ευθύνη να διασφαλίσετε τη συμμόρφωση με τους τοπικούς νόμους και κανονισμούς.",
+  "alreadyAuthorized": "Ήδη Εξουσιοδοτημένο",
+  "authorize": "Εξουσιοδότηση",
+  "revokeAuthorization": "Ανάκληση Εξουσιοδότησης",
+  "authorizationSuccessful": "Η εξουσιοδότηση ήταν επιτυχής!",
+  "failedToAuthorize": "Αποτυχία εξουσιοδότησης. Παρακαλώ δοκιμάστε ξανά.",
+  "authorizationRevoked": "Η εξουσιοδότηση ανακλήθηκε.",
+  "recordingsDeleted": "Οι εγγραφές διαγράφηκαν.",
+  "failedToRevoke": "Αποτυχία ανάκλησης εξουσιοδότησης. Παρακαλώ δοκιμάστε ξανά.",
+  "permissionRevokedTitle": "Η Άδεια Ανακλήθηκε",
+  "permissionRevokedMessage": "Θέλετε να αφαιρέσουμε επίσης όλες τις υπάρχουσες εγγραφές σας;",
+  "yes": "Ναι",
+  "editName": "Επεξεργασία Ονόματος",
+  "howShouldOmiCallYou": "Πώς θα πρέπει να σας αποκαλεί το Omi;",
+  "enterYourName": "Εισάγετε το όνομά σας",
+  "nameCannotBeEmpty": "Το όνομα δεν μπορεί να είναι κενό",
+  "nameUpdatedSuccessfully": "Το όνομα ενημερώθηκε επιτυχώς!",
+  "calendarSettings": "Ρυθμίσεις ημερολογίου",
+  "calendarProviders": "Πάροχοι Ημερολογίου",
+  "macOsCalendar": "Ημερολόγιο macOS",
+  "connectMacOsCalendar": "Συνδέστε το τοπικό σας ημερολόγιο macOS",
+  "googleCalendar": "Ημερολόγιο Google",
+  "syncGoogleAccount": "Συγχρονισμός με τον λογαριασμό σας Google",
+  "showMeetingsMenuBar": "Εμφάνιση επερχόμενων συναντήσεων στη γραμμή μενού",
+  "showMeetingsMenuBarDesc": "Εμφάνιση της επόμενης συνάντησής σας και του χρόνου μέχρι να ξεκινήσει στη γραμμή μενού του macOS",
+  "showEventsNoParticipants": "Εμφάνιση συμβάντων χωρίς συμμετέχοντες",
+  "showEventsNoParticipantsDesc": "Όταν είναι ενεργοποιημένο, το Coming Up εμφανίζει συμβάντα χωρίς συμμετέχοντες ή σύνδεσμο βίντεο.",
+  "yourMeetings": "Οι Συναντήσεις σας",
+  "refresh": "Ανανέωση",
+  "noUpcomingMeetings": "Δεν βρέθηκαν επερχόμενες συναντήσεις",
+  "checkingNextDays": "Έλεγχος επόμενων 30 ημερών",
+  "tomorrow": "Αύριο",
+  "googleCalendarComingSoon": "Η ενσωμάτωση με το Ημερολόγιο Google έρχεται σύντομα!",
+  "connectedAsUser": "Συνδεδεμένο ως χρήστης: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Προεπιλεγμένος Χώρος Εργασίας",
+  "tasksCreatedInWorkspace": "Οι εργασίες θα δημιουργηθούν σε αυτόν τον χώρο εργασίας",
+  "defaultProjectOptional": "Προεπιλεγμένο Έργο (Προαιρετικό)",
+  "leaveUnselectedTasks": "Αφήστε το ανεπίλεκτο για δημιουργία εργασιών χωρίς έργο",
+  "noProjectsInWorkspace": "Δεν βρέθηκαν έργα σε αυτόν τον χώρο εργασίας",
+  "conversationTimeoutDesc": "Επιλέξτε πόσο χρόνο να περιμένει σε σιωπή πριν τερματιστεί αυτόματα μια συνομιλία:",
+  "timeout2Minutes": "2 λεπτά",
+  "timeout2MinutesDesc": "Τερματισμός συνομιλίας μετά από 2 λεπτά σιωπής",
+  "timeout5Minutes": "5 λεπτά",
+  "timeout5MinutesDesc": "Τερματισμός συνομιλίας μετά από 5 λεπτά σιωπής",
+  "timeout10Minutes": "10 λεπτά",
+  "timeout10MinutesDesc": "Τερματισμός συνομιλίας μετά από 10 λεπτά σιωπής",
+  "timeout30Minutes": "30 λεπτά",
+  "timeout30MinutesDesc": "Τερματισμός συνομιλίας μετά από 30 λεπτά σιωπής",
+  "timeout4Hours": "4 ώρες",
+  "timeout4HoursDesc": "Τερματισμός συνομιλίας μετά από 4 ώρες σιωπής",
+  "conversationEndAfterHours": "Οι συνομιλίες θα τερματίζονται πλέον μετά από 4 ώρες σιωπής",
+  "conversationEndAfterMinutes": "Οι συνομιλίες θα τερματίζονται πλέον μετά από {minutes} λεπτό(-ά) σιωπής",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Πείτε μας την κύρια γλώσσα σας",
+  "languageForTranscription": "Ορίστε τη γλώσσα σας για πιο ακριβείς απομαγνητοφωνήσεις και εξατομικευμένη εμπειρία.",
+  "singleLanguageModeInfo": "Η Λειτουργία Μονής Γλώσσας είναι ενεργοποιημένη. Η μετάφραση είναι απενεργοποιημένη για μεγαλύτερη ακρίβεια.",
+  "searchLanguageHint": "Αναζήτηση γλώσσας με όνομα ή κωδικό",
+  "noLanguagesFound": "Δεν βρέθηκαν γλώσσες",
+  "skip": "Παράλειψη",
+  "languageSetTo": "Η γλώσσα ορίστηκε σε {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Αποτυχία ορισμού γλώσσας",
+  "appSettings": "Ρυθμίσεις {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Αποσύνδεση από {appName};",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Αυτό θα αφαιρέσει την πιστοποίησή σας στο {appName}. Θα χρειαστεί να επανασυνδεθείτε για να το χρησιμοποιήσετε ξανά.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Συνδεδεμένο στο {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Λογαριασμός",
+  "actionItemsSyncedTo": "Οι ενέργειές σας θα συγχρονιστούν με τον λογαριασμό σας {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Προεπιλεγμένος Χώρος",
+  "selectSpaceInWorkspace": "Επιλέξτε έναν χώρο στον χώρο εργασίας σας",
+  "noSpacesInWorkspace": "Δεν βρέθηκαν χώροι σε αυτόν τον χώρο εργασίας",
+  "defaultList": "Προεπιλεγμένη Λίστα",
+  "tasksAddedToList": "Οι εργασίες θα προστεθούν σε αυτή τη λίστα",
+  "noListsInSpace": "Δεν βρέθηκαν λίστες σε αυτόν τον χώρο",
+  "failedToLoadRepos": "Αποτυχία φόρτωσης αποθετηρίων: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Το προεπιλεγμένο αποθετήριο αποθηκεύτηκε",
+  "failedToSaveDefaultRepo": "Αποτυχία αποθήκευσης προεπιλεγμένου αποθετηρίου",
+  "defaultRepository": "Προεπιλεγμένο Αποθετήριο",
+  "selectDefaultRepoDesc": "Επιλέξτε ένα προεπιλεγμένο αποθετήριο για δημιουργία ζητημάτων. Μπορείτε ακόμα να καθορίσετε διαφορετικό αποθετήριο κατά τη δημιουργία ζητημάτων.",
+  "noReposFound": "Δεν βρέθηκαν αποθετήρια",
+  "private": "Ιδιωτικό",
+  "updatedDate": "Ενημερώθηκε {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "χθες",
+  "daysAgo": "πριν από {count} ημέρες",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "πριν από 1 εβδομάδα",
+  "weeksAgo": "πριν από {count} εβδομάδες",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "πριν από 1 μήνα",
+  "monthsAgo": "πριν από {count} μήνες",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Τα ζητήματα θα δημιουργηθούν στο προεπιλεγμένο σας αποθετήριο",
+  "taskIntegrations": "Ενσωματώσεις Εργασιών",
+  "configureSettings": "Διαμόρφωση Ρυθμίσεων",
+  "completeAuthBrowser": "Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.",
+  "failedToStartAppAuth": "Αποτυχία έναρξης πιστοποίησης {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Σύνδεση με {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Θα χρειαστεί να εξουσιοδοτήσετε το Omi να δημιουργεί εργασίες στον λογαριασμό σας {appName}. Αυτό θα ανοίξει το πρόγραμμα περιήγησής σας για πιστοποίηση.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Συνέχεια",
+  "appIntegration": "Ενσωμάτωση {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Η ενσωμάτωση με το {appName} έρχεται σύντομα! Εργαζόμαστε σκληρά για να σας φέρουμε περισσότερες επιλογές διαχείρισης εργασιών.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Το κατάλαβα",
+  "tasksExportedOneApp": "Οι εργασίες μπορούν να εξαχθούν σε μία εφαρμογή τη φορά.",
+  "completeYourUpgrade": "Ολοκληρώστε την Αναβάθμισή σας",
+  "importConfiguration": "Εισαγωγή Διαμόρφωσης",
+  "exportConfiguration": "Εξαγωγή διαμόρφωσης",
+  "bringYourOwn": "Φέρτε το δικό σας",
+  "payYourSttProvider": "Χρησιμοποιήστε ελεύθερα το omi. Πληρώνετε μόνο τον πάροχο STT σας απευθείας.",
+  "freeMinutesMonth": "1.200 δωρεάν λεπτά/μήνα συμπεριλαμβάνονται. Απεριόριστο με ",
+  "omiUnlimited": "Omi Απεριόριστο",
+  "hostRequired": "Απαιτείται διακομιστής",
+  "validPortRequired": "Απαιτείται έγκυρη θύρα",
+  "validWebsocketUrlRequired": "Απαιτείται έγκυρο URL WebSocket (wss://)",
+  "apiUrlRequired": "Απαιτείται URL API",
+  "apiKeyRequired": "Απαιτείται κλειδί API",
+  "invalidJsonConfig": "Μη έγκυρη διαμόρφωση JSON",
+  "errorSaving": "Σφάλμα αποθήκευσης: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Η διαμόρφωση αντιγράφηκε στο πρόχειρο",
+  "pasteJsonConfig": "Επικολλήστε τη διαμόρφωση JSON σας παρακάτω:",
+  "addApiKeyAfterImport": "Θα χρειαστεί να προσθέσετε το δικό σας κλειδί API μετά την εισαγωγή",
+  "paste": "Επικόλληση",
+  "import": "Εισαγωγή",
+  "invalidProviderInConfig": "Μη έγκυρος πάροχος στη διαμόρφωση",
+  "importedConfig": "Εισήχθη η διαμόρφωση {providerName}",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Μη έγκυρο JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Πάροχος",
+  "live": "Ζωντανά",
+  "onDevice": "Στη Συσκευή",
+  "apiUrl": "URL API",
+  "enterSttHttpEndpoint": "Εισάγετε το τελικό σημείο HTTP STT σας",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Εισάγετε το τελικό σημείο WebSocket STT ζωντανά",
+  "apiKey": "Κλειδί API",
+  "enterApiKey": "Εισάγετε το κλειδί API σας",
+  "storedLocallyNeverShared": "Αποθηκεύεται τοπικά, δεν κοινοποιείται ποτέ",
+  "host": "Διακομιστής",
+  "port": "Θύρα",
+  "advanced": "Προχωρημένα",
+  "configuration": "Διαμόρφωση",
+  "requestConfiguration": "Διαμόρφωση Αιτήματος",
+  "responseSchema": "Σχήμα Απόκρισης",
+  "modified": "Τροποποιημένο",
+  "resetRequestConfig": "Επαναφορά διαμόρφωσης αιτήματος στην προεπιλογή",
+  "logs": "Αρχεία Καταγραφής",
+  "logsCopied": "Τα αρχεία καταγραφής αντιγράφηκαν",
+  "noLogsYet": "Δεν υπάρχουν ακόμα αρχεία καταγραφής. Ξεκινήστε εγγραφή για να δείτε προσαρμοσμένη δραστηριότητα STT.",
+  "deviceUsesCodec": "Το {deviceName} χρησιμοποιεί {codecReason}. Θα χρησιμοποιηθεί το Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Απομαγνητοφώνηση Omi",
+  "bestInClassTranscription": "Κορυφαία απομαγνητοφώνηση χωρίς καμία ρύθμιση",
+  "instantSpeakerLabels": "Άμεσες ετικέτες ομιλητών",
+  "languageTranslation": "Μετάφραση 100+ γλωσσών",
+  "optimizedForConversation": "Βελτιστοποιημένο για συνομιλία",
+  "autoLanguageDetection": "Αυτόματη ανίχνευση γλώσσας",
+  "highAccuracy": "Υψηλή ακρίβεια",
+  "privacyFirst": "Πρώτα το απόρρητο",
+  "saveChanges": "Αποθήκευση Αλλαγών",
+  "resetToDefault": "Επαναφορά στην Προεπιλογή",
+  "viewTemplate": "Προβολή Προτύπου",
+  "trySomethingLike": "Δοκιμάστε κάτι σαν...",
+  "tryIt": "Δοκιμάστε το",
+  "creatingPlan": "Δημιουργία σχεδίου",
+  "developingLogic": "Ανάπτυξη λογικής",
+  "designingApp": "Σχεδιασμός εφαρμογής",
+  "generatingIconStep": "Δημιουργία εικονιδίου",
+  "finalTouches": "Τελικές πινελιές",
+  "processing": "Επεξεργασία...",
+  "features": "Χαρακτηριστικά",
+  "creatingYourApp": "Δημιουργία της εφαρμογής σας...",
+  "generatingIcon": "Δημιουργία εικονιδίου...",
+  "whatShouldWeMake": "Τι να φτιάξουμε;",
+  "appName": "Όνομα Εφαρμογής",
+  "description": "Περιγραφή",
+  "publicLabel": "Δημόσιο",
+  "privateLabel": "Ιδιωτικό",
+  "free": "Δωρεάν",
+  "perMonth": "/ Μήνα",
+  "tailoredConversationSummaries": "Εξατομικευμένες Περιλήψεις Συνομιλιών",
+  "customChatbotPersonality": "Προσαρμοσμένη Προσωπικότητα Chatbot",
+  "makePublic": "Δημοσίευση",
+  "anyoneCanDiscover": "Οποιοσδήποτε μπορεί να ανακαλύψει την εφαρμογή σας",
+  "onlyYouCanUse": "Μόνο εσείς μπορείτε να χρησιμοποιήσετε αυτή την εφαρμογή",
+  "paidApp": "Επί πληρωμή εφαρμογή",
+  "usersPayToUse": "Οι χρήστες πληρώνουν για να χρησιμοποιήσουν την εφαρμογή σας",
+  "freeForEveryone": "Δωρεάν για όλους",
+  "perMonthLabel": "/ μήνα",
+  "creating": "Δημιουργία...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Δημιουργία Εφαρμογής",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Αναζήτηση συσκευών...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{ΣΥΣΚΕΥΗ} other{ΣΥΣΚΕΥΕΣ}} ΒΡΕΘΗΚΑΝ ΚΟΝΤΑ",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "Η ΣΥΖΕΥΞΗ ΗΤΑΝ ΕΠΙΤΥΧΗΣ",
+  "errorConnectingAppleWatch": "Σφάλμα σύνδεσης με Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Να μην εμφανιστεί ξανά",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Κατάλαβα",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Ενεργοποίηση Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Το Omi χρειάζεται Bluetooth για σύνδεση με τη φορητή σας συσκευή. Παρακαλώ ενεργοποιήστε το Bluetooth και δοκιμάστε ξανά.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Επικοινωνία με Υποστήριξη;",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Σύνδεση Αργότερα",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Χορήγηση αδειών",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Δραστηριότητα παρασκηνίου",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Επιτρέψτε στο Omi να εκτελείται στο παρασκήνιο για καλύτερη σταθερότητα",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Πρόσβαση τοποθεσίας",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Ενεργοποιήστε την τοποθεσία παρασκηνίου για την πλήρη εμπειρία",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Ειδοποιήσεις",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Ενεργοποιήστε τις ειδοποιήσεις για να ενημερώνεστε",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Η Υπηρεσία Τοποθεσίας είναι Απενεργοποιημένη",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Η Υπηρεσία Τοποθεσίας είναι Απενεργοποιημένη. Παρακαλώ μεταβείτε στις Ρυθμίσεις > Απόρρητο & Ασφάλεια > Υπηρεσίες Τοποθεσίας και ενεργοποιήστε την",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Απορρίφθηκε η Πρόσβαση Τοποθεσίας Παρασκηνίου",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Παρακαλώ μεταβείτε στις ρυθμίσεις της συσκευής και ορίστε την άδεια τοποθεσίας σε \"Πάντα Να Επιτρέπεται\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Αγαπάτε το Omi;",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Βοηθήστε μας να φτάσουμε σε περισσότερους ανθρώπους αφήνοντας μια κριτική στο App Store. Τα σχόλιά σας σημαίνουν τα πάντα για εμάς!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Βοηθήστε μας να φτάσουμε σε περισσότερους ανθρώπους αφήνοντας μια κριτική στο Google Play Store. Τα σχόλιά σας σημαίνουν τα πάντα για εμάς!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Αξιολόγηση στο App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Αξιολόγηση στο Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Ίσως αργότερα",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Το Omi πρέπει να μάθει τους στόχους και τη φωνή σας. Θα μπορείτε να το τροποποιήσετε αργότερα.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Ξεκινήστε",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Όλα έτοιμα!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Συνεχίστε, τα πηγαίνετε υπέροχα",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Παράλειψη αυτής της ερώτησης",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Παράλειψη προς το παρόν",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Σφάλμα Σύνδεσης",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Αποτυχία σύνδεσης με τον διακομιστή. Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Ανιχνεύθηκε μη έγκυρη εγγραφή",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Φαίνεται ότι υπάρχουν πολλοί ομιλητές στην εγγραφή. Παρακαλώ βεβαιωθείτε ότι βρίσκεστε σε ήσυχο χώρο και δοκιμάστε ξανά.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Δεν ανιχνεύθηκε αρκετή ομιλία. Παρακαλώ μιλήστε περισσότερο και δοκιμάστε ξανά.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Παρακαλώ βεβαιωθείτε ότι μιλάτε για τουλάχιστον 5 δευτερόλεπτα και όχι περισσότερο από 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Είστε εκεί;",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Δεν μπορέσαμε να ανιχνεύσουμε καμία ομιλία. Παρακαλώ βεβαιωθείτε ότι μιλάτε για τουλάχιστον 10 δευτερόλεπτα και όχι περισσότερο από 3 λεπτά.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Η Σύνδεση Χάθηκε",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Η σύνδεση διακόπηκε. Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Δοκιμάστε Ξανά",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Σύνδεση Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Συνέχεια Χωρίς Συσκευή",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Απαιτούνται Άδειες",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Αυτή η εφαρμογή χρειάζεται άδειες Bluetooth και Τοποθεσίας για να λειτουργήσει σωστά. Παρακαλώ ενεργοποιήστε τις στις ρυθμίσεις.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Άνοιγμα Ρυθμίσεων",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Θέλετε να αποκαλείστε διαφορετικά;",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Ποιο είναι το όνομά σας;",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Μιλήστε. Απομαγνητοφώνηση. Περίληψη.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Σύνδεση με Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Σύνδεση με Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Συνεχίζοντας, συμφωνείτε με την ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Όροι Χρήσης",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Ο Βοηθός AI σας",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Καταγράψτε κάθε στιγμή. Λάβετε περιλήψεις\nμε AI. Μην κρατάτε ποτέ ξανά σημειώσεις.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Ρύθμιση Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Ζητήθηκε Άδεια!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Άδεια Μικροφώνου",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Η άδεια χορηγήθηκε! Τώρα:\n\nΑνοίξτε την εφαρμογή Omi στο ρολόι σας και πατήστε \"Συνέχεια\" παρακάτω",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Χρειαζόμαστε άδεια μικροφώνου.\n\n1. Πατήστε \"Χορήγηση Άδειας\"\n2. Επιτρέψτε στο iPhone σας\n3. Η εφαρμογή ρολογιού θα κλείσει\n4. Ανοίξτε ξανά και πατήστε \"Συνέχεια\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Χορήγηση Άδειας",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Χρειάζεστε Βοήθεια;",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Αντιμετώπιση προβλημάτων:\n\n1. Βεβαιωθείτε ότι το Omi είναι εγκατεστημένο στο ρολόι σας\n2. Ανοίξτε την εφαρμογή Omi στο ρολόι σας\n3. Αναζητήστε το αναδυόμενο παράθυρο άδειας\n4. Πατήστε \"Επιτρέπεται\" όταν σας ζητηθεί\n5. Η εφαρμογή στο ρολόι σας θα κλείσει - ανοίξτε την ξανά\n6. Επιστρέψτε και πατήστε \"Συνέχεια\" στο iPhone σας",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Η εγγραφή ξεκίνησε επιτυχώς!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Η άδεια δεν έχει χορηγηθεί ακόμα. Παρακαλώ βεβαιωθείτε ότι επιτρέψατε την πρόσβαση στο μικρόφωνο και ανοίξατε ξανά την εφαρμογή στο ρολόι σας.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Σφάλμα αιτήματος άδειας: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Σφάλμα έναρξης εγγραφής: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Επιλέξτε την κύρια γλώσσα σας",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Ορίστε τη γλώσσα σας για πιο ακριβείς απομαγνητοφωνήσεις και εξατομικευμένη εμπειρία",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Ποια είναι η κύρια γλώσσα σας;",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Επιλέξτε τη γλώσσα σας",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Το προσωπικό σας ταξίδι ανάπτυξης με AI που ακούει κάθε σας λέξη.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Προς Εκτέλεση",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Πατήστε για επεξεργασία • Παρατεταμένο πάτημα για επιλογή • Σύρετε για ενέργειες",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Προς Εκτέλεση",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Ολοκληρωμένα",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Παλιά",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Είστε ενημερωμένοι!\nΔεν υπάρχουν εκκρεμείς ενέργειες",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Δεν υπάρχουν ολοκληρωμένα στοιχεία ακόμα",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Δεν υπάρχουν παλιές εργασίες",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Δεν υπάρχουν στοιχεία",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Η ενέργεια επισημάνθηκε ως ημιτελής",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Η ενέργεια ολοκληρώθηκε",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Διαγραφή Ενέργειας",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή την ενέργεια;",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Διαγραφή Επιλεγμένων Στοιχείων",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Είστε βέβαιοι ότι θέλετε να διαγράψετε {count} επιλεγμένες ενέργειες{s};",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Η ενέργεια \"{description}\" διαγράφηκε",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} ενέργειες{s} διαγράφηκαν",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Αποτυχία διαγραφής ενέργειας",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Αποτυχία διαγραφής στοιχείων",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Αποτυχία διαγραφής ορισμένων στοιχείων",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Έτοιμοι για Ενέργειες",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Το AI σας θα εξάγει αυτόματα εργασίες και υποχρεώσεις από τις συνομιλίες σας. Θα εμφανιστούν εδώ όταν δημιουργηθούν.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Αυτόματη εξαγωγή από συνομιλίες",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Πατήστε για επεξεργασία, σύρετε για ολοκλήρωση ή διαγραφή",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} επιλεγμένα",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Επιλογή όλων",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Διαγραφή επιλεγμένων",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Αναζήτηση {count} Αναμνήσεων",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Η ανάμνηση διαγράφηκε.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Αναίρεση",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Δεν υπάρχουν αναμνήσεις ακόμα",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Δεν υπάρχουν αυτόματα εξαγόμενες αναμνήσεις ακόμα",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Δεν υπάρχουν χειροκίνητες αναμνήσεις ακόμα",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Δεν υπάρχουν αναμνήσεις σε αυτές τις κατηγορίες",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Δεν βρέθηκαν αναμνήσεις",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Προσθέστε την πρώτη σας ανάμνηση",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Εκκαθάριση Μνήμης του Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Είστε βέβαιοι ότι θέλετε να εκκαθαρίσετε τη μνήμη του Omi; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Εκκαθάριση Μνήμης",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Η μνήμη του Omi για εσάς έχει εκκαθαριστεί",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Δεν υπάρχουν αναμνήσεις προς διαγραφή",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Δημιουργία νέας ανάμνησης",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Δημιουργία νέας ενέργειας",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Διαχείριση Μνήμης",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Φιλτράρισμα Αναμνήσεων",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Έχετε {count} συνολικές αναμνήσεις",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Δημόσιες αναμνήσεις",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Ιδιωτικές αναμνήσεις",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Κάντε Όλες τις Αναμνήσεις Ιδιωτικές",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Κάντε Όλες τις Αναμνήσεις Δημόσιες",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Διαγραφή Όλων των Αναμνήσεων",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Όλες οι αναμνήσεις είναι πλέον ιδιωτικές",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Όλες οι αναμνήσεις είναι πλέον δημόσιες",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Νέα Ανάμνηση",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Επεξεργασία Ανάμνησης",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Μου αρέσει να τρώω παγωτό...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Αποτυχία αποθήκευσης. Παρακαλώ ελέγξτε τη σύνδεσή σας.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Αποθήκευση Ανάμνησης",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Επανάληψη",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Δημιουργία Ενέργειας",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Επεξεργασία Ενέργειας",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Τι πρέπει να γίνει;",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Η περιγραφή της ενέργειας δεν μπορεί να είναι κενή.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Η ενέργεια ενημερώθηκε",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Αποτυχία ενημέρωσης ενέργειας",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Η ενέργεια δημιουργήθηκε",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Αποτυχία δημιουργίας ενέργειας",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Ημερομηνία Λήξης",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Ώρα",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Προσθήκη ημερομηνίας λήξης",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Πατήστε τέλος για αποθήκευση",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Πατήστε τέλος για δημιουργία",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Όλα",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Σχετικά με Εσάς",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Πληροφορίες",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Χειροκίνητα",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Ολοκληρώθηκε",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Σήμανση ως ολοκληρωμένο",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Η ενέργεια διαγράφηκε",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Αποτυχία διαγραφής ενέργειας",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Διαγραφή Ενέργειας",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή την ενέργεια;",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Γλώσσα Εφαρμογής",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ΔΙΕΠΑΦΉ ΕΦΑΡΜΟΓΉΣ",
+  "speechTranscriptionSectionTitle": "ΟΜΙΛΊΑ ΚΑΙ ΜΕΤΑΓΡΑΦΉ",
+  "languageSettingsHelperText": "Η γλώσσα της εφαρμογής αλλάζει τα μενού και τα κουμπιά. Η γλώσσα ομιλίας επηρεάζει τον τρόπο μεταγραφής των ηχογραφήσεών σας."
+}

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -1,172 +1,138 @@
 {
   "@@locale": "en",
   "@@last_modified": "2024-12-26",
-  
   "appTitle": "Omi",
   "@appTitle": {
     "description": "The app title displayed in various places"
   },
-
   "conversationTab": "Conversation",
   "@conversationTab": {
     "description": "Tab label for conversation summary"
   },
-
   "transcriptTab": "Transcript",
   "@transcriptTab": {
     "description": "Tab label for transcript view"
   },
-
   "actionItemsTab": "Action Items",
   "@actionItemsTab": {
     "description": "Tab label for action items"
   },
-
   "deleteConversationTitle": "Delete Conversation?",
   "@deleteConversationTitle": {
     "description": "Title for delete confirmation dialog"
   },
-
   "deleteConversationMessage": "Are you sure you want to delete this conversation? This action cannot be undone.",
   "@deleteConversationMessage": {
     "description": "Message for delete confirmation dialog"
   },
-
   "confirm": "Confirm",
   "@confirm": {
     "description": "Confirm button label"
   },
-
   "cancel": "Cancel",
   "@cancel": {
-    "description": "Cancel button label"
+    "description": "Button label"
   },
-
-  "ok": "OK",
+  "ok": "Ok",
   "@ok": {
-    "description": "OK button label"
+    "description": "Generic OK button text"
   },
-
   "delete": "Delete",
   "@delete": {
-    "description": "Delete button/action label"
+    "description": "Button label"
   },
-
   "add": "Add",
   "@add": {
     "description": "Add button label"
   },
-
   "update": "Update",
   "@update": {
     "description": "Update button label"
   },
-
   "save": "Save",
   "@save": {
     "description": "Save button label"
   },
-
   "edit": "Edit",
   "@edit": {
     "description": "Edit button/action label"
   },
-
   "close": "Close",
   "@close": {
     "description": "Close button label"
   },
-
   "clear": "Clear",
   "@clear": {
     "description": "Clear button label"
   },
-
   "copyTranscript": "Copy Transcript",
   "@copyTranscript": {
     "description": "Menu item to copy transcript"
   },
-
   "copySummary": "Copy Summary",
   "@copySummary": {
     "description": "Menu item to copy summary"
   },
-
   "testPrompt": "Test Prompt",
   "@testPrompt": {
     "description": "Menu item for testing prompts"
   },
-
   "reprocessConversation": "Reprocess Conversation",
   "@reprocessConversation": {
     "description": "Menu item to reprocess a conversation"
   },
-
   "deleteConversation": "Delete Conversation",
   "@deleteConversation": {
     "description": "Menu item to delete a conversation"
   },
-
   "contentCopied": "Content copied to clipboard",
   "@contentCopied": {
     "description": "Snackbar message when content is copied"
   },
-
   "failedToUpdateStarred": "Failed to update starred status.",
   "@failedToUpdateStarred": {
     "description": "Error message when starring fails"
   },
-
   "conversationUrlNotShared": "Conversation URL could not be shared.",
   "@conversationUrlNotShared": {
     "description": "Error message when sharing fails"
   },
-
   "errorProcessingConversation": "Error while processing conversation. Please try again later.",
   "@errorProcessingConversation": {
     "description": "Error message for conversation processing failure"
   },
-
   "noInternetConnection": "Please check your internet connection and try again.",
   "@noInternetConnection": {
     "description": "Message shown when there's no internet"
   },
-
   "unableToDeleteConversation": "Unable to Delete Conversation",
   "@unableToDeleteConversation": {
     "description": "Title for delete error dialog"
   },
-
   "somethingWentWrong": "Something went wrong! Please try again later.",
   "@somethingWentWrong": {
     "description": "Generic error message"
   },
-
   "copyErrorMessage": "Copy error message",
   "@copyErrorMessage": {
     "description": "Button to copy error details"
   },
-
   "errorCopied": "Error message copied to clipboard",
   "@errorCopied": {
     "description": "Snackbar message after copying error"
   },
-
   "remaining": "Remaining",
   "@remaining": {
     "description": "Label for remaining time/items"
   },
-
   "loading": "Loading...",
   "@loading": {
     "description": "Loading indicator text"
   },
-
   "loadingDuration": "Loading duration...",
   "@loadingDuration": {
     "description": "Loading duration indicator"
   },
-
   "secondsCount": "{count} seconds",
   "@secondsCount": {
     "description": "Duration in seconds",
@@ -177,32 +143,26 @@
       }
     }
   },
-
   "people": "People",
   "@people": {
     "description": "People section title"
   },
-
   "addNewPerson": "Add New Person",
   "@addNewPerson": {
     "description": "Title for add person dialog"
   },
-
   "editPerson": "Edit Person",
   "@editPerson": {
     "description": "Title for edit person dialog"
   },
-
   "createPersonHint": "Create a new person and train Omi to recognize their speech too!",
   "@createPersonHint": {
     "description": "Hint text for creating a person"
   },
-
   "speechProfile": "Speech Profile",
   "@speechProfile": {
     "description": "Speech profile label"
   },
-
   "sampleNumber": "Sample {number}",
   "@sampleNumber": {
     "description": "Label for speech sample",
@@ -213,778 +173,620 @@
       }
     }
   },
-
   "settings": "Settings",
   "@settings": {
     "description": "Settings page title"
   },
-
   "language": "Language",
   "@language": {
     "description": "Language setting label"
   },
-
   "selectLanguage": "Select Language",
   "@selectLanguage": {
     "description": "Title for language selection"
   },
-
   "deleting": "Deleting...",
   "@deleting": {
     "description": "Deleting in progress indicator"
   },
-
   "pleaseCompleteAuthentication": "Please complete authentication in your browser. Once done, return to the app.",
   "@pleaseCompleteAuthentication": {
     "description": "Message shown during OAuth flow"
   },
-
   "failedToStartAuthentication": "Failed to start authentication",
   "@failedToStartAuthentication": {
     "description": "Error when OAuth fails to start"
   },
-
   "importStarted": "Import started! You'll be notified when it's complete.",
   "@importStarted": {
     "description": "Success message when import begins"
   },
-
   "failedToStartImport": "Failed to start import. Please try again.",
   "@failedToStartImport": {
     "description": "Error when import fails to start"
   },
-
   "couldNotAccessFile": "Could not access the selected file",
   "@couldNotAccessFile": {
     "description": "Error when file access fails"
   },
-
   "askOmi": "Ask Omi",
   "@askOmi": {
     "description": "Chat button label"
   },
-
   "done": "Done",
   "@done": {
-    "description": "Done button label"
+    "description": "Button label"
   },
-
   "disconnected": "Disconnected",
   "@disconnected": {
     "description": "Device disconnected status"
   },
-
   "searching": "Searching",
   "@searching": {
     "description": "Searching for device status"
   },
-
   "connectDevice": "Connect Device",
   "@connectDevice": {
     "description": "Button to connect a device"
   },
-
   "monthlyLimitReached": "You've reached your monthly limit.",
   "@monthlyLimitReached": {
     "description": "Message when usage limit is reached"
   },
-
   "checkUsage": "Check Usage",
   "@checkUsage": {
     "description": "Button to check usage details"
   },
-
   "syncingRecordings": "Syncing recordings",
   "@syncingRecordings": {
     "description": "Title when sync is in progress"
   },
-
   "recordingsToSync": "Recordings to sync",
   "@recordingsToSync": {
     "description": "Title when there are recordings to sync"
   },
-
   "allCaughtUp": "All caught up",
   "@allCaughtUp": {
     "description": "Title when everything is synced"
   },
-
   "sync": "Sync",
   "@sync": {
     "description": "Sync button label"
   },
-
   "pendantUpToDate": "Pendant is up to date",
   "@pendantUpToDate": {
     "description": "Status when pendant is synced"
   },
-
   "allRecordingsSynced": "All recordings are synced",
   "@allRecordingsSynced": {
     "description": "Status text when sync is complete"
   },
-
   "syncingInProgress": "Syncing in progress",
   "@syncingInProgress": {
     "description": "Status when sync is happening"
   },
-
   "readyToSync": "Ready to sync",
   "@readyToSync": {
     "description": "Status when ready to sync"
   },
-
   "tapSyncToStart": "Tap Sync to start",
   "@tapSyncToStart": {
     "description": "Hint to start sync"
   },
-
   "pendantNotConnected": "Pendant not connected. Connect to sync.",
   "@pendantNotConnected": {
     "description": "Warning when pendant is not connected"
   },
-
   "everythingSynced": "Everything is already synced.",
   "@everythingSynced": {
     "description": "Message when all is synced"
   },
-
   "recordingsNotSynced": "You have recordings that aren't synced yet.",
   "@recordingsNotSynced": {
     "description": "Message when there are unsynced recordings"
   },
-
   "syncingBackground": "We'll keep syncing your recordings in the background.",
   "@syncingBackground": {
     "description": "Message during background sync"
   },
-
   "noConversationsYet": "No conversations yet.",
   "@noConversationsYet": {
     "description": "Empty state when no conversations exist"
   },
-
   "noStarredConversations": "No starred conversations yet.",
   "@noStarredConversations": {
     "description": "Empty state for starred filter"
   },
-
   "starConversationHint": "To star a conversation, open it and tap the star icon in the header.",
   "@starConversationHint": {
     "description": "Hint explaining how to star conversations"
   },
-
   "searchConversations": "Search Conversations",
   "@searchConversations": {
     "description": "Search field placeholder"
   },
-
   "selectedCount": "{count} selected",
   "@selectedCount": {
     "description": "Selection count label",
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
-
   "merge": "Merge",
   "@merge": {
     "description": "Merge button label"
   },
-
   "mergeConversations": "Merge Conversations",
   "@mergeConversations": {
     "description": "Merge dialog title"
   },
-
   "mergeConversationsMessage": "This will combine {count} conversations into one. All content will be merged and regenerated.",
   "@mergeConversationsMessage": {
     "description": "Merge confirmation message",
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
-
   "mergingInBackground": "Merging in background. This may take a moment.",
   "@mergingInBackground": {
     "description": "Snackbar message during merge"
   },
-
   "failedToStartMerge": "Failed to start merge",
   "@failedToStartMerge": {
     "description": "Error message when merge fails"
   },
-
   "askAnything": "Ask anything",
   "@askAnything": {
     "description": "Chat input placeholder"
   },
-
   "noMessagesYet": "No messages yet!\nWhy don't you start a conversation?",
   "@noMessagesYet": {
     "description": "Empty chat state message"
   },
-
   "deletingMessages": "Deleting your messages from Omi's memory...",
   "@deletingMessages": {
     "description": "Loading text while clearing chat"
   },
-
   "messageCopied": "Message copied to clipboard.",
   "@messageCopied": {
     "description": "Snackbar after copying message"
   },
-
   "cannotReportOwnMessage": "You cannot report your own messages.",
   "@cannotReportOwnMessage": {
     "description": "Error when trying to report own message"
   },
-
   "reportMessage": "Report Message",
   "@reportMessage": {
     "description": "Report message dialog title"
   },
-
   "reportMessageConfirm": "Are you sure you want to report this message?",
   "@reportMessageConfirm": {
     "description": "Report message confirmation"
   },
-
   "messageReported": "Message reported successfully.",
   "@messageReported": {
     "description": "Confirmation after reporting message"
   },
-
   "thankYouFeedback": "Thank you for your feedback!",
   "@thankYouFeedback": {
     "description": "After thumbs up/down feedback"
   },
-
   "clearChat": "Clear Chat?",
   "@clearChat": {
     "description": "Clear chat dialog title"
   },
-
   "clearChatConfirm": "Are you sure you want to clear the chat? This action cannot be undone.",
   "@clearChatConfirm": {
     "description": "Clear chat confirmation message"
   },
-
   "maxFilesLimit": "You can only upload 4 files at a time",
   "@maxFilesLimit": {
     "description": "Max files upload warning"
   },
-
   "chatWithOmi": "Chat with Omi",
   "@chatWithOmi": {
     "description": "Chat share subject"
   },
-
   "apps": "Apps",
   "@apps": {
     "description": "Apps page title"
   },
-
   "noAppsFound": "No apps found",
   "@noAppsFound": {
     "description": "Empty state when no apps match"
   },
-
   "tryAdjustingSearch": "Try adjusting your search or filters",
   "@tryAdjustingSearch": {
     "description": "Hint when no apps found"
   },
-
   "createYourOwnApp": "Create Your Own App",
   "@createYourOwnApp": {
     "description": "Create app button title"
   },
-
   "buildAndShareApp": "Build and share your custom app",
   "@buildAndShareApp": {
     "description": "Create app button subtitle"
   },
-
   "searchApps": "Search 1500+ Apps",
   "@searchApps": {
     "description": "Apps search placeholder"
   },
-
   "myApps": "My Apps",
   "@myApps": {
     "description": "My Apps filter button"
   },
-
   "installedApps": "Installed Apps",
   "@installedApps": {
     "description": "Installed Apps filter button"
   },
-
   "unableToFetchApps": "Unable to fetch apps :(\n\nPlease check your internet connection and try again.",
   "@unableToFetchApps": {
     "description": "Error when apps fail to load"
   },
-
   "aboutOmi": "About Omi",
   "@aboutOmi": {
     "description": "About page title"
   },
-
   "privacyPolicy": "Privacy Policy",
   "@privacyPolicy": {
-    "description": "Privacy policy link"
+    "description": "Link text for Privacy Policy"
   },
-
   "visitWebsite": "Visit Website",
   "@visitWebsite": {
     "description": "Visit website link"
   },
-
   "helpOrInquiries": "Help or Inquiries?",
   "@helpOrInquiries": {
     "description": "Help link title"
   },
-
   "joinCommunity": "Join the community!",
   "@joinCommunity": {
     "description": "Discord community link"
   },
-
   "membersAndCounting": "8000+ members and counting.",
   "@membersAndCounting": {
     "description": "Discord member count"
   },
-
   "deleteAccountTitle": "Delete Account",
   "@deleteAccountTitle": {
     "description": "Delete account page title"
   },
-
   "deleteAccountConfirm": "Are you sure you want to delete your account?",
   "@deleteAccountConfirm": {
     "description": "Delete account confirmation"
   },
-
   "cannotBeUndone": "This cannot be undone.",
   "@cannotBeUndone": {
     "description": "Warning that action is permanent"
   },
-
   "allDataErased": "All of your memories and conversations will be permanently erased.",
   "@allDataErased": {
     "description": "Delete account warning 1"
   },
-
   "appsDisconnected": "Your Apps and Integrations will be disconnected effectively immediately.",
   "@appsDisconnected": {
     "description": "Delete account warning 2"
   },
-
   "exportBeforeDelete": "You can export your data before deleting your account, but once deleted, it cannot be recovered.",
   "@exportBeforeDelete": {
     "description": "Delete account warning 3"
   },
-
   "deleteAccountCheckbox": "I understand that deleting my account is permanent and all data, including memories and conversations, will be lost and cannot be recovered.",
   "@deleteAccountCheckbox": {
     "description": "Delete account checkbox confirmation"
   },
-
   "areYouSure": "Are you sure?",
   "@areYouSure": {
     "description": "Final confirmation title"
   },
-
   "deleteAccountFinal": "This action is irreversible and will permanently delete your account and all associated data. Are you sure you want to proceed?",
   "@deleteAccountFinal": {
     "description": "Final delete confirmation message"
   },
-
   "deleteNow": "Delete Now",
   "@deleteNow": {
     "description": "Delete now button"
   },
-
   "goBack": "Go Back",
   "@goBack": {
     "description": "Go back button"
   },
-
   "checkBoxToConfirm": "Check the box to confirm you understand that deleting your account is permanent and irreversible.",
   "@checkBoxToConfirm": {
     "description": "Checkbox validation error"
   },
-
   "profile": "Profile",
   "@profile": {
     "description": "Profile page title"
   },
-
   "name": "Name",
   "@name": {
     "description": "Name field label"
   },
-
   "email": "Email",
   "@email": {
     "description": "Email field label"
   },
-
   "customVocabulary": "Custom Vocabulary",
   "@customVocabulary": {
     "description": "Custom vocabulary setting"
   },
-
   "identifyingOthers": "Identifying Others",
   "@identifyingOthers": {
     "description": "People identification setting"
   },
-
   "paymentMethods": "Payment Methods",
   "@paymentMethods": {
     "description": "Payment methods setting"
   },
-
   "conversationDisplay": "Conversation Display",
   "@conversationDisplay": {
     "description": "Conversation display setting"
   },
-
   "dataPrivacy": "Data & Privacy",
   "@dataPrivacy": {
     "description": "Data and privacy setting"
   },
-
   "userId": "User ID",
   "@userId": {
     "description": "User ID label"
   },
-
   "notSet": "Not set",
   "@notSet": {
     "description": "Default value when not set"
   },
-
   "userIdCopied": "User ID copied to clipboard",
   "@userIdCopied": {
     "description": "Confirmation when user ID is copied"
   },
-
   "systemDefault": "System Default",
   "@systemDefault": {
     "description": "System language option"
   },
-
   "planAndUsage": "Plan & Usage",
   "@planAndUsage": {
     "description": "Plan and usage menu item"
   },
-
   "offlineSync": "Offline Sync",
   "@offlineSync": {
     "description": "Offline sync menu item"
   },
-
   "deviceSettings": "Device Settings",
   "@deviceSettings": {
     "description": "Device settings menu item"
   },
-
   "chatTools": "Chat Tools",
   "@chatTools": {
     "description": "Chat tools menu item"
   },
-
   "feedbackBug": "Feedback / Bug",
   "@feedbackBug": {
     "description": "Feedback menu item"
   },
-
   "helpCenter": "Help Center",
   "@helpCenter": {
     "description": "Help center menu item"
   },
-
   "developerSettings": "Developer Settings",
   "@developerSettings": {
     "description": "Developer settings menu item"
   },
-
   "getOmiForMac": "Get Omi for Mac",
   "@getOmiForMac": {
     "description": "Mac app download link"
   },
-
   "referralProgram": "Referral Program",
   "@referralProgram": {
     "description": "Referral program menu item"
   },
-
   "signOut": "Sign Out",
   "@signOut": {
     "description": "Sign out button"
   },
-
   "appAndDeviceCopied": "App and device details copied",
   "@appAndDeviceCopied": {
     "description": "Confirmation when version info is copied"
   },
-
   "wrapped2025": "Wrapped 2025",
   "@wrapped2025": {
     "description": "Wrapped 2025 menu item"
   },
-
   "yourPrivacyYourControl": "Your Privacy, Your Control",
   "@yourPrivacyYourControl": {
     "description": "Data privacy page heading"
   },
-
   "privacyIntro": "At Omi, we are committed to protecting your privacy. This page allows you to control how your data is stored and used.",
   "@privacyIntro": {
     "description": "Data privacy page introduction"
   },
-
   "learnMore": "Learn more...",
   "@learnMore": {
     "description": "Learn more link"
   },
-
   "dataProtectionLevel": "Data Protection Level",
   "@dataProtectionLevel": {
     "description": "Data protection section title"
   },
-
   "dataProtectionDesc": "Your data is secured by default with strong encryption. Review your settings and future privacy options below.",
   "@dataProtectionDesc": {
     "description": "Data protection section description"
   },
-
   "appAccess": "App Access",
   "@appAccess": {
     "description": "App access section title"
   },
-
   "appAccessDesc": "The following apps can access your data. Tap on an app to manage its permissions.",
   "@appAccessDesc": {
     "description": "App access section description"
   },
-
   "noAppsExternalAccess": "No installed apps have external access to your data.",
   "@noAppsExternalAccess": {
     "description": "Empty state for app access"
   },
-
   "deviceName": "Device Name",
   "@deviceName": {
     "description": "Device name label"
   },
-
   "deviceId": "Device ID",
   "@deviceId": {
     "description": "Device ID label"
   },
-
   "firmware": "Firmware",
   "@firmware": {
     "description": "Firmware label"
   },
-
   "sdCardSync": "SD Card Sync",
   "@sdCardSync": {
     "description": "SD Card sync label"
   },
-
   "hardwareRevision": "Hardware Revision",
   "@hardwareRevision": {
     "description": "Hardware revision label"
   },
-
   "modelNumber": "Model Number",
   "@modelNumber": {
     "description": "Model number label"
   },
-
   "manufacturer": "Manufacturer",
   "@manufacturer": {
     "description": "Manufacturer label"
   },
-
   "doubleTap": "Double Tap",
   "@doubleTap": {
     "description": "Double tap action label"
   },
-
-  "ledBrightness": "LED Brightness",
-  "@ledBrightness": {
-    "description": "LED brightness label"
-  },
-
-  "micGain": "Mic Gain",
-  "@micGain": {
-    "description": "Microphone gain label"
-  },
-
-  "disconnect": "Disconnect",
-  "@disconnect": {
-    "description": "Disconnect device button"
-  },
-
-  "forgetDevice": "Forget Device",
-  "@forgetDevice": {
-    "description": "Forget device button"
-  },
-
-  "chargingIssues": "Charging Issues",
-  "@chargingIssues": {
-    "description": "Charging issues help item"
-  },
-
-  "disconnectDevice": "Disconnect Device",
-  "@disconnectDevice": {
-    "description": "Disconnect device button"
-  },
-
-  "unpairDevice": "Unpair Device",
-  "@unpairDevice": {
-    "description": "Unpair device button"
-  },
-
-  "unpairAndForget": "Unpair and Forget Device",
-  "@unpairAndForget": {
-    "description": "Unpair and forget device button"
-  },
-
-  "deviceDisconnectedMessage": "Your Omi has been disconnected 😔",
-  "@deviceDisconnectedMessage": {
-    "description": "Message shown when device is disconnected"
-  },
-
-  "deviceUnpairedMessage": "Device unpaired. Go to Settings > Bluetooth and forget the device to complete unpairing.",
-  "@deviceUnpairedMessage": {
-    "description": "Message shown when device is unpaired"
-  },
-
-  "unpairDialogTitle": "Unpair Device",
-  "@unpairDialogTitle": {
-    "description": "Unpair dialog title"
-  },
-
-  "unpairDialogMessage": "This will unpair the device so it can be connected to another phone. You will need to go to Settings > Bluetooth and forget the device to complete the process.",
-  "@unpairDialogMessage": {
-    "description": "Unpair dialog message"
-  },
-
-  "deviceNotConnected": "Device Not Connected",
-  "@deviceNotConnected": {
-    "description": "Device not connected header"
-  },
-
-  "connectDeviceMessage": "Connect your Omi device to access\ndevice settings and customization",
-  "@connectDeviceMessage": {
-    "description": "Message encouraging user to connect device"
-  },
-
-  "deviceInfoSection": "Device Information",
-  "@deviceInfoSection": {
-    "description": "Device information section header"
-  },
-
-  "customizationSection": "Customization",
-  "@customizationSection": {
-    "description": "Customization section header"
-  },
-
-  "hardwareSection": "Hardware",
-  "@hardwareSection": {
-    "description": "Hardware section header"
-  },
-
-  "v2Undetected": "V2 undetected",
-  "@v2Undetected": {
-    "description": "V2 device undeteced dialog title"
-  },
-
-  "v2UndetectedMessage": "We see that you either have a V1 device or your device is not connected. SD Card functionality is available only for V2 devices.",
-  "@v2UndetectedMessage": {
-    "description": "V2 device undeteced dialog message"
-  },
-
-  "endConversation": "End Conversation",
-  "@endConversation": {
-    "description": "End conversation action"
-  },
-
-  "pauseResume": "Pause/Resume",
-  "@pauseResume": {
-    "description": "Pause/Resume action"
-  },
-
-  "starConversation": "Star Conversation",
-  "@starConversation": {
-    "description": "Star conversation action"
-  },
-
-  "doubleTapAction": "Double Tap Action",
-  "@doubleTapAction": {
-    "description": "Double tap action setting"
-  },
-
-  "endAndProcess": "End & Process Conversation",
-  "@endAndProcess": {
-    "description": "End and process action"
-  },
-
-  "pauseResumeRecording": "Pause/Resume Recording",
-  "@pauseResumeRecording": {
-    "description": "Pause/Resume recording action"
-  },
-
-  "starOngoing": "Star Ongoing Conversation",
-  "@starOngoing": {
-    "description": "Star ongoing conversation action"
-  },
-
   "ledBrightness": "LED Brightness",
   "@ledBrightness": {
     "description": "LED brightness setting"
   },
-
-  "off": "Off",
-  "@off": {
-    "description": "Off state"
-  },
-
-  "max": "Max",
-  "@max": {
-    "description": "Max state"
-  },
-
   "micGain": "Mic Gain",
   "@micGain": {
     "description": "Microphone gain setting"
   },
-
+  "disconnect": "Disconnect",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Forget Device",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Charging Issues",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Disconnect Device",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Unpair Device",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Unpair and Forget Device",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Your Omi has been disconnected 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Device unpaired. Go to Settings > Bluetooth and forget the device to complete unpairing.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Unpair Device",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "This will unpair the device so it can be connected to another phone. You will need to go to Settings > Bluetooth and forget the device to complete the process.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Device Not Connected",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Connect your Omi device to access\ndevice settings and customization",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Device Information",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Customization",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Hardware",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 undetected",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "We see that you either have a V1 device or your device is not connected. SD Card functionality is available only for V2 devices.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "End Conversation",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pause/Resume",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Star Conversation",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Double Tap Action",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "End & Process Conversation",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pause/Resume Recording",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Star Ongoing Conversation",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Off",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Max",
+  "@max": {
+    "description": "Max state"
+  },
   "mute": "Mute",
   "@mute": {
     "description": "Mute state"
   },
-
   "quiet": "Quiet",
   "@quiet": {
     "description": "Quiet preset"
   },
-
   "normal": "Normal",
   "@normal": {
     "description": "Normal preset"
   },
-
   "high": "High",
   "@high": {
     "description": "High preset"
   },
-
   "micGainDescMuted": "Microphone is muted",
   "@micGainDescMuted": {
     "description": "Mic gain description: Muted"
@@ -1021,172 +823,138 @@
   "@micGainDescMax": {
     "description": "Mic gain description: Max"
   },
-
   "developerSettingsTitle": "Developer Settings",
   "@developerSettingsTitle": {
     "description": "Developer settings page title"
   },
-
   "saving": "Saving...",
   "@saving": {
     "description": "Saving state text"
   },
-
   "personaConfig": "Configure your AI persona",
   "@personaConfig": {
     "description": "Persona configuration subtitle"
   },
-
   "beta": "BETA",
   "@beta": {
     "description": "Beta tag"
   },
-
   "transcription": "Transcription",
   "@transcription": {
     "description": "Transcription settings title"
   },
-
   "transcriptionConfig": "Configure STT provider",
   "@transcriptionConfig": {
     "description": "Transcription configuration subtitle"
   },
-
   "conversationTimeout": "Conversation Timeout",
   "@conversationTimeout": {
     "description": "Conversation timeout settings title"
   },
-
   "conversationTimeoutConfig": "Set when conversations auto-end",
   "@conversationTimeoutConfig": {
     "description": "Conversation timeout configuration subtitle"
   },
-
   "importData": "Import Data",
   "@importData": {
     "description": "Import data details title"
   },
-
   "importDataConfig": "Import data from other sources",
   "@importDataConfig": {
     "description": "Import data details subtitle"
   },
-
   "debugDiagnostics": "Debug & Diagnostics",
   "@debugDiagnostics": {
     "description": "Debug & Diagnostics section header"
   },
-
   "endpointUrl": "Endpoint URL",
   "@endpointUrl": {
     "description": "Endpoint URL label"
   },
-
   "noApiKeys": "No API keys yet",
   "@noApiKeys": {
     "description": "No API keys message"
   },
-
   "createKeyToStart": "Create a key to get started",
   "@createKeyToStart": {
     "description": "Create key instruction"
   },
-
   "createKey": "Create Key",
   "@createKey": {
     "description": "Create Key button"
   },
-
   "docs": "Docs",
   "@docs": {
     "description": "Documentation link"
   },
-
   "yourOmiInsights": "Your Omi Insights",
   "@yourOmiInsights": {
     "description": "Usage page title"
   },
-
   "today": "Today",
   "@today": {
     "description": "Time period: Today"
   },
-
   "thisMonth": "This Month",
   "@thisMonth": {
     "description": "Time period: This Month"
   },
-
   "thisYear": "This Year",
   "@thisYear": {
     "description": "Time period: This Year"
   },
-
   "allTime": "All Time",
   "@allTime": {
     "description": "Time period: All Time"
   },
-
   "noActivityYet": "No Activity Yet",
   "@noActivityYet": {
     "description": "Empty state title"
   },
-
   "startConversationToSeeInsights": "Start a conversation with Omi\nto see your usage insights here.",
   "@startConversationToSeeInsights": {
     "description": "Empty state description"
   },
-
   "listening": "Listening",
   "@listening": {
     "description": "Listening stat title"
   },
-
   "listeningSubtitle": "Total time Omi has actively listened.",
   "@listeningSubtitle": {
     "description": "Listening stat subtitle"
   },
-
   "understanding": "Understanding",
   "@understanding": {
     "description": "Understanding stat title"
   },
-
   "understandingSubtitle": "Words understood from your conversations.",
   "@understandingSubtitle": {
     "description": "Understanding stat subtitle"
   },
-
   "providing": "Providing",
   "@providing": {
     "description": "Providing stat title"
   },
-
   "providingSubtitle": "Action items, and notes automatically captured.",
   "@providingSubtitle": {
     "description": "Providing stat subtitle"
   },
-
   "remembering": "Remembering",
   "@remembering": {
     "description": "Remembering stat title"
   },
-
   "rememberingSubtitle": "Facts and details remembered for you.",
   "@rememberingSubtitle": {
     "description": "Remembering stat subtitle"
   },
-
   "unlimitedPlan": "Unlimited Plan",
   "@unlimitedPlan": {
     "description": "Unlimited plan name"
   },
-
   "managePlan": "Manage Plan",
   "@managePlan": {
     "description": "Manage plan button"
   },
-
   "cancelAtPeriodEnd": "Your plan will cancel on {date}.",
   "@cancelAtPeriodEnd": {
     "description": "Cancellation message",
@@ -1197,7 +965,6 @@
       }
     }
   },
-
   "renewsOn": "Your plan renews on {date}.",
   "@renewsOn": {
     "description": "Renewal message",
@@ -1208,12 +975,10 @@
       }
     }
   },
-
   "basicPlan": "Free Plan",
   "@basicPlan": {
     "description": "Basic plan name"
   },
-
   "usageLimitMessage": "{used} of {limit} mins used",
   "@usageLimitMessage": {
     "description": "Usage limit message",
@@ -1228,17 +993,14 @@
       }
     }
   },
-
   "upgrade": "Upgrade",
   "@upgrade": {
     "description": "Upgrade button"
   },
-
   "upgradeToUnlimited": "Upgrade to Unlimited",
   "@upgradeToUnlimited": {
     "description": "Upgrade to unlimited button"
   },
-
   "basicPlanDesc": "Your plan includes {limit} free minutes per month. Upgrade to go unlimited.",
   "@basicPlanDesc": {
     "description": "Basic plan description",
@@ -1249,32 +1011,26 @@
       }
     }
   },
-
   "shareStatsMessage": "Sharing my Omi stats! (omi.me - your always-on AI assistant)",
   "@shareStatsMessage": {
     "description": "Share stats base message"
   },
-
   "sharePeriodToday": "Today, omi has:",
   "@sharePeriodToday": {
     "description": "Share stats period: Today"
   },
-
   "sharePeriodMonth": "This month, omi has:",
   "@sharePeriodMonth": {
     "description": "Share stats period: Month"
   },
-
   "sharePeriodYear": "This year, omi has:",
   "@sharePeriodYear": {
     "description": "Share stats period: Year"
   },
-
   "sharePeriodAllTime": "So far, omi has:",
   "@sharePeriodAllTime": {
     "description": "Share stats period: All Time"
   },
-
   "shareStatsListened": "🎧 Listened for {minutes} minutes",
   "@shareStatsListened": {
     "description": "Share stats: listened",
@@ -1285,7 +1041,6 @@
       }
     }
   },
-
   "shareStatsWords": "🧠 Understood {words} words",
   "@shareStatsWords": {
     "description": "Share stats: words",
@@ -1296,7 +1051,6 @@
       }
     }
   },
-
   "shareStatsInsights": "✨ Provided {count} insights",
   "@shareStatsInsights": {
     "description": "Share stats: insights",
@@ -1307,7 +1061,6 @@
       }
     }
   },
-
   "shareStatsMemories": "📚 Remembered {count} memories",
   "@shareStatsMemories": {
     "description": "Share stats: memories",
@@ -1318,7 +1071,6 @@
       }
     }
   },
-
   "debugLogs": "Debug Logs",
   "debugLogsAutoDelete": "Auto-deletes after 3 days.",
   "debugLogsDesc": "Helps diagnose issues",
@@ -1373,40 +1125,54 @@
   "addToClaudeConfig": "Add to claude_desktop_config.json",
   "copyConfig": "Copy Config",
   "configCopied": "Config copied to clipboard",
-
   "listeningMins": "Listening (mins)",
   "understandingWords": "Understanding (words)",
   "insights": "Insights",
   "memories": "Memories",
   "minsUsedThisMonth": "{used} of {limit} min used this month",
   "@minsUsedThisMonth": {
-     "placeholders": {
-        "used": {"type": "String"},
-        "limit": {"type": "int"}
-     }
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
   },
   "wordsUsedThisMonth": "{used} of {limit} words used this month",
   "@wordsUsedThisMonth": {
-     "placeholders": {
-        "used": {"type": "String"},
-        "limit": {"type": "String"}
-     }
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
   },
   "insightsUsedThisMonth": "{used} of {limit} insights gained this month",
   "@insightsUsedThisMonth": {
-     "placeholders": {
-        "used": {"type": "String"},
-        "limit": {"type": "String"}
-     }
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
   },
   "memoriesUsedThisMonth": "{used} of {limit} memories created this month",
   "@memoriesUsedThisMonth": {
-     "placeholders": {
-        "used": {"type": "String"},
-        "limit": {"type": "String"}
-     }
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
   },
-
   "visibility": "Visibility",
   "visibilitySubtitle": "Control which conversations appear in your list",
   "showShortConversations": "Show Short Conversations",
@@ -1420,15 +1186,15 @@
   "minLabel": "{count} min",
   "@minLabel": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
-
   "customVocabularyTitle": "Custom Vocabulary",
   "addWords": "Add Words",
   "addWordsDesc": "Names, terms, or uncommon words",
   "vocabularyHint": "Omi, Callie, OpenAI",
-
   "connect": "Connect",
   "comingSoon": "Coming Soon",
   "chatToolsFooter": "Connect your apps to view data and metrics in chat.",
@@ -1436,47 +1202,57 @@
   "failedToStartAuth": "Failed to start {appName} authentication",
   "@failedToStartAuth": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "disconnectAppTitle": "Disconnect {appName}?",
   "@disconnectAppTitle": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "disconnectAppMessage": "Are you sure you want to disconnect from {appName}? You can reconnect anytime.",
   "@disconnectAppMessage": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "disconnectedFrom": "Disconnected from {appName}",
   "@disconnectedFrom": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "failedToDisconnect": "Failed to disconnect",
   "connectTo": "Connect to {appName}",
   "@connectTo": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "authAccessMessage": "You'll need to authorize Omi to access your {appName} data. This will open your browser for authentication.",
   "@authAccessMessage": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "continueAction": "Continue",
-
   "languageTitle": "Language",
   "primaryLanguage": "Primary Language",
   "automaticTranslation": "Automatic Translation",
   "detectLanguages": "Detect 10+ languages",
-
   "authorizeSavingRecordings": "Authorize Saving Recordings",
   "thanksForAuthorizing": "Thanks for authorizing!",
   "needYourPermission": "We need your permission",
@@ -1500,13 +1276,11 @@
   "permissionRevokedTitle": "Permission Revoked",
   "permissionRevokedMessage": "Do you want us to remove all your existing recordings too?",
   "yes": "Yes",
-
   "editName": "Edit Name",
   "howShouldOmiCallYou": "How should Omi call you?",
   "enterYourName": "Enter your name",
   "nameCannotBeEmpty": "Name cannot be empty",
   "nameUpdatedSuccessfully": "Name updated successfully!",
-
   "calendarSettings": "Calendar settings",
   "calendarProviders": "Calendar Providers",
   "macOsCalendar": "macOS Calendar",
@@ -1523,11 +1297,12 @@
   "checkingNextDays": "Checking next 30 days",
   "tomorrow": "Tomorrow",
   "googleCalendarComingSoon": "Google Calendar integration coming soon!",
-
   "connectedAsUser": "Connected as user: {userId}",
   "@connectedAsUser": {
     "placeholders": {
-      "userId": {"type": "String"}
+      "userId": {
+        "type": "String"
+      }
     }
   },
   "defaultWorkspace": "Default Workspace",
@@ -1535,8 +1310,6 @@
   "defaultProjectOptional": "Default Project (Optional)",
   "leaveUnselectedTasks": "Leave unselected to create tasks without a project",
   "noProjectsInWorkspace": "No projects found in this workspace",
-
-  "conversationTimeout": "Conversation Timeout",
   "conversationTimeoutDesc": "Choose how long to wait in silence before automatically ending a conversation:",
   "timeout2Minutes": "2 minutes",
   "timeout2MinutesDesc": "End conversation after 2 minutes of silence",
@@ -1552,10 +1325,11 @@
   "conversationEndAfterMinutes": "Conversations will now end after {minutes} minute(s) of silence",
   "@conversationEndAfterMinutes": {
     "placeholders": {
-      "minutes": {"type": "int"}
+      "minutes": {
+        "type": "int"
+      }
     }
   },
-
   "tellUsPrimaryLanguage": "Tell us your primary language",
   "languageForTranscription": "Set your language for sharper transcriptions and a personalized experience.",
   "singleLanguageModeInfo": "Single Language Mode is enabled. Translation is disabled for higher accuracy.",
@@ -1565,54 +1339,65 @@
   "languageSetTo": "Language set to {language}",
   "@languageSetTo": {
     "placeholders": {
-      "language": {"type": "String"}
+      "language": {
+        "type": "String"
+      }
     }
   },
   "failedToSetLanguage": "Failed to set language",
-
   "appSettings": "{appName} Settings",
   "@appSettings": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "disconnectFromApp": "Disconnect from {appName}?",
   "@disconnectFromApp": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "disconnectFromAppDesc": "This will remove your {appName} authentication. You'll need to reconnect to use it again.",
   "@disconnectFromAppDesc": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "connectedToApp": "Connected to {appName}",
   "@connectedToApp": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "account": "Account",
   "actionItemsSyncedTo": "Your action items will be synced to your {appName} account",
   "@actionItemsSyncedTo": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
-
   "defaultSpace": "Default Space",
   "selectSpaceInWorkspace": "Select a space in your workspace",
   "noSpacesInWorkspace": "No spaces found in this workspace",
   "defaultList": "Default List",
   "tasksAddedToList": "Tasks will be added to this list",
   "noListsInSpace": "No lists found in this space",
-
   "failedToLoadRepos": "Failed to load repositories: {error}",
   "@failedToLoadRepos": {
     "placeholders": {
-      "error": {"type": "String"}
+      "error": {
+        "type": "String"
+      }
     }
   },
   "defaultRepoSaved": "Default repository saved",
@@ -1624,79 +1409,92 @@
   "updatedDate": "Updated {date}",
   "@updatedDate": {
     "placeholders": {
-      "date": {"type": "String"}
+      "date": {
+        "type": "String"
+      }
     }
   },
   "yesterday": "yesterday",
   "daysAgo": "{count} days ago",
   "@daysAgo": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "oneWeekAgo": "1 week ago",
   "weeksAgo": "{count} weeks ago",
   "@weeksAgo": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "oneMonthAgo": "1 month ago",
   "monthsAgo": "{count} months ago",
   "@monthsAgo": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "issuesCreatedInRepo": "Issues will be created in your default repository",
-
   "taskIntegrations": "Task Integrations",
   "configureSettings": "Configure Settings",
   "completeAuthBrowser": "Please complete authentication in your browser. Once done, return to the app.",
   "failedToStartAppAuth": "Failed to start {appName} authentication",
   "@failedToStartAppAuth": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "connectToAppTitle": "Connect to {appName}",
   "@connectToAppTitle": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "authorizeOmiForTasks": "You'll need to authorize Omi to create tasks in your {appName} account. This will open your browser for authentication.",
   "@authorizeOmiForTasks": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "continueButton": "Continue",
   "appIntegration": "{appName} Integration",
   "@appIntegration": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "integrationComingSoon": "Integration with {appName} is coming soon! We're working hard to bring you more task management options.",
   "@integrationComingSoon": {
     "placeholders": {
-      "appName": {"type": "String"}
+      "appName": {
+        "type": "String"
+      }
     }
   },
   "gotIt": "Got it",
   "tasksExportedOneApp": "Tasks can be exported to one app at a time.",
-
   "completeYourUpgrade": "Complete Your Upgrade",
-
-  "transcription": "Transcription",
   "importConfiguration": "Import Configuration",
   "exportConfiguration": "Export configuration",
   "bringYourOwn": "Bring your own",
   "payYourSttProvider": "Freely use omi. You only pay your STT provider directly.",
   "freeMinutesMonth": "1,200 free minutes/month included. Unlimited with ",
   "omiUnlimited": "Omi Unlimited",
-  
   "hostRequired": "Host is required",
   "validPortRequired": "Valid port is required",
   "validWebsocketUrlRequired": "Valid WebSocket URL is required (wss://)",
@@ -1706,7 +1504,9 @@
   "errorSaving": "Error saving: {error}",
   "@errorSaving": {
     "placeholders": {
-      "error": {"type": "String"}
+      "error": {
+        "type": "String"
+      }
     }
   },
   "configCopiedToClipboard": "Configuration copied to clipboard",
@@ -1718,16 +1518,19 @@
   "importedConfig": "Imported {providerName} configuration",
   "@importedConfig": {
     "placeholders": {
-      "providerName": {"type": "String"}
+      "providerName": {
+        "type": "String"
+      }
     }
   },
   "invalidJson": "Invalid JSON: {error}",
   "@invalidJson": {
     "placeholders": {
-      "error": {"type": "String"}
+      "error": {
+        "type": "String"
+      }
     }
   },
-  
   "provider": "Provider",
   "live": "Live",
   "onDevice": "On Device",
@@ -1752,11 +1555,14 @@
   "deviceUsesCodec": "{deviceName} uses {codecReason}. Omi will be used.",
   "@deviceUsesCodec": {
     "placeholders": {
-      "deviceName": {"type": "String"},
-      "codecReason": {"type": "String"}
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
     }
   },
-  
   "omiTranscription": "Omi Transcription",
   "bestInClassTranscription": "Best in class transcription with zero setup",
   "instantSpeakerLabels": "Instant speaker labels",
@@ -1765,12 +1571,9 @@
   "autoLanguageDetection": "Auto language detection",
   "highAccuracy": "High accuracy",
   "privacyFirst": "Privacy first",
-  
   "saveChanges": "Save Changes",
-  "saving": "Saving...",
   "resetToDefault": "Reset to Default",
   "viewTemplate": "View Template",
-
   "trySomethingLike": "Try something like...",
   "tryIt": "Try it",
   "creatingPlan": "Creating plan",
@@ -1799,202 +1602,346 @@
   "freeForEveryone": "Free for everyone",
   "perMonthLabel": "/ month",
   "creating": "Creating...",
-  "@creating": {"description": "Loading state text when app generation is in progress"},
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
   "createApp": "Create App",
-  "@createApp": {"description": "Button text to initiate app creation"},
-
-  "connect": "Connect",
-  "@connect": {"description": "Title for device connection page"},
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
   "searchingForDevices": "Searching for devices...",
-  "@searchingForDevices": {"description": "Status text while scanning for Bluetooth devices"},
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
   "devicesFoundNearby": "{count} {count, plural, =1{DEVICE} other{DEVICES}} FOUND NEARBY",
   "@devicesFoundNearby": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "pairingSuccessful": "PAIRING SUCCESSFUL",
   "errorConnectingAppleWatch": "Error connecting to Apple Watch: {error}",
   "@errorConnectingAppleWatch": {
     "placeholders": {
-      "error": {"type": "String"}
+      "error": {
+        "type": "String"
+      }
     }
   },
   "dontShowAgain": "Don't show it again",
-  "@dontShowAgain": {"description": "Checkbox text to suppress future connection confirmations"},
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
   "iUnderstand": "I Understand",
-  "@iUnderstand": {"description": "Button text to acknowledge connection warnings"},
-
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
   "enableBluetooth": "Enable Bluetooth",
-  "@enableBluetooth": {"description": "Title for dialog prompting user to enable Bluetooth"},
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
   "bluetoothNeeded": "Omi needs Bluetooth to connect to your wearable. Please enable Bluetooth and try again.",
-  "@bluetoothNeeded": {"description": "Explanation text for why Bluetooth is required"},
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
   "contactSupport": "Contact Support?",
-  "@contactSupport": {"description": "Link text to contact support"},
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
   "connectLater": "Connect Later",
-  "@connectLater": {"description": "Button text to skip immediate device connection"},
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
   "grantPermissions": "Grant permissions",
-  "@grantPermissions": {"description": "Title for the permissions request page"},
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
   "backgroundActivity": "Background activity",
-  "@backgroundActivity": {"description": "Title for background activity permission"},
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
   "backgroundActivityDesc": "Let Omi run in the background for better stability",
-  "@backgroundActivityDesc": {"description": "Description for background activity permission"},
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
   "locationAccess": "Location access",
-  "@locationAccess": {"description": "Title for location access permission"},
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
   "locationAccessDesc": "Enable background location for the full experience",
-  "@locationAccessDesc": {"description": "Description for location access permission"},
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
   "notifications": "Notifications",
-  "@notifications": {"description": "Title for notifications permission"},
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
   "notificationsDesc": "Enable notifications to stay informed",
-  "@notificationsDesc": {"description": "Description for notifications permission"},
-  "continueButton": "Continue",
-  "@continueButton": {"description": "Generic continue button text"},
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
   "locationServiceDisabled": "Location Service Disabled",
-  "@locationServiceDisabled": {"description": "Title for dialog when location services are off"},
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
   "locationServiceDisabledDesc": "Location Service is Disabled. Please go to Settings > Privacy & Security > Location Services and enable it",
-  "@locationServiceDisabledDesc": {"description": "Instructions to enable location services"},
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
   "backgroundLocationDenied": "Background Location Access Denied",
-  "@backgroundLocationDenied": {"description": "Title for dialog when background location is denied"},
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
   "backgroundLocationDeniedDesc": "Please go to device settings and set location permission to \"Always Allow\"",
-  "@backgroundLocationDeniedDesc": {"description": "Instructions to grant background location permission"},
-
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
   "lovingOmi": "Loving Omi?",
-  "@lovingOmi": {"description": "Title for the app review prompt"},
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
   "leaveReviewIos": "Help us reach more people by leaving a review in the App Store. Your feedback means the world to us!",
-  "@leaveReviewIos": {"description": "App review prompt text for iOS users"},
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
   "leaveReviewAndroid": "Help us reach more people by leaving a review in the Google Play Store. Your feedback means the world to us!",
-  "@leaveReviewAndroid": {"description": "App review prompt text for Android users"},
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
   "rateOnAppStore": "Rate on App Store",
-  "@rateOnAppStore": {"description": "Button text to rate on Apple App Store"},
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
   "rateOnGooglePlay": "Rate on Google Play",
-  "@rateOnGooglePlay": {"description": "Button text to rate on Google Play Store"},
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
   "maybeLater": "Maybe later",
-  "@maybeLater": {"description": "Button text to dismiss the review prompt"},
-
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
   "speechProfileIntro": "Omi needs to learn your goals and your voice. You'll be able to modify it later.",
-  "@speechProfileIntro": {"description": "Introduction text for speech profile creation"},
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
   "getStarted": "Get Started",
-  "@getStarted": {"description": "Button text to begin a process"},
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
   "allDone": "All done!",
-  "@allDone": {"description": "Success message after completing a task"},
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
   "keepGoing": "Keep going, you are doing great",
-  "@keepGoing": {"description": "Encouragement text during a multi-step process"},
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
   "skipThisQuestion": "Skip this question",
-  "@skipThisQuestion": {"description": "Button text to skip the current question"},
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
   "skipForNow": "Skip for now",
-  "@skipForNow": {"description": "Button text to skip the entire process temporarily"},
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
   "connectionError": "Connection Error",
-  "@connectionError": {"description": "Title for connection error dialog"},
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
   "connectionErrorDesc": "Failed to connect to the server. Please check your internet connection and try again.",
-  "@connectionErrorDesc": {"description": "Description of connection error"},
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
   "invalidRecordingMultipleSpeakers": "Invalid recording detected",
-  "@invalidRecordingMultipleSpeakers": {"description": "Error title when multiple speakers are detected"},
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
   "multipleSpeakersDesc": "It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.",
-  "@multipleSpeakersDesc": {"description": "Error description for multiple speakers"},
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
   "tooShortDesc": "There is not enough speech detected. Please speak more and try again.",
-  "@tooShortDesc": {"description": "Error description for recording being too short"},
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
   "invalidRecordingDesc": "Please make sure you speak for at least 5 seconds and not more than 90.",
-  "@invalidRecordingDesc": {"description": "Error description for invalid recording duration"},
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
   "areYouThere": "Are you there?",
-  "@areYouThere": {"description": "Timeout warning title"},
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
   "noSpeechDesc": "We could not detect any speech. Please make sure to speak for at least 10 seconds and not more than 3 minutes.",
-  "@noSpeechDesc": {"description": "Error description when no speech is detected"},
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
   "connectionLost": "Connection Lost",
-  "@connectionLost": {"description": "Title for lost connection dialog"},
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
   "connectionLostDesc": "The connection was interrupted. Please check your internet connection and try again.",
-  "@connectionLostDesc": {"description": "Description for lost connection"},
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
   "tryAgain": "Try Again",
-  "@tryAgain": {"description": "Button text to retry an action"},
-  "ok": "Ok",
-  "@ok": {"description": "Generic OK button text"},
-
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
   "connectOmiOmiGlass": "Connect Omi / OmiGlass",
-  "@connectOmiOmiGlass": {"description": "Button text to connect specific device models"},
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
   "continueWithoutDevice": "Continue Without Device",
-  "@continueWithoutDevice": {"description": "Button text to proceed without connecting a hardware device"},
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
   "permissionsRequired": "Permissions Required",
-  "@permissionsRequired": {"description": "Title for permissions required dialog"},
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
   "permissionsRequiredDesc": "This app needs Bluetooth and Location permissions to function properly. Please enable them in the settings.",
-  "@permissionsRequiredDesc": {"description": "Explanation of why permissions are needed"},
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
   "openSettings": "Open Settings",
-  "@openSettings": {"description": "Button text to open app settings"},
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
   "wantDifferentName": "Want to go by something else?",
-  "@wantDifferentName": {"description": "Question asking if user wants to change their display name"},
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
   "whatsYourName": "What's your name?",
-  "@whatsYourName": {"description": "Question asking for user's name"},
-  "enterYourName": "Enter your name",
-  "@enterYourName": {"description": "Hint text for name input field"},
-
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
   "speakTranscribeSummarize": "Speak. Transcribe. Summarize.",
-  "@speakTranscribeSummarize": {"description": "Tagline or slogan on the welcome/auth screen"},
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
   "signInWithApple": "Sign in with Apple",
-  "@signInWithApple": {"description": "Button text for Apple Sign In"},
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
   "signInWithGoogle": "Sign in with Google",
-  "@signInWithGoogle": {"description": "Button text for Google Sign In"},
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
   "byContinuingAgree": "By continuing, you agree to our ",
-  "@byContinuingAgree": {"description": "Legal disclaimer prefix text"},
-  "privacyPolicy": "Privacy Policy",
-  "@privacyPolicy": {"description": "Link text for Privacy Policy"},
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
   "termsOfUse": "Terms of Use",
-  "@termsOfUse": {"description": "Link text for Terms of Use"},
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
   "omiYourAiCompanion": "Omi – Your AI Companion",
-  "@omiYourAiCompanion": {"description": "App title or branding on onboarding screen"},
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
   "captureEveryMoment": "Capture every moment. Get AI-powered\nsummaries. Never take notes again.",
-  "@captureEveryMoment": {"description": "App value proposition or description"},
-
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
   "appleWatchSetup": "Apple Watch Setup",
-  "@appleWatchSetup": {"description": "Title for Apple Watch setup page"},
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
   "permissionRequestedExclaim": "Permission Requested!",
-  "@permissionRequestedExclaim": {"description": "Title when permission has been requested"},
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
   "microphonePermission": "Microphone Permission",
-  "@microphonePermission": {"description": "Title for microphone permission section"},
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
   "permissionGrantedNow": "Permission granted! Now:\n\nOpen the Omi app on your watch and tap \"Continue\" below",
-  "@permissionGrantedNow": {"description": "Instructions after permission is granted"},
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
   "needMicrophonePermission": "We need microphone permission.\n\n1. Tap \"Grant Permission\"\n2. Allow on your iPhone\n3. Watch app will close\n4. Reopen and tap \"Continue\"",
-  "@needMicrophonePermission": {"description": "Instructions for granting microphone permission"},
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
   "grantPermissionButton": "Grant Permission",
-  "@grantPermissionButton": {"description": "Button to request permission"},
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
   "needHelp": "Need Help?",
-  "@needHelp": {"description": "Link to help dialog"},
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
   "troubleshootingSteps": "Troubleshooting:\n\n1. Ensure Omi is installed on your watch\n2. Open the Omi app on your watch\n3. Look for the permission popup\n4. Tap \"Allow\" when prompted\n5. App on your watch will close - reopen it\n6. Come back and tap \"Continue\" on your iPhone",
-  "@troubleshootingSteps": {"description": "Troubleshooting instructions for watch setup"},
-  "gotIt": "Got it",
-  "@gotIt": {"description": "Button to dismiss dialog"},
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
   "recordingStartedSuccessfully": "Recording started successfully!",
-  "@recordingStartedSuccessfully": {"description": "Success message"},
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
   "permissionNotGrantedYet": "Permission not granted yet. Please make sure you allowed microphone access and reopened the app on your watch.",
-  "@permissionNotGrantedYet": {"description": "Error message when permission is missing"},
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
   "errorRequestingPermission": "Error requesting permission: {error}",
   "@errorRequestingPermission": {
     "description": "Error message for permission request failure",
     "placeholders": {
-      "error": {"type": "String"}
+      "error": {
+        "type": "String"
+      }
     }
   },
   "errorStartingRecording": "Error starting recording: {error}",
   "@errorStartingRecording": {
     "description": "Error message for recording start failure",
     "placeholders": {
-      "error": {"type": "String"}
+      "error": {
+        "type": "String"
+      }
     }
   },
-
   "selectPrimaryLanguage": "Select your primary language",
-  "@selectPrimaryLanguage": {"description": "Title for language selection dialog"},
-  "done": "Done",
-  "@done": {"description": "Button to confirm selection"},
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
   "languageBenefits": "Set your language for sharper transcriptions and a personalized experience",
-  "@languageBenefits": {"description": "Explanation of why language selection matters"},
-  "searchLanguageHint": "Search language by name or code",
-  "@searchLanguageHint": {"description": "Hint text for language search"},
-  "noLanguagesFound": "No languages found",
-  "@noLanguagesFound": {"description": "Text when search returns no results"},
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
   "whatsYourPrimaryLanguage": "What's your primary language?",
-  "@whatsYourPrimaryLanguage": {"description": "Question asking for primary language"},
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
   "selectYourLanguage": "Select your language",
-  "@selectYourLanguage": {"description": "Placeholder for selected language name"},
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
   "personalGrowthJourney": "Your personal growth journey with AI that listens to your every word.",
-  "@personalGrowthJourney": {"description": "Tagline on onboarding wrapper"},
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
   "actionItemsTitle": "To-Do's",
   "@actionItemsTitle": {
     "description": "Title for the Action Items page"
@@ -2192,96 +2139,188 @@
     "description": "Snackbar message"
   },
   "createMemoryTooltip": "Create new memory",
-  "@createMemoryTooltip": {"description": "Tooltip for create memory FAB"},
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
   "createActionItemTooltip": "Create new action item",
-  "@createActionItemTooltip": {"description": "Tooltip for create action item FAB"},
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
   "memoryManagement": "Memory Management",
-  "@memoryManagement": {"description": "Title for memory management sheet"},
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
   "filterMemories": "Filter Memories",
-  "@filterMemories": {"description": "Section header"},
+  "@filterMemories": {
+    "description": "Section header"
+  },
   "totalMemoriesCount": "You have {count} total memories",
   "@totalMemoriesCount": {
     "description": "Count display",
-    "placeholders": {"count": {"type": "int"}}
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
   },
   "publicMemories": "Public memories",
-  "@publicMemories": {"description": "Label"},
+  "@publicMemories": {
+    "description": "Label"
+  },
   "privateMemories": "Private memories",
-  "@privateMemories": {"description": "Label"},
+  "@privateMemories": {
+    "description": "Label"
+  },
   "makeAllPrivate": "Make All Memories Private",
-  "@makeAllPrivate": {"description": "Button label"},
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
   "makeAllPublic": "Make All Memories Public",
-  "@makeAllPublic": {"description": "Button label"},
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
   "deleteAllMemories": "Delete All Memories",
-  "@deleteAllMemories": {"description": "Button label"},
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
   "allMemoriesPrivateResult": "All memories are now private",
-  "@allMemoriesPrivateResult": {"description": "Snackbar"},
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
   "allMemoriesPublicResult": "All memories are now public",
-  "@allMemoriesPublicResult": {"description": "Snackbar"},
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
   "newMemory": "New Memory",
-  "@newMemory": {"description": "Dialog title"},
+  "@newMemory": {
+    "description": "Dialog title"
+  },
   "editMemory": "Edit Memory",
-  "@editMemory": {"description": "Dialog title"},
+  "@editMemory": {
+    "description": "Dialog title"
+  },
   "memoryContentHint": "I like to eat ice cream...",
-  "@memoryContentHint": {"description": "Input hint"},
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
   "failedToSaveMemory": "Failed to save. Please check your connection.",
-  "@failedToSaveMemory": {"description": "Error message"},
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
   "saveMemory": "Save Memory",
-  "@saveMemory": {"description": "Button label"},
+  "@saveMemory": {
+    "description": "Button label"
+  },
   "retry": "Retry",
-  "@retry": {"description": "Button label"},
+  "@retry": {
+    "description": "Button label"
+  },
   "createActionItem": "Create Action Item",
-  "@createActionItem": {"description": "Sheet title"},
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
   "editActionItem": "Edit Action Item",
-  "@editActionItem": {"description": "Sheet title"},
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
   "actionItemDescriptionHint": "What needs to be done?",
-  "@actionItemDescriptionHint": {"description": "Input hint"},
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
   "actionItemDescriptionEmpty": "Action item description cannot be empty.",
-  "@actionItemDescriptionEmpty": {"description": "Error message"},
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
   "actionItemUpdated": "Action item updated",
-  "@actionItemUpdated": {"description": "Snackbar"},
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
   "failedToUpdateActionItem": "Failed to update action item",
-  "@failedToUpdateActionItem": {"description": "Snackbar"},
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
   "actionItemCreated": "Action item created",
-  "@actionItemCreated": {"description": "Snackbar"},
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
   "failedToCreateActionItem": "Failed to create action item",
-  "@failedToCreateActionItem": {"description": "Snackbar"},
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
   "dueDate": "Due Date",
-  "@dueDate": {"description": "Label"},
+  "@dueDate": {
+    "description": "Label"
+  },
   "time": "Time",
-  "@time": {"description": "Label"},
+  "@time": {
+    "description": "Label"
+  },
   "addDueDate": "Add due date",
-  "@addDueDate": {"description": "Placeholder"},
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
   "pressDoneToSave": "Press done to save",
-  "@pressDoneToSave": {"description": "Instruction"},
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
   "pressDoneToCreate": "Press done to create",
-  "@pressDoneToCreate": {"description": "Instruction"},
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
   "filterAll": "All",
-  "@filterAll": {"description": "Filter option"},
+  "@filterAll": {
+    "description": "Filter option"
+  },
   "filterSystem": "About You",
-  "@filterSystem": {"description": "Filter option for facts about the user"},
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
   "filterInteresting": "Insights",
-  "@filterInteresting": {"description": "Filter option for external wisdom/advice"},
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
   "filterManual": "Manual",
-  "@filterManual": {"description": "Filter option"},
-  "cancel": "Cancel",
-  "@cancel": {"description": "Button label"},
-  "done": "Done",
-  "@done": {"description": "Button label"},
+  "@filterManual": {
+    "description": "Filter option"
+  },
   "completed": "Completed",
-  "@completed": {"description": "Status label"},
+  "@completed": {
+    "description": "Status label"
+  },
   "markComplete": "Mark complete",
-  "@markComplete": {"description": "Action label"},
+  "@markComplete": {
+    "description": "Action label"
+  },
   "actionItemDeleted": "Action item deleted",
-  "@actionItemDeleted": {"description": "Snackbar"},
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
   "failedToDeleteActionItem": "Failed to delete action item",
-  "@failedToDeleteActionItem": {"description": "Snackbar"},
-  "delete": "Delete",
-  "@delete": {"description": "Button label"},
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
   "deleteActionItemConfirmTitle": "Delete Action Item",
-  "@deleteActionItemConfirmTitle": {"description": "Dialog title"},
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
   "deleteActionItemConfirmMessage": "Are you sure you want to delete this action item?",
-  "@deleteActionItemConfirmMessage": {"description": "Dialog message"},
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
   "appLanguage": "App Language",
-  "@appLanguage": {"description": "Label for app language selector"}
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "APP INTERFACE",
+  "@appInterfaceSectionTitle": {
+    "description": "Section title for app interface language settings"
+  },
+  "speechTranscriptionSectionTitle": "SPEECH & TRANSCRIPTION",
+  "@speechTranscriptionSectionTitle": {
+    "description": "Section title for speech and transcription language settings"
+  },
+  "languageSettingsHelperText": "App Language changes menus and buttons. Speech Language affects how your recordings are transcribed.",
+  "@languageSettingsHelperText": {
+    "description": "Helper text explaining the difference between app language and speech language"
+  }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -90,7 +90,9 @@
   "selectedCount": "{count} seleccionados",
   "@selectedCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "merge": "Fusionar",
@@ -98,7 +100,9 @@
   "mergeConversationsMessage": "Esto combinará {count} conversaciones en una sola. Todo el contenido se fusionará y regenerará.",
   "@mergeConversationsMessage": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "mergingInBackground": "Fusionando en segundo plano. Esto puede tardar un momento.",
@@ -408,7 +412,6 @@
   "defaultProjectOptional": "Proyecto por defecto (Opcional)",
   "leaveUnselectedTasks": "Dejar sin seleccionar para tareas sin proyecto",
   "noProjectsInWorkspace": "No se encontraron proyectos en este espacio",
-  "conversationTimeout": "Tiempo de espera de conversación",
   "conversationTimeoutDesc": "Elige cuánto tiempo esperar en silencio antes de terminar:",
   "timeout2Minutes": "2 minutos",
   "timeout2MinutesDesc": "Terminar tras 2 minutos de silencio",
@@ -696,6 +699,8 @@
   "pressDoneToCreate": "Pulsa Hecho para crear",
   "filterAll": "Todos",
   "filterAuto": "Auto",
+  "filterInteresting": "Perspectivas",
+  "filterSystem": "Sobre ti",
   "filterManual": "Manual",
   "completed": "Completado",
   "markComplete": "Marcar como hecho",
@@ -729,5 +734,8 @@
       }
     }
   },
-  "continueButton": "Continuar"
+  "continueButton": "Continuar",
+  "appInterfaceSectionTitle": "INTERFAZ DE LA APLICACIÓN",
+  "speechTranscriptionSectionTitle": "VOZ Y TRANSCRIPCIÓN",
+  "languageSettingsHelperText": "El idioma de la aplicación cambia los menús y botones. El idioma de voz afecta cómo se transcriben tus grabaciones."
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "et",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Vestlus",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkriptsioon",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Tegevuspunktid",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Kustuta vestlus?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Kas olete kindel, et soovite selle vestluse kustutada? Seda toimingut ei saa tagasi võtta.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Kinnita",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Tühista",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Kustuta",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Lisa",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Uuenda",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Salvesta",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Muuda",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Sulge",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Tühjenda",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopeeri transkriptsioon",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopeeri kokkuvõte",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Testi käsku",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Töötle vestlust uuesti",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Kustuta vestlus",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Sisu kopeeritud lõikelauale",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Tärni lisamine ebaõnnestus.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Vestluse URL-i ei saanud jagada.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Viga vestluse töötlemisel. Palun proovige hiljem uuesti.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Palun kontrollige oma internetiühendust ja proovige uuesti.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Vestlust ei õnnestunud kustutada",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Midagi läks valesti! Palun proovige hiljem uuesti.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopeeri veateade",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Veateade kopeeritud lõikelauale",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Järelejäänud",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Laadimine...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Kestuse laadimine...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekundit",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Inimesed",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Lisa uus isik",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Muuda isikut",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Looge uus isik ja õpetage Omi-le ära tundma ka tema kõnet!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Kõneprofiil",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Näidis {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Seaded",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Keel",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Vali keel",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Kustutamine...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Palun lõpetage autentimine oma brauseris. Kui olete valmis, naasake rakendusse.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Autentimise alustamine ebaõnnestus",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import algas! Saate teate, kui see on lõpetatud.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Impordi alustamine ebaõnnestus. Palun proovige uuesti.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Valitud failile ei pääsenud ligi",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Küsi Omi-lt",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Valmis",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Ühendus katkestatud",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Otsimine",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Ühenda seade",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Olete jõudnud oma kuulimiidini.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Kontrolli kasutust",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Salvestiste sünkroonimine",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Sünkroonimist vajavad salvestised",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Kõik on sünkroonitud",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Sünkrooni",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Ripats on ajakohane",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Kõik salvestised on sünkroonitud",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Sünkroonimine käib",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Valmis sünkroonimiseks",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Alustamiseks vajutage Sünkrooni",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Ripats pole ühendatud. Sünkroonimiseks ühendage see.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Kõik on juba sünkroonitud.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Teil on salvestisi, mis pole veel sünkroonitud.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Jätkame teie salvestiste sünkroonimist taustal.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Vestlusi pole veel.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Tärniga märgitud vestlusi pole veel.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Vestluse tärniga märkimiseks avage see ja puudutage päises tärni ikooni.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Otsi vestlusi",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} valitud",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Ühenda",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Ühenda vestlused",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "See ühendab {count} vestlust üheks. Kogu sisu ühendatakse ja luuakse uuesti.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Ühendamine käib taustal. See võib võtta hetke aega.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Ühendamise alustamine ebaõnnestus",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Küsi mida tahes",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Sõnumeid pole veel!\nMiks te ei alusta vestlust?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Teie sõnumite kustutamine Omi mälust...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Sõnum kopeeritud lõikelauale.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Te ei saa oma sõnumitest teatada.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Teata sõnumist",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Kas olete kindel, et soovite sellest sõnumist teatada?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Sõnumist teatati edukalt.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Täname tagasiside eest!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Tühjenda vestlus?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Kas olete kindel, et soovite vestluse tühjendada? Seda toimingut ei saa tagasi võtta.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Korraga saate üles laadida ainult 4 faili",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Vestlus Omi-ga",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Rakendused",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Rakendusi ei leitud",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Proovige otsingu või filtrite muutmist",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Looge oma rakendus",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Looge ja jagage oma kohandatud rakendust",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Otsi 1500+ rakendust",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Minu rakendused",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Paigaldatud rakendused",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Rakenduste laadimine ebaõnnestus :(\n\nPalun kontrollige oma internetiühendust ja proovige uuesti.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Omi teave",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Privaatsuspoliitikaga",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Külasta veebilehte",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Abi või päringud?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Liitu kogukonnaga!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ liiget ja kasvab.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Kustuta konto",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Kas olete kindel, et soovite oma konto kustutada?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Seda ei saa tagasi võtta.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Kõik teie mälestused ja vestlused kustutatakse jäädavalt.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Teie rakendused ja integratsioonid katkestatakse viivitamatult.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Saate oma andmed enne konto kustutamist eksportida, kuid pärast kustutamist ei saa neid taastada.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Mõistan, et minu konto kustutamine on püsiv ja kõik andmed, sealhulgas mälestused ja vestlused, lähevad kaotsi ega ole taastatavad.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Kas olete kindel?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "See toiming on pöördumatu ja kustutab jäädavalt teie konto ja kõik sellega seotud andmed. Kas olete kindel, et soovite jätkata?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Kustuta kohe",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Mine tagasi",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Märkige ruut, et kinnitada, et mõistate, et teie konto kustutamine on püsiv ja pöördumatu.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profiil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Nimi",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-post",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Kohandatud sõnavara",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Teiste tuvastamine",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Makseviisid",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Vestluse kuvamine",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Andmed ja privaatsus",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Kasutaja ID",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Pole määratud",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Kasutaja ID kopeeritud lõikelauale",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Süsteemi vaikimisi",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plaan ja kasutus",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Võrguühenduseta sünkroonimine",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Seadme seaded",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Vestlustööriistad",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Tagasiside / viga",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Abikeskus",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Arendaja seaded",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Hangi Omi Mac-ile",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Viiteprogramm",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Logi välja",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Rakenduse ja seadme üksikasjad kopeeritud",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Kokkuvõte 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Teie privaatsus, teie kontroll",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Omi-s oleme pühendunud teie privaatsuse kaitsmisele. See leht võimaldab teil kontrollida, kuidas teie andmeid säilitatakse ja kasutatakse.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Loe lähemalt...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Andmekaitse tase",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Teie andmed on vaikimisi kaitstud tugeva krüpteerimisega. Vaadake allpool oma seadeid ja tulevasi privaatsusvalikuid.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Rakenduse juurdepääs",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Järgmised rakendused pääsevad juurde teie andmetele. Puudutage rakendust selle õiguste haldamiseks.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Ühelgi paigaldatud rakendusel pole välise juurdepääsu teie andmetele.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Seadme nimi",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Seadme ID",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Püsivara",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD-kaardi sünkroonimine",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Riistvara versioon",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Mudeli number",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Tootja",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Topeltpuudutus",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED heledus",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Mikrofoni võimendus",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Katkesta ühendus",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Unusta seade",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Laadimisprobleemid",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Katkesta seadme ühendus",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Tühista seadme sidumine",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Tühista sidumine ja unusta seade",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Teie Omi on ühendus katkestatud 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Seadme sidumine tühistatud. Minege Seaded > Bluetooth ja unustage seade sidumise lõpetamiseks.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Tühista seadme sidumine",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "See tühistab seadme sidumise, et seda saaks ühendada teise telefoniga. Protsessi lõpetamiseks peate minema Seaded > Bluetooth ja unustama seadme.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Seade pole ühendatud",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Ühendage oma Omi seade, et pääseda juurde\nseadme seadetele ja kohandamisele",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Seadme teave",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Kohandamine",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Riistvara",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 tuvastamata",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Näeme, et teil on kas V1 seade või teie seade pole ühendatud. SD-kaardi funktsioon on saadaval ainult V2 seadmetele.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Lõpeta vestlus",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Peata/jätka",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Märgi vestlus tärniga",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Topeltpuudutuse tegevus",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Lõpeta ja töötle vestlus",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Peata/jätka salvestamine",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Märgi käimasolev vestlus tärniga",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Väljas",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maks",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Vaigista",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Vaikne",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Tavaline",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Kõrge",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon on vaigistatud",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Väga vaikne - valjude keskkondade jaoks",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Vaikne - mõõduka müra jaoks",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutraalne - tasakaalustatud salvestamine",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Veidi võimendatud - tavakasutus",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Võimendatud - vaiksetele keskkondadele",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Kõrge - kaugete või vaikste häälte jaoks",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Väga kõrge - väga vaiksetele allikatele",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimum - kasutage ettevaatusega",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Arendaja seaded",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Salvestamine...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Seadistage oma AI isiksus",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BEETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkriptsioon",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Seadistage STT pakkuja",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Vestluse aegumine",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Määrake, millal vestlused automaatselt lõpevad",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Impordi andmed",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importige andmed teistest allikatest",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Silumis- ja diagnostika",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Otspunkti URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "API võtmeid pole veel",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Alustamiseks looge võti",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Loo võti",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumendid",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Teie Omi ülevaated",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Täna",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "See kuu",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "See aasta",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Kogu aeg",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Tegevust pole veel",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Alustage Omi-ga vestlust,\net näha siinkohal oma kasutuse ülevaadet.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Kuulamine",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Aeg, mil Omi on aktiivselt kuulanud.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Mõistmine",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Teie vestlustest mõistetud sõnad.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Pakkumine",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Tegevuspunktid ja märkmed automaatselt salvestatud.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Meelde jätmine",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Teie jaoks meeles peetud faktid ja üksikasjad.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Piiramatu plaan",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Halda plaani",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Teie plaan tühistatakse {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Teie plaan uueneb {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Tasuta plaan",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used}/{limit} min kasutatud",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Uuenda",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Uuenda piiramatuks",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Teie plaan sisaldab {limit} tasuta minutit kuus. Uuendage piiramatuks.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Jagan oma Omi statistikat! (omi.me - teie alati sees AI assistent)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Täna on omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Sel kuul on omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Sel aastal on omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Seni on omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Kuulanud {minutes} minutit",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Mõistnud {words} sõna",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Pakkunud {count} ülevaadet",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Meelde jätnud {count} mälestust",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Silumislogid",
+  "debugLogsAutoDelete": "Kustutatakse automaatselt 3 päeva pärast.",
+  "debugLogsDesc": "Aitab diagnoosida probleeme",
+  "noLogFilesFound": "Logifaile ei leitud.",
+  "omiDebugLog": "Omi silumislogi",
+  "logShared": "Logi jagatud",
+  "selectLogFile": "Vali logifail",
+  "shareLogs": "Jaga logisid",
+  "debugLogCleared": "Silumislogi tühjendatud",
+  "exportStarted": "Eksport algas. See võib võtta mõne sekundi...",
+  "exportAllData": "Ekspordi kõik andmed",
+  "exportDataDesc": "Ekspordi vestlused JSON-failina",
+  "exportedConversations": "Omi-st eksporditud vestlused",
+  "exportShared": "Eksport jagatud",
+  "deleteKnowledgeGraphTitle": "Kustuta teadmiste graaf?",
+  "deleteKnowledgeGraphMessage": "See kustutab kõik tuletatud teadmiste graafi andmed (sõlmed ja ühendused). Teie algsed mälestused jäävad turvaliseks. Graaf taastatakse aja jooksul või järgmise päringu korral.",
+  "knowledgeGraphDeleted": "Teadmiste graaf kustutati edukalt",
+  "deleteGraphFailed": "Graafi kustutamine ebaõnnestus: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Kustuta teadmiste graaf",
+  "deleteKnowledgeGraphDesc": "Tühjenda kõik sõlmed ja ühendused",
+  "mcp": "MCP",
+  "mcpServer": "MCP server",
+  "mcpServerDesc": "Ühendage AI assistendid oma andmetega",
+  "serverUrl": "Serveri URL",
+  "urlCopied": "URL kopeeritud",
+  "apiKeyAuth": "API võtme autentimine",
+  "header": "Päis",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Kliendi ID",
+  "clientSecret": "Kliendi saladus",
+  "useMcpApiKey": "Kasutage oma MCP API võtit",
+  "webhooks": "Veebipoogid",
+  "conversationEvents": "Vestluse sündmused",
+  "newConversationCreated": "Uus vestlus loodud",
+  "realtimeTranscript": "Reaalajas transkriptsioon",
+  "transcriptReceived": "Transkriptsioon vastu võetud",
+  "audioBytes": "Helibaite",
+  "audioDataReceived": "Heliandmed vastu võetud",
+  "intervalSeconds": "Intervall (sekundid)",
+  "daySummary": "Päeva kokkuvõte",
+  "summaryGenerated": "Kokkuvõte loodud",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Lisa claude_desktop_config.json-i",
+  "copyConfig": "Kopeeri konfiguratsioon",
+  "configCopied": "Konfiguratsioon kopeeritud lõikelauale",
+  "listeningMins": "Kuulamine (min)",
+  "understandingWords": "Mõistmine (sõnad)",
+  "insights": "Ülevaated",
+  "memories": "Mälestused",
+  "minsUsedThisMonth": "{used}/{limit} min kasutatud sel kuul",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used}/{limit} sõna kasutatud sel kuul",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used}/{limit} ülevaadet saadud sel kuul",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used}/{limit} mälestust loodud sel kuul",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Nähtavus",
+  "visibilitySubtitle": "Kontrollige, millised vestlused teie loendis kuvatakse",
+  "showShortConversations": "Kuva lühikesed vestlused",
+  "showShortConversationsDesc": "Kuva künnisest lühemaid vestlusi",
+  "showDiscardedConversations": "Kuva hüljatud vestlused",
+  "showDiscardedConversationsDesc": "Kaasa hüljatuna märgitud vestlused",
+  "shortConversationThreshold": "Lühikese vestluse künnis",
+  "shortConversationThresholdSubtitle": "Sellest lühemad vestlused peidetakse, kui pole ülalpool lubatud",
+  "durationThreshold": "Kestuse künnis",
+  "durationThresholdDesc": "Peida sellest lühemad vestlused",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Kohandatud sõnavara",
+  "addWords": "Lisa sõnad",
+  "addWordsDesc": "Nimed, terminid või ebatavalised sõnad",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Ühenda",
+  "comingSoon": "Tulekul",
+  "chatToolsFooter": "Ühendage oma rakendused, et vestluses andmeid ja mõõdikuid vaadata.",
+  "completeAuthInBrowser": "Palun lõpetage autentimine oma brauseris. Kui olete valmis, naasake rakendusse.",
+  "failedToStartAuth": "{appName} autentimise alustamine ebaõnnestus",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Katkesta ühendus rakendusega {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Kas olete kindel, et soovite ühenduse rakendusega {appName} katkestada? Saate igal ajal uuesti ühendada.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Ühendus rakendusega {appName} katkestatud",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Ühenduse katkestamine ebaõnnestus",
+  "connectTo": "Ühenda rakendusega {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Peate andma Omi-le loa juurdepääsuks teie {appName} andmetele. See avab teie brauseri autentimiseks.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Jätka",
+  "languageTitle": "Keel",
+  "primaryLanguage": "Põhikeel",
+  "automaticTranslation": "Automaatne tõlge",
+  "detectLanguages": "Tuvasta 10+ keelt",
+  "authorizeSavingRecordings": "Luba salvestiste salvestamine",
+  "thanksForAuthorizing": "Täname loa andmise eest!",
+  "needYourPermission": "Vajame teie luba",
+  "alreadyGavePermission": "Olete juba andnud meile loa teie salvestiste salvestamiseks. Siin on meeldetuletus, miks me seda vajame:",
+  "wouldLikePermission": "Sooviksime teie luba teie helisalvestiste salvestamiseks. Siin on põhjus:",
+  "improveSpeechProfile": "Parandage oma kõneprofiili",
+  "improveSpeechProfileDesc": "Kasutame salvestisi, et edasi treenida ja parandada teie isiklikku kõneprofiili.",
+  "trainFamilyProfiles": "Treenige profiile sõprade ja pere jaoks",
+  "trainFamilyProfilesDesc": "Teie salvestised aitavad meil ära tunda ja luua profiile teie sõprade ja pere jaoks.",
+  "enhanceTranscriptAccuracy": "Parandage transkriptsiooni täpsust",
+  "enhanceTranscriptAccuracyDesc": "Kui meie mudel paraneb, saame pakkuda teie salvestiste jaoks paremaid transkriptsioone.",
+  "legalNotice": "Õiguslik teade: Häälsalvestuste salvestamise ja salvestamise seaduslikkus võib sõltuvalt teie asukohast ja selle funktsiooni kasutamisest erineda. Teie kohustus on tagada kohalike seaduste ja määruste järgimine.",
+  "alreadyAuthorized": "Juba autoriseeritud",
+  "authorize": "Autoriseeri",
+  "revokeAuthorization": "Tühista autoriseerimine",
+  "authorizationSuccessful": "Autoriseerimine õnnestus!",
+  "failedToAuthorize": "Autoriseerimine ebaõnnestus. Palun proovige uuesti.",
+  "authorizationRevoked": "Autoriseerimine tühistatud.",
+  "recordingsDeleted": "Salvestised kustutatud.",
+  "failedToRevoke": "Autoriseerimise tühistamine ebaõnnestus. Palun proovige uuesti.",
+  "permissionRevokedTitle": "Luba tühistatud",
+  "permissionRevokedMessage": "Kas soovite, et me eemaldaksime ka kõik teie olemasolevad salvestised?",
+  "yes": "Jah",
+  "editName": "Muuda nime",
+  "howShouldOmiCallYou": "Kuidas peaks Omi teid kutsuma?",
+  "enterYourName": "Sisestage oma nimi",
+  "nameCannotBeEmpty": "Nimi ei saa olla tühi",
+  "nameUpdatedSuccessfully": "Nimi edukalt uuendatud!",
+  "calendarSettings": "Kalendri seaded",
+  "calendarProviders": "Kalendri pakkujad",
+  "macOsCalendar": "macOS kalender",
+  "connectMacOsCalendar": "Ühendage oma kohalik macOS kalender",
+  "googleCalendar": "Google Calendar",
+  "syncGoogleAccount": "Sünkroonige oma Google'i kontoga",
+  "showMeetingsMenuBar": "Kuva tulevased koosolekud menüüribal",
+  "showMeetingsMenuBarDesc": "Kuva oma järgmine koosolek ja aeg selle alguseni macOS-i menüüribal",
+  "showEventsNoParticipants": "Kuva ilma osalejateta sündmusi",
+  "showEventsNoParticipantsDesc": "Kui lubatud, näitab Coming Up sündmusi ilma osalejate või videolingita.",
+  "yourMeetings": "Teie koosolekud",
+  "refresh": "Värskenda",
+  "noUpcomingMeetings": "Tulevasi koosolekuid ei leitud",
+  "checkingNextDays": "Kontrolli järgmist 30 päeva",
+  "tomorrow": "Homme",
+  "googleCalendarComingSoon": "Google Calendar integratsioon tuleb varsti!",
+  "connectedAsUser": "Ühendatud kasutajana: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Vaikimisi tööala",
+  "tasksCreatedInWorkspace": "Ülesanded luuakse sellesse tööalasse",
+  "defaultProjectOptional": "Vaikimisi projekt (valikuline)",
+  "leaveUnselectedTasks": "Jätke valimata, et luua ülesanded ilma projektita",
+  "noProjectsInWorkspace": "Selles tööalas projekte ei leitud",
+  "conversationTimeoutDesc": "Valige, kui kaua vaikuses oodatakse enne vestluse automaatset lõpetamist:",
+  "timeout2Minutes": "2 minutit",
+  "timeout2MinutesDesc": "Lõpeta vestlus pärast 2-minutilist vaikust",
+  "timeout5Minutes": "5 minutit",
+  "timeout5MinutesDesc": "Lõpeta vestlus pärast 5-minutilist vaikust",
+  "timeout10Minutes": "10 minutit",
+  "timeout10MinutesDesc": "Lõpeta vestlus pärast 10-minutilist vaikust",
+  "timeout30Minutes": "30 minutit",
+  "timeout30MinutesDesc": "Lõpeta vestlus pärast 30-minutilist vaikust",
+  "timeout4Hours": "4 tundi",
+  "timeout4HoursDesc": "Lõpeta vestlus pärast 4-tunnist vaikust",
+  "conversationEndAfterHours": "Vestlused lõpevad nüüd pärast 4-tunnist vaikust",
+  "conversationEndAfterMinutes": "Vestlused lõpevad nüüd pärast {minutes} minuti pikkust vaikust",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Öelge meile oma põhikeel",
+  "languageForTranscription": "Määrake oma keel täpsemate transkriptsioonide ja isikupärastatud kogemuse saamiseks.",
+  "singleLanguageModeInfo": "Ühe keele režiim on lubatud. Tõlge on keelatud suurema täpsuse jaoks.",
+  "searchLanguageHint": "Otsige keelt nime või koodi järgi",
+  "noLanguagesFound": "Keeli ei leitud",
+  "skip": "Jäta vahele",
+  "languageSetTo": "Keeleks määratud {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Keele määramine ebaõnnestus",
+  "appSettings": "{appName} seaded",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Katkesta ühendus rakendusega {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "See eemaldab teie {appName} autentimise. Peate uuesti ühendama, et seda uuesti kasutada.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Ühendatud rakendusega {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Konto",
+  "actionItemsSyncedTo": "Teie tegevuspunktid sünkroonitakse teie {appName} kontoga",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Vaikimisi ruum",
+  "selectSpaceInWorkspace": "Valige ruum oma tööalast",
+  "noSpacesInWorkspace": "Selles tööalas ruume ei leitud",
+  "defaultList": "Vaikimisi loend",
+  "tasksAddedToList": "Ülesanded lisatakse sellesse loendisse",
+  "noListsInSpace": "Selles ruumis loendeid ei leitud",
+  "failedToLoadRepos": "Hoidlate laadimine ebaõnnestus: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Vaikimisi hoidla salvestatud",
+  "failedToSaveDefaultRepo": "Vaikimisi hoidla salvestamine ebaõnnestus",
+  "defaultRepository": "Vaikimisi hoidla",
+  "selectDefaultRepoDesc": "Valige vaikimisi hoidla probleemide loomiseks. Probleemide loomisel saate siiski määrata teise hoidla.",
+  "noReposFound": "Hoidlaid ei leitud",
+  "private": "Privaatne",
+  "updatedDate": "Uuendatud {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "eile",
+  "daysAgo": "{count} päeva tagasi",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 nädal tagasi",
+  "weeksAgo": "{count} nädalat tagasi",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 kuu tagasi",
+  "monthsAgo": "{count} kuud tagasi",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Probleemid luuakse teie vaikimisi hoidlasse",
+  "taskIntegrations": "Ülesannete integratsioonid",
+  "configureSettings": "Seadista seaded",
+  "completeAuthBrowser": "Palun lõpetage autentimine oma brauseris. Kui olete valmis, naasake rakendusse.",
+  "failedToStartAppAuth": "{appName} autentimise alustamine ebaõnnestus",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Ühenda rakendusega {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Peate andma Omi-le loa ülesannete loomiseks teie {appName} kontol. See avab teie brauseri autentimiseks.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Jätka",
+  "appIntegration": "{appName} integratsioon",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "{appName} integratsioon tuleb varsti! Töötame selle nimel, et tuua teile rohkem ülesannete haldamise valikuid.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Sain aru",
+  "tasksExportedOneApp": "Ülesandeid saab eksportida korraga ühte rakendusse.",
+  "completeYourUpgrade": "Viige oma uuendamine lõpule",
+  "importConfiguration": "Impordi konfiguratsioon",
+  "exportConfiguration": "Ekspordi konfiguratsioon",
+  "bringYourOwn": "Tooge oma oma",
+  "payYourSttProvider": "Kasutage Omi-d vabalt. Maksite ainult oma STT pakkujale otse.",
+  "freeMinutesMonth": "1200 tasuta minutit kuus kaasa arvatud. Piiramatu koos ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Host on nõutud",
+  "validPortRequired": "Kehtiv port on nõutud",
+  "validWebsocketUrlRequired": "Kehtiv WebSocket URL on nõutud (wss://)",
+  "apiUrlRequired": "API URL on nõutud",
+  "apiKeyRequired": "API võti on nõutud",
+  "invalidJsonConfig": "Vigane JSON-konfiguratsioon",
+  "errorSaving": "Salvestamise viga: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfiguratsioon kopeeritud lõikelauale",
+  "pasteJsonConfig": "Kleepige oma JSON-konfiguratsioon allpool:",
+  "addApiKeyAfterImport": "Peate pärast importimist lisama oma API võtme",
+  "paste": "Kleebi",
+  "import": "Impordi",
+  "invalidProviderInConfig": "Vigane pakkuja konfiguratsioonis",
+  "importedConfig": "Imporditud {providerName} konfiguratsioon",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Vigane JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Pakkuja",
+  "live": "Otse",
+  "onDevice": "Seadmel",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "Sisestage oma STT HTTP otspunkt",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "Sisestage oma reaalajas STT WebSocket otspunkt",
+  "apiKey": "API võti",
+  "enterApiKey": "Sisestage oma API võti",
+  "storedLocallyNeverShared": "Salvestatud lokaalselt, ei jagata kunagi",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Täpsem",
+  "configuration": "Konfiguratsioon",
+  "requestConfiguration": "Päringu konfiguratsioon",
+  "responseSchema": "Vastuse skeem",
+  "modified": "Muudetud",
+  "resetRequestConfig": "Lähtesta päringu konfiguratsioon vaikimisi",
+  "logs": "Logid",
+  "logsCopied": "Logid kopeeritud",
+  "noLogsYet": "Logisid pole veel. Alustage salvestamist, et näha kohandatud STT tegevust.",
+  "deviceUsesCodec": "{deviceName} kasutab {codecReason}. Kasutatakse Omi-d.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi transkriptsioon",
+  "bestInClassTranscription": "Parim oma klassis transkriptsioon nullseadistusega",
+  "instantSpeakerLabels": "Kohesed kõneleja sildid",
+  "languageTranslation": "100+ keele tõlge",
+  "optimizedForConversation": "Optimeeritud vestluseks",
+  "autoLanguageDetection": "Automaatne keele tuvastamine",
+  "highAccuracy": "Kõrge täpsus",
+  "privacyFirst": "Privaatsus esmalt",
+  "saveChanges": "Salvesta muudatused",
+  "resetToDefault": "Lähtesta vaikimisi",
+  "viewTemplate": "Vaata malli",
+  "trySomethingLike": "Proovige midagi sellist nagu...",
+  "tryIt": "Proovi seda",
+  "creatingPlan": "Plaani loomine",
+  "developingLogic": "Loogika arendamine",
+  "designingApp": "Rakenduse kujundamine",
+  "generatingIconStep": "Ikooni genereerimine",
+  "finalTouches": "Viimased lihvid",
+  "processing": "Töötlemine...",
+  "features": "Funktsioonid",
+  "creatingYourApp": "Teie rakenduse loomine...",
+  "generatingIcon": "Ikooni genereerimine...",
+  "whatShouldWeMake": "Mida me peaksime tegema?",
+  "appName": "Rakenduse nimi",
+  "description": "Kirjeldus",
+  "publicLabel": "Avalik",
+  "privateLabel": "Privaatne",
+  "free": "Tasuta",
+  "perMonth": "/ kuu",
+  "tailoredConversationSummaries": "Kohandatud vestluste kokkuvõtted",
+  "customChatbotPersonality": "Kohandatud vestlusroboti isiksus",
+  "makePublic": "Tee avalikuks",
+  "anyoneCanDiscover": "Igaüks saab teie rakendust avastada",
+  "onlyYouCanUse": "Ainult teie saate seda rakendust kasutada",
+  "paidApp": "Tasuline rakendus",
+  "usersPayToUse": "Kasutajad maksavad teie rakenduse kasutamise eest",
+  "freeForEveryone": "Tasuta kõigile",
+  "perMonthLabel": "/ kuu",
+  "creating": "Loomine...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Loo rakendus",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Seadmete otsimine...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{SEADE} other{SEADET}} LEITUD LÄHEDALT",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "ÜHENDAMINE ÕNNESTUS",
+  "errorConnectingAppleWatch": "Viga Apple Watch'iga ühendamisel: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Ära näita seda enam",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Sain aru",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Luba Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi vajab Bluetoothi, et ühenduda teie kantava seadmega. Palun lubage Bluetooth ja proovige uuesti.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Võta ühendust toega?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Ühenda hiljem",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Anna load",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Taustegevus",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Lubage Omil töötada taustal parema stabiilsuse tagamiseks",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Asukoha juurdepääs",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Lubage tausta asukoht täieliku kogemuse saamiseks",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Teavitused",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Lubage teavitused, et püsida kursis",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Asukohateenused keelatud",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Asukohateenused on keelatud. Palun minge Seaded > Privaatsus ja turvalisus > Asukohateenused ja lubage see",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Tausta asukoha juurdepääs keelatud",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Palun minge seadme seadetesse ja määrake asukoha luba väärtusele \"Luba alati\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Meeldib Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Aidake meil jõuda rohkemate inimesteni, jättes arvustuse App Store'i. Teie tagasiside on meile ülimalt oluline!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Aidake meil jõuda rohkemate inimesteni, jättes arvustuse Google Play poodi. Teie tagasiside on meile ülimalt oluline!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Hinda App Store'is",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Hinda Google Play's",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Võib-olla hiljem",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi peab õppima teie eesmärke ja häält. Saate seda hiljem muuta.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Alusta",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Kõik tehtud!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Jätkake, teil läheb suurepäraselt",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Jäta see küsimus vahele",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Jäta praegu vahele",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Ühenduse viga",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Serveriga ühendamine ebaõnnestus. Palun kontrollige oma internetiühendust ja proovige uuesti.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Vigane salvestis tuvastatud",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Tundub, et salvestises on mitu kõnelejat. Palun veenduge, et olete vaikses kohas ja proovige uuesti.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Kõnet ei tuvastatud piisavalt. Palun rääkige rohkem ja proovige uuesti.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Palun veenduge, et räägite vähemalt 5 sekundit ja mitte rohkem kui 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Kas olete seal?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Me ei suutnud kõnet tuvastada. Palun veenduge, et räägite vähemalt 10 sekundit ja mitte rohkem kui 3 minutit.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Ühendus kadus",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Ühendus katkestati. Palun kontrollige oma internetiühendust ja proovige uuesti.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Proovi uuesti",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Ühenda Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Jätka ilma seadmeta",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Load on nõutud",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "See rakendus vajab nõuetekohaseks toimimiseks Bluetoothi ja asukoha lube. Palun lubage need seadetes.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Ava seaded",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Soovite kasutada muud nime?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Mis on teie nimi?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Räägi. Transkribeeri. Võta kokku.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Logi sisse Apple'iga",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Logi sisse Google'iga",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Jätkates nõustute meie ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Kasutustingimustega",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – teie AI kaaslane",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Jäädvustage iga hetk. Saage AI-põhiseid\nkokkuvõtteid. Ärge tehke enam kunagi märkmeid.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch'i seadistamine",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Luba taotletud!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Mikrofoni luba",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Luba antud! Nüüd:\n\nAvage Omi rakendus oma kellal ja puudutage allpool \"Jätka\"",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Vajame mikrofoni luba.\n\n1. Puudutage \"Anna luba\"\n2. Lubage oma iPhone'is\n3. Kella rakendus sulgub\n4. Avage uuesti ja puudutage \"Jätka\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Anna luba",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Vajate abi?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Tõrkeotsing:\n\n1. Veenduge, et Omi on teie kellale installitud\n2. Avage Omi rakendus oma kellal\n3. Otsige loa hüpikakent\n4. Puudutage \"Luba\", kui küsitakse\n5. Rakendus teie kellal sulgub - avage see uuesti\n6. Tulge tagasi ja puudutage \"Jätka\" oma iPhone'is",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Salvestamine algas edukalt!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Luba pole veel antud. Palun veenduge, et lubate mikrofoni juurdepääsu ja avasid rakenduse oma kellal uuesti.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Viga loa taotlemisel: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Viga salvestamise alustamisel: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Valige oma põhikeel",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Määrake oma keel täpsemate transkriptsioonide ja isikupärastatud kogemuse saamiseks",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Mis on teie põhikeel?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Valige oma keel",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Teie isiklik kasvuteekond AI-ga, mis kuulab iga teie sõna.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Tegevused",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Puudutage muutmiseks • Vajutage pikalt valimiseks • Libistage toimingute jaoks",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Teha",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Tehtud",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Vanad",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Kõik tehtud!\nOotel tegevuspunkte pole",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Lõpetatud punkte pole veel",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Vanu ülesandeid pole",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Punkte pole",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Tegevuspunkt märgitud mittelõpetatuks",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Tegevuspunkt lõpetatud",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Kustuta tegevuspunkt",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Kas olete kindel, et soovite selle tegevuspunkti kustutada?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Kustuta valitud punktid",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Kas olete kindel, et soovite kustutada {count} valitud tegevuspunkt{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Tegevuspunkt \"{description}\" kustutatud",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} tegevuspunkt{s} kustutatud",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Tegevuspunkti kustutamine ebaõnnestus",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Punktide kustutamine ebaõnnestus",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Mõne punkti kustutamine ebaõnnestus",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Valmis tegevuspunktide jaoks",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Teie AI eraldab automaatselt ülesanded ja tegevused teie vestlustest. Need ilmuvad siia, kui need luuakse.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automaatselt vestlustest eraldatud",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Puudutage muutmiseks, libistage lõpetamiseks või kustutamiseks",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} valitud",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Vali kõik",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Kustuta valitud",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Otsi {count} mälestust",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Mälestus kustutatud.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Tühista",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Mälestusi pole veel",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Automaatselt eraldatud mälestusi pole veel",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Käsitsi lisatud mälestusi pole veel",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Neis kategooriates pole mälestusi",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Mälestusi ei leitud",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Lisa oma esimene mälestus",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Tühjenda Omi mälu",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Kas olete kindel, et soovite Omi mälu tühjendada? Seda tegevust ei saa tagasi võtta.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Tühjenda mälu",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omi mälu teie kohta on tühjendatud",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Kustutatavaid mälestusi pole",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Loo uus mälestus",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Loo uus tegevuspunkt",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Mälu haldamine",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtreeri mälestusi",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Teil on kokku {count} mälestust",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Avalikud mälestused",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Privaatsed mälestused",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Muuda kõik mälestused privaatseks",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Muuda kõik mälestused avalikuks",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Kustuta kõik mälestused",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Kõik mälestused on nüüd privaatsed",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Kõik mälestused on nüüd avalikud",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Uus mälestus",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Muuda mälestust",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Mulle meeldib süüa jäätist...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Salvestamine ebaõnnestus. Palun kontrollige oma ühendust.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Salvesta mälestus",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Proovi uuesti",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Loo tegevuspunkt",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Muuda tegevuspunkti",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Mida on vaja teha?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Tegevuspunkti kirjeldus ei saa olla tühi.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Tegevuspunkt uuendatud",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Tegevuspunkti uuendamine ebaõnnestus",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Tegevuspunkt loodud",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Tegevuspunkti loomine ebaõnnestus",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Tähtaeg",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Aeg",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Lisa tähtaeg",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Vajutage valmis salvestamiseks",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Vajutage valmis loomiseks",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Kõik",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Teie kohta",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Ülevaated",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Käsitsi",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Lõpetatud",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Märgi lõpetatuks",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Tegevuspunkt kustutatud",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Tegevuspunkti kustutamine ebaõnnestus",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Kustuta tegevuspunkt",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Kas olete kindel, et soovite selle tegevuspunkti kustutada?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Rakenduse keel",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "RAKENDUSE LIIDES",
+  "speechTranscriptionSectionTitle": "KÕNE JA TRANSKRIPTSIOON",
+  "languageSettingsHelperText": "Rakenduse keel muudab menüüsid ja nuppe. Kõne keel mõjutab, kuidas teie salvestisi transkribeeritakse."
+}

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "fi",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Keskustelu",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Litterointi",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Tehtävät",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Poista keskustelu?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Haluatko varmasti poistaa tämän keskustelun? Tätä toimintoa ei voi perua.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Vahvista",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Peruuta",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "OK",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Poista",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Lisää",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Päivitä",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Tallenna",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Muokkaa",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Sulje",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Tyhjennä",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopioi litterointi",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopioi yhteenveto",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Testaa kehotetta",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Käsittele keskustelu uudelleen",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Poista keskustelu",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Sisältö kopioitu leikepöydälle",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Tähtimerkkauksen päivitys epäonnistui.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Keskustelun URL-osoitetta ei voitu jakaa.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Virhe keskustelun käsittelyssä. Yritä myöhemmin uudelleen.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Tarkista internet-yhteytesi ja yritä uudelleen.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Keskustelun poisto ei onnistu",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Jokin meni pieleen! Yritä myöhemmin uudelleen.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopioi virheilmoitus",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Virheilmoitus kopioitu leikepöydälle",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Jäljellä",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Ladataan...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Ladataan kestoa...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekuntia",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Ihmiset",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Lisää uusi henkilö",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Muokkaa henkilöä",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Luo uusi henkilö ja opeta Omi tunnistamaan hänen puheensa!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Puheprofiili",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Näyte {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Asetukset",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Kieli",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Valitse kieli",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Poistetaan...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Viimeistele todennus selaimessasi. Kun olet valmis, palaa sovellukseen.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Todennuksen aloitus epäonnistui",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Tuonti aloitettu! Saat ilmoituksen, kun se on valmis.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Tuonnin aloitus epäonnistui. Yritä uudelleen.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Valittua tiedostoa ei voitu käyttää",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Kysy Omilta",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Valmis",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Yhteys katkaistu",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Etsitään",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Yhdistä laite",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Olet saavuttanut kuukausirajan.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Tarkista käyttö",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Synkronoidaan nauhoituksia",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Synkronoitavat nauhoitukset",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Kaikki ajan tasalla",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Synkronoi",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Riipus on ajan tasalla",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Kaikki nauhoitukset synkronoitu",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Synkronointi käynnissä",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Valmis synkronointiin",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Aloita napauttamalla Synkronoi",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Riipus ei ole yhdistetty. Yhdistä synkronoidaksesi.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Kaikki on jo synkronoitu.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Sinulla on nauhoituksia, joita ei ole vielä synkronoitu.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Jatkamme nauhoitusten synkronointia taustalla.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Ei vielä keskusteluja.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Ei vielä tähdellä merkittyjä keskusteluja.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Merkitäksesi keskustelun tähdellä, avaa se ja napauta tähti-kuvaketta otsikossa.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Etsi keskusteluja",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} valittu",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Yhdistä",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Yhdistä keskustelut",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Tämä yhdistää {count} keskustelua yhdeksi. Kaikki sisältö yhdistetään ja luodaan uudelleen.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Yhdistetään taustalla. Tämä voi kestää hetken.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Yhdistämisen aloitus epäonnistui",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Kysy mitä tahansa",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Ei vielä viestejä!\nMikset aloittaisi keskustelua?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Poistetaan viestejäsi Omin muistista...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Viesti kopioitu leikepöydälle.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Et voi ilmoittaa omista viesteistäsi.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Ilmoita viestistä",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Haluatko varmasti ilmoittaa tästä viestistä?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Viesti ilmoitettu onnistuneesti.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Kiitos palautteestasi!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Tyhjennä keskustelu?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Haluatko varmasti tyhjentää keskustelun? Tätä toimintoa ei voi perua.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Voit ladata vain 4 tiedostoa kerrallaan",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Keskustele Omin kanssa",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Sovellukset",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Sovelluksia ei löytynyt",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Kokeile säätää hakua tai suodattimia",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Luo oma sovellus",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Rakenna ja jaa oma sovelluksesi",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Etsi yli 1500 sovelluksesta",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Omat sovellukset",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Asennetut sovellukset",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Sovellusten haku epäonnistui :(\n\nTarkista internet-yhteytesi ja yritä uudelleen.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Tietoja Omista",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Tietosuojakäytäntö",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Käy verkkosivulla",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Apua tai kysymyksiä?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Liity yhteisöön!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "Yli 8000 jäsentä ja kasvaa.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Poista tili",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Haluatko varmasti poistaa tilisi?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Tätä ei voi perua.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Kaikki muistosi ja keskustelusi poistetaan pysyvästi.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Sovelluksesi ja integraatiot katkaistaan välittömästi.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Voit viedä tietosi ennen tilin poistamista, mutta poiston jälkeen niitä ei voi palauttaa.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Ymmärrän, että tilini poistaminen on pysyvää ja kaikki tiedot, mukaan lukien muistot ja keskustelut, menetetään eikä niitä voi palauttaa.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Oletko varma?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Tämä toiminto on peruuttamaton ja poistaa tilisi ja kaikki siihen liittyvät tiedot pysyvästi. Haluatko varmasti jatkaa?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Poista nyt",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Palaa takaisin",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Valitse ruutu vahvistaaksesi, että ymmärrät tilin poistamisen olevan pysyvää ja peruuttamatonta.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profiili",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Nimi",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Sähköposti",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Mukautettu sanasto",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Muiden tunnistaminen",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Maksutavat",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Keskustelunäkymä",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Tiedot ja yksityisyys",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Käyttäjätunnus",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Ei asetettu",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Käyttäjätunnus kopioitu leikepöydälle",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Järjestelmän oletus",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Paketti ja käyttö",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Offline-synkronointi",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Laitteen asetukset",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Chat-työkalut",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Palaute / Virhe",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Ohjekeskus",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Kehittäjäasetukset",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Hanki Omi Macille",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Suositteluohjelma",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Kirjaudu ulos",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Sovelluksen ja laitteen tiedot kopioitu",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Yksityisyytesi, sinun hallinnassasi",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Omissa olemme sitoutuneet suojaamaan yksityisyyttäsi. Tämä sivu antaa sinulle mahdollisuuden hallita, miten tietojasi tallennetaan ja käytetään.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Lue lisää...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Tietosuojataso",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Tietosi on oletuksena suojattu vahvalla salauksella. Tarkista asetuksesi ja tulevat yksityisyysvaihtoehdot alla.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Sovelluspääsy",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Seuraavat sovellukset voivat käyttää tietojasi. Napauta sovellusta hallitaksesi sen käyttöoikeuksia.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Yhdelläkään asennetulla sovelluksella ei ole ulkoista pääsyä tietoihisi.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Laitteen nimi",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Laitetunnus",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Laiteohjelmisto",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD-kortin synkronointi",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Laitteistoversio",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Mallinumero",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Valmistaja",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Kaksoisnapautus",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED-kirkkaus",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Mikrofonin vahvistus",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Katkaise yhteys",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Unohda laite",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Latausongelmat",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Katkaise laitteen yhteys",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Pura laitepari",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Pura laitepari ja unohda laite",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Omin yhteys on katkaistu 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Laitepari purettu. Siirry kohtaan Asetukset > Bluetooth ja unohda laite viimeistelläksesi purkamisen.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Pura laitepari",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Tämä purkaa laiteparin, jotta se voidaan yhdistää toiseen puhelimeen. Sinun on siirryttävä kohtaan Asetukset > Bluetooth ja unohdettava laite prosessin viimeistelemiseksi.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Laitetta ei ole yhdistetty",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Yhdistä Omi-laite käyttääksesi\nlaiteasetuksia ja mukautusta",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Laitteen tiedot",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Mukautus",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Laitteisto",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 ei havaittu",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Sinulla näyttää olevan V1-laite tai laitteesi ei ole yhdistetty. SD-korttitoiminto on saatavilla vain V2-laitteille.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Lopeta keskustelu",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Keskeytä/Jatka",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Merkitse tähdellä",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Kaksoisnapaututstoiminto",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Lopeta ja käsittele keskustelu",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Keskeytä/Jatka nauhoitusta",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Merkitse käynnissä oleva keskustelu tähdellä",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Pois",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maks.",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Vaimenna",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Hiljainen",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normaali",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Korkea",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofoni on vaimennettu",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Erittäin hiljainen - meluisiin ympäristöihin",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Hiljainen - kohtalaiseen meluun",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutraali - tasapainoinen nauhoitus",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Hieman vahvistettu - normaalikäyttö",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Vahvistettu - hiljaisiin ympäristöihin",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Korkea - kaukaisille tai pehmeille äänille",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Erittäin korkea - erittäin hiljaisille lähteille",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimi - käytä varoen",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Kehittäjäasetukset",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Tallennetaan...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Määritä AI-persoonasi",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Litterointi",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Määritä STT-palveluntarjoaja",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Keskustelun aikakatkaisu",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Aseta milloin keskustelut päättyvät automaattisesti",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Tuo tietoja",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Tuo tietoja muista lähteistä",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Vianjäljitys ja diagnostiikka",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Päätepisteen URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Ei vielä API-avaimia",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Luo avain aloittaaksesi",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Luo avain",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentit",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Omi-näkemyksesi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Tänään",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Tässä kuussa",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Tänä vuonna",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Kaikki aika",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Ei vielä toimintaa",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Aloita keskustelu Omin kanssa\nnähdäksesi käyttötietosi täällä.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Kuunteleminen",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Kokonaisaika, jonka Omi on aktiivisesti kuunnellut.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Ymmärtäminen",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Keskusteluistasi ymmärretyt sanat.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Tarjoaminen",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Tehtävät ja muistiinpanot automaattisesti tallennettu.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Muistaminen",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Sinulle muistetut faktat ja yksityiskohdat.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Rajoittamaton paketti",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Hallitse pakettia",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Pakettisi peruuntuu {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Pakettisi uusiutuu {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Ilmaispaketti",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used}/{limit} min käytetty",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Päivitä",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Päivitä rajoittamattomaan",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Pakettisi sisältää {limit} ilmaisminuuttia kuukaudessa. Päivitä saadaksesi rajoittamattoman.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Jaan Omi-tilastoni! (omi.me - aina päällä oleva tekoälyavustajasi)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Tänään omi on:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Tässä kuussa omi on:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Tänä vuonna omi on:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Tähän mennessä omi on:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Kuunnellut {minutes} minuuttia",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Ymmärtänyt {words} sanaa",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Tarjonnut {count} näkemystä",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Muistanut {count} muistoa",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Vianjäljityslokit",
+  "debugLogsAutoDelete": "Poistetaan automaattisesti 3 päivän kuluttua.",
+  "debugLogsDesc": "Auttaa ongelmien diagnosoinnissa",
+  "noLogFilesFound": "Lokitiedostoja ei löytynyt.",
+  "omiDebugLog": "Omin vianjäljitysloki",
+  "logShared": "Loki jaettu",
+  "selectLogFile": "Valitse lokitiedosto",
+  "shareLogs": "Jaa lokit",
+  "debugLogCleared": "Vianjäljitysloki tyhjennetty",
+  "exportStarted": "Vienti aloitettu. Tämä voi kestää muutaman sekunnin...",
+  "exportAllData": "Vie kaikki tiedot",
+  "exportDataDesc": "Vie keskustelut JSON-tiedostoon",
+  "exportedConversations": "Viedyt keskustelut Omista",
+  "exportShared": "Vienti jaettu",
+  "deleteKnowledgeGraphTitle": "Poista tietograafi?",
+  "deleteKnowledgeGraphMessage": "Tämä poistaa kaikki johdetut tietograafitiedot (solmut ja yhteydet). Alkuperäiset muistosi pysyvät turvassa. Graafi rakennetaan uudelleen ajan myötä tai seuraavan pyynnön yhteydessä.",
+  "knowledgeGraphDeleted": "Tietograafi poistettu onnistuneesti",
+  "deleteGraphFailed": "Graafin poisto epäonnistui: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Poista tietograafi",
+  "deleteKnowledgeGraphDesc": "Tyhjennä kaikki solmut ja yhteydet",
+  "mcp": "MCP",
+  "mcpServer": "MCP-palvelin",
+  "mcpServerDesc": "Yhdistä tekoälyavustajat tietoihisi",
+  "serverUrl": "Palvelimen URL",
+  "urlCopied": "URL kopioitu",
+  "apiKeyAuth": "API-avaimen todennus",
+  "header": "Otsikko",
+  "authorizationBearer": "Authorization: Bearer <avain>",
+  "oauth": "OAuth",
+  "clientId": "Asiakas-ID",
+  "clientSecret": "Asiakassalaisuus",
+  "useMcpApiKey": "Käytä MCP API-avainta",
+  "webhooks": "Webhookit",
+  "conversationEvents": "Keskustelutapahtumat",
+  "newConversationCreated": "Uusi keskustelu luotu",
+  "realtimeTranscript": "Reaaliaikainen litterointi",
+  "transcriptReceived": "Litterointi vastaanotettu",
+  "audioBytes": "Äänitavut",
+  "audioDataReceived": "Ääniaineisto vastaanotettu",
+  "intervalSeconds": "Aikaväli (sekunteina)",
+  "daySummary": "Päivän yhteenveto",
+  "summaryGenerated": "Yhteenveto luotu",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Lisää claude_desktop_config.json-tiedostoon",
+  "copyConfig": "Kopioi kokoonpano",
+  "configCopied": "Kokoonpano kopioitu leikepöydälle",
+  "listeningMins": "Kuunteleminen (min)",
+  "understandingWords": "Ymmärtäminen (sanaa)",
+  "insights": "Näkemykset",
+  "memories": "Muistot",
+  "minsUsedThisMonth": "{used}/{limit} min käytetty tässä kuussa",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used}/{limit} sanaa käytetty tässä kuussa",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used}/{limit} näkemystä saavutettu tässä kuussa",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used}/{limit} muistoa luotu tässä kuussa",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Näkyvyys",
+  "visibilitySubtitle": "Hallitse mitä keskusteluja näkyy luettelossasi",
+  "showShortConversations": "Näytä lyhyet keskustelut",
+  "showShortConversationsDesc": "Näytä kynnysarvoa lyhyemmät keskustelut",
+  "showDiscardedConversations": "Näytä hylätyt keskustelut",
+  "showDiscardedConversationsDesc": "Sisällytä hylätyksi merkityt keskustelut",
+  "shortConversationThreshold": "Lyhyen keskustelun kynnysarvo",
+  "shortConversationThresholdSubtitle": "Tätä lyhyemmät keskustelut piilotetaan, ellei niitä ole otettu käyttöön yllä",
+  "durationThreshold": "Kestokynnys",
+  "durationThresholdDesc": "Piilota tätä lyhyemmät keskustelut",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Mukautettu sanasto",
+  "addWords": "Lisää sanoja",
+  "addWordsDesc": "Nimiä, termejä tai harvinaisia sanoja",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Yhdistä",
+  "comingSoon": "Tulossa pian",
+  "chatToolsFooter": "Yhdistä sovelluksesi nähdäksesi tiedot ja mittarit chatissa.",
+  "completeAuthInBrowser": "Viimeistele todennus selaimessasi. Kun olet valmis, palaa sovellukseen.",
+  "failedToStartAuth": "{appName}-todennuksen aloitus epäonnistui",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Katkaise yhteys palveluun {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Haluatko varmasti katkaista yhteyden palveluun {appName}? Voit yhdistää uudelleen milloin tahansa.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Yhteys katkaistu palveluun {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Yhteyden katkaisu epäonnistui",
+  "connectTo": "Yhdistä palveluun {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Sinun on valtuutettava Omi käyttämään {appName}-tietojasi. Tämä avaa selaimesi todennusta varten.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Jatka",
+  "languageTitle": "Kieli",
+  "primaryLanguage": "Ensisijainen kieli",
+  "automaticTranslation": "Automaattinen käännös",
+  "detectLanguages": "Tunnista yli 10 kieltä",
+  "authorizeSavingRecordings": "Valtuuta nauhoitusten tallentaminen",
+  "thanksForAuthorizing": "Kiitos valtuutuksesta!",
+  "needYourPermission": "Tarvitsemme lupasi",
+  "alreadyGavePermission": "Olet jo antanut meille luvan tallentaa nauhoituksiasi. Tässä muistutus siitä, miksi tarvitsemme sen:",
+  "wouldLikePermission": "Haluaisimme lupasi tallentaa ääninauhoituksesi. Tässä syy:",
+  "improveSpeechProfile": "Paranna puheprofiiliasi",
+  "improveSpeechProfileDesc": "Käytämme nauhoituksia henkilökohtaisen puheprofiilisi kouluttamiseen ja parantamiseen.",
+  "trainFamilyProfiles": "Kouluta profiileja ystäville ja perheelle",
+  "trainFamilyProfilesDesc": "Nauhoituksesi auttavat meitä tunnistamaan ja luomaan profiileja ystävillesi ja perheellesi.",
+  "enhanceTranscriptAccuracy": "Paranna litterointitarkkuutta",
+  "enhanceTranscriptAccuracyDesc": "Kun mallimme paranee, voimme tarjota parempia litterointituloksia nauhoituksillesi.",
+  "legalNotice": "Oikeudellinen huomautus: Äänidatan nauhoittamisen ja tallentamisen laillisuus voi vaihdella sijaintisi ja tämän ominaisuuden käyttötavan mukaan. Vastaat paikallisten lakien ja määräysten noudattamisesta.",
+  "alreadyAuthorized": "Jo valtuutettu",
+  "authorize": "Valtuuta",
+  "revokeAuthorization": "Peru valtuutus",
+  "authorizationSuccessful": "Valtuutus onnistui!",
+  "failedToAuthorize": "Valtuutus epäonnistui. Yritä uudelleen.",
+  "authorizationRevoked": "Valtuutus peruttu.",
+  "recordingsDeleted": "Nauhoitukset poistettu.",
+  "failedToRevoke": "Valtuutuksen peruutus epäonnistui. Yritä uudelleen.",
+  "permissionRevokedTitle": "Lupa peruttu",
+  "permissionRevokedMessage": "Haluatko meidän poistavan myös kaikki olemassa olevat nauhoituksesi?",
+  "yes": "Kyllä",
+  "editName": "Muokkaa nimeä",
+  "howShouldOmiCallYou": "Miten Omin pitäisi kutsua sinua?",
+  "enterYourName": "Kirjoita nimesi",
+  "nameCannotBeEmpty": "Nimi ei voi olla tyhjä",
+  "nameUpdatedSuccessfully": "Nimi päivitetty onnistuneesti!",
+  "calendarSettings": "Kalenteriasetukset",
+  "calendarProviders": "Kalenteripalvelut",
+  "macOsCalendar": "macOS-kalenteri",
+  "connectMacOsCalendar": "Yhdistä paikallinen macOS-kalenterisi",
+  "googleCalendar": "Google Kalenteri",
+  "syncGoogleAccount": "Synkronoi Google-tilisi kanssa",
+  "showMeetingsMenuBar": "Näytä tulevat kokoukset valikkorivissä",
+  "showMeetingsMenuBarDesc": "Näytä seuraava kokouksesi ja aika sen alkuun macOS-valikkorivissä",
+  "showEventsNoParticipants": "Näytä tapahtumat ilman osallistujia",
+  "showEventsNoParticipantsDesc": "Kun käytössä, Tulossa näyttää tapahtumat ilman osallistujia tai videolinkkiä.",
+  "yourMeetings": "Kokouksesi",
+  "refresh": "Päivitä",
+  "noUpcomingMeetings": "Tulevia kokouksia ei löytynyt",
+  "checkingNextDays": "Tarkistetaan seuraavat 30 päivää",
+  "tomorrow": "Huomenna",
+  "googleCalendarComingSoon": "Google Kalenteri -integraatio tulossa pian!",
+  "connectedAsUser": "Yhdistetty käyttäjänä: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Oletustyötila",
+  "tasksCreatedInWorkspace": "Tehtävät luodaan tähän työtilaan",
+  "defaultProjectOptional": "Oletusprojekti (valinnainen)",
+  "leaveUnselectedTasks": "Jätä valitsematta luodaksesi tehtäviä ilman projektia",
+  "noProjectsInWorkspace": "Projekteja ei löytynyt tästä työtilasta",
+  "conversationTimeoutDesc": "Valitse kuinka kauan odotetaan hiljaisuutta ennen keskustelun automaattista päättämistä:",
+  "timeout2Minutes": "2 minuuttia",
+  "timeout2MinutesDesc": "Lopeta keskustelu 2 minuutin hiljaisuuden jälkeen",
+  "timeout5Minutes": "5 minuuttia",
+  "timeout5MinutesDesc": "Lopeta keskustelu 5 minuutin hiljaisuuden jälkeen",
+  "timeout10Minutes": "10 minuuttia",
+  "timeout10MinutesDesc": "Lopeta keskustelu 10 minuutin hiljaisuuden jälkeen",
+  "timeout30Minutes": "30 minuuttia",
+  "timeout30MinutesDesc": "Lopeta keskustelu 30 minuutin hiljaisuuden jälkeen",
+  "timeout4Hours": "4 tuntia",
+  "timeout4HoursDesc": "Lopeta keskustelu 4 tunnin hiljaisuuden jälkeen",
+  "conversationEndAfterHours": "Keskustelut päättyvät nyt 4 tunnin hiljaisuuden jälkeen",
+  "conversationEndAfterMinutes": "Keskustelut päättyvät nyt {minutes} minuutin hiljaisuuden jälkeen",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Kerro meille ensisijainen kielesi",
+  "languageForTranscription": "Aseta kielesi tarkempaa litterointia ja henkilökohtaista kokemusta varten.",
+  "singleLanguageModeInfo": "Yhden kielen tila on käytössä. Käännös on poistettu käytöstä paremman tarkkuuden vuoksi.",
+  "searchLanguageHint": "Etsi kieltä nimen tai koodin perusteella",
+  "noLanguagesFound": "Kieliä ei löytynyt",
+  "skip": "Ohita",
+  "languageSetTo": "Kieleksi asetettu {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Kielen asetus epäonnistui",
+  "appSettings": "{appName}-asetukset",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Katkaise yhteys palveluun {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Tämä poistaa {appName}-todennuksesi. Sinun on yhdistettävä uudelleen käyttääksesi sitä uudelleen.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Yhdistetty palveluun {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Tili",
+  "actionItemsSyncedTo": "Tehtäväsi synkronoidaan {appName}-tilillesi",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Oletustila",
+  "selectSpaceInWorkspace": "Valitse tila työtilassasi",
+  "noSpacesInWorkspace": "Tiloja ei löytynyt tästä työtilasta",
+  "defaultList": "Oletusluettelo",
+  "tasksAddedToList": "Tehtävät lisätään tähän luetteloon",
+  "noListsInSpace": "Luetteloita ei löytynyt tästä tilasta",
+  "failedToLoadRepos": "Repositorioiden lataaminen epäonnistui: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Oletusrepositorio tallennettu",
+  "failedToSaveDefaultRepo": "Oletusrepositorion tallentaminen epäonnistui",
+  "defaultRepository": "Oletusrepositorio",
+  "selectDefaultRepoDesc": "Valitse oletusrepositorio ongelmien luomiseen. Voit silti määrittää eri repositorion ongelmia luodessa.",
+  "noReposFound": "Repositorioita ei löytynyt",
+  "private": "Yksityinen",
+  "updatedDate": "Päivitetty {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "eilen",
+  "daysAgo": "{count} päivää sitten",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "viikko sitten",
+  "weeksAgo": "{count} viikkoa sitten",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "kuukausi sitten",
+  "monthsAgo": "{count} kuukautta sitten",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Ongelmat luodaan oletusrepositoriossasi",
+  "taskIntegrations": "Tehtäväintegraatiot",
+  "configureSettings": "Määritä asetukset",
+  "completeAuthBrowser": "Viimeistele todennus selaimessasi. Kun olet valmis, palaa sovellukseen.",
+  "failedToStartAppAuth": "{appName}-todennuksen aloitus epäonnistui",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Yhdistä palveluun {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Sinun on valtuutettava Omi luomaan tehtäviä {appName}-tilillesi. Tämä avaa selaimesi todennusta varten.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Jatka",
+  "appIntegration": "{appName}-integraatio",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integraatio palvelun {appName} kanssa tulossa pian! Työskentelemme ahkerasti tuodaksemme sinulle lisää tehtävänhallinnan vaihtoehtoja.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Selvä",
+  "tasksExportedOneApp": "Tehtäviä voidaan viedä yhteen sovellukseen kerrallaan",
+  "completeYourUpgrade": "Viimeistele päivityksesi",
+  "importConfiguration": "Tuo kokoonpano",
+  "exportConfiguration": "Vie kokoonpano",
+  "bringYourOwn": "Tuo omasi",
+  "payYourSttProvider": "Käytä omia vapaasti. Maksat vain STT-palveluntarjoajallesi suoraan.",
+  "freeMinutesMonth": "1 200 ilmaisminuuttia kuukaudessa mukana. Rajoittamaton ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Isäntä vaaditaan",
+  "validPortRequired": "Kelvollinen portti vaaditaan",
+  "validWebsocketUrlRequired": "Kelvollinen WebSocket-URL vaaditaan (wss://)",
+  "apiUrlRequired": "API-URL vaaditaan",
+  "apiKeyRequired": "API-avain vaaditaan",
+  "invalidJsonConfig": "Virheellinen JSON-kokoonpano",
+  "errorSaving": "Virhe tallentaessa: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Kokoonpano kopioitu leikepöydälle",
+  "pasteJsonConfig": "Liitä JSON-kokoonpanosi alle:",
+  "addApiKeyAfterImport": "Sinun on lisättävä oma API-avaimesi tuonnin jälkeen",
+  "paste": "Liitä",
+  "import": "Tuo",
+  "invalidProviderInConfig": "Virheellinen palveluntarjoaja kokoonpanossa",
+  "importedConfig": "Tuotu {providerName}-kokoonpano",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Virheellinen JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Palveluntarjoaja",
+  "live": "Live",
+  "onDevice": "Laitteella",
+  "apiUrl": "API-URL",
+  "enterSttHttpEndpoint": "Kirjoita STT HTTP -päätepisteesi",
+  "websocketUrl": "WebSocket-URL",
+  "enterLiveSttWebsocket": "Kirjoita live-STT WebSocket -päätepisteesi",
+  "apiKey": "API-avain",
+  "enterApiKey": "Kirjoita API-avaimesi",
+  "storedLocallyNeverShared": "Tallennettu paikallisesti, ei koskaan jaettu",
+  "host": "Isäntä",
+  "port": "Portti",
+  "advanced": "Lisäasetukset",
+  "configuration": "Kokoonpano",
+  "requestConfiguration": "Pyyntökokoonpano",
+  "responseSchema": "Vastauskaavio",
+  "modified": "Muokattu",
+  "resetRequestConfig": "Palauta pyyntökokoonpano oletuksiin",
+  "logs": "Lokit",
+  "logsCopied": "Lokit kopioitu",
+  "noLogsYet": "Ei vielä lokeja. Aloita nauhoitus nähdäksesi mukautetun STT-toiminnan.",
+  "deviceUsesCodec": "{deviceName} käyttää {codecReason}. Omia käytetään.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi-litterointi",
+  "bestInClassTranscription": "Paras litterointi ilman asennusta",
+  "instantSpeakerLabels": "Välittömät puhujatunnisteet",
+  "languageTranslation": "Yli 100 kielen käännös",
+  "optimizedForConversation": "Optimoitu keskusteluille",
+  "autoLanguageDetection": "Automaattinen kielentunnistus",
+  "highAccuracy": "Korkea tarkkuus",
+  "privacyFirst": "Yksityisyys ensin",
+  "saveChanges": "Tallenna muutokset",
+  "resetToDefault": "Palauta oletuksiin",
+  "viewTemplate": "Näytä malli",
+  "trySomethingLike": "Kokeile jotain tällaista...",
+  "tryIt": "Kokeile",
+  "creatingPlan": "Luodaan suunnitelmaa",
+  "developingLogic": "Kehitetään logiikkaa",
+  "designingApp": "Suunnitellaan sovellusta",
+  "generatingIconStep": "Luodaan kuvaketta",
+  "finalTouches": "Viimeiset viimeistelyt",
+  "processing": "Käsitellään...",
+  "features": "Ominaisuudet",
+  "creatingYourApp": "Luodaan sovellustasi...",
+  "generatingIcon": "Luodaan kuvaketta...",
+  "whatShouldWeMake": "Mitä meidän pitäisi tehdä?",
+  "appName": "Sovelluksen nimi",
+  "description": "Kuvaus",
+  "publicLabel": "Julkinen",
+  "privateLabel": "Yksityinen",
+  "free": "Ilmainen",
+  "perMonth": "/ kuukausi",
+  "tailoredConversationSummaries": "Räätälöidyt keskusteluyhteenvedot",
+  "customChatbotPersonality": "Mukautettu chatbot-persoonallisuus",
+  "makePublic": "Tee julkiseksi",
+  "anyoneCanDiscover": "Kuka tahansa voi löytää sovelluksesi",
+  "onlyYouCanUse": "Vain sinä voit käyttää tätä sovellusta",
+  "paidApp": "Maksullinen sovellus",
+  "usersPayToUse": "Käyttäjät maksavat sovelluksesi käytöstä",
+  "freeForEveryone": "Ilmainen kaikille",
+  "perMonthLabel": "/ kuukausi",
+  "creating": "Luodaan...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Luo sovellus",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Etsitään laitteita...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{LAITE} other{LAITETTA}} LÖYDETTY LÄHISTÖLTÄ",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PARILIITOS ONNISTUI",
+  "errorConnectingAppleWatch": "Virhe yhdistettäessä Apple Watchiin: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Älä näytä uudelleen",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Ymmärrän",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Ota Bluetooth käyttöön",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi tarvitsee Bluetoothin yhdistääkseen puettavaan laitteeseesi. Ota Bluetooth käyttöön ja yritä uudelleen.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Ota yhteyttä tukeen?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Yhdistä myöhemmin",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Myönnä käyttöoikeudet",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Taustatoiminta",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Anna Omin toimia taustalla parempaa vakautta varten",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Sijaintipääsy",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Ota taustasijaintisi käyttöön täydelliseen kokemukseen",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Ilmoitukset",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Ota ilmoitukset käyttöön pysyäksesi ajan tasalla",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Sijaintipalvelu poistettu käytöstä",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Sijaintipalvelu on poistettu käytöstä. Siirry kohtaan Asetukset > Tietosuoja ja turvallisuus > Sijaintipalvelut ja ota se käyttöön",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Taustasijaintipääsy evätty",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Siirry laitteen asetuksiin ja aseta sijaintioikeus asentoon \"Salli aina\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Pidätkö Omista?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Auta meitä tavoittamaan lisää ihmisiä jättämällä arvostelu App Storeen. Palautteesi on meille tärkeää!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Auta meitä tavoittamaan lisää ihmisiä jättämällä arvostelu Google Play -kauppaan. Palautteesi on meille tärkeää!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Arvostele App Storessa",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Arvostele Google Playssa",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Ehkä myöhemmin",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omin on opittava tavoitteesi ja äänesi. Voit muokata sitä myöhemmin.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Aloita",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Kaikki valmista!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Jatka, teet loistavasti",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Ohita tämä kysymys",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Ohita toistaiseksi",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Yhteysvirhe",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Yhteys palvelimeen epäonnistui. Tarkista internet-yhteytesi ja yritä uudelleen.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Virheellinen nauhoitus havaittu",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Näyttää siltä, että nauhoituksessa on useita puhujia. Varmista, että olet hiljaisessa paikassa ja yritä uudelleen.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Puhetta ei havaittu tarpeeksi. Puhu enemmän ja yritä uudelleen.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Varmista, että puhut vähintään 5 sekuntia ja korkeintaan 90 sekuntia.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Oletko siellä?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Emme voineet havaita mitään puhetta. Varmista, että puhut vähintään 10 sekuntia ja korkeintaan 3 minuuttia.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Yhteys katkesi",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Yhteys keskeytyi. Tarkista internet-yhteytesi ja yritä uudelleen.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Yritä uudelleen",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Yhdistä Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Jatka ilman laitetta",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Käyttöoikeudet vaaditaan",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Tämä sovellus tarvitsee Bluetooth- ja sijaintioikeudet toimiakseen oikein. Ota ne käyttöön asetuksissa.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Avaa asetukset",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Haluatko käyttää eri nimeä?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Mikä nimesi on?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Puhu. Litteroi. Tee yhteenveto.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Kirjaudu Applella",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Kirjaudu Googlella",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Jatkamalla hyväksyt ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Käyttöehdot",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – tekoälykumppanisi",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Tallenna jokainen hetki. Saat tekoälyn\nluomat yhteenvedot. Älä enää tee muistiinpanoja.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch -asennus",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Käyttöoikeus pyydetty!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Mikrofonin käyttöoikeus",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Käyttöoikeus myönnetty! Nyt:\n\nAvaa Omi-sovellus kellossasi ja napauta \"Jatka\" alla",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Tarvitsemme mikrofonin käyttöoikeuden.\n\n1. Napauta \"Myönnä käyttöoikeus\"\n2. Salli iPhonessasi\n3. Kello-sovellus sulkeutuu\n4. Avaa uudelleen ja napauta \"Jatka\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Myönnä käyttöoikeus",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Tarvitsetko apua?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Vianmääritys:\n\n1. Varmista, että Omi on asennettu kelloosi\n2. Avaa Omi-sovellus kellossasi\n3. Etsi käyttöoikeuspyyntö\n4. Napauta \"Salli\" kehotettaessa\n5. Kello-sovellus sulkeutuu - avaa se uudelleen\n6. Palaa ja napauta \"Jatka\" iPhonessasi",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Nauhoitus aloitettu onnistuneesti!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Käyttöoikeutta ei ole vielä myönnetty. Varmista, että salloit mikrofonin käytön ja avasit sovelluksen kellossasi uudelleen.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Virhe pyydettäessä käyttöoikeutta: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Virhe nauhoituksen aloittamisessa: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Valitse ensisijainen kielesi",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Aseta kielesi tarkempaa litterointia ja henkilökohtaista kokemusta varten",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Mikä on ensisijainen kielesi?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Valitse kielesi",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Henkilökohtainen kasvumatkasi tekoälyn kanssa, joka kuuntelee jokaista sanaasi.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Tehtävät",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Napauta muokataksesi • Pidä painettuna valitaksesi • Pyyhkäise toiminnoille",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Tekemättä",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Tehty",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Vanhat",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Kaikki hoidettu!\nEi odottavia tehtäviä",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Ei vielä suoritettuja kohteita",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Ei vanhoja tehtäviä",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Ei kohteita",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Tehtävä merkitty keskeneräiseksi",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Tehtävä suoritettu",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Poista tehtävä",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Haluatko varmasti poistaa tämän tehtävän?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Poista valitut kohteet",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Haluatko varmasti poistaa {count} valittua tehtävää?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Tehtävä \"{description}\" poistettu",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} tehtävää poistettu",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Tehtävän poisto epäonnistui",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Kohteiden poisto epäonnistui",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Joidenkin kohteiden poisto epäonnistui",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Valmis tehtäville",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Tekoälysi poimii automaattisesti tehtävät ja to-do-listat keskusteluistasi. Ne näkyvät täällä, kun ne on luotu.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Poimittu automaattisesti keskusteluista",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Napauta muokataksesi, pyyhkäise suorittaaksesi tai poistaaksesi",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} valittu",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Valitse kaikki",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Poista valitut",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Etsi {count} muistoa",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Muisto poistettu.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Kumoa",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Ei vielä muistoja",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Ei vielä automaattisesti poimittuja muistoja",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Ei vielä manuaalisia muistoja",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Ei muistoja näissä kategorioissa",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Muistoja ei löytynyt",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Lisää ensimmäinen muistosi",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Tyhjennä Omin muisti",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Haluatko varmasti tyhjentää Omin muistin? Tätä toimintoa ei voi perua.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Tyhjennä muisti",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omin muisti sinusta on tyhjennetty",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Ei poistettavia muistoja",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Luo uusi muisto",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Luo uusi tehtävä",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Muistinhallinta",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Suodata muistoja",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Sinulla on {count} muistoa yhteensä",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Julkiset muistot",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Yksityiset muistot",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Tee kaikki muistot yksityisiksi",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Tee kaikki muistot julkisiksi",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Poista kaikki muistot",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Kaikki muistot ovat nyt yksityisiä",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Kaikki muistot ovat nyt julkisia",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Uusi muisto",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Muokkaa muistoa",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Pidän jäätelön syömisestä...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Tallennus epäonnistui. Tarkista yhteytesi.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Tallenna muisto",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Yritä uudelleen",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Luo tehtävä",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Muokkaa tehtävää",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Mitä pitää tehdä?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Tehtävän kuvaus ei voi olla tyhjä.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Tehtävä päivitetty",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Tehtävän päivitys epäonnistui",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Tehtävä luotu",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Tehtävän luonti epäonnistui",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Eräpäivä",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Aika",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Lisää eräpäivä",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Paina valmis tallentaaksesi",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Paina valmis luodaksesi",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Kaikki",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Tietoja sinusta",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Oivallukset",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuaalinen",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Suoritettu",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Merkitse suoritetuksi",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Tehtävä poistettu",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Tehtävän poisto epäonnistui",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Poista tehtävä",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Haluatko varmasti poistaa tämän tehtävän?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Sovelluksen kieli",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "SOVELLUKSEN KÄYTTÖLIITTYMÄ",
+  "speechTranscriptionSectionTitle": "PUHE JA LITTEROINTI",
+  "languageSettingsHelperText": "Sovelluksen kieli muuttaa valikkoja ja painikkeita. Puheen kieli vaikuttaa siihen, miten tallenteet litteroidaan."
+}

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -1,0 +1,1119 @@
+{
+  "@@locale": "fr",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "conversationTab": "Conversation",
+  "transcriptTab": "Transcription",
+  "actionItemsTab": "Actions à faire",
+  "deleteConversationTitle": "Supprimer la conversation ?",
+  "deleteConversationMessage": "Êtes-vous sûr de vouloir supprimer cette conversation ? Cette action est irréversible.",
+  "confirm": "Confirmer",
+  "cancel": "Annuler",
+  "ok": "OK",
+  "delete": "Supprimer",
+  "add": "Ajouter",
+  "update": "Mettre à jour",
+  "save": "Enregistrer",
+  "edit": "Modifier",
+  "close": "Fermer",
+  "clear": "Effacer",
+  "copyTranscript": "Copier la transcription",
+  "copySummary": "Copier le résumé",
+  "testPrompt": "Tester le prompt",
+  "reprocessConversation": "Retraiter la conversation",
+  "deleteConversation": "Supprimer la conversation",
+  "contentCopied": "Contenu copié dans le presse-papiers",
+  "failedToUpdateStarred": "Échec de la mise à jour du statut favori.",
+  "conversationUrlNotShared": "L'URL de la conversation n'a pas pu être partagée.",
+  "errorProcessingConversation": "Erreur lors du traitement de la conversation. Veuillez réessayer plus tard.",
+  "noInternetConnection": "Veuillez vérifier votre connexion internet et réessayer.",
+  "unableToDeleteConversation": "Impossible de supprimer la conversation",
+  "somethingWentWrong": "Une erreur s'est produite ! Veuillez réessayer plus tard.",
+  "copyErrorMessage": "Copier le message d'erreur",
+  "errorCopied": "Message d'erreur copié dans le presse-papiers",
+  "remaining": "Restant",
+  "loading": "Chargement...",
+  "loadingDuration": "Chargement de la durée...",
+  "secondsCount": "{count} secondes",
+  "@secondsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Personnes",
+  "addNewPerson": "Ajouter une nouvelle personne",
+  "editPerson": "Modifier la personne",
+  "createPersonHint": "Créez une nouvelle personne et entraînez Omi à reconnaître sa voix aussi !",
+  "speechProfile": "Profil vocal",
+  "sampleNumber": "Échantillon {number}",
+  "@sampleNumber": {
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Paramètres",
+  "language": "Langue",
+  "selectLanguage": "Sélectionner la langue",
+  "deleting": "Suppression...",
+  "pleaseCompleteAuthentication": "Veuillez compléter l'authentification dans votre navigateur. Une fois terminé, revenez à l'application.",
+  "failedToStartAuthentication": "Échec du démarrage de l'authentification",
+  "importStarted": "Importation démarrée ! Vous serez notifié une fois terminée.",
+  "failedToStartImport": "Échec du démarrage de l'importation. Veuillez réessayer.",
+  "couldNotAccessFile": "Impossible d'accéder au fichier sélectionné",
+  "askOmi": "Demander à Omi",
+  "done": "Terminé",
+  "disconnected": "Déconnecté",
+  "searching": "Recherche",
+  "connectDevice": "Connecter l'appareil",
+  "monthlyLimitReached": "Vous avez atteint votre limite mensuelle.",
+  "checkUsage": "Vérifier l'utilisation",
+  "syncingRecordings": "Synchronisation des enregistrements",
+  "recordingsToSync": "Enregistrements à synchroniser",
+  "allCaughtUp": "Tout est à jour",
+  "sync": "Synchroniser",
+  "pendantUpToDate": "Le pendentif est à jour",
+  "allRecordingsSynced": "Tous les enregistrements sont synchronisés",
+  "syncingInProgress": "Synchronisation en cours",
+  "readyToSync": "Prêt à synchroniser",
+  "tapSyncToStart": "Appuyez sur Synchroniser pour commencer",
+  "pendantNotConnected": "Pendentif non connecté. Connectez-vous pour synchroniser.",
+  "everythingSynced": "Tout est déjà synchronisé.",
+  "recordingsNotSynced": "Vous avez des enregistrements qui ne sont pas encore synchronisés.",
+  "syncingBackground": "Nous continuerons à synchroniser vos enregistrements en arrière-plan.",
+  "noConversationsYet": "Pas encore de conversations.",
+  "noStarredConversations": "Pas encore de conversations favorites.",
+  "starConversationHint": "Pour marquer une conversation comme favorite, ouvrez-la et appuyez sur l'icône étoile dans l'en-tête.",
+  "searchConversations": "Rechercher des conversations",
+  "selectedCount": "{count} sélectionné(s)",
+  "@selectedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Fusionner",
+  "mergeConversations": "Fusionner les conversations",
+  "mergeConversationsMessage": "Cela combinera {count} conversations en une seule. Tout le contenu sera fusionné et régénéré.",
+  "@mergeConversationsMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Fusion en cours en arrière-plan. Cela peut prendre un moment.",
+  "failedToStartMerge": "Échec du démarrage de la fusion",
+  "askAnything": "Demandez n'importe quoi",
+  "noMessagesYet": "Pas encore de messages !\nPourquoi ne pas commencer une conversation ?",
+  "deletingMessages": "Suppression de vos messages de la mémoire d'Omi...",
+  "messageCopied": "Message copié dans le presse-papiers.",
+  "cannotReportOwnMessage": "Vous ne pouvez pas signaler vos propres messages.",
+  "reportMessage": "Signaler le message",
+  "reportMessageConfirm": "Êtes-vous sûr de vouloir signaler ce message ?",
+  "messageReported": "Message signalé avec succès.",
+  "thankYouFeedback": "Merci pour votre retour !",
+  "clearChat": "Effacer la discussion ?",
+  "clearChatConfirm": "Êtes-vous sûr de vouloir effacer la discussion ? Cette action est irréversible.",
+  "maxFilesLimit": "Vous ne pouvez télécharger que 4 fichiers à la fois",
+  "chatWithOmi": "Discuter avec Omi",
+  "apps": "Applications",
+  "noAppsFound": "Aucune application trouvée",
+  "tryAdjustingSearch": "Essayez d'ajuster votre recherche ou vos filtres",
+  "createYourOwnApp": "Créez votre propre application",
+  "buildAndShareApp": "Créez et partagez votre application personnalisée",
+  "searchApps": "Rechercher plus de 1500 applications",
+  "myApps": "Mes applications",
+  "installedApps": "Applications installées",
+  "unableToFetchApps": "Impossible de récupérer les applications :(\n\nVeuillez vérifier votre connexion internet et réessayer.",
+  "aboutOmi": "À propos d'Omi",
+  "privacyPolicy": "Politique de confidentialité",
+  "visitWebsite": "Visiter le site web",
+  "helpOrInquiries": "Aide ou questions ?",
+  "joinCommunity": "Rejoignez la communauté !",
+  "membersAndCounting": "Plus de 8000 membres et ça continue.",
+  "deleteAccountTitle": "Supprimer le compte",
+  "deleteAccountConfirm": "Êtes-vous sûr de vouloir supprimer votre compte ?",
+  "cannotBeUndone": "Cette action est irréversible.",
+  "allDataErased": "Toutes vos mémoires et conversations seront définitivement effacées.",
+  "appsDisconnected": "Vos applications et intégrations seront déconnectées immédiatement.",
+  "exportBeforeDelete": "Vous pouvez exporter vos données avant de supprimer votre compte, mais une fois supprimé, il ne pourra pas être récupéré.",
+  "deleteAccountCheckbox": "Je comprends que la suppression de mon compte est permanente et que toutes les données, y compris les mémoires et conversations, seront perdues et ne pourront pas être récupérées.",
+  "areYouSure": "Êtes-vous sûr ?",
+  "deleteAccountFinal": "Cette action est irréversible et supprimera définitivement votre compte et toutes les données associées. Êtes-vous sûr de vouloir continuer ?",
+  "deleteNow": "Supprimer maintenant",
+  "goBack": "Retour",
+  "checkBoxToConfirm": "Cochez la case pour confirmer que vous comprenez que la suppression de votre compte est permanente et irréversible.",
+  "profile": "Profil",
+  "name": "Nom",
+  "email": "E-mail",
+  "customVocabulary": "Vocabulaire personnalisé",
+  "identifyingOthers": "Identification des autres",
+  "paymentMethods": "Moyens de paiement",
+  "conversationDisplay": "Affichage des conversations",
+  "dataPrivacy": "Données et confidentialité",
+  "userId": "ID utilisateur",
+  "notSet": "Non défini",
+  "userIdCopied": "ID utilisateur copié dans le presse-papiers",
+  "systemDefault": "Par défaut du système",
+  "planAndUsage": "Forfait et utilisation",
+  "offlineSync": "Synchronisation hors ligne",
+  "deviceSettings": "Paramètres de l'appareil",
+  "chatTools": "Outils de chat",
+  "feedbackBug": "Retour / Bug",
+  "helpCenter": "Centre d'aide",
+  "developerSettings": "Paramètres développeur",
+  "getOmiForMac": "Obtenir Omi pour Mac",
+  "referralProgram": "Programme de parrainage",
+  "signOut": "Déconnexion",
+  "appAndDeviceCopied": "Détails de l'application et de l'appareil copiés",
+  "wrapped2025": "Rétrospective 2025",
+  "yourPrivacyYourControl": "Votre vie privée, votre contrôle",
+  "privacyIntro": "Chez Omi, nous nous engageons à protéger votre vie privée. Cette page vous permet de contrôler la façon dont vos données sont stockées et utilisées.",
+  "learnMore": "En savoir plus...",
+  "dataProtectionLevel": "Niveau de protection des données",
+  "dataProtectionDesc": "Vos données sont sécurisées par défaut avec un cryptage fort. Vérifiez vos paramètres et les futures options de confidentialité ci-dessous.",
+  "appAccess": "Accès des applications",
+  "appAccessDesc": "Les applications suivantes peuvent accéder à vos données. Appuyez sur une application pour gérer ses autorisations.",
+  "noAppsExternalAccess": "Aucune application installée n'a d'accès externe à vos données.",
+  "deviceName": "Nom de l'appareil",
+  "deviceId": "ID de l'appareil",
+  "firmware": "Firmware",
+  "sdCardSync": "Synchronisation carte SD",
+  "hardwareRevision": "Révision matérielle",
+  "modelNumber": "Numéro de modèle",
+  "manufacturer": "Fabricant",
+  "doubleTap": "Double appui",
+  "ledBrightness": "Luminosité LED",
+  "micGain": "Gain du micro",
+  "disconnect": "Déconnecter",
+  "forgetDevice": "Oublier l'appareil",
+  "chargingIssues": "Problèmes de charge",
+  "disconnectDevice": "Déconnecter l'appareil",
+  "unpairDevice": "Dissocier l'appareil",
+  "unpairAndForget": "Dissocier et oublier l'appareil",
+  "deviceDisconnectedMessage": "Votre Omi a été déconnecté 😔",
+  "deviceUnpairedMessage": "Appareil dissocié. Allez dans Réglages > Bluetooth et oubliez l'appareil pour terminer la dissociation.",
+  "unpairDialogTitle": "Dissocier l'appareil",
+  "unpairDialogMessage": "Cela dissociera l'appareil afin qu'il puisse être connecté à un autre téléphone. Vous devrez aller dans Réglages > Bluetooth et oublier l'appareil pour terminer le processus.",
+  "deviceNotConnected": "Appareil non connecté",
+  "connectDeviceMessage": "Connectez votre appareil Omi pour accéder aux\nparamètres et à la personnalisation de l'appareil",
+  "deviceInfoSection": "Informations sur l'appareil",
+  "customizationSection": "Personnalisation",
+  "hardwareSection": "Matériel",
+  "v2Undetected": "V2 non détecté",
+  "v2UndetectedMessage": "Nous voyons que vous avez soit un appareil V1, soit votre appareil n'est pas connecté. La fonctionnalité carte SD n'est disponible que pour les appareils V2.",
+  "endConversation": "Terminer la conversation",
+  "pauseResume": "Pause/Reprendre",
+  "starConversation": "Marquer la conversation comme favorite",
+  "doubleTapAction": "Action double appui",
+  "endAndProcess": "Terminer et traiter la conversation",
+  "pauseResumeRecording": "Pause/Reprendre l'enregistrement",
+  "starOngoing": "Marquer la conversation en cours comme favorite",
+  "off": "Désactivé",
+  "max": "Max",
+  "mute": "Muet",
+  "quiet": "Silencieux",
+  "normal": "Normal",
+  "high": "Élevé",
+  "micGainDescMuted": "Le microphone est en sourdine",
+  "micGainDescLow": "Très silencieux - pour les environnements bruyants",
+  "micGainDescModerate": "Silencieux - pour un bruit modéré",
+  "micGainDescNeutral": "Neutre - enregistrement équilibré",
+  "micGainDescSlightlyBoosted": "Légèrement amplifié - utilisation normale",
+  "micGainDescBoosted": "Amplifié - pour les environnements calmes",
+  "micGainDescHigh": "Élevé - pour les voix distantes ou douces",
+  "micGainDescVeryHigh": "Très élevé - pour les sources très silencieuses",
+  "micGainDescMax": "Maximum - à utiliser avec précaution",
+  "developerSettingsTitle": "Paramètres développeur",
+  "saving": "Enregistrement...",
+  "personaConfig": "Configurez votre persona IA",
+  "beta": "BÊTA",
+  "transcription": "Transcription",
+  "transcriptionConfig": "Configurer le fournisseur STT",
+  "conversationTimeout": "Délai de conversation",
+  "conversationTimeoutConfig": "Définir quand les conversations se terminent automatiquement",
+  "importData": "Importer des données",
+  "importDataConfig": "Importer des données d'autres sources",
+  "debugDiagnostics": "Débogage et diagnostics",
+  "endpointUrl": "URL du point de terminaison",
+  "noApiKeys": "Pas encore de clés API",
+  "createKeyToStart": "Créez une clé pour commencer",
+  "createKey": "Créer une clé",
+  "docs": "Documentation",
+  "yourOmiInsights": "Vos statistiques Omi",
+  "today": "Aujourd'hui",
+  "thisMonth": "Ce mois-ci",
+  "thisYear": "Cette année",
+  "allTime": "Depuis toujours",
+  "noActivityYet": "Pas encore d'activité",
+  "startConversationToSeeInsights": "Commencez une conversation avec Omi\npour voir vos statistiques d'utilisation ici.",
+  "listening": "Écoute",
+  "listeningSubtitle": "Temps total d'écoute active d'Omi.",
+  "understanding": "Compréhension",
+  "understandingSubtitle": "Mots compris de vos conversations.",
+  "providing": "Fourniture",
+  "providingSubtitle": "Actions à faire et notes capturées automatiquement.",
+  "remembering": "Mémorisation",
+  "rememberingSubtitle": "Faits et détails mémorisés pour vous.",
+  "unlimitedPlan": "Forfait illimité",
+  "managePlan": "Gérer le forfait",
+  "cancelAtPeriodEnd": "Votre forfait sera annulé le {date}.",
+  "@cancelAtPeriodEnd": {
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "1 jan. 2026"
+      }
+    }
+  },
+  "renewsOn": "Votre forfait sera renouvelé le {date}.",
+  "@renewsOn": {
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "1 jan. 2026"
+      }
+    }
+  },
+  "basicPlan": "Forfait gratuit",
+  "usageLimitMessage": "{used} sur {limit} min utilisées",
+  "@usageLimitMessage": {
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Mettre à niveau",
+  "upgradeToUnlimited": "Passer à l'illimité",
+  "basicPlanDesc": "Votre forfait comprend {limit} minutes gratuites par mois. Passez à l'illimité.",
+  "@basicPlanDesc": {
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Je partage mes statistiques Omi ! (omi.me - votre assistant IA toujours actif)",
+  "sharePeriodToday": "Aujourd'hui, Omi a :",
+  "sharePeriodMonth": "Ce mois-ci, Omi a :",
+  "sharePeriodYear": "Cette année, Omi a :",
+  "sharePeriodAllTime": "Jusqu'à présent, Omi a :",
+  "shareStatsListened": "🎧 Écouté pendant {minutes} minutes",
+  "@shareStatsListened": {
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Compris {words} mots",
+  "@shareStatsWords": {
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Fourni {count} aperçus",
+  "@shareStatsInsights": {
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Mémorisé {count} souvenirs",
+  "@shareStatsMemories": {
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Journaux de débogage",
+  "debugLogsAutoDelete": "Suppression automatique après 3 jours.",
+  "debugLogsDesc": "Aide à diagnostiquer les problèmes",
+  "noLogFilesFound": "Aucun fichier journal trouvé.",
+  "omiDebugLog": "Journal de débogage Omi",
+  "logShared": "Journal partagé",
+  "selectLogFile": "Sélectionner un fichier journal",
+  "shareLogs": "Partager les journaux",
+  "debugLogCleared": "Journal de débogage effacé",
+  "exportStarted": "Exportation démarrée. Cela peut prendre quelques secondes...",
+  "exportAllData": "Exporter toutes les données",
+  "exportDataDesc": "Exporter les conversations vers un fichier JSON",
+  "exportedConversations": "Conversations exportées depuis Omi",
+  "exportShared": "Exportation partagée",
+  "deleteKnowledgeGraphTitle": "Supprimer le graphe de connaissances ?",
+  "deleteKnowledgeGraphMessage": "Cela supprimera toutes les données du graphe de connaissances dérivées (nœuds et connexions). Vos mémoires originales resteront intactes. Le graphe sera reconstruit au fil du temps ou lors de la prochaine demande.",
+  "knowledgeGraphDeleted": "Graphe de connaissances supprimé avec succès",
+  "deleteGraphFailed": "Échec de la suppression du graphe : {error}",
+  "@deleteGraphFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Supprimer le graphe de connaissances",
+  "deleteKnowledgeGraphDesc": "Effacer tous les nœuds et connexions",
+  "mcp": "MCP",
+  "mcpServer": "Serveur MCP",
+  "mcpServerDesc": "Connecter les assistants IA à vos données",
+  "serverUrl": "URL du serveur",
+  "urlCopied": "URL copiée",
+  "apiKeyAuth": "Authentification par clé API",
+  "header": "En-tête",
+  "authorizationBearer": "Authorization: Bearer <clé>",
+  "oauth": "OAuth",
+  "clientId": "ID client",
+  "clientSecret": "Secret client",
+  "useMcpApiKey": "Utilisez votre clé API MCP",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Événements de conversation",
+  "newConversationCreated": "Nouvelle conversation créée",
+  "realtimeTranscript": "Transcription en temps réel",
+  "transcriptReceived": "Transcription reçue",
+  "audioBytes": "Octets audio",
+  "audioDataReceived": "Données audio reçues",
+  "intervalSeconds": "Intervalle (secondes)",
+  "daySummary": "Résumé du jour",
+  "summaryGenerated": "Résumé généré",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Ajouter à claude_desktop_config.json",
+  "copyConfig": "Copier la configuration",
+  "configCopied": "Configuration copiée dans le presse-papiers",
+  "listeningMins": "Écoute (min)",
+  "understandingWords": "Compréhension (mots)",
+  "insights": "Aperçus",
+  "memories": "Mémoires",
+  "minsUsedThisMonth": "{used} sur {limit} min utilisées ce mois-ci",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} sur {limit} mots utilisés ce mois-ci",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} sur {limit} aperçus obtenus ce mois-ci",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} sur {limit} mémoires créées ce mois-ci",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Visibilité",
+  "visibilitySubtitle": "Contrôlez quelles conversations apparaissent dans votre liste",
+  "showShortConversations": "Afficher les conversations courtes",
+  "showShortConversationsDesc": "Afficher les conversations plus courtes que le seuil",
+  "showDiscardedConversations": "Afficher les conversations ignorées",
+  "showDiscardedConversationsDesc": "Inclure les conversations marquées comme ignorées",
+  "shortConversationThreshold": "Seuil de conversation courte",
+  "shortConversationThresholdSubtitle": "Les conversations plus courtes que cela seront masquées sauf si activé ci-dessus",
+  "durationThreshold": "Seuil de durée",
+  "durationThresholdDesc": "Masquer les conversations plus courtes que cela",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Vocabulaire personnalisé",
+  "addWords": "Ajouter des mots",
+  "addWordsDesc": "Noms, termes ou mots inhabituels",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Connecter",
+  "comingSoon": "Bientôt disponible",
+  "chatToolsFooter": "Connectez vos applications pour afficher les données et les métriques dans le chat.",
+  "completeAuthInBrowser": "Veuillez compléter l'authentification dans votre navigateur. Une fois terminé, revenez à l'application.",
+  "failedToStartAuth": "Échec du démarrage de l'authentification {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Déconnecter {appName} ?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Êtes-vous sûr de vouloir vous déconnecter de {appName} ? Vous pouvez vous reconnecter à tout moment.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Déconnecté de {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Échec de la déconnexion",
+  "connectTo": "Se connecter à {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Vous devrez autoriser Omi à accéder à vos données {appName}. Cela ouvrira votre navigateur pour l'authentification.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Continuer",
+  "languageTitle": "Langue",
+  "primaryLanguage": "Langue principale",
+  "automaticTranslation": "Traduction automatique",
+  "detectLanguages": "Détecter plus de 10 langues",
+  "authorizeSavingRecordings": "Autoriser l'enregistrement des enregistrements",
+  "thanksForAuthorizing": "Merci pour l'autorisation !",
+  "needYourPermission": "Nous avons besoin de votre permission",
+  "alreadyGavePermission": "Vous nous avez déjà donné la permission d'enregistrer vos enregistrements. Voici un rappel de pourquoi nous en avons besoin :",
+  "wouldLikePermission": "Nous aimerions avoir votre permission pour sauvegarder vos enregistrements vocaux. Voici pourquoi :",
+  "improveSpeechProfile": "Améliorer votre profil vocal",
+  "improveSpeechProfileDesc": "Nous utilisons les enregistrements pour entraîner et améliorer davantage votre profil vocal personnel.",
+  "trainFamilyProfiles": "Entraîner des profils pour les amis et la famille",
+  "trainFamilyProfilesDesc": "Vos enregistrements nous aident à reconnaître et créer des profils pour vos amis et votre famille.",
+  "enhanceTranscriptAccuracy": "Améliorer la précision de la transcription",
+  "enhanceTranscriptAccuracyDesc": "À mesure que notre modèle s'améliore, nous pouvons fournir de meilleurs résultats de transcription pour vos enregistrements.",
+  "legalNotice": "Avis juridique : La légalité de l'enregistrement et du stockage des données vocales peut varier selon votre emplacement et la façon dont vous utilisez cette fonctionnalité. Il est de votre responsabilité de vous assurer de la conformité aux lois et réglementations locales.",
+  "alreadyAuthorized": "Déjà autorisé",
+  "authorize": "Autoriser",
+  "revokeAuthorization": "Révoquer l'autorisation",
+  "authorizationSuccessful": "Autorisation réussie !",
+  "failedToAuthorize": "Échec de l'autorisation. Veuillez réessayer.",
+  "authorizationRevoked": "Autorisation révoquée.",
+  "recordingsDeleted": "Enregistrements supprimés.",
+  "failedToRevoke": "Échec de la révocation de l'autorisation. Veuillez réessayer.",
+  "permissionRevokedTitle": "Permission révoquée",
+  "permissionRevokedMessage": "Voulez-vous que nous supprimions également tous vos enregistrements existants ?",
+  "yes": "Oui",
+  "editName": "Modifier le nom",
+  "howShouldOmiCallYou": "Comment Omi devrait-il vous appeler ?",
+  "enterYourName": "Entrez votre nom",
+  "nameCannotBeEmpty": "Le nom ne peut pas être vide",
+  "nameUpdatedSuccessfully": "Nom mis à jour avec succès !",
+  "calendarSettings": "Paramètres du calendrier",
+  "calendarProviders": "Fournisseurs de calendrier",
+  "macOsCalendar": "Calendrier macOS",
+  "connectMacOsCalendar": "Connectez votre calendrier macOS local",
+  "googleCalendar": "Google Agenda",
+  "syncGoogleAccount": "Synchroniser avec votre compte Google",
+  "showMeetingsMenuBar": "Afficher les réunions à venir dans la barre de menus",
+  "showMeetingsMenuBarDesc": "Afficher votre prochaine réunion et le temps restant avant son début dans la barre de menus macOS",
+  "showEventsNoParticipants": "Afficher les événements sans participants",
+  "showEventsNoParticipantsDesc": "Lorsque activé, À venir affiche les événements sans participants ou lien vidéo.",
+  "yourMeetings": "Vos réunions",
+  "refresh": "Actualiser",
+  "noUpcomingMeetings": "Aucune réunion à venir trouvée",
+  "checkingNextDays": "Vérification des 30 prochains jours",
+  "tomorrow": "Demain",
+  "googleCalendarComingSoon": "L'intégration Google Agenda arrive bientôt !",
+  "connectedAsUser": "Connecté en tant qu'utilisateur : {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Espace de travail par défaut",
+  "tasksCreatedInWorkspace": "Les tâches seront créées dans cet espace de travail",
+  "defaultProjectOptional": "Projet par défaut (facultatif)",
+  "leaveUnselectedTasks": "Laissez non sélectionné pour créer des tâches sans projet",
+  "noProjectsInWorkspace": "Aucun projet trouvé dans cet espace de travail",
+  "conversationTimeoutDesc": "Choisissez combien de temps attendre en silence avant de terminer automatiquement une conversation :",
+  "timeout2Minutes": "2 minutes",
+  "timeout2MinutesDesc": "Terminer la conversation après 2 minutes de silence",
+  "timeout5Minutes": "5 minutes",
+  "timeout5MinutesDesc": "Terminer la conversation après 5 minutes de silence",
+  "timeout10Minutes": "10 minutes",
+  "timeout10MinutesDesc": "Terminer la conversation après 10 minutes de silence",
+  "timeout30Minutes": "30 minutes",
+  "timeout30MinutesDesc": "Terminer la conversation après 30 minutes de silence",
+  "timeout4Hours": "4 heures",
+  "timeout4HoursDesc": "Terminer la conversation après 4 heures de silence",
+  "conversationEndAfterHours": "Les conversations se termineront maintenant après 4 heures de silence",
+  "conversationEndAfterMinutes": "Les conversations se termineront maintenant après {minutes} minute(s) de silence",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Dites-nous votre langue principale",
+  "languageForTranscription": "Définissez votre langue pour des transcriptions plus précises et une expérience personnalisée.",
+  "singleLanguageModeInfo": "Le mode langue unique est activé. La traduction est désactivée pour une meilleure précision.",
+  "searchLanguageHint": "Rechercher une langue par nom ou code",
+  "noLanguagesFound": "Aucune langue trouvée",
+  "skip": "Passer",
+  "languageSetTo": "Langue définie sur {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Échec de la définition de la langue",
+  "appSettings": "Paramètres de {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Déconnecter de {appName} ?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Cela supprimera votre authentification {appName}. Vous devrez vous reconnecter pour l'utiliser à nouveau.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Connecté à {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Compte",
+  "actionItemsSyncedTo": "Vos actions à faire seront synchronisées avec votre compte {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Espace par défaut",
+  "selectSpaceInWorkspace": "Sélectionnez un espace dans votre espace de travail",
+  "noSpacesInWorkspace": "Aucun espace trouvé dans cet espace de travail",
+  "defaultList": "Liste par défaut",
+  "tasksAddedToList": "Les tâches seront ajoutées à cette liste",
+  "noListsInSpace": "Aucune liste trouvée dans cet espace",
+  "failedToLoadRepos": "Échec du chargement des dépôts : {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Dépôt par défaut enregistré",
+  "failedToSaveDefaultRepo": "Échec de l'enregistrement du dépôt par défaut",
+  "defaultRepository": "Dépôt par défaut",
+  "selectDefaultRepoDesc": "Sélectionnez un dépôt par défaut pour créer des issues. Vous pouvez toujours spécifier un autre dépôt lors de la création d'issues.",
+  "noReposFound": "Aucun dépôt trouvé",
+  "private": "Privé",
+  "updatedDate": "Mis à jour {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "hier",
+  "daysAgo": "il y a {count} jours",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "il y a 1 semaine",
+  "weeksAgo": "il y a {count} semaines",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "il y a 1 mois",
+  "monthsAgo": "il y a {count} mois",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Les issues seront créées dans votre dépôt par défaut",
+  "taskIntegrations": "Intégrations de tâches",
+  "configureSettings": "Configurer les paramètres",
+  "completeAuthBrowser": "Veuillez compléter l'authentification dans votre navigateur. Une fois terminé, revenez à l'application.",
+  "failedToStartAppAuth": "Échec du démarrage de l'authentification {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Se connecter à {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Vous devrez autoriser Omi à créer des tâches dans votre compte {appName}. Cela ouvrira votre navigateur pour l'authentification.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Continuer",
+  "appIntegration": "Intégration {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "L'intégration avec {appName} arrive bientôt ! Nous travaillons dur pour vous apporter plus d'options de gestion des tâches.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Compris",
+  "tasksExportedOneApp": "Les tâches peuvent être exportées vers une seule application à la fois.",
+  "completeYourUpgrade": "Complétez votre mise à niveau",
+  "importConfiguration": "Importer la configuration",
+  "exportConfiguration": "Exporter la configuration",
+  "bringYourOwn": "Apportez le vôtre",
+  "payYourSttProvider": "Utilisez Omi librement. Vous ne payez que votre fournisseur STT directement.",
+  "freeMinutesMonth": "1 200 minutes gratuites/mois incluses. Illimité avec ",
+  "omiUnlimited": "Omi Illimité",
+  "hostRequired": "L'hôte est requis",
+  "validPortRequired": "Un port valide est requis",
+  "validWebsocketUrlRequired": "Une URL WebSocket valide est requise (wss://)",
+  "apiUrlRequired": "L'URL de l'API est requise",
+  "apiKeyRequired": "La clé API est requise",
+  "invalidJsonConfig": "Configuration JSON invalide",
+  "errorSaving": "Erreur d'enregistrement : {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Configuration copiée dans le presse-papiers",
+  "pasteJsonConfig": "Collez votre configuration JSON ci-dessous :",
+  "addApiKeyAfterImport": "Vous devrez ajouter votre propre clé API après l'importation",
+  "paste": "Coller",
+  "import": "Importer",
+  "invalidProviderInConfig": "Fournisseur invalide dans la configuration",
+  "importedConfig": "Configuration {providerName} importée",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON invalide : {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Fournisseur",
+  "live": "En direct",
+  "onDevice": "Sur l'appareil",
+  "apiUrl": "URL de l'API",
+  "enterSttHttpEndpoint": "Entrez votre point de terminaison HTTP STT",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Entrez votre point de terminaison WebSocket STT en direct",
+  "apiKey": "Clé API",
+  "enterApiKey": "Entrez votre clé API",
+  "storedLocallyNeverShared": "Stocké localement, jamais partagé",
+  "host": "Hôte",
+  "port": "Port",
+  "advanced": "Avancé",
+  "configuration": "Configuration",
+  "requestConfiguration": "Configuration de la requête",
+  "responseSchema": "Schéma de réponse",
+  "modified": "Modifié",
+  "resetRequestConfig": "Réinitialiser la config de requête par défaut",
+  "logs": "Journaux",
+  "logsCopied": "Journaux copiés",
+  "noLogsYet": "Pas encore de journaux. Commencez à enregistrer pour voir l'activité STT personnalisée.",
+  "deviceUsesCodec": "{deviceName} utilise {codecReason}. Omi sera utilisé.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Transcription Omi",
+  "bestInClassTranscription": "Transcription de premier ordre sans configuration",
+  "instantSpeakerLabels": "Étiquettes de locuteur instantanées",
+  "languageTranslation": "Traduction dans plus de 100 langues",
+  "optimizedForConversation": "Optimisé pour la conversation",
+  "autoLanguageDetection": "Détection automatique de la langue",
+  "highAccuracy": "Haute précision",
+  "privacyFirst": "Confidentialité d'abord",
+  "saveChanges": "Enregistrer les modifications",
+  "resetToDefault": "Réinitialiser par défaut",
+  "viewTemplate": "Voir le modèle",
+  "trySomethingLike": "Essayez quelque chose comme...",
+  "tryIt": "Essayer",
+  "creatingPlan": "Création du plan",
+  "developingLogic": "Développement de la logique",
+  "designingApp": "Conception de l'application",
+  "generatingIconStep": "Génération de l'icône",
+  "finalTouches": "Touches finales",
+  "processing": "Traitement...",
+  "features": "Fonctionnalités",
+  "creatingYourApp": "Création de votre application...",
+  "generatingIcon": "Génération de l'icône...",
+  "whatShouldWeMake": "Que devrions-nous créer ?",
+  "appName": "Nom de l'application",
+  "description": "Description",
+  "publicLabel": "Public",
+  "privateLabel": "Privé",
+  "free": "Gratuit",
+  "perMonth": "/ Mois",
+  "tailoredConversationSummaries": "Résumés de conversation personnalisés",
+  "customChatbotPersonality": "Personnalité de chatbot personnalisée",
+  "makePublic": "Rendre public",
+  "anyoneCanDiscover": "N'importe qui peut découvrir votre application",
+  "onlyYouCanUse": "Vous seul pouvez utiliser cette application",
+  "paidApp": "Application payante",
+  "usersPayToUse": "Les utilisateurs paient pour utiliser votre application",
+  "freeForEveryone": "Gratuit pour tous",
+  "perMonthLabel": "/ mois",
+  "creating": "Création...",
+  "createApp": "Créer l'application",
+  "searchingForDevices": "Recherche d'appareils...",
+  "devicesFoundNearby": "{count} {count, plural, =1{APPAREIL} other{APPAREILS}} TROUVÉ(S) À PROXIMITÉ",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "APPAIRAGE RÉUSSI",
+  "errorConnectingAppleWatch": "Erreur de connexion à l'Apple Watch : {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Ne plus afficher",
+  "iUnderstand": "Je comprends",
+  "enableBluetooth": "Activer le Bluetooth",
+  "bluetoothNeeded": "Omi a besoin du Bluetooth pour se connecter à votre wearable. Veuillez activer le Bluetooth et réessayer.",
+  "contactSupport": "Contacter le support ?",
+  "connectLater": "Se connecter plus tard",
+  "grantPermissions": "Accorder les autorisations",
+  "backgroundActivity": "Activité en arrière-plan",
+  "backgroundActivityDesc": "Laissez Omi fonctionner en arrière-plan pour une meilleure stabilité",
+  "locationAccess": "Accès à la localisation",
+  "locationAccessDesc": "Activez la localisation en arrière-plan pour l'expérience complète",
+  "notifications": "Notifications",
+  "notificationsDesc": "Activez les notifications pour rester informé",
+  "locationServiceDisabled": "Service de localisation désactivé",
+  "locationServiceDisabledDesc": "Le service de localisation est désactivé. Veuillez aller dans Réglages > Confidentialité et sécurité > Services de localisation et l'activer",
+  "backgroundLocationDenied": "Accès à la localisation en arrière-plan refusé",
+  "backgroundLocationDeniedDesc": "Veuillez aller dans les paramètres de l'appareil et définir l'autorisation de localisation sur « Toujours autoriser »",
+  "lovingOmi": "Vous aimez Omi ?",
+  "leaveReviewIos": "Aidez-nous à atteindre plus de personnes en laissant un avis sur l'App Store. Votre retour compte énormément pour nous !",
+  "leaveReviewAndroid": "Aidez-nous à atteindre plus de personnes en laissant un avis sur le Google Play Store. Votre retour compte énormément pour nous !",
+  "rateOnAppStore": "Noter sur l'App Store",
+  "rateOnGooglePlay": "Noter sur Google Play",
+  "maybeLater": "Peut-être plus tard",
+  "speechProfileIntro": "Omi doit apprendre vos objectifs et votre voix. Vous pourrez les modifier plus tard.",
+  "getStarted": "Commencer",
+  "allDone": "Terminé !",
+  "keepGoing": "Continuez, vous vous en sortez très bien",
+  "skipThisQuestion": "Passer cette question",
+  "skipForNow": "Passer pour l'instant",
+  "connectionError": "Erreur de connexion",
+  "connectionErrorDesc": "Échec de la connexion au serveur. Veuillez vérifier votre connexion internet et réessayer.",
+  "invalidRecordingMultipleSpeakers": "Enregistrement invalide détecté",
+  "multipleSpeakersDesc": "Il semble y avoir plusieurs locuteurs dans l'enregistrement. Veuillez vous assurer d'être dans un endroit calme et réessayer.",
+  "tooShortDesc": "Pas assez de parole détectée. Veuillez parler davantage et réessayer.",
+  "invalidRecordingDesc": "Veuillez vous assurer de parler pendant au moins 5 secondes et pas plus de 90.",
+  "areYouThere": "Êtes-vous là ?",
+  "noSpeechDesc": "Nous n'avons pas pu détecter de parole. Veuillez vous assurer de parler pendant au moins 10 secondes et pas plus de 3 minutes.",
+  "connectionLost": "Connexion perdue",
+  "connectionLostDesc": "La connexion a été interrompue. Veuillez vérifier votre connexion internet et réessayer.",
+  "tryAgain": "Réessayer",
+  "connectOmiOmiGlass": "Connecter Omi / OmiGlass",
+  "continueWithoutDevice": "Continuer sans appareil",
+  "permissionsRequired": "Autorisations requises",
+  "permissionsRequiredDesc": "Cette application a besoin des autorisations Bluetooth et Localisation pour fonctionner correctement. Veuillez les activer dans les paramètres.",
+  "openSettings": "Ouvrir les paramètres",
+  "wantDifferentName": "Voulez-vous utiliser un autre nom ?",
+  "whatsYourName": "Comment vous appelez-vous ?",
+  "speakTranscribeSummarize": "Parlez. Transcrivez. Résumez.",
+  "signInWithApple": "Se connecter avec Apple",
+  "signInWithGoogle": "Se connecter avec Google",
+  "byContinuingAgree": "En continuant, vous acceptez notre ",
+  "termsOfUse": "Conditions d'utilisation",
+  "omiYourAiCompanion": "Omi – Votre compagnon IA",
+  "captureEveryMoment": "Capturez chaque moment. Obtenez des résumés\nalimentés par l'IA. Ne prenez plus jamais de notes.",
+  "appleWatchSetup": "Configuration Apple Watch",
+  "permissionRequestedExclaim": "Permission demandée !",
+  "microphonePermission": "Permission du microphone",
+  "permissionGrantedNow": "Permission accordée ! Maintenant :\n\nOuvrez l'application Omi sur votre montre et appuyez sur « Continuer » ci-dessous",
+  "needMicrophonePermission": "Nous avons besoin de la permission du microphone.\n\n1. Appuyez sur « Accorder la permission »\n2. Autorisez sur votre iPhone\n3. L'application de la montre se fermera\n4. Rouvrez et appuyez sur « Continuer »",
+  "grantPermissionButton": "Accorder la permission",
+  "needHelp": "Besoin d'aide ?",
+  "troubleshootingSteps": "Dépannage :\n\n1. Assurez-vous qu'Omi est installé sur votre montre\n2. Ouvrez l'application Omi sur votre montre\n3. Recherchez la fenêtre de permission\n4. Appuyez sur « Autoriser » lorsque demandé\n5. L'application sur votre montre se fermera - rouvrez-la\n6. Revenez et appuyez sur « Continuer » sur votre iPhone",
+  "recordingStartedSuccessfully": "Enregistrement démarré avec succès !",
+  "permissionNotGrantedYet": "Permission non encore accordée. Veuillez vous assurer d'avoir autorisé l'accès au microphone et rouvert l'application sur votre montre.",
+  "errorRequestingPermission": "Erreur lors de la demande de permission : {error}",
+  "@errorRequestingPermission": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Erreur lors du démarrage de l'enregistrement : {error}",
+  "@errorStartingRecording": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Sélectionnez votre langue principale",
+  "languageBenefits": "Définissez votre langue pour des transcriptions plus précises et une expérience personnalisée",
+  "whatsYourPrimaryLanguage": "Quelle est votre langue principale ?",
+  "selectYourLanguage": "Sélectionnez votre langue",
+  "personalGrowthJourney": "Votre parcours de croissance personnelle avec une IA qui écoute chacun de vos mots.",
+  "actionItemsTitle": "À faire",
+  "actionItemsDescription": "Appuyez pour modifier • Appui long pour sélectionner • Glissez pour les actions",
+  "tabToDo": "À faire",
+  "tabDone": "Terminé",
+  "tabOld": "Ancien",
+  "emptyTodoMessage": "🎉 Tout est à jour !\nAucune action en attente",
+  "emptyDoneMessage": "Aucun élément terminé pour le moment",
+  "emptyOldMessage": "✅ Aucune ancienne tâche",
+  "noItems": "Aucun élément",
+  "actionItemMarkedIncomplete": "Action marquée comme incomplète",
+  "actionItemCompleted": "Action terminée",
+  "deleteActionItemTitle": "Supprimer l'action",
+  "deleteActionItemMessage": "Êtes-vous sûr de vouloir supprimer cette action ?",
+  "deleteSelectedItemsTitle": "Supprimer les éléments sélectionnés",
+  "deleteSelectedItemsMessage": "Êtes-vous sûr de vouloir supprimer {count} action(s) sélectionnée(s) ?",
+  "@deleteSelectedItemsMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Action « {description} » supprimée",
+  "@actionItemDeletedResult": {
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} action(s) supprimée(s)",
+  "@itemsDeletedResult": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Échec de la suppression de l'action",
+  "failedToDeleteItems": "Échec de la suppression des éléments",
+  "failedToDeleteSomeItems": "Échec de la suppression de certains éléments",
+  "welcomeActionItemsTitle": "Prêt pour les actions",
+  "welcomeActionItemsDescription": "Votre IA extraira automatiquement les tâches et les choses à faire de vos conversations. Elles apparaîtront ici une fois créées.",
+  "autoExtractionFeature": "Extraites automatiquement des conversations",
+  "editSwipeFeature": "Appuyez pour modifier, glissez pour terminer ou supprimer",
+  "itemsSelected": "{count} sélectionné(s)",
+  "@itemsSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Tout sélectionner",
+  "deleteSelected": "Supprimer la sélection",
+  "searchMemories": "Rechercher {count} mémoires",
+  "@searchMemories": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Mémoire supprimée.",
+  "undo": "Annuler",
+  "noMemoriesYet": "Pas encore de mémoires",
+  "noAutoMemories": "Pas encore de mémoires extraites automatiquement",
+  "noManualMemories": "Pas encore de mémoires manuelles",
+  "noMemoriesInCategories": "Aucune mémoire dans ces catégories",
+  "noMemoriesFound": "Aucune mémoire trouvée",
+  "addFirstMemory": "Ajoutez votre première mémoire",
+  "clearMemoryTitle": "Effacer la mémoire d'Omi",
+  "clearMemoryMessage": "Êtes-vous sûr de vouloir effacer la mémoire d'Omi ? Cette action est irréversible.",
+  "clearMemoryButton": "Effacer la mémoire",
+  "memoryClearedSuccess": "La mémoire d'Omi vous concernant a été effacée",
+  "noMemoriesToDelete": "Aucune mémoire à supprimer",
+  "createMemoryTooltip": "Créer une nouvelle mémoire",
+  "createActionItemTooltip": "Créer une nouvelle action",
+  "memoryManagement": "Gestion des mémoires",
+  "filterMemories": "Filtrer les mémoires",
+  "totalMemoriesCount": "Vous avez {count} mémoires au total",
+  "@totalMemoriesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Mémoires publiques",
+  "privateMemories": "Mémoires privées",
+  "makeAllPrivate": "Rendre toutes les mémoires privées",
+  "makeAllPublic": "Rendre toutes les mémoires publiques",
+  "deleteAllMemories": "Supprimer toutes les mémoires",
+  "allMemoriesPrivateResult": "Toutes les mémoires sont maintenant privées",
+  "allMemoriesPublicResult": "Toutes les mémoires sont maintenant publiques",
+  "newMemory": "Nouvelle mémoire",
+  "editMemory": "Modifier la mémoire",
+  "memoryContentHint": "J'aime manger des glaces...",
+  "failedToSaveMemory": "Échec de l'enregistrement. Veuillez vérifier votre connexion.",
+  "saveMemory": "Enregistrer la mémoire",
+  "retry": "Réessayer",
+  "createActionItem": "Créer une action",
+  "editActionItem": "Modifier l'action",
+  "actionItemDescriptionHint": "Que faut-il faire ?",
+  "actionItemDescriptionEmpty": "La description de l'action ne peut pas être vide.",
+  "actionItemUpdated": "Action mise à jour",
+  "failedToUpdateActionItem": "Échec de la mise à jour de l'action",
+  "actionItemCreated": "Action créée",
+  "failedToCreateActionItem": "Échec de la création de l'action",
+  "dueDate": "Date d'échéance",
+  "time": "Heure",
+  "addDueDate": "Ajouter une date d'échéance",
+  "pressDoneToSave": "Appuyez sur Terminé pour enregistrer",
+  "pressDoneToCreate": "Appuyez sur Terminé pour créer",
+  "filterAll": "Tous",
+  "filterSystem": "À propos de vous",
+  "filterInteresting": "Aperçus",
+  "filterManual": "Manuel",
+  "completed": "Terminé",
+  "markComplete": "Marquer comme terminé",
+  "actionItemDeleted": "Action supprimée",
+  "failedToDeleteActionItem": "Échec de la suppression de l'action",
+  "deleteActionItemConfirmTitle": "Supprimer l'action",
+  "deleteActionItemConfirmMessage": "Êtes-vous sûr de vouloir supprimer cette action ?",
+  "appLanguage": "Langue de l'application",
+  "appInterfaceSectionTitle": "INTERFACE DE L'APPLICATION",
+  "speechTranscriptionSectionTitle": "VOIX ET TRANSCRIPTION",
+  "languageSettingsHelperText": "La langue de l'application modifie les menus et les boutons. La langue vocale affecte la transcription de vos enregistrements."
+}

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -90,7 +90,9 @@
   "selectedCount": "{count} चयनित",
   "@selectedCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "merge": "विलय करें",
@@ -98,7 +100,9 @@
   "mergeConversationsMessage": "यह {count} बातचीतों को एक में मिला देगा। सभी सामग्री विलय और पुन: उत्पन्न की जाएगी।",
   "@mergeConversationsMessage": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "mergingInBackground": "बैकग्राउंड में विलय हो रहा है। इसमें थोड़ा समय लग सकता है।",
@@ -408,7 +412,6 @@
   "defaultProjectOptional": "डिफ़ॉल्ट प्रोजेक्ट (वैकल्पिक)",
   "leaveUnselectedTasks": "बिना प्रोजेक्ट वाले कार्यों के लिए चयनित न छोड़ें",
   "noProjectsInWorkspace": "इस कार्यक्षेत्र में कोई प्रोजेक्ट नहीं मिला",
-  "conversationTimeout": "बातचीत समय समाप्त",
   "conversationTimeoutDesc": "स्वचालित रूप से समाप्त होने से पहले कितनी देर तक मौन रहना है, यह चुनें:",
   "timeout2Minutes": "2 मिनट",
   "timeout2MinutesDesc": "2 मिनट के मौन के बाद समाप्त",
@@ -696,6 +699,8 @@
   "pressDoneToCreate": "बनाने के लिए पूर्ण दबाएं",
   "filterAll": "सभी",
   "filterAuto": "स्वतः",
+  "filterInteresting": "अंतर्दृष्टि",
+  "filterSystem": "आपके बारे में",
   "filterManual": "मैनुअल",
   "completed": "पूर्ण",
   "markComplete": "पूर्ण चिह्नित करें",
@@ -729,5 +734,8 @@
       }
     }
   },
-  "continueButton": "जारी रखें"
+  "continueButton": "जारी रखें",
+  "appInterfaceSectionTitle": "ऐप इंटरफ़ेस",
+  "speechTranscriptionSectionTitle": "वाणी और ट्रांसक्रिप्शन",
+  "languageSettingsHelperText": "ऐप भाषा मेनू और बटन बदलती है। वाणी भाषा आपकी रिकॉर्डिंग के ट्रांसक्रिप्शन को प्रभावित करती है।"
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "hu",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Beszélgetés",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Átirat",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Teendők",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Beszélgetés törlése?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Biztosan törölni szeretnéd ezt a beszélgetést? Ez a művelet nem vonható vissza.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Megerősítés",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Mégse",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "OK",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Törlés",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Hozzáadás",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Frissítés",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Mentés",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Szerkesztés",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Bezárás",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Törlés",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Átirat másolása",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Összefoglaló másolása",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Prompt tesztelése",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Beszélgetés újrafeldolgozása",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Beszélgetés törlése",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Tartalom vágólapra másolva",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "A csillagozás frissítése sikertelen.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "A beszélgetés URL-je nem volt megosztható.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Hiba történt a beszélgetés feldolgozása során. Kérlek, próbáld újra később.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Nem lehet törölni a beszélgetést",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Valami hiba történt! Kérlek, próbáld újra később.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Hibaüzenet másolása",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Hibaüzenet vágólapra másolva",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Hátralévő",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Betöltés...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Időtartam betöltése...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} másodperc",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Személyek",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Új személy hozzáadása",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Személy szerkesztése",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Hozz létre egy új személyt, és tanítsd meg az Omi-t, hogy felismerje a beszédét is!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Beszédprofil",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "{number}. minta",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Beállítások",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Nyelv",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Nyelv kiválasztása",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Törlés...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "A hitelesítés indítása sikertelen",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Az importálás elkezdődött! Értesítünk, amikor befejeződik.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Az importálás indítása sikertelen. Kérlek, próbáld újra.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Nem sikerült hozzáférni a kiválasztott fájlhoz",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Kérdezd Omi-t",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Kész",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Leválasztva",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Keresés",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Eszköz csatlakoztatása",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Elérted a havi keretet.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Használat ellenőrzése",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Felvételek szinkronizálása",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Szinkronizálandó felvételek",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Minden naprakész",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Szinkronizálás",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "A medál naprakész",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Minden felvétel szinkronizálva",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Szinkronizálás folyamatban",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Készen áll a szinkronizálásra",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Érintsd meg a Szinkronizálást az indításhoz",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "A medál nincs csatlakoztatva. Csatlakoztasd a szinkronizáláshoz.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Minden már szinkronizálva van.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Vannak még szinkronizálatlan felvételeid.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Folytatjuk a felvételek szinkronizálását a háttérben.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Még nincsenek beszélgetések.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Még nincsenek csillagozott beszélgetések.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Beszélgetés csillagozásához nyisd meg, és érintsd meg a csillag ikont a fejlécben.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Beszélgetések keresése",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} kiválasztva",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Összevonás",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Beszélgetések összevonása",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Ez {count} beszélgetést egyesít egybe. Minden tartalom összevonásra és újragenerálásra kerül.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Összevonás a háttérben. Ez eltarthat egy pillanatig.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Az összevonás indítása sikertelen",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Kérdezz bármit",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Még nincsenek üzenetek!\nMiért nem kezdesz egy beszélgetést?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Üzenetek törlése az Omi memóriájából...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Üzenet vágólapra másolva.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Nem jelentheted be a saját üzeneteidet.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Üzenet bejelentése",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Biztosan be szeretnéd jelenteni ezt az üzenetet?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Üzenet sikeresen bejelentve.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Köszönjük a visszajelzést!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Csevegés törlése?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Biztosan törölni szeretnéd a csevegést? Ez a művelet nem vonható vissza.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Egyszerre csak 4 fájlt tölthetsz fel",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Csevegés Omi-val",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Alkalmazások",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Nem találhatók alkalmazások",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Próbáld módosítani a keresést vagy a szűrőket",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Saját alkalmazás létrehozása",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Építsd meg és oszd meg egyedi alkalmazásodat",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Keresés 1500+ alkalmazás között",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Saját alkalmazások",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Telepített alkalmazások",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Nem sikerült betölteni az alkalmazásokat :(\n\nKérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Az Omi-ról",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Adatvédelmi szabályzatot",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Weboldal meglátogatása",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Segítség vagy kérdések?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Csatlakozz a közösséghez!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ tag és még mindig nő.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Fiók törlése",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Biztosan törölni szeretnéd a fiókodat?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Ez nem vonható vissza.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Minden emléked és beszélgetésed véglegesen törlésre kerül.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Alkalmazásaid és integrációid azonnal leválasztásra kerülnek.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Exportálhatod az adataidat a fiók törlése előtt, de törlés után nem állítható vissza.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Megértettem, hogy a fiókom törlése végleges, és minden adat, beleértve az emlékeket és beszélgetéseket, elvész és nem állítható vissza.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Biztos vagy benne?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Ez a művelet visszafordíthatatlan, és véglegesen törli a fiókodat és minden kapcsolódó adatot. Biztosan folytatni szeretnéd?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Törlés most",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Vissza",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Jelöld be a négyzetet, hogy megerősítsd, megértetted, hogy a fiókod törlése végleges és visszafordíthatatlan.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Név",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-mail",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Egyedi szókincs",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Mások azonosítása",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Fizetési módok",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Beszélgetés megjelenítése",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Adatok és adatvédelem",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Felhasználói azonosító",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Nincs beállítva",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Felhasználói azonosító vágólapra másolva",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Rendszer alapértelmezett",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Előfizetés és használat",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Offline szinkronizálás",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Eszköz beállításai",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Csevegés eszközök",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Visszajelzés / hiba",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Súgó központ",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Fejlesztői beállítások",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Szerezd be az Omi-t Mac-re",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Ajánlói program",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Kijelentkezés",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Alkalmazás és eszköz részletei másolva",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Adatvédelem, saját ellenőrzésed alatt",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Az Omi-nál elkötelezettek vagyunk az adatvédelem iránt. Ez az oldal lehetővé teszi az adataid tárolásának és felhasználásának szabályozását.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "További információ...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Adatvédelmi szint",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Az adataid alapértelmezetten erős titkosítással védettek. Tekintsd át a beállításaidat és a jövőbeli adatvédelmi lehetőségeket alább.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Alkalmazás hozzáférés",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "A következő alkalmazások férhetnek hozzá az adataidhoz. Érintsd meg az alkalmazást az engedélyek kezeléséhez.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Egyik telepített alkalmazás sem rendelkezik külső hozzáféréssel az adataidhoz.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Eszköz neve",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Eszköz azonosító",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmware",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD kártya szinkronizálás",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Hardver verzió",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Modellszám",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Gyártó",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dupla érintés",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED fényerő",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Mikrofon erősítés",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Leválasztás",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Eszköz elfelejtése",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Töltési problémák",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Eszköz leválasztása",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Eszköz párosításának megszüntetése",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Párosítás megszüntetése és elfelejtés",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Az Omi leválasztásra került 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Eszköz párosítása megszüntetve. Menj a Beállítások > Bluetooth menübe, és felejtsd el az eszközt a folyamat befejezéséhez.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Eszköz párosításának megszüntetése",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Ez megszünteti az eszköz párosítását, így másik telefonhoz csatlakoztatható. Menned kell a Beállítások > Bluetooth menübe, és el kell felejtened az eszközt a folyamat befejezéséhez.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Eszköz nincs csatlakoztatva",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Csatlakoztasd az Omi eszközödet az eszköz\nbeállítások és testreszabás eléréséhez",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Eszköz információk",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Testreszabás",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Hardver",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 nem észlelhető",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Úgy látjuk, hogy vagy V1 eszközöd van, vagy az eszközöd nincs csatlakoztatva. Az SD kártya funkció csak V2 eszközökön érhető el.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Beszélgetés befejezése",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Szünet/folytatás",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Beszélgetés csillagozása",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Dupla érintés művelet",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Beszélgetés befejezése és feldolgozása",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Felvétel szüneteltetése/folytatása",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Folyamatban lévő beszélgetés csillagozása",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Ki",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maximum",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Némítás",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Halk",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normál",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Magas",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon némítva",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Nagyon halk - zajos környezethez",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Halk - közepes zajhoz",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Semleges - kiegyensúlyozott felvétel",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Enyhén felerősített - normál használat",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Felerősített - csendes környezethez",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Magas - távoli vagy halk hangokhoz",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Nagyon magas - nagyon csendes forrásokhoz",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maximum - óvatosan használd",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Fejlesztői beállítások",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Mentés...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "AI személyiség beállítása",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BÉTA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Átírás",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "STT szolgáltató beállítása",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Beszélgetés időkorlátja",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Beszélgetések automatikus befejezésének beállítása",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Adatok importálása",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Adatok importálása más forrásokból",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Hibakeresés és diagnosztika",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Végpont URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Még nincsenek API kulcsok",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Hozz létre egy kulcsot a kezdéshez",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Kulcs létrehozása",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentáció",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Omi statisztikáid",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Ma",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Ez a hónap",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Ez az év",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Minden idők",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Még nincs aktivitás",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Kezdj egy beszélgetést Omi-val,\nhogy itt lásd a használati statisztikáidat.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Figyelés",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Az összes idő, amit az Omi aktívan figyelt.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Megértés",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "A beszélgetéseidből megértett szavak.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Nyújtás",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Automatikusan rögzített teendők és jegyzetek.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Emlékezés",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Számodra megjegyzett tények és részletek.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Korlátlan csomag",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Csomag kezelése",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Előfizetésed {date}-án megszűnik.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Előfizetésed {date}-án megújul.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Ingyenes csomag",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} / {limit} perc felhasználva",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Frissítés",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Frissítés korlátlanra",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Csomagod {limit} ingyenes percet tartalmaz havonta. Frissíts a korlátlan használathoz.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Megosztom az Omi statisztikáimat! (omi.me - mindig rendelkezésre álló AI asszisztensed)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Ma az omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Ebben a hónapban az omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Ebben az évben az omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Eddig az omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 {minutes} percet figyelt",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 {words} szót megértett",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ {count} betekintést nyújtott",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 {count} emléket jegyzett meg",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Hibakeresési naplók",
+  "debugLogsAutoDelete": "Automatikus törlés 3 nap után.",
+  "debugLogsDesc": "Segít a problémák diagnosztizálásában",
+  "noLogFilesFound": "Nem találhatók naplófájlok.",
+  "omiDebugLog": "Omi hibakeresési napló",
+  "logShared": "Napló megosztva",
+  "selectLogFile": "Naplófájl kiválasztása",
+  "shareLogs": "Naplók megosztása",
+  "debugLogCleared": "Hibakeresési napló törölve",
+  "exportStarted": "Exportálás elkezdődött. Ez eltarthat néhány másodpercig...",
+  "exportAllData": "Minden adat exportálása",
+  "exportDataDesc": "Beszélgetések exportálása JSON fájlba",
+  "exportedConversations": "Exportált beszélgetések az Omi-ból",
+  "exportShared": "Exportálás megosztva",
+  "deleteKnowledgeGraphTitle": "Tudásgráf törlése?",
+  "deleteKnowledgeGraphMessage": "Ez törli az összes származtatott tudásgráf adatot (csomópontok és kapcsolatok). Az eredeti emlékeid biztonságban maradnak. A gráf idővel vagy a következő kérésre újjáépül.",
+  "knowledgeGraphDeleted": "Tudásgráf sikeresen törölve",
+  "deleteGraphFailed": "Gráf törlése sikertelen: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Tudásgráf törlése",
+  "deleteKnowledgeGraphDesc": "Összes csomópont és kapcsolat törlése",
+  "mcp": "MCP",
+  "mcpServer": "MCP szerver",
+  "mcpServerDesc": "AI asszisztensek csatlakoztatása az adataidhoz",
+  "serverUrl": "Szerver URL",
+  "urlCopied": "URL másolva",
+  "apiKeyAuth": "API kulcs hitelesítés",
+  "header": "Fejléc",
+  "authorizationBearer": "Engedélyezés: Bearer <kulcs>",
+  "oauth": "OAuth",
+  "clientId": "Kliens azonosító",
+  "clientSecret": "Kliens titok",
+  "useMcpApiKey": "Használd az MCP API kulcsodat",
+  "webhooks": "Webhookok",
+  "conversationEvents": "Beszélgetés események",
+  "newConversationCreated": "Új beszélgetés létrehozva",
+  "realtimeTranscript": "Valós idejű átirat",
+  "transcriptReceived": "Átirat fogadva",
+  "audioBytes": "Hang byte-ok",
+  "audioDataReceived": "Hangadatok fogadva",
+  "intervalSeconds": "Időköz (másodperc)",
+  "daySummary": "Napi összefoglaló",
+  "summaryGenerated": "Összefoglaló generálva",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Hozzáadás claude_desktop_config.json-hoz",
+  "copyConfig": "Konfiguráció másolása",
+  "configCopied": "Konfiguráció vágólapra másolva",
+  "listeningMins": "Figyelés (perc)",
+  "understandingWords": "Megértés (szavak)",
+  "insights": "Betekintések",
+  "memories": "Emlékek",
+  "minsUsedThisMonth": "{used} / {limit} perc felhasználva ebben a hónapban",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} / {limit} szó felhasználva ebben a hónapban",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} / {limit} betekintés nyerve ebben a hónapban",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} / {limit} emlék létrehozva ebben a hónapban",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Láthatóság",
+  "visibilitySubtitle": "Szabályozd, mely beszélgetések jelenjenek meg a listában",
+  "showShortConversations": "Rövid beszélgetések megjelenítése",
+  "showShortConversationsDesc": "Küszöbértéknél rövidebb beszélgetések megjelenítése",
+  "showDiscardedConversations": "Elvetett beszélgetések megjelenítése",
+  "showDiscardedConversationsDesc": "Elvetettként megjelölt beszélgetések hozzáadása",
+  "shortConversationThreshold": "Rövid beszélgetés küszöbérték",
+  "shortConversationThresholdSubtitle": "Ennél rövidebb beszélgetések el lesznek rejtve, ha fent nincs engedélyezve",
+  "durationThreshold": "Időtartam küszöbérték",
+  "durationThresholdDesc": "Ennél rövidebb beszélgetések elrejtése",
+  "minLabel": "{count} perc",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Egyedi szókincs",
+  "addWords": "Szavak hozzáadása",
+  "addWordsDesc": "Nevek, kifejezések vagy ritka szavak",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Csatlakozás",
+  "comingSoon": "Hamarosan",
+  "chatToolsFooter": "Csatlakoztasd az alkalmazásaidat az adatok és metrikák megjelenítéséhez a csevegésben.",
+  "completeAuthInBrowser": "Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.",
+  "failedToStartAuth": "{appName} hitelesítés indítása sikertelen",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "{appName} leválasztása?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Biztosan leválasztod a(z) {appName}-t? Bármikor újracsatlakozthatsz.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "{appName}-től leválasztva",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Leválasztás sikertelen",
+  "connectTo": "Csatlakozás: {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Engedélyezned kell az Omi-nak, hogy hozzáférjen a(z) {appName} adataidhoz. Ez megnyitja a böngésződ a hitelesítéshez.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Folytatás",
+  "languageTitle": "Nyelv",
+  "primaryLanguage": "Elsődleges nyelv",
+  "automaticTranslation": "Automatikus fordítás",
+  "detectLanguages": "10+ nyelv érzékelése",
+  "authorizeSavingRecordings": "Felvételek mentésének engedélyezése",
+  "thanksForAuthorizing": "Köszönjük az engedélyezést!",
+  "needYourPermission": "Szükségünk van az engedélyedre",
+  "alreadyGavePermission": "Már engedélyezted a felvételeid mentését. Itt egy emlékeztető, hogy miért van erre szükségünk:",
+  "wouldLikePermission": "Szeretnénk az engedélyedet kérni a hangfelvételeid mentéséhez. Itt van, hogy miért:",
+  "improveSpeechProfile": "Beszédprofil fejlesztése",
+  "improveSpeechProfileDesc": "A felvételeket használjuk a személyes beszédprofilod további tanítására és fejlesztésére.",
+  "trainFamilyProfiles": "Profilok tanítása barátoknak és családtagoknak",
+  "trainFamilyProfilesDesc": "A felvételeid segítenek felismerni és profilokat létrehozni a barátaidnak és családtagjaidnak.",
+  "enhanceTranscriptAccuracy": "Átirat pontosságának növelése",
+  "enhanceTranscriptAccuracyDesc": "Ahogy a modellünk fejlődik, jobb átírási eredményeket tudunk biztosítani a felvételeidhez.",
+  "legalNotice": "Jogi közlemény: A hangadatok rögzítésének és tárolásának jogszerűsége a tartózkodási helyedtől és a funkció használatától függően változhat. A helyi törvényeknek és szabályozásoknak való megfelelés a te felelősséged.",
+  "alreadyAuthorized": "Már engedélyezve",
+  "authorize": "Engedélyezés",
+  "revokeAuthorization": "Engedély visszavonása",
+  "authorizationSuccessful": "Engedélyezés sikeres!",
+  "failedToAuthorize": "Engedélyezés sikertelen. Kérlek, próbáld újra.",
+  "authorizationRevoked": "Engedély visszavonva.",
+  "recordingsDeleted": "Felvételek törölve.",
+  "failedToRevoke": "Engedély visszavonása sikertelen. Kérlek, próbáld újra.",
+  "permissionRevokedTitle": "Engedély visszavonva",
+  "permissionRevokedMessage": "Szeretnéd, hogy az összes meglévő felvételedet is töröljük?",
+  "yes": "Igen",
+  "editName": "Név szerkesztése",
+  "howShouldOmiCallYou": "Hogyan szólítson az Omi?",
+  "enterYourName": "Add meg a neved",
+  "nameCannotBeEmpty": "A név nem lehet üres",
+  "nameUpdatedSuccessfully": "Név sikeresen frissítve!",
+  "calendarSettings": "Naptár beállítások",
+  "calendarProviders": "Naptár szolgáltatók",
+  "macOsCalendar": "macOS naptár",
+  "connectMacOsCalendar": "Helyi macOS naptár csatlakoztatása",
+  "googleCalendar": "Google naptár",
+  "syncGoogleAccount": "Szinkronizálás Google fiókoddal",
+  "showMeetingsMenuBar": "Közelgő találkozók megjelenítése a menüsorban",
+  "showMeetingsMenuBarDesc": "A következő találkozód és a kezdésig hátralévő idő megjelenítése a macOS menüsorban",
+  "showEventsNoParticipants": "Résztvevők nélküli események megjelenítése",
+  "showEventsNoParticipantsDesc": "Ha engedélyezve van, a Közelgő események résztvevők vagy videó link nélküli eseményeket is mutat.",
+  "yourMeetings": "Találkozóid",
+  "refresh": "Frissítés",
+  "noUpcomingMeetings": "Nem találhatók közelgő találkozók",
+  "checkingNextDays": "Következő 30 nap ellenőrzése",
+  "tomorrow": "Holnap",
+  "googleCalendarComingSoon": "Google naptár integráció hamarosan!",
+  "connectedAsUser": "Csatlakozva mint felhasználó: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Alapértelmezett munkaterület",
+  "tasksCreatedInWorkspace": "A feladatok ebben a munkaterületen lesznek létrehozva",
+  "defaultProjectOptional": "Alapértelmezett projekt (opcionális)",
+  "leaveUnselectedTasks": "Hagyd kiválasztatlanul projekt nélküli feladatok létrehozásához",
+  "noProjectsInWorkspace": "Nem találhatók projektek ebben a munkaterületen",
+  "conversationTimeoutDesc": "Válaszd ki, mennyi ideig várjon csendben a beszélgetés automatikus befejezése előtt:",
+  "timeout2Minutes": "2 perc",
+  "timeout2MinutesDesc": "Beszélgetés befejezése 2 perc csend után",
+  "timeout5Minutes": "5 perc",
+  "timeout5MinutesDesc": "Beszélgetés befejezése 5 perc csend után",
+  "timeout10Minutes": "10 perc",
+  "timeout10MinutesDesc": "Beszélgetés befejezése 10 perc csend után",
+  "timeout30Minutes": "30 perc",
+  "timeout30MinutesDesc": "Beszélgetés befejezése 30 perc csend után",
+  "timeout4Hours": "4 óra",
+  "timeout4HoursDesc": "Beszélgetés befejezése 4 óra csend után",
+  "conversationEndAfterHours": "A beszélgetések mostantól 4 óra csend után végződnek",
+  "conversationEndAfterMinutes": "A beszélgetések mostantól {minutes} perc csend után végződnek",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Add meg az elsődleges nyelvedet",
+  "languageForTranscription": "Állítsd be a nyelvedet a pontosabb átíráshoz és személyre szabott élményhez.",
+  "singleLanguageModeInfo": "Egynyelvű mód engedélyezve. A fordítás ki van kapcsolva a nagyobb pontosság érdekében.",
+  "searchLanguageHint": "Keress nyelvet név vagy kód alapján",
+  "noLanguagesFound": "Nem találhatók nyelvek",
+  "skip": "Kihagyás",
+  "languageSetTo": "Nyelv beállítva: {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Nyelv beállítása sikertelen",
+  "appSettings": "{appName} beállítások",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "{appName} leválasztása?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Ez eltávolítja a(z) {appName} hitelesítésedet. Újra kell csatlakoznod a használathoz.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Csatlakozva: {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Fiók",
+  "actionItemsSyncedTo": "A teendőid szinkronizálva lesznek a(z) {appName} fiókodhoz",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Alapértelmezett terület",
+  "selectSpaceInWorkspace": "Válassz egy területet a munkaterületen",
+  "noSpacesInWorkspace": "Nem találhatók területek ebben a munkaterületen",
+  "defaultList": "Alapértelmezett lista",
+  "tasksAddedToList": "A feladatok ehhez a listához lesznek hozzáadva",
+  "noListsInSpace": "Nem találhatók listák ezen a területen",
+  "failedToLoadRepos": "Tárolók betöltése sikertelen: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Alapértelmezett tároló mentve",
+  "failedToSaveDefaultRepo": "Alapértelmezett tároló mentése sikertelen",
+  "defaultRepository": "Alapértelmezett tároló",
+  "selectDefaultRepoDesc": "Válassz egy alapértelmezett tárolót a problémák létrehozásához. Problémák létrehozásakor továbbra is megadhatsz másik tárolót.",
+  "noReposFound": "Nem találhatók tárolók",
+  "private": "Privát",
+  "updatedDate": "Frissítve: {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "tegnap",
+  "daysAgo": "{count} napja",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 hete",
+  "weeksAgo": "{count} hete",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 hónapja",
+  "monthsAgo": "{count} hónapja",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "A problémák az alapértelmezett tárolódban lesznek létrehozva",
+  "taskIntegrations": "Feladat integrációk",
+  "configureSettings": "Beállítások konfigurálása",
+  "completeAuthBrowser": "Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.",
+  "failedToStartAppAuth": "{appName} hitelesítés indítása sikertelen",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Csatlakozás: {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Engedélyezned kell az Omi-nak, hogy feladatokat hozzon létre a(z) {appName} fiókodban. Ez megnyitja a böngésződ a hitelesítéshez.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Folytatás",
+  "appIntegration": "{appName} integráció",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "A(z) {appName} integrációja hamarosan! Keményen dolgozunk, hogy több feladatkezelési lehetőséget hozzunk.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Értem",
+  "tasksExportedOneApp": "A feladatok egyszerre csak egy alkalmazásba exportálhatók.",
+  "completeYourUpgrade": "Fejezd be a frissítést",
+  "importConfiguration": "Konfiguráció importálása",
+  "exportConfiguration": "Konfiguráció exportálása",
+  "bringYourOwn": "Hozd a sajátod",
+  "payYourSttProvider": "Szabadon használd az omi-t. Csak az STT szolgáltatódnak fizetsz közvetlenül.",
+  "freeMinutesMonth": "1200 ingyenes perc/hónap tartalmazza. Korlátlan a következővel: ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Host szükséges",
+  "validPortRequired": "Érvényes port szükséges",
+  "validWebsocketUrlRequired": "Érvényes WebSocket URL szükséges (wss://)",
+  "apiUrlRequired": "API URL szükséges",
+  "apiKeyRequired": "API kulcs szükséges",
+  "invalidJsonConfig": "Érvénytelen JSON konfiguráció",
+  "errorSaving": "Mentési hiba: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfiguráció vágólapra másolva",
+  "pasteJsonConfig": "Illeszd be a JSON konfigurációdat alább:",
+  "addApiKeyAfterImport": "Importálás után hozzá kell adnod a saját API kulcsodat",
+  "paste": "Beillesztés",
+  "import": "Importálás",
+  "invalidProviderInConfig": "Érvénytelen szolgáltató a konfigurációban",
+  "importedConfig": "{providerName} konfiguráció importálva",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Érvénytelen JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Szolgáltató",
+  "live": "Élő",
+  "onDevice": "Eszközön",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "Add meg az STT HTTP végpontodat",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "Add meg az élő STT WebSocket végpontodat",
+  "apiKey": "API kulcs",
+  "enterApiKey": "Add meg az API kulcsodat",
+  "storedLocallyNeverShared": "Helyileg tárolva, soha nem megosztott",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Speciális",
+  "configuration": "Konfiguráció",
+  "requestConfiguration": "Kérés konfiguráció",
+  "responseSchema": "Válasz séma",
+  "modified": "Módosítva",
+  "resetRequestConfig": "Kérés konfiguráció alaphelyzetbe állítása",
+  "logs": "Naplók",
+  "logsCopied": "Naplók másolva",
+  "noLogsYet": "Még nincsenek naplók. Kezdj el rögzíteni az egyéni STT aktivitás megtekintéséhez.",
+  "deviceUsesCodec": "{deviceName} használja: {codecReason}. Az Omi-t fogjuk használni.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi átírás",
+  "bestInClassTranscription": "Legjobb átírás a kategóriában, zéró beállítással",
+  "instantSpeakerLabels": "Azonnali beszélő címkék",
+  "languageTranslation": "100+ nyelv fordítása",
+  "optimizedForConversation": "Beszélgetésre optimalizált",
+  "autoLanguageDetection": "Automatikus nyelvfelismerés",
+  "highAccuracy": "Nagy pontosság",
+  "privacyFirst": "Adatvédelem az első",
+  "saveChanges": "Változtatások mentése",
+  "resetToDefault": "Alaphelyzetbe állítás",
+  "viewTemplate": "Sablon megtekintése",
+  "trySomethingLike": "Próbálj valami ilyesmit...",
+  "tryIt": "Próbáld ki",
+  "creatingPlan": "Terv készítése",
+  "developingLogic": "Logika fejlesztése",
+  "designingApp": "Alkalmazás tervezése",
+  "generatingIconStep": "Ikon generálása",
+  "finalTouches": "Utolsó simítások",
+  "processing": "Feldolgozás...",
+  "features": "Funkciók",
+  "creatingYourApp": "Alkalmazásod létrehozása...",
+  "generatingIcon": "Ikon generálása...",
+  "whatShouldWeMake": "Mit készítsünk?",
+  "appName": "Alkalmazás neve",
+  "description": "Leírás",
+  "publicLabel": "Nyilvános",
+  "privateLabel": "Privát",
+  "free": "Ingyenes",
+  "perMonth": "/ hónap",
+  "tailoredConversationSummaries": "Személyre szabott beszélgetés összefoglalók",
+  "customChatbotPersonality": "Egyéni chatbot személyiség",
+  "makePublic": "Nyilvánossá tétel",
+  "anyoneCanDiscover": "Bárki felfedezheti az alkalmazásodat",
+  "onlyYouCanUse": "Csak te használhatod ezt az alkalmazást",
+  "paidApp": "Fizetős alkalmazás",
+  "usersPayToUse": "A felhasználók fizetnek az alkalmazásod használatáért",
+  "freeForEveryone": "Ingyenes mindenki számára",
+  "perMonthLabel": "/ hónap",
+  "creating": "Létrehozás...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Alkalmazás létrehozása",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Eszközök keresése...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{ESZKÖZ} other{ESZKÖZ}} TALÁLHATÓ A KÖZELBEN",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PÁROSÍTÁS SIKERES",
+  "errorConnectingAppleWatch": "Hiba az Apple Watch csatlakoztatása során: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Ne mutasd újra",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Megértettem",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Bluetooth engedélyezése",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Az Omi-nak Bluetoothra van szüksége a viselhető eszközhöz való csatlakozáshoz. Kérlek, engedélyezd a Bluetooth-t, és próbáld újra.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Ügyfélszolgálat elérése?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Csatlakozás később",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Engedélyek megadása",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Háttérműködés",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Engedd, hogy az Omi a háttérben fusson a jobb stabilitás érdekében",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Helymeghatározás",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Háttérhelymeghatározás engedélyezése a teljes élményhez",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Értesítések",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Értesítések engedélyezése tájékozott maradáshoz",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Helymeghatározási szolgáltatás letiltva",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "A helymeghatározási szolgáltatás le van tiltva. Kérlek, menj a Beállítások > Adatvédelem és biztonság > Helyszolgáltatások menübe, és engedélyezd",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Háttérhelymeghatározás megtagadva",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Kérlek, menj az eszköz beállításaihoz, és állítsd a helymeghatározási engedélyt \"Mindig engedélyezés\"-re",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Tetszik az Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Segíts elérni több embert azzal, hogy értékelést hagysz az App Store-ban. A visszajelzésed sokat jelent nekünk!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Segíts elérni több embert azzal, hogy értékelést hagysz a Google Play Áruházban. A visszajelzésed sokat jelent nekünk!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Értékelés az App Store-ban",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Értékelés a Google Play-en",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Talán később",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Az Omi-nak meg kell tanulnia a céljaidat és a hangodat. Később módosíthatod.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Kezdés",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Kész!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Csak így tovább, nagyszerűen csinálod",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Kérdés kihagyása",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Egyelőre kihagyom",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Kapcsolódási hiba",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Nem sikerült csatlakozni a szerverhez. Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Érvénytelen felvétel észlelve",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Úgy tűnik, több beszélő van a felvételen. Kérlek, győződj meg róla, hogy csendes helyen vagy, és próbáld újra.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Nem észlelhető elegendő beszéd. Kérlek, beszélj többet, és próbáld újra.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Kérlek, győződj meg róla, hogy legalább 5 másodpercig, de legfeljebb 90 másodpercig beszélsz.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Ott vagy?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Nem tudtunk beszédet észlelni. Kérlek, győződj meg róla, hogy legalább 10 másodpercig, de legfeljebb 3 percig beszélsz.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Kapcsolat megszakadt",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "A kapcsolat megszakadt. Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Próbáld újra",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Omi / OmiGlass csatlakoztatása",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Folytatás eszköz nélkül",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Engedélyek szükségesek",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Ez az alkalmazás Bluetooth és helymeghatározási engedélyekre van szüksége a megfelelő működéshez. Kérlek, engedélyezd őket a beállításokban.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Beállítások megnyitása",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Máshogy szeretnéd, hogy hívjanak?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Mi a neved?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Beszélj. Átírás. Összefoglalás.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Bejelentkezés Apple-lel",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Bejelentkezés Google-lel",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "A folytatással elfogadod az ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Felhasználási feltételeket",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – AI társad",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Rögzítsd minden pillanatot. Kapj AI-alapú\nösszefoglalókat. Soha többé ne kelljen jegyzetet készítened.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch beállítása",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Engedély kérve!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Mikrofon engedély",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Engedély megadva! Most:\n\nNyisd meg az Omi alkalmazást az órádon, és érintsd meg a \"Folytatás\" gombot alább",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Mikrofon engedélyre van szükségünk.\n\n1. Érintsd meg az \"Engedély megadása\" gombot\n2. Engedélyezd az iPhone-odon\n3. Az óra alkalmazás bezárul\n4. Nyisd meg újra, és érintsd meg a \"Folytatás\" gombot",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Engedély megadása",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Segítség kell?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Hibaelhárítás:\n\n1. Győződj meg róla, hogy az Omi telepítve van az órádon\n2. Nyisd meg az Omi alkalmazást az órádon\n3. Keresd az engedély felugró ablakot\n4. Érintsd meg az \"Engedélyezés\" gombot, amikor megjelenik\n5. Az óra alkalmazás bezárul - nyisd meg újra\n6. Térj vissza, és érintsd meg a \"Folytatás\" gombot az iPhone-odon",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Felvétel sikeresen elindult!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Az engedély még nincs megadva. Kérlek, győződj meg róla, hogy engedélyezted a mikrofon hozzáférést, és újra megnyitottad az alkalmazást az órádon.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Hiba az engedély kérésekor: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Hiba a felvétel indításakor: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Válaszd ki az elsődleges nyelvedet",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Állítsd be a nyelvedet a pontosabb átíráshoz és személyre szabott élményhez",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Mi az elsődleges nyelved?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Válaszd ki a nyelvedet",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Személyes fejlődési utad egy AI-val, amely minden szavadat figyeli.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Teendők",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Érintsd meg a szerkesztéshez • Hosszan nyomd a kiválasztáshoz • Húzd a műveletekhez",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Tennivaló",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Kész",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Régi",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Minden naprakész!\nNincsenek függőben lévő teendők",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Még nincsenek befejezett elemek",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Nincsenek régi feladatok",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Nincsenek elemek",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Teendő befejezetlenként megjelölve",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Teendő befejezve",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Teendő törlése",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Biztosan törölni szeretnéd ezt a teendőt?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Kiválasztott elemek törlése",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Biztosan törölni szeretnéd a(z) {count} kiválasztott teendő{s}t?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "\"{description}\" teendő törölve",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} teendő{s} törölve",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Teendő törlése sikertelen",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Elemek törlése sikertelen",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Néhány elem törlése sikertelen",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Készen állsz a teendőkre",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Az AI automatikusan kinyeri a feladatokat és teendőket a beszélgetéseidből. Itt jelennek meg, amikor létrejönnek.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automatikusan kinyerve a beszélgetésekből",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Érintsd meg a szerkesztéshez, húzd a befejezéshez vagy törléshez",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} kiválasztva",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Összes kiválasztása",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Kiválasztottak törlése",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "{count} emlék keresése",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Emlék törölve.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Visszavonás",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Még nincsenek emlékek",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Még nincsenek automatikusan kinyert emlékek",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Még nincsenek manuális emlékek",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Nincsenek emlékek ezekben a kategóriákban",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Nem találhatók emlékek",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Add hozzá az első emlékedet",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Omi emlékének törlése",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Biztosan törölni szeretnéd az Omi emlékét? Ez a művelet nem vonható vissza.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Emlék törlése",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Az Omi rólad szóló emléke törölve lett",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Nincsenek törlendő emlékek",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Új emlék létrehozása",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Új teendő létrehozása",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Emlékkezelés",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Emlékek szűrése",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Összesen {count} emléked van",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Nyilvános emlékek",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Privát emlékek",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Minden emlék priváttá tétele",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Minden emlék nyilvánossá tétele",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Minden emlék törlése",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Minden emlék most privát",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Minden emlék most nyilvános",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Új emlék",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Emlék szerkesztése",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Szeretek fagyit enni...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Mentés sikertelen. Kérlek, ellenőrizd a kapcsolatot.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Emlék mentése",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Újrapróbálkozás",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Teendő létrehozása",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Teendő szerkesztése",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Mit kell elvégezni?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "A teendő leírása nem lehet üres.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Teendő frissítve",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Teendő frissítése sikertelen",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Teendő létrehozva",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Teendő létrehozása sikertelen",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Határidő",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Idő",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Határidő hozzáadása",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Nyomd meg a kész gombot a mentéshez",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Nyomd meg a kész gombot a létrehozáshoz",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Összes",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Rólad",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Betekintések",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuális",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Befejezve",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Befejezettként megjelölés",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Teendő törölve",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Teendő törlése sikertelen",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Teendő törlése",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Biztosan törölni szeretnéd ezt a teendőt?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Alkalmazás nyelve",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ALKALMAZÁS FELÜLET",
+  "speechTranscriptionSectionTitle": "BESZÉD ÉS ÁTÍRÁS",
+  "languageSettingsHelperText": "Az alkalmazás nyelve megváltoztatja a menüket és gombokat. A beszéd nyelve befolyásolja, hogyan íródnak át a felvételei."
+}

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "id",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Percakapan",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkrip",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Item Tindakan",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Hapus Percakapan?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Apakah Anda yakin ingin menghapus percakapan ini? Tindakan ini tidak dapat dibatalkan.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Konfirmasi",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Batal",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Hapus",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Tambah",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Perbarui",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Simpan",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Edit",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Tutup",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Bersihkan",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Salin Transkrip",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Salin Ringkasan",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Uji Prompt",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Proses Ulang Percakapan",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Hapus Percakapan",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Konten disalin ke clipboard",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Gagal memperbarui status bintang.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "URL percakapan tidak dapat dibagikan.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Terjadi kesalahan saat memproses percakapan. Silakan coba lagi nanti.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Silakan periksa koneksi internet Anda dan coba lagi.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Tidak Dapat Menghapus Percakapan",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Terjadi kesalahan! Silakan coba lagi nanti.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Salin pesan kesalahan",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Pesan kesalahan disalin ke clipboard",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Tersisa",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Memuat...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Memuat durasi...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} detik",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Orang",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Tambah Orang Baru",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Edit Orang",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Buat orang baru dan latih Omi untuk mengenali suara mereka juga!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Profil Suara",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Sampel {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Pengaturan",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Bahasa",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Pilih Bahasa",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Menghapus...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Gagal memulai autentikasi",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Impor dimulai! Anda akan diberi tahu saat selesai.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Gagal memulai impor. Silakan coba lagi.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Tidak dapat mengakses file yang dipilih",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Tanya Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Selesai",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Terputus",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Mencari",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Hubungkan Perangkat",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Anda telah mencapai batas bulanan.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Periksa Penggunaan",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Menyinkronkan rekaman",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Rekaman untuk disinkronkan",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Semua sudah tersinkronisasi",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Sinkronkan",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Pendant sudah terbaru",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Semua rekaman sudah tersinkronisasi",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Sinkronisasi sedang berlangsung",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Siap untuk disinkronkan",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Ketuk Sinkronkan untuk memulai",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Pendant tidak terhubung. Hubungkan untuk menyinkronkan.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Semuanya sudah tersinkronisasi.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Anda memiliki rekaman yang belum disinkronkan.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Kami akan terus menyinkronkan rekaman Anda di latar belakang.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Belum ada percakapan.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Belum ada percakapan berbintang.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Untuk memberi bintang pada percakapan, buka dan ketuk ikon bintang di header.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Cari Percakapan",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} dipilih",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Gabungkan",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Gabungkan Percakapan",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Ini akan menggabungkan {count} percakapan menjadi satu. Semua konten akan digabungkan dan dibuat ulang.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Menggabungkan di latar belakang. Ini mungkin memakan waktu sebentar.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Gagal memulai penggabungan",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Tanyakan apa saja",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Belum ada pesan!\nMengapa tidak memulai percakapan?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Menghapus pesan Anda dari memori Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Pesan disalin ke clipboard.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Anda tidak dapat melaporkan pesan Anda sendiri.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Laporkan Pesan",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Apakah Anda yakin ingin melaporkan pesan ini?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Pesan berhasil dilaporkan.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Terima kasih atas masukan Anda!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Bersihkan Obrolan?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Apakah Anda yakin ingin menghapus obrolan? Tindakan ini tidak dapat dibatalkan.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Anda hanya dapat mengunggah 4 file sekaligus",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Obrolan dengan Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Aplikasi",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Tidak ada aplikasi ditemukan",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Coba sesuaikan pencarian atau filter Anda",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Buat Aplikasi Anda Sendiri",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Bangun dan bagikan aplikasi kustom Anda",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Cari 1500+ Aplikasi",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Aplikasi Saya",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Aplikasi Terinstal",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Tidak dapat mengambil aplikasi :(\n\nSilakan periksa koneksi internet Anda dan coba lagi.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Tentang Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Kebijakan Privasi",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Kunjungi Website",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Bantuan atau Pertanyaan?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Bergabung dengan komunitas!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ anggota dan terus bertambah.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Hapus Akun",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Apakah Anda yakin ingin menghapus akun Anda?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Ini tidak dapat dibatalkan.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Semua memori dan percakapan Anda akan dihapus secara permanen.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Aplikasi dan Integrasi Anda akan segera diputuskan.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Anda dapat mengekspor data Anda sebelum menghapus akun, tetapi setelah dihapus, tidak dapat dipulihkan.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Saya memahami bahwa menghapus akun saya bersifat permanen dan semua data, termasuk memori dan percakapan, akan hilang dan tidak dapat dipulihkan.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Apakah Anda yakin?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Tindakan ini tidak dapat dibatalkan dan akan menghapus akun dan semua data terkait secara permanen. Apakah Anda yakin ingin melanjutkan?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Hapus Sekarang",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Kembali",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Centang kotak untuk mengonfirmasi bahwa Anda memahami penghapusan akun bersifat permanen dan tidak dapat dibatalkan.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Nama",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Email",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Kosakata Kustom",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identifikasi Orang Lain",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Metode Pembayaran",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Tampilan Percakapan",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Data & Privasi",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID Pengguna",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Belum diatur",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID Pengguna disalin ke clipboard",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Bawaan Sistem",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Paket & Penggunaan",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Sinkronisasi Offline",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Pengaturan Perangkat",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Alat Obrolan",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Masukan / Bug",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Pusat Bantuan",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Pengaturan Pengembang",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Dapatkan Omi untuk Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Program Rujukan",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Keluar",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Detail aplikasi dan perangkat disalin",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Privasi Anda, Kontrol Anda",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Di Omi, kami berkomitmen untuk melindungi privasi Anda. Halaman ini memungkinkan Anda mengontrol bagaimana data Anda disimpan dan digunakan.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Pelajari lebih lanjut...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Tingkat Perlindungan Data",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Data Anda diamankan secara default dengan enkripsi yang kuat. Tinjau pengaturan dan opsi privasi Anda di bawah ini.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Akses Aplikasi",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Aplikasi berikut dapat mengakses data Anda. Ketuk aplikasi untuk mengelola izinnya.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Tidak ada aplikasi terinstal yang memiliki akses eksternal ke data Anda.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Nama Perangkat",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID Perangkat",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmware",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Sinkronisasi Kartu SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Revisi Perangkat Keras",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Nomor Model",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Produsen",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Ketuk Ganda",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Kecerahan LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Penguatan Mikrofon",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Putuskan",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Lupakan Perangkat",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Masalah Pengisian Daya",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Putuskan Perangkat",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Batalkan Pasangan Perangkat",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Batalkan Pasangan dan Lupakan Perangkat",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Omi Anda telah terputus 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Perangkat tidak terpasang. Buka Pengaturan > Bluetooth dan lupakan perangkat untuk menyelesaikan pembatalan pasangan.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Batalkan Pasangan Perangkat",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Ini akan membatalkan pasangan perangkat sehingga dapat dihubungkan ke ponsel lain. Anda perlu pergi ke Pengaturan > Bluetooth dan melupakan perangkat untuk menyelesaikan proses.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Perangkat Tidak Terhubung",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Hubungkan perangkat Omi Anda untuk mengakses\npengaturan dan kustomisasi perangkat",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Informasi Perangkat",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Kustomisasi",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Perangkat Keras",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 tidak terdeteksi",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Kami melihat bahwa Anda memiliki perangkat V1 atau perangkat Anda tidak terhubung. Fungsi Kartu SD hanya tersedia untuk perangkat V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Akhiri Percakapan",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Jeda/Lanjutkan",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Beri Bintang Percakapan",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Aksi Ketuk Ganda",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Akhiri & Proses Percakapan",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Jeda/Lanjutkan Perekaman",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Beri Bintang Percakapan yang Sedang Berlangsung",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Mati",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maksimal",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Bisukan",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Pelan",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normal",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Tinggi",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon dibisukan",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Sangat pelan - untuk lingkungan bising",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Pelan - untuk kebisingan sedang",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Netral - perekaman seimbang",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Sedikit ditingkatkan - penggunaan normal",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Ditingkatkan - untuk lingkungan sunyi",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Tinggi - untuk suara jauh atau lembut",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Sangat tinggi - untuk sumber sangat sunyi",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimum - gunakan dengan hati-hati",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Pengaturan Pengembang",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Menyimpan...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Konfigurasi persona AI Anda",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkripsi",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Konfigurasi penyedia STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Waktu Tunggu Percakapan",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Atur kapan percakapan berakhir otomatis",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Impor Data",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Impor data dari sumber lain",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Debug & Diagnostik",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL Endpoint",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Belum ada kunci API",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Buat kunci untuk memulai",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Buat Kunci",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentasi",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Wawasan Omi Anda",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Hari Ini",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Bulan Ini",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Tahun Ini",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Sepanjang Waktu",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Belum Ada Aktivitas",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Mulai percakapan dengan Omi\nuntuk melihat wawasan penggunaan Anda di sini.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Mendengarkan",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Total waktu Omi mendengarkan secara aktif.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Memahami",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Kata-kata yang dipahami dari percakapan Anda.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Memberikan",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Item tindakan dan catatan yang secara otomatis ditangkap.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Mengingat",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakta dan detail yang diingat untuk Anda.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Paket Tanpa Batas",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Kelola Paket",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Paket Anda akan dibatalkan pada {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Paket Anda diperbarui pada {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Paket Gratis",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} dari {limit} menit terpakai",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Tingkatkan",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Tingkatkan ke Tanpa Batas",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Paket Anda mencakup {limit} menit gratis per bulan. Tingkatkan untuk tanpa batas.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Membagikan statistik Omi saya! (omi.me - asisten AI yang selalu aktif)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Hari ini, omi telah:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Bulan ini, omi telah:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Tahun ini, omi telah:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Sejauh ini, omi telah:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Mendengarkan selama {minutes} menit",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Memahami {words} kata",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Memberikan {count} wawasan",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Mengingat {count} memori",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Log Debug",
+  "debugLogsAutoDelete": "Otomatis dihapus setelah 3 hari.",
+  "debugLogsDesc": "Membantu mendiagnosis masalah",
+  "noLogFilesFound": "Tidak ada file log ditemukan.",
+  "omiDebugLog": "Log debug Omi",
+  "logShared": "Log dibagikan",
+  "selectLogFile": "Pilih File Log",
+  "shareLogs": "Bagikan Log",
+  "debugLogCleared": "Log debug dibersihkan",
+  "exportStarted": "Ekspor dimulai. Ini mungkin memakan waktu beberapa detik...",
+  "exportAllData": "Ekspor Semua Data",
+  "exportDataDesc": "Ekspor percakapan ke file JSON",
+  "exportedConversations": "Percakapan yang Diekspor dari Omi",
+  "exportShared": "Ekspor dibagikan",
+  "deleteKnowledgeGraphTitle": "Hapus Grafik Pengetahuan?",
+  "deleteKnowledgeGraphMessage": "Ini akan menghapus semua data grafik pengetahuan turunan (simpul dan koneksi). Memori asli Anda akan tetap aman. Grafik akan dibangun kembali seiring waktu atau pada permintaan berikutnya.",
+  "knowledgeGraphDeleted": "Grafik Pengetahuan berhasil dihapus",
+  "deleteGraphFailed": "Gagal menghapus grafik: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Hapus Grafik Pengetahuan",
+  "deleteKnowledgeGraphDesc": "Bersihkan semua simpul dan koneksi",
+  "mcp": "MCP",
+  "mcpServer": "Server MCP",
+  "mcpServerDesc": "Hubungkan asisten AI ke data Anda",
+  "serverUrl": "URL Server",
+  "urlCopied": "URL disalin",
+  "apiKeyAuth": "Autentikasi Kunci API",
+  "header": "Header",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "ID Klien",
+  "clientSecret": "Rahasia Klien",
+  "useMcpApiKey": "Gunakan kunci API MCP Anda",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Peristiwa Percakapan",
+  "newConversationCreated": "Percakapan baru dibuat",
+  "realtimeTranscript": "Transkrip Real-time",
+  "transcriptReceived": "Transkrip diterima",
+  "audioBytes": "Byte Audio",
+  "audioDataReceived": "Data audio diterima",
+  "intervalSeconds": "Interval (detik)",
+  "daySummary": "Ringkasan Hari",
+  "summaryGenerated": "Ringkasan dibuat",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Tambahkan ke claude_desktop_config.json",
+  "copyConfig": "Salin Konfigurasi",
+  "configCopied": "Konfigurasi disalin ke clipboard",
+  "listeningMins": "Mendengarkan (menit)",
+  "understandingWords": "Memahami (kata)",
+  "insights": "Wawasan",
+  "memories": "Memori",
+  "minsUsedThisMonth": "{used} dari {limit} menit terpakai bulan ini",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} dari {limit} kata terpakai bulan ini",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} dari {limit} wawasan diperoleh bulan ini",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} dari {limit} memori dibuat bulan ini",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Visibilitas",
+  "visibilitySubtitle": "Kontrol percakapan mana yang muncul di daftar Anda",
+  "showShortConversations": "Tampilkan Percakapan Pendek",
+  "showShortConversationsDesc": "Tampilkan percakapan yang lebih pendek dari ambang batas",
+  "showDiscardedConversations": "Tampilkan Percakapan yang Dibuang",
+  "showDiscardedConversationsDesc": "Sertakan percakapan yang ditandai sebagai dibuang",
+  "shortConversationThreshold": "Ambang Percakapan Pendek",
+  "shortConversationThresholdSubtitle": "Percakapan yang lebih pendek dari ini akan disembunyikan kecuali diaktifkan di atas",
+  "durationThreshold": "Ambang Durasi",
+  "durationThresholdDesc": "Sembunyikan percakapan yang lebih pendek dari ini",
+  "minLabel": "{count} menit",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Kosakata Kustom",
+  "addWords": "Tambah Kata",
+  "addWordsDesc": "Nama, istilah, atau kata yang tidak umum",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Hubungkan",
+  "comingSoon": "Segera Hadir",
+  "chatToolsFooter": "Hubungkan aplikasi Anda untuk melihat data dan metrik dalam obrolan.",
+  "completeAuthInBrowser": "Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.",
+  "failedToStartAuth": "Gagal memulai autentikasi {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Putuskan {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Apakah Anda yakin ingin memutuskan dari {appName}? Anda dapat menyambung kembali kapan saja.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Terputus dari {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Gagal memutuskan",
+  "connectTo": "Hubungkan ke {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Anda perlu mengizinkan Omi untuk mengakses data {appName} Anda. Ini akan membuka browser Anda untuk autentikasi.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Lanjutkan",
+  "languageTitle": "Bahasa",
+  "primaryLanguage": "Bahasa Utama",
+  "automaticTranslation": "Terjemahan Otomatis",
+  "detectLanguages": "Deteksi 10+ bahasa",
+  "authorizeSavingRecordings": "Izinkan Menyimpan Rekaman",
+  "thanksForAuthorizing": "Terima kasih telah mengizinkan!",
+  "needYourPermission": "Kami memerlukan izin Anda",
+  "alreadyGavePermission": "Anda sudah memberi kami izin untuk menyimpan rekaman Anda. Berikut pengingat mengapa kami membutuhkannya:",
+  "wouldLikePermission": "Kami ingin izin Anda untuk menyimpan rekaman suara Anda. Berikut alasannya:",
+  "improveSpeechProfile": "Tingkatkan Profil Suara Anda",
+  "improveSpeechProfileDesc": "Kami menggunakan rekaman untuk melatih dan meningkatkan profil suara pribadi Anda lebih lanjut.",
+  "trainFamilyProfiles": "Latih Profil untuk Teman dan Keluarga",
+  "trainFamilyProfilesDesc": "Rekaman Anda membantu kami mengenali dan membuat profil untuk teman dan keluarga Anda.",
+  "enhanceTranscriptAccuracy": "Tingkatkan Akurasi Transkrip",
+  "enhanceTranscriptAccuracyDesc": "Seiring model kami meningkat, kami dapat memberikan hasil transkripsi yang lebih baik untuk rekaman Anda.",
+  "legalNotice": "Pemberitahuan Hukum: Legalitas merekam dan menyimpan data suara dapat bervariasi tergantung pada lokasi Anda dan bagaimana Anda menggunakan fitur ini. Ini adalah tanggung jawab Anda untuk memastikan kepatuhan terhadap hukum dan peraturan lokal.",
+  "alreadyAuthorized": "Sudah Diizinkan",
+  "authorize": "Izinkan",
+  "revokeAuthorization": "Cabut Izin",
+  "authorizationSuccessful": "Otorisasi berhasil!",
+  "failedToAuthorize": "Gagal mengotorisasi. Silakan coba lagi.",
+  "authorizationRevoked": "Otorisasi dicabut.",
+  "recordingsDeleted": "Rekaman dihapus.",
+  "failedToRevoke": "Gagal mencabut otorisasi. Silakan coba lagi.",
+  "permissionRevokedTitle": "Izin Dicabut",
+  "permissionRevokedMessage": "Apakah Anda ingin kami menghapus semua rekaman Anda yang ada juga?",
+  "yes": "Ya",
+  "editName": "Edit Nama",
+  "howShouldOmiCallYou": "Bagaimana Omi harus memanggil Anda?",
+  "enterYourName": "Masukkan nama Anda",
+  "nameCannotBeEmpty": "Nama tidak boleh kosong",
+  "nameUpdatedSuccessfully": "Nama berhasil diperbarui!",
+  "calendarSettings": "Pengaturan kalender",
+  "calendarProviders": "Penyedia Kalender",
+  "macOsCalendar": "Kalender macOS",
+  "connectMacOsCalendar": "Hubungkan kalender macOS lokal Anda",
+  "googleCalendar": "Google Calendar",
+  "syncGoogleAccount": "Sinkronkan dengan akun Google Anda",
+  "showMeetingsMenuBar": "Tampilkan rapat mendatang di bilah menu",
+  "showMeetingsMenuBarDesc": "Tampilkan rapat berikutnya dan waktu hingga dimulai di bilah menu macOS",
+  "showEventsNoParticipants": "Tampilkan acara tanpa peserta",
+  "showEventsNoParticipantsDesc": "Saat diaktifkan, Coming Up menampilkan acara tanpa peserta atau tautan video.",
+  "yourMeetings": "Rapat Anda",
+  "refresh": "Segarkan",
+  "noUpcomingMeetings": "Tidak ada rapat mendatang ditemukan",
+  "checkingNextDays": "Memeriksa 30 hari ke depan",
+  "tomorrow": "Besok",
+  "googleCalendarComingSoon": "Integrasi Google Calendar segera hadir!",
+  "connectedAsUser": "Terhubung sebagai pengguna: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Ruang Kerja Default",
+  "tasksCreatedInWorkspace": "Tugas akan dibuat di ruang kerja ini",
+  "defaultProjectOptional": "Proyek Default (Opsional)",
+  "leaveUnselectedTasks": "Biarkan tidak dipilih untuk membuat tugas tanpa proyek",
+  "noProjectsInWorkspace": "Tidak ada proyek ditemukan di ruang kerja ini",
+  "conversationTimeoutDesc": "Pilih berapa lama menunggu dalam keheningan sebelum otomatis mengakhiri percakapan:",
+  "timeout2Minutes": "2 menit",
+  "timeout2MinutesDesc": "Akhiri percakapan setelah 2 menit keheningan",
+  "timeout5Minutes": "5 menit",
+  "timeout5MinutesDesc": "Akhiri percakapan setelah 5 menit keheningan",
+  "timeout10Minutes": "10 menit",
+  "timeout10MinutesDesc": "Akhiri percakapan setelah 10 menit keheningan",
+  "timeout30Minutes": "30 menit",
+  "timeout30MinutesDesc": "Akhiri percakapan setelah 30 menit keheningan",
+  "timeout4Hours": "4 jam",
+  "timeout4HoursDesc": "Akhiri percakapan setelah 4 jam keheningan",
+  "conversationEndAfterHours": "Percakapan sekarang akan berakhir setelah 4 jam keheningan",
+  "conversationEndAfterMinutes": "Percakapan sekarang akan berakhir setelah {minutes} menit keheningan",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Beri tahu kami bahasa utama Anda",
+  "languageForTranscription": "Atur bahasa Anda untuk transkripsi yang lebih tajam dan pengalaman yang dipersonalisasi.",
+  "singleLanguageModeInfo": "Mode Bahasa Tunggal diaktifkan. Terjemahan dinonaktifkan untuk akurasi yang lebih tinggi.",
+  "searchLanguageHint": "Cari bahasa berdasarkan nama atau kode",
+  "noLanguagesFound": "Tidak ada bahasa ditemukan",
+  "skip": "Lewati",
+  "languageSetTo": "Bahasa diatur ke {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Gagal mengatur bahasa",
+  "appSettings": "Pengaturan {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Putuskan dari {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Ini akan menghapus autentikasi {appName} Anda. Anda perlu menyambung kembali untuk menggunakannya lagi.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Terhubung ke {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Akun",
+  "actionItemsSyncedTo": "Item tindakan Anda akan disinkronkan ke akun {appName} Anda",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Ruang Default",
+  "selectSpaceInWorkspace": "Pilih ruang di ruang kerja Anda",
+  "noSpacesInWorkspace": "Tidak ada ruang ditemukan di ruang kerja ini",
+  "defaultList": "Daftar Default",
+  "tasksAddedToList": "Tugas akan ditambahkan ke daftar ini",
+  "noListsInSpace": "Tidak ada daftar ditemukan di ruang ini",
+  "failedToLoadRepos": "Gagal memuat repositori: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Repositori default disimpan",
+  "failedToSaveDefaultRepo": "Gagal menyimpan repositori default",
+  "defaultRepository": "Repositori Default",
+  "selectDefaultRepoDesc": "Pilih repositori default untuk membuat issue. Anda masih dapat menentukan repositori yang berbeda saat membuat issue.",
+  "noReposFound": "Tidak ada repositori ditemukan",
+  "private": "Pribadi",
+  "updatedDate": "Diperbarui {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "kemarin",
+  "daysAgo": "{count} hari yang lalu",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 minggu yang lalu",
+  "weeksAgo": "{count} minggu yang lalu",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 bulan yang lalu",
+  "monthsAgo": "{count} bulan yang lalu",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Issue akan dibuat di repositori default Anda",
+  "taskIntegrations": "Integrasi Tugas",
+  "configureSettings": "Konfigurasi Pengaturan",
+  "completeAuthBrowser": "Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.",
+  "failedToStartAppAuth": "Gagal memulai autentikasi {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Hubungkan ke {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Anda perlu mengizinkan Omi untuk membuat tugas di akun {appName} Anda. Ini akan membuka browser Anda untuk autentikasi.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Lanjutkan",
+  "appIntegration": "Integrasi {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integrasi dengan {appName} segera hadir! Kami bekerja keras untuk memberikan Anda lebih banyak opsi manajemen tugas.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Mengerti",
+  "tasksExportedOneApp": "Tugas dapat diekspor ke satu aplikasi pada satu waktu.",
+  "completeYourUpgrade": "Selesaikan Peningkatan Anda",
+  "importConfiguration": "Impor Konfigurasi",
+  "exportConfiguration": "Ekspor konfigurasi",
+  "bringYourOwn": "Bawa sendiri",
+  "payYourSttProvider": "Gunakan omi secara bebas. Anda hanya membayar penyedia STT Anda secara langsung.",
+  "freeMinutesMonth": "1.200 menit gratis/bulan termasuk. Tanpa batas dengan ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Host diperlukan",
+  "validPortRequired": "Port yang valid diperlukan",
+  "validWebsocketUrlRequired": "URL WebSocket yang valid diperlukan (wss://)",
+  "apiUrlRequired": "URL API diperlukan",
+  "apiKeyRequired": "Kunci API diperlukan",
+  "invalidJsonConfig": "Konfigurasi JSON tidak valid",
+  "errorSaving": "Kesalahan menyimpan: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfigurasi disalin ke clipboard",
+  "pasteJsonConfig": "Tempel konfigurasi JSON Anda di bawah ini:",
+  "addApiKeyAfterImport": "Anda perlu menambahkan kunci API Anda sendiri setelah mengimpor",
+  "paste": "Tempel",
+  "import": "Impor",
+  "invalidProviderInConfig": "Penyedia tidak valid dalam konfigurasi",
+  "importedConfig": "Konfigurasi {providerName} diimpor",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON tidak valid: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Penyedia",
+  "live": "Langsung",
+  "onDevice": "Di Perangkat",
+  "apiUrl": "URL API",
+  "enterSttHttpEndpoint": "Masukkan endpoint HTTP STT Anda",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Masukkan endpoint WebSocket STT langsung Anda",
+  "apiKey": "Kunci API",
+  "enterApiKey": "Masukkan kunci API Anda",
+  "storedLocallyNeverShared": "Disimpan secara lokal, tidak pernah dibagikan",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Lanjutan",
+  "configuration": "Konfigurasi",
+  "requestConfiguration": "Konfigurasi Permintaan",
+  "responseSchema": "Skema Respons",
+  "modified": "Dimodifikasi",
+  "resetRequestConfig": "Setel ulang konfigurasi permintaan ke default",
+  "logs": "Log",
+  "logsCopied": "Log disalin",
+  "noLogsYet": "Belum ada log. Mulai merekam untuk melihat aktivitas STT kustom.",
+  "deviceUsesCodec": "{deviceName} menggunakan {codecReason}. Omi akan digunakan.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Transkripsi Omi",
+  "bestInClassTranscription": "Transkripsi terbaik di kelasnya tanpa pengaturan",
+  "instantSpeakerLabels": "Label pembicara instan",
+  "languageTranslation": "Terjemahan 100+ bahasa",
+  "optimizedForConversation": "Dioptimalkan untuk percakapan",
+  "autoLanguageDetection": "Deteksi bahasa otomatis",
+  "highAccuracy": "Akurasi tinggi",
+  "privacyFirst": "Privasi utama",
+  "saveChanges": "Simpan Perubahan",
+  "resetToDefault": "Setel Ulang ke Default",
+  "viewTemplate": "Lihat Template",
+  "trySomethingLike": "Coba sesuatu seperti...",
+  "tryIt": "Coba",
+  "creatingPlan": "Membuat rencana",
+  "developingLogic": "Mengembangkan logika",
+  "designingApp": "Mendesain aplikasi",
+  "generatingIconStep": "Menghasilkan ikon",
+  "finalTouches": "Sentuhan akhir",
+  "processing": "Memproses...",
+  "features": "Fitur",
+  "creatingYourApp": "Membuat aplikasi Anda...",
+  "generatingIcon": "Menghasilkan ikon...",
+  "whatShouldWeMake": "Apa yang harus kita buat?",
+  "appName": "Nama Aplikasi",
+  "description": "Deskripsi",
+  "publicLabel": "Publik",
+  "privateLabel": "Pribadi",
+  "free": "Gratis",
+  "perMonth": "/ Bulan",
+  "tailoredConversationSummaries": "Ringkasan Percakapan yang Disesuaikan",
+  "customChatbotPersonality": "Kepribadian Chatbot Kustom",
+  "makePublic": "Buat publik",
+  "anyoneCanDiscover": "Siapa saja dapat menemukan aplikasi Anda",
+  "onlyYouCanUse": "Hanya Anda yang dapat menggunakan aplikasi ini",
+  "paidApp": "Aplikasi berbayar",
+  "usersPayToUse": "Pengguna membayar untuk menggunakan aplikasi Anda",
+  "freeForEveryone": "Gratis untuk semua orang",
+  "perMonthLabel": "/ bulan",
+  "creating": "Membuat...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Buat Aplikasi",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Mencari perangkat...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{PERANGKAT} other{PERANGKAT}} DITEMUKAN DI SEKITAR",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PASANGAN BERHASIL",
+  "errorConnectingAppleWatch": "Kesalahan menghubungkan ke Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Jangan tampilkan lagi",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Saya Mengerti",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Aktifkan Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi membutuhkan Bluetooth untuk terhubung ke perangkat yang dapat dipakai Anda. Silakan aktifkan Bluetooth dan coba lagi.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Hubungi Dukungan?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Hubungkan Nanti",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Berikan izin",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Aktivitas latar belakang",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Biarkan Omi berjalan di latar belakang untuk stabilitas yang lebih baik",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Akses lokasi",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Aktifkan lokasi latar belakang untuk pengalaman penuh",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Notifikasi",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Aktifkan notifikasi agar tetap mendapat informasi",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Layanan Lokasi Dinonaktifkan",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Layanan Lokasi Dinonaktifkan. Silakan buka Pengaturan > Privasi & Keamanan > Layanan Lokasi dan aktifkan",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Akses Lokasi Latar Belakang Ditolak",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Silakan buka pengaturan perangkat dan atur izin lokasi ke \"Selalu Izinkan\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Menyukai Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Bantu kami menjangkau lebih banyak orang dengan meninggalkan ulasan di App Store. Masukan Anda sangat berarti bagi kami!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Bantu kami menjangkau lebih banyak orang dengan meninggalkan ulasan di Google Play Store. Masukan Anda sangat berarti bagi kami!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Beri Nilai di App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Beri Nilai di Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Mungkin nanti",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi perlu mempelajari tujuan dan suara Anda. Anda dapat memodifikasinya nanti.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Mulai",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Semua selesai!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Terus lanjutkan, Anda melakukannya dengan baik",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Lewati pertanyaan ini",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Lewati untuk sekarang",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Kesalahan Koneksi",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Gagal terhubung ke server. Silakan periksa koneksi internet Anda dan coba lagi.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Rekaman tidak valid terdeteksi",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Sepertinya ada beberapa pembicara dalam rekaman. Pastikan Anda berada di lokasi yang sunyi dan coba lagi.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Tidak cukup ucapan terdeteksi. Silakan berbicara lebih banyak dan coba lagi.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Pastikan Anda berbicara setidaknya selama 5 detik dan tidak lebih dari 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Apakah Anda di sana?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Kami tidak dapat mendeteksi ucapan apa pun. Pastikan untuk berbicara setidaknya selama 10 detik dan tidak lebih dari 3 menit.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Koneksi Terputus",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Koneksi terputus. Silakan periksa koneksi internet Anda dan coba lagi.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Coba Lagi",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Hubungkan Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Lanjutkan Tanpa Perangkat",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Izin Diperlukan",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Aplikasi ini memerlukan izin Bluetooth dan Lokasi agar berfungsi dengan baik. Silakan aktifkan di pengaturan.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Buka Pengaturan",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Ingin menggunakan nama lain?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Siapa nama Anda?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Bicara. Transkripsi. Ringkas.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Masuk dengan Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Masuk dengan Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Dengan melanjutkan, Anda menyetujui ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Ketentuan Penggunaan",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Pendamping AI Anda",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Tangkap setiap momen. Dapatkan ringkasan\nbertenaga AI. Jangan pernah mencatat lagi.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Pengaturan Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Izin Diminta!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Izin Mikrofon",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Izin diberikan! Sekarang:\n\nBuka aplikasi Omi di jam tangan Anda dan ketuk \"Lanjutkan\" di bawah ini",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Kami memerlukan izin mikrofon.\n\n1. Ketuk \"Berikan Izin\"\n2. Izinkan di iPhone Anda\n3. Aplikasi jam tangan akan tertutup\n4. Buka kembali dan ketuk \"Lanjutkan\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Berikan Izin",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Butuh Bantuan?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Pemecahan Masalah:\n\n1. Pastikan Omi terinstal di jam tangan Anda\n2. Buka aplikasi Omi di jam tangan Anda\n3. Cari popup izin\n4. Ketuk \"Izinkan\" saat diminta\n5. Aplikasi di jam tangan Anda akan tertutup - buka kembali\n6. Kembali dan ketuk \"Lanjutkan\" di iPhone Anda",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Rekaman berhasil dimulai!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Izin belum diberikan. Pastikan Anda telah mengizinkan akses mikrofon dan membuka kembali aplikasi di jam tangan Anda.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Kesalahan meminta izin: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Kesalahan memulai rekaman: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Pilih bahasa utama Anda",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Atur bahasa Anda untuk transkripsi yang lebih tajam dan pengalaman yang dipersonalisasi",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Apa bahasa utama Anda?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Pilih bahasa Anda",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Perjalanan pertumbuhan pribadi Anda dengan AI yang mendengarkan setiap kata Anda.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Daftar Tugas",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Ketuk untuk edit • Tekan lama untuk pilih • Geser untuk aksi",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Harus Dilakukan",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Selesai",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Lama",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Semua selesai!\nTidak ada item tindakan tertunda",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Belum ada item yang diselesaikan",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Tidak ada tugas lama",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Tidak ada item",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Item tindakan ditandai sebagai belum selesai",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Item tindakan selesai",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Hapus Item Tindakan",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Apakah Anda yakin ingin menghapus item tindakan ini?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Hapus Item yang Dipilih",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Apakah Anda yakin ingin menghapus {count} item tindakan{s} yang dipilih?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Item tindakan \"{description}\" dihapus",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} item tindakan{s} dihapus",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Gagal menghapus item tindakan",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Gagal menghapus item",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Gagal menghapus beberapa item",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Siap untuk Item Tindakan",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "AI Anda akan secara otomatis mengekstrak tugas dan hal-hal yang harus dilakukan dari percakapan Anda. Mereka akan muncul di sini saat dibuat.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Secara otomatis diekstrak dari percakapan",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Ketuk untuk edit, geser untuk selesaikan atau hapus",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} dipilih",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Pilih semua",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Hapus yang dipilih",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Cari {count} Memori",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Memori Dihapus.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Batalkan",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Belum ada memori",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Belum ada memori yang diekstrak otomatis",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Belum ada memori manual",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Tidak ada memori dalam kategori ini",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Tidak ada memori ditemukan",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Tambahkan memori pertama Anda",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Hapus Memori Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Apakah Anda yakin ingin menghapus memori Omi? Tindakan ini tidak dapat dibatalkan.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Hapus Memori",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Memori Omi tentang Anda telah dihapus",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Tidak ada memori untuk dihapus",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Buat memori baru",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Buat item tindakan baru",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Manajemen Memori",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filter Memori",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Anda memiliki {count} total memori",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Memori publik",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Memori pribadi",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Jadikan Semua Memori Pribadi",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Jadikan Semua Memori Publik",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Hapus Semua Memori",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Semua memori sekarang pribadi",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Semua memori sekarang publik",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Memori Baru",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Edit Memori",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Saya suka makan es krim...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Gagal menyimpan. Silakan periksa koneksi Anda.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Simpan Memori",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Coba Lagi",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Buat Item Tindakan",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Edit Item Tindakan",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Apa yang perlu dilakukan?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Deskripsi item tindakan tidak boleh kosong.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Item tindakan diperbarui",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Gagal memperbarui item tindakan",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Item tindakan dibuat",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Gagal membuat item tindakan",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Tenggat Waktu",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Waktu",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Tambahkan tenggat waktu",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Tekan selesai untuk menyimpan",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Tekan selesai untuk membuat",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Semua",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Tentang Anda",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Wawasan",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manual",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Selesai",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Tandai selesai",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Item tindakan dihapus",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Gagal menghapus item tindakan",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Hapus Item Tindakan",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Apakah Anda yakin ingin menghapus item tindakan ini?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Bahasa Aplikasi",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ANTARMUKA APLIKASI",
+  "speechTranscriptionSectionTitle": "UCAPAN & TRANSKRIPSI",
+  "languageSettingsHelperText": "Bahasa Aplikasi mengubah menu dan tombol. Bahasa Ucapan mempengaruhi cara rekaman Anda ditranskripsi."
+}

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -1,0 +1,2299 @@
+{
+  "@@locale": "it",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Conversazione",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Trascrizione",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Azioni",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Eliminare Conversazione?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Sei sicuro di voler eliminare questa conversazione? Questa azione non può essere annullata.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Conferma",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Annulla",
+  "@cancel": {
+    "description": "Cancel button label"
+  },
+  "ok": "OK",
+  "@ok": {
+    "description": "OK button label"
+  },
+  "delete": "Elimina",
+  "@delete": {
+    "description": "Delete button/action label"
+  },
+  "add": "Aggiungi",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Aggiorna",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Salva",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Modifica",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Chiudi",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Cancella",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Copia Trascrizione",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Copia Riepilogo",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Prova Prompt",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Rielabora Conversazione",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Elimina Conversazione",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Contenuto copiato negli appunti",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Impossibile aggiornare lo stato preferito.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "L'URL della conversazione non può essere condiviso.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Errore durante l'elaborazione della conversazione. Riprova più tardi.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Controlla la tua connessione internet e riprova.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Impossibile Eliminare Conversazione",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Qualcosa è andato storto! Riprova più tardi.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Copia messaggio di errore",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Messaggio di errore copiato negli appunti",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Rimanente",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Caricamento...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Caricamento durata...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} secondi",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Persone",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Aggiungi Nuova Persona",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Modifica Persona",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Crea una nuova persona e allena Omi a riconoscere anche il suo modo di parlare!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Profilo Vocale",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Campione {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Impostazioni",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Lingua",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Seleziona Lingua",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Eliminazione...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Completa l'autenticazione nel tuo browser. Una volta fatto, torna all'app.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Impossibile avviare l'autenticazione",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Importazione avviata! Riceverai una notifica quando sarà completata.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Impossibile avviare l'importazione. Riprova.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Impossibile accedere al file selezionato",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Chiedi a Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Fatto",
+  "@done": {
+    "description": "Done button label"
+  },
+  "disconnected": "Disconnesso",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Ricerca",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Connetti Dispositivo",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Hai raggiunto il tuo limite mensile.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Verifica Utilizzo",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Sincronizzazione registrazioni",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Registrazioni da sincronizzare",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Tutto aggiornato",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Sincronizza",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Il pendente è aggiornato",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Tutte le registrazioni sono sincronizzate",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Sincronizzazione in corso",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Pronto per sincronizzare",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Tocca Sincronizza per iniziare",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Pendente non connesso. Connettiti per sincronizzare.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Tutto è già sincronizzato.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Hai registrazioni che non sono ancora sincronizzate.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Continueremo a sincronizzare le tue registrazioni in background.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Nessuna conversazione ancora.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Nessuna conversazione preferita ancora.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Per aggiungere una conversazione ai preferiti, aprila e tocca l'icona stella nell'intestazione.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Cerca Conversazioni",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} selezionat{s}",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Unisci",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Unisci Conversazioni",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Questo combinerà {count} conversazioni in una. Tutti i contenuti saranno uniti e rigenerati.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Unione in background. Potrebbe richiedere un momento.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Impossibile avviare l'unione",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Chiedi qualsiasi cosa",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Nessun messaggio ancora!\nPerché non inizi una conversazione?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Eliminazione dei tuoi messaggi dalla memoria di Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Messaggio copiato negli appunti.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Non puoi segnalare i tuoi stessi messaggi.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Segnala Messaggio",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Sei sicuro di voler segnalare questo messaggio?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Messaggio segnalato con successo.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Grazie per il tuo feedback!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Cancellare Chat?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Sei sicuro di voler cancellare la chat? Questa azione non può essere annullata.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Puoi caricare solo 4 file alla volta",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Chatta con Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "App",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Nessuna app trovata",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Prova a modificare la tua ricerca o i filtri",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Crea la Tua App",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Costruisci e condividi la tua app personalizzata",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Cerca tra 1500+ App",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Le Mie App",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "App Installate",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Impossibile recuperare le app :(\n\nControlla la tua connessione internet e riprova.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Informazioni su Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Politica sulla Privacy",
+  "@privacyPolicy": {
+    "description": "Privacy policy link"
+  },
+  "visitWebsite": "Visita il Sito Web",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Aiuto o Richieste?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Unisciti alla community!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ membri e in crescita.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Elimina Account",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Sei sicuro di voler eliminare il tuo account?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Questa operazione non può essere annullata.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Tutti i tuoi ricordi e conversazioni saranno cancellati permanentemente.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Le tue App e Integrazioni saranno disconnesse immediatamente.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Puoi esportare i tuoi dati prima di eliminare il tuo account, ma una volta eliminato, non può essere recuperato.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Comprendo che l'eliminazione del mio account è permanente e tutti i dati, inclusi ricordi e conversazioni, saranno persi e non potranno essere recuperati.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Sei sicuro?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Questa azione è irreversibile e eliminerà permanentemente il tuo account e tutti i dati associati. Sei sicuro di voler procedere?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Elimina Ora",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Indietro",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Seleziona la casella per confermare di aver compreso che l'eliminazione del tuo account è permanente e irreversibile.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profilo",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Nome",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Email",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Vocabolario Personalizzato",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identificazione Altri",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Metodi di Pagamento",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Visualizzazione Conversazioni",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Dati e Privacy",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID Utente",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Non impostato",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID utente copiato negli appunti",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Predefinito del Sistema",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Piano e Utilizzo",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Sincronizzazione Offline",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Impostazioni Dispositivo",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Strumenti Chat",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Feedback / Bug",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Centro Assistenza",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Impostazioni Sviluppatore",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Ottieni Omi per Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Programma di Riferimento",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Disconnetti",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Dettagli app e dispositivo copiati",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Resoconto 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "La Tua Privacy, Il Tuo Controllo",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "In Omi ci impegniamo a proteggere la tua privacy. Questa pagina ti permette di controllare come vengono archiviati e utilizzati i tuoi dati.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Scopri di più...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Livello di Protezione Dati",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "I tuoi dati sono protetti di default con crittografia avanzata. Rivedi le tue impostazioni e le future opzioni di privacy qui sotto.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Accesso App",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Le seguenti app possono accedere ai tuoi dati. Tocca un'app per gestire i suoi permessi.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Nessuna app installata ha accesso esterno ai tuoi dati.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Nome Dispositivo",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID Dispositivo",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmware",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Sincronizzazione Scheda SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Revisione Hardware",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Numero Modello",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Produttore",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Doppio Tocco",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Luminosità LED",
+  "@ledBrightness": {
+    "description": "LED brightness label"
+  },
+  "micGain": "Guadagno Microfono",
+  "@micGain": {
+    "description": "Microphone gain label"
+  },
+  "disconnect": "Disconnetti",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Dimentica Dispositivo",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Problemi di Ricarica",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Disconnetti Dispositivo",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Disaccoppia Dispositivo",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Disaccoppia e Dimentica Dispositivo",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Il tuo Omi è stato disconnesso 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Dispositivo disaccoppiato. Vai su Impostazioni > Bluetooth e dimentica il dispositivo per completare il disaccoppiamento.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Disaccoppia Dispositivo",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Questo disaccoppierà il dispositivo in modo che possa essere connesso a un altro telefono. Dovrai andare su Impostazioni > Bluetooth e dimenticare il dispositivo per completare il processo.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Dispositivo Non Connesso",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Connetti il tuo dispositivo Omi per accedere\nalle impostazioni e alla personalizzazione del dispositivo",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Informazioni Dispositivo",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Personalizzazione",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Hardware",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 non rilevato",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Vediamo che hai un dispositivo V1 o il tuo dispositivo non è connesso. La funzionalità della scheda SD è disponibile solo per i dispositivi V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Termina Conversazione",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pausa/Riprendi",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Aggiungi ai Preferiti",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Azione Doppio Tocco",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Termina ed Elabora Conversazione",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pausa/Riprendi Registrazione",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Aggiungi Conversazione in Corso ai Preferiti",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Spento",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Massimo",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Muto",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Silenzioso",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normale",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Alto",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Microfono disattivato",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Molto silenzioso - per ambienti rumorosi",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Silenzioso - per rumore moderato",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutrale - registrazione bilanciata",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Leggermente amplificato - uso normale",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Amplificato - per ambienti silenziosi",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Alto - per voci distanti o basse",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Molto alto - per sorgenti molto silenziose",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Massimo - usare con cautela",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Impostazioni Sviluppatore",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Salvataggio...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Configura la tua AI persona",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Trascrizione",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Configura provider STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Timeout Conversazione",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Imposta quando le conversazioni terminano automaticamente",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importa Dati",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importa dati da altre fonti",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Debug e Diagnostica",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL Endpoint",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Nessuna chiave API ancora",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Crea una chiave per iniziare",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Crea Chiave",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Documenti",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Le Tue Statistiche Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Oggi",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Questo Mese",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Quest'Anno",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Sempre",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Nessuna Attività Ancora",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Inizia una conversazione con Omi\nper vedere le tue statistiche di utilizzo qui.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Ascolto",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Tempo totale in cui Omi ha ascoltato attivamente.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Comprensione",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Parole comprese dalle tue conversazioni.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Fornire",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Azioni e note automaticamente catturate.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Ricordare",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fatti e dettagli ricordati per te.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Piano Illimitato",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Gestisci Piano",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Il tuo piano sarà annullato il {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Il tuo piano si rinnova il {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Piano Gratuito",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} di {limit} min utilizzati",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Aggiorna",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Passa a Illimitato",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Il tuo piano include {limit} minuti gratuiti al mese. Aggiorna per passare a illimitato.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Condivido le mie statistiche Omi! (omi.me - il tuo assistente AI sempre attivo)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Oggi, Omi ha:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Questo mese, Omi ha:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Quest'anno, Omi ha:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Finora, Omi ha:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Ascoltato per {minutes} minuti",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Compreso {words} parole",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Fornito {count} insight",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Ricordato {count} ricordi",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Log di Debug",
+  "debugLogsAutoDelete": "Eliminazione automatica dopo 3 giorni.",
+  "debugLogsDesc": "Aiuta a diagnosticare i problemi",
+  "noLogFilesFound": "Nessun file di log trovato.",
+  "omiDebugLog": "Log di debug Omi",
+  "logShared": "Log condiviso",
+  "selectLogFile": "Seleziona File di Log",
+  "shareLogs": "Condividi Log",
+  "debugLogCleared": "Log di debug cancellato",
+  "exportStarted": "Esportazione avviata. Potrebbe richiedere alcuni secondi...",
+  "exportAllData": "Esporta Tutti i Dati",
+  "exportDataDesc": "Esporta conversazioni in un file JSON",
+  "exportedConversations": "Conversazioni Esportate da Omi",
+  "exportShared": "Esportazione condivisa",
+  "deleteKnowledgeGraphTitle": "Eliminare Grafo di Conoscenza?",
+  "deleteKnowledgeGraphMessage": "Questo eliminerà tutti i dati del grafo di conoscenza derivato (nodi e connessioni). I tuoi ricordi originali rimarranno al sicuro. Il grafo sarà ricostruito nel tempo o alla prossima richiesta.",
+  "knowledgeGraphDeleted": "Grafo di Conoscenza eliminato con successo",
+  "deleteGraphFailed": "Impossibile eliminare il grafo: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Elimina Grafo di Conoscenza",
+  "deleteKnowledgeGraphDesc": "Cancella tutti i nodi e le connessioni",
+  "mcp": "MCP",
+  "mcpServer": "Server MCP",
+  "mcpServerDesc": "Connetti assistenti AI ai tuoi dati",
+  "serverUrl": "URL Server",
+  "urlCopied": "URL copiato",
+  "apiKeyAuth": "Autenticazione Chiave API",
+  "header": "Intestazione",
+  "authorizationBearer": "Authorization: Bearer <chiave>",
+  "oauth": "OAuth",
+  "clientId": "ID Cliente",
+  "clientSecret": "Segreto Cliente",
+  "useMcpApiKey": "Usa la tua chiave API MCP",
+  "webhooks": "Webhook",
+  "conversationEvents": "Eventi Conversazione",
+  "newConversationCreated": "Nuova conversazione creata",
+  "realtimeTranscript": "Trascrizione in Tempo Reale",
+  "transcriptReceived": "Trascrizione ricevuta",
+  "audioBytes": "Byte Audio",
+  "audioDataReceived": "Dati audio ricevuti",
+  "intervalSeconds": "Intervallo (secondi)",
+  "daySummary": "Riepilogo Giornaliero",
+  "summaryGenerated": "Riepilogo generato",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Aggiungi a claude_desktop_config.json",
+  "copyConfig": "Copia Configurazione",
+  "configCopied": "Configurazione copiata negli appunti",
+  "listeningMins": "Ascolto (min)",
+  "understandingWords": "Comprensione (parole)",
+  "insights": "Insight",
+  "memories": "Ricordi",
+  "minsUsedThisMonth": "{used} di {limit} min utilizzati questo mese",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} di {limit} parole utilizzate questo mese",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} di {limit} insight ottenuti questo mese",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} di {limit} ricordi creati questo mese",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Visibilità",
+  "visibilitySubtitle": "Controlla quali conversazioni appaiono nella tua lista",
+  "showShortConversations": "Mostra Conversazioni Brevi",
+  "showShortConversationsDesc": "Visualizza conversazioni più brevi della soglia",
+  "showDiscardedConversations": "Mostra Conversazioni Scartate",
+  "showDiscardedConversationsDesc": "Includi conversazioni contrassegnate come scartate",
+  "shortConversationThreshold": "Soglia Conversazione Breve",
+  "shortConversationThresholdSubtitle": "Le conversazioni più brevi di questa soglia saranno nascoste se non abilitate sopra",
+  "durationThreshold": "Soglia Durata",
+  "durationThresholdDesc": "Nascondi conversazioni più brevi di questa soglia",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Vocabolario Personalizzato",
+  "addWords": "Aggiungi Parole",
+  "addWordsDesc": "Nomi, termini o parole non comuni",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Connetti",
+  "comingSoon": "Prossimamente",
+  "chatToolsFooter": "Connetti le tue app per visualizzare dati e metriche nella chat.",
+  "completeAuthInBrowser": "Completa l'autenticazione nel tuo browser. Una volta fatto, torna all'app.",
+  "failedToStartAuth": "Impossibile avviare l'autenticazione {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Disconnettere {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Sei sicuro di volerti disconnettere da {appName}? Puoi riconnetterti in qualsiasi momento.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Disconnesso da {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Impossibile disconnettere",
+  "connectTo": "Connetti a {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Dovrai autorizzare Omi ad accedere ai tuoi dati {appName}. Questo aprirà il tuo browser per l'autenticazione.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Continua",
+  "languageTitle": "Lingua",
+  "primaryLanguage": "Lingua Principale",
+  "automaticTranslation": "Traduzione Automatica",
+  "detectLanguages": "Rileva oltre 10 lingue",
+  "authorizeSavingRecordings": "Autorizza Salvataggio Registrazioni",
+  "thanksForAuthorizing": "Grazie per aver autorizzato!",
+  "needYourPermission": "Abbiamo bisogno del tuo permesso",
+  "alreadyGavePermission": "Ci hai già dato il permesso di salvare le tue registrazioni. Ecco un promemoria del perché ne abbiamo bisogno:",
+  "wouldLikePermission": "Vorremmo il tuo permesso per salvare le tue registrazioni vocali. Ecco perché:",
+  "improveSpeechProfile": "Migliora il Tuo Profilo Vocale",
+  "improveSpeechProfileDesc": "Utilizziamo le registrazioni per addestrare e migliorare ulteriormente il tuo profilo vocale personale.",
+  "trainFamilyProfiles": "Addestra Profili per Amici e Famiglia",
+  "trainFamilyProfilesDesc": "Le tue registrazioni ci aiutano a riconoscere e creare profili per i tuoi amici e familiari.",
+  "enhanceTranscriptAccuracy": "Migliora Precisione Trascrizione",
+  "enhanceTranscriptAccuracyDesc": "Man mano che il nostro modello migliora, possiamo fornire risultati di trascrizione migliori per le tue registrazioni.",
+  "legalNotice": "Avviso Legale: La legalità della registrazione e dell'archiviazione dei dati vocali può variare a seconda della tua posizione e di come utilizzi questa funzione. È tua responsabilità garantire la conformità con le leggi e i regolamenti locali.",
+  "alreadyAuthorized": "Già Autorizzato",
+  "authorize": "Autorizza",
+  "revokeAuthorization": "Revoca Autorizzazione",
+  "authorizationSuccessful": "Autorizzazione riuscita!",
+  "failedToAuthorize": "Impossibile autorizzare. Riprova.",
+  "authorizationRevoked": "Autorizzazione revocata.",
+  "recordingsDeleted": "Registrazioni eliminate.",
+  "failedToRevoke": "Impossibile revocare l'autorizzazione. Riprova.",
+  "permissionRevokedTitle": "Permesso Revocato",
+  "permissionRevokedMessage": "Vuoi che rimuoviamo anche tutte le tue registrazioni esistenti?",
+  "yes": "Sì",
+  "editName": "Modifica Nome",
+  "howShouldOmiCallYou": "Come dovrebbe chiamarti Omi?",
+  "enterYourName": "Inserisci il tuo nome",
+  "nameCannotBeEmpty": "Il nome non può essere vuoto",
+  "nameUpdatedSuccessfully": "Nome aggiornato con successo!",
+  "calendarSettings": "Impostazioni calendario",
+  "calendarProviders": "Provider Calendario",
+  "macOsCalendar": "Calendario macOS",
+  "connectMacOsCalendar": "Connetti il tuo calendario macOS locale",
+  "googleCalendar": "Google Calendar",
+  "syncGoogleAccount": "Sincronizza con il tuo account Google",
+  "showMeetingsMenuBar": "Mostra riunioni imminenti nella barra dei menu",
+  "showMeetingsMenuBarDesc": "Visualizza la tua prossima riunione e il tempo rimanente nella barra dei menu di macOS",
+  "showEventsNoParticipants": "Mostra eventi senza partecipanti",
+  "showEventsNoParticipantsDesc": "Quando abilitato, Prossimi Eventi mostra eventi senza partecipanti o link video.",
+  "yourMeetings": "Le Tue Riunioni",
+  "refresh": "Aggiorna",
+  "noUpcomingMeetings": "Nessuna riunione imminente trovata",
+  "checkingNextDays": "Controllo dei prossimi 30 giorni",
+  "tomorrow": "Domani",
+  "googleCalendarComingSoon": "Integrazione Google Calendar in arrivo!",
+  "connectedAsUser": "Connesso come utente: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Area di Lavoro Predefinita",
+  "tasksCreatedInWorkspace": "Le attività saranno create in quest'area di lavoro",
+  "defaultProjectOptional": "Progetto Predefinito (Facoltativo)",
+  "leaveUnselectedTasks": "Lascia non selezionato per creare attività senza un progetto",
+  "noProjectsInWorkspace": "Nessun progetto trovato in quest'area di lavoro",
+  "conversationTimeoutDesc": "Scegli quanto tempo attendere in silenzio prima di terminare automaticamente una conversazione:",
+  "timeout2Minutes": "2 minuti",
+  "timeout2MinutesDesc": "Termina conversazione dopo 2 minuti di silenzio",
+  "timeout5Minutes": "5 minuti",
+  "timeout5MinutesDesc": "Termina conversazione dopo 5 minuti di silenzio",
+  "timeout10Minutes": "10 minuti",
+  "timeout10MinutesDesc": "Termina conversazione dopo 10 minuti di silenzio",
+  "timeout30Minutes": "30 minuti",
+  "timeout30MinutesDesc": "Termina conversazione dopo 30 minuti di silenzio",
+  "timeout4Hours": "4 ore",
+  "timeout4HoursDesc": "Termina conversazione dopo 4 ore di silenzio",
+  "conversationEndAfterHours": "Le conversazioni termineranno ora dopo 4 ore di silenzio",
+  "conversationEndAfterMinutes": "Le conversazioni termineranno ora dopo {minutes} minuto/i di silenzio",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Dicci la tua lingua principale",
+  "languageForTranscription": "Imposta la tua lingua per trascrizioni più accurate e un'esperienza personalizzata.",
+  "singleLanguageModeInfo": "Modalità Lingua Singola attivata. La traduzione è disabilitata per una maggiore precisione.",
+  "searchLanguageHint": "Cerca lingua per nome o codice",
+  "noLanguagesFound": "Nessuna lingua trovata",
+  "skip": "Salta",
+  "languageSetTo": "Lingua impostata su {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Impossibile impostare la lingua",
+  "appSettings": "Impostazioni {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Disconnettere da {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Questo rimuoverà la tua autenticazione {appName}. Dovrai riconnetterti per usarlo di nuovo.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Connesso a {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Account",
+  "actionItemsSyncedTo": "Le tue azioni saranno sincronizzate con il tuo account {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Spazio Predefinito",
+  "selectSpaceInWorkspace": "Seleziona uno spazio nella tua area di lavoro",
+  "noSpacesInWorkspace": "Nessuno spazio trovato in quest'area di lavoro",
+  "defaultList": "Lista Predefinita",
+  "tasksAddedToList": "Le attività saranno aggiunte a questa lista",
+  "noListsInSpace": "Nessuna lista trovata in questo spazio",
+  "failedToLoadRepos": "Impossibile caricare i repository: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Repository predefinito salvato",
+  "failedToSaveDefaultRepo": "Impossibile salvare il repository predefinito",
+  "defaultRepository": "Repository Predefinito",
+  "selectDefaultRepoDesc": "Seleziona un repository predefinito per creare issue. Puoi comunque specificare un repository diverso durante la creazione di issue.",
+  "noReposFound": "Nessun repository trovato",
+  "private": "Privato",
+  "updatedDate": "Aggiornato {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "ieri",
+  "daysAgo": "{count} giorni fa",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 settimana fa",
+  "weeksAgo": "{count} settimane fa",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 mese fa",
+  "monthsAgo": "{count} mesi fa",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Le issue saranno create nel tuo repository predefinito",
+  "taskIntegrations": "Integrazioni Attività",
+  "configureSettings": "Configura Impostazioni",
+  "completeAuthBrowser": "Completa l'autenticazione nel tuo browser. Una volta fatto, torna all'app.",
+  "failedToStartAppAuth": "Impossibile avviare l'autenticazione {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Connetti a {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Dovrai autorizzare Omi a creare attività nel tuo account {appName}. Questo aprirà il tuo browser per l'autenticazione.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Continua",
+  "appIntegration": "Integrazione {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "L'integrazione con {appName} è in arrivo! Stiamo lavorando sodo per offrirti più opzioni di gestione delle attività.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Capito",
+  "tasksExportedOneApp": "Le attività possono essere esportate in un'app alla volta.",
+  "completeYourUpgrade": "Completa il Tuo Aggiornamento",
+  "importConfiguration": "Importa Configurazione",
+  "exportConfiguration": "Esporta configurazione",
+  "bringYourOwn": "Porta il tuo",
+  "payYourSttProvider": "Usa Omi liberamente. Paghi solo il tuo provider STT direttamente.",
+  "freeMinutesMonth": "1.200 minuti gratuiti/mese inclusi. Illimitato con ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "L'host è richiesto",
+  "validPortRequired": "È richiesta una porta valida",
+  "validWebsocketUrlRequired": "È richiesto un URL WebSocket valido (wss://)",
+  "apiUrlRequired": "L'URL API è richiesto",
+  "apiKeyRequired": "La chiave API è richiesta",
+  "invalidJsonConfig": "Configurazione JSON non valida",
+  "errorSaving": "Errore durante il salvataggio: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Configurazione copiata negli appunti",
+  "pasteJsonConfig": "Incolla la tua configurazione JSON qui sotto:",
+  "addApiKeyAfterImport": "Dovrai aggiungere la tua chiave API dopo l'importazione",
+  "paste": "Incolla",
+  "import": "Importa",
+  "invalidProviderInConfig": "Provider non valido nella configurazione",
+  "importedConfig": "Configurazione {providerName} importata",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON non valido: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Provider",
+  "live": "Live",
+  "onDevice": "Sul Dispositivo",
+  "apiUrl": "URL API",
+  "enterSttHttpEndpoint": "Inserisci il tuo endpoint HTTP STT",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Inserisci il tuo endpoint WebSocket STT live",
+  "apiKey": "Chiave API",
+  "enterApiKey": "Inserisci la tua chiave API",
+  "storedLocallyNeverShared": "Archiviato localmente, mai condiviso",
+  "host": "Host",
+  "port": "Porta",
+  "advanced": "Avanzate",
+  "configuration": "Configurazione",
+  "requestConfiguration": "Configurazione Richiesta",
+  "responseSchema": "Schema Risposta",
+  "modified": "Modificato",
+  "resetRequestConfig": "Ripristina configurazione richiesta predefinita",
+  "logs": "Log",
+  "logsCopied": "Log copiati",
+  "noLogsYet": "Nessun log ancora. Inizia a registrare per vedere l'attività STT personalizzata.",
+  "deviceUsesCodec": "{deviceName} usa {codecReason}. Verrà utilizzato Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Trascrizione Omi",
+  "bestInClassTranscription": "Trascrizione all'avanguardia senza configurazione",
+  "instantSpeakerLabels": "Etichette dei parlanti istantanee",
+  "languageTranslation": "Traduzione in oltre 100 lingue",
+  "optimizedForConversation": "Ottimizzato per la conversazione",
+  "autoLanguageDetection": "Rilevamento automatico della lingua",
+  "highAccuracy": "Alta precisione",
+  "privacyFirst": "Privacy al primo posto",
+  "saveChanges": "Salva Modifiche",
+  "resetToDefault": "Ripristina Predefinito",
+  "viewTemplate": "Visualizza Template",
+  "trySomethingLike": "Prova qualcosa come...",
+  "tryIt": "Provalo",
+  "creatingPlan": "Creazione piano",
+  "developingLogic": "Sviluppo logica",
+  "designingApp": "Progettazione app",
+  "generatingIconStep": "Generazione icona",
+  "finalTouches": "Ritocchi finali",
+  "processing": "Elaborazione...",
+  "features": "Funzionalità",
+  "creatingYourApp": "Creazione della tua app...",
+  "generatingIcon": "Generazione icona...",
+  "whatShouldWeMake": "Cosa dovremmo creare?",
+  "appName": "Nome App",
+  "description": "Descrizione",
+  "publicLabel": "Pubblico",
+  "privateLabel": "Privato",
+  "free": "Gratuito",
+  "perMonth": "/ Mese",
+  "tailoredConversationSummaries": "Riepiloghi Conversazione Personalizzati",
+  "customChatbotPersonality": "Personalità Chatbot Personalizzata",
+  "makePublic": "Rendi pubblico",
+  "anyoneCanDiscover": "Chiunque può scoprire la tua app",
+  "onlyYouCanUse": "Solo tu puoi usare questa app",
+  "paidApp": "App a pagamento",
+  "usersPayToUse": "Gli utenti pagano per usare la tua app",
+  "freeForEveryone": "Gratuito per tutti",
+  "perMonthLabel": "/ mese",
+  "creating": "Creazione...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Crea App",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "searchingForDevices": "Ricerca dispositivi...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{DISPOSITIVO} other{DISPOSITIVI}} TROVATO/I NELLE VICINANZE",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "ACCOPPIAMENTO RIUSCITO",
+  "errorConnectingAppleWatch": "Errore durante la connessione all'Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Non mostrare più",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Ho Capito",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Abilita Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi ha bisogno del Bluetooth per connettersi al tuo dispositivo indossabile. Abilita il Bluetooth e riprova.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Contatta Supporto?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Connetti Più Tardi",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Concedi permessi",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Attività in background",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Consenti a Omi di funzionare in background per una migliore stabilità",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Accesso posizione",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Abilita posizione in background per l'esperienza completa",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Notifiche",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Abilita le notifiche per rimanere informato",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "locationServiceDisabled": "Servizio di Localizzazione Disabilitato",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Il Servizio di Localizzazione è disabilitato. Vai su Impostazioni > Privacy e Sicurezza > Servizi di Localizzazione e abilitalo",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Accesso Posizione in Background Negato",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Vai nelle impostazioni del dispositivo e imposta il permesso di localizzazione su \"Consenti sempre\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Ti piace Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Aiutaci a raggiungere più persone lasciando una recensione sull'App Store. Il tuo feedback è prezioso per noi!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Aiutaci a raggiungere più persone lasciando una recensione sul Google Play Store. Il tuo feedback è prezioso per noi!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Valuta su App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Valuta su Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Forse più tardi",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi ha bisogno di conoscere i tuoi obiettivi e la tua voce. Potrai modificarli in seguito.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Inizia",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Tutto fatto!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Continua così, stai andando alla grande",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Salta questa domanda",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Salta per ora",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Errore di Connessione",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Impossibile connettersi al server. Controlla la tua connessione internet e riprova.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Registrazione non valida rilevata",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Sembra che ci siano più persone che parlano nella registrazione. Assicurati di essere in un luogo silenzioso e riprova.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Non è stato rilevato abbastanza parlato. Parla di più e riprova.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Assicurati di parlare per almeno 5 secondi e non più di 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Ci sei?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Non abbiamo rilevato nessun parlato. Assicurati di parlare per almeno 10 secondi e non più di 3 minuti.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Connessione Persa",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "La connessione è stata interrotta. Controlla la tua connessione internet e riprova.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Riprova",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Connetti Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Continua Senza Dispositivo",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Permessi Richiesti",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Questa app ha bisogno dei permessi Bluetooth e Posizione per funzionare correttamente. Abilitali nelle impostazioni.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Apri Impostazioni",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Vuoi farti chiamare diversamente?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Come ti chiami?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "speakTranscribeSummarize": "Parla. Trascrivi. Riassumi.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Accedi con Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Accedi con Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Continuando, accetti la nostra ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Condizioni d'Uso",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Il Tuo Compagno AI",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Cattura ogni momento. Ottieni riepiloghi\nbasati sull'AI. Non prendere mai più appunti.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Configurazione Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Permesso Richiesto!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Permesso Microfono",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Permesso concesso! Ora:\n\nApri l'app Omi sul tuo watch e tocca \"Continua\" qui sotto",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Abbiamo bisogno del permesso microfono.\n\n1. Tocca \"Concedi Permesso\"\n2. Consenti sul tuo iPhone\n3. L'app Watch si chiuderà\n4. Riaprila e tocca \"Continua\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Concedi Permesso",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Serve Aiuto?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Risoluzione problemi:\n\n1. Assicurati che Omi sia installato sul tuo watch\n2. Apri l'app Omi sul tuo watch\n3. Cerca il popup di permesso\n4. Tocca \"Consenti\" quando richiesto\n5. L'app sul watch si chiuderà - riaprila\n6. Torna e tocca \"Continua\" sul tuo iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "recordingStartedSuccessfully": "Registrazione avviata con successo!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Permesso non ancora concesso. Assicurati di aver consentito l'accesso al microfono e di aver riaperto l'app sul tuo watch.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Errore durante la richiesta del permesso: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Errore durante l'avvio della registrazione: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Seleziona la tua lingua principale",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Imposta la tua lingua per trascrizioni più accurate e un'esperienza personalizzata",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "whatsYourPrimaryLanguage": "Qual è la tua lingua principale?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Seleziona la tua lingua",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Il tuo percorso di crescita personale con un'AI che ascolta ogni tua parola.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Da Fare",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Tocca per modificare • Tieni premuto per selezionare • Scorri per azioni",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Da Fare",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Fatto",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Vecchi",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Tutto a posto!\nNessuna azione in sospeso",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Nessun elemento completato ancora",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Nessuna attività vecchia",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Nessun elemento",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Azione contrassegnata come non completata",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Azione completata",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Elimina Azione",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Sei sicuro di voler eliminare questa azione?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Elimina Elementi Selezionati",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Sei sicuro di voler eliminare {count} azione/i selezionata/e?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Azione \"{description}\" eliminata",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} azione/i eliminata/e",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Impossibile eliminare l'azione",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Impossibile eliminare gli elementi",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Impossibile eliminare alcuni elementi",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Pronto per le Azioni",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "La tua AI estrarrà automaticamente attività e cose da fare dalle tue conversazioni. Appariranno qui quando create.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Estratto automaticamente dalle conversazioni",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Tocca per modificare, scorri per completare o eliminare",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} selezionati",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Seleziona tutto",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Elimina selezionati",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Cerca {count} Ricordi",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Ricordo Eliminato.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Annulla",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Nessun ricordo ancora",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Nessun ricordo auto-estratto ancora",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Nessun ricordo manuale ancora",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Nessun ricordo in queste categorie",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Nessun ricordo trovato",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Aggiungi il tuo primo ricordo",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Cancella Memoria di Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Sei sicuro di voler cancellare la memoria di Omi? Questa azione non può essere annullata.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Cancella Memoria",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "La memoria di Omi su di te è stata cancellata",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Nessun ricordo da eliminare",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Crea nuovo ricordo",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Crea nuova azione",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Gestione Ricordi",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtra Ricordi",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Hai {count} ricordi totali",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Ricordi pubblici",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Ricordi privati",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Rendi Tutti i Ricordi Privati",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Rendi Tutti i Ricordi Pubblici",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Elimina Tutti i Ricordi",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Tutti i ricordi sono ora privati",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Tutti i ricordi sono ora pubblici",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Nuovo Ricordo",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Modifica Ricordo",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Mi piace mangiare il gelato...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Impossibile salvare. Controlla la tua connessione.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Salva Ricordo",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Riprova",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Crea Azione",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Modifica Azione",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Cosa bisogna fare?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "La descrizione dell'azione non può essere vuota.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Azione aggiornata",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Impossibile aggiornare l'azione",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Azione creata",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Impossibile creare l'azione",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Data di Scadenza",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Ora",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Aggiungi data di scadenza",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Premi fatto per salvare",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Premi fatto per creare",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Tutti",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Su di Te",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Insight",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuale",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Completato",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Segna come completato",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Azione eliminata",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Impossibile eliminare l'azione",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Elimina Azione",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Sei sicuro di voler eliminare questa azione?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Lingua App",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "INTERFACCIA APP",
+  "speechTranscriptionSectionTitle": "VOCE E TRASCRIZIONE",
+  "languageSettingsHelperText": "La lingua dell'app modifica menu e pulsanti. La lingua vocale influisce su come vengono trascritte le tue registrazioni."
+}

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -1,14 +1,11 @@
 {
   "@@locale": "ja",
-
   "appTitle": "Omi",
   "conversationTab": "会話",
   "transcriptTab": "トランスクリプト",
   "actionItemsTab": "アクションアイテム",
-
   "deleteConversationTitle": "会話を削除しますか？",
   "deleteConversationMessage": "この会話を削除してもよろしいですか？この操作は元に戻せません。",
-
   "confirm": "確認",
   "cancel": "キャンセル",
   "ok": "OK",
@@ -18,25 +15,20 @@
   "save": "保存",
   "edit": "編集",
   "close": "閉じる",
-
   "copyTranscript": "トランスクリプトをコピー",
   "copySummary": "サマリーをコピー",
   "testPrompt": "プロンプトをテスト",
   "reprocessConversation": "会話を再処理",
   "deleteConversation": "会話を削除",
-
   "contentCopied": "クリップボードにコピーしました",
   "failedToUpdateStarred": "スター状態の更新に失敗しました。",
   "conversationUrlNotShared": "会話URLを共有できませんでした。",
   "errorProcessingConversation": "会話の処理中にエラーが発生しました。後でもう一度お試しください。",
-
   "noInternetConnection": "インターネット接続を確認して、もう一度お試しください。",
   "unableToDeleteConversation": "会話を削除できません",
-
   "somethingWentWrong": "問題が発生しました！後でもう一度お試しください。",
   "copyErrorMessage": "エラーメッセージをコピー",
   "errorCopied": "エラーメッセージをクリップボードにコピーしました",
-
   "remaining": "残り",
   "loading": "読み込み中...",
   "loadingDuration": "再生時間を読み込み中...",
@@ -48,12 +40,11 @@
       }
     }
   },
-
   "people": "ピープル",
   "addNewPerson": "新しい人を追加",
   "editPerson": "人を編集",
   "createPersonHint": "新しい人を作成して、Omiにその人の声も認識させましょう！",
-  "speechProfile": "音声プロファイル",
+  "speechProfile": "音声プロフィール",
   "sampleNumber": "サンプル {number}",
   "@sampleNumber": {
     "placeholders": {
@@ -62,18 +53,15 @@
       }
     }
   },
-
   "settings": "設定",
   "language": "言語",
   "selectLanguage": "言語を選択",
-
   "deleting": "削除中...",
   "pleaseCompleteAuthentication": "ブラウザで認証を完了してください。完了したらアプリに戻ってください。",
   "failedToStartAuthentication": "認証の開始に失敗しました",
   "importStarted": "インポートを開始しました！完了したら通知されます。",
   "failedToStartImport": "インポートの開始に失敗しました。もう一度お試しください。",
   "couldNotAccessFile": "選択したファイルにアクセスできませんでした",
-
   "askOmi": "Omiに聞く",
   "done": "完了",
   "disconnected": "切断済み",
@@ -94,7 +82,6 @@
   "everythingSynced": "すべて同期済みです。",
   "recordingsNotSynced": "まだ同期されていない録音があります。",
   "syncingBackground": "バックグラウンドで録音を同期し続けます。",
-
   "noConversationsYet": "まだ会話がありません。",
   "noStarredConversations": "スター付きの会話はまだありません。",
   "starConversationHint": "会話をスターするには、会話を開いてヘッダーのスターアイコンをタップしてください。",
@@ -102,7 +89,9 @@
   "selectedCount": "{count}件選択中",
   "@selectedCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "merge": "マージ",
@@ -110,12 +99,13 @@
   "mergeConversationsMessage": "{count}件の会話が1つにまとめられます。すべてのコンテンツがマージされ、再生成されます。",
   "@mergeConversationsMessage": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "mergingInBackground": "バックグラウンドでマージ中。しばらくお待ちください。",
   "failedToStartMerge": "マージの開始に失敗しました",
-
   "askAnything": "何でも聞いてください",
   "noMessagesYet": "まだメッセージがありません！\n会話を始めてみませんか？",
   "deletingMessages": "Omiのメモリからメッセージを削除中...",
@@ -129,7 +119,6 @@
   "clearChatConfirm": "チャットを消去してもよろしいですか？この操作は元に戻せません。",
   "maxFilesLimit": "一度にアップロードできるファイルは4つまでです",
   "chatWithOmi": "Omiとチャット",
-
   "apps": "アプリ",
   "noAppsFound": "アプリが見つかりません",
   "tryAdjustingSearch": "検索やフィルターを調整してみてください",
@@ -139,7 +128,6 @@
   "myApps": "マイアプリ",
   "installedApps": "インストール済みアプリ",
   "unableToFetchApps": "アプリを取得できません :(\n\nインターネット接続を確認して、もう一度お試しください。",
-
   "aboutOmi": "Omiについて",
   "privacyPolicy": "プライバシーポリシー",
   "visitWebsite": "ウェブサイトを訪問",
@@ -158,13 +146,10 @@
   "deleteNow": "今すぐ削除",
   "goBack": "戻る",
   "checkBoxToConfirm": "アカウントの削除が永久的かつ取り消し不可能であることを確認するため、チェックボックスにチェックを入れてください。",
-
   "profile": "プロフィール",
   "name": "名前",
   "email": "メール",
-  "language": "言語",
   "customVocabulary": "カスタム語彙",
-  "speechProfile": "音声プロフィール",
   "identifyingOthers": "他者の識別",
   "paymentMethods": "お支払い方法",
   "conversationDisplay": "会話の表示",
@@ -172,8 +157,6 @@
   "userId": "ユーザーID",
   "notSet": "未設定",
   "userIdCopied": "ユーザーIDをクリップボードにコピーしました",
-
-  "selectLanguage": "言語を選択",
   "systemDefault": "システムの既定",
   "planAndUsage": "プランと使用状況",
   "offlineSync": "オフライン同期",
@@ -187,7 +170,6 @@
   "signOut": "ログアウト",
   "appAndDeviceCopied": "アプリとデバイスの詳細をコピーしました",
   "wrapped2025": "Wrapped 2025",
-
   "yourPrivacyYourControl": "プライバシーはあなたの手に",
   "privacyIntro": "Omiでは、あなたのプライバシーを守ることに尽力しています。このページでは、データの保存と使用方法を管理できます。",
   "learnMore": "詳細を見る...",
@@ -210,7 +192,6 @@
   "connect": "接続",
   "comingSoon": "近日公開",
   "forgetDevice": "デバイスを忘れる",
-
   "chargingIssues": "充電の問題",
   "disconnectDevice": "デバイスを切断",
   "unpairDevice": "デバイスのペアリング解除",
@@ -239,7 +220,6 @@
   "quiet": "静か",
   "normal": "通常",
   "high": "高",
-
   "micGainDescMuted": "マイクはミュートされています",
   "micGainDescLow": "非常に静か - 騒がしい環境向け",
   "micGainDescModerate": "静か - 適度な騒音向け",
@@ -249,15 +229,13 @@
   "micGainDescHigh": "高 - 遠くの声や柔らかい声向け",
   "micGainDescVeryHigh": "非常に高 - 非常に静かな音源向け",
   "micGainDescMax": "最大 - 注意して使用してください",
-
   "developerSettingsTitle": "開発者設定",
-  "save": "保存",
   "saving": "保存中...",
   "personaConfig": "AIペルソナを設定",
   "beta": "ベータ",
   "transcription": "文字起こし",
   "transcriptionConfig": "STTプロバイダーを設定",
-  "conversationTimeout": "会話タイムアウト",
+  "conversationTimeout": "会話のタイムアウト",
   "conversationTimeoutConfig": "会話の自動終了時間を設定",
   "importData": "データのインポート",
   "importDataConfig": "他のソースからデータをインポート",
@@ -267,7 +245,6 @@
   "createKeyToStart": "キーを作成して開始",
   "createKey": "キーを作成",
   "docs": "ドキュメント",
-
   "yourOmiInsights": "Omiの分析情報",
   "today": "今日",
   "thisMonth": "今月",
@@ -283,7 +260,6 @@
   "providingSubtitle": "自動的にキャプチャされたアクションアイテムとメモ。",
   "remembering": "記憶",
   "rememberingSubtitle": "あなたのために記憶された事実と詳細。",
-
   "unlimitedPlan": "無制限プラン",
   "managePlan": "プランの管理",
   "cancelAtPeriodEnd": "プランは{date}にキャンセルされます。",
@@ -293,7 +269,6 @@
   "upgrade": "アップグレード",
   "upgradeToUnlimited": "無制限プランにアップグレード",
   "basicPlanDesc": "プランには月{limit}分の無料枠が含まれています。無制限にするにはアップグレードしてください。",
-
   "shareStatsMessage": "Omiの統計をシェア！(omi.me - 常時ONのAIアシスタント)",
   "sharePeriodToday": "今日、Omiは:",
   "sharePeriodMonth": "今月、Omiは:",
@@ -303,7 +278,6 @@
   "shareStatsWords": "🧠 {words}語を理解しました",
   "shareStatsInsights": "✨ {count}個のインサイトを提供しました",
   "shareStatsMemories": "📚 {count}個の記憶を保存しました",
-
   "debugLogs": "デバッグログ",
   "debugLogsAutoDelete": "3日後に自動削除されます。",
   "debugLogsDesc": "問題の診断に役立ちます",
@@ -321,8 +295,6 @@
   "exportShared": "エクスポートを共有しました",
   "deleteKnowledgeGraphTitle": "ナレッジグラフを削除しますか？",
   "deleteKnowledgeGraphMessage": "これにより、派生したすべてのナレッジグラフデータ（ノードと接続）が削除されます。元の記憶は安全なままです。グラフは時間の経過とともに、または次のリクエスト時に再構築されます。",
-  "cancel": "キャンセル",
-  "delete": "削除",
   "knowledgeGraphDeleted": "ナレッジグラフが正常に削除されました",
   "deleteGraphFailed": "グラフの削除に失敗しました: {error}",
   "deleteKnowledgeGraph": "ナレッジグラフを削除",
@@ -353,7 +325,6 @@
   "addToClaudeConfig": "claude_desktop_config.jsonに追加",
   "copyConfig": "設定をコピー",
   "configCopied": "設定をクリップボードにコピーしました",
-
   "listeningMins": "リスニング（分）",
   "understandingWords": "理解（語数）",
   "insights": "インサイト",
@@ -362,7 +333,6 @@
   "wordsUsedThisMonth": "今月 {limit}語中{used}語使用済み",
   "insightsUsedThisMonth": "今月 {limit}個中{used}個のインサイト取得済み",
   "memoriesUsedThisMonth": "今月 {limit}個中{used}個の記憶作成済み",
-
   "visibility": "表示設定",
   "visibilitySubtitle": "リストに表示する会話を管理します",
   "showShortConversations": "短い会話を表示",
@@ -374,12 +344,10 @@
   "durationThreshold": "時間のしきい値",
   "durationThresholdDesc": "これより短い会話を非表示にします",
   "minLabel": "{count}分",
-
   "customVocabularyTitle": "カスタム語彙",
   "addWords": "単語を追加",
   "addWordsDesc": "名前、用語、珍しい単語",
   "vocabularyHint": "Omi, Callie, OpenAI",
-
   "chatToolsFooter": "アプリを接続して、チャットでデータや指標を表示できます。",
   "completeAuthInBrowser": "ブラウザで認証を完了してください。完了したらアプリに戻ってください。",
   "failedToStartAuth": "{appName}の認証開始に失敗しました",
@@ -390,12 +358,10 @@
   "connectTo": "{appName}に接続",
   "authAccessMessage": "Omiが{appName}のデータにアクセスすることを許可する必要があります。ブラウザで認証が開きます。",
   "continueAction": "続行",
-
   "languageTitle": "言語",
   "primaryLanguage": "主要言語",
   "automaticTranslation": "自動翻訳",
   "detectLanguages": "10以上の言語を検出",
-
   "authorizeSavingRecordings": "録音の保存を許可",
   "thanksForAuthorizing": "許可いただきありがとうございます！",
   "needYourPermission": "許可が必要です",
@@ -419,13 +385,11 @@
   "permissionRevokedTitle": "許可が取り消されました",
   "permissionRevokedMessage": "既存の録音もすべて削除しますか？",
   "yes": "はい",
-
   "editName": "名前を編集",
   "howShouldOmiCallYou": "Omiはあなたをどう呼べばいいですか？",
   "enterYourName": "名前を入力",
   "nameCannotBeEmpty": "名前を空にすることはできません",
   "nameUpdatedSuccessfully": "名前が正常に更新されました！",
-
   "calendarSettings": "カレンダー設定",
   "calendarProviders": "カレンダープロバイダー",
   "macOsCalendar": "macOSカレンダー",
@@ -442,15 +406,12 @@
   "checkingNextDays": "次の30日間を確認中",
   "tomorrow": "明日",
   "googleCalendarComingSoon": "Googleカレンダー連携は近日公開予定です！",
-
   "connectedAsUser": "ユーザーとして接続: {userId}",
   "defaultWorkspace": "デフォルトのワークスペース",
   "tasksCreatedInWorkspace": "タスクはこのワークスペースに作成されます",
   "defaultProjectOptional": "デフォルトプロジェクト（任意）",
   "leaveUnselectedTasks": "プロジェクトなしでタスクを作成するには、選択を解除したままにしてください",
   "noProjectsInWorkspace": "このワークスペースにはプロジェクトがありません",
-
-  "conversationTimeout": "会話のタイムアウト",
   "conversationTimeoutDesc": "会話を自動終了するまでの無音時間を選択してください：",
   "timeout2Minutes": "2分",
   "timeout2MinutesDesc": "2分の無音で会話を終了",
@@ -464,30 +425,26 @@
   "timeout4HoursDesc": "4時間の無音で会話を終了",
   "conversationEndAfterHours": "4時間の無音後に会話が終了します",
   "conversationEndAfterMinutes": "{minutes}分の無音後に会話が終了します",
-
   "tellUsPrimaryLanguage": "主要言語を教えてください",
   "languageForTranscription": "より正確な文字起こしとパーソナライズされた体験のために言語を設定してください。",
   "singleLanguageModeInfo": "単一言語モードが有効です。より高い精度のため翻訳は無効になっています。",
-  "searchLanguageHint": "名前またはコードで言語を検索",
+  "searchLanguageHint": "言語名またはコードで検索",
   "noLanguagesFound": "言語が見つかりません",
   "skip": "スキップ",
   "languageSetTo": "言語を{language}に設定しました",
   "failedToSetLanguage": "言語の設定に失敗しました",
-
   "appSettings": "{appName}設定",
   "disconnectFromApp": "{appName}から切断しますか？",
   "disconnectFromAppDesc": "{appName}の認証が削除されます。再利用するには再接続が必要です。",
   "connectedToApp": "{appName}に接続済み",
   "account": "アカウント",
   "actionItemsSyncedTo": "アクションアイテムは{appName}アカウントに同期されます",
-
   "defaultSpace": "デフォルトスペース",
   "selectSpaceInWorkspace": "ワークスペース内のスペースを選択",
   "noSpacesInWorkspace": "このワークスペースにスペースが見つかりません",
   "defaultList": "デフォルトリスト",
   "tasksAddedToList": "タスクはこのリストに追加されます",
   "noListsInSpace": "このスペースにリストが見つかりません",
-
   "failedToLoadRepos": "リポジトリの読み込みに失敗しました: {error}",
   "defaultRepoSaved": "デフォルトリポジトリを保存しました",
   "failedToSaveDefaultRepo": "デフォルトリポジトリの保存に失敗しました",
@@ -503,29 +460,24 @@
   "oneMonthAgo": "1ヶ月前",
   "monthsAgo": "{count}ヶ月前",
   "issuesCreatedInRepo": "イシューはデフォルトリポジトリに作成されます",
-
   "taskIntegrations": "タスク連携",
   "configureSettings": "設定を構成",
   "completeAuthBrowser": "ブラウザで認証を完了してください。完了したらアプリに戻ってください。",
   "failedToStartAppAuth": "{appName}の認証開始に失敗しました",
   "connectToAppTitle": "{appName}に接続",
   "authorizeOmiForTasks": "Omiが{appName}アカウントでタスクを作成することを許可する必要があります。ブラウザで認証が開きます。",
-  "continueButton": "続行",
+  "continueButton": "続ける",
   "appIntegration": "{appName}連携",
   "integrationComingSoon": "{appName}との連携は近日公開予定です！より多くのタスク管理オプションを提供するため取り組んでいます。",
   "gotIt": "了解",
   "tasksExportedOneApp": "タスクは一度に1つのアプリにのみエクスポートできます。",
-
   "completeYourUpgrade": "アップグレードを完了",
-
-  "transcription": "文字起こし",
   "importConfiguration": "設定をインポート",
   "exportConfiguration": "設定をエクスポート",
   "bringYourOwn": "自分で用意",
   "payYourSttProvider": "omiを無料で使用。STTプロバイダーに直接支払います。",
   "freeMinutesMonth": "月1,200分無料。無制限は",
   "omiUnlimited": "Omi Unlimited",
-  
   "hostRequired": "ホストが必要です",
   "validPortRequired": "有効なポートが必要です",
   "validWebsocketUrlRequired": "有効なWebSocket URL（wss://）が必要です",
@@ -541,7 +493,6 @@
   "invalidProviderInConfig": "設定内の無効なプロバイダー",
   "importedConfig": "{providerName}設定をインポートしました",
   "invalidJson": "無効なJSON: {error}",
-  
   "provider": "プロバイダー",
   "live": "ライブ",
   "onDevice": "オンデバイス",
@@ -564,7 +515,6 @@
   "logsCopied": "ログをコピーしました",
   "noLogsYet": "ログはまだありません。録音を開始するとカスタムSTTアクティビティが表示されます。",
   "deviceUsesCodec": "{deviceName}は{codecReason}を使用しています。Omiが使用されます。",
-  
   "omiTranscription": "Omi文字起こし",
   "bestInClassTranscription": "設定不要で最高クラスの文字起こし",
   "instantSpeakerLabels": "即座に話者ラベル付け",
@@ -573,12 +523,9 @@
   "autoLanguageDetection": "自動言語検出",
   "highAccuracy": "高精度",
   "privacyFirst": "プライバシー優先",
-  
   "saveChanges": "変更を保存",
-  "saving": "保存中...",
   "resetToDefault": "デフォルトにリセット",
   "viewTemplate": "テンプレートを表示",
-
   "trySomethingLike": "例えば...",
   "tryIt": "試す",
   "creatingPlan": "プランを作成中",
@@ -608,15 +555,12 @@
   "perMonthLabel": "/月",
   "creating": "作成中...",
   "createApp": "アプリを作成",
-
-  "connect": "接続",
   "searchingForDevices": "デバイスを検索中...",
   "devicesFoundNearby": "{count}台のデバイスが近くに見つかりました",
   "pairingSuccessful": "ペアリング成功",
   "errorConnectingAppleWatch": "Apple Watchへの接続エラー: {error}",
   "dontShowAgain": "今後表示しない",
   "iUnderstand": "理解しました",
-
   "enableBluetooth": "Bluetoothを有効にする",
   "bluetoothNeeded": "Omiはウェアラブルに接続するためにBluetoothが必要です。Bluetoothを有効にして再試行してください。",
   "contactSupport": "サポートに連絡しますか？",
@@ -628,19 +572,16 @@
   "locationAccessDesc": "完全な体験のためにバックグラウンド位置情報を有効にする",
   "notifications": "通知",
   "notificationsDesc": "最新情報を受け取るために通知を有効にする",
-  "continueButton": "続ける",
   "locationServiceDisabled": "位置情報サービスが無効",
   "locationServiceDisabledDesc": "位置情報サービスが無効です。設定 > プライバシーとセキュリティ > 位置情報サービスに移動して有効にしてください",
   "backgroundLocationDenied": "バックグラウンド位置情報アクセスが拒否されました",
   "backgroundLocationDeniedDesc": "デバイスの設定に移動して、位置情報の権限を「常に許可」に設定してください",
-
   "lovingOmi": "Omiを楽しんでいますか？",
   "leaveReviewIos": "App Storeでレビューを残して、より多くの人に届けるお手伝いをしてください。皆様のフィードバックは私たちにとって非常に大切です！",
   "leaveReviewAndroid": "Google Playストアでレビューを残して、より多くの人に届けるお手伝いをしてください。皆様のフィードバックは私たちにとって非常に大切です！",
   "rateOnAppStore": "App Storeで評価",
   "rateOnGooglePlay": "Google Playで評価",
   "maybeLater": "後で",
-
   "speechProfileIntro": "Omiはあなたの目標と声を学習する必要があります。後から変更することもできます。",
   "getStarted": "始める",
   "allDone": "完了しました！",
@@ -658,8 +599,6 @@
   "connectionLost": "接続が切断されました",
   "connectionLostDesc": "接続が中断されました。インターネット接続を確認してもう一度お試しください。",
   "tryAgain": "再試行",
-  "ok": "OK",
-
   "connectOmiOmiGlass": "Omi / OmiGlassを接続",
   "continueWithoutDevice": "デバイスなしで続ける",
   "permissionsRequired": "権限が必要です",
@@ -667,13 +606,10 @@
   "openSettings": "設定を開く",
   "wantDifferentName": "別の名前を使いますか？",
   "whatsYourName": "お名前は？",
-  "enterYourName": "名前を入力",
-
   "speakTranscribeSummarize": "話す。文字起こし。要約。",
   "signInWithApple": "Appleでサインイン",
   "signInWithGoogle": "Googleでサインイン",
   "byContinuingAgree": "続行することで、",
-  "privacyPolicy": "プライバシーポリシー",
   "termsOfUse": "利用規約",
   "omiYourAiCompanion": "Omi – あなたのAIコンパニオン",
   "captureEveryMoment": "すべての瞬間を記録。AI搭載のサマリーで、もうメモを取る必要はありません。",
@@ -685,17 +621,12 @@
   "grantPermissionButton": "許可する",
   "needHelp": "ヘルプ",
   "troubleshootingSteps": "トラブルシューティング：\n\n1. WatchにOmiがインストールされているか確認\n2. WatchでOmiアプリを開く\n3. 許可のポップアップを探す\n4. 「許可」をタップ\n5. Watchアプリが閉じたら再度開く\n6. iPhoneに戻り「続ける」をタップ",
-  "gotIt": "了解",
   "recordingStartedSuccessfully": "録音が正常に開始されました！",
   "permissionNotGrantedYet": "許可がまだ付与されていません。マイクアクセスを許可し、Watchでアプリを再度開いたことを確認してください。",
   "errorRequestingPermission": "許可のリクエスト中にエラーが発生しました：{error}",
   "errorStartingRecording": "録音の開始中にエラーが発生しました：{error}",
-
   "selectPrimaryLanguage": "主要言語を選択",
-  "done": "完了",
   "languageBenefits": "言語を設定すると、より正確な文字起こしとパーソナライズされた体験が得られます",
-  "searchLanguageHint": "言語名またはコードで検索",
-  "noLanguagesFound": "言語が見つかりません",
   "whatsYourPrimaryLanguage": "主要言語は何ですか？",
   "selectYourLanguage": "言語を選択",
   "personalGrowthJourney": "あなたの言葉すべてに耳を傾けるAIと共に、個人の成長の旅へ。",
@@ -773,15 +704,17 @@
   "pressDoneToCreate": "完了を押して作成",
   "filterAll": "すべて",
   "filterAuto": "自動",
+  "filterInteresting": "インサイト",
+  "filterSystem": "あなたについて",
   "filterManual": "手動",
-  "cancel": "キャンセル",
-  "done": "完了",
   "completed": "完了",
   "markComplete": "完了としてマーク",
   "actionItemDeleted": "アクションアイテムを削除しました",
   "failedToDeleteActionItem": "アクションアイテムの削除に失敗しました",
-  "delete": "削除",
   "deleteActionItemConfirmTitle": "アクションアイテムの削除",
   "deleteActionItemConfirmMessage": "このアクションアイテムを削除してもよろしいですか？",
-  "appLanguage": "アプリ言語"
+  "appLanguage": "アプリ言語",
+  "appInterfaceSectionTitle": "アプリインターフェース",
+  "speechTranscriptionSectionTitle": "音声と文字起こし",
+  "languageSettingsHelperText": "アプリ言語はメニューとボタンを変更します。音声言語は録音の文字起こし方法に影響します。"
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "ko",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "대화",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "녹취록",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "할 일",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "대화를 삭제하시겠습니까?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "이 대화를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "확인",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "취소",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "확인",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "삭제",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "추가",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "업데이트",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "저장",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "편집",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "닫기",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "지우기",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "녹취록 복사",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "요약 복사",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "프롬프트 테스트",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "대화 재처리",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "대화 삭제",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "콘텐츠가 클립보드에 복사되었습니다",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "즐겨찾기 상태 업데이트에 실패했습니다.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "대화 URL을 공유할 수 없습니다.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "대화 처리 중 오류가 발생했습니다. 나중에 다시 시도해 주세요.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "인터넷 연결을 확인하고 다시 시도해 주세요.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "대화를 삭제할 수 없습니다",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "문제가 발생했습니다! 나중에 다시 시도해 주세요.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "오류 메시지 복사",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "오류 메시지가 클립보드에 복사되었습니다",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "남은",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "로딩 중...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "지속 시간 로딩 중...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count}초",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "사람들",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "새로운 사람 추가",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "사람 편집",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "새로운 사람을 만들고 Omi가 그들의 음성을 인식하도록 학습시키세요!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "음성 프로필",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "샘플 {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "설정",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "언어",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "언어 선택",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "삭제 중...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "브라우저에서 인증을 완료해 주세요. 완료되면 앱으로 돌아가세요.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "인증 시작에 실패했습니다",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "가져오기가 시작되었습니다! 완료되면 알려드리겠습니다.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "가져오기 시작에 실패했습니다. 다시 시도해 주세요.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "선택한 파일에 접근할 수 없습니다",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Omi에게 질문하기",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "완료",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "연결 끊김",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "검색 중",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "기기 연결",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "월간 한도에 도달했습니다.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "사용량 확인",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "녹음 동기화 중",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "동기화할 녹음",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "모두 완료",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "동기화",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "펜던트가 최신 상태입니다",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "모든 녹음이 동기화되었습니다",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "동기화 진행 중",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "동기화 준비 완료",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "동기화를 탭하여 시작하세요",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "펜던트가 연결되지 않았습니다. 동기화하려면 연결하세요.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "모든 항목이 이미 동기화되었습니다.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "아직 동기화되지 않은 녹음이 있습니다.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "백그라운드에서 녹음을 계속 동기화하겠습니다.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "아직 대화가 없습니다.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "아직 즐겨찾기한 대화가 없습니다.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "대화를 즐겨찾기하려면 대화를 열고 헤더의 별 아이콘을 탭하세요.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "대화 검색",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count}개 선택됨",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "병합",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "대화 병합",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "{count}개의 대화를 하나로 결합합니다. 모든 내용이 병합되고 재생성됩니다.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "백그라운드에서 병합 중입니다. 잠시 시간이 걸릴 수 있습니다.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "병합 시작에 실패했습니다",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "무엇이든 물어보세요",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "아직 메시지가 없습니다!\n대화를 시작해보는 건 어떨까요?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Omi의 메모리에서 메시지를 삭제하는 중...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "메시지가 클립보드에 복사되었습니다.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "자신의 메시지는 신고할 수 없습니다.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "메시지 신고",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "이 메시지를 신고하시겠습니까?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "메시지가 성공적으로 신고되었습니다.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "피드백 감사합니다!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "채팅을 지우시겠습니까?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "채팅을 지우시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "한 번에 최대 4개의 파일만 업로드할 수 있습니다",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Omi와 채팅하기",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "앱",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "앱을 찾을 수 없습니다",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "검색어나 필터를 조정해 보세요",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "나만의 앱 만들기",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "맞춤형 앱을 만들고 공유하세요",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "1500개 이상의 앱 검색",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "내 앱",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "설치된 앱",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "앱을 가져올 수 없습니다 :(\n\n인터넷 연결을 확인하고 다시 시도해 주세요.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Omi 정보",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "개인정보 처리방침",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "웹사이트 방문",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "도움말 또는 문의사항이 있으신가요?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "커뮤니티에 참여하세요!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000명 이상의 멤버가 함께하고 있습니다.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "계정 삭제",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "계정을 삭제하시겠습니까?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "이 작업은 되돌릴 수 없습니다.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "모든 기억과 대화가 영구적으로 삭제됩니다.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "앱 및 통합 기능이 즉시 연결 해제됩니다.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "계정을 삭제하기 전에 데이터를 내보낼 수 있지만, 삭제된 후에는 복구할 수 없습니다.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "계정 삭제는 영구적이며 기억과 대화를 포함한 모든 데이터가 손실되어 복구할 수 없음을 이해합니다.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "정말 확실하신가요?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "이 작업은 되돌릴 수 없으며 계정과 관련된 모든 데이터가 영구적으로 삭제됩니다. 계속하시겠습니까?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "지금 삭제",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "돌아가기",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "계정 삭제가 영구적이고 되돌릴 수 없음을 이해했음을 확인하려면 체크박스를 선택하세요.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "프로필",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "이름",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "이메일",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "사용자 지정 어휘",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "다른 사람 식별",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "결제 수단",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "대화 표시",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "데이터 및 개인정보",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "사용자 ID",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "설정되지 않음",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "사용자 ID가 클립보드에 복사되었습니다",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "시스템 기본값",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "플랜 및 사용량",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "오프라인 동기화",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "기기 설정",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "채팅 도구",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "피드백 / 버그",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "고객센터",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "개발자 설정",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Mac용 Omi 다운로드",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "추천 프로그램",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "로그아웃",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "앱 및 기기 정보가 복사되었습니다",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "당신의 개인정보, 당신의 제어",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Omi는 귀하의 개인정보 보호에 최선을 다하고 있습니다. 이 페이지에서 데이터 저장 및 사용 방법을 제어할 수 있습니다.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "자세히 알아보기...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "데이터 보호 수준",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "귀하의 데이터는 기본적으로 강력한 암호화로 보호됩니다. 아래에서 설정 및 향후 개인정보 옵션을 검토하세요.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "앱 접근",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "다음 앱이 귀하의 데이터에 접근할 수 있습니다. 앱을 탭하여 권한을 관리하세요.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "설치된 앱 중 귀하의 데이터에 외부 접근 권한이 있는 앱이 없습니다.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "기기 이름",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "기기 ID",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "펌웨어",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD 카드 동기화",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "하드웨어 버전",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "모델 번호",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "제조사",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "더블 탭",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED 밝기",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "마이크 게인",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "연결 해제",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "기기 삭제",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "충전 문제",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "기기 연결 해제",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "기기 페어링 해제",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "기기 페어링 해제 및 삭제",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Omi 기기의 연결이 해제되었습니다 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "기기 페어링이 해제되었습니다. 페어링 해제를 완료하려면 설정 > 블루투스로 이동하여 기기를 삭제하세요.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "기기 페어링 해제",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "다른 휴대폰에 연결할 수 있도록 기기의 페어링을 해제합니다. 프로세스를 완료하려면 설정 > 블루투스로 이동하여 기기를 삭제해야 합니다.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "기기가 연결되지 않음",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Omi 기기를 연결하여\n기기 설정 및 사용자 지정에 접근하세요",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "기기 정보",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "사용자 지정",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "하드웨어",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2를 감지할 수 없음",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "V1 기기를 사용하고 있거나 기기가 연결되지 않았습니다. SD 카드 기능은 V2 기기에서만 사용할 수 있습니다.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "대화 종료",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "일시정지/재개",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "대화 즐겨찾기",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "더블 탭 동작",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "대화 종료 및 처리",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "녹음 일시정지/재개",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "진행 중인 대화 즐겨찾기",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "끄기",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "최대",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "음소거",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "조용함",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "보통",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "높음",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "마이크가 음소거되었습니다",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "매우 조용함 - 시끄러운 환경용",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "조용함 - 보통 소음용",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "중립 - 균형 잡힌 녹음",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "약간 증폭 - 일반 사용",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "증폭 - 조용한 환경용",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "높음 - 멀리 있거나 부드러운 목소리용",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "매우 높음 - 매우 조용한 소스용",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "최대 - 주의해서 사용",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "개발자 설정",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "저장 중...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "AI 페르소나 구성",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "베타",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "음성 변환",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "STT 제공업체 구성",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "대화 시간 제한",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "대화 자동 종료 시간 설정",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "데이터 가져오기",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "다른 소스에서 데이터 가져오기",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "디버그 및 진단",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "엔드포인트 URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "아직 API 키가 없습니다",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "시작하려면 키를 만드세요",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "키 만들기",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "문서",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Omi 인사이트",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "오늘",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "이번 달",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "올해",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "전체 기간",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "아직 활동이 없습니다",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Omi와 대화를 시작하여\n사용량 인사이트를 확인하세요.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "청취",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Omi가 적극적으로 청취한 총 시간입니다.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "이해",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "대화에서 이해한 단어 수입니다.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "제공",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "자동으로 캡처된 할 일 및 메모입니다.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "기억",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "당신을 위해 기억된 사실과 세부 정보입니다.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "무제한 플랜",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "플랜 관리",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "플랜이 {date}에 취소됩니다.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "플랜이 {date}에 갱신됩니다.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "무료 플랜",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{limit}분 중 {used}분 사용",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "업그레이드",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "무제한으로 업그레이드",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "플랜에는 매월 {limit}분의 무료 시간이 포함됩니다. 무제한으로 업그레이드하세요.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "내 Omi 통계를 공유합니다! (omi.me - 항상 켜져 있는 AI 어시스턴트)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "오늘 Omi는:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "이번 달 Omi는:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "올해 Omi는:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "지금까지 Omi는:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 {minutes}분 동안 청취했습니다",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 {words}개의 단어를 이해했습니다",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ {count}개의 인사이트를 제공했습니다",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 {count}개의 기억을 저장했습니다",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "디버그 로그",
+  "debugLogsAutoDelete": "3일 후 자동 삭제됩니다.",
+  "debugLogsDesc": "문제 진단에 도움이 됩니다",
+  "noLogFilesFound": "로그 파일을 찾을 수 없습니다.",
+  "omiDebugLog": "Omi 디버그 로그",
+  "logShared": "로그가 공유되었습니다",
+  "selectLogFile": "로그 파일 선택",
+  "shareLogs": "로그 공유",
+  "debugLogCleared": "디버그 로그가 지워졌습니다",
+  "exportStarted": "내보내기가 시작되었습니다. 몇 초 정도 걸릴 수 있습니다...",
+  "exportAllData": "모든 데이터 내보내기",
+  "exportDataDesc": "대화를 JSON 파일로 내보내기",
+  "exportedConversations": "Omi에서 내보낸 대화",
+  "exportShared": "내보내기가 공유되었습니다",
+  "deleteKnowledgeGraphTitle": "지식 그래프를 삭제하시겠습니까?",
+  "deleteKnowledgeGraphMessage": "파생된 모든 지식 그래프 데이터(노드 및 연결)가 삭제됩니다. 원본 기억은 안전하게 유지됩니다. 그래프는 시간이 지나면 다시 구축되거나 다음 요청 시 재구축됩니다.",
+  "knowledgeGraphDeleted": "지식 그래프가 성공적으로 삭제되었습니다",
+  "deleteGraphFailed": "그래프 삭제 실패: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "지식 그래프 삭제",
+  "deleteKnowledgeGraphDesc": "모든 노드 및 연결 지우기",
+  "mcp": "MCP",
+  "mcpServer": "MCP 서버",
+  "mcpServerDesc": "AI 어시스턴트를 데이터에 연결",
+  "serverUrl": "서버 URL",
+  "urlCopied": "URL이 복사되었습니다",
+  "apiKeyAuth": "API 키 인증",
+  "header": "헤더",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "클라이언트 ID",
+  "clientSecret": "클라이언트 시크릿",
+  "useMcpApiKey": "MCP API 키 사용",
+  "webhooks": "웹훅",
+  "conversationEvents": "대화 이벤트",
+  "newConversationCreated": "새 대화가 생성됨",
+  "realtimeTranscript": "실시간 녹취록",
+  "transcriptReceived": "녹취록 수신됨",
+  "audioBytes": "오디오 바이트",
+  "audioDataReceived": "오디오 데이터 수신됨",
+  "intervalSeconds": "간격(초)",
+  "daySummary": "일일 요약",
+  "summaryGenerated": "요약 생성됨",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "claude_desktop_config.json에 추가",
+  "copyConfig": "구성 복사",
+  "configCopied": "구성이 클립보드에 복사되었습니다",
+  "listeningMins": "청취(분)",
+  "understandingWords": "이해(단어)",
+  "insights": "인사이트",
+  "memories": "기억",
+  "minsUsedThisMonth": "이번 달 {limit}분 중 {used}분 사용",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "이번 달 {limit}단어 중 {used}단어 사용",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "이번 달 {limit}개 중 {used}개의 인사이트 획득",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "이번 달 {limit}개 중 {used}개의 기억 생성",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "가시성",
+  "visibilitySubtitle": "목록에 표시할 대화 제어",
+  "showShortConversations": "짧은 대화 표시",
+  "showShortConversationsDesc": "임계값보다 짧은 대화 표시",
+  "showDiscardedConversations": "폐기된 대화 표시",
+  "showDiscardedConversationsDesc": "폐기된 것으로 표시된 대화 포함",
+  "shortConversationThreshold": "짧은 대화 임계값",
+  "shortConversationThresholdSubtitle": "이보다 짧은 대화는 위에서 활성화하지 않는 한 숨겨집니다",
+  "durationThreshold": "지속 시간 임계값",
+  "durationThresholdDesc": "이보다 짧은 대화 숨기기",
+  "minLabel": "{count}분",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "사용자 지정 어휘",
+  "addWords": "단어 추가",
+  "addWordsDesc": "이름, 용어 또는 일반적이지 않은 단어",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "연결",
+  "comingSoon": "곧 출시",
+  "chatToolsFooter": "채팅에서 데이터 및 지표를 보려면 앱을 연결하세요.",
+  "completeAuthInBrowser": "브라우저에서 인증을 완료해 주세요. 완료되면 앱으로 돌아가세요.",
+  "failedToStartAuth": "{appName} 인증 시작에 실패했습니다",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "{appName}의 연결을 해제하시겠습니까?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "{appName}과의 연결을 해제하시겠습니까? 언제든지 다시 연결할 수 있습니다.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "{appName}과의 연결이 해제되었습니다",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "연결 해제 실패",
+  "connectTo": "{appName}에 연결",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Omi가 {appName} 데이터에 접근하도록 권한을 부여해야 합니다. 인증을 위해 브라우저가 열립니다.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "계속",
+  "languageTitle": "언어",
+  "primaryLanguage": "기본 언어",
+  "automaticTranslation": "자동 번역",
+  "detectLanguages": "10개 이상의 언어 감지",
+  "authorizeSavingRecordings": "녹음 저장 권한 부여",
+  "thanksForAuthorizing": "권한을 부여해 주셔서 감사합니다!",
+  "needYourPermission": "귀하의 권한이 필요합니다",
+  "alreadyGavePermission": "녹음 저장 권한을 이미 부여하셨습니다. 필요한 이유를 다시 안내드립니다:",
+  "wouldLikePermission": "음성 녹음 저장 권한을 부여해 주세요. 그 이유는 다음과 같습니다:",
+  "improveSpeechProfile": "음성 프로필 개선",
+  "improveSpeechProfileDesc": "녹음을 사용하여 개인 음성 프로필을 추가로 학습하고 향상시킵니다.",
+  "trainFamilyProfiles": "친구 및 가족 프로필 학습",
+  "trainFamilyProfilesDesc": "녹음은 친구와 가족을 인식하고 프로필을 만드는 데 도움이 됩니다.",
+  "enhanceTranscriptAccuracy": "녹취록 정확도 향상",
+  "enhanceTranscriptAccuracyDesc": "모델이 개선됨에 따라 녹음에 대한 더 나은 변환 결과를 제공할 수 있습니다.",
+  "legalNotice": "법적 고지: 음성 데이터 녹음 및 저장의 합법성은 위치 및 이 기능 사용 방법에 따라 다를 수 있습니다. 현지 법률 및 규정을 준수하는지 확인하는 것은 귀하의 책임입니다.",
+  "alreadyAuthorized": "이미 승인됨",
+  "authorize": "권한 부여",
+  "revokeAuthorization": "권한 취소",
+  "authorizationSuccessful": "권한 부여 성공!",
+  "failedToAuthorize": "권한 부여에 실패했습니다. 다시 시도해 주세요.",
+  "authorizationRevoked": "권한이 취소되었습니다.",
+  "recordingsDeleted": "녹음이 삭제되었습니다.",
+  "failedToRevoke": "권한 취소에 실패했습니다. 다시 시도해 주세요.",
+  "permissionRevokedTitle": "권한 취소됨",
+  "permissionRevokedMessage": "기존 녹음도 모두 삭제하시겠습니까?",
+  "yes": "예",
+  "editName": "이름 편집",
+  "howShouldOmiCallYou": "Omi가 어떻게 불러드릴까요?",
+  "enterYourName": "이름을 입력하세요",
+  "nameCannotBeEmpty": "이름은 비워둘 수 없습니다",
+  "nameUpdatedSuccessfully": "이름이 성공적으로 업데이트되었습니다!",
+  "calendarSettings": "캘린더 설정",
+  "calendarProviders": "캘린더 제공업체",
+  "macOsCalendar": "macOS 캘린더",
+  "connectMacOsCalendar": "로컬 macOS 캘린더 연결",
+  "googleCalendar": "Google 캘린더",
+  "syncGoogleAccount": "Google 계정과 동기화",
+  "showMeetingsMenuBar": "메뉴 바에 예정된 회의 표시",
+  "showMeetingsMenuBarDesc": "macOS 메뉴 바에 다음 회의 및 시작까지의 시간 표시",
+  "showEventsNoParticipants": "참가자가 없는 이벤트 표시",
+  "showEventsNoParticipantsDesc": "활성화하면 참가자나 비디오 링크가 없는 이벤트가 Coming Up에 표시됩니다.",
+  "yourMeetings": "내 회의",
+  "refresh": "새로고침",
+  "noUpcomingMeetings": "예정된 회의를 찾을 수 없습니다",
+  "checkingNextDays": "향후 30일 확인",
+  "tomorrow": "내일",
+  "googleCalendarComingSoon": "Google 캘린더 통합이 곧 출시됩니다!",
+  "connectedAsUser": "다음 사용자로 연결됨: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "기본 워크스페이스",
+  "tasksCreatedInWorkspace": "작업이 이 워크스페이스에 생성됩니다",
+  "defaultProjectOptional": "기본 프로젝트(선택 사항)",
+  "leaveUnselectedTasks": "프로젝트 없이 작업을 생성하려면 선택하지 마세요",
+  "noProjectsInWorkspace": "이 워크스페이스에서 프로젝트를 찾을 수 없습니다",
+  "conversationTimeoutDesc": "대화를 자동으로 종료하기 전에 대기할 침묵 시간을 선택하세요:",
+  "timeout2Minutes": "2분",
+  "timeout2MinutesDesc": "2분간 침묵 후 대화 종료",
+  "timeout5Minutes": "5분",
+  "timeout5MinutesDesc": "5분간 침묵 후 대화 종료",
+  "timeout10Minutes": "10분",
+  "timeout10MinutesDesc": "10분간 침묵 후 대화 종료",
+  "timeout30Minutes": "30분",
+  "timeout30MinutesDesc": "30분간 침묵 후 대화 종료",
+  "timeout4Hours": "4시간",
+  "timeout4HoursDesc": "4시간 침묵 후 대화 종료",
+  "conversationEndAfterHours": "이제 4시간 침묵 후 대화가 종료됩니다",
+  "conversationEndAfterMinutes": "이제 {minutes}분 침묵 후 대화가 종료됩니다",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "기본 언어를 알려주세요",
+  "languageForTranscription": "더 정확한 변환과 맞춤형 경험을 위해 언어를 설정하세요.",
+  "singleLanguageModeInfo": "단일 언어 모드가 활성화되었습니다. 정확도 향상을 위해 번역이 비활성화됩니다.",
+  "searchLanguageHint": "이름 또는 코드로 언어 검색",
+  "noLanguagesFound": "언어를 찾을 수 없습니다",
+  "skip": "건너뛰기",
+  "languageSetTo": "언어가 {language}(으)로 설정되었습니다",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "언어 설정 실패",
+  "appSettings": "{appName} 설정",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "{appName}과의 연결을 해제하시겠습니까?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "{appName} 인증이 제거됩니다. 다시 사용하려면 다시 연결해야 합니다.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "{appName}에 연결됨",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "계정",
+  "actionItemsSyncedTo": "할 일 항목이 {appName} 계정과 동기화됩니다",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "기본 스페이스",
+  "selectSpaceInWorkspace": "워크스페이스에서 스페이스 선택",
+  "noSpacesInWorkspace": "이 워크스페이스에서 스페이스를 찾을 수 없습니다",
+  "defaultList": "기본 목록",
+  "tasksAddedToList": "작업이 이 목록에 추가됩니다",
+  "noListsInSpace": "이 스페이스에서 목록을 찾을 수 없습니다",
+  "failedToLoadRepos": "저장소 로드 실패: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "기본 저장소가 저장되었습니다",
+  "failedToSaveDefaultRepo": "기본 저장소 저장 실패",
+  "defaultRepository": "기본 저장소",
+  "selectDefaultRepoDesc": "이슈 생성을 위한 기본 저장소를 선택하세요. 이슈 생성 시 다른 저장소를 지정할 수도 있습니다.",
+  "noReposFound": "저장소를 찾을 수 없습니다",
+  "private": "비공개",
+  "updatedDate": "{date} 업데이트됨",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "어제",
+  "daysAgo": "{count}일 전",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1주일 전",
+  "weeksAgo": "{count}주 전",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1개월 전",
+  "monthsAgo": "{count}개월 전",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "이슈가 기본 저장소에 생성됩니다",
+  "taskIntegrations": "작업 통합",
+  "configureSettings": "설정 구성",
+  "completeAuthBrowser": "브라우저에서 인증을 완료해 주세요. 완료되면 앱으로 돌아가세요.",
+  "failedToStartAppAuth": "{appName} 인증 시작에 실패했습니다",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "{appName}에 연결",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "{appName} 계정에서 작업을 생성하도록 Omi에 권한을 부여해야 합니다. 인증을 위해 브라우저가 열립니다.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "계속",
+  "appIntegration": "{appName} 통합",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "{appName}과의 통합이 곧 출시됩니다! 더 많은 작업 관리 옵션을 제공하기 위해 열심히 노력하고 있습니다.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "알겠습니다",
+  "tasksExportedOneApp": "작업은 한 번에 하나의 앱으로 내보낼 수 있습니다.",
+  "completeYourUpgrade": "업그레이드 완료",
+  "importConfiguration": "구성 가져오기",
+  "exportConfiguration": "구성 내보내기",
+  "bringYourOwn": "직접 가져오기",
+  "payYourSttProvider": "Omi를 자유롭게 사용하세요. STT 제공업체에 직접 비용을 지불하기만 하면 됩니다.",
+  "freeMinutesMonth": "월 1,200분 무료 포함. ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "호스트가 필요합니다",
+  "validPortRequired": "유효한 포트가 필요합니다",
+  "validWebsocketUrlRequired": "유효한 WebSocket URL이 필요합니다(wss://)",
+  "apiUrlRequired": "API URL이 필요합니다",
+  "apiKeyRequired": "API 키가 필요합니다",
+  "invalidJsonConfig": "잘못된 JSON 구성",
+  "errorSaving": "저장 오류: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "구성이 클립보드에 복사되었습니다",
+  "pasteJsonConfig": "아래에 JSON 구성을 붙여넣으세요:",
+  "addApiKeyAfterImport": "가져오기 후 자신의 API 키를 추가해야 합니다",
+  "paste": "붙여넣기",
+  "import": "가져오기",
+  "invalidProviderInConfig": "구성의 제공업체가 잘못되었습니다",
+  "importedConfig": "{providerName} 구성을 가져왔습니다",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "잘못된 JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "제공업체",
+  "live": "실시간",
+  "onDevice": "기기에서",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "STT HTTP 엔드포인트를 입력하세요",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "실시간 STT WebSocket 엔드포인트를 입력하세요",
+  "apiKey": "API 키",
+  "enterApiKey": "API 키를 입력하세요",
+  "storedLocallyNeverShared": "로컬에 저장되며 절대 공유되지 않습니다",
+  "host": "호스트",
+  "port": "포트",
+  "advanced": "고급",
+  "configuration": "구성",
+  "requestConfiguration": "요청 구성",
+  "responseSchema": "응답 스키마",
+  "modified": "수정됨",
+  "resetRequestConfig": "요청 구성을 기본값으로 재설정",
+  "logs": "로그",
+  "logsCopied": "로그가 복사되었습니다",
+  "noLogsYet": "아직 로그가 없습니다. 녹음을 시작하여 사용자 지정 STT 활동을 확인하세요.",
+  "deviceUsesCodec": "{deviceName}은(는) {codecReason}을(를) 사용합니다. Omi가 사용됩니다.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi 음성 변환",
+  "bestInClassTranscription": "설정이 필요 없는 최고 수준의 음성 변환",
+  "instantSpeakerLabels": "즉시 화자 레이블 지정",
+  "languageTranslation": "100개 이상의 언어 번역",
+  "optimizedForConversation": "대화에 최적화",
+  "autoLanguageDetection": "자동 언어 감지",
+  "highAccuracy": "높은 정확도",
+  "privacyFirst": "개인정보 보호 우선",
+  "saveChanges": "변경 사항 저장",
+  "resetToDefault": "기본값으로 재설정",
+  "viewTemplate": "템플릿 보기",
+  "trySomethingLike": "다음과 같이 시도해 보세요...",
+  "tryIt": "시도해 보기",
+  "creatingPlan": "계획 생성 중",
+  "developingLogic": "로직 개발 중",
+  "designingApp": "앱 디자인 중",
+  "generatingIconStep": "아이콘 생성 중",
+  "finalTouches": "최종 마무리",
+  "processing": "처리 중...",
+  "features": "기능",
+  "creatingYourApp": "앱을 만드는 중...",
+  "generatingIcon": "아이콘 생성 중...",
+  "whatShouldWeMake": "무엇을 만들까요?",
+  "appName": "앱 이름",
+  "description": "설명",
+  "publicLabel": "공개",
+  "privateLabel": "비공개",
+  "free": "무료",
+  "perMonth": "/ 월",
+  "tailoredConversationSummaries": "맞춤형 대화 요약",
+  "customChatbotPersonality": "사용자 지정 챗봇 성격",
+  "makePublic": "공개하기",
+  "anyoneCanDiscover": "누구나 앱을 찾을 수 있습니다",
+  "onlyYouCanUse": "본인만 이 앱을 사용할 수 있습니다",
+  "paidApp": "유료 앱",
+  "usersPayToUse": "사용자가 앱을 사용하려면 비용을 지불합니다",
+  "freeForEveryone": "모두에게 무료",
+  "perMonthLabel": "/ 월",
+  "creating": "생성 중...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "앱 만들기",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "기기 검색 중...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "근처에서 {count}개의 기기 발견",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "페어링 성공",
+  "errorConnectingAppleWatch": "Apple Watch 연결 오류: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "다시 표시하지 않기",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "이해했습니다",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "블루투스 활성화",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi가 웨어러블에 연결하려면 블루투스가 필요합니다. 블루투스를 활성화하고 다시 시도해 주세요.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "지원팀에 문의하시겠습니까?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "나중에 연결",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "권한 부여",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "백그라운드 활동",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "더 나은 안정성을 위해 Omi가 백그라운드에서 실행되도록 허용",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "위치 접근",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "완전한 경험을 위해 백그라운드 위치 활성화",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "알림",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "정보를 받기 위해 알림 활성화",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "위치 서비스 비활성화됨",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "위치 서비스가 비활성화되어 있습니다. 설정 > 개인정보 보호 및 보안 > 위치 서비스로 이동하여 활성화하세요",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "백그라운드 위치 접근 거부됨",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "기기 설정으로 이동하여 위치 권한을 \"항상 허용\"으로 설정하세요",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Omi가 마음에 드시나요?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "App Store에 리뷰를 남겨 더 많은 사람들에게 다가가도록 도와주세요. 귀하의 피드백은 저희에게 큰 의미가 있습니다!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Google Play 스토어에 리뷰를 남겨 더 많은 사람들에게 다가가도록 도와주세요. 귀하의 피드백은 저희에게 큰 의미가 있습니다!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "App Store에서 평가하기",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Google Play에서 평가하기",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "나중에",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi가 귀하의 목표와 음성을 학습해야 합니다. 나중에 수정할 수 있습니다.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "시작하기",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "모두 완료!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "계속하세요, 잘하고 있습니다",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "이 질문 건너뛰기",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "지금은 건너뛰기",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "연결 오류",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "서버 연결에 실패했습니다. 인터넷 연결을 확인하고 다시 시도해 주세요.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "잘못된 녹음 감지됨",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "녹음에 여러 명의 화자가 있는 것 같습니다. 조용한 장소에 있는지 확인하고 다시 시도하세요.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "음성이 충분히 감지되지 않았습니다. 더 많이 말하고 다시 시도하세요.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "최소 5초 이상 90초 이하로 말씀해 주세요.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "계십니까?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "음성을 감지할 수 없습니다. 최소 10초 이상 3분 이하로 말씀해 주세요.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "연결 끊김",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "연결이 중단되었습니다. 인터넷 연결을 확인하고 다시 시도해 주세요.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "다시 시도",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Omi / OmiGlass 연결",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "기기 없이 계속",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "권한 필요",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "이 앱은 제대로 작동하려면 블루투스 및 위치 권한이 필요합니다. 설정에서 활성화하세요.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "설정 열기",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "다른 이름으로 부르시겠습니까?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "이름이 무엇인가요?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "말하기. 변환. 요약.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Apple로 로그인",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Google로 로그인",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "계속하면 다음에 동의하는 것입니다 ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "이용약관",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – 당신의 AI 동반자",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "모든 순간을 기록하세요. AI 기반\n요약을 받으세요. 더 이상 메모할 필요가 없습니다.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch 설정",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "권한 요청됨!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "마이크 권한",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "권한이 부여되었습니다! 이제:\n\n워치에서 Omi 앱을 열고 아래의 \"계속\"을 탭하세요",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "마이크 권한이 필요합니다.\n\n1. \"권한 부여\" 탭\n2. iPhone에서 허용\n3. 워치 앱이 닫힙니다\n4. 다시 열고 \"계속\" 탭",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "권한 부여",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "도움이 필요하신가요?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "문제 해결:\n\n1. 워치에 Omi가 설치되어 있는지 확인\n2. 워치에서 Omi 앱 열기\n3. 권한 팝업 찾기\n4. 메시지가 나타나면 \"허용\" 탭\n5. 워치의 앱이 닫힙니다 - 다시 열기\n6. 돌아와서 iPhone에서 \"계속\" 탭",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "녹음이 성공적으로 시작되었습니다!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "아직 권한이 부여되지 않았습니다. 마이크 접근을 허용하고 워치에서 앱을 다시 열었는지 확인하세요.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "권한 요청 오류: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "녹음 시작 오류: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "기본 언어 선택",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "더 정확한 변환과 맞춤형 경험을 위해 언어를 설정하세요",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "기본 언어가 무엇인가요?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "언어를 선택하세요",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "당신의 모든 말을 듣는 AI와 함께하는 개인 성장 여정.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "할 일",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "탭하여 편집 • 길게 눌러 선택 • 스와이프하여 작업",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "할 일",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "완료",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "이전",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 모두 완료!\n대기 중인 작업 항목이 없습니다",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "아직 완료된 항목이 없습니다",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ 오래된 작업 없음",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "항목 없음",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "작업 항목이 미완료로 표시되었습니다",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "작업 항목이 완료되었습니다",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "작업 항목 삭제",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "이 작업 항목을 삭제하시겠습니까?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "선택한 항목 삭제",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "선택한 {count}개의 작업 항목{s}을(를) 삭제하시겠습니까?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "작업 항목 \"{description}\"이(가) 삭제되었습니다",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count}개의 작업 항목{s}이(가) 삭제되었습니다",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "작업 항목 삭제 실패",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "항목 삭제 실패",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "일부 항목 삭제 실패",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "작업 항목 준비 완료",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "AI가 대화에서 작업과 할 일을 자동으로 추출합니다. 생성되면 여기에 표시됩니다.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "대화에서 자동 추출",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "탭하여 편집, 스와이프하여 완료 또는 삭제",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count}개 선택됨",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "모두 선택",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "선택 항목 삭제",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "{count}개의 기억 검색",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "기억이 삭제되었습니다.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "실행 취소",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "아직 기억이 없습니다",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "아직 자동 추출된 기억이 없습니다",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "아직 수동 기억이 없습니다",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "이 카테고리에 기억이 없습니다",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "기억을 찾을 수 없습니다",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "첫 번째 기억 추가",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Omi의 기억 지우기",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Omi의 기억을 지우시겠습니까? 이 작업은 되돌릴 수 없습니다.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "기억 지우기",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omi의 기억이 지워졌습니다",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "삭제할 기억이 없습니다",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "새 기억 만들기",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "새 작업 항목 만들기",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "기억 관리",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "기억 필터링",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "총 {count}개의 기억이 있습니다",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "공개 기억",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "비공개 기억",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "모든 기억을 비공개로 만들기",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "모든 기억을 공개로 만들기",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "모든 기억 삭제",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "모든 기억이 이제 비공개입니다",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "모든 기억이 이제 공개입니다",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "새 기억",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "기억 편집",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "아이스크림 먹는 걸 좋아해요...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "저장에 실패했습니다. 연결을 확인하세요.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "기억 저장",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "다시 시도",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "작업 항목 만들기",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "작업 항목 편집",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "무엇을 해야 하나요?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "작업 항목 설명은 비워둘 수 없습니다.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "작업 항목이 업데이트되었습니다",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "작업 항목 업데이트 실패",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "작업 항목이 생성되었습니다",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "작업 항목 생성 실패",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "마감일",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "시간",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "마감일 추가",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "완료를 눌러 저장하세요",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "완료를 눌러 생성하세요",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "모두",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "본인 정보",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "인사이트",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "수동",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "완료됨",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "완료로 표시",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "작업 항목이 삭제되었습니다",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "작업 항목 삭제 실패",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "작업 항목 삭제",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "이 작업 항목을 삭제하시겠습니까?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "앱 언어",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "앱 인터페이스",
+  "speechTranscriptionSectionTitle": "음성 및 전사",
+  "languageSettingsHelperText": "앱 언어는 메뉴와 버튼을 변경합니다. 음성 언어는 녹음이 전사되는 방식에 영향을 줍니다."
+}

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -5,12 +5,39 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:intl/intl.dart' as intl;
 
+import 'app_localizations_ar.dart';
+import 'app_localizations_bg.dart';
+import 'app_localizations_ca.dart';
+import 'app_localizations_cs.dart';
+import 'app_localizations_da.dart';
 import 'app_localizations_de.dart';
+import 'app_localizations_el.dart';
 import 'app_localizations_en.dart';
 import 'app_localizations_es.dart';
+import 'app_localizations_et.dart';
+import 'app_localizations_fi.dart';
+import 'app_localizations_fr.dart';
 import 'app_localizations_hi.dart';
+import 'app_localizations_hu.dart';
+import 'app_localizations_id.dart';
+import 'app_localizations_it.dart';
 import 'app_localizations_ja.dart';
+import 'app_localizations_ko.dart';
+import 'app_localizations_lt.dart';
+import 'app_localizations_lv.dart';
+import 'app_localizations_ms.dart';
+import 'app_localizations_nl.dart';
+import 'app_localizations_no.dart';
+import 'app_localizations_pl.dart';
 import 'app_localizations_pt.dart';
+import 'app_localizations_ro.dart';
+import 'app_localizations_ru.dart';
+import 'app_localizations_sk.dart';
+import 'app_localizations_sv.dart';
+import 'app_localizations_th.dart';
+import 'app_localizations_tr.dart';
+import 'app_localizations_uk.dart';
+import 'app_localizations_vi.dart';
 import 'app_localizations_zh.dart';
 
 // ignore_for_file: type=lint
@@ -96,12 +123,39 @@ abstract class AppLocalizations {
 
   /// A list of this localizations delegate's supported locales.
   static const List<Locale> supportedLocales = <Locale>[
+    Locale('ar'),
+    Locale('bg'),
+    Locale('ca'),
+    Locale('cs'),
+    Locale('da'),
     Locale('de'),
+    Locale('el'),
     Locale('en'),
     Locale('es'),
+    Locale('et'),
+    Locale('fi'),
+    Locale('fr'),
     Locale('hi'),
+    Locale('hu'),
+    Locale('id'),
+    Locale('it'),
     Locale('ja'),
+    Locale('ko'),
+    Locale('lt'),
+    Locale('lv'),
+    Locale('ms'),
+    Locale('nl'),
+    Locale('no'),
+    Locale('pl'),
     Locale('pt'),
+    Locale('ro'),
+    Locale('ru'),
+    Locale('sk'),
+    Locale('sv'),
+    Locale('th'),
+    Locale('tr'),
+    Locale('uk'),
+    Locale('vi'),
     Locale('zh')
   ];
 
@@ -547,7 +601,7 @@ abstract class AppLocalizations {
   ///
   /// In en, this message translates to:
   /// **'{count} selected'**
-  String selectedCount(int count);
+  String selectedCount(int count, Object s);
 
   /// Merge button label
   ///
@@ -4214,6 +4268,24 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'App Language'**
   String get appLanguage;
+
+  /// Section title for app interface language settings
+  ///
+  /// In en, this message translates to:
+  /// **'APP INTERFACE'**
+  String get appInterfaceSectionTitle;
+
+  /// Section title for speech and transcription language settings
+  ///
+  /// In en, this message translates to:
+  /// **'SPEECH & TRANSCRIPTION'**
+  String get speechTranscriptionSectionTitle;
+
+  /// Helper text explaining the difference between app language and speech language
+  ///
+  /// In en, this message translates to:
+  /// **'App Language changes menus and buttons. Speech Language affects how your recordings are transcribed.'**
+  String get languageSettingsHelperText;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {
@@ -4225,7 +4297,42 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
   }
 
   @override
-  bool isSupported(Locale locale) => <String>['de', 'en', 'es', 'hi', 'ja', 'pt', 'zh'].contains(locale.languageCode);
+  bool isSupported(Locale locale) => <String>[
+        'ar',
+        'bg',
+        'ca',
+        'cs',
+        'da',
+        'de',
+        'el',
+        'en',
+        'es',
+        'et',
+        'fi',
+        'fr',
+        'hi',
+        'hu',
+        'id',
+        'it',
+        'ja',
+        'ko',
+        'lt',
+        'lv',
+        'ms',
+        'nl',
+        'no',
+        'pl',
+        'pt',
+        'ro',
+        'ru',
+        'sk',
+        'sv',
+        'th',
+        'tr',
+        'uk',
+        'vi',
+        'zh'
+      ].contains(locale.languageCode);
 
   @override
   bool shouldReload(_AppLocalizationsDelegate old) => false;
@@ -4234,18 +4341,72 @@ class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> 
 AppLocalizations lookupAppLocalizations(Locale locale) {
   // Lookup logic when only language code is specified.
   switch (locale.languageCode) {
+    case 'ar':
+      return AppLocalizationsAr();
+    case 'bg':
+      return AppLocalizationsBg();
+    case 'ca':
+      return AppLocalizationsCa();
+    case 'cs':
+      return AppLocalizationsCs();
+    case 'da':
+      return AppLocalizationsDa();
     case 'de':
       return AppLocalizationsDe();
+    case 'el':
+      return AppLocalizationsEl();
     case 'en':
       return AppLocalizationsEn();
     case 'es':
       return AppLocalizationsEs();
+    case 'et':
+      return AppLocalizationsEt();
+    case 'fi':
+      return AppLocalizationsFi();
+    case 'fr':
+      return AppLocalizationsFr();
     case 'hi':
       return AppLocalizationsHi();
+    case 'hu':
+      return AppLocalizationsHu();
+    case 'id':
+      return AppLocalizationsId();
+    case 'it':
+      return AppLocalizationsIt();
     case 'ja':
       return AppLocalizationsJa();
+    case 'ko':
+      return AppLocalizationsKo();
+    case 'lt':
+      return AppLocalizationsLt();
+    case 'lv':
+      return AppLocalizationsLv();
+    case 'ms':
+      return AppLocalizationsMs();
+    case 'nl':
+      return AppLocalizationsNl();
+    case 'no':
+      return AppLocalizationsNo();
+    case 'pl':
+      return AppLocalizationsPl();
     case 'pt':
       return AppLocalizationsPt();
+    case 'ro':
+      return AppLocalizationsRo();
+    case 'ru':
+      return AppLocalizationsRu();
+    case 'sk':
+      return AppLocalizationsSk();
+    case 'sv':
+      return AppLocalizationsSv();
+    case 'th':
+      return AppLocalizationsTh();
+    case 'tr':
+      return AppLocalizationsTr();
+    case 'uk':
+      return AppLocalizationsUk();
+    case 'vi':
+      return AppLocalizationsVi();
     case 'zh':
       return AppLocalizationsZh();
   }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -1,0 +1,2213 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Arabic (`ar`).
+class AppLocalizationsAr extends AppLocalizations {
+  AppLocalizationsAr([String locale = 'ar']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'المحادثة';
+
+  @override
+  String get transcriptTab => 'النص المكتوب';
+
+  @override
+  String get actionItemsTab => 'المهام';
+
+  @override
+  String get deleteConversationTitle => 'حذف المحادثة؟';
+
+  @override
+  String get deleteConversationMessage => 'هل أنت متأكد من رغبتك في حذف هذه المحادثة؟ لا يمكن التراجع عن هذا الإجراء.';
+
+  @override
+  String get confirm => 'تأكيد';
+
+  @override
+  String get cancel => 'إلغاء';
+
+  @override
+  String get ok => 'حسناً';
+
+  @override
+  String get delete => 'حذف';
+
+  @override
+  String get add => 'إضافة';
+
+  @override
+  String get update => 'تحديث';
+
+  @override
+  String get save => 'حفظ';
+
+  @override
+  String get edit => 'تعديل';
+
+  @override
+  String get close => 'إغلاق';
+
+  @override
+  String get clear => 'مسح';
+
+  @override
+  String get copyTranscript => 'نسخ النص المكتوب';
+
+  @override
+  String get copySummary => 'نسخ الملخص';
+
+  @override
+  String get testPrompt => 'اختبار الأمر';
+
+  @override
+  String get reprocessConversation => 'إعادة معالجة المحادثة';
+
+  @override
+  String get deleteConversation => 'حذف المحادثة';
+
+  @override
+  String get contentCopied => 'تم نسخ المحتوى إلى الحافظة';
+
+  @override
+  String get failedToUpdateStarred => 'فشل تحديث حالة التمييز بنجمة.';
+
+  @override
+  String get conversationUrlNotShared => 'تعذرت مشاركة رابط المحادثة.';
+
+  @override
+  String get errorProcessingConversation => 'خطأ أثناء معالجة المحادثة. يرجى المحاولة مرة أخرى لاحقاً.';
+
+  @override
+  String get noInternetConnection => 'يرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.';
+
+  @override
+  String get unableToDeleteConversation => 'تعذر حذف المحادثة';
+
+  @override
+  String get somethingWentWrong => 'حدث خطأ ما! يرجى المحاولة مرة أخرى لاحقاً.';
+
+  @override
+  String get copyErrorMessage => 'نسخ رسالة الخطأ';
+
+  @override
+  String get errorCopied => 'تم نسخ رسالة الخطأ إلى الحافظة';
+
+  @override
+  String get remaining => 'المتبقي';
+
+  @override
+  String get loading => 'جاري التحميل...';
+
+  @override
+  String get loadingDuration => 'جاري تحميل المدة...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count ثانية';
+  }
+
+  @override
+  String get people => 'الأشخاص';
+
+  @override
+  String get addNewPerson => 'إضافة شخص جديد';
+
+  @override
+  String get editPerson => 'تعديل الشخص';
+
+  @override
+  String get createPersonHint => 'أنشئ شخصاً جديداً ودرب Omi على التعرف على صوته أيضاً!';
+
+  @override
+  String get speechProfile => 'ملف الصوت';
+
+  @override
+  String sampleNumber(int number) {
+    return 'عينة $number';
+  }
+
+  @override
+  String get settings => 'الإعدادات';
+
+  @override
+  String get language => 'اللغة';
+
+  @override
+  String get selectLanguage => 'اختر اللغة';
+
+  @override
+  String get deleting => 'جاري الحذف...';
+
+  @override
+  String get pleaseCompleteAuthentication => 'يرجى إكمال المصادقة في متصفحك. بعد الانتهاء، ارجع إلى التطبيق.';
+
+  @override
+  String get failedToStartAuthentication => 'فشل بدء المصادقة';
+
+  @override
+  String get importStarted => 'بدأ الاستيراد! سيتم إشعارك عند اكتماله.';
+
+  @override
+  String get failedToStartImport => 'فشل بدء الاستيراد. يرجى المحاولة مرة أخرى.';
+
+  @override
+  String get couldNotAccessFile => 'تعذر الوصول إلى الملف المحدد';
+
+  @override
+  String get askOmi => 'اسأل Omi';
+
+  @override
+  String get done => 'تم';
+
+  @override
+  String get disconnected => 'غير متصل';
+
+  @override
+  String get searching => 'جاري البحث';
+
+  @override
+  String get connectDevice => 'توصيل جهاز';
+
+  @override
+  String get monthlyLimitReached => 'لقد وصلت إلى الحد الشهري.';
+
+  @override
+  String get checkUsage => 'التحقق من الاستخدام';
+
+  @override
+  String get syncingRecordings => 'مزامنة التسجيلات';
+
+  @override
+  String get recordingsToSync => 'التسجيلات المراد مزامنتها';
+
+  @override
+  String get allCaughtUp => 'كل شيء محدث';
+
+  @override
+  String get sync => 'مزامنة';
+
+  @override
+  String get pendantUpToDate => 'القلادة محدثة';
+
+  @override
+  String get allRecordingsSynced => 'جميع التسجيلات متزامنة';
+
+  @override
+  String get syncingInProgress => 'المزامنة قيد التنفيذ';
+
+  @override
+  String get readyToSync => 'جاهز للمزامنة';
+
+  @override
+  String get tapSyncToStart => 'اضغط على مزامنة للبدء';
+
+  @override
+  String get pendantNotConnected => 'القلادة غير متصلة. قم بالتوصيل للمزامنة.';
+
+  @override
+  String get everythingSynced => 'كل شيء متزامن بالفعل.';
+
+  @override
+  String get recordingsNotSynced => 'لديك تسجيلات لم تتم مزامنتها بعد.';
+
+  @override
+  String get syncingBackground => 'سنستمر في مزامنة تسجيلاتك في الخلفية.';
+
+  @override
+  String get noConversationsYet => 'لا توجد محادثات بعد.';
+
+  @override
+  String get noStarredConversations => 'لا توجد محادثات مميزة بنجمة بعد.';
+
+  @override
+  String get starConversationHint => 'لتمييز محادثة بنجمة، افتحها واضغط على أيقونة النجمة في الرأس.';
+
+  @override
+  String get searchConversations => 'بحث في المحادثات';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count محدد';
+  }
+
+  @override
+  String get merge => 'دمج';
+
+  @override
+  String get mergeConversations => 'دمج المحادثات';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'سيؤدي هذا إلى دمج $count محادثة في واحدة. سيتم دمج وإعادة إنشاء جميع المحتويات.';
+  }
+
+  @override
+  String get mergingInBackground => 'جاري الدمج في الخلفية. قد يستغرق هذا لحظة.';
+
+  @override
+  String get failedToStartMerge => 'فشل بدء الدمج';
+
+  @override
+  String get askAnything => 'اسأل أي شيء';
+
+  @override
+  String get noMessagesYet => 'لا توجد رسائل بعد!\nلماذا لا تبدأ محادثة؟';
+
+  @override
+  String get deletingMessages => 'جاري حذف رسائلك من ذاكرة Omi...';
+
+  @override
+  String get messageCopied => 'تم نسخ الرسالة إلى الحافظة.';
+
+  @override
+  String get cannotReportOwnMessage => 'لا يمكنك الإبلاغ عن رسائلك الخاصة.';
+
+  @override
+  String get reportMessage => 'الإبلاغ عن رسالة';
+
+  @override
+  String get reportMessageConfirm => 'هل أنت متأكد من رغبتك في الإبلاغ عن هذه الرسالة؟';
+
+  @override
+  String get messageReported => 'تم الإبلاغ عن الرسالة بنجاح.';
+
+  @override
+  String get thankYouFeedback => 'شكراً لك على ملاحظاتك!';
+
+  @override
+  String get clearChat => 'مسح المحادثة؟';
+
+  @override
+  String get clearChatConfirm => 'هل أنت متأكد من رغبتك في مسح المحادثة؟ لا يمكن التراجع عن هذا الإجراء.';
+
+  @override
+  String get maxFilesLimit => 'يمكنك تحميل 4 ملفات فقط في كل مرة';
+
+  @override
+  String get chatWithOmi => 'الدردشة مع Omi';
+
+  @override
+  String get apps => 'التطبيقات';
+
+  @override
+  String get noAppsFound => 'لم يتم العثور على تطبيقات';
+
+  @override
+  String get tryAdjustingSearch => 'حاول تعديل البحث أو الفلاتر';
+
+  @override
+  String get createYourOwnApp => 'أنشئ تطبيقك الخاص';
+
+  @override
+  String get buildAndShareApp => 'أنشئ وشارك تطبيقك المخصص';
+
+  @override
+  String get searchApps => 'بحث في أكثر من 1500 تطبيق';
+
+  @override
+  String get myApps => 'تطبيقاتي';
+
+  @override
+  String get installedApps => 'التطبيقات المثبتة';
+
+  @override
+  String get unableToFetchApps => 'تعذر جلب التطبيقات :(\n\nيرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.';
+
+  @override
+  String get aboutOmi => 'عن Omi';
+
+  @override
+  String get privacyPolicy => 'سياسة الخصوصية';
+
+  @override
+  String get visitWebsite => 'زيارة الموقع';
+
+  @override
+  String get helpOrInquiries => 'مساعدة أو استفسارات؟';
+
+  @override
+  String get joinCommunity => 'انضم إلى المجتمع!';
+
+  @override
+  String get membersAndCounting => 'أكثر من 8000 عضو وما زال العدد في ازدياد.';
+
+  @override
+  String get deleteAccountTitle => 'حذف الحساب';
+
+  @override
+  String get deleteAccountConfirm => 'هل أنت متأكد من رغبتك في حذف حسابك؟';
+
+  @override
+  String get cannotBeUndone => 'لا يمكن التراجع عن هذا.';
+
+  @override
+  String get allDataErased => 'سيتم حذف جميع ذكرياتك ومحادثاتك بشكل دائم.';
+
+  @override
+  String get appsDisconnected => 'سيتم فصل تطبيقاتك وتكاملاتك فوراً.';
+
+  @override
+  String get exportBeforeDelete => 'يمكنك تصدير بياناتك قبل حذف حسابك، ولكن بمجرد الحذف، لا يمكن استردادها.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'أدرك أن حذف حسابي دائم وأن جميع البيانات، بما في ذلك الذكريات والمحادثات، ستُفقد ولا يمكن استردادها.';
+
+  @override
+  String get areYouSure => 'هل أنت متأكد؟';
+
+  @override
+  String get deleteAccountFinal =>
+      'هذا الإجراء لا رجعة فيه وسيحذف حسابك وجميع البيانات المرتبطة به نهائياً. هل أنت متأكد من رغبتك في المتابعة؟';
+
+  @override
+  String get deleteNow => 'احذف الآن';
+
+  @override
+  String get goBack => 'العودة';
+
+  @override
+  String get checkBoxToConfirm => 'حدد المربع لتأكيد فهمك أن حذف حسابك دائم ولا رجعة فيه.';
+
+  @override
+  String get profile => 'الملف الشخصي';
+
+  @override
+  String get name => 'الاسم';
+
+  @override
+  String get email => 'البريد الإلكتروني';
+
+  @override
+  String get customVocabulary => 'المفردات المخصصة';
+
+  @override
+  String get identifyingOthers => 'التعرف على الآخرين';
+
+  @override
+  String get paymentMethods => 'طرق الدفع';
+
+  @override
+  String get conversationDisplay => 'عرض المحادثة';
+
+  @override
+  String get dataPrivacy => 'البيانات والخصوصية';
+
+  @override
+  String get userId => 'معرف المستخدم';
+
+  @override
+  String get notSet => 'غير محدد';
+
+  @override
+  String get userIdCopied => 'تم نسخ معرف المستخدم إلى الحافظة';
+
+  @override
+  String get systemDefault => 'افتراضي النظام';
+
+  @override
+  String get planAndUsage => 'الخطة والاستخدام';
+
+  @override
+  String get offlineSync => 'المزامنة دون اتصال';
+
+  @override
+  String get deviceSettings => 'إعدادات الجهاز';
+
+  @override
+  String get chatTools => 'أدوات الدردشة';
+
+  @override
+  String get feedbackBug => 'ملاحظات / خطأ';
+
+  @override
+  String get helpCenter => 'مركز المساعدة';
+
+  @override
+  String get developerSettings => 'إعدادات المطور';
+
+  @override
+  String get getOmiForMac => 'احصل على Omi لنظام Mac';
+
+  @override
+  String get referralProgram => 'برنامج الإحالة';
+
+  @override
+  String get signOut => 'تسجيل الخروج';
+
+  @override
+  String get appAndDeviceCopied => 'تم نسخ تفاصيل التطبيق والجهاز';
+
+  @override
+  String get wrapped2025 => 'ملخص 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'خصوصيتك، تحكمك';
+
+  @override
+  String get privacyIntro =>
+      'في Omi، نحن ملتزمون بحماية خصوصيتك. تتيح لك هذه الصفحة التحكم في كيفية تخزين بياناتك واستخدامها.';
+
+  @override
+  String get learnMore => 'اعرف المزيد...';
+
+  @override
+  String get dataProtectionLevel => 'مستوى حماية البيانات';
+
+  @override
+  String get dataProtectionDesc =>
+      'بياناتك محمية افتراضياً بتشفير قوي. راجع إعداداتك وخيارات الخصوصية المستقبلية أدناه.';
+
+  @override
+  String get appAccess => 'وصول التطبيقات';
+
+  @override
+  String get appAccessDesc => 'يمكن للتطبيقات التالية الوصول إلى بياناتك. اضغط على تطبيق لإدارة أذوناته.';
+
+  @override
+  String get noAppsExternalAccess => 'لا توجد تطبيقات مثبتة لها وصول خارجي إلى بياناتك.';
+
+  @override
+  String get deviceName => 'اسم الجهاز';
+
+  @override
+  String get deviceId => 'معرف الجهاز';
+
+  @override
+  String get firmware => 'البرنامج الثابت';
+
+  @override
+  String get sdCardSync => 'مزامنة بطاقة SD';
+
+  @override
+  String get hardwareRevision => 'مراجعة الأجهزة';
+
+  @override
+  String get modelNumber => 'رقم الطراز';
+
+  @override
+  String get manufacturer => 'الشركة المصنعة';
+
+  @override
+  String get doubleTap => 'نقرة مزدوجة';
+
+  @override
+  String get ledBrightness => 'سطوع LED';
+
+  @override
+  String get micGain => 'تضخيم الميكروفون';
+
+  @override
+  String get disconnect => 'قطع الاتصال';
+
+  @override
+  String get forgetDevice => 'نسيان الجهاز';
+
+  @override
+  String get chargingIssues => 'مشاكل الشحن';
+
+  @override
+  String get disconnectDevice => 'قطع اتصال الجهاز';
+
+  @override
+  String get unpairDevice => 'إلغاء إقران الجهاز';
+
+  @override
+  String get unpairAndForget => 'إلغاء الإقران ونسيان الجهاز';
+
+  @override
+  String get deviceDisconnectedMessage => 'تم قطع اتصال Omi الخاص بك 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'تم إلغاء إقران الجهاز. انتقل إلى الإعدادات > البلوتوث وانسَ الجهاز لإكمال إلغاء الإقران.';
+
+  @override
+  String get unpairDialogTitle => 'إلغاء إقران الجهاز';
+
+  @override
+  String get unpairDialogMessage =>
+      'سيؤدي هذا إلى إلغاء إقران الجهاز بحيث يمكن توصيله بهاتف آخر. ستحتاج إلى الذهاب إلى الإعدادات > البلوتوث ونسيان الجهاز لإكمال العملية.';
+
+  @override
+  String get deviceNotConnected => 'الجهاز غير متصل';
+
+  @override
+  String get connectDeviceMessage => 'قم بتوصيل جهاز Omi الخاص بك للوصول\nإلى إعدادات الجهاز والتخصيص';
+
+  @override
+  String get deviceInfoSection => 'معلومات الجهاز';
+
+  @override
+  String get customizationSection => 'التخصيص';
+
+  @override
+  String get hardwareSection => 'الأجهزة';
+
+  @override
+  String get v2Undetected => 'لم يتم اكتشاف V2';
+
+  @override
+  String get v2UndetectedMessage => 'نرى أن لديك جهاز V1 أو أن جهازك غير متصل. وظيفة بطاقة SD متاحة فقط لأجهزة V2.';
+
+  @override
+  String get endConversation => 'إنهاء المحادثة';
+
+  @override
+  String get pauseResume => 'إيقاف مؤقت/استئناف';
+
+  @override
+  String get starConversation => 'تمييز المحادثة بنجمة';
+
+  @override
+  String get doubleTapAction => 'إجراء النقر المزدوج';
+
+  @override
+  String get endAndProcess => 'إنهاء ومعالجة المحادثة';
+
+  @override
+  String get pauseResumeRecording => 'إيقاف مؤقت/استئناف التسجيل';
+
+  @override
+  String get starOngoing => 'تمييز المحادثة الجارية بنجمة';
+
+  @override
+  String get off => 'متوقف';
+
+  @override
+  String get max => 'الحد الأقصى';
+
+  @override
+  String get mute => 'كتم';
+
+  @override
+  String get quiet => 'هادئ';
+
+  @override
+  String get normal => 'عادي';
+
+  @override
+  String get high => 'عالي';
+
+  @override
+  String get micGainDescMuted => 'الميكروفون مكتوم';
+
+  @override
+  String get micGainDescLow => 'هادئ جداً - للبيئات الصاخبة';
+
+  @override
+  String get micGainDescModerate => 'هادئ - للضوضاء المعتدلة';
+
+  @override
+  String get micGainDescNeutral => 'متعادل - تسجيل متوازن';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'معزز قليلاً - للاستخدام العادي';
+
+  @override
+  String get micGainDescBoosted => 'معزز - للبيئات الهادئة';
+
+  @override
+  String get micGainDescHigh => 'عالي - للأصوات البعيدة أو الناعمة';
+
+  @override
+  String get micGainDescVeryHigh => 'عالي جداً - للمصادر الهادئة جداً';
+
+  @override
+  String get micGainDescMax => 'الحد الأقصى - استخدم بحذر';
+
+  @override
+  String get developerSettingsTitle => 'إعدادات المطور';
+
+  @override
+  String get saving => 'جاري الحفظ...';
+
+  @override
+  String get personaConfig => 'قم بتكوين شخصية الذكاء الاصطناعي الخاصة بك';
+
+  @override
+  String get beta => 'تجريبي';
+
+  @override
+  String get transcription => 'النسخ الصوتي';
+
+  @override
+  String get transcriptionConfig => 'قم بتكوين موفر STT';
+
+  @override
+  String get conversationTimeout => 'انتهاء مهلة المحادثة';
+
+  @override
+  String get conversationTimeoutConfig => 'حدد متى تنتهي المحادثات تلقائياً';
+
+  @override
+  String get importData => 'استيراد البيانات';
+
+  @override
+  String get importDataConfig => 'استيراد البيانات من مصادر أخرى';
+
+  @override
+  String get debugDiagnostics => 'تصحيح الأخطاء والتشخيصات';
+
+  @override
+  String get endpointUrl => 'رابط نقطة النهاية';
+
+  @override
+  String get noApiKeys => 'لا توجد مفاتيح API بعد';
+
+  @override
+  String get createKeyToStart => 'أنشئ مفتاحاً للبدء';
+
+  @override
+  String get createKey => 'إنشاء مفتاح';
+
+  @override
+  String get docs => 'المستندات';
+
+  @override
+  String get yourOmiInsights => 'رؤى Omi الخاصة بك';
+
+  @override
+  String get today => 'اليوم';
+
+  @override
+  String get thisMonth => 'هذا الشهر';
+
+  @override
+  String get thisYear => 'هذا العام';
+
+  @override
+  String get allTime => 'كل الأوقات';
+
+  @override
+  String get noActivityYet => 'لا يوجد نشاط بعد';
+
+  @override
+  String get startConversationToSeeInsights => 'ابدأ محادثة مع Omi\nلرؤية رؤى استخدامك هنا.';
+
+  @override
+  String get listening => 'الاستماع';
+
+  @override
+  String get listeningSubtitle => 'إجمالي الوقت الذي استمع فيه Omi بنشاط.';
+
+  @override
+  String get understanding => 'الفهم';
+
+  @override
+  String get understandingSubtitle => 'الكلمات المفهومة من محادثاتك.';
+
+  @override
+  String get providing => 'التوفير';
+
+  @override
+  String get providingSubtitle => 'المهام والملاحظات الملتقطة تلقائياً.';
+
+  @override
+  String get remembering => 'التذكر';
+
+  @override
+  String get rememberingSubtitle => 'الحقائق والتفاصيل المحفوظة من أجلك.';
+
+  @override
+  String get unlimitedPlan => 'خطة غير محدودة';
+
+  @override
+  String get managePlan => 'إدارة الخطة';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'ستنتهي خطتك في $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'تتجدد خطتك في $date.';
+  }
+
+  @override
+  String get basicPlan => 'خطة مجانية';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used من $limit دقيقة مستخدمة';
+  }
+
+  @override
+  String get upgrade => 'ترقية';
+
+  @override
+  String get upgradeToUnlimited => 'الترقية إلى غير محدود';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'تتضمن خطتك $limit دقيقة مجانية شهرياً. قم بالترقية للحصول على دقائق غير محدودة.';
+  }
+
+  @override
+  String get shareStatsMessage => 'مشاركة إحصائيات Omi الخاصة بي! (omi.me - مساعدك الذكي الدائم)';
+
+  @override
+  String get sharePeriodToday => 'اليوم، قام omi بـ:';
+
+  @override
+  String get sharePeriodMonth => 'هذا الشهر، قام omi بـ:';
+
+  @override
+  String get sharePeriodYear => 'هذا العام، قام omi بـ:';
+
+  @override
+  String get sharePeriodAllTime => 'حتى الآن، قام omi بـ:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 استمع لمدة $minutes دقيقة';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 فهم $words كلمة';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ قدم $count رؤية';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 تذكر $count ذكرى';
+  }
+
+  @override
+  String get debugLogs => 'سجلات التصحيح';
+
+  @override
+  String get debugLogsAutoDelete => 'يتم الحذف التلقائي بعد 3 أيام.';
+
+  @override
+  String get debugLogsDesc => 'يساعد في تشخيص المشاكل';
+
+  @override
+  String get noLogFilesFound => 'لم يتم العثور على ملفات سجل.';
+
+  @override
+  String get omiDebugLog => 'سجل تصحيح Omi';
+
+  @override
+  String get logShared => 'تمت مشاركة السجل';
+
+  @override
+  String get selectLogFile => 'حدد ملف السجل';
+
+  @override
+  String get shareLogs => 'مشاركة السجلات';
+
+  @override
+  String get debugLogCleared => 'تم مسح سجل التصحيح';
+
+  @override
+  String get exportStarted => 'بدأ التصدير. قد يستغرق هذا بضع ثوان...';
+
+  @override
+  String get exportAllData => 'تصدير جميع البيانات';
+
+  @override
+  String get exportDataDesc => 'تصدير المحادثات إلى ملف JSON';
+
+  @override
+  String get exportedConversations => 'المحادثات المصدرة من Omi';
+
+  @override
+  String get exportShared => 'تمت مشاركة التصدير';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'حذف رسم المعرفة؟';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'سيؤدي هذا إلى حذف جميع بيانات رسم المعرفة المشتقة (العقد والاتصالات). ستبقى ذكرياتك الأصلية آمنة. سيتم إعادة بناء الرسم بمرور الوقت أو عند الطلب التالي.';
+
+  @override
+  String get knowledgeGraphDeleted => 'تم حذف رسم المعرفة بنجاح';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'فشل حذف الرسم: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'حذف رسم المعرفة';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'مسح جميع العقد والاتصالات';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'خادم MCP';
+
+  @override
+  String get mcpServerDesc => 'ربط مساعدي الذكاء الاصطناعي ببياناتك';
+
+  @override
+  String get serverUrl => 'رابط الخادم';
+
+  @override
+  String get urlCopied => 'تم نسخ الرابط';
+
+  @override
+  String get apiKeyAuth => 'مصادقة مفتاح API';
+
+  @override
+  String get header => 'الترويسة';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'معرف العميل';
+
+  @override
+  String get clientSecret => 'سر العميل';
+
+  @override
+  String get useMcpApiKey => 'استخدم مفتاح MCP API الخاص بك';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'أحداث المحادثة';
+
+  @override
+  String get newConversationCreated => 'تم إنشاء محادثة جديدة';
+
+  @override
+  String get realtimeTranscript => 'نص مباشر';
+
+  @override
+  String get transcriptReceived => 'تم استلام النص';
+
+  @override
+  String get audioBytes => 'بايتات الصوت';
+
+  @override
+  String get audioDataReceived => 'تم استلام بيانات الصوت';
+
+  @override
+  String get intervalSeconds => 'الفاصل الزمني (بالثواني)';
+
+  @override
+  String get daySummary => 'ملخص اليوم';
+
+  @override
+  String get summaryGenerated => 'تم إنشاء الملخص';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'أضف إلى claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'نسخ التكوين';
+
+  @override
+  String get configCopied => 'تم نسخ التكوين إلى الحافظة';
+
+  @override
+  String get listeningMins => 'الاستماع (دقائق)';
+
+  @override
+  String get understandingWords => 'الفهم (كلمات)';
+
+  @override
+  String get insights => 'رؤى';
+
+  @override
+  String get memories => 'ذكريات';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used من $limit دقيقة مستخدمة هذا الشهر';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used من $limit كلمة مستخدمة هذا الشهر';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used من $limit رؤية تم اكتسابها هذا الشهر';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used من $limit ذكرى تم إنشاؤها هذا الشهر';
+  }
+
+  @override
+  String get visibility => 'الرؤية';
+
+  @override
+  String get visibilitySubtitle => 'تحكم في المحادثات التي تظهر في قائمتك';
+
+  @override
+  String get showShortConversations => 'إظهار المحادثات القصيرة';
+
+  @override
+  String get showShortConversationsDesc => 'عرض المحادثات الأقصر من الحد الأدنى';
+
+  @override
+  String get showDiscardedConversations => 'إظهار المحادثات المهملة';
+
+  @override
+  String get showDiscardedConversationsDesc => 'تضمين المحادثات المميزة كمهملة';
+
+  @override
+  String get shortConversationThreshold => 'حد المحادثة القصيرة';
+
+  @override
+  String get shortConversationThresholdSubtitle => 'سيتم إخفاء المحادثات الأقصر من هذا ما لم يتم تمكينها أعلاه';
+
+  @override
+  String get durationThreshold => 'حد المدة';
+
+  @override
+  String get durationThresholdDesc => 'إخفاء المحادثات الأقصر من هذا';
+
+  @override
+  String minLabel(int count) {
+    return '$count دقيقة';
+  }
+
+  @override
+  String get customVocabularyTitle => 'المفردات المخصصة';
+
+  @override
+  String get addWords => 'إضافة كلمات';
+
+  @override
+  String get addWordsDesc => 'أسماء أو مصطلحات أو كلمات غير شائعة';
+
+  @override
+  String get vocabularyHint => 'Omi، Callie، OpenAI';
+
+  @override
+  String get connect => 'اتصال';
+
+  @override
+  String get comingSoon => 'قريباً';
+
+  @override
+  String get chatToolsFooter => 'قم بتوصيل تطبيقاتك لعرض البيانات والمقاييس في الدردشة.';
+
+  @override
+  String get completeAuthInBrowser => 'يرجى إكمال المصادقة في متصفحك. بعد الانتهاء، ارجع إلى التطبيق.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'فشل بدء مصادقة $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'قطع الاتصال بـ $appName؟';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'هل أنت متأكد من رغبتك في قطع الاتصال بـ $appName؟ يمكنك إعادة الاتصال في أي وقت.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'تم قطع الاتصال بـ $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'فشل قطع الاتصال';
+
+  @override
+  String connectTo(String appName) {
+    return 'الاتصال بـ $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'ستحتاج إلى تفويض Omi للوصول إلى بيانات $appName الخاصة بك. سيتم فتح متصفحك للمصادقة.';
+  }
+
+  @override
+  String get continueAction => 'متابعة';
+
+  @override
+  String get languageTitle => 'اللغة';
+
+  @override
+  String get primaryLanguage => 'اللغة الأساسية';
+
+  @override
+  String get automaticTranslation => 'الترجمة التلقائية';
+
+  @override
+  String get detectLanguages => 'اكتشاف أكثر من 10 لغات';
+
+  @override
+  String get authorizeSavingRecordings => 'التفويض بحفظ التسجيلات';
+
+  @override
+  String get thanksForAuthorizing => 'شكراً على التفويض!';
+
+  @override
+  String get needYourPermission => 'نحتاج إذنك';
+
+  @override
+  String get alreadyGavePermission => 'لقد منحتنا بالفعل إذناً بحفظ تسجيلاتك. إليك تذكير بسبب حاجتنا إليه:';
+
+  @override
+  String get wouldLikePermission => 'نود الحصول على إذنك لحفظ تسجيلاتك الصوتية. إليك السبب:';
+
+  @override
+  String get improveSpeechProfile => 'تحسين ملف الصوت الخاص بك';
+
+  @override
+  String get improveSpeechProfileDesc => 'نستخدم التسجيلات لمواصلة تدريب وتحسين ملف الصوت الشخصي الخاص بك.';
+
+  @override
+  String get trainFamilyProfiles => 'تدريب ملفات تعريف الأصدقاء والعائلة';
+
+  @override
+  String get trainFamilyProfilesDesc => 'تساعدنا تسجيلاتك في التعرف على أصدقائك وعائلتك وإنشاء ملفات تعريف لهم.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'تحسين دقة النص المكتوب';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc => 'مع تحسن نموذجنا، يمكننا توفير نتائج نسخ أفضل لتسجيلاتك.';
+
+  @override
+  String get legalNotice =>
+      'إشعار قانوني: قد تختلف قانونية تسجيل وتخزين البيانات الصوتية اعتماداً على موقعك وكيفية استخدامك لهذه الميزة. من مسؤوليتك ضمان الامتثال للقوانين واللوائح المحلية.';
+
+  @override
+  String get alreadyAuthorized => 'تم التفويض بالفعل';
+
+  @override
+  String get authorize => 'تفويض';
+
+  @override
+  String get revokeAuthorization => 'إلغاء التفويض';
+
+  @override
+  String get authorizationSuccessful => 'التفويض ناجح!';
+
+  @override
+  String get failedToAuthorize => 'فشل التفويض. يرجى المحاولة مرة أخرى.';
+
+  @override
+  String get authorizationRevoked => 'تم إلغاء التفويض.';
+
+  @override
+  String get recordingsDeleted => 'تم حذف التسجيلات.';
+
+  @override
+  String get failedToRevoke => 'فشل إلغاء التفويض. يرجى المحاولة مرة أخرى.';
+
+  @override
+  String get permissionRevokedTitle => 'تم إلغاء الإذن';
+
+  @override
+  String get permissionRevokedMessage => 'هل تريد منا حذف جميع تسجيلاتك الحالية أيضاً؟';
+
+  @override
+  String get yes => 'نعم';
+
+  @override
+  String get editName => 'تعديل الاسم';
+
+  @override
+  String get howShouldOmiCallYou => 'كيف يجب على Omi أن يناديك؟';
+
+  @override
+  String get enterYourName => 'أدخل اسمك';
+
+  @override
+  String get nameCannotBeEmpty => 'لا يمكن أن يكون الاسم فارغاً';
+
+  @override
+  String get nameUpdatedSuccessfully => 'تم تحديث الاسم بنجاح!';
+
+  @override
+  String get calendarSettings => 'إعدادات التقويم';
+
+  @override
+  String get calendarProviders => 'موفرو التقويم';
+
+  @override
+  String get macOsCalendar => 'تقويم macOS';
+
+  @override
+  String get connectMacOsCalendar => 'قم بتوصيل تقويم macOS المحلي الخاص بك';
+
+  @override
+  String get googleCalendar => 'تقويم Google';
+
+  @override
+  String get syncGoogleAccount => 'المزامنة مع حساب Google الخاص بك';
+
+  @override
+  String get showMeetingsMenuBar => 'إظهار الاجتماعات القادمة في شريط القوائم';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'عرض اجتماعك التالي والوقت حتى يبدأ في شريط قوائم macOS';
+
+  @override
+  String get showEventsNoParticipants => 'إظهار الأحداث بدون مشاركين';
+
+  @override
+  String get showEventsNoParticipantsDesc => 'عند التمكين، يعرض القادم الأحداث بدون مشاركين أو رابط فيديو.';
+
+  @override
+  String get yourMeetings => 'اجتماعاتك';
+
+  @override
+  String get refresh => 'تحديث';
+
+  @override
+  String get noUpcomingMeetings => 'لم يتم العثور على اجتماعات قادمة';
+
+  @override
+  String get checkingNextDays => 'التحقق من الـ 30 يوماً القادمة';
+
+  @override
+  String get tomorrow => 'غداً';
+
+  @override
+  String get googleCalendarComingSoon => 'تكامل تقويم Google قريباً!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'متصل كمستخدم: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'مساحة العمل الافتراضية';
+
+  @override
+  String get tasksCreatedInWorkspace => 'سيتم إنشاء المهام في مساحة العمل هذه';
+
+  @override
+  String get defaultProjectOptional => 'المشروع الافتراضي (اختياري)';
+
+  @override
+  String get leaveUnselectedTasks => 'اترك غير محدد لإنشاء مهام بدون مشروع';
+
+  @override
+  String get noProjectsInWorkspace => 'لم يتم العثور على مشاريع في مساحة العمل هذه';
+
+  @override
+  String get conversationTimeoutDesc => 'اختر المدة التي يجب الانتظار فيها في صمت قبل إنهاء المحادثة تلقائياً:';
+
+  @override
+  String get timeout2Minutes => 'دقيقتان';
+
+  @override
+  String get timeout2MinutesDesc => 'إنهاء المحادثة بعد دقيقتين من الصمت';
+
+  @override
+  String get timeout5Minutes => '5 دقائق';
+
+  @override
+  String get timeout5MinutesDesc => 'إنهاء المحادثة بعد 5 دقائق من الصمت';
+
+  @override
+  String get timeout10Minutes => '10 دقائق';
+
+  @override
+  String get timeout10MinutesDesc => 'إنهاء المحادثة بعد 10 دقائق من الصمت';
+
+  @override
+  String get timeout30Minutes => '30 دقيقة';
+
+  @override
+  String get timeout30MinutesDesc => 'إنهاء المحادثة بعد 30 دقيقة من الصمت';
+
+  @override
+  String get timeout4Hours => '4 ساعات';
+
+  @override
+  String get timeout4HoursDesc => 'إنهاء المحادثة بعد 4 ساعات من الصمت';
+
+  @override
+  String get conversationEndAfterHours => 'ستنتهي المحادثات الآن بعد 4 ساعات من الصمت';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'ستنتهي المحادثات الآن بعد $minutes دقيقة من الصمت';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'أخبرنا بلغتك الأساسية';
+
+  @override
+  String get languageForTranscription => 'حدد لغتك للحصول على نسخ أكثر دقة وتجربة شخصية.';
+
+  @override
+  String get singleLanguageModeInfo => 'وضع اللغة الواحدة ممكّن. الترجمة معطلة لدقة أعلى.';
+
+  @override
+  String get searchLanguageHint => 'بحث عن اللغة بالاسم أو الرمز';
+
+  @override
+  String get noLanguagesFound => 'لم يتم العثور على لغات';
+
+  @override
+  String get skip => 'تخطي';
+
+  @override
+  String languageSetTo(String language) {
+    return 'تم تعيين اللغة إلى $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'فشل تعيين اللغة';
+
+  @override
+  String appSettings(String appName) {
+    return 'إعدادات $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'قطع الاتصال بـ $appName؟';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'سيؤدي هذا إلى حذف مصادقة $appName الخاصة بك. ستحتاج إلى إعادة الاتصال لاستخدامه مرة أخرى.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'متصل بـ $appName';
+  }
+
+  @override
+  String get account => 'الحساب';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'سيتم مزامنة مهامك مع حساب $appName الخاص بك';
+  }
+
+  @override
+  String get defaultSpace => 'المساحة الافتراضية';
+
+  @override
+  String get selectSpaceInWorkspace => 'حدد مساحة في مساحة العمل الخاصة بك';
+
+  @override
+  String get noSpacesInWorkspace => 'لم يتم العثور على مساحات في مساحة العمل هذه';
+
+  @override
+  String get defaultList => 'القائمة الافتراضية';
+
+  @override
+  String get tasksAddedToList => 'سيتم إضافة المهام إلى هذه القائمة';
+
+  @override
+  String get noListsInSpace => 'لم يتم العثور على قوائم في هذه المساحة';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'فشل تحميل المستودعات: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'تم حفظ المستودع الافتراضي';
+
+  @override
+  String get failedToSaveDefaultRepo => 'فشل حفظ المستودع الافتراضي';
+
+  @override
+  String get defaultRepository => 'المستودع الافتراضي';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'حدد مستودعاً افتراضياً لإنشاء المشكلات. لا يزال بإمكانك تحديد مستودع مختلف عند إنشاء المشكلات.';
+
+  @override
+  String get noReposFound => 'لم يتم العثور على مستودعات';
+
+  @override
+  String get private => 'خاص';
+
+  @override
+  String updatedDate(String date) {
+    return 'تم التحديث $date';
+  }
+
+  @override
+  String get yesterday => 'أمس';
+
+  @override
+  String daysAgo(int count) {
+    return 'منذ $count أيام';
+  }
+
+  @override
+  String get oneWeekAgo => 'منذ أسبوع';
+
+  @override
+  String weeksAgo(int count) {
+    return 'منذ $count أسابيع';
+  }
+
+  @override
+  String get oneMonthAgo => 'منذ شهر';
+
+  @override
+  String monthsAgo(int count) {
+    return 'منذ $count أشهر';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'سيتم إنشاء المشكلات في مستودعك الافتراضي';
+
+  @override
+  String get taskIntegrations => 'تكاملات المهام';
+
+  @override
+  String get configureSettings => 'تكوين الإعدادات';
+
+  @override
+  String get completeAuthBrowser => 'يرجى إكمال المصادقة في متصفحك. بعد الانتهاء، ارجع إلى التطبيق.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'فشل بدء مصادقة $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'الاتصال بـ $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'ستحتاج إلى تفويض Omi لإنشاء مهام في حساب $appName الخاص بك. سيتم فتح متصفحك للمصادقة.';
+  }
+
+  @override
+  String get continueButton => 'متابعة';
+
+  @override
+  String appIntegration(String appName) {
+    return 'تكامل $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'التكامل مع $appName قريباً! نعمل بجد لنوفر لك المزيد من خيارات إدارة المهام.';
+  }
+
+  @override
+  String get gotIt => 'فهمت';
+
+  @override
+  String get tasksExportedOneApp => 'يمكن تصدير المهام إلى تطبيق واحد في كل مرة.';
+
+  @override
+  String get completeYourUpgrade => 'أكمل ترقيتك';
+
+  @override
+  String get importConfiguration => 'استيراد التكوين';
+
+  @override
+  String get exportConfiguration => 'تصدير التكوين';
+
+  @override
+  String get bringYourOwn => 'احضر الخاص بك';
+
+  @override
+  String get payYourSttProvider => 'استخدم omi بحرية. أنت تدفع فقط لموفر STT الخاص بك مباشرة.';
+
+  @override
+  String get freeMinutesMonth => '1,200 دقيقة مجانية شهرياً متضمنة. غير محدود مع ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'المضيف مطلوب';
+
+  @override
+  String get validPortRequired => 'المنفذ الصحيح مطلوب';
+
+  @override
+  String get validWebsocketUrlRequired => 'رابط WebSocket صحيح مطلوب (wss://)';
+
+  @override
+  String get apiUrlRequired => 'رابط API مطلوب';
+
+  @override
+  String get apiKeyRequired => 'مفتاح API مطلوب';
+
+  @override
+  String get invalidJsonConfig => 'تكوين JSON غير صالح';
+
+  @override
+  String errorSaving(String error) {
+    return 'خطأ في الحفظ: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'تم نسخ التكوين إلى الحافظة';
+
+  @override
+  String get pasteJsonConfig => 'الصق تكوين JSON الخاص بك أدناه:';
+
+  @override
+  String get addApiKeyAfterImport => 'ستحتاج إلى إضافة مفتاح API الخاص بك بعد الاستيراد';
+
+  @override
+  String get paste => 'لصق';
+
+  @override
+  String get import => 'استيراد';
+
+  @override
+  String get invalidProviderInConfig => 'موفر غير صالح في التكوين';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'تم استيراد تكوين $providerName';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON غير صالح: $error';
+  }
+
+  @override
+  String get provider => 'الموفر';
+
+  @override
+  String get live => 'مباشر';
+
+  @override
+  String get onDevice => 'على الجهاز';
+
+  @override
+  String get apiUrl => 'رابط API';
+
+  @override
+  String get enterSttHttpEndpoint => 'أدخل نقطة نهاية STT HTTP الخاصة بك';
+
+  @override
+  String get websocketUrl => 'رابط WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'أدخل نقطة نهاية WebSocket STT المباشرة';
+
+  @override
+  String get apiKey => 'مفتاح API';
+
+  @override
+  String get enterApiKey => 'أدخل مفتاح API الخاص بك';
+
+  @override
+  String get storedLocallyNeverShared => 'يُخزن محلياً، ولا يُشارك أبداً';
+
+  @override
+  String get host => 'المضيف';
+
+  @override
+  String get port => 'المنفذ';
+
+  @override
+  String get advanced => 'متقدم';
+
+  @override
+  String get configuration => 'التكوين';
+
+  @override
+  String get requestConfiguration => 'تكوين الطلب';
+
+  @override
+  String get responseSchema => 'مخطط الاستجابة';
+
+  @override
+  String get modified => 'معدل';
+
+  @override
+  String get resetRequestConfig => 'إعادة تعيين تكوين الطلب إلى الافتراضي';
+
+  @override
+  String get logs => 'السجلات';
+
+  @override
+  String get logsCopied => 'تم نسخ السجلات';
+
+  @override
+  String get noLogsYet => 'لا توجد سجلات بعد. ابدأ التسجيل لرؤية نشاط STT المخصص.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName يستخدم $codecReason. سيتم استخدام Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'نسخ Omi';
+
+  @override
+  String get bestInClassTranscription => 'أفضل نسخ في فئته بدون إعداد';
+
+  @override
+  String get instantSpeakerLabels => 'تسميات المتحدثين الفورية';
+
+  @override
+  String get languageTranslation => 'ترجمة أكثر من 100 لغة';
+
+  @override
+  String get optimizedForConversation => 'محسّن للمحادثة';
+
+  @override
+  String get autoLanguageDetection => 'اكتشاف اللغة التلقائي';
+
+  @override
+  String get highAccuracy => 'دقة عالية';
+
+  @override
+  String get privacyFirst => 'الخصوصية أولاً';
+
+  @override
+  String get saveChanges => 'حفظ التغييرات';
+
+  @override
+  String get resetToDefault => 'إعادة التعيين إلى الافتراضي';
+
+  @override
+  String get viewTemplate => 'عرض النموذج';
+
+  @override
+  String get trySomethingLike => 'جرب شيئاً مثل...';
+
+  @override
+  String get tryIt => 'جربه';
+
+  @override
+  String get creatingPlan => 'إنشاء خطة';
+
+  @override
+  String get developingLogic => 'تطوير المنطق';
+
+  @override
+  String get designingApp => 'تصميم التطبيق';
+
+  @override
+  String get generatingIconStep => 'إنشاء أيقونة';
+
+  @override
+  String get finalTouches => 'اللمسات الأخيرة';
+
+  @override
+  String get processing => 'جاري المعالجة...';
+
+  @override
+  String get features => 'الميزات';
+
+  @override
+  String get creatingYourApp => 'جاري إنشاء تطبيقك...';
+
+  @override
+  String get generatingIcon => 'جاري إنشاء الأيقونة...';
+
+  @override
+  String get whatShouldWeMake => 'ماذا يجب أن نصنع؟';
+
+  @override
+  String get appName => 'اسم التطبيق';
+
+  @override
+  String get description => 'الوصف';
+
+  @override
+  String get publicLabel => 'عام';
+
+  @override
+  String get privateLabel => 'خاص';
+
+  @override
+  String get free => 'مجاني';
+
+  @override
+  String get perMonth => '/ شهرياً';
+
+  @override
+  String get tailoredConversationSummaries => 'ملخصات محادثة مخصصة';
+
+  @override
+  String get customChatbotPersonality => 'شخصية chatbot مخصصة';
+
+  @override
+  String get makePublic => 'جعله عاماً';
+
+  @override
+  String get anyoneCanDiscover => 'يمكن لأي شخص اكتشاف تطبيقك';
+
+  @override
+  String get onlyYouCanUse => 'أنت فقط يمكنك استخدام هذا التطبيق';
+
+  @override
+  String get paidApp => 'تطبيق مدفوع';
+
+  @override
+  String get usersPayToUse => 'يدفع المستخدمون لاستخدام تطبيقك';
+
+  @override
+  String get freeForEveryone => 'مجاني للجميع';
+
+  @override
+  String get perMonthLabel => '/ شهرياً';
+
+  @override
+  String get creating => 'جاري الإنشاء...';
+
+  @override
+  String get createApp => 'إنشاء تطبيق';
+
+  @override
+  String get searchingForDevices => 'جاري البحث عن الأجهزة...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'أجهزة',
+      one: 'جهاز',
+    );
+    return '$count $_temp0 تم العثور عليها بالقرب منك';
+  }
+
+  @override
+  String get pairingSuccessful => 'نجح الإقران';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'خطأ في الاتصال بـ Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'لا تظهر مرة أخرى';
+
+  @override
+  String get iUnderstand => 'أفهم';
+
+  @override
+  String get enableBluetooth => 'تمكين البلوتوث';
+
+  @override
+  String get bluetoothNeeded =>
+      'يحتاج Omi إلى البلوتوث للاتصال بجهازك القابل للارتداء. يرجى تمكين البلوتوث والمحاولة مرة أخرى.';
+
+  @override
+  String get contactSupport => 'الاتصال بالدعم؟';
+
+  @override
+  String get connectLater => 'الاتصال لاحقاً';
+
+  @override
+  String get grantPermissions => 'منح الأذونات';
+
+  @override
+  String get backgroundActivity => 'النشاط في الخلفية';
+
+  @override
+  String get backgroundActivityDesc => 'دع Omi يعمل في الخلفية لاستقرار أفضل';
+
+  @override
+  String get locationAccess => 'الوصول إلى الموقع';
+
+  @override
+  String get locationAccessDesc => 'تمكين الموقع في الخلفية للحصول على التجربة الكاملة';
+
+  @override
+  String get notifications => 'الإشعارات';
+
+  @override
+  String get notificationsDesc => 'تمكين الإشعارات للبقاء على اطلاع';
+
+  @override
+  String get locationServiceDisabled => 'خدمة الموقع معطلة';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'خدمة الموقع معطلة. يرجى الذهاب إلى الإعدادات > الخصوصية والأمان > خدمات الموقع وتمكينها';
+
+  @override
+  String get backgroundLocationDenied => 'تم رفض الوصول إلى الموقع في الخلفية';
+
+  @override
+  String get backgroundLocationDeniedDesc => 'يرجى الذهاب إلى إعدادات الجهاز وتعيين إذن الموقع إلى \"السماح دائماً\"';
+
+  @override
+  String get lovingOmi => 'تحب Omi؟';
+
+  @override
+  String get leaveReviewIos =>
+      'ساعدنا في الوصول إلى المزيد من الأشخاص من خلال ترك تقييم في App Store. ملاحظاتك تعني لنا الكثير!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'ساعدنا في الوصول إلى المزيد من الأشخاص من خلال ترك تقييم في Google Play Store. ملاحظاتك تعني لنا الكثير!';
+
+  @override
+  String get rateOnAppStore => 'التقييم على App Store';
+
+  @override
+  String get rateOnGooglePlay => 'التقييم على Google Play';
+
+  @override
+  String get maybeLater => 'ربما لاحقاً';
+
+  @override
+  String get speechProfileIntro => 'يحتاج Omi إلى تعلم أهدافك وصوتك. ستتمكن من تعديله لاحقاً.';
+
+  @override
+  String get getStarted => 'ابدأ';
+
+  @override
+  String get allDone => 'تم كل شيء!';
+
+  @override
+  String get keepGoing => 'استمر، أنت تقوم بعمل رائع';
+
+  @override
+  String get skipThisQuestion => 'تخطي هذا السؤال';
+
+  @override
+  String get skipForNow => 'تخطي الآن';
+
+  @override
+  String get connectionError => 'خطأ في الاتصال';
+
+  @override
+  String get connectionErrorDesc => 'فشل الاتصال بالخادم. يرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'تم اكتشاف تسجيل غير صالح';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'يبدو أن هناك عدة متحدثين في التسجيل. يرجى التأكد من أنك في موقع هادئ والمحاولة مرة أخرى.';
+
+  @override
+  String get tooShortDesc => 'لا يوجد كلام كافٍ مكتشف. يرجى التحدث أكثر والمحاولة مرة أخرى.';
+
+  @override
+  String get invalidRecordingDesc => 'يرجى التأكد من التحدث لمدة 5 ثوانٍ على الأقل وليس أكثر من 90.';
+
+  @override
+  String get areYouThere => 'هل أنت هناك؟';
+
+  @override
+  String get noSpeechDesc =>
+      'لم نتمكن من اكتشاف أي كلام. يرجى التأكد من التحدث لمدة 10 ثوانٍ على الأقل وليس أكثر من 3 دقائق.';
+
+  @override
+  String get connectionLost => 'فُقد الاتصال';
+
+  @override
+  String get connectionLostDesc => 'تم انقطاع الاتصال. يرجى التحقق من اتصالك بالإنترنت والمحاولة مرة أخرى.';
+
+  @override
+  String get tryAgain => 'حاول مرة أخرى';
+
+  @override
+  String get connectOmiOmiGlass => 'توصيل Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'متابعة بدون جهاز';
+
+  @override
+  String get permissionsRequired => 'الأذونات مطلوبة';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'يحتاج هذا التطبيق إلى أذونات البلوتوث والموقع للعمل بشكل صحيح. يرجى تمكينها في الإعدادات.';
+
+  @override
+  String get openSettings => 'فتح الإعدادات';
+
+  @override
+  String get wantDifferentName => 'تريد أن يُناديك باسم آخر؟';
+
+  @override
+  String get whatsYourName => 'ما اسمك؟';
+
+  @override
+  String get speakTranscribeSummarize => 'تحدث. انسخ. لخص.';
+
+  @override
+  String get signInWithApple => 'تسجيل الدخول باستخدام Apple';
+
+  @override
+  String get signInWithGoogle => 'تسجيل الدخول باستخدام Google';
+
+  @override
+  String get byContinuingAgree => 'بالمتابعة، فإنك توافق على ';
+
+  @override
+  String get termsOfUse => 'شروط الاستخدام';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – رفيقك الذكي';
+
+  @override
+  String get captureEveryMoment =>
+      'احتفظ بكل لحظة. احصل على ملخصات مدعومة بالذكاء الاصطناعي.\nلا تدون ملاحظات بعد الآن.';
+
+  @override
+  String get appleWatchSetup => 'إعداد Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'تم طلب الإذن!';
+
+  @override
+  String get microphonePermission => 'إذن الميكروفون';
+
+  @override
+  String get permissionGrantedNow => 'تم منح الإذن! الآن:\n\nافتح تطبيق Omi على ساعتك واضغط على \"متابعة\" أدناه';
+
+  @override
+  String get needMicrophonePermission =>
+      'نحتاج إذن الميكروفون.\n\n1. اضغط على \"منح الإذن\"\n2. اسمح على iPhone الخاص بك\n3. سيُغلق تطبيق الساعة\n4. أعد فتحه واضغط على \"متابعة\"';
+
+  @override
+  String get grantPermissionButton => 'منح الإذن';
+
+  @override
+  String get needHelp => 'تحتاج مساعدة؟';
+
+  @override
+  String get troubleshootingSteps =>
+      'استكشاف الأخطاء وإصلاحها:\n\n1. تأكد من تثبيت Omi على ساعتك\n2. افتح تطبيق Omi على ساعتك\n3. ابحث عن نافذة الإذن المنبثقة\n4. اضغط على \"السماح\" عند المطالبة\n5. سيغلق التطبيق على ساعتك - أعد فتحه\n6. ارجع واضغط على \"متابعة\" على iPhone الخاص بك';
+
+  @override
+  String get recordingStartedSuccessfully => 'بدأ التسجيل بنجاح!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'لم يتم منح الإذن بعد. يرجى التأكد من أنك سمحت بالوصول إلى الميكروفون وأعدت فتح التطبيق على ساعتك.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'خطأ في طلب الإذن: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'خطأ في بدء التسجيل: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'حدد لغتك الأساسية';
+
+  @override
+  String get languageBenefits => 'حدد لغتك للحصول على نسخ أكثر دقة وتجربة شخصية';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'ما هي لغتك الأساسية؟';
+
+  @override
+  String get selectYourLanguage => 'حدد لغتك';
+
+  @override
+  String get personalGrowthJourney => 'رحلة نموك الشخصية مع الذكاء الاصطناعي الذي يستمع إلى كل كلمة تقولها.';
+
+  @override
+  String get actionItemsTitle => 'المهام';
+
+  @override
+  String get actionItemsDescription => 'اضغط للتعديل • اضغط مطولاً للتحديد • اسحب للإجراءات';
+
+  @override
+  String get tabToDo => 'للقيام به';
+
+  @override
+  String get tabDone => 'تم';
+
+  @override
+  String get tabOld => 'قديم';
+
+  @override
+  String get emptyTodoMessage => '🎉 كل شيء محدث!\nلا توجد مهام معلقة';
+
+  @override
+  String get emptyDoneMessage => 'لا توجد عناصر مكتملة بعد';
+
+  @override
+  String get emptyOldMessage => '✅ لا توجد مهام قديمة';
+
+  @override
+  String get noItems => 'لا توجد عناصر';
+
+  @override
+  String get actionItemMarkedIncomplete => 'تم وضع علامة على المهمة كغير مكتملة';
+
+  @override
+  String get actionItemCompleted => 'تم إنجاز المهمة';
+
+  @override
+  String get deleteActionItemTitle => 'حذف المهمة';
+
+  @override
+  String get deleteActionItemMessage => 'هل أنت متأكد من رغبتك في حذف هذه المهمة؟';
+
+  @override
+  String get deleteSelectedItemsTitle => 'حذف العناصر المحددة';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'هل أنت متأكد من رغبتك في حذف $count مهمة محددة$s؟';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'تم حذف المهمة \"$description\"';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return 'تم حذف $count مهمة$s';
+  }
+
+  @override
+  String get failedToDeleteItem => 'فشل حذف المهمة';
+
+  @override
+  String get failedToDeleteItems => 'فشل حذف المهام';
+
+  @override
+  String get failedToDeleteSomeItems => 'فشل حذف بعض المهام';
+
+  @override
+  String get welcomeActionItemsTitle => 'جاهز للمهام';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'سيستخرج الذكاء الاصطناعي الخاص بك المهام والأعمال تلقائياً من محادثاتك. ستظهر هنا عند إنشائها.';
+
+  @override
+  String get autoExtractionFeature => 'يتم استخراجها تلقائياً من المحادثات';
+
+  @override
+  String get editSwipeFeature => 'اضغط للتعديل، اسحب للإكمال أو الحذف';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count محدد';
+  }
+
+  @override
+  String get selectAll => 'تحديد الكل';
+
+  @override
+  String get deleteSelected => 'حذف المحدد';
+
+  @override
+  String searchMemories(int count) {
+    return 'بحث في $count ذكرى';
+  }
+
+  @override
+  String get memoryDeleted => 'تم حذف الذكرى.';
+
+  @override
+  String get undo => 'تراجع';
+
+  @override
+  String get noMemoriesYet => 'لا توجد ذكريات بعد';
+
+  @override
+  String get noAutoMemories => 'لا توجد ذكريات مستخرجة تلقائياً بعد';
+
+  @override
+  String get noManualMemories => 'لا توجد ذكريات يدوية بعد';
+
+  @override
+  String get noMemoriesInCategories => 'لا توجد ذكريات في هذه الفئات';
+
+  @override
+  String get noMemoriesFound => 'لم يتم العثور على ذكريات';
+
+  @override
+  String get addFirstMemory => 'أضف ذكرتك الأولى';
+
+  @override
+  String get clearMemoryTitle => 'مسح ذاكرة Omi';
+
+  @override
+  String get clearMemoryMessage => 'هل أنت متأكد من رغبتك في مسح ذاكرة Omi؟ لا يمكن التراجع عن هذا الإجراء.';
+
+  @override
+  String get clearMemoryButton => 'مسح الذاكرة';
+
+  @override
+  String get memoryClearedSuccess => 'تم مسح ذاكرة Omi عنك';
+
+  @override
+  String get noMemoriesToDelete => 'لا توجد ذكريات لحذفها';
+
+  @override
+  String get createMemoryTooltip => 'إنشاء ذكرى جديدة';
+
+  @override
+  String get createActionItemTooltip => 'إنشاء مهمة جديدة';
+
+  @override
+  String get memoryManagement => 'إدارة الذاكرة';
+
+  @override
+  String get filterMemories => 'تصفية الذكريات';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'لديك $count ذكرى إجمالية';
+  }
+
+  @override
+  String get publicMemories => 'ذكريات عامة';
+
+  @override
+  String get privateMemories => 'ذكريات خاصة';
+
+  @override
+  String get makeAllPrivate => 'جعل جميع الذكريات خاصة';
+
+  @override
+  String get makeAllPublic => 'جعل جميع الذكريات عامة';
+
+  @override
+  String get deleteAllMemories => 'حذف جميع الذكريات';
+
+  @override
+  String get allMemoriesPrivateResult => 'جميع الذكريات خاصة الآن';
+
+  @override
+  String get allMemoriesPublicResult => 'جميع الذكريات عامة الآن';
+
+  @override
+  String get newMemory => 'ذكرى جديدة';
+
+  @override
+  String get editMemory => 'تعديل الذكرى';
+
+  @override
+  String get memoryContentHint => 'أحب تناول الآيس كريم...';
+
+  @override
+  String get failedToSaveMemory => 'فشل الحفظ. يرجى التحقق من اتصالك.';
+
+  @override
+  String get saveMemory => 'حفظ الذكرى';
+
+  @override
+  String get retry => 'إعادة المحاولة';
+
+  @override
+  String get createActionItem => 'إنشاء مهمة';
+
+  @override
+  String get editActionItem => 'تعديل المهمة';
+
+  @override
+  String get actionItemDescriptionHint => 'ما الذي يجب القيام به؟';
+
+  @override
+  String get actionItemDescriptionEmpty => 'لا يمكن أن يكون وصف المهمة فارغاً.';
+
+  @override
+  String get actionItemUpdated => 'تم تحديث المهمة';
+
+  @override
+  String get failedToUpdateActionItem => 'فشل تحديث المهمة';
+
+  @override
+  String get actionItemCreated => 'تم إنشاء المهمة';
+
+  @override
+  String get failedToCreateActionItem => 'فشل إنشاء المهمة';
+
+  @override
+  String get dueDate => 'تاريخ الاستحقاق';
+
+  @override
+  String get time => 'الوقت';
+
+  @override
+  String get addDueDate => 'إضافة تاريخ استحقاق';
+
+  @override
+  String get pressDoneToSave => 'اضغط على تم للحفظ';
+
+  @override
+  String get pressDoneToCreate => 'اضغط على تم للإنشاء';
+
+  @override
+  String get filterAll => 'الكل';
+
+  @override
+  String get filterSystem => 'عنك';
+
+  @override
+  String get filterInteresting => 'رؤى';
+
+  @override
+  String get filterManual => 'يدوي';
+
+  @override
+  String get completed => 'مكتمل';
+
+  @override
+  String get markComplete => 'وضع علامة كمكتمل';
+
+  @override
+  String get actionItemDeleted => 'تم حذف المهمة';
+
+  @override
+  String get failedToDeleteActionItem => 'فشل حذف المهمة';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'حذف المهمة';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'هل أنت متأكد من رغبتك في حذف هذه المهمة؟';
+
+  @override
+  String get appLanguage => 'لغة التطبيق';
+
+  @override
+  String get appInterfaceSectionTitle => 'واجهة التطبيق';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'الكلام والنسخ';
+
+  @override
+  String get languageSettingsHelperText => 'لغة التطبيق تغير القوائم والأزرار. لغة الكلام تؤثر على كيفية نسخ تسجيلاتك.';
+}

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -1,0 +1,2235 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Bulgarian (`bg`).
+class AppLocalizationsBg extends AppLocalizations {
+  AppLocalizationsBg([String locale = 'bg']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Разговор';
+
+  @override
+  String get transcriptTab => 'Транскрипт';
+
+  @override
+  String get actionItemsTab => 'Задачи';
+
+  @override
+  String get deleteConversationTitle => 'Изтриване на разговор?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Сигурни ли сте, че искате да изтриете този разговор? Това действие не може да бъде отменено.';
+
+  @override
+  String get confirm => 'Потвърди';
+
+  @override
+  String get cancel => 'Отказ';
+
+  @override
+  String get ok => 'ОК';
+
+  @override
+  String get delete => 'Изтрий';
+
+  @override
+  String get add => 'Добави';
+
+  @override
+  String get update => 'Актуализирай';
+
+  @override
+  String get save => 'Запази';
+
+  @override
+  String get edit => 'Редактирай';
+
+  @override
+  String get close => 'Затвори';
+
+  @override
+  String get clear => 'Изчисти';
+
+  @override
+  String get copyTranscript => 'Копирай транскрипт';
+
+  @override
+  String get copySummary => 'Копирай резюме';
+
+  @override
+  String get testPrompt => 'Тествай подсказка';
+
+  @override
+  String get reprocessConversation => 'Преработи разговор';
+
+  @override
+  String get deleteConversation => 'Изтрий разговор';
+
+  @override
+  String get contentCopied => 'Съдържанието е копирано в клипборда';
+
+  @override
+  String get failedToUpdateStarred => 'Неуспешна актуализация на статуса с отметка.';
+
+  @override
+  String get conversationUrlNotShared => 'URL адресът на разговора не можа да бъде споделен.';
+
+  @override
+  String get errorProcessingConversation => 'Грешка при обработка на разговора. Моля, опитайте отново по-късно.';
+
+  @override
+  String get noInternetConnection => 'Моля, проверете интернет връзката си и опитайте отново.';
+
+  @override
+  String get unableToDeleteConversation => 'Невъзможно изтриване на разговор';
+
+  @override
+  String get somethingWentWrong => 'Нещо се обърка! Моля, опитайте отново по-късно.';
+
+  @override
+  String get copyErrorMessage => 'Копирай съобщение за грешка';
+
+  @override
+  String get errorCopied => 'Съобщението за грешка е копирано в клипборда';
+
+  @override
+  String get remaining => 'Остават';
+
+  @override
+  String get loading => 'Зареждане...';
+
+  @override
+  String get loadingDuration => 'Зареждане на продължителност...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count секунди';
+  }
+
+  @override
+  String get people => 'Хора';
+
+  @override
+  String get addNewPerson => 'Добави нов човек';
+
+  @override
+  String get editPerson => 'Редактирай човек';
+
+  @override
+  String get createPersonHint => 'Създайте нов човек и обучете Omi да разпознава и тяхната реч!';
+
+  @override
+  String get speechProfile => 'Гласов профил';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Образец $number';
+  }
+
+  @override
+  String get settings => 'Настройки';
+
+  @override
+  String get language => 'Език';
+
+  @override
+  String get selectLanguage => 'Изберете език';
+
+  @override
+  String get deleting => 'Изтриване...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
+
+  @override
+  String get failedToStartAuthentication => 'Неуспешно стартиране на удостоверяване';
+
+  @override
+  String get importStarted => 'Импортирането започна! Ще получите известие, когато приключи.';
+
+  @override
+  String get failedToStartImport => 'Неуспешно стартиране на импортиране. Моля, опитайте отново.';
+
+  @override
+  String get couldNotAccessFile => 'Не можа да се получи достъп до избрания файл';
+
+  @override
+  String get askOmi => 'Попитай Omi';
+
+  @override
+  String get done => 'Готово';
+
+  @override
+  String get disconnected => 'Прекъснато';
+
+  @override
+  String get searching => 'Търсене';
+
+  @override
+  String get connectDevice => 'Свържи устройство';
+
+  @override
+  String get monthlyLimitReached => 'Достигнахте месечния си лимит.';
+
+  @override
+  String get checkUsage => 'Провери използване';
+
+  @override
+  String get syncingRecordings => 'Синхронизиране на записи';
+
+  @override
+  String get recordingsToSync => 'Записи за синхронизиране';
+
+  @override
+  String get allCaughtUp => 'Всичко е актуално';
+
+  @override
+  String get sync => 'Синхронизирай';
+
+  @override
+  String get pendantUpToDate => 'Медальонът е актуален';
+
+  @override
+  String get allRecordingsSynced => 'Всички записи са синхронизирани';
+
+  @override
+  String get syncingInProgress => 'Синхронизацията е в ход';
+
+  @override
+  String get readyToSync => 'Готово за синхронизация';
+
+  @override
+  String get tapSyncToStart => 'Натиснете Синхронизирай за начало';
+
+  @override
+  String get pendantNotConnected => 'Медальонът не е свързан. Свържете за синхронизация.';
+
+  @override
+  String get everythingSynced => 'Всичко вече е синхронизирано.';
+
+  @override
+  String get recordingsNotSynced => 'Имате записи, които все още не са синхронизирани.';
+
+  @override
+  String get syncingBackground => 'Ще продължим да синхронизираме записите ви във фонов режим.';
+
+  @override
+  String get noConversationsYet => 'Все още няма разговори.';
+
+  @override
+  String get noStarredConversations => 'Все още няма отбелязани разговори.';
+
+  @override
+  String get starConversationHint =>
+      'За да отбележите разговор, отворете го и натиснете иконката със звезда в заглавието.';
+
+  @override
+  String get searchConversations => 'Търсене на разговори';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count избрани';
+  }
+
+  @override
+  String get merge => 'Обедини';
+
+  @override
+  String get mergeConversations => 'Обедини разговори';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Това ще комбинира $count разговора в един. Всичко съдържание ще бъде обединено и регенерирано.';
+  }
+
+  @override
+  String get mergingInBackground => 'Обединяване във фонов режим. Това може да отнеме момент.';
+
+  @override
+  String get failedToStartMerge => 'Неуспешно стартиране на обединяване';
+
+  @override
+  String get askAnything => 'Попитайте каквото и да е';
+
+  @override
+  String get noMessagesYet => 'Все още няма съобщения!\nЗащо не започнете разговор?';
+
+  @override
+  String get deletingMessages => 'Изтриване на съобщенията ви от паметта на Omi...';
+
+  @override
+  String get messageCopied => 'Съобщението е копирано в клипборда.';
+
+  @override
+  String get cannotReportOwnMessage => 'Не можете да докладвате собствените си съобщения.';
+
+  @override
+  String get reportMessage => 'Докладвай съобщение';
+
+  @override
+  String get reportMessageConfirm => 'Сигурни ли сте, че искате да докладвате това съобщение?';
+
+  @override
+  String get messageReported => 'Съобщението е докладвано успешно.';
+
+  @override
+  String get thankYouFeedback => 'Благодарим за обратната връзка!';
+
+  @override
+  String get clearChat => 'Изчисти чат?';
+
+  @override
+  String get clearChatConfirm => 'Сигурни ли сте, че искате да изчистите чата? Това действие не може да бъде отменено.';
+
+  @override
+  String get maxFilesLimit => 'Можете да качите само 4 файла наведнъж';
+
+  @override
+  String get chatWithOmi => 'Чат с Omi';
+
+  @override
+  String get apps => 'Приложения';
+
+  @override
+  String get noAppsFound => 'Не са намерени приложения';
+
+  @override
+  String get tryAdjustingSearch => 'Опитайте да коригирате търсенето или филтрите си';
+
+  @override
+  String get createYourOwnApp => 'Създайте свое приложение';
+
+  @override
+  String get buildAndShareApp => 'Създайте и споделете персонализирано приложение';
+
+  @override
+  String get searchApps => 'Търсене в над 1500 приложения';
+
+  @override
+  String get myApps => 'Моите приложения';
+
+  @override
+  String get installedApps => 'Инсталирани приложения';
+
+  @override
+  String get unableToFetchApps =>
+      'Не могат да се заредят приложенията :(\n\nМоля, проверете интернет връзката си и опитайте отново.';
+
+  @override
+  String get aboutOmi => 'Относно Omi';
+
+  @override
+  String get privacyPolicy => 'Политика за поверителност';
+
+  @override
+  String get visitWebsite => 'Посетете уебсайта';
+
+  @override
+  String get helpOrInquiries => 'Помощ или запитвания?';
+
+  @override
+  String get joinCommunity => 'Присъединете се към общността!';
+
+  @override
+  String get membersAndCounting => '8000+ членове и продължават да се увеличават.';
+
+  @override
+  String get deleteAccountTitle => 'Изтриване на акаунт';
+
+  @override
+  String get deleteAccountConfirm => 'Сигурни ли сте, че искате да изтриете акаунта си?';
+
+  @override
+  String get cannotBeUndone => 'Това не може да бъде отменено.';
+
+  @override
+  String get allDataErased => 'Всички ваши спомени и разговори ще бъдат изтрити завинаги.';
+
+  @override
+  String get appsDisconnected => 'Вашите приложения и интеграции ще бъдат прекратени незабавно.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Можете да експортирате данните си преди да изтриете акаунта си, но след като бъде изтрит, не може да бъде възстановен.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Разбирам, че изтриването на акаунта ми е постоянно и всички данни, включително спомени и разговори, ще бъдат загубени и не могат да бъдат възстановени.';
+
+  @override
+  String get areYouSure => 'Сигурни ли сте?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Това действие е необратимо и ще изтрие завинаги вашия акаунт и всички свързани данни. Сигурни ли сте, че искате да продължите?';
+
+  @override
+  String get deleteNow => 'Изтрий сега';
+
+  @override
+  String get goBack => 'Назад';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Отметнете квадратчето, за да потвърдите, че разбирате, че изтриването на акаунта ви е постоянно и необратимо.';
+
+  @override
+  String get profile => 'Профил';
+
+  @override
+  String get name => 'Име';
+
+  @override
+  String get email => 'Имейл';
+
+  @override
+  String get customVocabulary => 'Персонализиран речник';
+
+  @override
+  String get identifyingOthers => 'Идентифициране на други';
+
+  @override
+  String get paymentMethods => 'Методи на плащане';
+
+  @override
+  String get conversationDisplay => 'Показване на разговор';
+
+  @override
+  String get dataPrivacy => 'Данни и поверителност';
+
+  @override
+  String get userId => 'ID на потребител';
+
+  @override
+  String get notSet => 'Не е зададено';
+
+  @override
+  String get userIdCopied => 'ID на потребителя е копиран в клипборда';
+
+  @override
+  String get systemDefault => 'По подразбиране на системата';
+
+  @override
+  String get planAndUsage => 'План и използване';
+
+  @override
+  String get offlineSync => 'Офлайн синхронизация';
+
+  @override
+  String get deviceSettings => 'Настройки на устройството';
+
+  @override
+  String get chatTools => 'Инструменти за чат';
+
+  @override
+  String get feedbackBug => 'Обратна връзка / Грешка';
+
+  @override
+  String get helpCenter => 'Център за помощ';
+
+  @override
+  String get developerSettings => 'Настройки за разработчици';
+
+  @override
+  String get getOmiForMac => 'Вземете Omi за Mac';
+
+  @override
+  String get referralProgram => 'Програма за препоръки';
+
+  @override
+  String get signOut => 'Излез';
+
+  @override
+  String get appAndDeviceCopied => 'Детайлите за приложението и устройството са копирани';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Вашата поверителност, вашият контрол';
+
+  @override
+  String get privacyIntro =>
+      'В Omi сме ангажирани със защитата на вашата поверителност. Тази страница ви позволява да контролирате как вашите данни се съхраняват и използват.';
+
+  @override
+  String get learnMore => 'Научете повече...';
+
+  @override
+  String get dataProtectionLevel => 'Ниво на защита на данните';
+
+  @override
+  String get dataProtectionDesc =>
+      'Вашите данни са защитени по подразбиране със силно криптиране. Прегледайте настройките си и бъдещите опции за поверителност по-долу.';
+
+  @override
+  String get appAccess => 'Достъп до приложение';
+
+  @override
+  String get appAccessDesc =>
+      'Следните приложения могат да имат достъп до вашите данни. Докоснете приложение, за да управлявате неговите разрешения.';
+
+  @override
+  String get noAppsExternalAccess => 'Няма инсталирани приложения с външен достъп до вашите данни.';
+
+  @override
+  String get deviceName => 'Име на устройство';
+
+  @override
+  String get deviceId => 'ID на устройство';
+
+  @override
+  String get firmware => 'Фърмуер';
+
+  @override
+  String get sdCardSync => 'Синхронизация на SD карта';
+
+  @override
+  String get hardwareRevision => 'Хардуерна ревизия';
+
+  @override
+  String get modelNumber => 'Модел номер';
+
+  @override
+  String get manufacturer => 'Производител';
+
+  @override
+  String get doubleTap => 'Двойно докосване';
+
+  @override
+  String get ledBrightness => 'Яркост на LED';
+
+  @override
+  String get micGain => 'Усилване на микрофон';
+
+  @override
+  String get disconnect => 'Прекъсни';
+
+  @override
+  String get forgetDevice => 'Забрави устройство';
+
+  @override
+  String get chargingIssues => 'Проблеми със зареждането';
+
+  @override
+  String get disconnectDevice => 'Прекъсни устройство';
+
+  @override
+  String get unpairDevice => 'Разедини устройство';
+
+  @override
+  String get unpairAndForget => 'Разедини и забрави устройство';
+
+  @override
+  String get deviceDisconnectedMessage => 'Вашият Omi беше прекъснат 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Устройството е разединено. Отидете в Настройки > Bluetooth и забравете устройството, за да завършите разединяването.';
+
+  @override
+  String get unpairDialogTitle => 'Разедини устройство';
+
+  @override
+  String get unpairDialogMessage =>
+      'Това ще разедини устройството, така че да може да бъде свързано с друг телефон. Ще трябва да отидете в Настройки > Bluetooth и да забравите устройството, за да завършите процеса.';
+
+  @override
+  String get deviceNotConnected => 'Устройството не е свързано';
+
+  @override
+  String get connectDeviceMessage =>
+      'Свържете вашето Omi устройство за достъп\nдо настройките на устройството и персонализация';
+
+  @override
+  String get deviceInfoSection => 'Информация за устройството';
+
+  @override
+  String get customizationSection => 'Персонализация';
+
+  @override
+  String get hardwareSection => 'Хардуер';
+
+  @override
+  String get v2Undetected => 'V2 не е открит';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Виждаме, че имате V1 устройство или устройството ви не е свързано. Функционалността на SD картата е налична само за V2 устройства.';
+
+  @override
+  String get endConversation => 'Край на разговор';
+
+  @override
+  String get pauseResume => 'Пауза/Възобнови';
+
+  @override
+  String get starConversation => 'Отбележи разговор';
+
+  @override
+  String get doubleTapAction => 'Действие при двойно докосване';
+
+  @override
+  String get endAndProcess => 'Край и обработка на разговор';
+
+  @override
+  String get pauseResumeRecording => 'Пауза/Възобнови записването';
+
+  @override
+  String get starOngoing => 'Отбележи текущ разговор';
+
+  @override
+  String get off => 'Изключено';
+
+  @override
+  String get max => 'Макс';
+
+  @override
+  String get mute => 'Заглуши';
+
+  @override
+  String get quiet => 'Тихо';
+
+  @override
+  String get normal => 'Нормално';
+
+  @override
+  String get high => 'Високо';
+
+  @override
+  String get micGainDescMuted => 'Микрофонът е заглушен';
+
+  @override
+  String get micGainDescLow => 'Много тихо - за шумни среди';
+
+  @override
+  String get micGainDescModerate => 'Тихо - за умерен шум';
+
+  @override
+  String get micGainDescNeutral => 'Неутрално - балансирано записване';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Леко засилено - нормално използване';
+
+  @override
+  String get micGainDescBoosted => 'Засилено - за тихи среди';
+
+  @override
+  String get micGainDescHigh => 'Високо - за далечни или тихи гласове';
+
+  @override
+  String get micGainDescVeryHigh => 'Много високо - за много тихи източници';
+
+  @override
+  String get micGainDescMax => 'Максимално - използвайте с внимание';
+
+  @override
+  String get developerSettingsTitle => 'Настройки за разработчици';
+
+  @override
+  String get saving => 'Запазване...';
+
+  @override
+  String get personaConfig => 'Конфигурирайте вашата AI персона';
+
+  @override
+  String get beta => 'БЕТА';
+
+  @override
+  String get transcription => 'Транскрипция';
+
+  @override
+  String get transcriptionConfig => 'Конфигурирай STT доставчик';
+
+  @override
+  String get conversationTimeout => 'Изчакване на разговор';
+
+  @override
+  String get conversationTimeoutConfig => 'Задайте кога разговорите приключват автоматично';
+
+  @override
+  String get importData => 'Импортирай данни';
+
+  @override
+  String get importDataConfig => 'Импортирайте данни от други източници';
+
+  @override
+  String get debugDiagnostics => 'Отстраняване на грешки и диагностика';
+
+  @override
+  String get endpointUrl => 'URL на крайна точка';
+
+  @override
+  String get noApiKeys => 'Все още няма API ключове';
+
+  @override
+  String get createKeyToStart => 'Създайте ключ, за да започнете';
+
+  @override
+  String get createKey => 'Създай ключ';
+
+  @override
+  String get docs => 'Документация';
+
+  @override
+  String get yourOmiInsights => 'Вашите Omi прозрения';
+
+  @override
+  String get today => 'Днес';
+
+  @override
+  String get thisMonth => 'Този месец';
+
+  @override
+  String get thisYear => 'Тази година';
+
+  @override
+  String get allTime => 'Цялото време';
+
+  @override
+  String get noActivityYet => 'Все още няма дейност';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Започнете разговор с Omi,\nза да видите прозренията си за използване тук.';
+
+  @override
+  String get listening => 'Слушане';
+
+  @override
+  String get listeningSubtitle => 'Общо време, през което Omi активно е слушал.';
+
+  @override
+  String get understanding => 'Разбиране';
+
+  @override
+  String get understandingSubtitle => 'Думи, разбрани от вашите разговори.';
+
+  @override
+  String get providing => 'Предоставяне';
+
+  @override
+  String get providingSubtitle => 'Задачи и бележки, автоматично записани.';
+
+  @override
+  String get remembering => 'Запомняне';
+
+  @override
+  String get rememberingSubtitle => 'Факти и детайли, запомнени за вас.';
+
+  @override
+  String get unlimitedPlan => 'Неограничен план';
+
+  @override
+  String get managePlan => 'Управлявай план';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Вашият план ще бъде анулиран на $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Вашият план се подновява на $date.';
+  }
+
+  @override
+  String get basicPlan => 'Безплатен план';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used от $limit мин използвани';
+  }
+
+  @override
+  String get upgrade => 'Надстрой';
+
+  @override
+  String get upgradeToUnlimited => 'Надстрой до неограничен';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Вашият план включва $limit безплатни минути на месец. Надстройте за неограничен достъп.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Споделям моите Omi статистики! (omi.me - вашият винаги включен AI асистент)';
+
+  @override
+  String get sharePeriodToday => 'Днес omi има:';
+
+  @override
+  String get sharePeriodMonth => 'Този месец omi има:';
+
+  @override
+  String get sharePeriodYear => 'Тази година omi има:';
+
+  @override
+  String get sharePeriodAllTime => 'Досега omi има:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Слушал $minutes минути';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Разбрал $words думи';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Предоставил $count прозрения';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Запомнил $count спомена';
+  }
+
+  @override
+  String get debugLogs => 'Дневници за отстраняване на грешки';
+
+  @override
+  String get debugLogsAutoDelete => 'Автоматично се изтриват след 3 дни.';
+
+  @override
+  String get debugLogsDesc => 'Помага за диагностициране на проблеми';
+
+  @override
+  String get noLogFilesFound => 'Не са намерени файлове с дневници.';
+
+  @override
+  String get omiDebugLog => 'Omi дневник за отстраняване на грешки';
+
+  @override
+  String get logShared => 'Дневникът е споделен';
+
+  @override
+  String get selectLogFile => 'Изберете файл с дневник';
+
+  @override
+  String get shareLogs => 'Споделете дневници';
+
+  @override
+  String get debugLogCleared => 'Дневникът за отстраняване на грешки е изчистен';
+
+  @override
+  String get exportStarted => 'Експортирането започна. Може да отнеме няколко секунди...';
+
+  @override
+  String get exportAllData => 'Експортирай всички данни';
+
+  @override
+  String get exportDataDesc => 'Експортирайте разговори в JSON файл';
+
+  @override
+  String get exportedConversations => 'Експортирани разговори от Omi';
+
+  @override
+  String get exportShared => 'Експортът е споделен';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Изтриване на граф на знанията?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Това ще изтрие всички производни данни от графа на знанията (възли и връзки). Вашите оригинални спомени ще останат в безопасност. Графът ще бъде възстановен с течение на времето или при следващо запитване.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Графът на знанията е изтрит успешно';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Неуспешно изтриване на граф: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Изтрий граф на знанията';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Изчисти всички възли и връзки';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP сървър';
+
+  @override
+  String get mcpServerDesc => 'Свържете AI асистенти с вашите данни';
+
+  @override
+  String get serverUrl => 'URL на сървър';
+
+  @override
+  String get urlCopied => 'URL е копиран';
+
+  @override
+  String get apiKeyAuth => 'Удостоверяване с API ключ';
+
+  @override
+  String get header => 'Заглавка';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID на клиент';
+
+  @override
+  String get clientSecret => 'Тайна на клиент';
+
+  @override
+  String get useMcpApiKey => 'Използвайте вашия MCP API ключ';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'События на разговор';
+
+  @override
+  String get newConversationCreated => 'Създаден нов разговор';
+
+  @override
+  String get realtimeTranscript => 'Транскрипт в реално време';
+
+  @override
+  String get transcriptReceived => 'Получен транскрипт';
+
+  @override
+  String get audioBytes => 'Аудио байтове';
+
+  @override
+  String get audioDataReceived => 'Получени аудио данни';
+
+  @override
+  String get intervalSeconds => 'Интервал (секунди)';
+
+  @override
+  String get daySummary => 'Дневно резюме';
+
+  @override
+  String get summaryGenerated => 'Генерирано резюме';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Добавете към claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Копирай конфигурация';
+
+  @override
+  String get configCopied => 'Конфигурацията е копирана в клипборда';
+
+  @override
+  String get listeningMins => 'Слушане (мин)';
+
+  @override
+  String get understandingWords => 'Разбиране (думи)';
+
+  @override
+  String get insights => 'Прозрения';
+
+  @override
+  String get memories => 'Спомени';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used от $limit мин използвани този месец';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used от $limit думи използвани този месец';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used от $limit прозрения получени този месец';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used от $limit спомена създадени този месец';
+  }
+
+  @override
+  String get visibility => 'Видимост';
+
+  @override
+  String get visibilitySubtitle => 'Контролирайте кои разговори се появяват във вашия списък';
+
+  @override
+  String get showShortConversations => 'Показвай кратки разговори';
+
+  @override
+  String get showShortConversationsDesc => 'Показвай разговори по-къси от прага';
+
+  @override
+  String get showDiscardedConversations => 'Показвай изхвърлени разговори';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Включи разговори, маркирани като изхвърлени';
+
+  @override
+  String get shortConversationThreshold => 'Праг за кратък разговор';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Разговорите по-къси от това ще бъдат скрити, освен ако не са активирани по-горе';
+
+  @override
+  String get durationThreshold => 'Праг на продължителност';
+
+  @override
+  String get durationThresholdDesc => 'Скривай разговори по-къси от това';
+
+  @override
+  String minLabel(int count) {
+    return '$count мин';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Персонализиран речник';
+
+  @override
+  String get addWords => 'Добавете думи';
+
+  @override
+  String get addWordsDesc => 'Имена, термини или необичайни думи';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Свържи';
+
+  @override
+  String get comingSoon => 'Скоро';
+
+  @override
+  String get chatToolsFooter => 'Свържете вашите приложения, за да виждате данни и метрики в чата.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Неуспешно стартиране на $appName удостоверяване';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Прекъсни връзката с $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Сигурни ли сте, че искате да прекъснете връзката с $appName? Можете да се свържете отново по всяко време.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Прекъсната връзка с $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Неуспешно прекъсване на връзката';
+
+  @override
+  String connectTo(String appName) {
+    return 'Свържи се с $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Ще трябва да упълномощите Omi за достъп до вашите $appName данни. Това ще отвори браузъра ви за удостоверяване.';
+  }
+
+  @override
+  String get continueAction => 'Продължи';
+
+  @override
+  String get languageTitle => 'Език';
+
+  @override
+  String get primaryLanguage => 'Основен език';
+
+  @override
+  String get automaticTranslation => 'Автоматичен превод';
+
+  @override
+  String get detectLanguages => 'Разпознавай 10+ езика';
+
+  @override
+  String get authorizeSavingRecordings => 'Разрешете запазване на записи';
+
+  @override
+  String get thanksForAuthorizing => 'Благодарим, че разрешихте!';
+
+  @override
+  String get needYourPermission => 'Нуждаем се от вашето разрешение';
+
+  @override
+  String get alreadyGavePermission =>
+      'Вече сте ни дали разрешение да запазваме вашите записи. Ето напомняне защо го нуждаем:';
+
+  @override
+  String get wouldLikePermission => 'Бихме искали вашето разрешение да запазваме вашите гласови записи. Ето защо:';
+
+  @override
+  String get improveSpeechProfile => 'Подобрете вашия гласов профил';
+
+  @override
+  String get improveSpeechProfileDesc => 'Използваме записи, за да обучим и подобрим вашия личен гласов профил.';
+
+  @override
+  String get trainFamilyProfiles => 'Обучете профили за приятели и семейство';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Вашите записи ни помагат да разпознаем и създадем профили за вашите приятели и семейство.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Подобрете точността на транскрипта';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'С подобряването на нашия модел, можем да предоставим по-добри резултати от транскрипцията за вашите записи.';
+
+  @override
+  String get legalNotice =>
+      'Юридическо уведомление: Законността на записването и съхраняването на гласови данни може да варира в зависимост от вашето местоположение и как използвате тази функция. Вие сте отговорни за спазването на местните закони и разпоредби.';
+
+  @override
+  String get alreadyAuthorized => 'Вече разрешено';
+
+  @override
+  String get authorize => 'Разреши';
+
+  @override
+  String get revokeAuthorization => 'Оттегли разрешение';
+
+  @override
+  String get authorizationSuccessful => 'Разрешението е успешно!';
+
+  @override
+  String get failedToAuthorize => 'Неуспешно разрешаване. Моля, опитайте отново.';
+
+  @override
+  String get authorizationRevoked => 'Разрешението е оттеглено.';
+
+  @override
+  String get recordingsDeleted => 'Записите са изтрити.';
+
+  @override
+  String get failedToRevoke => 'Неуспешно оттегляне на разрешение. Моля, опитайте отново.';
+
+  @override
+  String get permissionRevokedTitle => 'Разрешението е оттеглено';
+
+  @override
+  String get permissionRevokedMessage => 'Искате ли да премахнем и всички ваши съществуващи записи?';
+
+  @override
+  String get yes => 'Да';
+
+  @override
+  String get editName => 'Редактирай име';
+
+  @override
+  String get howShouldOmiCallYou => 'Как Omi да ви нарича?';
+
+  @override
+  String get enterYourName => 'Въведете вашето име';
+
+  @override
+  String get nameCannotBeEmpty => 'Името не може да бъде празно';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Името е актуализирано успешно!';
+
+  @override
+  String get calendarSettings => 'Настройки на календар';
+
+  @override
+  String get calendarProviders => 'Доставчици на календар';
+
+  @override
+  String get macOsCalendar => 'macOS Календар';
+
+  @override
+  String get connectMacOsCalendar => 'Свържете вашия локален macOS календар';
+
+  @override
+  String get googleCalendar => 'Google Календар';
+
+  @override
+  String get syncGoogleAccount => 'Синхронизирай с вашия Google акаунт';
+
+  @override
+  String get showMeetingsMenuBar => 'Показвай предстоящи срещи в лентата с менюта';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Показвай следващата ви среща и време до нея в macOS лентата с менюта';
+
+  @override
+  String get showEventsNoParticipants => 'Показвай събития без участници';
+
+  @override
+  String get showEventsNoParticipantsDesc => 'Когато е активирано, показва събития без участници или видео връзка.';
+
+  @override
+  String get yourMeetings => 'Вашите срещи';
+
+  @override
+  String get refresh => 'Обнови';
+
+  @override
+  String get noUpcomingMeetings => 'Няма намерени предстоящи срещи';
+
+  @override
+  String get checkingNextDays => 'Проверка на следващите 30 дни';
+
+  @override
+  String get tomorrow => 'Утре';
+
+  @override
+  String get googleCalendarComingSoon => 'Google Календар интеграция скоро!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Свързан като потребител: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Работно пространство по подразбиране';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Задачите ще бъдат създадени в това работно пространство';
+
+  @override
+  String get defaultProjectOptional => 'Проект по подразбиране (Незадължително)';
+
+  @override
+  String get leaveUnselectedTasks => 'Оставете неизбрано, за да създавате задачи без проект';
+
+  @override
+  String get noProjectsInWorkspace => 'Няма намерени проекти в това работно пространство';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Изберете колко дълго да се чака в тишина преди автоматично приключване на разговор:';
+
+  @override
+  String get timeout2Minutes => '2 минути';
+
+  @override
+  String get timeout2MinutesDesc => 'Приключи разговор след 2 минути тишина';
+
+  @override
+  String get timeout5Minutes => '5 минути';
+
+  @override
+  String get timeout5MinutesDesc => 'Приключи разговор след 5 минути тишина';
+
+  @override
+  String get timeout10Minutes => '10 минути';
+
+  @override
+  String get timeout10MinutesDesc => 'Приключи разговор след 10 минути тишина';
+
+  @override
+  String get timeout30Minutes => '30 минути';
+
+  @override
+  String get timeout30MinutesDesc => 'Приключи разговор след 30 минути тишина';
+
+  @override
+  String get timeout4Hours => '4 часа';
+
+  @override
+  String get timeout4HoursDesc => 'Приключи разговор след 4 часа тишина';
+
+  @override
+  String get conversationEndAfterHours => 'Разговорите сега ще приключват след 4 часа тишина';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Разговорите сега ще приключват след $minutes минута(и) тишина';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Кажете ни вашия основен език';
+
+  @override
+  String get languageForTranscription => 'Задайте вашия език за по-точни транскрипции и персонализирано изживяване.';
+
+  @override
+  String get singleLanguageModeInfo => 'Режимът с един език е активиран. Преводът е деактивиран за по-висока точност.';
+
+  @override
+  String get searchLanguageHint => 'Търсете език по име или код';
+
+  @override
+  String get noLanguagesFound => 'Не са намерени езици';
+
+  @override
+  String get skip => 'Пропусни';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Езикът е зададен на $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Неуспешно задаване на език';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName Настройки';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Прекъсни връзката с $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Това ще премахне вашето $appName удостоверяване. Ще трябва да се свържете отново, за да го използвате.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Свързан с $appName';
+  }
+
+  @override
+  String get account => 'Акаунт';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Вашите задачи ще бъдат синхронизирани с вашия $appName акаунт';
+  }
+
+  @override
+  String get defaultSpace => 'Пространство по подразбиране';
+
+  @override
+  String get selectSpaceInWorkspace => 'Изберете пространство във вашето работно пространство';
+
+  @override
+  String get noSpacesInWorkspace => 'Няма намерени пространства в това работно пространство';
+
+  @override
+  String get defaultList => 'Списък по подразбиране';
+
+  @override
+  String get tasksAddedToList => 'Задачите ще бъдат добавени в този списък';
+
+  @override
+  String get noListsInSpace => 'Няма намерени списъци в това пространство';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Неуспешно зареждане на хранилища: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Хранилището по подразбиране е запазено';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Неуспешно запазване на хранилище по подразбиране';
+
+  @override
+  String get defaultRepository => 'Хранилище по подразбиране';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Изберете хранилище по подразбиране за създаване на проблеми. Все още можете да посочите различно хранилище при създаване на проблеми.';
+
+  @override
+  String get noReposFound => 'Не са намерени хранилища';
+
+  @override
+  String get private => 'Частно';
+
+  @override
+  String updatedDate(String date) {
+    return 'Актуализиран $date';
+  }
+
+  @override
+  String get yesterday => 'вчера';
+
+  @override
+  String daysAgo(int count) {
+    return 'преди $count дни';
+  }
+
+  @override
+  String get oneWeekAgo => 'преди 1 седмица';
+
+  @override
+  String weeksAgo(int count) {
+    return 'преди $count седмици';
+  }
+
+  @override
+  String get oneMonthAgo => 'преди 1 месец';
+
+  @override
+  String monthsAgo(int count) {
+    return 'преди $count месеца';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Проблемите ще бъдат създадени във вашето хранилище по подразбиране';
+
+  @override
+  String get taskIntegrations => 'Интеграции на задачи';
+
+  @override
+  String get configureSettings => 'Конфигурирай настройки';
+
+  @override
+  String get completeAuthBrowser =>
+      'Моля, завършете удостоверяването в браузъра си. След това се върнете в приложението.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Неуспешно стартиране на $appName удостоверяване';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Свържи се с $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Ще трябва да упълномощите Omi за създаване на задачи в вашия $appName акаунт. Това ще отвори браузъра ви за удостоверяване.';
+  }
+
+  @override
+  String get continueButton => 'Продължи';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName Интеграция';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Интеграцията с $appName идва скоро! Работим усилено, за да ви предоставим повече опции за управление на задачи.';
+  }
+
+  @override
+  String get gotIt => 'Разбрах';
+
+  @override
+  String get tasksExportedOneApp => 'Задачите могат да бъдат експортирани в едно приложение наведнъж.';
+
+  @override
+  String get completeYourUpgrade => 'Завършете вашата надстройка';
+
+  @override
+  String get importConfiguration => 'Импортирай конфигурация';
+
+  @override
+  String get exportConfiguration => 'Експортирай конфигурация';
+
+  @override
+  String get bringYourOwn => 'Донесете свой собствен';
+
+  @override
+  String get payYourSttProvider => 'Използвайте omi свободно. Плащате само на вашия STT доставчик директно.';
+
+  @override
+  String get freeMinutesMonth => '1 200 безплатни минути/месец включени. Неограничено с ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Хостът е задължителен';
+
+  @override
+  String get validPortRequired => 'Валиден порт е задължителен';
+
+  @override
+  String get validWebsocketUrlRequired => 'Валиден WebSocket URL е задължителен (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL е задължителен';
+
+  @override
+  String get apiKeyRequired => 'API ключ е задължителен';
+
+  @override
+  String get invalidJsonConfig => 'Невалидна JSON конфигурация';
+
+  @override
+  String errorSaving(String error) {
+    return 'Грешка при запазване: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Конфигурацията е копирана в клипборда';
+
+  @override
+  String get pasteJsonConfig => 'Поставете вашата JSON конфигурация по-долу:';
+
+  @override
+  String get addApiKeyAfterImport => 'Ще трябва да добавите собствен API ключ след импортиране';
+
+  @override
+  String get paste => 'Постави';
+
+  @override
+  String get import => 'Импортирай';
+
+  @override
+  String get invalidProviderInConfig => 'Невалиден доставчик в конфигурацията';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Импортирана $providerName конфигурация';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Невалиден JSON: $error';
+  }
+
+  @override
+  String get provider => 'Доставчик';
+
+  @override
+  String get live => 'На живо';
+
+  @override
+  String get onDevice => 'На устройството';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Въведете вашата STT HTTP крайна точка';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Въведете вашата STT WebSocket крайна точка на живо';
+
+  @override
+  String get apiKey => 'API ключ';
+
+  @override
+  String get enterApiKey => 'Въведете вашия API ключ';
+
+  @override
+  String get storedLocallyNeverShared => 'Съхранено локално, никога не се споделя';
+
+  @override
+  String get host => 'Хост';
+
+  @override
+  String get port => 'Порт';
+
+  @override
+  String get advanced => 'Разширени';
+
+  @override
+  String get configuration => 'Конфигурация';
+
+  @override
+  String get requestConfiguration => 'Конфигурация на заявка';
+
+  @override
+  String get responseSchema => 'Схема на отговор';
+
+  @override
+  String get modified => 'Модифициран';
+
+  @override
+  String get resetRequestConfig => 'Нулирай конфигурацията на заявката по подразбиране';
+
+  @override
+  String get logs => 'Дневници';
+
+  @override
+  String get logsCopied => 'Дневниците са копирани';
+
+  @override
+  String get noLogsYet =>
+      'Все още няма дневници. Започнете записване, за да видите активността на персонализирания STT.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName използва $codecReason. Ще се използва Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi транскрипция';
+
+  @override
+  String get bestInClassTranscription => 'Най-добра транскрипция в класа си без настройки';
+
+  @override
+  String get instantSpeakerLabels => 'Моментални етикети на говорител';
+
+  @override
+  String get languageTranslation => 'Превод на 100+ езика';
+
+  @override
+  String get optimizedForConversation => 'Оптимизирано за разговор';
+
+  @override
+  String get autoLanguageDetection => 'Автоматично разпознаване на език';
+
+  @override
+  String get highAccuracy => 'Висока точност';
+
+  @override
+  String get privacyFirst => 'Поверителност на първо място';
+
+  @override
+  String get saveChanges => 'Запази промени';
+
+  @override
+  String get resetToDefault => 'Нулирай по подразбиране';
+
+  @override
+  String get viewTemplate => 'Виж шаблон';
+
+  @override
+  String get trySomethingLike => 'Опитайте нещо като...';
+
+  @override
+  String get tryIt => 'Опитай го';
+
+  @override
+  String get creatingPlan => 'Създаване на план';
+
+  @override
+  String get developingLogic => 'Разработване на логика';
+
+  @override
+  String get designingApp => 'Дизайниране на приложение';
+
+  @override
+  String get generatingIconStep => 'Генериране на икона';
+
+  @override
+  String get finalTouches => 'Финални щрихи';
+
+  @override
+  String get processing => 'Обработка...';
+
+  @override
+  String get features => 'Функции';
+
+  @override
+  String get creatingYourApp => 'Създаване на вашето приложение...';
+
+  @override
+  String get generatingIcon => 'Генериране на икона...';
+
+  @override
+  String get whatShouldWeMake => 'Какво да направим?';
+
+  @override
+  String get appName => 'Име на приложение';
+
+  @override
+  String get description => 'Описание';
+
+  @override
+  String get publicLabel => 'Публично';
+
+  @override
+  String get privateLabel => 'Частно';
+
+  @override
+  String get free => 'Безплатно';
+
+  @override
+  String get perMonth => '/ Месец';
+
+  @override
+  String get tailoredConversationSummaries => 'Персонализирани резюмета на разговори';
+
+  @override
+  String get customChatbotPersonality => 'Персонализирана личност на чатбот';
+
+  @override
+  String get makePublic => 'Направи публично';
+
+  @override
+  String get anyoneCanDiscover => 'Всеки може да открие вашето приложение';
+
+  @override
+  String get onlyYouCanUse => 'Само вие можете да използвате това приложение';
+
+  @override
+  String get paidApp => 'Платено приложение';
+
+  @override
+  String get usersPayToUse => 'Потребителите плащат, за да използват вашето приложение';
+
+  @override
+  String get freeForEveryone => 'Безплатно за всички';
+
+  @override
+  String get perMonthLabel => '/ месец';
+
+  @override
+  String get creating => 'Създаване...';
+
+  @override
+  String get createApp => 'Създай приложение';
+
+  @override
+  String get searchingForDevices => 'Търсене на устройства...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'УСТРОЙСТВА',
+      one: 'УСТРОЙСТВО',
+    );
+    return '$count $_temp0 НАМЕРЕНИ НАБЛИЗО';
+  }
+
+  @override
+  String get pairingSuccessful => 'СДВОЯВАНЕТО Е УСПЕШНО';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Грешка при свързване с Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Не го показвай отново';
+
+  @override
+  String get iUnderstand => 'Разбирам';
+
+  @override
+  String get enableBluetooth => 'Активирай Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi се нуждае от Bluetooth, за да се свърже с вашето носимо устройство. Моля, активирайте Bluetooth и опитайте отново.';
+
+  @override
+  String get contactSupport => 'Свържете се с поддръжката?';
+
+  @override
+  String get connectLater => 'Свържи по-късно';
+
+  @override
+  String get grantPermissions => 'Дайте разрешения';
+
+  @override
+  String get backgroundActivity => 'Фонова активност';
+
+  @override
+  String get backgroundActivityDesc => 'Позволете на Omi да работи на заден план за по-добра стабилност';
+
+  @override
+  String get locationAccess => 'Достъп до местоположение';
+
+  @override
+  String get locationAccessDesc => 'Активирайте фоново местоположение за пълното изживяване';
+
+  @override
+  String get notifications => 'Известия';
+
+  @override
+  String get notificationsDesc => 'Активирайте известия, за да сте информирани';
+
+  @override
+  String get locationServiceDisabled => 'Услугата за местоположение е деактивирана';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Услугата за местоположение е деактивирана. Моля, отидете в Настройки > Поверителност и сигурност > Услуги за местоположение и я активирайте';
+
+  @override
+  String get backgroundLocationDenied => 'Отказан достъп до фоново местоположение';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Моля, отидете в настройките на устройството и задайте разрешението за местоположение на \"Винаги разрешавай\"';
+
+  @override
+  String get lovingOmi => 'Обичате ли Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Помогнете ни да достигнем до повече хора, като оставите отзив в App Store. Вашата обратна връзка е много важна за нас!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Помогнете ни да достигнем до повече хора, като оставите отзив в Google Play Store. Вашата обратна връзка е много важна за нас!';
+
+  @override
+  String get rateOnAppStore => 'Оценете в App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Оценете в Google Play';
+
+  @override
+  String get maybeLater => 'Може би по-късно';
+
+  @override
+  String get speechProfileIntro => 'Omi трябва да научи вашите цели и вашия глас. Ще можете да го промените по-късно.';
+
+  @override
+  String get getStarted => 'Започнете';
+
+  @override
+  String get allDone => 'Готово!';
+
+  @override
+  String get keepGoing => 'Продължавайте, справяте се страхотно';
+
+  @override
+  String get skipThisQuestion => 'Пропусни този въпрос';
+
+  @override
+  String get skipForNow => 'Пропусни засега';
+
+  @override
+  String get connectionError => 'Грешка в връзката';
+
+  @override
+  String get connectionErrorDesc =>
+      'Неуспешна връзка със сървъра. Моля, проверете интернет връзката си и опитайте отново.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Открит е невалиден запис';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Изглежда има множество говорители в записа. Моля, уверете се, че сте на тихо място и опитайте отново.';
+
+  @override
+  String get tooShortDesc => 'Не е открита достатъчно реч. Моля, говорете повече и опитайте отново.';
+
+  @override
+  String get invalidRecordingDesc => 'Моля, уверете се, че говорите поне 5 секунди и не повече от 90.';
+
+  @override
+  String get areYouThere => 'Там ли сте?';
+
+  @override
+  String get noSpeechDesc =>
+      'Не можахме да открием реч. Моля, уверете се, че говорите поне 10 секунди и не повече от 3 минути.';
+
+  @override
+  String get connectionLost => 'Връзката е изгубена';
+
+  @override
+  String get connectionLostDesc => 'Връзката беше прекъсната. Моля, проверете интернет връзката си и опитайте отново.';
+
+  @override
+  String get tryAgain => 'Опитай отново';
+
+  @override
+  String get connectOmiOmiGlass => 'Свържи Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Продължи без устройство';
+
+  @override
+  String get permissionsRequired => 'Изискват се разрешения';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Това приложение се нуждае от разрешения за Bluetooth и местоположение, за да функционира правилно. Моля, активирайте ги в настройките.';
+
+  @override
+  String get openSettings => 'Отвори настройки';
+
+  @override
+  String get wantDifferentName => 'Искате ли различно име?';
+
+  @override
+  String get whatsYourName => 'Как се казвате?';
+
+  @override
+  String get speakTranscribeSummarize => 'Говорете. Транскрибирайте. Обобщавайте.';
+
+  @override
+  String get signInWithApple => 'Влезте с Apple';
+
+  @override
+  String get signInWithGoogle => 'Влезте с Google';
+
+  @override
+  String get byContinuingAgree => 'Като продължавате, вие се съгласявате с нашата ';
+
+  @override
+  String get termsOfUse => 'Условия за ползване';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Вашият AI спътник';
+
+  @override
+  String get captureEveryMoment => 'Уловете всеки момент. Получавайте резюмета с\nAI. Никога повече бележки.';
+
+  @override
+  String get appleWatchSetup => 'Настройка на Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Разрешение заявено!';
+
+  @override
+  String get microphonePermission => 'Разрешение за микрофон';
+
+  @override
+  String get permissionGrantedNow =>
+      'Разрешението е дадено! Сега:\n\nОтворете приложението Omi на часовника си и натиснете \"Продължи\" по-долу';
+
+  @override
+  String get needMicrophonePermission =>
+      'Нуждаем се от разрешение за микрофон.\n\n1. Натиснете \"Дайте разрешение\"\n2. Разрешете на вашия iPhone\n3. Приложението на часовника ще се затвори\n4. Отворете отново и натиснете \"Продължи\"';
+
+  @override
+  String get grantPermissionButton => 'Дайте разрешение';
+
+  @override
+  String get needHelp => 'Нужда от помощ?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Отстраняване на проблеми:\n\n1. Уверете се, че Omi е инсталиран на часовника ви\n2. Отворете приложението Omi на часовника си\n3. Потърсете изскачащия прозорец за разрешение\n4. Натиснете \"Разреши\" когато бъдете подканени\n5. Приложението на часовника ще се затвори - отворете го отново\n6. Върнете се и натиснете \"Продължи\" на вашия iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Записването започна успешно!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Разрешението все още не е дадено. Моля, уверете се, че сте разрешили достъп до микрофона и сте отворили отново приложението на часовника си.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Грешка при заявяване на разрешение: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Грешка при стартиране на записване: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Изберете вашия основен език';
+
+  @override
+  String get languageBenefits => 'Задайте вашия език за по-точни транскрипции и персонализирано изживяване';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Кой е вашият основен език?';
+
+  @override
+  String get selectYourLanguage => 'Изберете вашия език';
+
+  @override
+  String get personalGrowthJourney => 'Вашето пътешествие на личностен растеж с AI, който слуша всяка ваша дума.';
+
+  @override
+  String get actionItemsTitle => 'Задачи';
+
+  @override
+  String get actionItemsDescription => 'Докоснете за редактиране • Натиснете дълго за избор • Плъзнете за действия';
+
+  @override
+  String get tabToDo => 'За изпълнение';
+
+  @override
+  String get tabDone => 'Готово';
+
+  @override
+  String get tabOld => 'Стари';
+
+  @override
+  String get emptyTodoMessage => '🎉 Всичко е актуално!\nНяма чакащи задачи';
+
+  @override
+  String get emptyDoneMessage => 'Все още няма завършени елементи';
+
+  @override
+  String get emptyOldMessage => '✅ Няма стари задачи';
+
+  @override
+  String get noItems => 'Няма елементи';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Задачата е маркирана като незавършена';
+
+  @override
+  String get actionItemCompleted => 'Задачата е завършена';
+
+  @override
+  String get deleteActionItemTitle => 'Изтриване на задача';
+
+  @override
+  String get deleteActionItemMessage => 'Сигурни ли сте, че искате да изтриете тази задача?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Изтриване на избраните елементи';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Сигурни ли сте, че искате да изтриете $count избрана(и) задача(и)$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Задачата \"$description\" е изтрита';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count задача(и)$s изтрити';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Неуспешно изтриване на задача';
+
+  @override
+  String get failedToDeleteItems => 'Неуспешно изтриване на елементи';
+
+  @override
+  String get failedToDeleteSomeItems => 'Неуспешно изтриване на някои елементи';
+
+  @override
+  String get welcomeActionItemsTitle => 'Готови за задачи';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Вашият AI автоматично ще извлича задачи и дейности от вашите разговори. Те ще се появят тук, когато бъдат създадени.';
+
+  @override
+  String get autoExtractionFeature => 'Автоматично извлечени от разговори';
+
+  @override
+  String get editSwipeFeature => 'Докоснете за редактиране, плъзнете за завършване или изтриване';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count избрани';
+  }
+
+  @override
+  String get selectAll => 'Избери всички';
+
+  @override
+  String get deleteSelected => 'Изтрий избраните';
+
+  @override
+  String searchMemories(int count) {
+    return 'Търсене в $count спомени';
+  }
+
+  @override
+  String get memoryDeleted => 'Споменът е изтрит.';
+
+  @override
+  String get undo => 'Отмени';
+
+  @override
+  String get noMemoriesYet => 'Все още няма спомени';
+
+  @override
+  String get noAutoMemories => 'Все още няма автоматично извлечени спомени';
+
+  @override
+  String get noManualMemories => 'Все още няма ръчно добавени спомени';
+
+  @override
+  String get noMemoriesInCategories => 'Няма спомени в тези категории';
+
+  @override
+  String get noMemoriesFound => 'Не са намерени спомени';
+
+  @override
+  String get addFirstMemory => 'Добавете вашия първи спомен';
+
+  @override
+  String get clearMemoryTitle => 'Изчистване на паметта на Omi';
+
+  @override
+  String get clearMemoryMessage =>
+      'Сигурни ли сте, че искате да изчистите паметта на Omi? Това действие не може да бъде отменено.';
+
+  @override
+  String get clearMemoryButton => 'Изчисти паметта';
+
+  @override
+  String get memoryClearedSuccess => 'Паметта на Omi за вас е изчистена';
+
+  @override
+  String get noMemoriesToDelete => 'Няма спомени за изтриване';
+
+  @override
+  String get createMemoryTooltip => 'Създай нов спомен';
+
+  @override
+  String get createActionItemTooltip => 'Създай нова задача';
+
+  @override
+  String get memoryManagement => 'Управление на паметта';
+
+  @override
+  String get filterMemories => 'Филтриране на спомени';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Имате общо $count спомена';
+  }
+
+  @override
+  String get publicMemories => 'Публични спомени';
+
+  @override
+  String get privateMemories => 'Частни спомени';
+
+  @override
+  String get makeAllPrivate => 'Направи всички спомени частни';
+
+  @override
+  String get makeAllPublic => 'Направи всички спомени публични';
+
+  @override
+  String get deleteAllMemories => 'Изтрий всички спомени';
+
+  @override
+  String get allMemoriesPrivateResult => 'Всички спомени сега са частни';
+
+  @override
+  String get allMemoriesPublicResult => 'Всички спомени сега са публични';
+
+  @override
+  String get newMemory => 'Нов спомен';
+
+  @override
+  String get editMemory => 'Редактирай спомен';
+
+  @override
+  String get memoryContentHint => 'Обичам да ям сладолед...';
+
+  @override
+  String get failedToSaveMemory => 'Неуспешно запазване. Моля, проверете връзката си.';
+
+  @override
+  String get saveMemory => 'Запази спомен';
+
+  @override
+  String get retry => 'Опитай отново';
+
+  @override
+  String get createActionItem => 'Създай задача';
+
+  @override
+  String get editActionItem => 'Редактирай задача';
+
+  @override
+  String get actionItemDescriptionHint => 'Какво трябва да се направи?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Описанието на задачата не може да бъде празно.';
+
+  @override
+  String get actionItemUpdated => 'Задачата е актуализирана';
+
+  @override
+  String get failedToUpdateActionItem => 'Неуспешна актуализация на задачата';
+
+  @override
+  String get actionItemCreated => 'Задачата е създадена';
+
+  @override
+  String get failedToCreateActionItem => 'Неуспешно създаване на задача';
+
+  @override
+  String get dueDate => 'Краен срок';
+
+  @override
+  String get time => 'Час';
+
+  @override
+  String get addDueDate => 'Добави краен срок';
+
+  @override
+  String get pressDoneToSave => 'Натиснете готово за запазване';
+
+  @override
+  String get pressDoneToCreate => 'Натиснете готово за създаване';
+
+  @override
+  String get filterAll => 'Всички';
+
+  @override
+  String get filterSystem => 'За вас';
+
+  @override
+  String get filterInteresting => 'Прозрения';
+
+  @override
+  String get filterManual => 'Ръчно';
+
+  @override
+  String get completed => 'Завършено';
+
+  @override
+  String get markComplete => 'Маркирай като завършено';
+
+  @override
+  String get actionItemDeleted => 'Задачата е изтрита';
+
+  @override
+  String get failedToDeleteActionItem => 'Неуспешно изтриване на задача';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Изтриване на задача';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Сигурни ли сте, че искате да изтриете тази задача?';
+
+  @override
+  String get appLanguage => 'Език на приложението';
+
+  @override
+  String get appInterfaceSectionTitle => 'ИНТЕРФЕЙС НА ПРИЛОЖЕНИЕТО';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'РЕЧ И ТРАНСКРИПЦИЯ';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Езикът на приложението променя менютата и бутоните. Езикът на речта влияе на начина, по който се транскрибират вашите записи.';
+}

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -1,0 +1,2243 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Catalan Valencian (`ca`).
+class AppLocalizationsCa extends AppLocalizations {
+  AppLocalizationsCa([String locale = 'ca']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Conversa';
+
+  @override
+  String get transcriptTab => 'Transcripció';
+
+  @override
+  String get actionItemsTab => 'Tasques';
+
+  @override
+  String get deleteConversationTitle => 'Eliminar conversa?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Esteu segur que voleu eliminar aquesta conversa? Aquesta acció no es pot desfer.';
+
+  @override
+  String get confirm => 'Confirmar';
+
+  @override
+  String get cancel => 'Cancel·lar';
+
+  @override
+  String get ok => 'D\'acord';
+
+  @override
+  String get delete => 'Eliminar';
+
+  @override
+  String get add => 'Afegir';
+
+  @override
+  String get update => 'Actualitzar';
+
+  @override
+  String get save => 'Desar';
+
+  @override
+  String get edit => 'Editar';
+
+  @override
+  String get close => 'Tancar';
+
+  @override
+  String get clear => 'Netejar';
+
+  @override
+  String get copyTranscript => 'Copiar transcripció';
+
+  @override
+  String get copySummary => 'Copiar resum';
+
+  @override
+  String get testPrompt => 'Provar indicació';
+
+  @override
+  String get reprocessConversation => 'Reprocessar conversa';
+
+  @override
+  String get deleteConversation => 'Eliminar conversa';
+
+  @override
+  String get contentCopied => 'Contingut copiat al porta-retalls';
+
+  @override
+  String get failedToUpdateStarred => 'No s\'ha pogut actualitzar l\'estat de destacat.';
+
+  @override
+  String get conversationUrlNotShared => 'No s\'ha pogut compartir l\'URL de la conversa.';
+
+  @override
+  String get errorProcessingConversation => 'Error en processar la conversa. Torneu-ho a provar més tard.';
+
+  @override
+  String get noInternetConnection => 'Comproveu la vostra connexió a internet i torneu-ho a provar.';
+
+  @override
+  String get unableToDeleteConversation => 'No es pot eliminar la conversa';
+
+  @override
+  String get somethingWentWrong => 'Alguna cosa ha anat malament! Torneu-ho a provar més tard.';
+
+  @override
+  String get copyErrorMessage => 'Copiar missatge d\'error';
+
+  @override
+  String get errorCopied => 'Missatge d\'error copiat al porta-retalls';
+
+  @override
+  String get remaining => 'Restants';
+
+  @override
+  String get loading => 'Carregant...';
+
+  @override
+  String get loadingDuration => 'Carregant durada...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count segons';
+  }
+
+  @override
+  String get people => 'Persones';
+
+  @override
+  String get addNewPerson => 'Afegir nova persona';
+
+  @override
+  String get editPerson => 'Editar persona';
+
+  @override
+  String get createPersonHint => 'Creeu una nova persona i ensenyeu a Omi a reconèixer la seva veu també!';
+
+  @override
+  String get speechProfile => 'Perfil de veu';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Mostra $number';
+  }
+
+  @override
+  String get settings => 'Configuració';
+
+  @override
+  String get language => 'Idioma';
+
+  @override
+  String get selectLanguage => 'Seleccionar idioma';
+
+  @override
+  String get deleting => 'Eliminant...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Completeu l\'autenticació al vostre navegador. Un cop fet, torneu a l\'aplicació.';
+
+  @override
+  String get failedToStartAuthentication => 'No s\'ha pogut iniciar l\'autenticació';
+
+  @override
+  String get importStarted => 'Importació iniciada! Se us notificarà quan estigui completa.';
+
+  @override
+  String get failedToStartImport => 'No s\'ha pogut iniciar la importació. Torneu-ho a provar.';
+
+  @override
+  String get couldNotAccessFile => 'No s\'ha pogut accedir al fitxer seleccionat';
+
+  @override
+  String get askOmi => 'Preguntar a Omi';
+
+  @override
+  String get done => 'Fet';
+
+  @override
+  String get disconnected => 'Desconnectat';
+
+  @override
+  String get searching => 'Cercant';
+
+  @override
+  String get connectDevice => 'Connectar dispositiu';
+
+  @override
+  String get monthlyLimitReached => 'Heu arribat al vostre límit mensual.';
+
+  @override
+  String get checkUsage => 'Comprovar ús';
+
+  @override
+  String get syncingRecordings => 'Sincronitzant enregistraments';
+
+  @override
+  String get recordingsToSync => 'Enregistraments per sincronitzar';
+
+  @override
+  String get allCaughtUp => 'Tot al dia';
+
+  @override
+  String get sync => 'Sincronitzar';
+
+  @override
+  String get pendantUpToDate => 'El penjoll està actualitzat';
+
+  @override
+  String get allRecordingsSynced => 'Tots els enregistraments estan sincronitzats';
+
+  @override
+  String get syncingInProgress => 'Sincronització en curs';
+
+  @override
+  String get readyToSync => 'Llest per sincronitzar';
+
+  @override
+  String get tapSyncToStart => 'Toqueu Sincronitzar per començar';
+
+  @override
+  String get pendantNotConnected => 'Penjoll no connectat. Connecteu-lo per sincronitzar.';
+
+  @override
+  String get everythingSynced => 'Tot està ja sincronitzat.';
+
+  @override
+  String get recordingsNotSynced => 'Teniu enregistraments que encara no s\'han sincronitzat.';
+
+  @override
+  String get syncingBackground => 'Continuarem sincronitzant els vostres enregistraments en segon pla.';
+
+  @override
+  String get noConversationsYet => 'Encara no hi ha converses.';
+
+  @override
+  String get noStarredConversations => 'Encara no hi ha converses destacades.';
+
+  @override
+  String get starConversationHint =>
+      'Per destacar una conversa, obriu-la i toqueu la icona d\'estrella a la capçalera.';
+
+  @override
+  String get searchConversations => 'Cercar converses';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count seleccionats';
+  }
+
+  @override
+  String get merge => 'Fusionar';
+
+  @override
+  String get mergeConversations => 'Fusionar converses';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Això combinarà $count converses en una. Tot el contingut es fusionarà i regenerarà.';
+  }
+
+  @override
+  String get mergingInBackground => 'Fusionant en segon pla. Això pot trigar una mica.';
+
+  @override
+  String get failedToStartMerge => 'No s\'ha pogut iniciar la fusió';
+
+  @override
+  String get askAnything => 'Pregunta qualsevol cosa';
+
+  @override
+  String get noMessagesYet => 'Encara no hi ha missatges!\nPer què no comenceu una conversa?';
+
+  @override
+  String get deletingMessages => 'Eliminant els vostres missatges de la memòria d\'Omi...';
+
+  @override
+  String get messageCopied => 'Missatge copiat al porta-retalls.';
+
+  @override
+  String get cannotReportOwnMessage => 'No podeu denunciar els vostres propis missatges.';
+
+  @override
+  String get reportMessage => 'Denunciar missatge';
+
+  @override
+  String get reportMessageConfirm => 'Esteu segur que voleu denunciar aquest missatge?';
+
+  @override
+  String get messageReported => 'Missatge denunciat correctament.';
+
+  @override
+  String get thankYouFeedback => 'Gràcies pels vostres comentaris!';
+
+  @override
+  String get clearChat => 'Netejar xat?';
+
+  @override
+  String get clearChatConfirm => 'Esteu segur que voleu netejar el xat? Aquesta acció no es pot desfer.';
+
+  @override
+  String get maxFilesLimit => 'Només podeu pujar 4 fitxers alhora';
+
+  @override
+  String get chatWithOmi => 'Xatejar amb Omi';
+
+  @override
+  String get apps => 'Aplicacions';
+
+  @override
+  String get noAppsFound => 'No s\'han trobat aplicacions';
+
+  @override
+  String get tryAdjustingSearch => 'Proveu d\'ajustar la cerca o els filtres';
+
+  @override
+  String get createYourOwnApp => 'Creeu la vostra pròpia aplicació';
+
+  @override
+  String get buildAndShareApp => 'Construïu i compartiu la vostra aplicació personalitzada';
+
+  @override
+  String get searchApps => 'Cercar més de 1500 aplicacions';
+
+  @override
+  String get myApps => 'Les meves aplicacions';
+
+  @override
+  String get installedApps => 'Aplicacions instal·lades';
+
+  @override
+  String get unableToFetchApps =>
+      'No s\'han pogut obtenir les aplicacions :(\n\nComproveu la vostra connexió a internet i torneu-ho a provar.';
+
+  @override
+  String get aboutOmi => 'Sobre Omi';
+
+  @override
+  String get privacyPolicy => 'Política de privadesa';
+
+  @override
+  String get visitWebsite => 'Visitar lloc web';
+
+  @override
+  String get helpOrInquiries => 'Ajuda o consultes?';
+
+  @override
+  String get joinCommunity => 'Uniu-vos a la comunitat!';
+
+  @override
+  String get membersAndCounting => 'Més de 8000 membres i sumant.';
+
+  @override
+  String get deleteAccountTitle => 'Eliminar compte';
+
+  @override
+  String get deleteAccountConfirm => 'Esteu segur que voleu eliminar el vostre compte?';
+
+  @override
+  String get cannotBeUndone => 'Això no es pot desfer.';
+
+  @override
+  String get allDataErased => 'Tots els vostres records i converses s\'eliminaran permanentment.';
+
+  @override
+  String get appsDisconnected => 'Les vostres aplicacions i integracions es desconnectaran immediatament.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Podeu exportar les vostres dades abans d\'eliminar el compte, però un cop eliminat, no es pot recuperar.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Entenc que eliminar el meu compte és permanent i totes les dades, incloent records i converses, es perdran i no es poden recuperar.';
+
+  @override
+  String get areYouSure => 'Esteu segur?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Aquesta acció és irreversible i eliminarà permanentment el vostre compte i totes les dades associades. Esteu segur que voleu continuar?';
+
+  @override
+  String get deleteNow => 'Eliminar ara';
+
+  @override
+  String get goBack => 'Tornar';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Marqueu la casella per confirmar que enteneu que eliminar el vostre compte és permanent i irreversible.';
+
+  @override
+  String get profile => 'Perfil';
+
+  @override
+  String get name => 'Nom';
+
+  @override
+  String get email => 'Correu electrònic';
+
+  @override
+  String get customVocabulary => 'Vocabulari personalitzat';
+
+  @override
+  String get identifyingOthers => 'Identificar altres';
+
+  @override
+  String get paymentMethods => 'Mètodes de pagament';
+
+  @override
+  String get conversationDisplay => 'Visualització de converses';
+
+  @override
+  String get dataPrivacy => 'Dades i privadesa';
+
+  @override
+  String get userId => 'ID d\'usuari';
+
+  @override
+  String get notSet => 'No establert';
+
+  @override
+  String get userIdCopied => 'ID d\'usuari copiat al porta-retalls';
+
+  @override
+  String get systemDefault => 'Per defecte del sistema';
+
+  @override
+  String get planAndUsage => 'Pla i ús';
+
+  @override
+  String get offlineSync => 'Sincronització fora de línia';
+
+  @override
+  String get deviceSettings => 'Configuració del dispositiu';
+
+  @override
+  String get chatTools => 'Eines de xat';
+
+  @override
+  String get feedbackBug => 'Comentaris / Error';
+
+  @override
+  String get helpCenter => 'Centre d\'ajuda';
+
+  @override
+  String get developerSettings => 'Configuració de desenvolupador';
+
+  @override
+  String get getOmiForMac => 'Obtenir Omi per a Mac';
+
+  @override
+  String get referralProgram => 'Programa de recomanacions';
+
+  @override
+  String get signOut => 'Tancar sessió';
+
+  @override
+  String get appAndDeviceCopied => 'Detalls de l\'aplicació i el dispositiu copiats';
+
+  @override
+  String get wrapped2025 => 'Resum 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'La vostra privadesa, el vostre control';
+
+  @override
+  String get privacyIntro =>
+      'A Omi, estem compromesos a protegir la vostra privadesa. Aquesta pàgina us permet controlar com s\'emmagatzemen i utilitzen les vostres dades.';
+
+  @override
+  String get learnMore => 'Més informació...';
+
+  @override
+  String get dataProtectionLevel => 'Nivell de protecció de dades';
+
+  @override
+  String get dataProtectionDesc =>
+      'Les vostres dades estan protegides per defecte amb un xifratge fort. Reviseu la vostra configuració i opcions futures de privadesa a continuació.';
+
+  @override
+  String get appAccess => 'Accés d\'aplicacions';
+
+  @override
+  String get appAccessDesc =>
+      'Les següents aplicacions poden accedir a les vostres dades. Toqueu una aplicació per gestionar els seus permisos.';
+
+  @override
+  String get noAppsExternalAccess => 'Cap aplicació instal·lada té accés extern a les vostres dades.';
+
+  @override
+  String get deviceName => 'Nom del dispositiu';
+
+  @override
+  String get deviceId => 'ID del dispositiu';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'Sincronització de targeta SD';
+
+  @override
+  String get hardwareRevision => 'Revisió de maquinari';
+
+  @override
+  String get modelNumber => 'Número de model';
+
+  @override
+  String get manufacturer => 'Fabricant';
+
+  @override
+  String get doubleTap => 'Doble toc';
+
+  @override
+  String get ledBrightness => 'Brillantor LED';
+
+  @override
+  String get micGain => 'Guany del micròfon';
+
+  @override
+  String get disconnect => 'Desconnectar';
+
+  @override
+  String get forgetDevice => 'Oblidar dispositiu';
+
+  @override
+  String get chargingIssues => 'Problemes de càrrega';
+
+  @override
+  String get disconnectDevice => 'Desconnectar dispositiu';
+
+  @override
+  String get unpairDevice => 'Desvincular dispositiu';
+
+  @override
+  String get unpairAndForget => 'Desvincular i oblidar dispositiu';
+
+  @override
+  String get deviceDisconnectedMessage => 'El vostre Omi s\'ha desconnectat 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Dispositiu desvinculat. Aneu a Configuració > Bluetooth i oblideu el dispositiu per completar la desvinculació.';
+
+  @override
+  String get unpairDialogTitle => 'Desvincular dispositiu';
+
+  @override
+  String get unpairDialogMessage =>
+      'Això desvin cularà el dispositiu perquè es pugui connectar a un altre telèfon. Haureu d\'anar a Configuració > Bluetooth i oblidar el dispositiu per completar el procés.';
+
+  @override
+  String get deviceNotConnected => 'Dispositiu no connectat';
+
+  @override
+  String get connectDeviceMessage =>
+      'Connecteu el vostre dispositiu Omi per accedir\na la configuració i personalització del dispositiu';
+
+  @override
+  String get deviceInfoSection => 'Informació del dispositiu';
+
+  @override
+  String get customizationSection => 'Personalització';
+
+  @override
+  String get hardwareSection => 'Maquinari';
+
+  @override
+  String get v2Undetected => 'V2 no detectat';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Veiem que teniu un dispositiu V1 o que el vostre dispositiu no està connectat. La funcionalitat de targeta SD només està disponible per a dispositius V2.';
+
+  @override
+  String get endConversation => 'Finalitzar conversa';
+
+  @override
+  String get pauseResume => 'Pausar/Reprendre';
+
+  @override
+  String get starConversation => 'Destacar conversa';
+
+  @override
+  String get doubleTapAction => 'Acció de doble toc';
+
+  @override
+  String get endAndProcess => 'Finalitzar i processar conversa';
+
+  @override
+  String get pauseResumeRecording => 'Pausar/Reprendre enregistrament';
+
+  @override
+  String get starOngoing => 'Destacar conversa en curs';
+
+  @override
+  String get off => 'Apagat';
+
+  @override
+  String get max => 'Màxim';
+
+  @override
+  String get mute => 'Silenciar';
+
+  @override
+  String get quiet => 'Silenciós';
+
+  @override
+  String get normal => 'Normal';
+
+  @override
+  String get high => 'Alt';
+
+  @override
+  String get micGainDescMuted => 'El micròfon està silenciat';
+
+  @override
+  String get micGainDescLow => 'Molt silenciós - per entorns sorollosos';
+
+  @override
+  String get micGainDescModerate => 'Silenciós - per soroll moderat';
+
+  @override
+  String get micGainDescNeutral => 'Neutre - enregistrament equilibrat';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Lleugerament potenciat - ús normal';
+
+  @override
+  String get micGainDescBoosted => 'Potenciat - per entorns silenciosos';
+
+  @override
+  String get micGainDescHigh => 'Alt - per veus distants o suaus';
+
+  @override
+  String get micGainDescVeryHigh => 'Molt alt - per fonts molt silencioses';
+
+  @override
+  String get micGainDescMax => 'Màxim - utilitzeu amb precaució';
+
+  @override
+  String get developerSettingsTitle => 'Configuració de desenvolupador';
+
+  @override
+  String get saving => 'Desant...';
+
+  @override
+  String get personaConfig => 'Configureu la vostra personalitat d\'IA';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transcripció';
+
+  @override
+  String get transcriptionConfig => 'Configurar proveïdor STT';
+
+  @override
+  String get conversationTimeout => 'Temps d\'espera de conversa';
+
+  @override
+  String get conversationTimeoutConfig => 'Establir quan finalitzen automàticament les converses';
+
+  @override
+  String get importData => 'Importar dades';
+
+  @override
+  String get importDataConfig => 'Importar dades d\'altres fonts';
+
+  @override
+  String get debugDiagnostics => 'Depuració i diagnòstics';
+
+  @override
+  String get endpointUrl => 'URL del punt final';
+
+  @override
+  String get noApiKeys => 'Encara no hi ha claus API';
+
+  @override
+  String get createKeyToStart => 'Creeu una clau per començar';
+
+  @override
+  String get createKey => 'Crear clau';
+
+  @override
+  String get docs => 'Documentació';
+
+  @override
+  String get yourOmiInsights => 'Les vostres estadístiques d\'Omi';
+
+  @override
+  String get today => 'Avui';
+
+  @override
+  String get thisMonth => 'Aquest mes';
+
+  @override
+  String get thisYear => 'Enguany';
+
+  @override
+  String get allTime => 'Des de sempre';
+
+  @override
+  String get noActivityYet => 'Encara no hi ha activitat';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Comenceu una conversa amb Omi\nper veure les vostres estadístiques d\'ús aquí.';
+
+  @override
+  String get listening => 'Escoltant';
+
+  @override
+  String get listeningSubtitle => 'Temps total que Omi ha estat escoltant activament.';
+
+  @override
+  String get understanding => 'Entenent';
+
+  @override
+  String get understandingSubtitle => 'Paraules enteses de les vostres converses.';
+
+  @override
+  String get providing => 'Proporcionant';
+
+  @override
+  String get providingSubtitle => 'Tasques i notes capturades automàticament.';
+
+  @override
+  String get remembering => 'Recordant';
+
+  @override
+  String get rememberingSubtitle => 'Fets i detalls recordats per a vosaltres.';
+
+  @override
+  String get unlimitedPlan => 'Pla il·limitat';
+
+  @override
+  String get managePlan => 'Gestionar pla';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'El vostre pla es cancel·larà el $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'El vostre pla es renova el $date.';
+  }
+
+  @override
+  String get basicPlan => 'Pla gratuït';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used de $limit min utilitzats';
+  }
+
+  @override
+  String get upgrade => 'Actualitzar';
+
+  @override
+  String get upgradeToUnlimited => 'Actualitzar a il·limitat';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'El vostre pla inclou $limit minuts gratuïts al mes. Actualitzeu per tenir-ne il·limitats.';
+  }
+
+  @override
+  String get shareStatsMessage =>
+      'Compartint les meves estadístiques d\'Omi! (omi.me - el vostre assistent d\'IA sempre actiu)';
+
+  @override
+  String get sharePeriodToday => 'Avui, omi ha:';
+
+  @override
+  String get sharePeriodMonth => 'Aquest mes, omi ha:';
+
+  @override
+  String get sharePeriodYear => 'Enguany, omi ha:';
+
+  @override
+  String get sharePeriodAllTime => 'Fins ara, omi ha:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Escoltat durant $minutes minuts';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Entès $words paraules';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Proporcionat $count informacions';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Recordat $count records';
+  }
+
+  @override
+  String get debugLogs => 'Registres de depuració';
+
+  @override
+  String get debugLogsAutoDelete => 'S\'eliminen automàticament després de 3 dies.';
+
+  @override
+  String get debugLogsDesc => 'Ajuda a diagnosticar problemes';
+
+  @override
+  String get noLogFilesFound => 'No s\'han trobat fitxers de registre.';
+
+  @override
+  String get omiDebugLog => 'Registre de depuració d\'Omi';
+
+  @override
+  String get logShared => 'Registre compartit';
+
+  @override
+  String get selectLogFile => 'Seleccionar fitxer de registre';
+
+  @override
+  String get shareLogs => 'Compartir registres';
+
+  @override
+  String get debugLogCleared => 'Registre de depuració netejat';
+
+  @override
+  String get exportStarted => 'Exportació iniciada. Això pot trigar uns segons...';
+
+  @override
+  String get exportAllData => 'Exportar totes les dades';
+
+  @override
+  String get exportDataDesc => 'Exportar converses a un fitxer JSON';
+
+  @override
+  String get exportedConversations => 'Converses exportades d\'Omi';
+
+  @override
+  String get exportShared => 'Exportació compartida';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Eliminar graf de coneixement?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Això eliminarà totes les dades derivades del graf de coneixement (nodes i connexions). Els vostres records originals restaran segurs. El graf es reconstruirà amb el temps o a la propera sol·licitud.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Graf de coneixement eliminat correctament';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'No s\'ha pogut eliminar el graf: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Eliminar graf de coneixement';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Esborrar tots els nodes i connexions';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Servidor MCP';
+
+  @override
+  String get mcpServerDesc => 'Connectar assistents d\'IA a les vostres dades';
+
+  @override
+  String get serverUrl => 'URL del servidor';
+
+  @override
+  String get urlCopied => 'URL copiada';
+
+  @override
+  String get apiKeyAuth => 'Autenticació amb clau API';
+
+  @override
+  String get header => 'Capçalera';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID de client';
+
+  @override
+  String get clientSecret => 'Secret de client';
+
+  @override
+  String get useMcpApiKey => 'Utilitzeu la vostra clau API MCP';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Esdeveniments de conversa';
+
+  @override
+  String get newConversationCreated => 'Nova conversa creada';
+
+  @override
+  String get realtimeTranscript => 'Transcripció en temps real';
+
+  @override
+  String get transcriptReceived => 'Transcripció rebuda';
+
+  @override
+  String get audioBytes => 'Bytes d\'àudio';
+
+  @override
+  String get audioDataReceived => 'Dades d\'àudio rebudes';
+
+  @override
+  String get intervalSeconds => 'Interval (segons)';
+
+  @override
+  String get daySummary => 'Resum del dia';
+
+  @override
+  String get summaryGenerated => 'Resum generat';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Afegir a claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Copiar configuració';
+
+  @override
+  String get configCopied => 'Configuració copiada al porta-retalls';
+
+  @override
+  String get listeningMins => 'Escoltant (min)';
+
+  @override
+  String get understandingWords => 'Entenent (paraules)';
+
+  @override
+  String get insights => 'Informacions';
+
+  @override
+  String get memories => 'Records';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used de $limit min utilitzats aquest mes';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used de $limit paraules utilitzades aquest mes';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used de $limit informacions obtingudes aquest mes';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used de $limit records creats aquest mes';
+  }
+
+  @override
+  String get visibility => 'Visibilitat';
+
+  @override
+  String get visibilitySubtitle => 'Controleu quines converses apareixen a la vostra llista';
+
+  @override
+  String get showShortConversations => 'Mostrar converses curtes';
+
+  @override
+  String get showShortConversationsDesc => 'Mostrar converses més curtes que el llindar';
+
+  @override
+  String get showDiscardedConversations => 'Mostrar converses descartades';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Incloure converses marcades com a descartades';
+
+  @override
+  String get shortConversationThreshold => 'Llindar de conversa curta';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Les converses més curtes que això s\'amagaran tret que s\'activi a dalt';
+
+  @override
+  String get durationThreshold => 'Llindar de durada';
+
+  @override
+  String get durationThresholdDesc => 'Amagar converses més curtes que això';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Vocabulari personalitzat';
+
+  @override
+  String get addWords => 'Afegir paraules';
+
+  @override
+  String get addWordsDesc => 'Noms, termes o paraules poc comunes';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Connectar';
+
+  @override
+  String get comingSoon => 'Properament';
+
+  @override
+  String get chatToolsFooter => 'Connecteu les vostres aplicacions per veure dades i estadístiques al xat.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Completeu l\'autenticació al vostre navegador. Un cop fet, torneu a l\'aplicació.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'No s\'ha pogut iniciar l\'autenticació de $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Desconnectar $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Esteu segur que voleu desconnectar-vos de $appName? Podeu reconnectar en qualsevol moment.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Desconnectat de $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'No s\'ha pogut desconnectar';
+
+  @override
+  String connectTo(String appName) {
+    return 'Connectar a $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Haureu d\'autoritzar Omi per accedir a les vostres dades de $appName. Això obrirà el vostre navegador per a l\'autenticació.';
+  }
+
+  @override
+  String get continueAction => 'Continuar';
+
+  @override
+  String get languageTitle => 'Idioma';
+
+  @override
+  String get primaryLanguage => 'Idioma principal';
+
+  @override
+  String get automaticTranslation => 'Traducció automàtica';
+
+  @override
+  String get detectLanguages => 'Detectar més de 10 idiomes';
+
+  @override
+  String get authorizeSavingRecordings => 'Autoritzar desar enregistraments';
+
+  @override
+  String get thanksForAuthorizing => 'Gràcies per autoritzar!';
+
+  @override
+  String get needYourPermission => 'Necessitem el vostre permís';
+
+  @override
+  String get alreadyGavePermission =>
+      'Ja ens heu donat permís per desar els vostres enregistraments. Aquí teniu un recordatori de per què ho necessitem:';
+
+  @override
+  String get wouldLikePermission =>
+      'Ens agradaria el vostre permís per desar els vostres enregistraments de veu. Aquesta és la raó:';
+
+  @override
+  String get improveSpeechProfile => 'Millorar el vostre perfil de veu';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Utilitzem els enregistraments per entrenar i millorar el vostre perfil de veu personal.';
+
+  @override
+  String get trainFamilyProfiles => 'Entrenar perfils d\'amics i família';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Els vostres enregistraments ens ajuden a reconèixer i crear perfils per als vostres amics i família.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Millorar la precisió de transcripció';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'A mesura que el nostre model millora, podem proporcionar millors resultats de transcripció per als vostres enregistraments.';
+
+  @override
+  String get legalNotice =>
+      'Avís legal: La legalitat d\'enregistrar i emmagatzemar dades de veu pot variar segons la vostra ubicació i com utilitzeu aquesta funció. És la vostra responsabilitat assegurar el compliment de les lleis i regulacions locals.';
+
+  @override
+  String get alreadyAuthorized => 'Ja autoritzat';
+
+  @override
+  String get authorize => 'Autoritzar';
+
+  @override
+  String get revokeAuthorization => 'Revocar autorització';
+
+  @override
+  String get authorizationSuccessful => 'Autorització correcta!';
+
+  @override
+  String get failedToAuthorize => 'No s\'ha pogut autoritzar. Torneu-ho a provar.';
+
+  @override
+  String get authorizationRevoked => 'Autorització revocada.';
+
+  @override
+  String get recordingsDeleted => 'Enregistraments eliminats.';
+
+  @override
+  String get failedToRevoke => 'No s\'ha pogut revocar l\'autorització. Torneu-ho a provar.';
+
+  @override
+  String get permissionRevokedTitle => 'Permís revocat';
+
+  @override
+  String get permissionRevokedMessage => 'Voleu que eliminem també tots els vostres enregistraments existents?';
+
+  @override
+  String get yes => 'Sí';
+
+  @override
+  String get editName => 'Editar nom';
+
+  @override
+  String get howShouldOmiCallYou => 'Com hauria d\'anomenar-vos Omi?';
+
+  @override
+  String get enterYourName => 'Introduïu el vostre nom';
+
+  @override
+  String get nameCannotBeEmpty => 'El nom no pot estar buit';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Nom actualitzat correctament!';
+
+  @override
+  String get calendarSettings => 'Configuració del calendari';
+
+  @override
+  String get calendarProviders => 'Proveïdors de calendari';
+
+  @override
+  String get macOsCalendar => 'Calendari de macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Connectar el vostre calendari local de macOS';
+
+  @override
+  String get googleCalendar => 'Google Calendar';
+
+  @override
+  String get syncGoogleAccount => 'Sincronitzar amb el vostre compte de Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Mostrar reunions properes a la barra de menú';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'Mostrar la vostra propera reunió i el temps fins que comenci a la barra de menú de macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Mostrar esdeveniments sense participants';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Quan s\'activa, Properament mostra esdeveniments sense participants o enllaç de vídeo.';
+
+  @override
+  String get yourMeetings => 'Les vostres reunions';
+
+  @override
+  String get refresh => 'Actualitzar';
+
+  @override
+  String get noUpcomingMeetings => 'No s\'han trobat reunions properes';
+
+  @override
+  String get checkingNextDays => 'Comprovant els propers 30 dies';
+
+  @override
+  String get tomorrow => 'Demà';
+
+  @override
+  String get googleCalendarComingSoon => 'Integració de Google Calendar properament!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Connectat com a usuari: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Espai de treball per defecte';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Les tasques es crearan en aquest espai de treball';
+
+  @override
+  String get defaultProjectOptional => 'Projecte per defecte (opcional)';
+
+  @override
+  String get leaveUnselectedTasks => 'Deixeu sense seleccionar per crear tasques sense projecte';
+
+  @override
+  String get noProjectsInWorkspace => 'No s\'han trobat projectes en aquest espai de treball';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Trieu quant temps esperar en silenci abans de finalitzar automàticament una conversa:';
+
+  @override
+  String get timeout2Minutes => '2 minuts';
+
+  @override
+  String get timeout2MinutesDesc => 'Finalitzar conversa després de 2 minuts de silenci';
+
+  @override
+  String get timeout5Minutes => '5 minuts';
+
+  @override
+  String get timeout5MinutesDesc => 'Finalitzar conversa després de 5 minuts de silenci';
+
+  @override
+  String get timeout10Minutes => '10 minuts';
+
+  @override
+  String get timeout10MinutesDesc => 'Finalitzar conversa després de 10 minuts de silenci';
+
+  @override
+  String get timeout30Minutes => '30 minuts';
+
+  @override
+  String get timeout30MinutesDesc => 'Finalitzar conversa després de 30 minuts de silenci';
+
+  @override
+  String get timeout4Hours => '4 hores';
+
+  @override
+  String get timeout4HoursDesc => 'Finalitzar conversa després de 4 hores de silenci';
+
+  @override
+  String get conversationEndAfterHours => 'Les converses ara finalitzaran després de 4 hores de silenci';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Les converses ara finalitzaran després de $minutes minut(s) de silenci';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Digueu-nos el vostre idioma principal';
+
+  @override
+  String get languageForTranscription =>
+      'Establiu el vostre idioma per a transcripcions més precises i una experiència personalitzada.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'El mode d\'idioma únic està activat. La traducció està desactivada per a una major precisió.';
+
+  @override
+  String get searchLanguageHint => 'Cercar idioma per nom o codi';
+
+  @override
+  String get noLanguagesFound => 'No s\'han trobat idiomes';
+
+  @override
+  String get skip => 'Ometre';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Idioma establert a $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'No s\'ha pogut establir l\'idioma';
+
+  @override
+  String appSettings(String appName) {
+    return 'Configuració de $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Desconnectar de $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Això eliminarà la vostra autenticació de $appName. Haureu de reconnectar per utilitzar-la de nou.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Connectat a $appName';
+  }
+
+  @override
+  String get account => 'Compte';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Les vostres tasques es sincronitzaran amb el vostre compte de $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Espai per defecte';
+
+  @override
+  String get selectSpaceInWorkspace => 'Seleccioneu un espai al vostre espai de treball';
+
+  @override
+  String get noSpacesInWorkspace => 'No s\'han trobat espais en aquest espai de treball';
+
+  @override
+  String get defaultList => 'Llista per defecte';
+
+  @override
+  String get tasksAddedToList => 'Les tasques s\'afegiran a aquesta llista';
+
+  @override
+  String get noListsInSpace => 'No s\'han trobat llistes en aquest espai';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'No s\'han pogut carregar els repositoris: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Repositori per defecte desat';
+
+  @override
+  String get failedToSaveDefaultRepo => 'No s\'ha pogut desar el repositori per defecte';
+
+  @override
+  String get defaultRepository => 'Repositori per defecte';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Seleccioneu un repositori per defecte per crear incidències. Encara podeu especificar un repositori diferent quan creeu incidències.';
+
+  @override
+  String get noReposFound => 'No s\'han trobat repositoris';
+
+  @override
+  String get private => 'Privat';
+
+  @override
+  String updatedDate(String date) {
+    return 'Actualitzat $date';
+  }
+
+  @override
+  String get yesterday => 'ahir';
+
+  @override
+  String daysAgo(int count) {
+    return 'fa $count dies';
+  }
+
+  @override
+  String get oneWeekAgo => 'fa 1 setmana';
+
+  @override
+  String weeksAgo(int count) {
+    return 'fa $count setmanes';
+  }
+
+  @override
+  String get oneMonthAgo => 'fa 1 mes';
+
+  @override
+  String monthsAgo(int count) {
+    return 'fa $count mesos';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Les incidències es crearan al vostre repositori per defecte';
+
+  @override
+  String get taskIntegrations => 'Integracions de tasques';
+
+  @override
+  String get configureSettings => 'Configurar opcions';
+
+  @override
+  String get completeAuthBrowser => 'Completeu l\'autenticació al vostre navegador. Un cop fet, torneu a l\'aplicació.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'No s\'ha pogut iniciar l\'autenticació de $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Connectar a $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Haureu d\'autoritzar Omi per crear tasques al vostre compte de $appName. Això obrirà el vostre navegador per a l\'autenticació.';
+  }
+
+  @override
+  String get continueButton => 'Continuar';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Integració de $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'La integració amb $appName arribarà aviat! Estem treballant dur per oferir-vos més opcions de gestió de tasques.';
+  }
+
+  @override
+  String get gotIt => 'Entès';
+
+  @override
+  String get tasksExportedOneApp => 'Les tasques es poden exportar a una aplicació alhora.';
+
+  @override
+  String get completeYourUpgrade => 'Completeu la vostra actualització';
+
+  @override
+  String get importConfiguration => 'Importar configuració';
+
+  @override
+  String get exportConfiguration => 'Exportar configuració';
+
+  @override
+  String get bringYourOwn => 'Utilitzeu el vostre propi';
+
+  @override
+  String get payYourSttProvider => 'Utilitzeu omi lliurement. Només pagueu directament al vostre proveïdor STT.';
+
+  @override
+  String get freeMinutesMonth => '1.200 minuts gratuïts/mes inclosos. Il·limitat amb ';
+
+  @override
+  String get omiUnlimited => 'Omi Il·limitat';
+
+  @override
+  String get hostRequired => 'Cal un amfitrió';
+
+  @override
+  String get validPortRequired => 'Cal un port vàlid';
+
+  @override
+  String get validWebsocketUrlRequired => 'Cal un URL WebSocket vàlid (wss://)';
+
+  @override
+  String get apiUrlRequired => 'Cal un URL API';
+
+  @override
+  String get apiKeyRequired => 'Cal una clau API';
+
+  @override
+  String get invalidJsonConfig => 'Configuració JSON no vàlida';
+
+  @override
+  String errorSaving(String error) {
+    return 'Error en desar: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Configuració copiada al porta-retalls';
+
+  @override
+  String get pasteJsonConfig => 'Enganxeu la vostra configuració JSON a continuació:';
+
+  @override
+  String get addApiKeyAfterImport => 'Haureu d\'afegir la vostra pròpia clau API després d\'importar';
+
+  @override
+  String get paste => 'Enganxar';
+
+  @override
+  String get import => 'Importar';
+
+  @override
+  String get invalidProviderInConfig => 'Proveïdor no vàlid a la configuració';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Configuració de $providerName importada';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON no vàlid: $error';
+  }
+
+  @override
+  String get provider => 'Proveïdor';
+
+  @override
+  String get live => 'En directe';
+
+  @override
+  String get onDevice => 'Al dispositiu';
+
+  @override
+  String get apiUrl => 'URL de l\'API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Introduïu el vostre punt final HTTP STT';
+
+  @override
+  String get websocketUrl => 'URL de WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Introduïu el vostre punt final WebSocket STT en directe';
+
+  @override
+  String get apiKey => 'Clau API';
+
+  @override
+  String get enterApiKey => 'Introduïu la vostra clau API';
+
+  @override
+  String get storedLocallyNeverShared => 'Emmagatzemat localment, mai compartit';
+
+  @override
+  String get host => 'Amfitrió';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Avançat';
+
+  @override
+  String get configuration => 'Configuració';
+
+  @override
+  String get requestConfiguration => 'Configuració de sol·licitud';
+
+  @override
+  String get responseSchema => 'Esquema de resposta';
+
+  @override
+  String get modified => 'Modificat';
+
+  @override
+  String get resetRequestConfig => 'Restablir configuració de sol·licitud per defecte';
+
+  @override
+  String get logs => 'Registres';
+
+  @override
+  String get logsCopied => 'Registres copiats';
+
+  @override
+  String get noLogsYet =>
+      'Encara no hi ha registres. Comenceu a enregistrar per veure l\'activitat STT personalitzada.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName utilitza $codecReason. S\'utilitzarà Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Transcripció d\'Omi';
+
+  @override
+  String get bestInClassTranscription => 'Transcripció de millor qualitat sense configuració';
+
+  @override
+  String get instantSpeakerLabels => 'Etiquetes d\'interlocutor instantànies';
+
+  @override
+  String get languageTranslation => 'Traducció de més de 100 idiomes';
+
+  @override
+  String get optimizedForConversation => 'Optimitzat per a converses';
+
+  @override
+  String get autoLanguageDetection => 'Detecció automàtica d\'idioma';
+
+  @override
+  String get highAccuracy => 'Alta precisió';
+
+  @override
+  String get privacyFirst => 'Privadesa primer';
+
+  @override
+  String get saveChanges => 'Desar canvis';
+
+  @override
+  String get resetToDefault => 'Restablir per defecte';
+
+  @override
+  String get viewTemplate => 'Veure plantilla';
+
+  @override
+  String get trySomethingLike => 'Proveu quelcom com...';
+
+  @override
+  String get tryIt => 'Provar-ho';
+
+  @override
+  String get creatingPlan => 'Creant pla';
+
+  @override
+  String get developingLogic => 'Desenvolupant lògica';
+
+  @override
+  String get designingApp => 'Dissenyant aplicació';
+
+  @override
+  String get generatingIconStep => 'Generant icona';
+
+  @override
+  String get finalTouches => 'Tocs finals';
+
+  @override
+  String get processing => 'Processant...';
+
+  @override
+  String get features => 'Funcionalitats';
+
+  @override
+  String get creatingYourApp => 'Creant la vostra aplicació...';
+
+  @override
+  String get generatingIcon => 'Generant icona...';
+
+  @override
+  String get whatShouldWeMake => 'Què hauríem de fer?';
+
+  @override
+  String get appName => 'Nom de l\'aplicació';
+
+  @override
+  String get description => 'Descripció';
+
+  @override
+  String get publicLabel => 'Pública';
+
+  @override
+  String get privateLabel => 'Privada';
+
+  @override
+  String get free => 'Gratuïta';
+
+  @override
+  String get perMonth => '/ Mes';
+
+  @override
+  String get tailoredConversationSummaries => 'Resums de converses personalitzats';
+
+  @override
+  String get customChatbotPersonality => 'Personalitat de xatbot personalitzada';
+
+  @override
+  String get makePublic => 'Fer pública';
+
+  @override
+  String get anyoneCanDiscover => 'Qualsevol pot descobrir la vostra aplicació';
+
+  @override
+  String get onlyYouCanUse => 'Només vós podeu utilitzar aquesta aplicació';
+
+  @override
+  String get paidApp => 'Aplicació de pagament';
+
+  @override
+  String get usersPayToUse => 'Els usuaris paguen per utilitzar la vostra aplicació';
+
+  @override
+  String get freeForEveryone => 'Gratuïta per a tothom';
+
+  @override
+  String get perMonthLabel => '/ mes';
+
+  @override
+  String get creating => 'Creant...';
+
+  @override
+  String get createApp => 'Crear aplicació';
+
+  @override
+  String get searchingForDevices => 'Cercant dispositius...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'DISPOSITIUS',
+      one: 'DISPOSITIU',
+    );
+    return '$count $_temp0 TROBATS A PROP';
+  }
+
+  @override
+  String get pairingSuccessful => 'VINCULACIÓ CORRECTA';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Error en connectar amb l\'Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'No ho tornis a mostrar';
+
+  @override
+  String get iUnderstand => 'Ho entenc';
+
+  @override
+  String get enableBluetooth => 'Activar Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi necessita Bluetooth per connectar-se al vostre dispositiu portàtil. Activeu Bluetooth i torneu-ho a provar.';
+
+  @override
+  String get contactSupport => 'Contactar amb suport?';
+
+  @override
+  String get connectLater => 'Connectar més tard';
+
+  @override
+  String get grantPermissions => 'Atorgar permisos';
+
+  @override
+  String get backgroundActivity => 'Activitat en segon pla';
+
+  @override
+  String get backgroundActivityDesc => 'Deixeu que Omi s\'executi en segon pla per a una millor estabilitat';
+
+  @override
+  String get locationAccess => 'Accés a la ubicació';
+
+  @override
+  String get locationAccessDesc => 'Activeu la ubicació en segon pla per a l\'experiència completa';
+
+  @override
+  String get notifications => 'Notificacions';
+
+  @override
+  String get notificationsDesc => 'Activeu les notificacions per mantenir-vos informat';
+
+  @override
+  String get locationServiceDisabled => 'Servei d\'ubicació desactivat';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'El servei d\'ubicació està desactivat. Aneu a Configuració > Privadesa i seguretat > Serveis d\'ubicació i activeu-lo';
+
+  @override
+  String get backgroundLocationDenied => 'Accés a la ubicació en segon pla denegat';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Aneu a la configuració del dispositiu i establiu el permís d\'ubicació a \"Permetre sempre\"';
+
+  @override
+  String get lovingOmi => 'T\'agrada Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Ajudeu-nos a arribar a més gent deixant una ressenya a l\'App Store. Els vostres comentaris són molt importants per a nosaltres!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Ajudeu-nos a arribar a més gent deixant una ressenya a Google Play Store. Els vostres comentaris són molt importants per a nosaltres!';
+
+  @override
+  String get rateOnAppStore => 'Valorar a l\'App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Valorar a Google Play';
+
+  @override
+  String get maybeLater => 'Potser més tard';
+
+  @override
+  String get speechProfileIntro =>
+      'Omi necessita aprendre els vostres objectius i la vostra veu. Podreu modificar-ho més tard.';
+
+  @override
+  String get getStarted => 'Començar';
+
+  @override
+  String get allDone => 'Tot fet!';
+
+  @override
+  String get keepGoing => 'Continueu, ho esteu fent molt bé';
+
+  @override
+  String get skipThisQuestion => 'Ometre aquesta pregunta';
+
+  @override
+  String get skipForNow => 'Ometre ara';
+
+  @override
+  String get connectionError => 'Error de connexió';
+
+  @override
+  String get connectionErrorDesc =>
+      'No s\'ha pogut connectar amb el servidor. Comproveu la vostra connexió a internet i torneu-ho a provar.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'S\'ha detectat un enregistrament no vàlid';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Sembla que hi ha diversos parlants a l\'enregistrament. Assegureu-vos que esteu en un lloc tranquil i torneu-ho a provar.';
+
+  @override
+  String get tooShortDesc => 'No s\'ha detectat prou veu. Parleu més i torneu-ho a provar.';
+
+  @override
+  String get invalidRecordingDesc => 'Assegureu-vos de parlar durant almenys 5 segons i no més de 90.';
+
+  @override
+  String get areYouThere => 'Hi sou?';
+
+  @override
+  String get noSpeechDesc =>
+      'No hem pogut detectar cap veu. Assegureu-vos de parlar durant almenys 10 segons i no més de 3 minuts.';
+
+  @override
+  String get connectionLost => 'Connexió perduda';
+
+  @override
+  String get connectionLostDesc =>
+      'La connexió s\'ha interromput. Comproveu la vostra connexió a internet i torneu-ho a provar.';
+
+  @override
+  String get tryAgain => 'Tornar a provar';
+
+  @override
+  String get connectOmiOmiGlass => 'Connectar Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Continuar sense dispositiu';
+
+  @override
+  String get permissionsRequired => 'Permisos necessaris';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Aquesta aplicació necessita permisos de Bluetooth i ubicació per funcionar correctament. Activeu-los a la configuració.';
+
+  @override
+  String get openSettings => 'Obrir configuració';
+
+  @override
+  String get wantDifferentName => 'Voleu que us anomeni d\'una altra manera?';
+
+  @override
+  String get whatsYourName => 'Com us dieu?';
+
+  @override
+  String get speakTranscribeSummarize => 'Parlar. Transcriure. Resumir.';
+
+  @override
+  String get signInWithApple => 'Iniciar sessió amb Apple';
+
+  @override
+  String get signInWithGoogle => 'Iniciar sessió amb Google';
+
+  @override
+  String get byContinuingAgree => 'En continuar, accepteu la nostra ';
+
+  @override
+  String get termsOfUse => 'Condicions d\'ús';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – El vostre company d\'IA';
+
+  @override
+  String get captureEveryMoment => 'Captureu cada moment. Obteniu resums\nimpulsats per IA. No prengueu més notes.';
+
+  @override
+  String get appleWatchSetup => 'Configuració de l\'Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Permís sol·licitat!';
+
+  @override
+  String get microphonePermission => 'Permís del micròfon';
+
+  @override
+  String get permissionGrantedNow =>
+      'Permís atorgat! Ara:\n\nObriu l\'aplicació Omi al vostre rellotge i toqueu \"Continuar\" a continuació';
+
+  @override
+  String get needMicrophonePermission =>
+      'Necessitem permís del micròfon.\n\n1. Toqueu \"Atorgar permís\"\n2. Permeteu al vostre iPhone\n3. L\'aplicació del rellotge es tancarà\n4. Torneu a obrir-la i toqueu \"Continuar\"';
+
+  @override
+  String get grantPermissionButton => 'Atorgar permís';
+
+  @override
+  String get needHelp => 'Necessiteu ajuda?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Resolució de problemes:\n\n1. Assegureu-vos que Omi està instal·lat al vostre rellotge\n2. Obriu l\'aplicació Omi al vostre rellotge\n3. Busqueu la finestra emergent de permisos\n4. Toqueu \"Permetre\" quan se us demani\n5. L\'aplicació al vostre rellotge es tancarà - torneu a obrir-la\n6. Torneu i toqueu \"Continuar\" al vostre iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Enregistrament iniciat correctament!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Permís encara no atorgat. Assegureu-vos que heu permès l\'accés al micròfon i heu tornat a obrir l\'aplicació al vostre rellotge.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Error en sol·licitar permís: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Error en iniciar l\'enregistrament: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Seleccioneu el vostre idioma principal';
+
+  @override
+  String get languageBenefits =>
+      'Establiu el vostre idioma per a transcripcions més precises i una experiència personalitzada';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Quin és el vostre idioma principal?';
+
+  @override
+  String get selectYourLanguage => 'Seleccioneu el vostre idioma';
+
+  @override
+  String get personalGrowthJourney => 'El vostre viatge de creixement personal amb IA que escolta cada paraula vostra.';
+
+  @override
+  String get actionItemsTitle => 'Tasques';
+
+  @override
+  String get actionItemsDescription => 'Toqueu per editar • Manteniu per seleccionar • Llisqueu per a accions';
+
+  @override
+  String get tabToDo => 'Per fer';
+
+  @override
+  String get tabDone => 'Fet';
+
+  @override
+  String get tabOld => 'Antic';
+
+  @override
+  String get emptyTodoMessage => '🎉 Tot al dia!\nNo hi ha tasques pendents';
+
+  @override
+  String get emptyDoneMessage => 'Encara no hi ha elements completats';
+
+  @override
+  String get emptyOldMessage => '✅ No hi ha tasques antigues';
+
+  @override
+  String get noItems => 'No hi ha elements';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Tasca marcada com a incompleta';
+
+  @override
+  String get actionItemCompleted => 'Tasca completada';
+
+  @override
+  String get deleteActionItemTitle => 'Eliminar tasca';
+
+  @override
+  String get deleteActionItemMessage => 'Esteu segur que voleu eliminar aquesta tasca?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Eliminar elements seleccionats';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Esteu segur que voleu eliminar $count tasca$s seleccionada$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Tasca \"$description\" eliminada';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count tasca$s eliminada$s';
+  }
+
+  @override
+  String get failedToDeleteItem => 'No s\'ha pogut eliminar la tasca';
+
+  @override
+  String get failedToDeleteItems => 'No s\'han pogut eliminar els elements';
+
+  @override
+  String get failedToDeleteSomeItems => 'No s\'han pogut eliminar alguns elements';
+
+  @override
+  String get welcomeActionItemsTitle => 'Llest per a les tasques';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'La vostra IA extraurà automàticament tasques de les vostres converses. Apareixeran aquí quan es creïn.';
+
+  @override
+  String get autoExtractionFeature => 'Extret automàticament de converses';
+
+  @override
+  String get editSwipeFeature => 'Toqueu per editar, llisqueu per completar o eliminar';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count seleccionats';
+  }
+
+  @override
+  String get selectAll => 'Seleccionar tot';
+
+  @override
+  String get deleteSelected => 'Eliminar seleccionats';
+
+  @override
+  String searchMemories(int count) {
+    return 'Cercar $count records';
+  }
+
+  @override
+  String get memoryDeleted => 'Record eliminat.';
+
+  @override
+  String get undo => 'Desfer';
+
+  @override
+  String get noMemoriesYet => 'Encara no hi ha records';
+
+  @override
+  String get noAutoMemories => 'Encara no hi ha records extrets automàticament';
+
+  @override
+  String get noManualMemories => 'Encara no hi ha records manuals';
+
+  @override
+  String get noMemoriesInCategories => 'No hi ha records en aquestes categories';
+
+  @override
+  String get noMemoriesFound => 'No s\'han trobat records';
+
+  @override
+  String get addFirstMemory => 'Afegiu el vostre primer record';
+
+  @override
+  String get clearMemoryTitle => 'Esborrar la memòria d\'Omi';
+
+  @override
+  String get clearMemoryMessage => 'Esteu segur que voleu esborrar la memòria d\'Omi? Aquesta acció no es pot desfer.';
+
+  @override
+  String get clearMemoryButton => 'Esborrar memòria';
+
+  @override
+  String get memoryClearedSuccess => 'La memòria d\'Omi sobre vós s\'ha esborrat';
+
+  @override
+  String get noMemoriesToDelete => 'No hi ha records per eliminar';
+
+  @override
+  String get createMemoryTooltip => 'Crear nou record';
+
+  @override
+  String get createActionItemTooltip => 'Crear nova tasca';
+
+  @override
+  String get memoryManagement => 'Gestió de records';
+
+  @override
+  String get filterMemories => 'Filtrar records';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Teniu $count records en total';
+  }
+
+  @override
+  String get publicMemories => 'Records públics';
+
+  @override
+  String get privateMemories => 'Records privats';
+
+  @override
+  String get makeAllPrivate => 'Fer tots els records privats';
+
+  @override
+  String get makeAllPublic => 'Fer tots els records públics';
+
+  @override
+  String get deleteAllMemories => 'Eliminar tots els records';
+
+  @override
+  String get allMemoriesPrivateResult => 'Tots els records són ara privats';
+
+  @override
+  String get allMemoriesPublicResult => 'Tots els records són ara públics';
+
+  @override
+  String get newMemory => 'Nou record';
+
+  @override
+  String get editMemory => 'Editar record';
+
+  @override
+  String get memoryContentHint => 'M\'agrada menjar gelat...';
+
+  @override
+  String get failedToSaveMemory => 'No s\'ha pogut desar. Comproveu la vostra connexió.';
+
+  @override
+  String get saveMemory => 'Desar record';
+
+  @override
+  String get retry => 'Tornar a provar';
+
+  @override
+  String get createActionItem => 'Crear tasca';
+
+  @override
+  String get editActionItem => 'Editar tasca';
+
+  @override
+  String get actionItemDescriptionHint => 'Què cal fer?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'La descripció de la tasca no pot estar buida.';
+
+  @override
+  String get actionItemUpdated => 'Tasca actualitzada';
+
+  @override
+  String get failedToUpdateActionItem => 'No s\'ha pogut actualitzar la tasca';
+
+  @override
+  String get actionItemCreated => 'Tasca creada';
+
+  @override
+  String get failedToCreateActionItem => 'No s\'ha pogut crear la tasca';
+
+  @override
+  String get dueDate => 'Data de venciment';
+
+  @override
+  String get time => 'Hora';
+
+  @override
+  String get addDueDate => 'Afegir data de venciment';
+
+  @override
+  String get pressDoneToSave => 'Premeu fet per desar';
+
+  @override
+  String get pressDoneToCreate => 'Premeu fet per crear';
+
+  @override
+  String get filterAll => 'Tot';
+
+  @override
+  String get filterSystem => 'Sobre vós';
+
+  @override
+  String get filterInteresting => 'Informacions';
+
+  @override
+  String get filterManual => 'Manual';
+
+  @override
+  String get completed => 'Completat';
+
+  @override
+  String get markComplete => 'Marcar com a complet';
+
+  @override
+  String get actionItemDeleted => 'Tasca eliminada';
+
+  @override
+  String get failedToDeleteActionItem => 'No s\'ha pogut eliminar la tasca';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Eliminar tasca';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Esteu segur que voleu eliminar aquesta tasca?';
+
+  @override
+  String get appLanguage => 'Idioma de l\'aplicació';
+
+  @override
+  String get appInterfaceSectionTitle => 'INTERFÍCIE DE L\'APLICACIÓ';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'VEU I TRANSCRIPCIÓ';
+
+  @override
+  String get languageSettingsHelperText =>
+      'L\'idioma de l\'aplicació canvia els menús i els botons. L\'idioma de la veu afecta com es transcriuen les teves gravacions.';
+}

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -1,0 +1,2232 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Czech (`cs`).
+class AppLocalizationsCs extends AppLocalizations {
+  AppLocalizationsCs([String locale = 'cs']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Konverzace';
+
+  @override
+  String get transcriptTab => 'Přepis';
+
+  @override
+  String get actionItemsTab => 'Úkoly';
+
+  @override
+  String get deleteConversationTitle => 'Smazat konverzaci?';
+
+  @override
+  String get deleteConversationMessage => 'Opravdu chcete smazat tuto konverzaci? Tuto akci nelze vrátit zpět.';
+
+  @override
+  String get confirm => 'Potvrdit';
+
+  @override
+  String get cancel => 'Zrušit';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Smazat';
+
+  @override
+  String get add => 'Přidat';
+
+  @override
+  String get update => 'Aktualizovat';
+
+  @override
+  String get save => 'Uložit';
+
+  @override
+  String get edit => 'Upravit';
+
+  @override
+  String get close => 'Zavřít';
+
+  @override
+  String get clear => 'Vymazat';
+
+  @override
+  String get copyTranscript => 'Kopírovat přepis';
+
+  @override
+  String get copySummary => 'Kopírovat shrnutí';
+
+  @override
+  String get testPrompt => 'Testovat výzvu';
+
+  @override
+  String get reprocessConversation => 'Znovu zpracovat konverzaci';
+
+  @override
+  String get deleteConversation => 'Smazat konverzaci';
+
+  @override
+  String get contentCopied => 'Obsah zkopírován do schránky';
+
+  @override
+  String get failedToUpdateStarred => 'Nepodařilo se aktualizovat stav oblíbených.';
+
+  @override
+  String get conversationUrlNotShared => 'URL konverzace nelze sdílet.';
+
+  @override
+  String get errorProcessingConversation => 'Chyba při zpracování konverzace. Zkuste to prosím později.';
+
+  @override
+  String get noInternetConnection => 'Zkontrolujte prosím připojení k internetu a zkuste to znovu.';
+
+  @override
+  String get unableToDeleteConversation => 'Nelze smazat konverzaci';
+
+  @override
+  String get somethingWentWrong => 'Něco se pokazilo! Zkuste to prosím později.';
+
+  @override
+  String get copyErrorMessage => 'Kopírovat chybovou zprávu';
+
+  @override
+  String get errorCopied => 'Chybová zpráva zkopírována do schránky';
+
+  @override
+  String get remaining => 'Zbývá';
+
+  @override
+  String get loading => 'Načítání...';
+
+  @override
+  String get loadingDuration => 'Načítání délky...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekund';
+  }
+
+  @override
+  String get people => 'Lidé';
+
+  @override
+  String get addNewPerson => 'Přidat novou osobu';
+
+  @override
+  String get editPerson => 'Upravit osobu';
+
+  @override
+  String get createPersonHint => 'Vytvořte novou osobu a naučte Omi rozpoznat i její řeč!';
+
+  @override
+  String get speechProfile => 'Hlasový profil';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Vzorek $number';
+  }
+
+  @override
+  String get settings => 'Nastavení';
+
+  @override
+  String get language => 'Jazyk';
+
+  @override
+  String get selectLanguage => 'Vybrat jazyk';
+
+  @override
+  String get deleting => 'Mazání...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
+
+  @override
+  String get failedToStartAuthentication => 'Nepodařilo se spustit ověření';
+
+  @override
+  String get importStarted => 'Import byl zahájen! Budete informováni, až bude dokončen.';
+
+  @override
+  String get failedToStartImport => 'Nepodařilo se spustit import. Zkuste to prosím znovu.';
+
+  @override
+  String get couldNotAccessFile => 'K vybranému souboru se nepodařilo získat přístup';
+
+  @override
+  String get askOmi => 'Zeptat se Omi';
+
+  @override
+  String get done => 'Hotovo';
+
+  @override
+  String get disconnected => 'Odpojeno';
+
+  @override
+  String get searching => 'Vyhledávání';
+
+  @override
+  String get connectDevice => 'Připojit zařízení';
+
+  @override
+  String get monthlyLimitReached => 'Dosáhli jste měsíčního limitu.';
+
+  @override
+  String get checkUsage => 'Zkontrolovat využití';
+
+  @override
+  String get syncingRecordings => 'Synchronizace nahrávek';
+
+  @override
+  String get recordingsToSync => 'Nahrávky k synchronizaci';
+
+  @override
+  String get allCaughtUp => 'Vše je aktuální';
+
+  @override
+  String get sync => 'Synchronizovat';
+
+  @override
+  String get pendantUpToDate => 'Přívěsek je aktuální';
+
+  @override
+  String get allRecordingsSynced => 'Všechny nahrávky jsou synchronizovány';
+
+  @override
+  String get syncingInProgress => 'Probíhá synchronizace';
+
+  @override
+  String get readyToSync => 'Připraveno k synchronizaci';
+
+  @override
+  String get tapSyncToStart => 'Klepněte na Synchronizovat';
+
+  @override
+  String get pendantNotConnected => 'Přívěsek není připojen. Připojte jej pro synchronizaci.';
+
+  @override
+  String get everythingSynced => 'Vše je již synchronizováno.';
+
+  @override
+  String get recordingsNotSynced => 'Máte nahrávky, které ještě nejsou synchronizovány.';
+
+  @override
+  String get syncingBackground => 'Budeme pokračovat v synchronizaci vašich nahrávek na pozadí.';
+
+  @override
+  String get noConversationsYet => 'Zatím žádné konverzace.';
+
+  @override
+  String get noStarredConversations => 'Zatím žádné oblíbené konverzace.';
+
+  @override
+  String get starConversationHint =>
+      'Chcete-li konverzaci označit hvězdičkou, otevřete ji a klepněte na ikonu hvězdičky v záhlaví.';
+
+  @override
+  String get searchConversations => 'Hledat konverzace';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return 'Vybráno: $count';
+  }
+
+  @override
+  String get merge => 'Sloučit';
+
+  @override
+  String get mergeConversations => 'Sloučit konverzace';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Tím se spojí $count konverzací do jedné. Veškerý obsah bude sloučen a znovu vygenerován.';
+  }
+
+  @override
+  String get mergingInBackground => 'Slučování na pozadí. Může to chvíli trvat.';
+
+  @override
+  String get failedToStartMerge => 'Nepodařilo se spustit sloučení';
+
+  @override
+  String get askAnything => 'Zeptejte se na cokoliv';
+
+  @override
+  String get noMessagesYet => 'Zatím žádné zprávy!\nProč nezačít konverzaci?';
+
+  @override
+  String get deletingMessages => 'Mazání vašich zpráv z paměti Omi...';
+
+  @override
+  String get messageCopied => 'Zpráva zkopírována do schránky.';
+
+  @override
+  String get cannotReportOwnMessage => 'Nemůžete nahlásit vlastní zprávy.';
+
+  @override
+  String get reportMessage => 'Nahlásit zprávu';
+
+  @override
+  String get reportMessageConfirm => 'Opravdu chcete nahlásit tuto zprávu?';
+
+  @override
+  String get messageReported => 'Zpráva úspěšně nahlášena.';
+
+  @override
+  String get thankYouFeedback => 'Děkujeme za vaši zpětnou vazbu!';
+
+  @override
+  String get clearChat => 'Vymazat chat?';
+
+  @override
+  String get clearChatConfirm => 'Opravdu chcete vymazat chat? Tuto akci nelze vrátit zpět.';
+
+  @override
+  String get maxFilesLimit => 'Najednou můžete nahrát pouze 4 soubory';
+
+  @override
+  String get chatWithOmi => 'Chat s Omi';
+
+  @override
+  String get apps => 'Aplikace';
+
+  @override
+  String get noAppsFound => 'Nenalezeny žádné aplikace';
+
+  @override
+  String get tryAdjustingSearch => 'Zkuste upravit vyhledávání nebo filtry';
+
+  @override
+  String get createYourOwnApp => 'Vytvořte vlastní aplikaci';
+
+  @override
+  String get buildAndShareApp => 'Vytvořte a sdílejte vlastní aplikaci';
+
+  @override
+  String get searchApps => 'Hledat v 1500+ aplikacích';
+
+  @override
+  String get myApps => 'Moje aplikace';
+
+  @override
+  String get installedApps => 'Nainstalované aplikace';
+
+  @override
+  String get unableToFetchApps =>
+      'Nelze načíst aplikace :(\n\nZkontrolujte prosím připojení k internetu a zkuste to znovu.';
+
+  @override
+  String get aboutOmi => 'O aplikaci Omi';
+
+  @override
+  String get privacyPolicy => 'Zásadami ochrany osobních údajů';
+
+  @override
+  String get visitWebsite => 'Navštívit webové stránky';
+
+  @override
+  String get helpOrInquiries => 'Pomoc nebo dotazy?';
+
+  @override
+  String get joinCommunity => 'Připojte se ke komunitě!';
+
+  @override
+  String get membersAndCounting => '8000+ členů a stále přibývá.';
+
+  @override
+  String get deleteAccountTitle => 'Smazat účet';
+
+  @override
+  String get deleteAccountConfirm => 'Opravdu chcete smazat svůj účet?';
+
+  @override
+  String get cannotBeUndone => 'Toto nelze vrátit zpět.';
+
+  @override
+  String get allDataErased => 'Všechny vaše vzpomínky a konverzace budou trvale smazány.';
+
+  @override
+  String get appsDisconnected => 'Vaše aplikace a integrace budou okamžitě odpojeny.';
+
+  @override
+  String get exportBeforeDelete => 'Před smazáním účtu si můžete exportovat data, ale po smazání je nelze obnovit.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Rozumím tomu, že smazání mého účtu je trvalé a všechna data včetně vzpomínek a konverzací budou ztracena a nelze je obnovit.';
+
+  @override
+  String get areYouSure => 'Jste si jisti?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Tato akce je nevratná a trvale smaže váš účet a všechna související data. Opravdu chcete pokračovat?';
+
+  @override
+  String get deleteNow => 'Smazat nyní';
+
+  @override
+  String get goBack => 'Zpět';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Zaškrtněte políčko pro potvrzení, že rozumíte tomu, že smazání účtu je trvalé a nevratné.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Jméno';
+
+  @override
+  String get email => 'E-mail';
+
+  @override
+  String get customVocabulary => 'Vlastní slovník';
+
+  @override
+  String get identifyingOthers => 'Identifikace ostatních';
+
+  @override
+  String get paymentMethods => 'Platební metody';
+
+  @override
+  String get conversationDisplay => 'Zobrazení konverzace';
+
+  @override
+  String get dataPrivacy => 'Data a soukromí';
+
+  @override
+  String get userId => 'ID uživatele';
+
+  @override
+  String get notSet => 'Nenastaveno';
+
+  @override
+  String get userIdCopied => 'ID uživatele zkopírováno do schránky';
+
+  @override
+  String get systemDefault => 'Výchozí systém';
+
+  @override
+  String get planAndUsage => 'Plán a využití';
+
+  @override
+  String get offlineSync => 'Offline synchronizace';
+
+  @override
+  String get deviceSettings => 'Nastavení zařízení';
+
+  @override
+  String get chatTools => 'Nástroje chatu';
+
+  @override
+  String get feedbackBug => 'Zpětná vazba / Chyba';
+
+  @override
+  String get helpCenter => 'Centrum nápovědy';
+
+  @override
+  String get developerSettings => 'Nastavení pro vývojáře';
+
+  @override
+  String get getOmiForMac => 'Získat Omi pro Mac';
+
+  @override
+  String get referralProgram => 'Doporučovací program';
+
+  @override
+  String get signOut => 'Odhlásit se';
+
+  @override
+  String get appAndDeviceCopied => 'Podrobnosti o aplikaci a zařízení zkopírovány';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Vaše soukromí, vaše kontrola';
+
+  @override
+  String get privacyIntro =>
+      'V Omi se zavazujeme chránit vaše soukromí. Tato stránka vám umožňuje kontrolovat, jak jsou vaše data ukládána a používána.';
+
+  @override
+  String get learnMore => 'Dozvědět se více...';
+
+  @override
+  String get dataProtectionLevel => 'Úroveň ochrany dat';
+
+  @override
+  String get dataProtectionDesc =>
+      'Vaše data jsou standardně zabezpečena silným šifrováním. Níže si prohlédněte svá nastavení a budoucí možnosti ochrany soukromí.';
+
+  @override
+  String get appAccess => 'Přístup aplikací';
+
+  @override
+  String get appAccessDesc =>
+      'Následující aplikace mají přístup k vašim datům. Klepnutím na aplikaci spravujete její oprávnění.';
+
+  @override
+  String get noAppsExternalAccess => 'Žádné nainstalované aplikace nemají externí přístup k vašim datům.';
+
+  @override
+  String get deviceName => 'Název zařízení';
+
+  @override
+  String get deviceId => 'ID zařízení';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'Synchronizace SD karty';
+
+  @override
+  String get hardwareRevision => 'Revize hardwaru';
+
+  @override
+  String get modelNumber => 'Číslo modelu';
+
+  @override
+  String get manufacturer => 'Výrobce';
+
+  @override
+  String get doubleTap => 'Dvojité klepnutí';
+
+  @override
+  String get ledBrightness => 'Jas LED';
+
+  @override
+  String get micGain => 'Zesílení mikrofonu';
+
+  @override
+  String get disconnect => 'Odpojit';
+
+  @override
+  String get forgetDevice => 'Zapomenout zařízení';
+
+  @override
+  String get chargingIssues => 'Problémy s nabíjením';
+
+  @override
+  String get disconnectDevice => 'Odpojit zařízení';
+
+  @override
+  String get unpairDevice => 'Zrušit párování zařízení';
+
+  @override
+  String get unpairAndForget => 'Zrušit párování a zapomenout zařízení';
+
+  @override
+  String get deviceDisconnectedMessage => 'Vaše Omi bylo odpojeno 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Párování zařízení zrušeno. Přejděte do Nastavení > Bluetooth a zapomeňte zařízení pro dokončení zrušení párování.';
+
+  @override
+  String get unpairDialogTitle => 'Zrušit párování zařízení';
+
+  @override
+  String get unpairDialogMessage =>
+      'Tím se zruší párování zařízení, aby mohlo být připojeno k jinému telefonu. Budete muset přejít do Nastavení > Bluetooth a zapomenout zařízení pro dokončení procesu.';
+
+  @override
+  String get deviceNotConnected => 'Zařízení není připojeno';
+
+  @override
+  String get connectDeviceMessage => 'Připojte své zařízení Omi pro přístup\nk nastavením a přizpůsobení zařízení';
+
+  @override
+  String get deviceInfoSection => 'Informace o zařízení';
+
+  @override
+  String get customizationSection => 'Přizpůsobení';
+
+  @override
+  String get hardwareSection => 'Hardware';
+
+  @override
+  String get v2Undetected => 'V2 nedetekováno';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Vidíme, že máte buď zařízení V1, nebo vaše zařízení není připojeno. Funkce SD karty je dostupná pouze pro zařízení V2.';
+
+  @override
+  String get endConversation => 'Ukončit konverzaci';
+
+  @override
+  String get pauseResume => 'Pozastavit/Obnovit';
+
+  @override
+  String get starConversation => 'Označit konverzaci hvězdičkou';
+
+  @override
+  String get doubleTapAction => 'Akce dvojitého klepnutí';
+
+  @override
+  String get endAndProcess => 'Ukončit a zpracovat konverzaci';
+
+  @override
+  String get pauseResumeRecording => 'Pozastavit/Obnovit nahrávání';
+
+  @override
+  String get starOngoing => 'Označit probíhající konverzaci hvězdičkou';
+
+  @override
+  String get off => 'Vypnuto';
+
+  @override
+  String get max => 'Maximum';
+
+  @override
+  String get mute => 'Ztlumit';
+
+  @override
+  String get quiet => 'Tiché';
+
+  @override
+  String get normal => 'Normální';
+
+  @override
+  String get high => 'Vysoké';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon je ztlumený';
+
+  @override
+  String get micGainDescLow => 'Velmi tiché - pro hlučná prostředí';
+
+  @override
+  String get micGainDescModerate => 'Tiché - pro mírný hluk';
+
+  @override
+  String get micGainDescNeutral => 'Neutrální - vyvážené nahrávání';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Mírně zesílené - běžné použití';
+
+  @override
+  String get micGainDescBoosted => 'Zesílené - pro tichá prostředí';
+
+  @override
+  String get micGainDescHigh => 'Vysoké - pro vzdálené nebo tiché hlasy';
+
+  @override
+  String get micGainDescVeryHigh => 'Velmi vysoké - pro velmi tiché zdroje';
+
+  @override
+  String get micGainDescMax => 'Maximum - používejte opatrně';
+
+  @override
+  String get developerSettingsTitle => 'Nastavení pro vývojáře';
+
+  @override
+  String get saving => 'Ukládání...';
+
+  @override
+  String get personaConfig => 'Nakonfigurujte svou AI personu';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Přepis';
+
+  @override
+  String get transcriptionConfig => 'Nakonfigurovat poskytovatele STT';
+
+  @override
+  String get conversationTimeout => 'Časový limit konverzace';
+
+  @override
+  String get conversationTimeoutConfig => 'Nastavit, kdy konverzace automaticky skončí';
+
+  @override
+  String get importData => 'Importovat data';
+
+  @override
+  String get importDataConfig => 'Importovat data z jiných zdrojů';
+
+  @override
+  String get debugDiagnostics => 'Ladění a diagnostika';
+
+  @override
+  String get endpointUrl => 'URL koncového bodu';
+
+  @override
+  String get noApiKeys => 'Zatím žádné API klíče';
+
+  @override
+  String get createKeyToStart => 'Vytvořte klíč pro začátek';
+
+  @override
+  String get createKey => 'Vytvořit klíč';
+
+  @override
+  String get docs => 'Dokumentace';
+
+  @override
+  String get yourOmiInsights => 'Vaše přehledy Omi';
+
+  @override
+  String get today => 'Dnes';
+
+  @override
+  String get thisMonth => 'Tento měsíc';
+
+  @override
+  String get thisYear => 'Letos';
+
+  @override
+  String get allTime => 'Vždy';
+
+  @override
+  String get noActivityYet => 'Zatím žádná aktivita';
+
+  @override
+  String get startConversationToSeeInsights => 'Začněte konverzaci s Omi,\nabyste zde viděli své přehledy využití.';
+
+  @override
+  String get listening => 'Naslouchání';
+
+  @override
+  String get listeningSubtitle => 'Celková doba, po kterou Omi aktivně naslouchalo.';
+
+  @override
+  String get understanding => 'Porozumění';
+
+  @override
+  String get understandingSubtitle => 'Slova pochopená z vašich konverzací.';
+
+  @override
+  String get providing => 'Poskytování';
+
+  @override
+  String get providingSubtitle => 'Úkoly a poznámky automaticky zachycené.';
+
+  @override
+  String get remembering => 'Zapamatování';
+
+  @override
+  String get rememberingSubtitle => 'Fakta a detaily zapamatované pro vás.';
+
+  @override
+  String get unlimitedPlan => 'Neomezený plán';
+
+  @override
+  String get managePlan => 'Spravovat plán';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Váš plán bude zrušen dne $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Váš plán se obnoví dne $date.';
+  }
+
+  @override
+  String get basicPlan => 'Bezplatný plán';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return 'Využito $used z $limit min';
+  }
+
+  @override
+  String get upgrade => 'Upgradovat';
+
+  @override
+  String get upgradeToUnlimited => 'Upgradovat na neomezený';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Váš plán zahrnuje $limit bezplatných minut měsíčně. Upgradujte pro neomezený přístup.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Sdílím své statistiky Omi! (omi.me - váš AI asistent, který je vždy online)';
+
+  @override
+  String get sharePeriodToday => 'Dnes Omi:';
+
+  @override
+  String get sharePeriodMonth => 'Tento měsíc Omi:';
+
+  @override
+  String get sharePeriodYear => 'Letos Omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Dosud Omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Naslouchalo $minutes minut';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Porozumělo $words slovům';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Poskytlo $count přehledů';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Zapamatovalo si $count vzpomínek';
+  }
+
+  @override
+  String get debugLogs => 'Protokoly ladění';
+
+  @override
+  String get debugLogsAutoDelete => 'Automaticky se smažou po 3 dnech.';
+
+  @override
+  String get debugLogsDesc => 'Pomáhá diagnostikovat problémy';
+
+  @override
+  String get noLogFilesFound => 'Nenalezeny žádné soubory protokolu.';
+
+  @override
+  String get omiDebugLog => 'Protokol ladění Omi';
+
+  @override
+  String get logShared => 'Protokol sdílen';
+
+  @override
+  String get selectLogFile => 'Vybrat soubor protokolu';
+
+  @override
+  String get shareLogs => 'Sdílet protokoly';
+
+  @override
+  String get debugLogCleared => 'Protokol ladění vymazán';
+
+  @override
+  String get exportStarted => 'Export zahájen. Může to trvat několik sekund...';
+
+  @override
+  String get exportAllData => 'Exportovat všechna data';
+
+  @override
+  String get exportDataDesc => 'Exportovat konverzace do souboru JSON';
+
+  @override
+  String get exportedConversations => 'Exportované konverzace z Omi';
+
+  @override
+  String get exportShared => 'Export sdílen';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Smazat graf znalostí?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Tím se smažou všechna odvozená data grafu znalostí (uzly a spojení). Vaše původní vzpomínky zůstanou v bezpečí. Graf bude v průběhu času znovu vytvořen nebo při dalším požadavku.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Graf znalostí úspěšně smazán';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Smazání grafu se nezdařilo: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Smazat graf znalostí';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Vymazat všechny uzly a spojení';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Server MCP';
+
+  @override
+  String get mcpServerDesc => 'Připojit AI asistenty k vašim datům';
+
+  @override
+  String get serverUrl => 'URL serveru';
+
+  @override
+  String get urlCopied => 'URL zkopírována';
+
+  @override
+  String get apiKeyAuth => 'Ověření API klíčem';
+
+  @override
+  String get header => 'Záhlaví';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <klíč>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID klienta';
+
+  @override
+  String get clientSecret => 'Tajný klíč klienta';
+
+  @override
+  String get useMcpApiKey => 'Použijte svůj MCP API klíč';
+
+  @override
+  String get webhooks => 'Webhooky';
+
+  @override
+  String get conversationEvents => 'Události konverzace';
+
+  @override
+  String get newConversationCreated => 'Vytvořena nová konverzace';
+
+  @override
+  String get realtimeTranscript => 'Přepis v reálném čase';
+
+  @override
+  String get transcriptReceived => 'Přepis přijat';
+
+  @override
+  String get audioBytes => 'Audio bajty';
+
+  @override
+  String get audioDataReceived => 'Audio data přijata';
+
+  @override
+  String get intervalSeconds => 'Interval (sekundy)';
+
+  @override
+  String get daySummary => 'Denní souhrn';
+
+  @override
+  String get summaryGenerated => 'Souhrn vygenerován';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Přidat do claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Kopírovat konfiguraci';
+
+  @override
+  String get configCopied => 'Konfigurace zkopírována do schránky';
+
+  @override
+  String get listeningMins => 'Naslouchání (min)';
+
+  @override
+  String get understandingWords => 'Porozumění (slova)';
+
+  @override
+  String get insights => 'Přehledy';
+
+  @override
+  String get memories => 'Vzpomínky';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return 'Tento měsíc využito $used z $limit min';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return 'Tento měsíc pochopeno $used z $limit slov';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return 'Tento měsíc získáno $used z $limit přehledů';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return 'Tento měsíc vytvořeno $used z $limit vzpomínek';
+  }
+
+  @override
+  String get visibility => 'Viditelnost';
+
+  @override
+  String get visibilitySubtitle => 'Kontrolujte, které konverzace se zobrazují ve vašem seznamu';
+
+  @override
+  String get showShortConversations => 'Zobrazit krátké konverzace';
+
+  @override
+  String get showShortConversationsDesc => 'Zobrazit konverzace kratší než prahová hodnota';
+
+  @override
+  String get showDiscardedConversations => 'Zobrazit zahozené konverzace';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Zahrnout konverzace označené jako zahozené';
+
+  @override
+  String get shortConversationThreshold => 'Prahová hodnota krátkých konverzací';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Konverzace kratší než tato hodnota budou skryty, pokud nejsou výše povoleny';
+
+  @override
+  String get durationThreshold => 'Prahová hodnota trvání';
+
+  @override
+  String get durationThresholdDesc => 'Skrýt konverzace kratší než tato hodnota';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Vlastní slovník';
+
+  @override
+  String get addWords => 'Přidat slova';
+
+  @override
+  String get addWordsDesc => 'Jména, výrazy nebo neobvyklá slova';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Připojit';
+
+  @override
+  String get comingSoon => 'Již brzy';
+
+  @override
+  String get chatToolsFooter => 'Připojte své aplikace k zobrazení dat a metrik v chatu.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Nepodařilo se spustit ověření $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Odpojit $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Opravdu chcete odpojit od $appName? Můžete se kdykoli znovu připojit.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Odpojeno od $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Nepodařilo se odpojit';
+
+  @override
+  String connectTo(String appName) {
+    return 'Připojit k $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Budete muset autorizovat Omi pro přístup k vašim datům $appName. Tím se otevře váš prohlížeč pro ověření.';
+  }
+
+  @override
+  String get continueAction => 'Pokračovat';
+
+  @override
+  String get languageTitle => 'Jazyk';
+
+  @override
+  String get primaryLanguage => 'Primární jazyk';
+
+  @override
+  String get automaticTranslation => 'Automatický překlad';
+
+  @override
+  String get detectLanguages => 'Detekovat 10+ jazyků';
+
+  @override
+  String get authorizeSavingRecordings => 'Autorizovat ukládání nahrávek';
+
+  @override
+  String get thanksForAuthorizing => 'Děkujeme za autorizaci!';
+
+  @override
+  String get needYourPermission => 'Potřebujeme vaše povolení';
+
+  @override
+  String get alreadyGavePermission =>
+      'Již jste nám dali povolení k ukládání vašich nahrávek. Zde je připomenutí, proč to potřebujeme:';
+
+  @override
+  String get wouldLikePermission => 'Rádi bychom vaše povolení k ukládání vašich hlasových nahrávek. Zde je proč:';
+
+  @override
+  String get improveSpeechProfile => 'Vylepšit váš hlasový profil';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Nahrávky používáme k dalšímu trénování a vylepšování vašeho osobního hlasového profilu.';
+
+  @override
+  String get trainFamilyProfiles => 'Trénovat profily pro přátele a rodinu';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Vaše nahrávky nám pomáhají rozpoznat a vytvářet profily pro vaše přátele a rodinu.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Zvýšit přesnost přepisu';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'S vylepšením našeho modelu můžeme pro vaše nahrávky poskytovat lepší výsledky přepisu.';
+
+  @override
+  String get legalNotice =>
+      'Právní upozornění: Legálnost nahrávání a ukládání hlasových dat se může lišit v závislosti na vaší lokalitě a způsobu použití této funkce. Je vaší odpovědností zajistit dodržování místních zákonů a předpisů.';
+
+  @override
+  String get alreadyAuthorized => 'Již autorizováno';
+
+  @override
+  String get authorize => 'Autorizovat';
+
+  @override
+  String get revokeAuthorization => 'Zrušit autorizaci';
+
+  @override
+  String get authorizationSuccessful => 'Autorizace úspěšná!';
+
+  @override
+  String get failedToAuthorize => 'Autorizace se nezdařila. Zkuste to prosím znovu.';
+
+  @override
+  String get authorizationRevoked => 'Autorizace zrušena.';
+
+  @override
+  String get recordingsDeleted => 'Nahrávky smazány.';
+
+  @override
+  String get failedToRevoke => 'Zrušení autorizace se nezdařilo. Zkuste to prosím znovu.';
+
+  @override
+  String get permissionRevokedTitle => 'Povolení zrušeno';
+
+  @override
+  String get permissionRevokedMessage => 'Chcete, abychom odstranili také všechny vaše existující nahrávky?';
+
+  @override
+  String get yes => 'Ano';
+
+  @override
+  String get editName => 'Upravit jméno';
+
+  @override
+  String get howShouldOmiCallYou => 'Jak vás má Omi oslovovat?';
+
+  @override
+  String get enterYourName => 'Zadejte své jméno';
+
+  @override
+  String get nameCannotBeEmpty => 'Jméno nemůže být prázdné';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Jméno úspěšně aktualizováno!';
+
+  @override
+  String get calendarSettings => 'Nastavení kalendáře';
+
+  @override
+  String get calendarProviders => 'Poskytovatelé kalendáře';
+
+  @override
+  String get macOsCalendar => 'Kalendář macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Připojit váš místní kalendář macOS';
+
+  @override
+  String get googleCalendar => 'Kalendář Google';
+
+  @override
+  String get syncGoogleAccount => 'Synchronizovat s vaším účtem Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Zobrazit nadcházející schůzky v menu baru';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Zobrazit vaši další schůzku a čas do jejího začátku v menu baru macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Zobrazit události bez účastníků';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Pokud je povoleno, Již brzy zobrazuje události bez účastníků nebo video odkazu.';
+
+  @override
+  String get yourMeetings => 'Vaše schůzky';
+
+  @override
+  String get refresh => 'Obnovit';
+
+  @override
+  String get noUpcomingMeetings => 'Nenalezeny žádné nadcházející schůzky';
+
+  @override
+  String get checkingNextDays => 'Kontrola dalších 30 dnů';
+
+  @override
+  String get tomorrow => 'Zítra';
+
+  @override
+  String get googleCalendarComingSoon => 'Integrace s Kalendářem Google již brzy!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Připojeno jako uživatel: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Výchozí pracovní prostor';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Úkoly budou vytvořeny v tomto pracovním prostoru';
+
+  @override
+  String get defaultProjectOptional => 'Výchozí projekt (volitelné)';
+
+  @override
+  String get leaveUnselectedTasks => 'Ponechte nevybrané pro vytváření úkolů bez projektu';
+
+  @override
+  String get noProjectsInWorkspace => 'V tomto pracovním prostoru nebyly nalezeny žádné projekty';
+
+  @override
+  String get conversationTimeoutDesc => 'Vyberte, jak dlouho čekat v tichosti před automatickým ukončením konverzace:';
+
+  @override
+  String get timeout2Minutes => '2 minuty';
+
+  @override
+  String get timeout2MinutesDesc => 'Ukončit konverzaci po 2 minutách ticha';
+
+  @override
+  String get timeout5Minutes => '5 minut';
+
+  @override
+  String get timeout5MinutesDesc => 'Ukončit konverzaci po 5 minutách ticha';
+
+  @override
+  String get timeout10Minutes => '10 minut';
+
+  @override
+  String get timeout10MinutesDesc => 'Ukončit konverzaci po 10 minutách ticha';
+
+  @override
+  String get timeout30Minutes => '30 minut';
+
+  @override
+  String get timeout30MinutesDesc => 'Ukončit konverzaci po 30 minutách ticha';
+
+  @override
+  String get timeout4Hours => '4 hodiny';
+
+  @override
+  String get timeout4HoursDesc => 'Ukončit konverzaci po 4 hodinách ticha';
+
+  @override
+  String get conversationEndAfterHours => 'Konverzace nyní skončí po 4 hodinách ticha';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Konverzace nyní skončí po $minutes minutě/minutách ticha';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Řekněte nám svůj primární jazyk';
+
+  @override
+  String get languageForTranscription => 'Nastavte svůj jazyk pro ostřejší přepisy a personalizovaný zážitek.';
+
+  @override
+  String get singleLanguageModeInfo => 'Režim jednoho jazyka je povolen. Překlad je zakázán pro vyšší přesnost.';
+
+  @override
+  String get searchLanguageHint => 'Hledat jazyk podle názvu nebo kódu';
+
+  @override
+  String get noLanguagesFound => 'Nenalezeny žádné jazyky';
+
+  @override
+  String get skip => 'Přeskočit';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Jazyk nastaven na $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Nastavení jazyka se nezdařilo';
+
+  @override
+  String appSettings(String appName) {
+    return 'Nastavení $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Odpojit od $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Tím se odstraní vaše ověření $appName. Pro opětovné použití se budete muset znovu připojit.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Připojeno k $appName';
+  }
+
+  @override
+  String get account => 'Účet';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Vaše úkoly budou synchronizovány s vaším účtem $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Výchozí prostor';
+
+  @override
+  String get selectSpaceInWorkspace => 'Vyberte prostor ve vašem pracovním prostoru';
+
+  @override
+  String get noSpacesInWorkspace => 'V tomto pracovním prostoru nebyly nalezeny žádné prostory';
+
+  @override
+  String get defaultList => 'Výchozí seznam';
+
+  @override
+  String get tasksAddedToList => 'Úkoly budou přidány do tohoto seznamu';
+
+  @override
+  String get noListsInSpace => 'V tomto prostoru nebyly nalezeny žádné seznamy';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Načtení repozitářů se nezdařilo: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Výchozí repozitář uložen';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Uložení výchozího repozitáře se nezdařilo';
+
+  @override
+  String get defaultRepository => 'Výchozí repozitář';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Vyberte výchozí repozitář pro vytváření problémů. Při vytváření problémů můžete stále specifikovat jiný repozitář.';
+
+  @override
+  String get noReposFound => 'Nenalezeny žádné repozitáře';
+
+  @override
+  String get private => 'Soukromé';
+
+  @override
+  String updatedDate(String date) {
+    return 'Aktualizováno $date';
+  }
+
+  @override
+  String get yesterday => 'včera';
+
+  @override
+  String daysAgo(int count) {
+    return 'před $count dny';
+  }
+
+  @override
+  String get oneWeekAgo => 'před 1 týdnem';
+
+  @override
+  String weeksAgo(int count) {
+    return 'před $count týdny';
+  }
+
+  @override
+  String get oneMonthAgo => 'před 1 měsícem';
+
+  @override
+  String monthsAgo(int count) {
+    return 'před $count měsíci';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Problémy budou vytvořeny ve vašem výchozím repozitáři';
+
+  @override
+  String get taskIntegrations => 'Integrace úkolů';
+
+  @override
+  String get configureSettings => 'Nakonfigurovat nastavení';
+
+  @override
+  String get completeAuthBrowser =>
+      'Dokončete prosím ověření v prohlížeči. Jakmile budete hotovi, vraťte se do aplikace.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Spuštění ověření $appName se nezdařilo';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Připojit k $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Budete muset autorizovat Omi k vytváření úkolů ve vašem účtu $appName. Tím se otevře váš prohlížeč pro ověření.';
+  }
+
+  @override
+  String get continueButton => 'Pokračovat';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Integrace $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integrace s $appName již brzy! Usilovně pracujeme na tom, abychom vám přinesli více možností správy úkolů.';
+  }
+
+  @override
+  String get gotIt => 'Rozumím';
+
+  @override
+  String get tasksExportedOneApp => 'Úkoly lze exportovat do jedné aplikace najednou.';
+
+  @override
+  String get completeYourUpgrade => 'Dokončete svůj upgrade';
+
+  @override
+  String get importConfiguration => 'Importovat konfiguraci';
+
+  @override
+  String get exportConfiguration => 'Exportovat konfiguraci';
+
+  @override
+  String get bringYourOwn => 'Přineste si vlastní';
+
+  @override
+  String get payYourSttProvider => 'Používejte Omi zdarma. Platíte pouze svému poskytovateli STT přímo.';
+
+  @override
+  String get freeMinutesMonth => '1 200 bezplatných minut měsíčně. Neomezené s ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Host je povinný';
+
+  @override
+  String get validPortRequired => 'Je vyžadován platný port';
+
+  @override
+  String get validWebsocketUrlRequired => 'Je vyžadována platná URL WebSocket (wss://)';
+
+  @override
+  String get apiUrlRequired => 'URL API je povinná';
+
+  @override
+  String get apiKeyRequired => 'API klíč je povinný';
+
+  @override
+  String get invalidJsonConfig => 'Neplatná konfigurace JSON';
+
+  @override
+  String errorSaving(String error) {
+    return 'Chyba při ukládání: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfigurace zkopírována do schránky';
+
+  @override
+  String get pasteJsonConfig => 'Vložte níže svou konfiguraci JSON:';
+
+  @override
+  String get addApiKeyAfterImport => 'Po importu budete muset přidat svůj vlastní API klíč';
+
+  @override
+  String get paste => 'Vložit';
+
+  @override
+  String get import => 'Importovat';
+
+  @override
+  String get invalidProviderInConfig => 'Neplatný poskytovatel v konfiguraci';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Importována konfigurace $providerName';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Neplatný JSON: $error';
+  }
+
+  @override
+  String get provider => 'Poskytovatel';
+
+  @override
+  String get live => 'Živě';
+
+  @override
+  String get onDevice => 'Na zařízení';
+
+  @override
+  String get apiUrl => 'URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Zadejte koncový bod HTTP vašeho STT';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Zadejte WebSocket koncový bod vašeho živého STT';
+
+  @override
+  String get apiKey => 'API klíč';
+
+  @override
+  String get enterApiKey => 'Zadejte svůj API klíč';
+
+  @override
+  String get storedLocallyNeverShared => 'Uloženo lokálně, nikdy nesdíleno';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Pokročilé';
+
+  @override
+  String get configuration => 'Konfigurace';
+
+  @override
+  String get requestConfiguration => 'Konfigurace požadavku';
+
+  @override
+  String get responseSchema => 'Schéma odpovědi';
+
+  @override
+  String get modified => 'Upraveno';
+
+  @override
+  String get resetRequestConfig => 'Obnovit výchozí konfiguraci požadavku';
+
+  @override
+  String get logs => 'Protokoly';
+
+  @override
+  String get logsCopied => 'Protokoly zkopírovány';
+
+  @override
+  String get noLogsYet => 'Zatím žádné protokoly. Začněte nahrávat, abyste viděli aktivitu vlastního STT.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName používá $codecReason. Bude použito Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Přepis Omi';
+
+  @override
+  String get bestInClassTranscription => 'Nejlepší přepis ve své třídě bez nutnosti nastavení';
+
+  @override
+  String get instantSpeakerLabels => 'Okamžité štítky mluvčích';
+
+  @override
+  String get languageTranslation => 'Překlad 100+ jazyků';
+
+  @override
+  String get optimizedForConversation => 'Optimalizováno pro konverzaci';
+
+  @override
+  String get autoLanguageDetection => 'Automatická detekce jazyka';
+
+  @override
+  String get highAccuracy => 'Vysoká přesnost';
+
+  @override
+  String get privacyFirst => 'Soukromí na prvním místě';
+
+  @override
+  String get saveChanges => 'Uložit změny';
+
+  @override
+  String get resetToDefault => 'Obnovit na výchozí';
+
+  @override
+  String get viewTemplate => 'Zobrazit šablonu';
+
+  @override
+  String get trySomethingLike => 'Zkuste něco jako...';
+
+  @override
+  String get tryIt => 'Vyzkoušejte to';
+
+  @override
+  String get creatingPlan => 'Vytváření plánu';
+
+  @override
+  String get developingLogic => 'Vývoj logiky';
+
+  @override
+  String get designingApp => 'Navrhování aplikace';
+
+  @override
+  String get generatingIconStep => 'Generování ikony';
+
+  @override
+  String get finalTouches => 'Závěrečné úpravy';
+
+  @override
+  String get processing => 'Zpracování...';
+
+  @override
+  String get features => 'Funkce';
+
+  @override
+  String get creatingYourApp => 'Vytváření vaší aplikace...';
+
+  @override
+  String get generatingIcon => 'Generování ikony...';
+
+  @override
+  String get whatShouldWeMake => 'Co bychom měli vytvořit?';
+
+  @override
+  String get appName => 'Název aplikace';
+
+  @override
+  String get description => 'Popis';
+
+  @override
+  String get publicLabel => 'Veřejné';
+
+  @override
+  String get privateLabel => 'Soukromé';
+
+  @override
+  String get free => 'Zdarma';
+
+  @override
+  String get perMonth => '/ Měsíc';
+
+  @override
+  String get tailoredConversationSummaries => 'Přizpůsobená shrnutí konverzací';
+
+  @override
+  String get customChatbotPersonality => 'Vlastní osobnost chatbota';
+
+  @override
+  String get makePublic => 'Zveřejnit';
+
+  @override
+  String get anyoneCanDiscover => 'Kdokoli může objevit vaši aplikaci';
+
+  @override
+  String get onlyYouCanUse => 'Pouze vy můžete používat tuto aplikaci';
+
+  @override
+  String get paidApp => 'Placená aplikace';
+
+  @override
+  String get usersPayToUse => 'Uživatelé platí za použití vaší aplikace';
+
+  @override
+  String get freeForEveryone => 'Zdarma pro všechny';
+
+  @override
+  String get perMonthLabel => '/ měsíc';
+
+  @override
+  String get creating => 'Vytváření...';
+
+  @override
+  String get createApp => 'Vytvořit aplikaci';
+
+  @override
+  String get searchingForDevices => 'Hledání zařízení...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ZAŘÍZENÍ',
+      one: 'ZAŘÍZENÍ',
+    );
+    return '$count $_temp0 NALEZENO V BLÍZKOSTI';
+  }
+
+  @override
+  String get pairingSuccessful => 'PÁROVÁNÍ ÚSPĚŠNÉ';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Chyba při připojování k Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Už nezobrazovat';
+
+  @override
+  String get iUnderstand => 'Rozumím';
+
+  @override
+  String get enableBluetooth => 'Povolit Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi potřebuje Bluetooth pro připojení k vašemu nositelného zařízení. Povolte prosím Bluetooth a zkuste to znovu.';
+
+  @override
+  String get contactSupport => 'Kontaktovat podporu?';
+
+  @override
+  String get connectLater => 'Připojit později';
+
+  @override
+  String get grantPermissions => 'Udělit oprávnění';
+
+  @override
+  String get backgroundActivity => 'Aktivita na pozadí';
+
+  @override
+  String get backgroundActivityDesc => 'Umožněte Omi běžet na pozadí pro lepší stabilitu';
+
+  @override
+  String get locationAccess => 'Přístup k poloze';
+
+  @override
+  String get locationAccessDesc => 'Povolte polohu na pozadí pro plný zážitek';
+
+  @override
+  String get notifications => 'Oznámení';
+
+  @override
+  String get notificationsDesc => 'Povolte oznámení, abyste byli informováni';
+
+  @override
+  String get locationServiceDisabled => 'Služba určování polohy zakázána';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Služba určování polohy je zakázána. Přejděte do Nastavení > Soukromí a zabezpečení > Služby určování polohy a povolte ji';
+
+  @override
+  String get backgroundLocationDenied => 'Přístup k poloze na pozadí odepřen';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Přejděte do nastavení zařízení a nastavte oprávnění k poloze na \"Vždy povolit\"';
+
+  @override
+  String get lovingOmi => 'Líbí se vám Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Pomozte nám oslovit více lidí tím, že zanecháte hodnocení v App Store. Vaše zpětná vazba pro nás hodně znamená!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Pomozte nám oslovit více lidí tím, že zanecháte hodnocení v Obchodě Google Play. Vaše zpětná vazba pro nás hodně znamená!';
+
+  @override
+  String get rateOnAppStore => 'Ohodnotit v App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Ohodnotit v Google Play';
+
+  @override
+  String get maybeLater => 'Možná později';
+
+  @override
+  String get speechProfileIntro => 'Omi potřebuje poznat vaše cíle a váš hlas. Později to budete moci upravit.';
+
+  @override
+  String get getStarted => 'Začít';
+
+  @override
+  String get allDone => 'Vše hotovo!';
+
+  @override
+  String get keepGoing => 'Pokračujte dál, jde vám to skvěle';
+
+  @override
+  String get skipThisQuestion => 'Přeskočit tuto otázku';
+
+  @override
+  String get skipForNow => 'Zatím přeskočit';
+
+  @override
+  String get connectionError => 'Chyba připojení';
+
+  @override
+  String get connectionErrorDesc =>
+      'Nepodařilo se připojit k serveru. Zkontrolujte prosím připojení k internetu a zkuste to znovu.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Detekována neplatná nahrávka';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Zdá se, že v nahrávce je více mluvčích. Ujistěte se prosím, že jste na tichém místě, a zkuste to znovu.';
+
+  @override
+  String get tooShortDesc => 'Není detekován dostatek řeči. Mluvte prosím více a zkuste to znovu.';
+
+  @override
+  String get invalidRecordingDesc => 'Ujistěte se prosím, že mluvíte alespoň 5 sekund a ne více než 90.';
+
+  @override
+  String get areYouThere => 'Jste tam?';
+
+  @override
+  String get noSpeechDesc =>
+      'Nemohli jsme detekovat žádnou řeč. Ujistěte se prosím, že mluvíte alespoň 10 sekund a ne více než 3 minuty.';
+
+  @override
+  String get connectionLost => 'Spojení ztraceno';
+
+  @override
+  String get connectionLostDesc =>
+      'Spojení bylo přerušeno. Zkontrolujte prosím připojení k internetu a zkuste to znovu.';
+
+  @override
+  String get tryAgain => 'Zkusit znovu';
+
+  @override
+  String get connectOmiOmiGlass => 'Připojit Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Pokračovat bez zařízení';
+
+  @override
+  String get permissionsRequired => 'Vyžadována oprávnění';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Tato aplikace potřebuje oprávnění Bluetooth a Poloha, aby fungovala správně. Povolte je prosím v nastavení.';
+
+  @override
+  String get openSettings => 'Otevřít nastavení';
+
+  @override
+  String get wantDifferentName => 'Chcete jiné jméno?';
+
+  @override
+  String get whatsYourName => 'Jak se jmenujete?';
+
+  @override
+  String get speakTranscribeSummarize => 'Mluvte. Přepisujte. Shrňte.';
+
+  @override
+  String get signInWithApple => 'Přihlásit se přes Apple';
+
+  @override
+  String get signInWithGoogle => 'Přihlásit se přes Google';
+
+  @override
+  String get byContinuingAgree => 'Pokračováním souhlasíte s našimi ';
+
+  @override
+  String get termsOfUse => 'Podmínkami použití';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Váš AI společník';
+
+  @override
+  String get captureEveryMoment =>
+      'Zachyťte každý okamžik. Získejte souhrny\npodporované AI. Už nikdy si nedělejte poznámky.';
+
+  @override
+  String get appleWatchSetup => 'Nastavení Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Oprávnění požadováno!';
+
+  @override
+  String get microphonePermission => 'Oprávnění k mikrofonu';
+
+  @override
+  String get permissionGrantedNow =>
+      'Oprávnění uděleno! Nyní:\n\nOtevřete aplikaci Omi na hodinkách a klepněte níže na \"Pokračovat\"';
+
+  @override
+  String get needMicrophonePermission =>
+      'Potřebujeme oprávnění k mikrofonu.\n\n1. Klepněte na \"Udělit oprávnění\"\n2. Povolte na svém iPhone\n3. Aplikace na hodinkách se zavře\n4. Znovu otevřete a klepněte na \"Pokračovat\"';
+
+  @override
+  String get grantPermissionButton => 'Udělit oprávnění';
+
+  @override
+  String get needHelp => 'Potřebujete pomoc?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Řešení problémů:\n\n1. Ujistěte se, že Omi je nainstalováno na vašich hodinkách\n2. Otevřete aplikaci Omi na hodinkách\n3. Hledejte vyskakovací okno s oprávněním\n4. Klepněte na \"Povolit\", když budete vyzváni\n5. Aplikace na hodinkách se zavře - znovu ji otevřete\n6. Vraťte se a klepněte na \"Pokračovat\" na svém iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Nahrávání úspěšně zahájeno!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Oprávnění ještě nebylo uděleno. Ujistěte se prosím, že jste povolili přístup k mikrofonu a znovu otevřeli aplikaci na hodinkách.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Chyba při žádosti o oprávnění: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Chyba při zahájení nahrávání: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Vyberte svůj primární jazyk';
+
+  @override
+  String get languageBenefits => 'Nastavte svůj jazyk pro ostřejší přepisy a personalizovaný zážitek';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Jaký je váš primární jazyk?';
+
+  @override
+  String get selectYourLanguage => 'Vyberte svůj jazyk';
+
+  @override
+  String get personalGrowthJourney => 'Vaše cesta osobního růstu s AI, které naslouchá každému vašemu slovu.';
+
+  @override
+  String get actionItemsTitle => 'Úkoly';
+
+  @override
+  String get actionItemsDescription => 'Klepněte pro úpravu • Dlouze stiskněte pro výběr • Přejeďte pro akce';
+
+  @override
+  String get tabToDo => 'K provedení';
+
+  @override
+  String get tabDone => 'Hotovo';
+
+  @override
+  String get tabOld => 'Staré';
+
+  @override
+  String get emptyTodoMessage => '🎉 Vše máte hotové!\nŽádné nevyřízené úkoly';
+
+  @override
+  String get emptyDoneMessage => 'Zatím žádné dokončené položky';
+
+  @override
+  String get emptyOldMessage => '✅ Žádné staré úkoly';
+
+  @override
+  String get noItems => 'Žádné položky';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Úkol označen jako nedokončený';
+
+  @override
+  String get actionItemCompleted => 'Úkol dokončen';
+
+  @override
+  String get deleteActionItemTitle => 'Smazat úkol';
+
+  @override
+  String get deleteActionItemMessage => 'Opravdu chcete smazat tento úkol?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Smazat vybrané položky';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Opravdu chcete smazat $count vybraný/vybrané/vybraných úkol$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Úkol \"$description\" smazán';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return 'Smazáno $count úkol$s';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Smazání úkolu se nezdařilo';
+
+  @override
+  String get failedToDeleteItems => 'Smazání položek se nezdařilo';
+
+  @override
+  String get failedToDeleteSomeItems => 'Smazání některých položek se nezdařilo';
+
+  @override
+  String get welcomeActionItemsTitle => 'Připraveno na úkoly';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Vaše AI automaticky extrahuje úkoly a to-dos z vašich konverzací. Objeví se zde, když budou vytvořeny.';
+
+  @override
+  String get autoExtractionFeature => 'Automaticky extrahováno z konverzací';
+
+  @override
+  String get editSwipeFeature => 'Klepněte pro úpravu, přejeďte pro dokončení nebo smazání';
+
+  @override
+  String itemsSelected(int count) {
+    return 'Vybráno: $count';
+  }
+
+  @override
+  String get selectAll => 'Vybrat vše';
+
+  @override
+  String get deleteSelected => 'Smazat vybrané';
+
+  @override
+  String searchMemories(int count) {
+    return 'Hledat ve $count vzpomínkách';
+  }
+
+  @override
+  String get memoryDeleted => 'Vzpomínka smazána.';
+
+  @override
+  String get undo => 'Vrátit zpět';
+
+  @override
+  String get noMemoriesYet => 'Zatím žádné vzpomínky';
+
+  @override
+  String get noAutoMemories => 'Zatím žádné automaticky extrahované vzpomínky';
+
+  @override
+  String get noManualMemories => 'Zatím žádné manuální vzpomínky';
+
+  @override
+  String get noMemoriesInCategories => 'Žádné vzpomínky v těchto kategoriích';
+
+  @override
+  String get noMemoriesFound => 'Nenalezeny žádné vzpomínky';
+
+  @override
+  String get addFirstMemory => 'Přidat první vzpomínku';
+
+  @override
+  String get clearMemoryTitle => 'Vymazat paměť Omi';
+
+  @override
+  String get clearMemoryMessage => 'Opravdu chcete vymazat paměť Omi? Tuto akci nelze vrátit zpět.';
+
+  @override
+  String get clearMemoryButton => 'Vymazat paměť';
+
+  @override
+  String get memoryClearedSuccess => 'Paměť Omi o vás byla vymazána';
+
+  @override
+  String get noMemoriesToDelete => 'Žádné vzpomínky ke smazání';
+
+  @override
+  String get createMemoryTooltip => 'Vytvořit novou vzpomínku';
+
+  @override
+  String get createActionItemTooltip => 'Vytvořit nový úkol';
+
+  @override
+  String get memoryManagement => 'Správa vzpomínek';
+
+  @override
+  String get filterMemories => 'Filtrovat vzpomínky';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Máte celkem $count vzpomínek';
+  }
+
+  @override
+  String get publicMemories => 'Veřejné vzpomínky';
+
+  @override
+  String get privateMemories => 'Soukromé vzpomínky';
+
+  @override
+  String get makeAllPrivate => 'Nastavit všechny vzpomínky jako soukromé';
+
+  @override
+  String get makeAllPublic => 'Nastavit všechny vzpomínky jako veřejné';
+
+  @override
+  String get deleteAllMemories => 'Smazat všechny vzpomínky';
+
+  @override
+  String get allMemoriesPrivateResult => 'Všechny vzpomínky jsou nyní soukromé';
+
+  @override
+  String get allMemoriesPublicResult => 'Všechny vzpomínky jsou nyní veřejné';
+
+  @override
+  String get newMemory => 'Nová vzpomínka';
+
+  @override
+  String get editMemory => 'Upravit vzpomínku';
+
+  @override
+  String get memoryContentHint => 'Rád/a jím zmrzlinu...';
+
+  @override
+  String get failedToSaveMemory => 'Uložení se nezdařilo. Zkontrolujte prosím připojení.';
+
+  @override
+  String get saveMemory => 'Uložit vzpomínku';
+
+  @override
+  String get retry => 'Zkusit znovu';
+
+  @override
+  String get createActionItem => 'Vytvořit úkol';
+
+  @override
+  String get editActionItem => 'Upravit úkol';
+
+  @override
+  String get actionItemDescriptionHint => 'Co je třeba udělat?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Popis úkolu nemůže být prázdný.';
+
+  @override
+  String get actionItemUpdated => 'Úkol aktualizován';
+
+  @override
+  String get failedToUpdateActionItem => 'Aktualizace úkolu se nezdařila';
+
+  @override
+  String get actionItemCreated => 'Úkol vytvořen';
+
+  @override
+  String get failedToCreateActionItem => 'Vytvoření úkolu se nezdařilo';
+
+  @override
+  String get dueDate => 'Termín dokončení';
+
+  @override
+  String get time => 'Čas';
+
+  @override
+  String get addDueDate => 'Přidat termín dokončení';
+
+  @override
+  String get pressDoneToSave => 'Stiskněte hotovo pro uložení';
+
+  @override
+  String get pressDoneToCreate => 'Stiskněte hotovo pro vytvoření';
+
+  @override
+  String get filterAll => 'Vše';
+
+  @override
+  String get filterSystem => 'O vás';
+
+  @override
+  String get filterInteresting => 'Přehledy';
+
+  @override
+  String get filterManual => 'Manuální';
+
+  @override
+  String get completed => 'Dokončeno';
+
+  @override
+  String get markComplete => 'Označit jako dokončené';
+
+  @override
+  String get actionItemDeleted => 'Úkol smazán';
+
+  @override
+  String get failedToDeleteActionItem => 'Smazání úkolu se nezdařilo';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Smazat úkol';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Opravdu chcete smazat tento úkol?';
+
+  @override
+  String get appLanguage => 'Jazyk aplikace';
+
+  @override
+  String get appInterfaceSectionTitle => 'ROZHRANÍ APLIKACE';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'ŘEČ A PŘEPIS';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Jazyk aplikace mění nabídky a tlačítka. Jazyk řeči ovlivňuje, jak jsou vaše nahrávky přepisovány.';
+}

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -1,0 +1,2234 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Danish (`da`).
+class AppLocalizationsDa extends AppLocalizations {
+  AppLocalizationsDa([String locale = 'da']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Samtale';
+
+  @override
+  String get transcriptTab => 'Udskrift';
+
+  @override
+  String get actionItemsTab => 'Handlingspunkter';
+
+  @override
+  String get deleteConversationTitle => 'Slet samtale?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Er du sikker på, at du vil slette denne samtale? Denne handling kan ikke fortrydes.';
+
+  @override
+  String get confirm => 'Bekræft';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Delete';
+
+  @override
+  String get add => 'Tilføj';
+
+  @override
+  String get update => 'Opdater';
+
+  @override
+  String get save => 'Gem';
+
+  @override
+  String get edit => 'Rediger';
+
+  @override
+  String get close => 'Luk';
+
+  @override
+  String get clear => 'Ryd';
+
+  @override
+  String get copyTranscript => 'Kopier udskrift';
+
+  @override
+  String get copySummary => 'Kopier sammenfatning';
+
+  @override
+  String get testPrompt => 'Test prompt';
+
+  @override
+  String get reprocessConversation => 'Genbehandl samtale';
+
+  @override
+  String get deleteConversation => 'Slet samtale';
+
+  @override
+  String get contentCopied => 'Indhold kopieret til udklipsholder';
+
+  @override
+  String get failedToUpdateStarred => 'Kunne ikke opdatere stjerne-status.';
+
+  @override
+  String get conversationUrlNotShared => 'Samtale-URL kunne ikke deles.';
+
+  @override
+  String get errorProcessingConversation => 'Fejl under behandling af samtale. Prøv venligst igen senere.';
+
+  @override
+  String get noInternetConnection => 'Tjek venligst din internetforbindelse og prøv igen.';
+
+  @override
+  String get unableToDeleteConversation => 'Kan ikke slette samtale';
+
+  @override
+  String get somethingWentWrong => 'Noget gik galt! Prøv venligst igen senere.';
+
+  @override
+  String get copyErrorMessage => 'Kopier fejlbesked';
+
+  @override
+  String get errorCopied => 'Fejlbesked kopieret til udklipsholder';
+
+  @override
+  String get remaining => 'Resterende';
+
+  @override
+  String get loading => 'Indlæser...';
+
+  @override
+  String get loadingDuration => 'Indlæser varighed...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekunder';
+  }
+
+  @override
+  String get people => 'Personer';
+
+  @override
+  String get addNewPerson => 'Tilføj ny person';
+
+  @override
+  String get editPerson => 'Rediger person';
+
+  @override
+  String get createPersonHint => 'Opret en ny person og træn Omi til at genkende deres tale også!';
+
+  @override
+  String get speechProfile => 'Taleprofil';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Prøve $number';
+  }
+
+  @override
+  String get settings => 'Indstillinger';
+
+  @override
+  String get language => 'Sprog';
+
+  @override
+  String get selectLanguage => 'Vælg sprog';
+
+  @override
+  String get deleting => 'Sletter...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Fuldfør venligst godkendelse i din browser. Når det er færdigt, vend tilbage til appen.';
+
+  @override
+  String get failedToStartAuthentication => 'Kunne ikke starte godkendelse';
+
+  @override
+  String get importStarted => 'Import startet! Du får besked når den er færdig.';
+
+  @override
+  String get failedToStartImport => 'Kunne ikke starte import. Prøv venligst igen.';
+
+  @override
+  String get couldNotAccessFile => 'Kunne ikke få adgang til den valgte fil';
+
+  @override
+  String get askOmi => 'Spørg Omi';
+
+  @override
+  String get done => 'Done';
+
+  @override
+  String get disconnected => 'Frakoblet';
+
+  @override
+  String get searching => 'Søger';
+
+  @override
+  String get connectDevice => 'Tilslut enhed';
+
+  @override
+  String get monthlyLimitReached => 'Du har nået din månedlige grænse.';
+
+  @override
+  String get checkUsage => 'Tjek forbrug';
+
+  @override
+  String get syncingRecordings => 'Synkroniserer optagelser';
+
+  @override
+  String get recordingsToSync => 'Optagelser til synkronisering';
+
+  @override
+  String get allCaughtUp => 'Alt er opdateret';
+
+  @override
+  String get sync => 'Synkroniser';
+
+  @override
+  String get pendantUpToDate => 'Vedhæng er opdateret';
+
+  @override
+  String get allRecordingsSynced => 'Alle optagelser er synkroniseret';
+
+  @override
+  String get syncingInProgress => 'Synkronisering i gang';
+
+  @override
+  String get readyToSync => 'Klar til synkronisering';
+
+  @override
+  String get tapSyncToStart => 'Tryk på Synkroniser for at starte';
+
+  @override
+  String get pendantNotConnected => 'Vedhæng ikke tilsluttet. Tilslut for at synkronisere.';
+
+  @override
+  String get everythingSynced => 'Alt er allerede synkroniseret.';
+
+  @override
+  String get recordingsNotSynced => 'Du har optagelser, der ikke er synkroniseret endnu.';
+
+  @override
+  String get syncingBackground => 'Vi fortsætter med at synkronisere dine optagelser i baggrunden.';
+
+  @override
+  String get noConversationsYet => 'Ingen samtaler endnu.';
+
+  @override
+  String get noStarredConversations => 'Ingen stjernemarkerede samtaler endnu.';
+
+  @override
+  String get starConversationHint =>
+      'For at stjernemarkere en samtale skal du åbne den og trykke på stjerneikonet i overskriften.';
+
+  @override
+  String get searchConversations => 'Søg samtaler';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count valgt';
+  }
+
+  @override
+  String get merge => 'Flet';
+
+  @override
+  String get mergeConversations => 'Flet samtaler';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Dette vil kombinere $count samtaler til én. Alt indhold vil blive flettet og regenereret.';
+  }
+
+  @override
+  String get mergingInBackground => 'Fletter i baggrunden. Dette kan tage et øjeblik.';
+
+  @override
+  String get failedToStartMerge => 'Kunne ikke starte fletning';
+
+  @override
+  String get askAnything => 'Spørg om hvad som helst';
+
+  @override
+  String get noMessagesYet => 'Ingen beskeder endnu!\nHvorfor starter du ikke en samtale?';
+
+  @override
+  String get deletingMessages => 'Sletter dine beskeder fra Omis hukommelse...';
+
+  @override
+  String get messageCopied => 'Besked kopieret til udklipsholder.';
+
+  @override
+  String get cannotReportOwnMessage => 'Du kan ikke rapportere dine egne beskeder.';
+
+  @override
+  String get reportMessage => 'Rapporter besked';
+
+  @override
+  String get reportMessageConfirm => 'Er du sikker på, at du vil rapportere denne besked?';
+
+  @override
+  String get messageReported => 'Besked rapporteret.';
+
+  @override
+  String get thankYouFeedback => 'Tak for din feedback!';
+
+  @override
+  String get clearChat => 'Ryd chat?';
+
+  @override
+  String get clearChatConfirm => 'Er du sikker på, at du vil rydde chatten? Denne handling kan ikke fortrydes.';
+
+  @override
+  String get maxFilesLimit => 'Du kan kun uploade 4 filer ad gangen';
+
+  @override
+  String get chatWithOmi => 'Chat med Omi';
+
+  @override
+  String get apps => 'Apps';
+
+  @override
+  String get noAppsFound => 'Ingen apps fundet';
+
+  @override
+  String get tryAdjustingSearch => 'Prøv at justere din søgning eller filtre';
+
+  @override
+  String get createYourOwnApp => 'Opret din egen app';
+
+  @override
+  String get buildAndShareApp => 'Byg og del din tilpassede app';
+
+  @override
+  String get searchApps => 'Søg i 1500+ apps';
+
+  @override
+  String get myApps => 'Mine apps';
+
+  @override
+  String get installedApps => 'Installerede apps';
+
+  @override
+  String get unableToFetchApps => 'Kan ikke hente apps :(\n\nTjek venligst din internetforbindelse og prøv igen.';
+
+  @override
+  String get aboutOmi => 'Om Omi';
+
+  @override
+  String get privacyPolicy => 'Privacy Policy';
+
+  @override
+  String get visitWebsite => 'Besøg hjemmeside';
+
+  @override
+  String get helpOrInquiries => 'Hjælp eller forespørgsler?';
+
+  @override
+  String get joinCommunity => 'Bliv en del af fællesskabet!';
+
+  @override
+  String get membersAndCounting => '8000+ medlemmer og tæller.';
+
+  @override
+  String get deleteAccountTitle => 'Slet konto';
+
+  @override
+  String get deleteAccountConfirm => 'Er du sikker på, at du vil slette din konto?';
+
+  @override
+  String get cannotBeUndone => 'Dette kan ikke fortrydes.';
+
+  @override
+  String get allDataErased => 'Alle dine minder og samtaler vil blive permanent slettet.';
+
+  @override
+  String get appsDisconnected => 'Dine apps og integrationer vil blive afbrudt øjeblikkeligt.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Du kan eksportere dine data før du sletter din konto, men når den er slettet, kan den ikke gendannes.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Jeg forstår, at sletning af min konto er permanent, og at alle data, inklusive minder og samtaler, vil gå tabt og ikke kan gendannes.';
+
+  @override
+  String get areYouSure => 'Er du sikker?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Denne handling er irreversibel og vil permanent slette din konto og alle tilknyttede data. Er du sikker på, at du vil fortsætte?';
+
+  @override
+  String get deleteNow => 'Slet nu';
+
+  @override
+  String get goBack => 'Gå tilbage';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Marker afkrydsningsfeltet for at bekræfte, at du forstår, at sletning af din konto er permanent og irreversibel.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Navn';
+
+  @override
+  String get email => 'E-mail';
+
+  @override
+  String get customVocabulary => 'Brugerdefineret ordforråd';
+
+  @override
+  String get identifyingOthers => 'Identifikation af andre';
+
+  @override
+  String get paymentMethods => 'Betalingsmetoder';
+
+  @override
+  String get conversationDisplay => 'Samtalevisning';
+
+  @override
+  String get dataPrivacy => 'Data og privatliv';
+
+  @override
+  String get userId => 'Bruger-ID';
+
+  @override
+  String get notSet => 'Ikke angivet';
+
+  @override
+  String get userIdCopied => 'Bruger-ID kopieret til udklipsholder';
+
+  @override
+  String get systemDefault => 'Systemstandard';
+
+  @override
+  String get planAndUsage => 'Plan og forbrug';
+
+  @override
+  String get offlineSync => 'Offline synkronisering';
+
+  @override
+  String get deviceSettings => 'Enhedsindstillinger';
+
+  @override
+  String get chatTools => 'Chatværktøjer';
+
+  @override
+  String get feedbackBug => 'Feedback / Fejl';
+
+  @override
+  String get helpCenter => 'Hjælpecenter';
+
+  @override
+  String get developerSettings => 'Udviklerindstillinger';
+
+  @override
+  String get getOmiForMac => 'Få Omi til Mac';
+
+  @override
+  String get referralProgram => 'Henvisningsprogram';
+
+  @override
+  String get signOut => 'Log ud';
+
+  @override
+  String get appAndDeviceCopied => 'App- og enhedsdetaljer kopieret';
+
+  @override
+  String get wrapped2025 => 'Opsamling 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Dit privatliv, din kontrol';
+
+  @override
+  String get privacyIntro =>
+      'Hos Omi er vi forpligtede til at beskytte dit privatliv. Denne side giver dig mulighed for at styre, hvordan dine data gemmes og bruges.';
+
+  @override
+  String get learnMore => 'Læs mere...';
+
+  @override
+  String get dataProtectionLevel => 'Databeskyttelsesniveau';
+
+  @override
+  String get dataProtectionDesc =>
+      'Dine data er som standard sikret med stærk kryptering. Gennemgå dine indstillinger og fremtidige privatlivsindstillinger nedenfor.';
+
+  @override
+  String get appAccess => 'App-adgang';
+
+  @override
+  String get appAccessDesc =>
+      'Følgende apps kan få adgang til dine data. Tryk på en app for at administrere dens tilladelser.';
+
+  @override
+  String get noAppsExternalAccess => 'Ingen installerede apps har ekstern adgang til dine data.';
+
+  @override
+  String get deviceName => 'Enhedsnavn';
+
+  @override
+  String get deviceId => 'Enheds-ID';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'SD-kort synkronisering';
+
+  @override
+  String get hardwareRevision => 'Hardware-revision';
+
+  @override
+  String get modelNumber => 'Modelnummer';
+
+  @override
+  String get manufacturer => 'Producent';
+
+  @override
+  String get doubleTap => 'Dobbelttryk';
+
+  @override
+  String get ledBrightness => 'LED-lysstyrke';
+
+  @override
+  String get micGain => 'Mikrofonforstærkning';
+
+  @override
+  String get disconnect => 'Afbryd';
+
+  @override
+  String get forgetDevice => 'Glem enhed';
+
+  @override
+  String get chargingIssues => 'Opladningsproblemer';
+
+  @override
+  String get disconnectDevice => 'Afbryd enhed';
+
+  @override
+  String get unpairDevice => 'Afpar enhed';
+
+  @override
+  String get unpairAndForget => 'Afpar og glem enhed';
+
+  @override
+  String get deviceDisconnectedMessage => 'Din Omi er blevet afbrudt 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Enhed afparret. Gå til Indstillinger > Bluetooth og glem enheden for at fuldføre afparringen.';
+
+  @override
+  String get unpairDialogTitle => 'Afpar enhed';
+
+  @override
+  String get unpairDialogMessage =>
+      'Dette vil afparre enheden, så den kan tilsluttes en anden telefon. Du skal gå til Indstillinger > Bluetooth og glemme enheden for at fuldføre processen.';
+
+  @override
+  String get deviceNotConnected => 'Enhed ikke tilsluttet';
+
+  @override
+  String get connectDeviceMessage => 'Tilslut din Omi-enhed for at få adgang til\nenhedsindstillinger og tilpasning';
+
+  @override
+  String get deviceInfoSection => 'Enhedsinformation';
+
+  @override
+  String get customizationSection => 'Tilpasning';
+
+  @override
+  String get hardwareSection => 'Hardware';
+
+  @override
+  String get v2Undetected => 'V2 ikke opdaget';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Vi kan se, at du enten har en V1-enhed, eller at din enhed ikke er tilsluttet. SD-kort-funktionalitet er kun tilgængelig for V2-enheder.';
+
+  @override
+  String get endConversation => 'Afslut samtale';
+
+  @override
+  String get pauseResume => 'Pause/Genoptag';
+
+  @override
+  String get starConversation => 'Stjernemarkér samtale';
+
+  @override
+  String get doubleTapAction => 'Dobbelttryk-handling';
+
+  @override
+  String get endAndProcess => 'Afslut og behandl samtale';
+
+  @override
+  String get pauseResumeRecording => 'Pause/Genoptag optagelse';
+
+  @override
+  String get starOngoing => 'Stjernemarkér igangværende samtale';
+
+  @override
+  String get off => 'Fra';
+
+  @override
+  String get max => 'Maks';
+
+  @override
+  String get mute => 'Lydløs';
+
+  @override
+  String get quiet => 'Stille';
+
+  @override
+  String get normal => 'Normal';
+
+  @override
+  String get high => 'Høj';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon er lydløs';
+
+  @override
+  String get micGainDescLow => 'Meget stille - til høje omgivelser';
+
+  @override
+  String get micGainDescModerate => 'Stille - til moderat støj';
+
+  @override
+  String get micGainDescNeutral => 'Neutral - afbalanceret optagelse';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Let forstærket - normal brug';
+
+  @override
+  String get micGainDescBoosted => 'Forstærket - til stille omgivelser';
+
+  @override
+  String get micGainDescHigh => 'Høj - til fjerne eller bløde stemmer';
+
+  @override
+  String get micGainDescVeryHigh => 'Meget høj - til meget stille kilder';
+
+  @override
+  String get micGainDescMax => 'Maksimum - brug med forsigtighed';
+
+  @override
+  String get developerSettingsTitle => 'Udviklerindstillinger';
+
+  @override
+  String get saving => 'Saving...';
+
+  @override
+  String get personaConfig => 'Konfigurer din AI-persona';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transcription';
+
+  @override
+  String get transcriptionConfig => 'Konfigurer STT-udbyder';
+
+  @override
+  String get conversationTimeout => 'Samtale timeout';
+
+  @override
+  String get conversationTimeoutConfig => 'Indstil hvornår samtaler automatisk afsluttes';
+
+  @override
+  String get importData => 'Importer data';
+
+  @override
+  String get importDataConfig => 'Importer data fra andre kilder';
+
+  @override
+  String get debugDiagnostics => 'Debug og diagnostik';
+
+  @override
+  String get endpointUrl => 'Endpoint URL';
+
+  @override
+  String get noApiKeys => 'Ingen API-nøgler endnu';
+
+  @override
+  String get createKeyToStart => 'Opret en nøgle for at komme i gang';
+
+  @override
+  String get createKey => 'Opret nøgle';
+
+  @override
+  String get docs => 'Dokumentation';
+
+  @override
+  String get yourOmiInsights => 'Dine Omi-indsigter';
+
+  @override
+  String get today => 'I dag';
+
+  @override
+  String get thisMonth => 'Denne måned';
+
+  @override
+  String get thisYear => 'Dette år';
+
+  @override
+  String get allTime => 'Altid';
+
+  @override
+  String get noActivityYet => 'Ingen aktivitet endnu';
+
+  @override
+  String get startConversationToSeeInsights => 'Start en samtale med Omi\nfor at se dine forbrugsindsigter her.';
+
+  @override
+  String get listening => 'Lytter';
+
+  @override
+  String get listeningSubtitle => 'Samlet tid Omi har lyttet aktivt.';
+
+  @override
+  String get understanding => 'Forstår';
+
+  @override
+  String get understandingSubtitle => 'Ord forstået fra dine samtaler.';
+
+  @override
+  String get providing => 'Leverer';
+
+  @override
+  String get providingSubtitle => 'Handlingspunkter og notater automatisk registreret.';
+
+  @override
+  String get remembering => 'Husker';
+
+  @override
+  String get rememberingSubtitle => 'Fakta og detaljer husket for dig.';
+
+  @override
+  String get unlimitedPlan => 'Ubegrænset plan';
+
+  @override
+  String get managePlan => 'Administrer plan';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Din plan annulleres den $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Din plan fornyes den $date.';
+  }
+
+  @override
+  String get basicPlan => 'Gratis plan';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used af $limit min brugt';
+  }
+
+  @override
+  String get upgrade => 'Opgrader';
+
+  @override
+  String get upgradeToUnlimited => 'Opgrader til ubegrænset';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Din plan inkluderer $limit gratis minutter om måneden. Opgrader for at få ubegrænset.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Deler mine Omi-statistikker! (omi.me - din altid-aktive AI-assistent)';
+
+  @override
+  String get sharePeriodToday => 'I dag har omi:';
+
+  @override
+  String get sharePeriodMonth => 'Denne måned har omi:';
+
+  @override
+  String get sharePeriodYear => 'Dette år har omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Indtil videre har omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Lyttet i $minutes minutter';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Forstået $words ord';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Leveret $count indsigter';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Husket $count minder';
+  }
+
+  @override
+  String get debugLogs => 'Debug-logfiler';
+
+  @override
+  String get debugLogsAutoDelete => 'Slettes automatisk efter 3 dage.';
+
+  @override
+  String get debugLogsDesc => 'Hjælper med at diagnosticere problemer';
+
+  @override
+  String get noLogFilesFound => 'Ingen logfiler fundet.';
+
+  @override
+  String get omiDebugLog => 'Omi debug-log';
+
+  @override
+  String get logShared => 'Log delt';
+
+  @override
+  String get selectLogFile => 'Vælg logfil';
+
+  @override
+  String get shareLogs => 'Del logfiler';
+
+  @override
+  String get debugLogCleared => 'Debug-log ryddet';
+
+  @override
+  String get exportStarted => 'Eksport startet. Dette kan tage et par sekunder...';
+
+  @override
+  String get exportAllData => 'Eksporter alle data';
+
+  @override
+  String get exportDataDesc => 'Eksporter samtaler til en JSON-fil';
+
+  @override
+  String get exportedConversations => 'Eksporterede samtaler fra Omi';
+
+  @override
+  String get exportShared => 'Eksport delt';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Slet videngraf?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Dette vil slette alle afledte videngraf-data (noder og forbindelser). Dine originale minder forbliver sikre. Grafen vil blive genopbygget over tid eller ved næste anmodning.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Videngraf slettet';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Kunne ikke slette graf: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Slet videngraf';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Ryd alle noder og forbindelser';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP-server';
+
+  @override
+  String get mcpServerDesc => 'Forbind AI-assistenter til dine data';
+
+  @override
+  String get serverUrl => 'Server-URL';
+
+  @override
+  String get urlCopied => 'URL kopieret';
+
+  @override
+  String get apiKeyAuth => 'API-nøglegodkendelse';
+
+  @override
+  String get header => 'Header';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Klient-ID';
+
+  @override
+  String get clientSecret => 'Klient-hemmelighed';
+
+  @override
+  String get useMcpApiKey => 'Brug din MCP API-nøgle';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Samtalehændelser';
+
+  @override
+  String get newConversationCreated => 'Ny samtale oprettet';
+
+  @override
+  String get realtimeTranscript => 'Realtids-udskrift';
+
+  @override
+  String get transcriptReceived => 'Udskrift modtaget';
+
+  @override
+  String get audioBytes => 'Lyd-bytes';
+
+  @override
+  String get audioDataReceived => 'Lyddata modtaget';
+
+  @override
+  String get intervalSeconds => 'Interval (sekunder)';
+
+  @override
+  String get daySummary => 'Dagsammenfatning';
+
+  @override
+  String get summaryGenerated => 'Sammenfatning genereret';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Tilføj til claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Kopier konfiguration';
+
+  @override
+  String get configCopied => 'Konfiguration kopieret til udklipsholder';
+
+  @override
+  String get listeningMins => 'Lytning (min)';
+
+  @override
+  String get understandingWords => 'Forståelse (ord)';
+
+  @override
+  String get insights => 'Indsigter';
+
+  @override
+  String get memories => 'Minder';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used af $limit min brugt denne måned';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used af $limit ord brugt denne måned';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used af $limit indsigter opnået denne måned';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used af $limit minder oprettet denne måned';
+  }
+
+  @override
+  String get visibility => 'Synlighed';
+
+  @override
+  String get visibilitySubtitle => 'Styr hvilke samtaler der vises i din liste';
+
+  @override
+  String get showShortConversations => 'Vis korte samtaler';
+
+  @override
+  String get showShortConversationsDesc => 'Vis samtaler kortere end tærsklen';
+
+  @override
+  String get showDiscardedConversations => 'Vis kasserede samtaler';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Inkluder samtaler markeret som kasseret';
+
+  @override
+  String get shortConversationThreshold => 'Kort samtale-tærskel';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Samtaler kortere end denne vil blive skjult, medmindre aktiveret ovenfor';
+
+  @override
+  String get durationThreshold => 'Varighedstærskel';
+
+  @override
+  String get durationThresholdDesc => 'Skjul samtaler kortere end denne';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Brugerdefineret ordforråd';
+
+  @override
+  String get addWords => 'Tilføj ord';
+
+  @override
+  String get addWordsDesc => 'Navne, termer eller usædvanlige ord';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Connect';
+
+  @override
+  String get comingSoon => 'Kommer snart';
+
+  @override
+  String get chatToolsFooter => 'Forbind dine apps for at se data og målinger i chat.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Fuldfør venligst godkendelse i din browser. Når det er færdigt, vend tilbage til appen.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Kunne ikke starte $appName-godkendelse';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Afbryd $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Er du sikker på, at du vil afbryde forbindelsen til $appName? Du kan genoprette forbindelsen når som helst.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Afbrudt fra $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Kunne ikke afbryde';
+
+  @override
+  String connectTo(String appName) {
+    return 'Tilslut til $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Du skal give Omi tilladelse til at få adgang til dine $appName-data. Dette åbner din browser til godkendelse.';
+  }
+
+  @override
+  String get continueAction => 'Fortsæt';
+
+  @override
+  String get languageTitle => 'Sprog';
+
+  @override
+  String get primaryLanguage => 'Primært sprog';
+
+  @override
+  String get automaticTranslation => 'Automatisk oversættelse';
+
+  @override
+  String get detectLanguages => 'Registrer 10+ sprog';
+
+  @override
+  String get authorizeSavingRecordings => 'Godkend lagring af optagelser';
+
+  @override
+  String get thanksForAuthorizing => 'Tak for godkendelsen!';
+
+  @override
+  String get needYourPermission => 'Vi har brug for din tilladelse';
+
+  @override
+  String get alreadyGavePermission =>
+      'Du har allerede givet os tilladelse til at gemme dine optagelser. Her er en påmindelse om, hvorfor vi har brug for det:';
+
+  @override
+  String get wouldLikePermission =>
+      'Vi vil gerne have din tilladelse til at gemme dine stemmeoptagelser. Her er hvorfor:';
+
+  @override
+  String get improveSpeechProfile => 'Forbedr din taleprofil';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Vi bruger optagelser til yderligere at træne og forbedre din personlige taleprofil.';
+
+  @override
+  String get trainFamilyProfiles => 'Træn profiler for venner og familie';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Dine optagelser hjælper os med at genkende og oprette profiler for dine venner og familie.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Forbedr udskriftspræcision';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Efterhånden som vores model forbedres, kan vi levere bedre transskriptionsresultater for dine optagelser.';
+
+  @override
+  String get legalNotice =>
+      'Juridisk meddelelse: Lovligheden af at optage og gemme stemmedata kan variere afhængigt af din placering og hvordan du bruger denne funktion. Det er dit ansvar at sikre overholdelse af lokale love og regler.';
+
+  @override
+  String get alreadyAuthorized => 'Allerede godkendt';
+
+  @override
+  String get authorize => 'Godkend';
+
+  @override
+  String get revokeAuthorization => 'Tilbagekald godkendelse';
+
+  @override
+  String get authorizationSuccessful => 'Godkendelse vellykket!';
+
+  @override
+  String get failedToAuthorize => 'Kunne ikke godkende. Prøv venligst igen.';
+
+  @override
+  String get authorizationRevoked => 'Godkendelse tilbagekaldt.';
+
+  @override
+  String get recordingsDeleted => 'Optagelser slettet.';
+
+  @override
+  String get failedToRevoke => 'Kunne ikke tilbagekalde godkendelse. Prøv venligst igen.';
+
+  @override
+  String get permissionRevokedTitle => 'Tilladelse tilbagekaldt';
+
+  @override
+  String get permissionRevokedMessage => 'Vil du have os til også at fjerne alle dine eksisterende optagelser?';
+
+  @override
+  String get yes => 'Ja';
+
+  @override
+  String get editName => 'Rediger navn';
+
+  @override
+  String get howShouldOmiCallYou => 'Hvad skal Omi kalde dig?';
+
+  @override
+  String get enterYourName => 'Enter your name';
+
+  @override
+  String get nameCannotBeEmpty => 'Navn kan ikke være tomt';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Navn opdateret!';
+
+  @override
+  String get calendarSettings => 'Kalenderindstillinger';
+
+  @override
+  String get calendarProviders => 'Kalenderudbydere';
+
+  @override
+  String get macOsCalendar => 'macOS-kalender';
+
+  @override
+  String get connectMacOsCalendar => 'Tilslut din lokale macOS-kalender';
+
+  @override
+  String get googleCalendar => 'Google Calendar';
+
+  @override
+  String get syncGoogleAccount => 'Synkroniser med din Google-konto';
+
+  @override
+  String get showMeetingsMenuBar => 'Vis kommende møder i menulinjen';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Vis dit næste møde og tid indtil det starter i macOS-menulinjen';
+
+  @override
+  String get showEventsNoParticipants => 'Vis begivenheder uden deltagere';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Når aktiveret, viser Kommende begivenheder uden deltagere eller videolink.';
+
+  @override
+  String get yourMeetings => 'Dine møder';
+
+  @override
+  String get refresh => 'Opdater';
+
+  @override
+  String get noUpcomingMeetings => 'Ingen kommende møder fundet';
+
+  @override
+  String get checkingNextDays => 'Tjekker de næste 30 dage';
+
+  @override
+  String get tomorrow => 'I morgen';
+
+  @override
+  String get googleCalendarComingSoon => 'Google Calendar-integration kommer snart!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Tilsluttet som bruger: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Standard arbejdsområde';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Opgaver oprettes i dette arbejdsområde';
+
+  @override
+  String get defaultProjectOptional => 'Standardprojekt (valgfrit)';
+
+  @override
+  String get leaveUnselectedTasks => 'Lad være uvalgt for at oprette opgaver uden projekt';
+
+  @override
+  String get noProjectsInWorkspace => 'Ingen projekter fundet i dette arbejdsområde';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Vælg hvor længe der skal ventes i stilhed før automatisk afslutning af samtale:';
+
+  @override
+  String get timeout2Minutes => '2 minutter';
+
+  @override
+  String get timeout2MinutesDesc => 'Afslut samtale efter 2 minutters stilhed';
+
+  @override
+  String get timeout5Minutes => '5 minutter';
+
+  @override
+  String get timeout5MinutesDesc => 'Afslut samtale efter 5 minutters stilhed';
+
+  @override
+  String get timeout10Minutes => '10 minutter';
+
+  @override
+  String get timeout10MinutesDesc => 'Afslut samtale efter 10 minutters stilhed';
+
+  @override
+  String get timeout30Minutes => '30 minutter';
+
+  @override
+  String get timeout30MinutesDesc => 'Afslut samtale efter 30 minutters stilhed';
+
+  @override
+  String get timeout4Hours => '4 timer';
+
+  @override
+  String get timeout4HoursDesc => 'Afslut samtale efter 4 timers stilhed';
+
+  @override
+  String get conversationEndAfterHours => 'Samtaler afsluttes nu efter 4 timers stilhed';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Samtaler afsluttes nu efter $minutes minut(ter) i stilhed';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Fortæl os dit primære sprog';
+
+  @override
+  String get languageForTranscription => 'Indstil dit sprog for skarpere transskriptioner og en personlig oplevelse.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Enkeltsprogs-tilstand er aktiveret. Oversættelse er deaktiveret for højere nøjagtighed.';
+
+  @override
+  String get searchLanguageHint => 'Search language by name or code';
+
+  @override
+  String get noLanguagesFound => 'No languages found';
+
+  @override
+  String get skip => 'Spring over';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Sprog indstillet til $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Kunne ikke indstille sprog';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName Settings';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Disconnect from $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'This will remove your $appName authentication. You\'ll need to reconnect to use it again.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Connected to $appName';
+  }
+
+  @override
+  String get account => 'Account';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Your action items will be synced to your $appName account';
+  }
+
+  @override
+  String get defaultSpace => 'Default Space';
+
+  @override
+  String get selectSpaceInWorkspace => 'Select a space in your workspace';
+
+  @override
+  String get noSpacesInWorkspace => 'No spaces found in this workspace';
+
+  @override
+  String get defaultList => 'Default List';
+
+  @override
+  String get tasksAddedToList => 'Tasks will be added to this list';
+
+  @override
+  String get noListsInSpace => 'No lists found in this space';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Failed to load repositories: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Default repository saved';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Failed to save default repository';
+
+  @override
+  String get defaultRepository => 'Default Repository';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Select a default repository for creating issues. You can still specify a different repository when creating issues.';
+
+  @override
+  String get noReposFound => 'No repositories found';
+
+  @override
+  String get private => 'Private';
+
+  @override
+  String updatedDate(String date) {
+    return 'Updated $date';
+  }
+
+  @override
+  String get yesterday => 'yesterday';
+
+  @override
+  String daysAgo(int count) {
+    return '$count days ago';
+  }
+
+  @override
+  String get oneWeekAgo => '1 week ago';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count weeks ago';
+  }
+
+  @override
+  String get oneMonthAgo => '1 month ago';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count months ago';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Issues will be created in your default repository';
+
+  @override
+  String get taskIntegrations => 'Task Integrations';
+
+  @override
+  String get configureSettings => 'Configure Settings';
+
+  @override
+  String get completeAuthBrowser => 'Please complete authentication in your browser. Once done, return to the app.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Failed to start $appName authentication';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Connect to $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'You\'ll need to authorize Omi to create tasks in your $appName account. This will open your browser for authentication.';
+  }
+
+  @override
+  String get continueButton => 'Continue';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName Integration';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integration with $appName is coming soon! We\'re working hard to bring you more task management options.';
+  }
+
+  @override
+  String get gotIt => 'Got it';
+
+  @override
+  String get tasksExportedOneApp => 'Tasks can be exported to one app at a time.';
+
+  @override
+  String get completeYourUpgrade => 'Complete Your Upgrade';
+
+  @override
+  String get importConfiguration => 'Import Configuration';
+
+  @override
+  String get exportConfiguration => 'Export configuration';
+
+  @override
+  String get bringYourOwn => 'Bring your own';
+
+  @override
+  String get payYourSttProvider => 'Freely use omi. You only pay your STT provider directly.';
+
+  @override
+  String get freeMinutesMonth => '1,200 free minutes/month included. Unlimited with ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Host is required';
+
+  @override
+  String get validPortRequired => 'Valid port is required';
+
+  @override
+  String get validWebsocketUrlRequired => 'Valid WebSocket URL is required (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL is required';
+
+  @override
+  String get apiKeyRequired => 'API key is required';
+
+  @override
+  String get invalidJsonConfig => 'Invalid JSON configuration';
+
+  @override
+  String errorSaving(String error) {
+    return 'Error saving: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Configuration copied to clipboard';
+
+  @override
+  String get pasteJsonConfig => 'Paste your JSON configuration below:';
+
+  @override
+  String get addApiKeyAfterImport => 'You\'ll need to add your own API key after importing';
+
+  @override
+  String get paste => 'Paste';
+
+  @override
+  String get import => 'Import';
+
+  @override
+  String get invalidProviderInConfig => 'Invalid provider in configuration';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Imported $providerName configuration';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Invalid JSON: $error';
+  }
+
+  @override
+  String get provider => 'Provider';
+
+  @override
+  String get live => 'Live';
+
+  @override
+  String get onDevice => 'On Device';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Enter your STT HTTP endpoint';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Enter your live STT WebSocket endpoint';
+
+  @override
+  String get apiKey => 'API Key';
+
+  @override
+  String get enterApiKey => 'Enter your API key';
+
+  @override
+  String get storedLocallyNeverShared => 'Stored locally, never shared';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Advanced';
+
+  @override
+  String get configuration => 'Configuration';
+
+  @override
+  String get requestConfiguration => 'Request Configuration';
+
+  @override
+  String get responseSchema => 'Response Schema';
+
+  @override
+  String get modified => 'Modified';
+
+  @override
+  String get resetRequestConfig => 'Reset request config to default';
+
+  @override
+  String get logs => 'Logs';
+
+  @override
+  String get logsCopied => 'Logs copied';
+
+  @override
+  String get noLogsYet => 'No logs yet. Start recording to see custom STT activity.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName uses $codecReason. Omi will be used.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi Transcription';
+
+  @override
+  String get bestInClassTranscription => 'Best in class transcription with zero setup';
+
+  @override
+  String get instantSpeakerLabels => 'Instant speaker labels';
+
+  @override
+  String get languageTranslation => '100+ language translation';
+
+  @override
+  String get optimizedForConversation => 'Optimized for conversation';
+
+  @override
+  String get autoLanguageDetection => 'Auto language detection';
+
+  @override
+  String get highAccuracy => 'High accuracy';
+
+  @override
+  String get privacyFirst => 'Privacy first';
+
+  @override
+  String get saveChanges => 'Save Changes';
+
+  @override
+  String get resetToDefault => 'Reset to Default';
+
+  @override
+  String get viewTemplate => 'View Template';
+
+  @override
+  String get trySomethingLike => 'Try something like...';
+
+  @override
+  String get tryIt => 'Try it';
+
+  @override
+  String get creatingPlan => 'Creating plan';
+
+  @override
+  String get developingLogic => 'Developing logic';
+
+  @override
+  String get designingApp => 'Designing app';
+
+  @override
+  String get generatingIconStep => 'Generating icon';
+
+  @override
+  String get finalTouches => 'Final touches';
+
+  @override
+  String get processing => 'Processing...';
+
+  @override
+  String get features => 'Features';
+
+  @override
+  String get creatingYourApp => 'Creating your app...';
+
+  @override
+  String get generatingIcon => 'Generating icon...';
+
+  @override
+  String get whatShouldWeMake => 'What should we make?';
+
+  @override
+  String get appName => 'App Name';
+
+  @override
+  String get description => 'Description';
+
+  @override
+  String get publicLabel => 'Public';
+
+  @override
+  String get privateLabel => 'Private';
+
+  @override
+  String get free => 'Free';
+
+  @override
+  String get perMonth => '/ Month';
+
+  @override
+  String get tailoredConversationSummaries => 'Tailored Conversation Summaries';
+
+  @override
+  String get customChatbotPersonality => 'Custom Chatbot Personality';
+
+  @override
+  String get makePublic => 'Make public';
+
+  @override
+  String get anyoneCanDiscover => 'Anyone can discover your app';
+
+  @override
+  String get onlyYouCanUse => 'Only you can use this app';
+
+  @override
+  String get paidApp => 'Paid app';
+
+  @override
+  String get usersPayToUse => 'Users pay to use your app';
+
+  @override
+  String get freeForEveryone => 'Free for everyone';
+
+  @override
+  String get perMonthLabel => '/ month';
+
+  @override
+  String get creating => 'Creating...';
+
+  @override
+  String get createApp => 'Create App';
+
+  @override
+  String get searchingForDevices => 'Searching for devices...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'DEVICES',
+      one: 'DEVICE',
+    );
+    return '$count $_temp0 FOUND NEARBY';
+  }
+
+  @override
+  String get pairingSuccessful => 'PAIRING SUCCESSFUL';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Error connecting to Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Don\'t show it again';
+
+  @override
+  String get iUnderstand => 'I Understand';
+
+  @override
+  String get enableBluetooth => 'Enable Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi needs Bluetooth to connect to your wearable. Please enable Bluetooth and try again.';
+
+  @override
+  String get contactSupport => 'Contact Support?';
+
+  @override
+  String get connectLater => 'Connect Later';
+
+  @override
+  String get grantPermissions => 'Grant permissions';
+
+  @override
+  String get backgroundActivity => 'Background activity';
+
+  @override
+  String get backgroundActivityDesc => 'Let Omi run in the background for better stability';
+
+  @override
+  String get locationAccess => 'Location access';
+
+  @override
+  String get locationAccessDesc => 'Enable background location for the full experience';
+
+  @override
+  String get notifications => 'Notifications';
+
+  @override
+  String get notificationsDesc => 'Enable notifications to stay informed';
+
+  @override
+  String get locationServiceDisabled => 'Location Service Disabled';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Location Service is Disabled. Please go to Settings > Privacy & Security > Location Services and enable it';
+
+  @override
+  String get backgroundLocationDenied => 'Background Location Access Denied';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Please go to device settings and set location permission to \"Always Allow\"';
+
+  @override
+  String get lovingOmi => 'Loving Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Help us reach more people by leaving a review in the App Store. Your feedback means the world to us!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Help us reach more people by leaving a review in the Google Play Store. Your feedback means the world to us!';
+
+  @override
+  String get rateOnAppStore => 'Rate on App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Rate on Google Play';
+
+  @override
+  String get maybeLater => 'Maybe later';
+
+  @override
+  String get speechProfileIntro => 'Omi needs to learn your goals and your voice. You\'ll be able to modify it later.';
+
+  @override
+  String get getStarted => 'Get Started';
+
+  @override
+  String get allDone => 'All done!';
+
+  @override
+  String get keepGoing => 'Keep going, you are doing great';
+
+  @override
+  String get skipThisQuestion => 'Skip this question';
+
+  @override
+  String get skipForNow => 'Skip for now';
+
+  @override
+  String get connectionError => 'Connection Error';
+
+  @override
+  String get connectionErrorDesc =>
+      'Failed to connect to the server. Please check your internet connection and try again.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Invalid recording detected';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.';
+
+  @override
+  String get tooShortDesc => 'There is not enough speech detected. Please speak more and try again.';
+
+  @override
+  String get invalidRecordingDesc => 'Please make sure you speak for at least 5 seconds and not more than 90.';
+
+  @override
+  String get areYouThere => 'Are you there?';
+
+  @override
+  String get noSpeechDesc =>
+      'We could not detect any speech. Please make sure to speak for at least 10 seconds and not more than 3 minutes.';
+
+  @override
+  String get connectionLost => 'Connection Lost';
+
+  @override
+  String get connectionLostDesc =>
+      'The connection was interrupted. Please check your internet connection and try again.';
+
+  @override
+  String get tryAgain => 'Try Again';
+
+  @override
+  String get connectOmiOmiGlass => 'Connect Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Continue Without Device';
+
+  @override
+  String get permissionsRequired => 'Permissions Required';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'This app needs Bluetooth and Location permissions to function properly. Please enable them in the settings.';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
+  String get wantDifferentName => 'Want to go by something else?';
+
+  @override
+  String get whatsYourName => 'What\'s your name?';
+
+  @override
+  String get speakTranscribeSummarize => 'Speak. Transcribe. Summarize.';
+
+  @override
+  String get signInWithApple => 'Sign in with Apple';
+
+  @override
+  String get signInWithGoogle => 'Sign in with Google';
+
+  @override
+  String get byContinuingAgree => 'By continuing, you agree to our ';
+
+  @override
+  String get termsOfUse => 'Terms of Use';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Your AI Companion';
+
+  @override
+  String get captureEveryMoment => 'Capture every moment. Get AI-powered\nsummaries. Never take notes again.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch Setup';
+
+  @override
+  String get permissionRequestedExclaim => 'Permission Requested!';
+
+  @override
+  String get microphonePermission => 'Microphone Permission';
+
+  @override
+  String get permissionGrantedNow =>
+      'Permission granted! Now:\n\nOpen the Omi app on your watch and tap \"Continue\" below';
+
+  @override
+  String get needMicrophonePermission =>
+      'We need microphone permission.\n\n1. Tap \"Grant Permission\"\n2. Allow on your iPhone\n3. Watch app will close\n4. Reopen and tap \"Continue\"';
+
+  @override
+  String get grantPermissionButton => 'Grant Permission';
+
+  @override
+  String get needHelp => 'Need Help?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Troubleshooting:\n\n1. Ensure Omi is installed on your watch\n2. Open the Omi app on your watch\n3. Look for the permission popup\n4. Tap \"Allow\" when prompted\n5. App on your watch will close - reopen it\n6. Come back and tap \"Continue\" on your iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Recording started successfully!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Permission not granted yet. Please make sure you allowed microphone access and reopened the app on your watch.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Error requesting permission: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Error starting recording: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Select your primary language';
+
+  @override
+  String get languageBenefits => 'Set your language for sharper transcriptions and a personalized experience';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'What\'s your primary language?';
+
+  @override
+  String get selectYourLanguage => 'Select your language';
+
+  @override
+  String get personalGrowthJourney => 'Your personal growth journey with AI that listens to your every word.';
+
+  @override
+  String get actionItemsTitle => 'To-Do\'s';
+
+  @override
+  String get actionItemsDescription => 'Tap to edit • Long press to select • Swipe for actions';
+
+  @override
+  String get tabToDo => 'To Do';
+
+  @override
+  String get tabDone => 'Done';
+
+  @override
+  String get tabOld => 'Old';
+
+  @override
+  String get emptyTodoMessage => '🎉 All caught up!\nNo pending action items';
+
+  @override
+  String get emptyDoneMessage => 'No completed items yet';
+
+  @override
+  String get emptyOldMessage => '✅ No old tasks';
+
+  @override
+  String get noItems => 'No items';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Action item marked as incomplete';
+
+  @override
+  String get actionItemCompleted => 'Action item completed';
+
+  @override
+  String get deleteActionItemTitle => 'Delete Action Item';
+
+  @override
+  String get deleteActionItemMessage => 'Are you sure you want to delete this action item?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Delete Selected Items';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Are you sure you want to delete $count selected action item$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Action item \"$description\" deleted';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count action item$s deleted';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Failed to delete action item';
+
+  @override
+  String get failedToDeleteItems => 'Failed to delete items';
+
+  @override
+  String get failedToDeleteSomeItems => 'Failed to delete some items';
+
+  @override
+  String get welcomeActionItemsTitle => 'Ready for Action Items';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Your AI will automatically extract tasks and to-dos from your conversations. They\'ll appear here when created.';
+
+  @override
+  String get autoExtractionFeature => 'Automatically extracted from conversations';
+
+  @override
+  String get editSwipeFeature => 'Tap to edit, swipe to complete or delete';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count selected';
+  }
+
+  @override
+  String get selectAll => 'Select all';
+
+  @override
+  String get deleteSelected => 'Delete selected';
+
+  @override
+  String searchMemories(int count) {
+    return 'Search $count Memories';
+  }
+
+  @override
+  String get memoryDeleted => 'Memory Deleted.';
+
+  @override
+  String get undo => 'Undo';
+
+  @override
+  String get noMemoriesYet => 'No memories yet';
+
+  @override
+  String get noAutoMemories => 'No auto-extracted memories yet';
+
+  @override
+  String get noManualMemories => 'No manual memories yet';
+
+  @override
+  String get noMemoriesInCategories => 'No memories in these categories';
+
+  @override
+  String get noMemoriesFound => 'No memories found';
+
+  @override
+  String get addFirstMemory => 'Add your first memory';
+
+  @override
+  String get clearMemoryTitle => 'Clear Omi\'s Memory';
+
+  @override
+  String get clearMemoryMessage => 'Are you sure you want to clear Omi\'s memory? This action cannot be undone.';
+
+  @override
+  String get clearMemoryButton => 'Clear Memory';
+
+  @override
+  String get memoryClearedSuccess => 'Omi\'s memory about you has been cleared';
+
+  @override
+  String get noMemoriesToDelete => 'No memories to delete';
+
+  @override
+  String get createMemoryTooltip => 'Create new memory';
+
+  @override
+  String get createActionItemTooltip => 'Create new action item';
+
+  @override
+  String get memoryManagement => 'Memory Management';
+
+  @override
+  String get filterMemories => 'Filter Memories';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'You have $count total memories';
+  }
+
+  @override
+  String get publicMemories => 'Public memories';
+
+  @override
+  String get privateMemories => 'Private memories';
+
+  @override
+  String get makeAllPrivate => 'Make All Memories Private';
+
+  @override
+  String get makeAllPublic => 'Make All Memories Public';
+
+  @override
+  String get deleteAllMemories => 'Delete All Memories';
+
+  @override
+  String get allMemoriesPrivateResult => 'All memories are now private';
+
+  @override
+  String get allMemoriesPublicResult => 'All memories are now public';
+
+  @override
+  String get newMemory => 'New Memory';
+
+  @override
+  String get editMemory => 'Edit Memory';
+
+  @override
+  String get memoryContentHint => 'I like to eat ice cream...';
+
+  @override
+  String get failedToSaveMemory => 'Failed to save. Please check your connection.';
+
+  @override
+  String get saveMemory => 'Save Memory';
+
+  @override
+  String get retry => 'Retry';
+
+  @override
+  String get createActionItem => 'Create Action Item';
+
+  @override
+  String get editActionItem => 'Edit Action Item';
+
+  @override
+  String get actionItemDescriptionHint => 'What needs to be done?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Action item description cannot be empty.';
+
+  @override
+  String get actionItemUpdated => 'Action item updated';
+
+  @override
+  String get failedToUpdateActionItem => 'Failed to update action item';
+
+  @override
+  String get actionItemCreated => 'Action item created';
+
+  @override
+  String get failedToCreateActionItem => 'Failed to create action item';
+
+  @override
+  String get dueDate => 'Due Date';
+
+  @override
+  String get time => 'Time';
+
+  @override
+  String get addDueDate => 'Add due date';
+
+  @override
+  String get pressDoneToSave => 'Press done to save';
+
+  @override
+  String get pressDoneToCreate => 'Press done to create';
+
+  @override
+  String get filterAll => 'All';
+
+  @override
+  String get filterSystem => 'About You';
+
+  @override
+  String get filterInteresting => 'Insights';
+
+  @override
+  String get filterManual => 'Manual';
+
+  @override
+  String get completed => 'Completed';
+
+  @override
+  String get markComplete => 'Mark complete';
+
+  @override
+  String get actionItemDeleted => 'Action item deleted';
+
+  @override
+  String get failedToDeleteActionItem => 'Failed to delete action item';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Delete Action Item';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Are you sure you want to delete this action item?';
+
+  @override
+  String get appLanguage => 'App Language';
+
+  @override
+  String get appInterfaceSectionTitle => 'APP-GRÆNSEFLADE';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'TALE OG TRANSSKRIPTION';
+
+  @override
+  String get languageSettingsHelperText =>
+      'App-sprog ændrer menuer og knapper. Talesprog påvirker, hvordan dine optagelser transskriberes.';
+}

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -237,7 +237,7 @@ class AppLocalizationsDe extends AppLocalizations {
   String get searchConversations => 'Unterhaltungen durchsuchen';
 
   @override
-  String selectedCount(int count) {
+  String selectedCount(int count, Object s) {
     return '$count ausgewählt';
   }
 
@@ -2208,10 +2208,10 @@ class AppLocalizationsDe extends AppLocalizations {
   String get filterAll => 'Alle';
 
   @override
-  String get filterSystem => 'About You';
+  String get filterSystem => 'Über Sie';
 
   @override
-  String get filterInteresting => 'Insights';
+  String get filterInteresting => 'Einblicke';
 
   @override
   String get filterManual => 'Manuell';
@@ -2236,4 +2236,14 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get appLanguage => 'App-Sprache';
+
+  @override
+  String get appInterfaceSectionTitle => 'APP-OBERFLÄCHE';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'SPRACHE UND TRANSKRIPTION';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Die App-Sprache ändert Menüs und Schaltflächen. Die Sprachsprache beeinflusst, wie Ihre Aufnahmen transkribiert werden.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -1,0 +1,2248 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Modern Greek (`el`).
+class AppLocalizationsEl extends AppLocalizations {
+  AppLocalizationsEl([String locale = 'el']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Συνομιλία';
+
+  @override
+  String get transcriptTab => 'Απομαγνητοφώνηση';
+
+  @override
+  String get actionItemsTab => 'Ενέργειες';
+
+  @override
+  String get deleteConversationTitle => 'Διαγραφή Συνομιλίας;';
+
+  @override
+  String get deleteConversationMessage =>
+      'Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+
+  @override
+  String get confirm => 'Επιβεβαίωση';
+
+  @override
+  String get cancel => 'Ακύρωση';
+
+  @override
+  String get ok => 'Εντάξει';
+
+  @override
+  String get delete => 'Διαγραφή';
+
+  @override
+  String get add => 'Προσθήκη';
+
+  @override
+  String get update => 'Ενημέρωση';
+
+  @override
+  String get save => 'Αποθήκευση';
+
+  @override
+  String get edit => 'Επεξεργασία';
+
+  @override
+  String get close => 'Κλείσιμο';
+
+  @override
+  String get clear => 'Εκκαθάριση';
+
+  @override
+  String get copyTranscript => 'Αντιγραφή Απομαγνητοφώνησης';
+
+  @override
+  String get copySummary => 'Αντιγραφή Περίληψης';
+
+  @override
+  String get testPrompt => 'Δοκιμή Εντολής';
+
+  @override
+  String get reprocessConversation => 'Επανεπεξεργασία Συνομιλίας';
+
+  @override
+  String get deleteConversation => 'Διαγραφή Συνομιλίας';
+
+  @override
+  String get contentCopied => 'Το περιεχόμενο αντιγράφηκε στο πρόχειρο';
+
+  @override
+  String get failedToUpdateStarred => 'Αποτυχία ενημέρωσης της κατάστασης αγαπημένων.';
+
+  @override
+  String get conversationUrlNotShared => 'Δεν ήταν δυνατή η κοινοποίηση του URL της συνομιλίας.';
+
+  @override
+  String get errorProcessingConversation =>
+      'Σφάλμα κατά την επεξεργασία της συνομιλίας. Παρακαλώ δοκιμάστε ξανά αργότερα.';
+
+  @override
+  String get noInternetConnection => 'Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
+
+  @override
+  String get unableToDeleteConversation => 'Αδυναμία Διαγραφής Συνομιλίας';
+
+  @override
+  String get somethingWentWrong => 'Κάτι πήγε στραβά! Παρακαλώ δοκιμάστε ξανά αργότερα.';
+
+  @override
+  String get copyErrorMessage => 'Αντιγραφή μηνύματος σφάλματος';
+
+  @override
+  String get errorCopied => 'Το μήνυμα σφάλματος αντιγράφηκε στο πρόχειρο';
+
+  @override
+  String get remaining => 'Υπολειπόμενα';
+
+  @override
+  String get loading => 'Φόρτωση...';
+
+  @override
+  String get loadingDuration => 'Φόρτωση διάρκειας...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count δευτερόλεπτα';
+  }
+
+  @override
+  String get people => 'Άτομα';
+
+  @override
+  String get addNewPerson => 'Προσθήκη Νέου Ατόμου';
+
+  @override
+  String get editPerson => 'Επεξεργασία Ατόμου';
+
+  @override
+  String get createPersonHint => 'Δημιουργήστε ένα νέο άτομο και εκπαιδεύστε το Omi να αναγνωρίζει και την ομιλία του!';
+
+  @override
+  String get speechProfile => 'Προφίλ Ομιλίας';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Δείγμα $number';
+  }
+
+  @override
+  String get settings => 'Ρυθμίσεις';
+
+  @override
+  String get language => 'Γλώσσα';
+
+  @override
+  String get selectLanguage => 'Επιλογή Γλώσσας';
+
+  @override
+  String get deleting => 'Διαγραφή...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
+
+  @override
+  String get failedToStartAuthentication => 'Αποτυχία έναρξης πιστοποίησης';
+
+  @override
+  String get importStarted => 'Η εισαγωγή ξεκίνησε! Θα ειδοποιηθείτε όταν ολοκληρωθεί.';
+
+  @override
+  String get failedToStartImport => 'Αποτυχία έναρξης εισαγωγής. Παρακαλώ δοκιμάστε ξανά.';
+
+  @override
+  String get couldNotAccessFile => 'Δεν ήταν δυνατή η πρόσβαση στο επιλεγμένο αρχείο';
+
+  @override
+  String get askOmi => 'Ρωτήστε το Omi';
+
+  @override
+  String get done => 'Τέλος';
+
+  @override
+  String get disconnected => 'Αποσυνδέθηκε';
+
+  @override
+  String get searching => 'Αναζήτηση';
+
+  @override
+  String get connectDevice => 'Σύνδεση Συσκευής';
+
+  @override
+  String get monthlyLimitReached => 'Φτάσατε το μηνιαίο όριό σας.';
+
+  @override
+  String get checkUsage => 'Έλεγχος Χρήσης';
+
+  @override
+  String get syncingRecordings => 'Συγχρονισμός ηχογραφήσεων';
+
+  @override
+  String get recordingsToSync => 'Ηχογραφήσεις για συγχρονισμό';
+
+  @override
+  String get allCaughtUp => 'Όλα ενημερωμένα';
+
+  @override
+  String get sync => 'Συγχρονισμός';
+
+  @override
+  String get pendantUpToDate => 'Το περιδέραιο είναι ενημερωμένο';
+
+  @override
+  String get allRecordingsSynced => 'Όλες οι ηχογραφήσεις συγχρονίστηκαν';
+
+  @override
+  String get syncingInProgress => 'Συγχρονισμός σε εξέλιξη';
+
+  @override
+  String get readyToSync => 'Έτοιμο για συγχρονισμό';
+
+  @override
+  String get tapSyncToStart => 'Πατήστε Συγχρονισμός για έναρξη';
+
+  @override
+  String get pendantNotConnected => 'Το περιδέραιο δεν είναι συνδεδεμένο. Συνδεθείτε για συγχρονισμό.';
+
+  @override
+  String get everythingSynced => 'Όλα είναι ήδη συγχρονισμένα.';
+
+  @override
+  String get recordingsNotSynced => 'Έχετε ηχογραφήσεις που δεν έχουν συγχρονιστεί ακόμα.';
+
+  @override
+  String get syncingBackground => 'Θα συνεχίσουμε να συγχρονίζουμε τις ηχογραφήσεις σας στο παρασκήνιο.';
+
+  @override
+  String get noConversationsYet => 'Δεν υπάρχουν συνομιλίες ακόμα.';
+
+  @override
+  String get noStarredConversations => 'Δεν υπάρχουν αγαπημένες συνομιλίες ακόμα.';
+
+  @override
+  String get starConversationHint =>
+      'Για να προσθέσετε μια συνομιλία στα αγαπημένα, ανοίξτε τη και πατήστε το εικονίδιο αστεριού στην κεφαλίδα.';
+
+  @override
+  String get searchConversations => 'Αναζήτηση Συνομιλιών';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count επιλεγμένα';
+  }
+
+  @override
+  String get merge => 'Συγχώνευση';
+
+  @override
+  String get mergeConversations => 'Συγχώνευση Συνομιλιών';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Αυτό θα συνδυάσει $count συνομιλίες σε μία. Όλο το περιεχόμενο θα συγχωνευτεί και θα αναδημιουργηθεί.';
+  }
+
+  @override
+  String get mergingInBackground => 'Συγχώνευση στο παρασκήνιο. Μπορεί να πάρει λίγο χρόνο.';
+
+  @override
+  String get failedToStartMerge => 'Αποτυχία έναρξης συγχώνευσης';
+
+  @override
+  String get askAnything => 'Ρωτήστε οτιδήποτε';
+
+  @override
+  String get noMessagesYet => 'Δεν υπάρχουν μηνύματα ακόμα!\nΓιατί δεν ξεκινάτε μια συνομιλία;';
+
+  @override
+  String get deletingMessages => 'Διαγραφή των μηνυμάτων σας από τη μνήμη του Omi...';
+
+  @override
+  String get messageCopied => 'Το μήνυμα αντιγράφηκε στο πρόχειρο.';
+
+  @override
+  String get cannotReportOwnMessage => 'Δεν μπορείτε να αναφέρετε τα δικά σας μηνύματα.';
+
+  @override
+  String get reportMessage => 'Αναφορά Μηνύματος';
+
+  @override
+  String get reportMessageConfirm => 'Είστε βέβαιοι ότι θέλετε να αναφέρετε αυτό το μήνυμα;';
+
+  @override
+  String get messageReported => 'Το μήνυμα αναφέρθηκε επιτυχώς.';
+
+  @override
+  String get thankYouFeedback => 'Ευχαριστούμε για τα σχόλιά σας!';
+
+  @override
+  String get clearChat => 'Εκκαθάριση Συνομιλίας;';
+
+  @override
+  String get clearChatConfirm =>
+      'Είστε βέβαιοι ότι θέλετε να εκκαθαρίσετε τη συνομιλία; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+
+  @override
+  String get maxFilesLimit => 'Μπορείτε να ανεβάσετε μόνο 4 αρχεία τη φορά';
+
+  @override
+  String get chatWithOmi => 'Συνομιλία με το Omi';
+
+  @override
+  String get apps => 'Εφαρμογές';
+
+  @override
+  String get noAppsFound => 'Δεν βρέθηκαν εφαρμογές';
+
+  @override
+  String get tryAdjustingSearch => 'Δοκιμάστε να προσαρμόσετε την αναζήτηση ή τα φίλτρα σας';
+
+  @override
+  String get createYourOwnApp => 'Δημιουργήστε τη Δική σας Εφαρμογή';
+
+  @override
+  String get buildAndShareApp => 'Δημιουργήστε και μοιραστείτε την προσαρμοσμένη εφαρμογή σας';
+
+  @override
+  String get searchApps => 'Αναζήτηση 1500+ Εφαρμογών';
+
+  @override
+  String get myApps => 'Οι Εφαρμογές μου';
+
+  @override
+  String get installedApps => 'Εγκατεστημένες Εφαρμογές';
+
+  @override
+  String get unableToFetchApps =>
+      'Αδυναμία λήψης εφαρμογών :(\n\nΠαρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
+
+  @override
+  String get aboutOmi => 'Σχετικά με το Omi';
+
+  @override
+  String get privacyPolicy => 'Πολιτική Απορρήτου';
+
+  @override
+  String get visitWebsite => 'Επισκεφτείτε τον Ιστότοπο';
+
+  @override
+  String get helpOrInquiries => 'Βοήθεια ή Ερωτήσεις;';
+
+  @override
+  String get joinCommunity => 'Γίνετε μέλος της κοινότητας!';
+
+  @override
+  String get membersAndCounting => '8000+ μέλη και συνεχίζουν.';
+
+  @override
+  String get deleteAccountTitle => 'Διαγραφή Λογαριασμού';
+
+  @override
+  String get deleteAccountConfirm => 'Είστε βέβαιοι ότι θέλετε να διαγράψετε τον λογαριασμό σας;';
+
+  @override
+  String get cannotBeUndone => 'Αυτό δεν μπορεί να αναιρεθεί.';
+
+  @override
+  String get allDataErased => 'Όλες οι αναμνήσεις και οι συνομιλίες σας θα διαγραφούν μόνιμα.';
+
+  @override
+  String get appsDisconnected => 'Οι Εφαρμογές και οι Ενσωματώσεις σας θα αποσυνδεθούν αμέσως.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Μπορείτε να εξάγετε τα δεδομένα σας πριν διαγράψετε τον λογαριασμό σας, αλλά μόλις διαγραφεί, δεν μπορεί να ανακτηθεί.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Κατανοώ ότι η διαγραφή του λογαριασμού μου είναι μόνιμη και όλα τα δεδομένα, συμπεριλαμβανομένων των αναμνήσεων και των συνομιλιών, θα χαθούν και δεν μπορούν να ανακτηθούν.';
+
+  @override
+  String get areYouSure => 'Είστε βέβαιοι;';
+
+  @override
+  String get deleteAccountFinal =>
+      'Αυτή η ενέργεια είναι μη αναστρέψιμη και θα διαγράψει μόνιμα τον λογαριασμό σας και όλα τα σχετικά δεδομένα. Είστε βέβαιοι ότι θέλετε να συνεχίσετε;';
+
+  @override
+  String get deleteNow => 'Διαγραφή Τώρα';
+
+  @override
+  String get goBack => 'Επιστροφή';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Επιλέξτε το πλαίσιο για να επιβεβαιώσετε ότι κατανοείτε ότι η διαγραφή του λογαριασμού σας είναι μόνιμη και μη αναστρέψιμη.';
+
+  @override
+  String get profile => 'Προφίλ';
+
+  @override
+  String get name => 'Όνομα';
+
+  @override
+  String get email => 'Email';
+
+  @override
+  String get customVocabulary => 'Προσαρμοσμένο Λεξιλόγιο';
+
+  @override
+  String get identifyingOthers => 'Αναγνώριση Άλλων';
+
+  @override
+  String get paymentMethods => 'Μέθοδοι Πληρωμής';
+
+  @override
+  String get conversationDisplay => 'Εμφάνιση Συνομιλίας';
+
+  @override
+  String get dataPrivacy => 'Δεδομένα & Απόρρητο';
+
+  @override
+  String get userId => 'Αναγνωριστικό Χρήστη';
+
+  @override
+  String get notSet => 'Δεν έχει οριστεί';
+
+  @override
+  String get userIdCopied => 'Το αναγνωριστικό χρήστη αντιγράφηκε στο πρόχειρο';
+
+  @override
+  String get systemDefault => 'Προεπιλογή Συστήματος';
+
+  @override
+  String get planAndUsage => 'Πρόγραμμα & Χρήση';
+
+  @override
+  String get offlineSync => 'Συγχρονισμός Εκτός Σύνδεσης';
+
+  @override
+  String get deviceSettings => 'Ρυθμίσεις Συσκευής';
+
+  @override
+  String get chatTools => 'Εργαλεία Συνομιλίας';
+
+  @override
+  String get feedbackBug => 'Σχόλια / Σφάλμα';
+
+  @override
+  String get helpCenter => 'Κέντρο Βοήθειας';
+
+  @override
+  String get developerSettings => 'Ρυθμίσεις Προγραμματιστή';
+
+  @override
+  String get getOmiForMac => 'Αποκτήστε το Omi για Mac';
+
+  @override
+  String get referralProgram => 'Πρόγραμμα Παραπομπών';
+
+  @override
+  String get signOut => 'Αποσύνδεση';
+
+  @override
+  String get appAndDeviceCopied => 'Τα στοιχεία εφαρμογής και συσκευής αντιγράφηκαν';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Το Απόρρητό σας, ο Έλεγχός σας';
+
+  @override
+  String get privacyIntro =>
+      'Στο Omi, δεσμευόμαστε να προστατεύουμε το απόρρητό σας. Αυτή η σελίδα σας επιτρέπει να ελέγχετε πώς αποθηκεύονται και χρησιμοποιούνται τα δεδομένα σας.';
+
+  @override
+  String get learnMore => 'Μάθετε περισσότερα...';
+
+  @override
+  String get dataProtectionLevel => 'Επίπεδο Προστασίας Δεδομένων';
+
+  @override
+  String get dataProtectionDesc =>
+      'Τα δεδομένα σας είναι ασφαλισμένα από προεπιλογή με ισχυρή κρυπτογράφηση. Ελέγξτε τις ρυθμίσεις σας και τις μελλοντικές επιλογές απορρήτου παρακάτω.';
+
+  @override
+  String get appAccess => 'Πρόσβαση Εφαρμογών';
+
+  @override
+  String get appAccessDesc =>
+      'Οι παρακάτω εφαρμογές μπορούν να έχουν πρόσβαση στα δεδομένα σας. Πατήστε σε μια εφαρμογή για να διαχειριστείτε τα δικαιώματά της.';
+
+  @override
+  String get noAppsExternalAccess => 'Καμία εγκατεστημένη εφαρμογή δεν έχει εξωτερική πρόσβαση στα δεδομένα σας.';
+
+  @override
+  String get deviceName => 'Όνομα Συσκευής';
+
+  @override
+  String get deviceId => 'Αναγνωριστικό Συσκευής';
+
+  @override
+  String get firmware => 'Λογισμικό';
+
+  @override
+  String get sdCardSync => 'Συγχρονισμός Κάρτας SD';
+
+  @override
+  String get hardwareRevision => 'Αναθεώρηση Υλικού';
+
+  @override
+  String get modelNumber => 'Αριθμός Μοντέλου';
+
+  @override
+  String get manufacturer => 'Κατασκευαστής';
+
+  @override
+  String get doubleTap => 'Διπλό Πάτημα';
+
+  @override
+  String get ledBrightness => 'Φωτεινότητα LED';
+
+  @override
+  String get micGain => 'Ενίσχυση Μικροφώνου';
+
+  @override
+  String get disconnect => 'Αποσύνδεση';
+
+  @override
+  String get forgetDevice => 'Διαγραφή Συσκευής';
+
+  @override
+  String get chargingIssues => 'Προβλήματα Φόρτισης';
+
+  @override
+  String get disconnectDevice => 'Αποσύνδεση Συσκευής';
+
+  @override
+  String get unpairDevice => 'Κατάργηση Σύζευξης Συσκευής';
+
+  @override
+  String get unpairAndForget => 'Κατάργηση Σύζευξης και Διαγραφή Συσκευής';
+
+  @override
+  String get deviceDisconnectedMessage => 'Το Omi σας έχει αποσυνδεθεί 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Η σύζευξη της συσκευής καταργήθηκε. Μεταβείτε στις Ρυθμίσεις > Bluetooth και διαγράψτε τη συσκευή για να ολοκληρώσετε την κατάργηση της σύζευξης.';
+
+  @override
+  String get unpairDialogTitle => 'Κατάργηση Σύζευξης Συσκευής';
+
+  @override
+  String get unpairDialogMessage =>
+      'Αυτό θα καταργήσει τη σύζευξη της συσκευής ώστε να μπορεί να συνδεθεί σε άλλο τηλέφωνο. Θα χρειαστεί να μεταβείτε στις Ρυθμίσεις > Bluetooth και να διαγράψετε τη συσκευή για να ολοκληρώσετε τη διαδικασία.';
+
+  @override
+  String get deviceNotConnected => 'Η Συσκευή Δεν Είναι Συνδεδεμένη';
+
+  @override
+  String get connectDeviceMessage =>
+      'Συνδέστε τη συσκευή Omi για να αποκτήσετε πρόσβαση\nστις ρυθμίσεις και την προσαρμογή της συσκευής';
+
+  @override
+  String get deviceInfoSection => 'Πληροφορίες Συσκευής';
+
+  @override
+  String get customizationSection => 'Προσαρμογή';
+
+  @override
+  String get hardwareSection => 'Υλικό';
+
+  @override
+  String get v2Undetected => 'Δεν ανιχνεύτηκε V2';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Βλέπουμε ότι είτε έχετε συσκευή V1 είτε η συσκευή σας δεν είναι συνδεδεμένη. Η λειτουργικότητα κάρτας SD είναι διαθέσιμη μόνο για συσκευές V2.';
+
+  @override
+  String get endConversation => 'Τερματισμός Συνομιλίας';
+
+  @override
+  String get pauseResume => 'Παύση/Συνέχιση';
+
+  @override
+  String get starConversation => 'Αγαπημένη Συνομιλία';
+
+  @override
+  String get doubleTapAction => 'Ενέργεια Διπλού Πατήματος';
+
+  @override
+  String get endAndProcess => 'Τερματισμός & Επεξεργασία Συνομιλίας';
+
+  @override
+  String get pauseResumeRecording => 'Παύση/Συνέχιση Εγγραφής';
+
+  @override
+  String get starOngoing => 'Αγαπημένη Τρέχουσα Συνομιλία';
+
+  @override
+  String get off => 'Ανενεργό';
+
+  @override
+  String get max => 'Μέγιστο';
+
+  @override
+  String get mute => 'Σίγαση';
+
+  @override
+  String get quiet => 'Ήσυχο';
+
+  @override
+  String get normal => 'Κανονικό';
+
+  @override
+  String get high => 'Υψηλό';
+
+  @override
+  String get micGainDescMuted => 'Το μικρόφωνο είναι σε σίγαση';
+
+  @override
+  String get micGainDescLow => 'Πολύ ήσυχο - για θορυβώδη περιβάλλοντα';
+
+  @override
+  String get micGainDescModerate => 'Ήσυχο - για μέτριο θόρυβο';
+
+  @override
+  String get micGainDescNeutral => 'Ουδέτερο - ισορροπημένη εγγραφή';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Ελαφρώς ενισχυμένο - κανονική χρήση';
+
+  @override
+  String get micGainDescBoosted => 'Ενισχυμένο - για ήσυχα περιβάλλοντα';
+
+  @override
+  String get micGainDescHigh => 'Υψηλό - για απομακρυσμένες ή απαλές φωνές';
+
+  @override
+  String get micGainDescVeryHigh => 'Πολύ υψηλό - για πολύ ήσυχες πηγές';
+
+  @override
+  String get micGainDescMax => 'Μέγιστο - χρησιμοποιήστε με προσοχή';
+
+  @override
+  String get developerSettingsTitle => 'Ρυθμίσεις Προγραμματιστή';
+
+  @override
+  String get saving => 'Αποθήκευση...';
+
+  @override
+  String get personaConfig => 'Διαμορφώστε την προσωπικότητα του AI σας';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Απομαγνητοφώνηση';
+
+  @override
+  String get transcriptionConfig => 'Διαμόρφωση παρόχου STT';
+
+  @override
+  String get conversationTimeout => 'Λήξη Χρόνου Συνομιλίας';
+
+  @override
+  String get conversationTimeoutConfig => 'Ορίστε πότε τελειώνουν αυτόματα οι συνομιλίες';
+
+  @override
+  String get importData => 'Εισαγωγή Δεδομένων';
+
+  @override
+  String get importDataConfig => 'Εισαγωγή δεδομένων από άλλες πηγές';
+
+  @override
+  String get debugDiagnostics => 'Εντοπισμός Σφαλμάτων & Διαγνωστικά';
+
+  @override
+  String get endpointUrl => 'URL Τελικού Σημείου';
+
+  @override
+  String get noApiKeys => 'Δεν υπάρχουν κλειδιά API ακόμα';
+
+  @override
+  String get createKeyToStart => 'Δημιουργήστε ένα κλειδί για να ξεκινήσετε';
+
+  @override
+  String get createKey => 'Δημιουργία Κλειδιού';
+
+  @override
+  String get docs => 'Τεκμηρίωση';
+
+  @override
+  String get yourOmiInsights => 'Οι Πληροφορίες σας στο Omi';
+
+  @override
+  String get today => 'Σήμερα';
+
+  @override
+  String get thisMonth => 'Αυτόν τον Μήνα';
+
+  @override
+  String get thisYear => 'Φέτος';
+
+  @override
+  String get allTime => 'Συνολικά';
+
+  @override
+  String get noActivityYet => 'Καμία Δραστηριότητα Ακόμα';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Ξεκινήστε μια συνομιλία με το Omi\nγια να δείτε τις πληροφορίες χρήσης σας εδώ.';
+
+  @override
+  String get listening => 'Ακρόαση';
+
+  @override
+  String get listeningSubtitle => 'Συνολικός χρόνος που το Omi έχει ακούσει ενεργά.';
+
+  @override
+  String get understanding => 'Κατανόηση';
+
+  @override
+  String get understandingSubtitle => 'Λέξεις που κατανοήθηκαν από τις συνομιλίες σας.';
+
+  @override
+  String get providing => 'Παροχή';
+
+  @override
+  String get providingSubtitle => 'Ενέργειες και σημειώσεις που καταγράφονται αυτόματα.';
+
+  @override
+  String get remembering => 'Απομνημόνευση';
+
+  @override
+  String get rememberingSubtitle => 'Γεγονότα και λεπτομέρειες που απομνημονεύονται για εσάς.';
+
+  @override
+  String get unlimitedPlan => 'Απεριόριστο Πρόγραμμα';
+
+  @override
+  String get managePlan => 'Διαχείριση Προγράμματος';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Το πρόγραμμά σας θα ακυρωθεί στις $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Το πρόγραμμά σας ανανεώνεται στις $date.';
+  }
+
+  @override
+  String get basicPlan => 'Δωρεάν Πρόγραμμα';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used από $limit λεπτά χρησιμοποιήθηκαν';
+  }
+
+  @override
+  String get upgrade => 'Αναβάθμιση';
+
+  @override
+  String get upgradeToUnlimited => 'Αναβάθμιση σε Απεριόριστο';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Το πρόγραμμά σας περιλαμβάνει $limit δωρεάν λεπτά ανά μήνα. Αναβαθμίστε για απεριόριστη χρήση.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Μοιράζομαι τα στατιστικά μου στο Omi! (omi.me - ο πάντα ενεργός βοηθός AI σας)';
+
+  @override
+  String get sharePeriodToday => 'Σήμερα, το omi:';
+
+  @override
+  String get sharePeriodMonth => 'Αυτόν τον μήνα, το omi:';
+
+  @override
+  String get sharePeriodYear => 'Φέτος, το omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Μέχρι τώρα, το omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Άκουσε για $minutes λεπτά';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Κατανόησε $words λέξεις';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Παρείχε $count πληροφορίες';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Απομνημόνευσε $count αναμνήσεις';
+  }
+
+  @override
+  String get debugLogs => 'Αρχεία Εντοπισμού Σφαλμάτων';
+
+  @override
+  String get debugLogsAutoDelete => 'Αυτόματη διαγραφή μετά από 3 ημέρες.';
+
+  @override
+  String get debugLogsDesc => 'Βοηθά στη διάγνωση προβλημάτων';
+
+  @override
+  String get noLogFilesFound => 'Δεν βρέθηκαν αρχεία καταγραφής.';
+
+  @override
+  String get omiDebugLog => 'Αρχείο εντοπισμού σφαλμάτων Omi';
+
+  @override
+  String get logShared => 'Το αρχείο καταγραφής κοινοποιήθηκε';
+
+  @override
+  String get selectLogFile => 'Επιλογή Αρχείου Καταγραφής';
+
+  @override
+  String get shareLogs => 'Κοινοποίηση Αρχείων Καταγραφής';
+
+  @override
+  String get debugLogCleared => 'Το αρχείο εντοπισμού σφαλμάτων εκκαθαρίστηκε';
+
+  @override
+  String get exportStarted => 'Η εξαγωγή ξεκίνησε. Μπορεί να διαρκέσει μερικά δευτερόλεπτα...';
+
+  @override
+  String get exportAllData => 'Εξαγωγή Όλων των Δεδομένων';
+
+  @override
+  String get exportDataDesc => 'Εξαγωγή συνομιλιών σε αρχείο JSON';
+
+  @override
+  String get exportedConversations => 'Εξαγωγή Συνομιλιών από το Omi';
+
+  @override
+  String get exportShared => 'Η εξαγωγή κοινοποιήθηκε';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Διαγραφή Γραφήματος Γνώσης;';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Αυτό θα διαγράψει όλα τα παράγωγα δεδομένα του γραφήματος γνώσης (κόμβοι και συνδέσεις). Οι αρχικές αναμνήσεις σας θα παραμείνουν ασφαλείς. Το γράφημα θα ξαναδημιουργηθεί με το χρόνο ή στο επόμενο αίτημα.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Το Γράφημα Γνώσης διαγράφηκε επιτυχώς';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Αποτυχία διαγραφής γραφήματος: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Διαγραφή Γραφήματος Γνώσης';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Εκκαθάριση όλων των κόμβων και των συνδέσεων';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Διακομιστής MCP';
+
+  @override
+  String get mcpServerDesc => 'Συνδέστε βοηθούς AI στα δεδομένα σας';
+
+  @override
+  String get serverUrl => 'URL Διακομιστή';
+
+  @override
+  String get urlCopied => 'Το URL αντιγράφηκε';
+
+  @override
+  String get apiKeyAuth => 'Πιστοποίηση Κλειδιού API';
+
+  @override
+  String get header => 'Κεφαλίδα';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Αναγνωριστικό Πελάτη';
+
+  @override
+  String get clientSecret => 'Μυστικό Πελάτη';
+
+  @override
+  String get useMcpApiKey => 'Χρησιμοποιήστε το κλειδί MCP API σας';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Συμβάντα Συνομιλίας';
+
+  @override
+  String get newConversationCreated => 'Δημιουργήθηκε νέα συνομιλία';
+
+  @override
+  String get realtimeTranscript => 'Απομαγνητοφώνηση σε Πραγματικό Χρόνο';
+
+  @override
+  String get transcriptReceived => 'Λήφθηκε απομαγνητοφώνηση';
+
+  @override
+  String get audioBytes => 'Bytes Ήχου';
+
+  @override
+  String get audioDataReceived => 'Λήφθηκαν δεδομένα ήχου';
+
+  @override
+  String get intervalSeconds => 'Διάστημα (δευτερόλεπτα)';
+
+  @override
+  String get daySummary => 'Περίληψη Ημέρας';
+
+  @override
+  String get summaryGenerated => 'Δημιουργήθηκε περίληψη';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Προσθήκη στο claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Αντιγραφή Διαμόρφωσης';
+
+  @override
+  String get configCopied => 'Η διαμόρφωση αντιγράφηκε στο πρόχειρο';
+
+  @override
+  String get listeningMins => 'Ακρόαση (λεπτά)';
+
+  @override
+  String get understandingWords => 'Κατανόηση (λέξεις)';
+
+  @override
+  String get insights => 'Πληροφορίες';
+
+  @override
+  String get memories => 'Αναμνήσεις';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used από $limit λεπτά χρησιμοποιήθηκαν αυτόν τον μήνα';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used από $limit λέξεις χρησιμοποιήθηκαν αυτόν τον μήνα';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used από $limit πληροφορίες αποκτήθηκαν αυτόν τον μήνα';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used από $limit αναμνήσεις δημιουργήθηκαν αυτόν τον μήνα';
+  }
+
+  @override
+  String get visibility => 'Ορατότητα';
+
+  @override
+  String get visibilitySubtitle => 'Ελέγξτε ποιες συνομιλίες εμφανίζονται στη λίστα σας';
+
+  @override
+  String get showShortConversations => 'Εμφάνιση Σύντομων Συνομιλιών';
+
+  @override
+  String get showShortConversationsDesc => 'Εμφάνιση συνομιλιών συντομότερων από το όριο';
+
+  @override
+  String get showDiscardedConversations => 'Εμφάνιση Απορριφθεισών Συνομιλιών';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Συμπερίληψη συνομιλιών που επισημάνθηκαν ως απορριφθείσες';
+
+  @override
+  String get shortConversationThreshold => 'Όριο Σύντομης Συνομιλίας';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Οι συνομιλίες συντομότερες από αυτό θα αποκρύπτονται εκτός αν ενεργοποιηθούν παραπάνω';
+
+  @override
+  String get durationThreshold => 'Όριο Διάρκειας';
+
+  @override
+  String get durationThresholdDesc => 'Απόκρυψη συνομιλιών συντομότερων από αυτό';
+
+  @override
+  String minLabel(int count) {
+    return '$count λεπτά';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Προσαρμοσμένο Λεξιλόγιο';
+
+  @override
+  String get addWords => 'Προσθήκη Λέξεων';
+
+  @override
+  String get addWordsDesc => 'Ονόματα, όροι ή ασυνήθιστες λέξεις';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Σύνδεση';
+
+  @override
+  String get comingSoon => 'Σύντομα Διαθέσιμο';
+
+  @override
+  String get chatToolsFooter => 'Συνδέστε τις εφαρμογές σας για να δείτε δεδομένα και μετρήσεις στη συνομιλία.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Αποτυχία έναρξης πιστοποίησης $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Αποσύνδεση από $appName;';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Είστε βέβαιοι ότι θέλετε να αποσυνδεθείτε από το $appName; Μπορείτε να επανασυνδεθείτε ανά πάσα στιγμή.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Αποσυνδέθηκε από $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Αποτυχία αποσύνδεσης';
+
+  @override
+  String connectTo(String appName) {
+    return 'Σύνδεση με $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Θα χρειαστεί να εξουσιοδοτήσετε το Omi να έχει πρόσβαση στα δεδομένα σας στο $appName. Αυτό θα ανοίξει το πρόγραμμα περιήγησής σας για πιστοποίηση.';
+  }
+
+  @override
+  String get continueAction => 'Συνέχεια';
+
+  @override
+  String get languageTitle => 'Γλώσσα';
+
+  @override
+  String get primaryLanguage => 'Κύρια Γλώσσα';
+
+  @override
+  String get automaticTranslation => 'Αυτόματη Μετάφραση';
+
+  @override
+  String get detectLanguages => 'Ανίχνευση 10+ γλωσσών';
+
+  @override
+  String get authorizeSavingRecordings => 'Εξουσιοδότηση Αποθήκευσης Εγγραφών';
+
+  @override
+  String get thanksForAuthorizing => 'Ευχαριστούμε για την εξουσιοδότηση!';
+
+  @override
+  String get needYourPermission => 'Χρειαζόμαστε την άδειά σας';
+
+  @override
+  String get alreadyGavePermission =>
+      'Έχετε ήδη δώσει την άδειά σας για αποθήκευση των εγγραφών σας. Ορίστε μια υπενθύμιση γιατί το χρειαζόμαστε:';
+
+  @override
+  String get wouldLikePermission =>
+      'Θα θέλαμε την άδειά σας για αποθήκευση των φωνητικών σας εγγραφών. Εδώ είναι γιατί:';
+
+  @override
+  String get improveSpeechProfile => 'Βελτίωση του Προφίλ Ομιλίας σας';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Χρησιμοποιούμε τις εγγραφές για περαιτέρω εκπαίδευση και βελτίωση του προσωπικού σας προφίλ ομιλίας.';
+
+  @override
+  String get trainFamilyProfiles => 'Εκπαίδευση Προφίλ για Φίλους και Οικογένεια';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Οι εγγραφές σας μας βοηθούν να αναγνωρίζουμε και να δημιουργούμε προφίλ για τους φίλους και την οικογένειά σας.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Βελτίωση της Ακρίβειας Απομαγνητοφώνησης';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Καθώς το μοντέλο μας βελτιώνεται, μπορούμε να παρέχουμε καλύτερα αποτελέσματα απομαγνητοφώνησης για τις εγγραφές σας.';
+
+  @override
+  String get legalNotice =>
+      'Νομική Ειδοποίηση: Η νομιμότητα της εγγραφής και αποθήκευσης φωνητικών δεδομένων μπορεί να διαφέρει ανάλογα με την τοποθεσία σας και τον τρόπο χρήσης αυτής της λειτουργίας. Είναι δική σας ευθύνη να διασφαλίσετε τη συμμόρφωση με τους τοπικούς νόμους και κανονισμούς.';
+
+  @override
+  String get alreadyAuthorized => 'Ήδη Εξουσιοδοτημένο';
+
+  @override
+  String get authorize => 'Εξουσιοδότηση';
+
+  @override
+  String get revokeAuthorization => 'Ανάκληση Εξουσιοδότησης';
+
+  @override
+  String get authorizationSuccessful => 'Η εξουσιοδότηση ήταν επιτυχής!';
+
+  @override
+  String get failedToAuthorize => 'Αποτυχία εξουσιοδότησης. Παρακαλώ δοκιμάστε ξανά.';
+
+  @override
+  String get authorizationRevoked => 'Η εξουσιοδότηση ανακλήθηκε.';
+
+  @override
+  String get recordingsDeleted => 'Οι εγγραφές διαγράφηκαν.';
+
+  @override
+  String get failedToRevoke => 'Αποτυχία ανάκλησης εξουσιοδότησης. Παρακαλώ δοκιμάστε ξανά.';
+
+  @override
+  String get permissionRevokedTitle => 'Η Άδεια Ανακλήθηκε';
+
+  @override
+  String get permissionRevokedMessage => 'Θέλετε να αφαιρέσουμε επίσης όλες τις υπάρχουσες εγγραφές σας;';
+
+  @override
+  String get yes => 'Ναι';
+
+  @override
+  String get editName => 'Επεξεργασία Ονόματος';
+
+  @override
+  String get howShouldOmiCallYou => 'Πώς θα πρέπει να σας αποκαλεί το Omi;';
+
+  @override
+  String get enterYourName => 'Εισάγετε το όνομά σας';
+
+  @override
+  String get nameCannotBeEmpty => 'Το όνομα δεν μπορεί να είναι κενό';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Το όνομα ενημερώθηκε επιτυχώς!';
+
+  @override
+  String get calendarSettings => 'Ρυθμίσεις ημερολογίου';
+
+  @override
+  String get calendarProviders => 'Πάροχοι Ημερολογίου';
+
+  @override
+  String get macOsCalendar => 'Ημερολόγιο macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Συνδέστε το τοπικό σας ημερολόγιο macOS';
+
+  @override
+  String get googleCalendar => 'Ημερολόγιο Google';
+
+  @override
+  String get syncGoogleAccount => 'Συγχρονισμός με τον λογαριασμό σας Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Εμφάνιση επερχόμενων συναντήσεων στη γραμμή μενού';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'Εμφάνιση της επόμενης συνάντησής σας και του χρόνου μέχρι να ξεκινήσει στη γραμμή μενού του macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Εμφάνιση συμβάντων χωρίς συμμετέχοντες';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Όταν είναι ενεργοποιημένο, το Coming Up εμφανίζει συμβάντα χωρίς συμμετέχοντες ή σύνδεσμο βίντεο.';
+
+  @override
+  String get yourMeetings => 'Οι Συναντήσεις σας';
+
+  @override
+  String get refresh => 'Ανανέωση';
+
+  @override
+  String get noUpcomingMeetings => 'Δεν βρέθηκαν επερχόμενες συναντήσεις';
+
+  @override
+  String get checkingNextDays => 'Έλεγχος επόμενων 30 ημερών';
+
+  @override
+  String get tomorrow => 'Αύριο';
+
+  @override
+  String get googleCalendarComingSoon => 'Η ενσωμάτωση με το Ημερολόγιο Google έρχεται σύντομα!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Συνδεδεμένο ως χρήστης: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Προεπιλεγμένος Χώρος Εργασίας';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Οι εργασίες θα δημιουργηθούν σε αυτόν τον χώρο εργασίας';
+
+  @override
+  String get defaultProjectOptional => 'Προεπιλεγμένο Έργο (Προαιρετικό)';
+
+  @override
+  String get leaveUnselectedTasks => 'Αφήστε το ανεπίλεκτο για δημιουργία εργασιών χωρίς έργο';
+
+  @override
+  String get noProjectsInWorkspace => 'Δεν βρέθηκαν έργα σε αυτόν τον χώρο εργασίας';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Επιλέξτε πόσο χρόνο να περιμένει σε σιωπή πριν τερματιστεί αυτόματα μια συνομιλία:';
+
+  @override
+  String get timeout2Minutes => '2 λεπτά';
+
+  @override
+  String get timeout2MinutesDesc => 'Τερματισμός συνομιλίας μετά από 2 λεπτά σιωπής';
+
+  @override
+  String get timeout5Minutes => '5 λεπτά';
+
+  @override
+  String get timeout5MinutesDesc => 'Τερματισμός συνομιλίας μετά από 5 λεπτά σιωπής';
+
+  @override
+  String get timeout10Minutes => '10 λεπτά';
+
+  @override
+  String get timeout10MinutesDesc => 'Τερματισμός συνομιλίας μετά από 10 λεπτά σιωπής';
+
+  @override
+  String get timeout30Minutes => '30 λεπτά';
+
+  @override
+  String get timeout30MinutesDesc => 'Τερματισμός συνομιλίας μετά από 30 λεπτά σιωπής';
+
+  @override
+  String get timeout4Hours => '4 ώρες';
+
+  @override
+  String get timeout4HoursDesc => 'Τερματισμός συνομιλίας μετά από 4 ώρες σιωπής';
+
+  @override
+  String get conversationEndAfterHours => 'Οι συνομιλίες θα τερματίζονται πλέον μετά από 4 ώρες σιωπής';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Οι συνομιλίες θα τερματίζονται πλέον μετά από $minutes λεπτό(-ά) σιωπής';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Πείτε μας την κύρια γλώσσα σας';
+
+  @override
+  String get languageForTranscription =>
+      'Ορίστε τη γλώσσα σας για πιο ακριβείς απομαγνητοφωνήσεις και εξατομικευμένη εμπειρία.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Η Λειτουργία Μονής Γλώσσας είναι ενεργοποιημένη. Η μετάφραση είναι απενεργοποιημένη για μεγαλύτερη ακρίβεια.';
+
+  @override
+  String get searchLanguageHint => 'Αναζήτηση γλώσσας με όνομα ή κωδικό';
+
+  @override
+  String get noLanguagesFound => 'Δεν βρέθηκαν γλώσσες';
+
+  @override
+  String get skip => 'Παράλειψη';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Η γλώσσα ορίστηκε σε $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Αποτυχία ορισμού γλώσσας';
+
+  @override
+  String appSettings(String appName) {
+    return 'Ρυθμίσεις $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Αποσύνδεση από $appName;';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Αυτό θα αφαιρέσει την πιστοποίησή σας στο $appName. Θα χρειαστεί να επανασυνδεθείτε για να το χρησιμοποιήσετε ξανά.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Συνδεδεμένο στο $appName';
+  }
+
+  @override
+  String get account => 'Λογαριασμός';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Οι ενέργειές σας θα συγχρονιστούν με τον λογαριασμό σας $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Προεπιλεγμένος Χώρος';
+
+  @override
+  String get selectSpaceInWorkspace => 'Επιλέξτε έναν χώρο στον χώρο εργασίας σας';
+
+  @override
+  String get noSpacesInWorkspace => 'Δεν βρέθηκαν χώροι σε αυτόν τον χώρο εργασίας';
+
+  @override
+  String get defaultList => 'Προεπιλεγμένη Λίστα';
+
+  @override
+  String get tasksAddedToList => 'Οι εργασίες θα προστεθούν σε αυτή τη λίστα';
+
+  @override
+  String get noListsInSpace => 'Δεν βρέθηκαν λίστες σε αυτόν τον χώρο';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Αποτυχία φόρτωσης αποθετηρίων: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Το προεπιλεγμένο αποθετήριο αποθηκεύτηκε';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Αποτυχία αποθήκευσης προεπιλεγμένου αποθετηρίου';
+
+  @override
+  String get defaultRepository => 'Προεπιλεγμένο Αποθετήριο';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Επιλέξτε ένα προεπιλεγμένο αποθετήριο για δημιουργία ζητημάτων. Μπορείτε ακόμα να καθορίσετε διαφορετικό αποθετήριο κατά τη δημιουργία ζητημάτων.';
+
+  @override
+  String get noReposFound => 'Δεν βρέθηκαν αποθετήρια';
+
+  @override
+  String get private => 'Ιδιωτικό';
+
+  @override
+  String updatedDate(String date) {
+    return 'Ενημερώθηκε $date';
+  }
+
+  @override
+  String get yesterday => 'χθες';
+
+  @override
+  String daysAgo(int count) {
+    return 'πριν από $count ημέρες';
+  }
+
+  @override
+  String get oneWeekAgo => 'πριν από 1 εβδομάδα';
+
+  @override
+  String weeksAgo(int count) {
+    return 'πριν από $count εβδομάδες';
+  }
+
+  @override
+  String get oneMonthAgo => 'πριν από 1 μήνα';
+
+  @override
+  String monthsAgo(int count) {
+    return 'πριν από $count μήνες';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Τα ζητήματα θα δημιουργηθούν στο προεπιλεγμένο σας αποθετήριο';
+
+  @override
+  String get taskIntegrations => 'Ενσωματώσεις Εργασιών';
+
+  @override
+  String get configureSettings => 'Διαμόρφωση Ρυθμίσεων';
+
+  @override
+  String get completeAuthBrowser =>
+      'Παρακαλώ ολοκληρώστε την πιστοποίηση στο πρόγραμμα περιήγησής σας. Μόλις ολοκληρωθεί, επιστρέψτε στην εφαρμογή.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Αποτυχία έναρξης πιστοποίησης $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Σύνδεση με $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Θα χρειαστεί να εξουσιοδοτήσετε το Omi να δημιουργεί εργασίες στον λογαριασμό σας $appName. Αυτό θα ανοίξει το πρόγραμμα περιήγησής σας για πιστοποίηση.';
+  }
+
+  @override
+  String get continueButton => 'Συνέχεια';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Ενσωμάτωση $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Η ενσωμάτωση με το $appName έρχεται σύντομα! Εργαζόμαστε σκληρά για να σας φέρουμε περισσότερες επιλογές διαχείρισης εργασιών.';
+  }
+
+  @override
+  String get gotIt => 'Το κατάλαβα';
+
+  @override
+  String get tasksExportedOneApp => 'Οι εργασίες μπορούν να εξαχθούν σε μία εφαρμογή τη φορά.';
+
+  @override
+  String get completeYourUpgrade => 'Ολοκληρώστε την Αναβάθμισή σας';
+
+  @override
+  String get importConfiguration => 'Εισαγωγή Διαμόρφωσης';
+
+  @override
+  String get exportConfiguration => 'Εξαγωγή διαμόρφωσης';
+
+  @override
+  String get bringYourOwn => 'Φέρτε το δικό σας';
+
+  @override
+  String get payYourSttProvider => 'Χρησιμοποιήστε ελεύθερα το omi. Πληρώνετε μόνο τον πάροχο STT σας απευθείας.';
+
+  @override
+  String get freeMinutesMonth => '1.200 δωρεάν λεπτά/μήνα συμπεριλαμβάνονται. Απεριόριστο με ';
+
+  @override
+  String get omiUnlimited => 'Omi Απεριόριστο';
+
+  @override
+  String get hostRequired => 'Απαιτείται διακομιστής';
+
+  @override
+  String get validPortRequired => 'Απαιτείται έγκυρη θύρα';
+
+  @override
+  String get validWebsocketUrlRequired => 'Απαιτείται έγκυρο URL WebSocket (wss://)';
+
+  @override
+  String get apiUrlRequired => 'Απαιτείται URL API';
+
+  @override
+  String get apiKeyRequired => 'Απαιτείται κλειδί API';
+
+  @override
+  String get invalidJsonConfig => 'Μη έγκυρη διαμόρφωση JSON';
+
+  @override
+  String errorSaving(String error) {
+    return 'Σφάλμα αποθήκευσης: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Η διαμόρφωση αντιγράφηκε στο πρόχειρο';
+
+  @override
+  String get pasteJsonConfig => 'Επικολλήστε τη διαμόρφωση JSON σας παρακάτω:';
+
+  @override
+  String get addApiKeyAfterImport => 'Θα χρειαστεί να προσθέσετε το δικό σας κλειδί API μετά την εισαγωγή';
+
+  @override
+  String get paste => 'Επικόλληση';
+
+  @override
+  String get import => 'Εισαγωγή';
+
+  @override
+  String get invalidProviderInConfig => 'Μη έγκυρος πάροχος στη διαμόρφωση';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Εισήχθη η διαμόρφωση $providerName';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Μη έγκυρο JSON: $error';
+  }
+
+  @override
+  String get provider => 'Πάροχος';
+
+  @override
+  String get live => 'Ζωντανά';
+
+  @override
+  String get onDevice => 'Στη Συσκευή';
+
+  @override
+  String get apiUrl => 'URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Εισάγετε το τελικό σημείο HTTP STT σας';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Εισάγετε το τελικό σημείο WebSocket STT ζωντανά';
+
+  @override
+  String get apiKey => 'Κλειδί API';
+
+  @override
+  String get enterApiKey => 'Εισάγετε το κλειδί API σας';
+
+  @override
+  String get storedLocallyNeverShared => 'Αποθηκεύεται τοπικά, δεν κοινοποιείται ποτέ';
+
+  @override
+  String get host => 'Διακομιστής';
+
+  @override
+  String get port => 'Θύρα';
+
+  @override
+  String get advanced => 'Προχωρημένα';
+
+  @override
+  String get configuration => 'Διαμόρφωση';
+
+  @override
+  String get requestConfiguration => 'Διαμόρφωση Αιτήματος';
+
+  @override
+  String get responseSchema => 'Σχήμα Απόκρισης';
+
+  @override
+  String get modified => 'Τροποποιημένο';
+
+  @override
+  String get resetRequestConfig => 'Επαναφορά διαμόρφωσης αιτήματος στην προεπιλογή';
+
+  @override
+  String get logs => 'Αρχεία Καταγραφής';
+
+  @override
+  String get logsCopied => 'Τα αρχεία καταγραφής αντιγράφηκαν';
+
+  @override
+  String get noLogsYet =>
+      'Δεν υπάρχουν ακόμα αρχεία καταγραφής. Ξεκινήστε εγγραφή για να δείτε προσαρμοσμένη δραστηριότητα STT.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return 'Το $deviceName χρησιμοποιεί $codecReason. Θα χρησιμοποιηθεί το Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Απομαγνητοφώνηση Omi';
+
+  @override
+  String get bestInClassTranscription => 'Κορυφαία απομαγνητοφώνηση χωρίς καμία ρύθμιση';
+
+  @override
+  String get instantSpeakerLabels => 'Άμεσες ετικέτες ομιλητών';
+
+  @override
+  String get languageTranslation => 'Μετάφραση 100+ γλωσσών';
+
+  @override
+  String get optimizedForConversation => 'Βελτιστοποιημένο για συνομιλία';
+
+  @override
+  String get autoLanguageDetection => 'Αυτόματη ανίχνευση γλώσσας';
+
+  @override
+  String get highAccuracy => 'Υψηλή ακρίβεια';
+
+  @override
+  String get privacyFirst => 'Πρώτα το απόρρητο';
+
+  @override
+  String get saveChanges => 'Αποθήκευση Αλλαγών';
+
+  @override
+  String get resetToDefault => 'Επαναφορά στην Προεπιλογή';
+
+  @override
+  String get viewTemplate => 'Προβολή Προτύπου';
+
+  @override
+  String get trySomethingLike => 'Δοκιμάστε κάτι σαν...';
+
+  @override
+  String get tryIt => 'Δοκιμάστε το';
+
+  @override
+  String get creatingPlan => 'Δημιουργία σχεδίου';
+
+  @override
+  String get developingLogic => 'Ανάπτυξη λογικής';
+
+  @override
+  String get designingApp => 'Σχεδιασμός εφαρμογής';
+
+  @override
+  String get generatingIconStep => 'Δημιουργία εικονιδίου';
+
+  @override
+  String get finalTouches => 'Τελικές πινελιές';
+
+  @override
+  String get processing => 'Επεξεργασία...';
+
+  @override
+  String get features => 'Χαρακτηριστικά';
+
+  @override
+  String get creatingYourApp => 'Δημιουργία της εφαρμογής σας...';
+
+  @override
+  String get generatingIcon => 'Δημιουργία εικονιδίου...';
+
+  @override
+  String get whatShouldWeMake => 'Τι να φτιάξουμε;';
+
+  @override
+  String get appName => 'Όνομα Εφαρμογής';
+
+  @override
+  String get description => 'Περιγραφή';
+
+  @override
+  String get publicLabel => 'Δημόσιο';
+
+  @override
+  String get privateLabel => 'Ιδιωτικό';
+
+  @override
+  String get free => 'Δωρεάν';
+
+  @override
+  String get perMonth => '/ Μήνα';
+
+  @override
+  String get tailoredConversationSummaries => 'Εξατομικευμένες Περιλήψεις Συνομιλιών';
+
+  @override
+  String get customChatbotPersonality => 'Προσαρμοσμένη Προσωπικότητα Chatbot';
+
+  @override
+  String get makePublic => 'Δημοσίευση';
+
+  @override
+  String get anyoneCanDiscover => 'Οποιοσδήποτε μπορεί να ανακαλύψει την εφαρμογή σας';
+
+  @override
+  String get onlyYouCanUse => 'Μόνο εσείς μπορείτε να χρησιμοποιήσετε αυτή την εφαρμογή';
+
+  @override
+  String get paidApp => 'Επί πληρωμή εφαρμογή';
+
+  @override
+  String get usersPayToUse => 'Οι χρήστες πληρώνουν για να χρησιμοποιήσουν την εφαρμογή σας';
+
+  @override
+  String get freeForEveryone => 'Δωρεάν για όλους';
+
+  @override
+  String get perMonthLabel => '/ μήνα';
+
+  @override
+  String get creating => 'Δημιουργία...';
+
+  @override
+  String get createApp => 'Δημιουργία Εφαρμογής';
+
+  @override
+  String get searchingForDevices => 'Αναζήτηση συσκευών...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ΣΥΣΚΕΥΕΣ',
+      one: 'ΣΥΣΚΕΥΗ',
+    );
+    return '$count $_temp0 ΒΡΕΘΗΚΑΝ ΚΟΝΤΑ';
+  }
+
+  @override
+  String get pairingSuccessful => 'Η ΣΥΖΕΥΞΗ ΗΤΑΝ ΕΠΙΤΥΧΗΣ';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Σφάλμα σύνδεσης με Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Να μην εμφανιστεί ξανά';
+
+  @override
+  String get iUnderstand => 'Κατάλαβα';
+
+  @override
+  String get enableBluetooth => 'Ενεργοποίηση Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Το Omi χρειάζεται Bluetooth για σύνδεση με τη φορητή σας συσκευή. Παρακαλώ ενεργοποιήστε το Bluetooth και δοκιμάστε ξανά.';
+
+  @override
+  String get contactSupport => 'Επικοινωνία με Υποστήριξη;';
+
+  @override
+  String get connectLater => 'Σύνδεση Αργότερα';
+
+  @override
+  String get grantPermissions => 'Χορήγηση αδειών';
+
+  @override
+  String get backgroundActivity => 'Δραστηριότητα παρασκηνίου';
+
+  @override
+  String get backgroundActivityDesc => 'Επιτρέψτε στο Omi να εκτελείται στο παρασκήνιο για καλύτερη σταθερότητα';
+
+  @override
+  String get locationAccess => 'Πρόσβαση τοποθεσίας';
+
+  @override
+  String get locationAccessDesc => 'Ενεργοποιήστε την τοποθεσία παρασκηνίου για την πλήρη εμπειρία';
+
+  @override
+  String get notifications => 'Ειδοποιήσεις';
+
+  @override
+  String get notificationsDesc => 'Ενεργοποιήστε τις ειδοποιήσεις για να ενημερώνεστε';
+
+  @override
+  String get locationServiceDisabled => 'Η Υπηρεσία Τοποθεσίας είναι Απενεργοποιημένη';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Η Υπηρεσία Τοποθεσίας είναι Απενεργοποιημένη. Παρακαλώ μεταβείτε στις Ρυθμίσεις > Απόρρητο & Ασφάλεια > Υπηρεσίες Τοποθεσίας και ενεργοποιήστε την';
+
+  @override
+  String get backgroundLocationDenied => 'Απορρίφθηκε η Πρόσβαση Τοποθεσίας Παρασκηνίου';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Παρακαλώ μεταβείτε στις ρυθμίσεις της συσκευής και ορίστε την άδεια τοποθεσίας σε \"Πάντα Να Επιτρέπεται\"';
+
+  @override
+  String get lovingOmi => 'Αγαπάτε το Omi;';
+
+  @override
+  String get leaveReviewIos =>
+      'Βοηθήστε μας να φτάσουμε σε περισσότερους ανθρώπους αφήνοντας μια κριτική στο App Store. Τα σχόλιά σας σημαίνουν τα πάντα για εμάς!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Βοηθήστε μας να φτάσουμε σε περισσότερους ανθρώπους αφήνοντας μια κριτική στο Google Play Store. Τα σχόλιά σας σημαίνουν τα πάντα για εμάς!';
+
+  @override
+  String get rateOnAppStore => 'Αξιολόγηση στο App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Αξιολόγηση στο Google Play';
+
+  @override
+  String get maybeLater => 'Ίσως αργότερα';
+
+  @override
+  String get speechProfileIntro =>
+      'Το Omi πρέπει να μάθει τους στόχους και τη φωνή σας. Θα μπορείτε να το τροποποιήσετε αργότερα.';
+
+  @override
+  String get getStarted => 'Ξεκινήστε';
+
+  @override
+  String get allDone => 'Όλα έτοιμα!';
+
+  @override
+  String get keepGoing => 'Συνεχίστε, τα πηγαίνετε υπέροχα';
+
+  @override
+  String get skipThisQuestion => 'Παράλειψη αυτής της ερώτησης';
+
+  @override
+  String get skipForNow => 'Παράλειψη προς το παρόν';
+
+  @override
+  String get connectionError => 'Σφάλμα Σύνδεσης';
+
+  @override
+  String get connectionErrorDesc =>
+      'Αποτυχία σύνδεσης με τον διακομιστή. Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Ανιχνεύθηκε μη έγκυρη εγγραφή';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Φαίνεται ότι υπάρχουν πολλοί ομιλητές στην εγγραφή. Παρακαλώ βεβαιωθείτε ότι βρίσκεστε σε ήσυχο χώρο και δοκιμάστε ξανά.';
+
+  @override
+  String get tooShortDesc => 'Δεν ανιχνεύθηκε αρκετή ομιλία. Παρακαλώ μιλήστε περισσότερο και δοκιμάστε ξανά.';
+
+  @override
+  String get invalidRecordingDesc =>
+      'Παρακαλώ βεβαιωθείτε ότι μιλάτε για τουλάχιστον 5 δευτερόλεπτα και όχι περισσότερο από 90.';
+
+  @override
+  String get areYouThere => 'Είστε εκεί;';
+
+  @override
+  String get noSpeechDesc =>
+      'Δεν μπορέσαμε να ανιχνεύσουμε καμία ομιλία. Παρακαλώ βεβαιωθείτε ότι μιλάτε για τουλάχιστον 10 δευτερόλεπτα και όχι περισσότερο από 3 λεπτά.';
+
+  @override
+  String get connectionLost => 'Η Σύνδεση Χάθηκε';
+
+  @override
+  String get connectionLostDesc =>
+      'Η σύνδεση διακόπηκε. Παρακαλώ ελέγξτε τη σύνδεσή σας στο διαδίκτυο και δοκιμάστε ξανά.';
+
+  @override
+  String get tryAgain => 'Δοκιμάστε Ξανά';
+
+  @override
+  String get connectOmiOmiGlass => 'Σύνδεση Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Συνέχεια Χωρίς Συσκευή';
+
+  @override
+  String get permissionsRequired => 'Απαιτούνται Άδειες';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Αυτή η εφαρμογή χρειάζεται άδειες Bluetooth και Τοποθεσίας για να λειτουργήσει σωστά. Παρακαλώ ενεργοποιήστε τις στις ρυθμίσεις.';
+
+  @override
+  String get openSettings => 'Άνοιγμα Ρυθμίσεων';
+
+  @override
+  String get wantDifferentName => 'Θέλετε να αποκαλείστε διαφορετικά;';
+
+  @override
+  String get whatsYourName => 'Ποιο είναι το όνομά σας;';
+
+  @override
+  String get speakTranscribeSummarize => 'Μιλήστε. Απομαγνητοφώνηση. Περίληψη.';
+
+  @override
+  String get signInWithApple => 'Σύνδεση με Apple';
+
+  @override
+  String get signInWithGoogle => 'Σύνδεση με Google';
+
+  @override
+  String get byContinuingAgree => 'Συνεχίζοντας, συμφωνείτε με την ';
+
+  @override
+  String get termsOfUse => 'Όροι Χρήσης';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Ο Βοηθός AI σας';
+
+  @override
+  String get captureEveryMoment =>
+      'Καταγράψτε κάθε στιγμή. Λάβετε περιλήψεις\nμε AI. Μην κρατάτε ποτέ ξανά σημειώσεις.';
+
+  @override
+  String get appleWatchSetup => 'Ρύθμιση Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Ζητήθηκε Άδεια!';
+
+  @override
+  String get microphonePermission => 'Άδεια Μικροφώνου';
+
+  @override
+  String get permissionGrantedNow =>
+      'Η άδεια χορηγήθηκε! Τώρα:\n\nΑνοίξτε την εφαρμογή Omi στο ρολόι σας και πατήστε \"Συνέχεια\" παρακάτω';
+
+  @override
+  String get needMicrophonePermission =>
+      'Χρειαζόμαστε άδεια μικροφώνου.\n\n1. Πατήστε \"Χορήγηση Άδειας\"\n2. Επιτρέψτε στο iPhone σας\n3. Η εφαρμογή ρολογιού θα κλείσει\n4. Ανοίξτε ξανά και πατήστε \"Συνέχεια\"';
+
+  @override
+  String get grantPermissionButton => 'Χορήγηση Άδειας';
+
+  @override
+  String get needHelp => 'Χρειάζεστε Βοήθεια;';
+
+  @override
+  String get troubleshootingSteps =>
+      'Αντιμετώπιση προβλημάτων:\n\n1. Βεβαιωθείτε ότι το Omi είναι εγκατεστημένο στο ρολόι σας\n2. Ανοίξτε την εφαρμογή Omi στο ρολόι σας\n3. Αναζητήστε το αναδυόμενο παράθυρο άδειας\n4. Πατήστε \"Επιτρέπεται\" όταν σας ζητηθεί\n5. Η εφαρμογή στο ρολόι σας θα κλείσει - ανοίξτε την ξανά\n6. Επιστρέψτε και πατήστε \"Συνέχεια\" στο iPhone σας';
+
+  @override
+  String get recordingStartedSuccessfully => 'Η εγγραφή ξεκίνησε επιτυχώς!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Η άδεια δεν έχει χορηγηθεί ακόμα. Παρακαλώ βεβαιωθείτε ότι επιτρέψατε την πρόσβαση στο μικρόφωνο και ανοίξατε ξανά την εφαρμογή στο ρολόι σας.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Σφάλμα αιτήματος άδειας: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Σφάλμα έναρξης εγγραφής: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Επιλέξτε την κύρια γλώσσα σας';
+
+  @override
+  String get languageBenefits => 'Ορίστε τη γλώσσα σας για πιο ακριβείς απομαγνητοφωνήσεις και εξατομικευμένη εμπειρία';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Ποια είναι η κύρια γλώσσα σας;';
+
+  @override
+  String get selectYourLanguage => 'Επιλέξτε τη γλώσσα σας';
+
+  @override
+  String get personalGrowthJourney => 'Το προσωπικό σας ταξίδι ανάπτυξης με AI που ακούει κάθε σας λέξη.';
+
+  @override
+  String get actionItemsTitle => 'Προς Εκτέλεση';
+
+  @override
+  String get actionItemsDescription =>
+      'Πατήστε για επεξεργασία • Παρατεταμένο πάτημα για επιλογή • Σύρετε για ενέργειες';
+
+  @override
+  String get tabToDo => 'Προς Εκτέλεση';
+
+  @override
+  String get tabDone => 'Ολοκληρωμένα';
+
+  @override
+  String get tabOld => 'Παλιά';
+
+  @override
+  String get emptyTodoMessage => '🎉 Είστε ενημερωμένοι!\nΔεν υπάρχουν εκκρεμείς ενέργειες';
+
+  @override
+  String get emptyDoneMessage => 'Δεν υπάρχουν ολοκληρωμένα στοιχεία ακόμα';
+
+  @override
+  String get emptyOldMessage => '✅ Δεν υπάρχουν παλιές εργασίες';
+
+  @override
+  String get noItems => 'Δεν υπάρχουν στοιχεία';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Η ενέργεια επισημάνθηκε ως ημιτελής';
+
+  @override
+  String get actionItemCompleted => 'Η ενέργεια ολοκληρώθηκε';
+
+  @override
+  String get deleteActionItemTitle => 'Διαγραφή Ενέργειας';
+
+  @override
+  String get deleteActionItemMessage => 'Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή την ενέργεια;';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Διαγραφή Επιλεγμένων Στοιχείων';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Είστε βέβαιοι ότι θέλετε να διαγράψετε $count επιλεγμένες ενέργειες$s;';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Η ενέργεια \"$description\" διαγράφηκε';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count ενέργειες$s διαγράφηκαν';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Αποτυχία διαγραφής ενέργειας';
+
+  @override
+  String get failedToDeleteItems => 'Αποτυχία διαγραφής στοιχείων';
+
+  @override
+  String get failedToDeleteSomeItems => 'Αποτυχία διαγραφής ορισμένων στοιχείων';
+
+  @override
+  String get welcomeActionItemsTitle => 'Έτοιμοι για Ενέργειες';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Το AI σας θα εξάγει αυτόματα εργασίες και υποχρεώσεις από τις συνομιλίες σας. Θα εμφανιστούν εδώ όταν δημιουργηθούν.';
+
+  @override
+  String get autoExtractionFeature => 'Αυτόματη εξαγωγή από συνομιλίες';
+
+  @override
+  String get editSwipeFeature => 'Πατήστε για επεξεργασία, σύρετε για ολοκλήρωση ή διαγραφή';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count επιλεγμένα';
+  }
+
+  @override
+  String get selectAll => 'Επιλογή όλων';
+
+  @override
+  String get deleteSelected => 'Διαγραφή επιλεγμένων';
+
+  @override
+  String searchMemories(int count) {
+    return 'Αναζήτηση $count Αναμνήσεων';
+  }
+
+  @override
+  String get memoryDeleted => 'Η ανάμνηση διαγράφηκε.';
+
+  @override
+  String get undo => 'Αναίρεση';
+
+  @override
+  String get noMemoriesYet => 'Δεν υπάρχουν αναμνήσεις ακόμα';
+
+  @override
+  String get noAutoMemories => 'Δεν υπάρχουν αυτόματα εξαγόμενες αναμνήσεις ακόμα';
+
+  @override
+  String get noManualMemories => 'Δεν υπάρχουν χειροκίνητες αναμνήσεις ακόμα';
+
+  @override
+  String get noMemoriesInCategories => 'Δεν υπάρχουν αναμνήσεις σε αυτές τις κατηγορίες';
+
+  @override
+  String get noMemoriesFound => 'Δεν βρέθηκαν αναμνήσεις';
+
+  @override
+  String get addFirstMemory => 'Προσθέστε την πρώτη σας ανάμνηση';
+
+  @override
+  String get clearMemoryTitle => 'Εκκαθάριση Μνήμης του Omi';
+
+  @override
+  String get clearMemoryMessage =>
+      'Είστε βέβαιοι ότι θέλετε να εκκαθαρίσετε τη μνήμη του Omi; Αυτή η ενέργεια δεν μπορεί να αναιρεθεί.';
+
+  @override
+  String get clearMemoryButton => 'Εκκαθάριση Μνήμης';
+
+  @override
+  String get memoryClearedSuccess => 'Η μνήμη του Omi για εσάς έχει εκκαθαριστεί';
+
+  @override
+  String get noMemoriesToDelete => 'Δεν υπάρχουν αναμνήσεις προς διαγραφή';
+
+  @override
+  String get createMemoryTooltip => 'Δημιουργία νέας ανάμνησης';
+
+  @override
+  String get createActionItemTooltip => 'Δημιουργία νέας ενέργειας';
+
+  @override
+  String get memoryManagement => 'Διαχείριση Μνήμης';
+
+  @override
+  String get filterMemories => 'Φιλτράρισμα Αναμνήσεων';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Έχετε $count συνολικές αναμνήσεις';
+  }
+
+  @override
+  String get publicMemories => 'Δημόσιες αναμνήσεις';
+
+  @override
+  String get privateMemories => 'Ιδιωτικές αναμνήσεις';
+
+  @override
+  String get makeAllPrivate => 'Κάντε Όλες τις Αναμνήσεις Ιδιωτικές';
+
+  @override
+  String get makeAllPublic => 'Κάντε Όλες τις Αναμνήσεις Δημόσιες';
+
+  @override
+  String get deleteAllMemories => 'Διαγραφή Όλων των Αναμνήσεων';
+
+  @override
+  String get allMemoriesPrivateResult => 'Όλες οι αναμνήσεις είναι πλέον ιδιωτικές';
+
+  @override
+  String get allMemoriesPublicResult => 'Όλες οι αναμνήσεις είναι πλέον δημόσιες';
+
+  @override
+  String get newMemory => 'Νέα Ανάμνηση';
+
+  @override
+  String get editMemory => 'Επεξεργασία Ανάμνησης';
+
+  @override
+  String get memoryContentHint => 'Μου αρέσει να τρώω παγωτό...';
+
+  @override
+  String get failedToSaveMemory => 'Αποτυχία αποθήκευσης. Παρακαλώ ελέγξτε τη σύνδεσή σας.';
+
+  @override
+  String get saveMemory => 'Αποθήκευση Ανάμνησης';
+
+  @override
+  String get retry => 'Επανάληψη';
+
+  @override
+  String get createActionItem => 'Δημιουργία Ενέργειας';
+
+  @override
+  String get editActionItem => 'Επεξεργασία Ενέργειας';
+
+  @override
+  String get actionItemDescriptionHint => 'Τι πρέπει να γίνει;';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Η περιγραφή της ενέργειας δεν μπορεί να είναι κενή.';
+
+  @override
+  String get actionItemUpdated => 'Η ενέργεια ενημερώθηκε';
+
+  @override
+  String get failedToUpdateActionItem => 'Αποτυχία ενημέρωσης ενέργειας';
+
+  @override
+  String get actionItemCreated => 'Η ενέργεια δημιουργήθηκε';
+
+  @override
+  String get failedToCreateActionItem => 'Αποτυχία δημιουργίας ενέργειας';
+
+  @override
+  String get dueDate => 'Ημερομηνία Λήξης';
+
+  @override
+  String get time => 'Ώρα';
+
+  @override
+  String get addDueDate => 'Προσθήκη ημερομηνίας λήξης';
+
+  @override
+  String get pressDoneToSave => 'Πατήστε τέλος για αποθήκευση';
+
+  @override
+  String get pressDoneToCreate => 'Πατήστε τέλος για δημιουργία';
+
+  @override
+  String get filterAll => 'Όλα';
+
+  @override
+  String get filterSystem => 'Σχετικά με Εσάς';
+
+  @override
+  String get filterInteresting => 'Πληροφορίες';
+
+  @override
+  String get filterManual => 'Χειροκίνητα';
+
+  @override
+  String get completed => 'Ολοκληρώθηκε';
+
+  @override
+  String get markComplete => 'Σήμανση ως ολοκληρωμένο';
+
+  @override
+  String get actionItemDeleted => 'Η ενέργεια διαγράφηκε';
+
+  @override
+  String get failedToDeleteActionItem => 'Αποτυχία διαγραφής ενέργειας';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Διαγραφή Ενέργειας';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Είστε βέβαιοι ότι θέλετε να διαγράψετε αυτή την ενέργεια;';
+
+  @override
+  String get appLanguage => 'Γλώσσα Εφαρμογής';
+
+  @override
+  String get appInterfaceSectionTitle => 'ΔΙΕΠΑΦΉ ΕΦΑΡΜΟΓΉΣ';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'ΟΜΙΛΊΑ ΚΑΙ ΜΕΤΑΓΡΑΦΉ';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Η γλώσσα της εφαρμογής αλλάζει τα μενού και τα κουμπιά. Η γλώσσα ομιλίας επηρεάζει τον τρόπο μεταγραφής των ηχογραφήσεών σας.';
+}

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -234,7 +234,7 @@ class AppLocalizationsEn extends AppLocalizations {
   String get searchConversations => 'Search Conversations';
 
   @override
-  String selectedCount(int count) {
+  String selectedCount(int count, Object s) {
     return '$count selected';
   }
 
@@ -2215,4 +2215,14 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get appLanguage => 'App Language';
+
+  @override
+  String get appInterfaceSectionTitle => 'APP INTERFACE';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'SPEECH & TRANSCRIPTION';
+
+  @override
+  String get languageSettingsHelperText =>
+      'App Language changes menus and buttons. Speech Language affects how your recordings are transcribed.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -235,7 +235,7 @@ class AppLocalizationsEs extends AppLocalizations {
   String get searchConversations => 'Buscar conversaciones';
 
   @override
-  String selectedCount(int count) {
+  String selectedCount(int count, Object s) {
     return '$count seleccionados';
   }
 
@@ -2171,10 +2171,10 @@ class AppLocalizationsEs extends AppLocalizations {
   String get filterAll => 'Todos';
 
   @override
-  String get filterSystem => 'About You';
+  String get filterSystem => 'Sobre ti';
 
   @override
-  String get filterInteresting => 'Insights';
+  String get filterInteresting => 'Perspectivas';
 
   @override
   String get filterManual => 'Manual';
@@ -2199,4 +2199,14 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get appLanguage => 'Idioma de la App';
+
+  @override
+  String get appInterfaceSectionTitle => 'INTERFAZ DE LA APLICACIÓN';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'VOZ Y TRANSCRIPCIÓN';
+
+  @override
+  String get languageSettingsHelperText =>
+      'El idioma de la aplicación cambia los menús y botones. El idioma de voz afecta cómo se transcriben tus grabaciones.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -1,0 +1,2231 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Estonian (`et`).
+class AppLocalizationsEt extends AppLocalizations {
+  AppLocalizationsEt([String locale = 'et']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Vestlus';
+
+  @override
+  String get transcriptTab => 'Transkriptsioon';
+
+  @override
+  String get actionItemsTab => 'Tegevuspunktid';
+
+  @override
+  String get deleteConversationTitle => 'Kustuta vestlus?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Kas olete kindel, et soovite selle vestluse kustutada? Seda toimingut ei saa tagasi võtta.';
+
+  @override
+  String get confirm => 'Kinnita';
+
+  @override
+  String get cancel => 'Tühista';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Kustuta';
+
+  @override
+  String get add => 'Lisa';
+
+  @override
+  String get update => 'Uuenda';
+
+  @override
+  String get save => 'Salvesta';
+
+  @override
+  String get edit => 'Muuda';
+
+  @override
+  String get close => 'Sulge';
+
+  @override
+  String get clear => 'Tühjenda';
+
+  @override
+  String get copyTranscript => 'Kopeeri transkriptsioon';
+
+  @override
+  String get copySummary => 'Kopeeri kokkuvõte';
+
+  @override
+  String get testPrompt => 'Testi käsku';
+
+  @override
+  String get reprocessConversation => 'Töötle vestlust uuesti';
+
+  @override
+  String get deleteConversation => 'Kustuta vestlus';
+
+  @override
+  String get contentCopied => 'Sisu kopeeritud lõikelauale';
+
+  @override
+  String get failedToUpdateStarred => 'Tärni lisamine ebaõnnestus.';
+
+  @override
+  String get conversationUrlNotShared => 'Vestluse URL-i ei saanud jagada.';
+
+  @override
+  String get errorProcessingConversation => 'Viga vestluse töötlemisel. Palun proovige hiljem uuesti.';
+
+  @override
+  String get noInternetConnection => 'Palun kontrollige oma internetiühendust ja proovige uuesti.';
+
+  @override
+  String get unableToDeleteConversation => 'Vestlust ei õnnestunud kustutada';
+
+  @override
+  String get somethingWentWrong => 'Midagi läks valesti! Palun proovige hiljem uuesti.';
+
+  @override
+  String get copyErrorMessage => 'Kopeeri veateade';
+
+  @override
+  String get errorCopied => 'Veateade kopeeritud lõikelauale';
+
+  @override
+  String get remaining => 'Järelejäänud';
+
+  @override
+  String get loading => 'Laadimine...';
+
+  @override
+  String get loadingDuration => 'Kestuse laadimine...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekundit';
+  }
+
+  @override
+  String get people => 'Inimesed';
+
+  @override
+  String get addNewPerson => 'Lisa uus isik';
+
+  @override
+  String get editPerson => 'Muuda isikut';
+
+  @override
+  String get createPersonHint => 'Looge uus isik ja õpetage Omi-le ära tundma ka tema kõnet!';
+
+  @override
+  String get speechProfile => 'Kõneprofiil';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Näidis $number';
+  }
+
+  @override
+  String get settings => 'Seaded';
+
+  @override
+  String get language => 'Keel';
+
+  @override
+  String get selectLanguage => 'Vali keel';
+
+  @override
+  String get deleting => 'Kustutamine...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Palun lõpetage autentimine oma brauseris. Kui olete valmis, naasake rakendusse.';
+
+  @override
+  String get failedToStartAuthentication => 'Autentimise alustamine ebaõnnestus';
+
+  @override
+  String get importStarted => 'Import algas! Saate teate, kui see on lõpetatud.';
+
+  @override
+  String get failedToStartImport => 'Impordi alustamine ebaõnnestus. Palun proovige uuesti.';
+
+  @override
+  String get couldNotAccessFile => 'Valitud failile ei pääsenud ligi';
+
+  @override
+  String get askOmi => 'Küsi Omi-lt';
+
+  @override
+  String get done => 'Valmis';
+
+  @override
+  String get disconnected => 'Ühendus katkestatud';
+
+  @override
+  String get searching => 'Otsimine';
+
+  @override
+  String get connectDevice => 'Ühenda seade';
+
+  @override
+  String get monthlyLimitReached => 'Olete jõudnud oma kuulimiidini.';
+
+  @override
+  String get checkUsage => 'Kontrolli kasutust';
+
+  @override
+  String get syncingRecordings => 'Salvestiste sünkroonimine';
+
+  @override
+  String get recordingsToSync => 'Sünkroonimist vajavad salvestised';
+
+  @override
+  String get allCaughtUp => 'Kõik on sünkroonitud';
+
+  @override
+  String get sync => 'Sünkrooni';
+
+  @override
+  String get pendantUpToDate => 'Ripats on ajakohane';
+
+  @override
+  String get allRecordingsSynced => 'Kõik salvestised on sünkroonitud';
+
+  @override
+  String get syncingInProgress => 'Sünkroonimine käib';
+
+  @override
+  String get readyToSync => 'Valmis sünkroonimiseks';
+
+  @override
+  String get tapSyncToStart => 'Alustamiseks vajutage Sünkrooni';
+
+  @override
+  String get pendantNotConnected => 'Ripats pole ühendatud. Sünkroonimiseks ühendage see.';
+
+  @override
+  String get everythingSynced => 'Kõik on juba sünkroonitud.';
+
+  @override
+  String get recordingsNotSynced => 'Teil on salvestisi, mis pole veel sünkroonitud.';
+
+  @override
+  String get syncingBackground => 'Jätkame teie salvestiste sünkroonimist taustal.';
+
+  @override
+  String get noConversationsYet => 'Vestlusi pole veel.';
+
+  @override
+  String get noStarredConversations => 'Tärniga märgitud vestlusi pole veel.';
+
+  @override
+  String get starConversationHint => 'Vestluse tärniga märkimiseks avage see ja puudutage päises tärni ikooni.';
+
+  @override
+  String get searchConversations => 'Otsi vestlusi';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count valitud';
+  }
+
+  @override
+  String get merge => 'Ühenda';
+
+  @override
+  String get mergeConversations => 'Ühenda vestlused';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'See ühendab $count vestlust üheks. Kogu sisu ühendatakse ja luuakse uuesti.';
+  }
+
+  @override
+  String get mergingInBackground => 'Ühendamine käib taustal. See võib võtta hetke aega.';
+
+  @override
+  String get failedToStartMerge => 'Ühendamise alustamine ebaõnnestus';
+
+  @override
+  String get askAnything => 'Küsi mida tahes';
+
+  @override
+  String get noMessagesYet => 'Sõnumeid pole veel!\nMiks te ei alusta vestlust?';
+
+  @override
+  String get deletingMessages => 'Teie sõnumite kustutamine Omi mälust...';
+
+  @override
+  String get messageCopied => 'Sõnum kopeeritud lõikelauale.';
+
+  @override
+  String get cannotReportOwnMessage => 'Te ei saa oma sõnumitest teatada.';
+
+  @override
+  String get reportMessage => 'Teata sõnumist';
+
+  @override
+  String get reportMessageConfirm => 'Kas olete kindel, et soovite sellest sõnumist teatada?';
+
+  @override
+  String get messageReported => 'Sõnumist teatati edukalt.';
+
+  @override
+  String get thankYouFeedback => 'Täname tagasiside eest!';
+
+  @override
+  String get clearChat => 'Tühjenda vestlus?';
+
+  @override
+  String get clearChatConfirm =>
+      'Kas olete kindel, et soovite vestluse tühjendada? Seda toimingut ei saa tagasi võtta.';
+
+  @override
+  String get maxFilesLimit => 'Korraga saate üles laadida ainult 4 faili';
+
+  @override
+  String get chatWithOmi => 'Vestlus Omi-ga';
+
+  @override
+  String get apps => 'Rakendused';
+
+  @override
+  String get noAppsFound => 'Rakendusi ei leitud';
+
+  @override
+  String get tryAdjustingSearch => 'Proovige otsingu või filtrite muutmist';
+
+  @override
+  String get createYourOwnApp => 'Looge oma rakendus';
+
+  @override
+  String get buildAndShareApp => 'Looge ja jagage oma kohandatud rakendust';
+
+  @override
+  String get searchApps => 'Otsi 1500+ rakendust';
+
+  @override
+  String get myApps => 'Minu rakendused';
+
+  @override
+  String get installedApps => 'Paigaldatud rakendused';
+
+  @override
+  String get unableToFetchApps =>
+      'Rakenduste laadimine ebaõnnestus :(\n\nPalun kontrollige oma internetiühendust ja proovige uuesti.';
+
+  @override
+  String get aboutOmi => 'Omi teave';
+
+  @override
+  String get privacyPolicy => 'Privaatsuspoliitikaga';
+
+  @override
+  String get visitWebsite => 'Külasta veebilehte';
+
+  @override
+  String get helpOrInquiries => 'Abi või päringud?';
+
+  @override
+  String get joinCommunity => 'Liitu kogukonnaga!';
+
+  @override
+  String get membersAndCounting => '8000+ liiget ja kasvab.';
+
+  @override
+  String get deleteAccountTitle => 'Kustuta konto';
+
+  @override
+  String get deleteAccountConfirm => 'Kas olete kindel, et soovite oma konto kustutada?';
+
+  @override
+  String get cannotBeUndone => 'Seda ei saa tagasi võtta.';
+
+  @override
+  String get allDataErased => 'Kõik teie mälestused ja vestlused kustutatakse jäädavalt.';
+
+  @override
+  String get appsDisconnected => 'Teie rakendused ja integratsioonid katkestatakse viivitamatult.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Saate oma andmed enne konto kustutamist eksportida, kuid pärast kustutamist ei saa neid taastada.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Mõistan, et minu konto kustutamine on püsiv ja kõik andmed, sealhulgas mälestused ja vestlused, lähevad kaotsi ega ole taastatavad.';
+
+  @override
+  String get areYouSure => 'Kas olete kindel?';
+
+  @override
+  String get deleteAccountFinal =>
+      'See toiming on pöördumatu ja kustutab jäädavalt teie konto ja kõik sellega seotud andmed. Kas olete kindel, et soovite jätkata?';
+
+  @override
+  String get deleteNow => 'Kustuta kohe';
+
+  @override
+  String get goBack => 'Mine tagasi';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Märkige ruut, et kinnitada, et mõistate, et teie konto kustutamine on püsiv ja pöördumatu.';
+
+  @override
+  String get profile => 'Profiil';
+
+  @override
+  String get name => 'Nimi';
+
+  @override
+  String get email => 'E-post';
+
+  @override
+  String get customVocabulary => 'Kohandatud sõnavara';
+
+  @override
+  String get identifyingOthers => 'Teiste tuvastamine';
+
+  @override
+  String get paymentMethods => 'Makseviisid';
+
+  @override
+  String get conversationDisplay => 'Vestluse kuvamine';
+
+  @override
+  String get dataPrivacy => 'Andmed ja privaatsus';
+
+  @override
+  String get userId => 'Kasutaja ID';
+
+  @override
+  String get notSet => 'Pole määratud';
+
+  @override
+  String get userIdCopied => 'Kasutaja ID kopeeritud lõikelauale';
+
+  @override
+  String get systemDefault => 'Süsteemi vaikimisi';
+
+  @override
+  String get planAndUsage => 'Plaan ja kasutus';
+
+  @override
+  String get offlineSync => 'Võrguühenduseta sünkroonimine';
+
+  @override
+  String get deviceSettings => 'Seadme seaded';
+
+  @override
+  String get chatTools => 'Vestlustööriistad';
+
+  @override
+  String get feedbackBug => 'Tagasiside / viga';
+
+  @override
+  String get helpCenter => 'Abikeskus';
+
+  @override
+  String get developerSettings => 'Arendaja seaded';
+
+  @override
+  String get getOmiForMac => 'Hangi Omi Mac-ile';
+
+  @override
+  String get referralProgram => 'Viiteprogramm';
+
+  @override
+  String get signOut => 'Logi välja';
+
+  @override
+  String get appAndDeviceCopied => 'Rakenduse ja seadme üksikasjad kopeeritud';
+
+  @override
+  String get wrapped2025 => 'Kokkuvõte 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Teie privaatsus, teie kontroll';
+
+  @override
+  String get privacyIntro =>
+      'Omi-s oleme pühendunud teie privaatsuse kaitsmisele. See leht võimaldab teil kontrollida, kuidas teie andmeid säilitatakse ja kasutatakse.';
+
+  @override
+  String get learnMore => 'Loe lähemalt...';
+
+  @override
+  String get dataProtectionLevel => 'Andmekaitse tase';
+
+  @override
+  String get dataProtectionDesc =>
+      'Teie andmed on vaikimisi kaitstud tugeva krüpteerimisega. Vaadake allpool oma seadeid ja tulevasi privaatsusvalikuid.';
+
+  @override
+  String get appAccess => 'Rakenduse juurdepääs';
+
+  @override
+  String get appAccessDesc =>
+      'Järgmised rakendused pääsevad juurde teie andmetele. Puudutage rakendust selle õiguste haldamiseks.';
+
+  @override
+  String get noAppsExternalAccess => 'Ühelgi paigaldatud rakendusel pole välise juurdepääsu teie andmetele.';
+
+  @override
+  String get deviceName => 'Seadme nimi';
+
+  @override
+  String get deviceId => 'Seadme ID';
+
+  @override
+  String get firmware => 'Püsivara';
+
+  @override
+  String get sdCardSync => 'SD-kaardi sünkroonimine';
+
+  @override
+  String get hardwareRevision => 'Riistvara versioon';
+
+  @override
+  String get modelNumber => 'Mudeli number';
+
+  @override
+  String get manufacturer => 'Tootja';
+
+  @override
+  String get doubleTap => 'Topeltpuudutus';
+
+  @override
+  String get ledBrightness => 'LED heledus';
+
+  @override
+  String get micGain => 'Mikrofoni võimendus';
+
+  @override
+  String get disconnect => 'Katkesta ühendus';
+
+  @override
+  String get forgetDevice => 'Unusta seade';
+
+  @override
+  String get chargingIssues => 'Laadimisprobleemid';
+
+  @override
+  String get disconnectDevice => 'Katkesta seadme ühendus';
+
+  @override
+  String get unpairDevice => 'Tühista seadme sidumine';
+
+  @override
+  String get unpairAndForget => 'Tühista sidumine ja unusta seade';
+
+  @override
+  String get deviceDisconnectedMessage => 'Teie Omi on ühendus katkestatud 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Seadme sidumine tühistatud. Minege Seaded > Bluetooth ja unustage seade sidumise lõpetamiseks.';
+
+  @override
+  String get unpairDialogTitle => 'Tühista seadme sidumine';
+
+  @override
+  String get unpairDialogMessage =>
+      'See tühistab seadme sidumise, et seda saaks ühendada teise telefoniga. Protsessi lõpetamiseks peate minema Seaded > Bluetooth ja unustama seadme.';
+
+  @override
+  String get deviceNotConnected => 'Seade pole ühendatud';
+
+  @override
+  String get connectDeviceMessage => 'Ühendage oma Omi seade, et pääseda juurde\nseadme seadetele ja kohandamisele';
+
+  @override
+  String get deviceInfoSection => 'Seadme teave';
+
+  @override
+  String get customizationSection => 'Kohandamine';
+
+  @override
+  String get hardwareSection => 'Riistvara';
+
+  @override
+  String get v2Undetected => 'V2 tuvastamata';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Näeme, et teil on kas V1 seade või teie seade pole ühendatud. SD-kaardi funktsioon on saadaval ainult V2 seadmetele.';
+
+  @override
+  String get endConversation => 'Lõpeta vestlus';
+
+  @override
+  String get pauseResume => 'Peata/jätka';
+
+  @override
+  String get starConversation => 'Märgi vestlus tärniga';
+
+  @override
+  String get doubleTapAction => 'Topeltpuudutuse tegevus';
+
+  @override
+  String get endAndProcess => 'Lõpeta ja töötle vestlus';
+
+  @override
+  String get pauseResumeRecording => 'Peata/jätka salvestamine';
+
+  @override
+  String get starOngoing => 'Märgi käimasolev vestlus tärniga';
+
+  @override
+  String get off => 'Väljas';
+
+  @override
+  String get max => 'Maks';
+
+  @override
+  String get mute => 'Vaigista';
+
+  @override
+  String get quiet => 'Vaikne';
+
+  @override
+  String get normal => 'Tavaline';
+
+  @override
+  String get high => 'Kõrge';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon on vaigistatud';
+
+  @override
+  String get micGainDescLow => 'Väga vaikne - valjude keskkondade jaoks';
+
+  @override
+  String get micGainDescModerate => 'Vaikne - mõõduka müra jaoks';
+
+  @override
+  String get micGainDescNeutral => 'Neutraalne - tasakaalustatud salvestamine';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Veidi võimendatud - tavakasutus';
+
+  @override
+  String get micGainDescBoosted => 'Võimendatud - vaiksetele keskkondadele';
+
+  @override
+  String get micGainDescHigh => 'Kõrge - kaugete või vaikste häälte jaoks';
+
+  @override
+  String get micGainDescVeryHigh => 'Väga kõrge - väga vaiksetele allikatele';
+
+  @override
+  String get micGainDescMax => 'Maksimum - kasutage ettevaatusega';
+
+  @override
+  String get developerSettingsTitle => 'Arendaja seaded';
+
+  @override
+  String get saving => 'Salvestamine...';
+
+  @override
+  String get personaConfig => 'Seadistage oma AI isiksus';
+
+  @override
+  String get beta => 'BEETA';
+
+  @override
+  String get transcription => 'Transkriptsioon';
+
+  @override
+  String get transcriptionConfig => 'Seadistage STT pakkuja';
+
+  @override
+  String get conversationTimeout => 'Vestluse aegumine';
+
+  @override
+  String get conversationTimeoutConfig => 'Määrake, millal vestlused automaatselt lõpevad';
+
+  @override
+  String get importData => 'Impordi andmed';
+
+  @override
+  String get importDataConfig => 'Importige andmed teistest allikatest';
+
+  @override
+  String get debugDiagnostics => 'Silumis- ja diagnostika';
+
+  @override
+  String get endpointUrl => 'Otspunkti URL';
+
+  @override
+  String get noApiKeys => 'API võtmeid pole veel';
+
+  @override
+  String get createKeyToStart => 'Alustamiseks looge võti';
+
+  @override
+  String get createKey => 'Loo võti';
+
+  @override
+  String get docs => 'Dokumendid';
+
+  @override
+  String get yourOmiInsights => 'Teie Omi ülevaated';
+
+  @override
+  String get today => 'Täna';
+
+  @override
+  String get thisMonth => 'See kuu';
+
+  @override
+  String get thisYear => 'See aasta';
+
+  @override
+  String get allTime => 'Kogu aeg';
+
+  @override
+  String get noActivityYet => 'Tegevust pole veel';
+
+  @override
+  String get startConversationToSeeInsights => 'Alustage Omi-ga vestlust,\net näha siinkohal oma kasutuse ülevaadet.';
+
+  @override
+  String get listening => 'Kuulamine';
+
+  @override
+  String get listeningSubtitle => 'Aeg, mil Omi on aktiivselt kuulanud.';
+
+  @override
+  String get understanding => 'Mõistmine';
+
+  @override
+  String get understandingSubtitle => 'Teie vestlustest mõistetud sõnad.';
+
+  @override
+  String get providing => 'Pakkumine';
+
+  @override
+  String get providingSubtitle => 'Tegevuspunktid ja märkmed automaatselt salvestatud.';
+
+  @override
+  String get remembering => 'Meelde jätmine';
+
+  @override
+  String get rememberingSubtitle => 'Teie jaoks meeles peetud faktid ja üksikasjad.';
+
+  @override
+  String get unlimitedPlan => 'Piiramatu plaan';
+
+  @override
+  String get managePlan => 'Halda plaani';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Teie plaan tühistatakse $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Teie plaan uueneb $date.';
+  }
+
+  @override
+  String get basicPlan => 'Tasuta plaan';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used/$limit min kasutatud';
+  }
+
+  @override
+  String get upgrade => 'Uuenda';
+
+  @override
+  String get upgradeToUnlimited => 'Uuenda piiramatuks';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Teie plaan sisaldab $limit tasuta minutit kuus. Uuendage piiramatuks.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Jagan oma Omi statistikat! (omi.me - teie alati sees AI assistent)';
+
+  @override
+  String get sharePeriodToday => 'Täna on omi:';
+
+  @override
+  String get sharePeriodMonth => 'Sel kuul on omi:';
+
+  @override
+  String get sharePeriodYear => 'Sel aastal on omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Seni on omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Kuulanud $minutes minutit';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Mõistnud $words sõna';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Pakkunud $count ülevaadet';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Meelde jätnud $count mälestust';
+  }
+
+  @override
+  String get debugLogs => 'Silumislogid';
+
+  @override
+  String get debugLogsAutoDelete => 'Kustutatakse automaatselt 3 päeva pärast.';
+
+  @override
+  String get debugLogsDesc => 'Aitab diagnoosida probleeme';
+
+  @override
+  String get noLogFilesFound => 'Logifaile ei leitud.';
+
+  @override
+  String get omiDebugLog => 'Omi silumislogi';
+
+  @override
+  String get logShared => 'Logi jagatud';
+
+  @override
+  String get selectLogFile => 'Vali logifail';
+
+  @override
+  String get shareLogs => 'Jaga logisid';
+
+  @override
+  String get debugLogCleared => 'Silumislogi tühjendatud';
+
+  @override
+  String get exportStarted => 'Eksport algas. See võib võtta mõne sekundi...';
+
+  @override
+  String get exportAllData => 'Ekspordi kõik andmed';
+
+  @override
+  String get exportDataDesc => 'Ekspordi vestlused JSON-failina';
+
+  @override
+  String get exportedConversations => 'Omi-st eksporditud vestlused';
+
+  @override
+  String get exportShared => 'Eksport jagatud';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Kustuta teadmiste graaf?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'See kustutab kõik tuletatud teadmiste graafi andmed (sõlmed ja ühendused). Teie algsed mälestused jäävad turvaliseks. Graaf taastatakse aja jooksul või järgmise päringu korral.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Teadmiste graaf kustutati edukalt';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Graafi kustutamine ebaõnnestus: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Kustuta teadmiste graaf';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Tühjenda kõik sõlmed ja ühendused';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP server';
+
+  @override
+  String get mcpServerDesc => 'Ühendage AI assistendid oma andmetega';
+
+  @override
+  String get serverUrl => 'Serveri URL';
+
+  @override
+  String get urlCopied => 'URL kopeeritud';
+
+  @override
+  String get apiKeyAuth => 'API võtme autentimine';
+
+  @override
+  String get header => 'Päis';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Kliendi ID';
+
+  @override
+  String get clientSecret => 'Kliendi saladus';
+
+  @override
+  String get useMcpApiKey => 'Kasutage oma MCP API võtit';
+
+  @override
+  String get webhooks => 'Veebipoogid';
+
+  @override
+  String get conversationEvents => 'Vestluse sündmused';
+
+  @override
+  String get newConversationCreated => 'Uus vestlus loodud';
+
+  @override
+  String get realtimeTranscript => 'Reaalajas transkriptsioon';
+
+  @override
+  String get transcriptReceived => 'Transkriptsioon vastu võetud';
+
+  @override
+  String get audioBytes => 'Helibaite';
+
+  @override
+  String get audioDataReceived => 'Heliandmed vastu võetud';
+
+  @override
+  String get intervalSeconds => 'Intervall (sekundid)';
+
+  @override
+  String get daySummary => 'Päeva kokkuvõte';
+
+  @override
+  String get summaryGenerated => 'Kokkuvõte loodud';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Lisa claude_desktop_config.json-i';
+
+  @override
+  String get copyConfig => 'Kopeeri konfiguratsioon';
+
+  @override
+  String get configCopied => 'Konfiguratsioon kopeeritud lõikelauale';
+
+  @override
+  String get listeningMins => 'Kuulamine (min)';
+
+  @override
+  String get understandingWords => 'Mõistmine (sõnad)';
+
+  @override
+  String get insights => 'Ülevaated';
+
+  @override
+  String get memories => 'Mälestused';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used/$limit min kasutatud sel kuul';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used/$limit sõna kasutatud sel kuul';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used/$limit ülevaadet saadud sel kuul';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used/$limit mälestust loodud sel kuul';
+  }
+
+  @override
+  String get visibility => 'Nähtavus';
+
+  @override
+  String get visibilitySubtitle => 'Kontrollige, millised vestlused teie loendis kuvatakse';
+
+  @override
+  String get showShortConversations => 'Kuva lühikesed vestlused';
+
+  @override
+  String get showShortConversationsDesc => 'Kuva künnisest lühemaid vestlusi';
+
+  @override
+  String get showDiscardedConversations => 'Kuva hüljatud vestlused';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Kaasa hüljatuna märgitud vestlused';
+
+  @override
+  String get shortConversationThreshold => 'Lühikese vestluse künnis';
+
+  @override
+  String get shortConversationThresholdSubtitle => 'Sellest lühemad vestlused peidetakse, kui pole ülalpool lubatud';
+
+  @override
+  String get durationThreshold => 'Kestuse künnis';
+
+  @override
+  String get durationThresholdDesc => 'Peida sellest lühemad vestlused';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Kohandatud sõnavara';
+
+  @override
+  String get addWords => 'Lisa sõnad';
+
+  @override
+  String get addWordsDesc => 'Nimed, terminid või ebatavalised sõnad';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Ühenda';
+
+  @override
+  String get comingSoon => 'Tulekul';
+
+  @override
+  String get chatToolsFooter => 'Ühendage oma rakendused, et vestluses andmeid ja mõõdikuid vaadata.';
+
+  @override
+  String get completeAuthInBrowser => 'Palun lõpetage autentimine oma brauseris. Kui olete valmis, naasake rakendusse.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return '$appName autentimise alustamine ebaõnnestus';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Katkesta ühendus rakendusega $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Kas olete kindel, et soovite ühenduse rakendusega $appName katkestada? Saate igal ajal uuesti ühendada.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Ühendus rakendusega $appName katkestatud';
+  }
+
+  @override
+  String get failedToDisconnect => 'Ühenduse katkestamine ebaõnnestus';
+
+  @override
+  String connectTo(String appName) {
+    return 'Ühenda rakendusega $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Peate andma Omi-le loa juurdepääsuks teie $appName andmetele. See avab teie brauseri autentimiseks.';
+  }
+
+  @override
+  String get continueAction => 'Jätka';
+
+  @override
+  String get languageTitle => 'Keel';
+
+  @override
+  String get primaryLanguage => 'Põhikeel';
+
+  @override
+  String get automaticTranslation => 'Automaatne tõlge';
+
+  @override
+  String get detectLanguages => 'Tuvasta 10+ keelt';
+
+  @override
+  String get authorizeSavingRecordings => 'Luba salvestiste salvestamine';
+
+  @override
+  String get thanksForAuthorizing => 'Täname loa andmise eest!';
+
+  @override
+  String get needYourPermission => 'Vajame teie luba';
+
+  @override
+  String get alreadyGavePermission =>
+      'Olete juba andnud meile loa teie salvestiste salvestamiseks. Siin on meeldetuletus, miks me seda vajame:';
+
+  @override
+  String get wouldLikePermission => 'Sooviksime teie luba teie helisalvestiste salvestamiseks. Siin on põhjus:';
+
+  @override
+  String get improveSpeechProfile => 'Parandage oma kõneprofiili';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Kasutame salvestisi, et edasi treenida ja parandada teie isiklikku kõneprofiili.';
+
+  @override
+  String get trainFamilyProfiles => 'Treenige profiile sõprade ja pere jaoks';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Teie salvestised aitavad meil ära tunda ja luua profiile teie sõprade ja pere jaoks.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Parandage transkriptsiooni täpsust';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Kui meie mudel paraneb, saame pakkuda teie salvestiste jaoks paremaid transkriptsioone.';
+
+  @override
+  String get legalNotice =>
+      'Õiguslik teade: Häälsalvestuste salvestamise ja salvestamise seaduslikkus võib sõltuvalt teie asukohast ja selle funktsiooni kasutamisest erineda. Teie kohustus on tagada kohalike seaduste ja määruste järgimine.';
+
+  @override
+  String get alreadyAuthorized => 'Juba autoriseeritud';
+
+  @override
+  String get authorize => 'Autoriseeri';
+
+  @override
+  String get revokeAuthorization => 'Tühista autoriseerimine';
+
+  @override
+  String get authorizationSuccessful => 'Autoriseerimine õnnestus!';
+
+  @override
+  String get failedToAuthorize => 'Autoriseerimine ebaõnnestus. Palun proovige uuesti.';
+
+  @override
+  String get authorizationRevoked => 'Autoriseerimine tühistatud.';
+
+  @override
+  String get recordingsDeleted => 'Salvestised kustutatud.';
+
+  @override
+  String get failedToRevoke => 'Autoriseerimise tühistamine ebaõnnestus. Palun proovige uuesti.';
+
+  @override
+  String get permissionRevokedTitle => 'Luba tühistatud';
+
+  @override
+  String get permissionRevokedMessage => 'Kas soovite, et me eemaldaksime ka kõik teie olemasolevad salvestised?';
+
+  @override
+  String get yes => 'Jah';
+
+  @override
+  String get editName => 'Muuda nime';
+
+  @override
+  String get howShouldOmiCallYou => 'Kuidas peaks Omi teid kutsuma?';
+
+  @override
+  String get enterYourName => 'Sisestage oma nimi';
+
+  @override
+  String get nameCannotBeEmpty => 'Nimi ei saa olla tühi';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Nimi edukalt uuendatud!';
+
+  @override
+  String get calendarSettings => 'Kalendri seaded';
+
+  @override
+  String get calendarProviders => 'Kalendri pakkujad';
+
+  @override
+  String get macOsCalendar => 'macOS kalender';
+
+  @override
+  String get connectMacOsCalendar => 'Ühendage oma kohalik macOS kalender';
+
+  @override
+  String get googleCalendar => 'Google Calendar';
+
+  @override
+  String get syncGoogleAccount => 'Sünkroonige oma Google\'i kontoga';
+
+  @override
+  String get showMeetingsMenuBar => 'Kuva tulevased koosolekud menüüribal';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Kuva oma järgmine koosolek ja aeg selle alguseni macOS-i menüüribal';
+
+  @override
+  String get showEventsNoParticipants => 'Kuva ilma osalejateta sündmusi';
+
+  @override
+  String get showEventsNoParticipantsDesc => 'Kui lubatud, näitab Coming Up sündmusi ilma osalejate või videolingita.';
+
+  @override
+  String get yourMeetings => 'Teie koosolekud';
+
+  @override
+  String get refresh => 'Värskenda';
+
+  @override
+  String get noUpcomingMeetings => 'Tulevasi koosolekuid ei leitud';
+
+  @override
+  String get checkingNextDays => 'Kontrolli järgmist 30 päeva';
+
+  @override
+  String get tomorrow => 'Homme';
+
+  @override
+  String get googleCalendarComingSoon => 'Google Calendar integratsioon tuleb varsti!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Ühendatud kasutajana: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Vaikimisi tööala';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Ülesanded luuakse sellesse tööalasse';
+
+  @override
+  String get defaultProjectOptional => 'Vaikimisi projekt (valikuline)';
+
+  @override
+  String get leaveUnselectedTasks => 'Jätke valimata, et luua ülesanded ilma projektita';
+
+  @override
+  String get noProjectsInWorkspace => 'Selles tööalas projekte ei leitud';
+
+  @override
+  String get conversationTimeoutDesc => 'Valige, kui kaua vaikuses oodatakse enne vestluse automaatset lõpetamist:';
+
+  @override
+  String get timeout2Minutes => '2 minutit';
+
+  @override
+  String get timeout2MinutesDesc => 'Lõpeta vestlus pärast 2-minutilist vaikust';
+
+  @override
+  String get timeout5Minutes => '5 minutit';
+
+  @override
+  String get timeout5MinutesDesc => 'Lõpeta vestlus pärast 5-minutilist vaikust';
+
+  @override
+  String get timeout10Minutes => '10 minutit';
+
+  @override
+  String get timeout10MinutesDesc => 'Lõpeta vestlus pärast 10-minutilist vaikust';
+
+  @override
+  String get timeout30Minutes => '30 minutit';
+
+  @override
+  String get timeout30MinutesDesc => 'Lõpeta vestlus pärast 30-minutilist vaikust';
+
+  @override
+  String get timeout4Hours => '4 tundi';
+
+  @override
+  String get timeout4HoursDesc => 'Lõpeta vestlus pärast 4-tunnist vaikust';
+
+  @override
+  String get conversationEndAfterHours => 'Vestlused lõpevad nüüd pärast 4-tunnist vaikust';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Vestlused lõpevad nüüd pärast $minutes minuti pikkust vaikust';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Öelge meile oma põhikeel';
+
+  @override
+  String get languageForTranscription =>
+      'Määrake oma keel täpsemate transkriptsioonide ja isikupärastatud kogemuse saamiseks.';
+
+  @override
+  String get singleLanguageModeInfo => 'Ühe keele režiim on lubatud. Tõlge on keelatud suurema täpsuse jaoks.';
+
+  @override
+  String get searchLanguageHint => 'Otsige keelt nime või koodi järgi';
+
+  @override
+  String get noLanguagesFound => 'Keeli ei leitud';
+
+  @override
+  String get skip => 'Jäta vahele';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Keeleks määratud $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Keele määramine ebaõnnestus';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName seaded';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Katkesta ühendus rakendusega $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'See eemaldab teie $appName autentimise. Peate uuesti ühendama, et seda uuesti kasutada.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Ühendatud rakendusega $appName';
+  }
+
+  @override
+  String get account => 'Konto';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Teie tegevuspunktid sünkroonitakse teie $appName kontoga';
+  }
+
+  @override
+  String get defaultSpace => 'Vaikimisi ruum';
+
+  @override
+  String get selectSpaceInWorkspace => 'Valige ruum oma tööalast';
+
+  @override
+  String get noSpacesInWorkspace => 'Selles tööalas ruume ei leitud';
+
+  @override
+  String get defaultList => 'Vaikimisi loend';
+
+  @override
+  String get tasksAddedToList => 'Ülesanded lisatakse sellesse loendisse';
+
+  @override
+  String get noListsInSpace => 'Selles ruumis loendeid ei leitud';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Hoidlate laadimine ebaõnnestus: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Vaikimisi hoidla salvestatud';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Vaikimisi hoidla salvestamine ebaõnnestus';
+
+  @override
+  String get defaultRepository => 'Vaikimisi hoidla';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Valige vaikimisi hoidla probleemide loomiseks. Probleemide loomisel saate siiski määrata teise hoidla.';
+
+  @override
+  String get noReposFound => 'Hoidlaid ei leitud';
+
+  @override
+  String get private => 'Privaatne';
+
+  @override
+  String updatedDate(String date) {
+    return 'Uuendatud $date';
+  }
+
+  @override
+  String get yesterday => 'eile';
+
+  @override
+  String daysAgo(int count) {
+    return '$count päeva tagasi';
+  }
+
+  @override
+  String get oneWeekAgo => '1 nädal tagasi';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count nädalat tagasi';
+  }
+
+  @override
+  String get oneMonthAgo => '1 kuu tagasi';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count kuud tagasi';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Probleemid luuakse teie vaikimisi hoidlasse';
+
+  @override
+  String get taskIntegrations => 'Ülesannete integratsioonid';
+
+  @override
+  String get configureSettings => 'Seadista seaded';
+
+  @override
+  String get completeAuthBrowser => 'Palun lõpetage autentimine oma brauseris. Kui olete valmis, naasake rakendusse.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return '$appName autentimise alustamine ebaõnnestus';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Ühenda rakendusega $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Peate andma Omi-le loa ülesannete loomiseks teie $appName kontol. See avab teie brauseri autentimiseks.';
+  }
+
+  @override
+  String get continueButton => 'Jätka';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName integratsioon';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return '$appName integratsioon tuleb varsti! Töötame selle nimel, et tuua teile rohkem ülesannete haldamise valikuid.';
+  }
+
+  @override
+  String get gotIt => 'Sain aru';
+
+  @override
+  String get tasksExportedOneApp => 'Ülesandeid saab eksportida korraga ühte rakendusse.';
+
+  @override
+  String get completeYourUpgrade => 'Viige oma uuendamine lõpule';
+
+  @override
+  String get importConfiguration => 'Impordi konfiguratsioon';
+
+  @override
+  String get exportConfiguration => 'Ekspordi konfiguratsioon';
+
+  @override
+  String get bringYourOwn => 'Tooge oma oma';
+
+  @override
+  String get payYourSttProvider => 'Kasutage Omi-d vabalt. Maksite ainult oma STT pakkujale otse.';
+
+  @override
+  String get freeMinutesMonth => '1200 tasuta minutit kuus kaasa arvatud. Piiramatu koos ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Host on nõutud';
+
+  @override
+  String get validPortRequired => 'Kehtiv port on nõutud';
+
+  @override
+  String get validWebsocketUrlRequired => 'Kehtiv WebSocket URL on nõutud (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL on nõutud';
+
+  @override
+  String get apiKeyRequired => 'API võti on nõutud';
+
+  @override
+  String get invalidJsonConfig => 'Vigane JSON-konfiguratsioon';
+
+  @override
+  String errorSaving(String error) {
+    return 'Salvestamise viga: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfiguratsioon kopeeritud lõikelauale';
+
+  @override
+  String get pasteJsonConfig => 'Kleepige oma JSON-konfiguratsioon allpool:';
+
+  @override
+  String get addApiKeyAfterImport => 'Peate pärast importimist lisama oma API võtme';
+
+  @override
+  String get paste => 'Kleebi';
+
+  @override
+  String get import => 'Impordi';
+
+  @override
+  String get invalidProviderInConfig => 'Vigane pakkuja konfiguratsioonis';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Imporditud $providerName konfiguratsioon';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Vigane JSON: $error';
+  }
+
+  @override
+  String get provider => 'Pakkuja';
+
+  @override
+  String get live => 'Otse';
+
+  @override
+  String get onDevice => 'Seadmel';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Sisestage oma STT HTTP otspunkt';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Sisestage oma reaalajas STT WebSocket otspunkt';
+
+  @override
+  String get apiKey => 'API võti';
+
+  @override
+  String get enterApiKey => 'Sisestage oma API võti';
+
+  @override
+  String get storedLocallyNeverShared => 'Salvestatud lokaalselt, ei jagata kunagi';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Täpsem';
+
+  @override
+  String get configuration => 'Konfiguratsioon';
+
+  @override
+  String get requestConfiguration => 'Päringu konfiguratsioon';
+
+  @override
+  String get responseSchema => 'Vastuse skeem';
+
+  @override
+  String get modified => 'Muudetud';
+
+  @override
+  String get resetRequestConfig => 'Lähtesta päringu konfiguratsioon vaikimisi';
+
+  @override
+  String get logs => 'Logid';
+
+  @override
+  String get logsCopied => 'Logid kopeeritud';
+
+  @override
+  String get noLogsYet => 'Logisid pole veel. Alustage salvestamist, et näha kohandatud STT tegevust.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName kasutab $codecReason. Kasutatakse Omi-d.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi transkriptsioon';
+
+  @override
+  String get bestInClassTranscription => 'Parim oma klassis transkriptsioon nullseadistusega';
+
+  @override
+  String get instantSpeakerLabels => 'Kohesed kõneleja sildid';
+
+  @override
+  String get languageTranslation => '100+ keele tõlge';
+
+  @override
+  String get optimizedForConversation => 'Optimeeritud vestluseks';
+
+  @override
+  String get autoLanguageDetection => 'Automaatne keele tuvastamine';
+
+  @override
+  String get highAccuracy => 'Kõrge täpsus';
+
+  @override
+  String get privacyFirst => 'Privaatsus esmalt';
+
+  @override
+  String get saveChanges => 'Salvesta muudatused';
+
+  @override
+  String get resetToDefault => 'Lähtesta vaikimisi';
+
+  @override
+  String get viewTemplate => 'Vaata malli';
+
+  @override
+  String get trySomethingLike => 'Proovige midagi sellist nagu...';
+
+  @override
+  String get tryIt => 'Proovi seda';
+
+  @override
+  String get creatingPlan => 'Plaani loomine';
+
+  @override
+  String get developingLogic => 'Loogika arendamine';
+
+  @override
+  String get designingApp => 'Rakenduse kujundamine';
+
+  @override
+  String get generatingIconStep => 'Ikooni genereerimine';
+
+  @override
+  String get finalTouches => 'Viimased lihvid';
+
+  @override
+  String get processing => 'Töötlemine...';
+
+  @override
+  String get features => 'Funktsioonid';
+
+  @override
+  String get creatingYourApp => 'Teie rakenduse loomine...';
+
+  @override
+  String get generatingIcon => 'Ikooni genereerimine...';
+
+  @override
+  String get whatShouldWeMake => 'Mida me peaksime tegema?';
+
+  @override
+  String get appName => 'Rakenduse nimi';
+
+  @override
+  String get description => 'Kirjeldus';
+
+  @override
+  String get publicLabel => 'Avalik';
+
+  @override
+  String get privateLabel => 'Privaatne';
+
+  @override
+  String get free => 'Tasuta';
+
+  @override
+  String get perMonth => '/ kuu';
+
+  @override
+  String get tailoredConversationSummaries => 'Kohandatud vestluste kokkuvõtted';
+
+  @override
+  String get customChatbotPersonality => 'Kohandatud vestlusroboti isiksus';
+
+  @override
+  String get makePublic => 'Tee avalikuks';
+
+  @override
+  String get anyoneCanDiscover => 'Igaüks saab teie rakendust avastada';
+
+  @override
+  String get onlyYouCanUse => 'Ainult teie saate seda rakendust kasutada';
+
+  @override
+  String get paidApp => 'Tasuline rakendus';
+
+  @override
+  String get usersPayToUse => 'Kasutajad maksavad teie rakenduse kasutamise eest';
+
+  @override
+  String get freeForEveryone => 'Tasuta kõigile';
+
+  @override
+  String get perMonthLabel => '/ kuu';
+
+  @override
+  String get creating => 'Loomine...';
+
+  @override
+  String get createApp => 'Loo rakendus';
+
+  @override
+  String get searchingForDevices => 'Seadmete otsimine...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'SEADET',
+      one: 'SEADE',
+    );
+    return '$count $_temp0 LEITUD LÄHEDALT';
+  }
+
+  @override
+  String get pairingSuccessful => 'ÜHENDAMINE ÕNNESTUS';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Viga Apple Watch\'iga ühendamisel: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Ära näita seda enam';
+
+  @override
+  String get iUnderstand => 'Sain aru';
+
+  @override
+  String get enableBluetooth => 'Luba Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi vajab Bluetoothi, et ühenduda teie kantava seadmega. Palun lubage Bluetooth ja proovige uuesti.';
+
+  @override
+  String get contactSupport => 'Võta ühendust toega?';
+
+  @override
+  String get connectLater => 'Ühenda hiljem';
+
+  @override
+  String get grantPermissions => 'Anna load';
+
+  @override
+  String get backgroundActivity => 'Taustegevus';
+
+  @override
+  String get backgroundActivityDesc => 'Lubage Omil töötada taustal parema stabiilsuse tagamiseks';
+
+  @override
+  String get locationAccess => 'Asukoha juurdepääs';
+
+  @override
+  String get locationAccessDesc => 'Lubage tausta asukoht täieliku kogemuse saamiseks';
+
+  @override
+  String get notifications => 'Teavitused';
+
+  @override
+  String get notificationsDesc => 'Lubage teavitused, et püsida kursis';
+
+  @override
+  String get locationServiceDisabled => 'Asukohateenused keelatud';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Asukohateenused on keelatud. Palun minge Seaded > Privaatsus ja turvalisus > Asukohateenused ja lubage see';
+
+  @override
+  String get backgroundLocationDenied => 'Tausta asukoha juurdepääs keelatud';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Palun minge seadme seadetesse ja määrake asukoha luba väärtusele \"Luba alati\"';
+
+  @override
+  String get lovingOmi => 'Meeldib Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Aidake meil jõuda rohkemate inimesteni, jättes arvustuse App Store\'i. Teie tagasiside on meile ülimalt oluline!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Aidake meil jõuda rohkemate inimesteni, jättes arvustuse Google Play poodi. Teie tagasiside on meile ülimalt oluline!';
+
+  @override
+  String get rateOnAppStore => 'Hinda App Store\'is';
+
+  @override
+  String get rateOnGooglePlay => 'Hinda Google Play\'s';
+
+  @override
+  String get maybeLater => 'Võib-olla hiljem';
+
+  @override
+  String get speechProfileIntro => 'Omi peab õppima teie eesmärke ja häält. Saate seda hiljem muuta.';
+
+  @override
+  String get getStarted => 'Alusta';
+
+  @override
+  String get allDone => 'Kõik tehtud!';
+
+  @override
+  String get keepGoing => 'Jätkake, teil läheb suurepäraselt';
+
+  @override
+  String get skipThisQuestion => 'Jäta see küsimus vahele';
+
+  @override
+  String get skipForNow => 'Jäta praegu vahele';
+
+  @override
+  String get connectionError => 'Ühenduse viga';
+
+  @override
+  String get connectionErrorDesc =>
+      'Serveriga ühendamine ebaõnnestus. Palun kontrollige oma internetiühendust ja proovige uuesti.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Vigane salvestis tuvastatud';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Tundub, et salvestises on mitu kõnelejat. Palun veenduge, et olete vaikses kohas ja proovige uuesti.';
+
+  @override
+  String get tooShortDesc => 'Kõnet ei tuvastatud piisavalt. Palun rääkige rohkem ja proovige uuesti.';
+
+  @override
+  String get invalidRecordingDesc => 'Palun veenduge, et räägite vähemalt 5 sekundit ja mitte rohkem kui 90.';
+
+  @override
+  String get areYouThere => 'Kas olete seal?';
+
+  @override
+  String get noSpeechDesc =>
+      'Me ei suutnud kõnet tuvastada. Palun veenduge, et räägite vähemalt 10 sekundit ja mitte rohkem kui 3 minutit.';
+
+  @override
+  String get connectionLost => 'Ühendus kadus';
+
+  @override
+  String get connectionLostDesc => 'Ühendus katkestati. Palun kontrollige oma internetiühendust ja proovige uuesti.';
+
+  @override
+  String get tryAgain => 'Proovi uuesti';
+
+  @override
+  String get connectOmiOmiGlass => 'Ühenda Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Jätka ilma seadmeta';
+
+  @override
+  String get permissionsRequired => 'Load on nõutud';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'See rakendus vajab nõuetekohaseks toimimiseks Bluetoothi ja asukoha lube. Palun lubage need seadetes.';
+
+  @override
+  String get openSettings => 'Ava seaded';
+
+  @override
+  String get wantDifferentName => 'Soovite kasutada muud nime?';
+
+  @override
+  String get whatsYourName => 'Mis on teie nimi?';
+
+  @override
+  String get speakTranscribeSummarize => 'Räägi. Transkribeeri. Võta kokku.';
+
+  @override
+  String get signInWithApple => 'Logi sisse Apple\'iga';
+
+  @override
+  String get signInWithGoogle => 'Logi sisse Google\'iga';
+
+  @override
+  String get byContinuingAgree => 'Jätkates nõustute meie ';
+
+  @override
+  String get termsOfUse => 'Kasutustingimustega';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – teie AI kaaslane';
+
+  @override
+  String get captureEveryMoment =>
+      'Jäädvustage iga hetk. Saage AI-põhiseid\nkokkuvõtteid. Ärge tehke enam kunagi märkmeid.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch\'i seadistamine';
+
+  @override
+  String get permissionRequestedExclaim => 'Luba taotletud!';
+
+  @override
+  String get microphonePermission => 'Mikrofoni luba';
+
+  @override
+  String get permissionGrantedNow =>
+      'Luba antud! Nüüd:\n\nAvage Omi rakendus oma kellal ja puudutage allpool \"Jätka\"';
+
+  @override
+  String get needMicrophonePermission =>
+      'Vajame mikrofoni luba.\n\n1. Puudutage \"Anna luba\"\n2. Lubage oma iPhone\'is\n3. Kella rakendus sulgub\n4. Avage uuesti ja puudutage \"Jätka\"';
+
+  @override
+  String get grantPermissionButton => 'Anna luba';
+
+  @override
+  String get needHelp => 'Vajate abi?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Tõrkeotsing:\n\n1. Veenduge, et Omi on teie kellale installitud\n2. Avage Omi rakendus oma kellal\n3. Otsige loa hüpikakent\n4. Puudutage \"Luba\", kui küsitakse\n5. Rakendus teie kellal sulgub - avage see uuesti\n6. Tulge tagasi ja puudutage \"Jätka\" oma iPhone\'is';
+
+  @override
+  String get recordingStartedSuccessfully => 'Salvestamine algas edukalt!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Luba pole veel antud. Palun veenduge, et lubate mikrofoni juurdepääsu ja avasid rakenduse oma kellal uuesti.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Viga loa taotlemisel: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Viga salvestamise alustamisel: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Valige oma põhikeel';
+
+  @override
+  String get languageBenefits => 'Määrake oma keel täpsemate transkriptsioonide ja isikupärastatud kogemuse saamiseks';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Mis on teie põhikeel?';
+
+  @override
+  String get selectYourLanguage => 'Valige oma keel';
+
+  @override
+  String get personalGrowthJourney => 'Teie isiklik kasvuteekond AI-ga, mis kuulab iga teie sõna.';
+
+  @override
+  String get actionItemsTitle => 'Tegevused';
+
+  @override
+  String get actionItemsDescription => 'Puudutage muutmiseks • Vajutage pikalt valimiseks • Libistage toimingute jaoks';
+
+  @override
+  String get tabToDo => 'Teha';
+
+  @override
+  String get tabDone => 'Tehtud';
+
+  @override
+  String get tabOld => 'Vanad';
+
+  @override
+  String get emptyTodoMessage => '🎉 Kõik tehtud!\nOotel tegevuspunkte pole';
+
+  @override
+  String get emptyDoneMessage => 'Lõpetatud punkte pole veel';
+
+  @override
+  String get emptyOldMessage => '✅ Vanu ülesandeid pole';
+
+  @override
+  String get noItems => 'Punkte pole';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Tegevuspunkt märgitud mittelõpetatuks';
+
+  @override
+  String get actionItemCompleted => 'Tegevuspunkt lõpetatud';
+
+  @override
+  String get deleteActionItemTitle => 'Kustuta tegevuspunkt';
+
+  @override
+  String get deleteActionItemMessage => 'Kas olete kindel, et soovite selle tegevuspunkti kustutada?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Kustuta valitud punktid';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Kas olete kindel, et soovite kustutada $count valitud tegevuspunkt$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Tegevuspunkt \"$description\" kustutatud';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count tegevuspunkt$s kustutatud';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Tegevuspunkti kustutamine ebaõnnestus';
+
+  @override
+  String get failedToDeleteItems => 'Punktide kustutamine ebaõnnestus';
+
+  @override
+  String get failedToDeleteSomeItems => 'Mõne punkti kustutamine ebaõnnestus';
+
+  @override
+  String get welcomeActionItemsTitle => 'Valmis tegevuspunktide jaoks';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Teie AI eraldab automaatselt ülesanded ja tegevused teie vestlustest. Need ilmuvad siia, kui need luuakse.';
+
+  @override
+  String get autoExtractionFeature => 'Automaatselt vestlustest eraldatud';
+
+  @override
+  String get editSwipeFeature => 'Puudutage muutmiseks, libistage lõpetamiseks või kustutamiseks';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count valitud';
+  }
+
+  @override
+  String get selectAll => 'Vali kõik';
+
+  @override
+  String get deleteSelected => 'Kustuta valitud';
+
+  @override
+  String searchMemories(int count) {
+    return 'Otsi $count mälestust';
+  }
+
+  @override
+  String get memoryDeleted => 'Mälestus kustutatud.';
+
+  @override
+  String get undo => 'Tühista';
+
+  @override
+  String get noMemoriesYet => 'Mälestusi pole veel';
+
+  @override
+  String get noAutoMemories => 'Automaatselt eraldatud mälestusi pole veel';
+
+  @override
+  String get noManualMemories => 'Käsitsi lisatud mälestusi pole veel';
+
+  @override
+  String get noMemoriesInCategories => 'Neis kategooriates pole mälestusi';
+
+  @override
+  String get noMemoriesFound => 'Mälestusi ei leitud';
+
+  @override
+  String get addFirstMemory => 'Lisa oma esimene mälestus';
+
+  @override
+  String get clearMemoryTitle => 'Tühjenda Omi mälu';
+
+  @override
+  String get clearMemoryMessage =>
+      'Kas olete kindel, et soovite Omi mälu tühjendada? Seda tegevust ei saa tagasi võtta.';
+
+  @override
+  String get clearMemoryButton => 'Tühjenda mälu';
+
+  @override
+  String get memoryClearedSuccess => 'Omi mälu teie kohta on tühjendatud';
+
+  @override
+  String get noMemoriesToDelete => 'Kustutatavaid mälestusi pole';
+
+  @override
+  String get createMemoryTooltip => 'Loo uus mälestus';
+
+  @override
+  String get createActionItemTooltip => 'Loo uus tegevuspunkt';
+
+  @override
+  String get memoryManagement => 'Mälu haldamine';
+
+  @override
+  String get filterMemories => 'Filtreeri mälestusi';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Teil on kokku $count mälestust';
+  }
+
+  @override
+  String get publicMemories => 'Avalikud mälestused';
+
+  @override
+  String get privateMemories => 'Privaatsed mälestused';
+
+  @override
+  String get makeAllPrivate => 'Muuda kõik mälestused privaatseks';
+
+  @override
+  String get makeAllPublic => 'Muuda kõik mälestused avalikuks';
+
+  @override
+  String get deleteAllMemories => 'Kustuta kõik mälestused';
+
+  @override
+  String get allMemoriesPrivateResult => 'Kõik mälestused on nüüd privaatsed';
+
+  @override
+  String get allMemoriesPublicResult => 'Kõik mälestused on nüüd avalikud';
+
+  @override
+  String get newMemory => 'Uus mälestus';
+
+  @override
+  String get editMemory => 'Muuda mälestust';
+
+  @override
+  String get memoryContentHint => 'Mulle meeldib süüa jäätist...';
+
+  @override
+  String get failedToSaveMemory => 'Salvestamine ebaõnnestus. Palun kontrollige oma ühendust.';
+
+  @override
+  String get saveMemory => 'Salvesta mälestus';
+
+  @override
+  String get retry => 'Proovi uuesti';
+
+  @override
+  String get createActionItem => 'Loo tegevuspunkt';
+
+  @override
+  String get editActionItem => 'Muuda tegevuspunkti';
+
+  @override
+  String get actionItemDescriptionHint => 'Mida on vaja teha?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Tegevuspunkti kirjeldus ei saa olla tühi.';
+
+  @override
+  String get actionItemUpdated => 'Tegevuspunkt uuendatud';
+
+  @override
+  String get failedToUpdateActionItem => 'Tegevuspunkti uuendamine ebaõnnestus';
+
+  @override
+  String get actionItemCreated => 'Tegevuspunkt loodud';
+
+  @override
+  String get failedToCreateActionItem => 'Tegevuspunkti loomine ebaõnnestus';
+
+  @override
+  String get dueDate => 'Tähtaeg';
+
+  @override
+  String get time => 'Aeg';
+
+  @override
+  String get addDueDate => 'Lisa tähtaeg';
+
+  @override
+  String get pressDoneToSave => 'Vajutage valmis salvestamiseks';
+
+  @override
+  String get pressDoneToCreate => 'Vajutage valmis loomiseks';
+
+  @override
+  String get filterAll => 'Kõik';
+
+  @override
+  String get filterSystem => 'Teie kohta';
+
+  @override
+  String get filterInteresting => 'Ülevaated';
+
+  @override
+  String get filterManual => 'Käsitsi';
+
+  @override
+  String get completed => 'Lõpetatud';
+
+  @override
+  String get markComplete => 'Märgi lõpetatuks';
+
+  @override
+  String get actionItemDeleted => 'Tegevuspunkt kustutatud';
+
+  @override
+  String get failedToDeleteActionItem => 'Tegevuspunkti kustutamine ebaõnnestus';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Kustuta tegevuspunkt';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Kas olete kindel, et soovite selle tegevuspunkti kustutada?';
+
+  @override
+  String get appLanguage => 'Rakenduse keel';
+
+  @override
+  String get appInterfaceSectionTitle => 'RAKENDUSE LIIDES';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'KÕNE JA TRANSKRIPTSIOON';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Rakenduse keel muudab menüüsid ja nuppe. Kõne keel mõjutab, kuidas teie salvestisi transkribeeritakse.';
+}

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -1,0 +1,2228 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Finnish (`fi`).
+class AppLocalizationsFi extends AppLocalizations {
+  AppLocalizationsFi([String locale = 'fi']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Keskustelu';
+
+  @override
+  String get transcriptTab => 'Litterointi';
+
+  @override
+  String get actionItemsTab => 'Tehtävät';
+
+  @override
+  String get deleteConversationTitle => 'Poista keskustelu?';
+
+  @override
+  String get deleteConversationMessage => 'Haluatko varmasti poistaa tämän keskustelun? Tätä toimintoa ei voi perua.';
+
+  @override
+  String get confirm => 'Vahvista';
+
+  @override
+  String get cancel => 'Peruuta';
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get delete => 'Poista';
+
+  @override
+  String get add => 'Lisää';
+
+  @override
+  String get update => 'Päivitä';
+
+  @override
+  String get save => 'Tallenna';
+
+  @override
+  String get edit => 'Muokkaa';
+
+  @override
+  String get close => 'Sulje';
+
+  @override
+  String get clear => 'Tyhjennä';
+
+  @override
+  String get copyTranscript => 'Kopioi litterointi';
+
+  @override
+  String get copySummary => 'Kopioi yhteenveto';
+
+  @override
+  String get testPrompt => 'Testaa kehotetta';
+
+  @override
+  String get reprocessConversation => 'Käsittele keskustelu uudelleen';
+
+  @override
+  String get deleteConversation => 'Poista keskustelu';
+
+  @override
+  String get contentCopied => 'Sisältö kopioitu leikepöydälle';
+
+  @override
+  String get failedToUpdateStarred => 'Tähtimerkkauksen päivitys epäonnistui.';
+
+  @override
+  String get conversationUrlNotShared => 'Keskustelun URL-osoitetta ei voitu jakaa.';
+
+  @override
+  String get errorProcessingConversation => 'Virhe keskustelun käsittelyssä. Yritä myöhemmin uudelleen.';
+
+  @override
+  String get noInternetConnection => 'Tarkista internet-yhteytesi ja yritä uudelleen.';
+
+  @override
+  String get unableToDeleteConversation => 'Keskustelun poisto ei onnistu';
+
+  @override
+  String get somethingWentWrong => 'Jokin meni pieleen! Yritä myöhemmin uudelleen.';
+
+  @override
+  String get copyErrorMessage => 'Kopioi virheilmoitus';
+
+  @override
+  String get errorCopied => 'Virheilmoitus kopioitu leikepöydälle';
+
+  @override
+  String get remaining => 'Jäljellä';
+
+  @override
+  String get loading => 'Ladataan...';
+
+  @override
+  String get loadingDuration => 'Ladataan kestoa...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekuntia';
+  }
+
+  @override
+  String get people => 'Ihmiset';
+
+  @override
+  String get addNewPerson => 'Lisää uusi henkilö';
+
+  @override
+  String get editPerson => 'Muokkaa henkilöä';
+
+  @override
+  String get createPersonHint => 'Luo uusi henkilö ja opeta Omi tunnistamaan hänen puheensa!';
+
+  @override
+  String get speechProfile => 'Puheprofiili';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Näyte $number';
+  }
+
+  @override
+  String get settings => 'Asetukset';
+
+  @override
+  String get language => 'Kieli';
+
+  @override
+  String get selectLanguage => 'Valitse kieli';
+
+  @override
+  String get deleting => 'Poistetaan...';
+
+  @override
+  String get pleaseCompleteAuthentication => 'Viimeistele todennus selaimessasi. Kun olet valmis, palaa sovellukseen.';
+
+  @override
+  String get failedToStartAuthentication => 'Todennuksen aloitus epäonnistui';
+
+  @override
+  String get importStarted => 'Tuonti aloitettu! Saat ilmoituksen, kun se on valmis.';
+
+  @override
+  String get failedToStartImport => 'Tuonnin aloitus epäonnistui. Yritä uudelleen.';
+
+  @override
+  String get couldNotAccessFile => 'Valittua tiedostoa ei voitu käyttää';
+
+  @override
+  String get askOmi => 'Kysy Omilta';
+
+  @override
+  String get done => 'Valmis';
+
+  @override
+  String get disconnected => 'Yhteys katkaistu';
+
+  @override
+  String get searching => 'Etsitään';
+
+  @override
+  String get connectDevice => 'Yhdistä laite';
+
+  @override
+  String get monthlyLimitReached => 'Olet saavuttanut kuukausirajan.';
+
+  @override
+  String get checkUsage => 'Tarkista käyttö';
+
+  @override
+  String get syncingRecordings => 'Synkronoidaan nauhoituksia';
+
+  @override
+  String get recordingsToSync => 'Synkronoitavat nauhoitukset';
+
+  @override
+  String get allCaughtUp => 'Kaikki ajan tasalla';
+
+  @override
+  String get sync => 'Synkronoi';
+
+  @override
+  String get pendantUpToDate => 'Riipus on ajan tasalla';
+
+  @override
+  String get allRecordingsSynced => 'Kaikki nauhoitukset synkronoitu';
+
+  @override
+  String get syncingInProgress => 'Synkronointi käynnissä';
+
+  @override
+  String get readyToSync => 'Valmis synkronointiin';
+
+  @override
+  String get tapSyncToStart => 'Aloita napauttamalla Synkronoi';
+
+  @override
+  String get pendantNotConnected => 'Riipus ei ole yhdistetty. Yhdistä synkronoidaksesi.';
+
+  @override
+  String get everythingSynced => 'Kaikki on jo synkronoitu.';
+
+  @override
+  String get recordingsNotSynced => 'Sinulla on nauhoituksia, joita ei ole vielä synkronoitu.';
+
+  @override
+  String get syncingBackground => 'Jatkamme nauhoitusten synkronointia taustalla.';
+
+  @override
+  String get noConversationsYet => 'Ei vielä keskusteluja.';
+
+  @override
+  String get noStarredConversations => 'Ei vielä tähdellä merkittyjä keskusteluja.';
+
+  @override
+  String get starConversationHint => 'Merkitäksesi keskustelun tähdellä, avaa se ja napauta tähti-kuvaketta otsikossa.';
+
+  @override
+  String get searchConversations => 'Etsi keskusteluja';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count valittu';
+  }
+
+  @override
+  String get merge => 'Yhdistä';
+
+  @override
+  String get mergeConversations => 'Yhdistä keskustelut';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Tämä yhdistää $count keskustelua yhdeksi. Kaikki sisältö yhdistetään ja luodaan uudelleen.';
+  }
+
+  @override
+  String get mergingInBackground => 'Yhdistetään taustalla. Tämä voi kestää hetken.';
+
+  @override
+  String get failedToStartMerge => 'Yhdistämisen aloitus epäonnistui';
+
+  @override
+  String get askAnything => 'Kysy mitä tahansa';
+
+  @override
+  String get noMessagesYet => 'Ei vielä viestejä!\nMikset aloittaisi keskustelua?';
+
+  @override
+  String get deletingMessages => 'Poistetaan viestejäsi Omin muistista...';
+
+  @override
+  String get messageCopied => 'Viesti kopioitu leikepöydälle.';
+
+  @override
+  String get cannotReportOwnMessage => 'Et voi ilmoittaa omista viesteistäsi.';
+
+  @override
+  String get reportMessage => 'Ilmoita viestistä';
+
+  @override
+  String get reportMessageConfirm => 'Haluatko varmasti ilmoittaa tästä viestistä?';
+
+  @override
+  String get messageReported => 'Viesti ilmoitettu onnistuneesti.';
+
+  @override
+  String get thankYouFeedback => 'Kiitos palautteestasi!';
+
+  @override
+  String get clearChat => 'Tyhjennä keskustelu?';
+
+  @override
+  String get clearChatConfirm => 'Haluatko varmasti tyhjentää keskustelun? Tätä toimintoa ei voi perua.';
+
+  @override
+  String get maxFilesLimit => 'Voit ladata vain 4 tiedostoa kerrallaan';
+
+  @override
+  String get chatWithOmi => 'Keskustele Omin kanssa';
+
+  @override
+  String get apps => 'Sovellukset';
+
+  @override
+  String get noAppsFound => 'Sovelluksia ei löytynyt';
+
+  @override
+  String get tryAdjustingSearch => 'Kokeile säätää hakua tai suodattimia';
+
+  @override
+  String get createYourOwnApp => 'Luo oma sovellus';
+
+  @override
+  String get buildAndShareApp => 'Rakenna ja jaa oma sovelluksesi';
+
+  @override
+  String get searchApps => 'Etsi yli 1500 sovelluksesta';
+
+  @override
+  String get myApps => 'Omat sovellukset';
+
+  @override
+  String get installedApps => 'Asennetut sovellukset';
+
+  @override
+  String get unableToFetchApps => 'Sovellusten haku epäonnistui :(\n\nTarkista internet-yhteytesi ja yritä uudelleen.';
+
+  @override
+  String get aboutOmi => 'Tietoja Omista';
+
+  @override
+  String get privacyPolicy => 'Tietosuojakäytäntö';
+
+  @override
+  String get visitWebsite => 'Käy verkkosivulla';
+
+  @override
+  String get helpOrInquiries => 'Apua tai kysymyksiä?';
+
+  @override
+  String get joinCommunity => 'Liity yhteisöön!';
+
+  @override
+  String get membersAndCounting => 'Yli 8000 jäsentä ja kasvaa.';
+
+  @override
+  String get deleteAccountTitle => 'Poista tili';
+
+  @override
+  String get deleteAccountConfirm => 'Haluatko varmasti poistaa tilisi?';
+
+  @override
+  String get cannotBeUndone => 'Tätä ei voi perua.';
+
+  @override
+  String get allDataErased => 'Kaikki muistosi ja keskustelusi poistetaan pysyvästi.';
+
+  @override
+  String get appsDisconnected => 'Sovelluksesi ja integraatiot katkaistaan välittömästi.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Voit viedä tietosi ennen tilin poistamista, mutta poiston jälkeen niitä ei voi palauttaa.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Ymmärrän, että tilini poistaminen on pysyvää ja kaikki tiedot, mukaan lukien muistot ja keskustelut, menetetään eikä niitä voi palauttaa.';
+
+  @override
+  String get areYouSure => 'Oletko varma?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Tämä toiminto on peruuttamaton ja poistaa tilisi ja kaikki siihen liittyvät tiedot pysyvästi. Haluatko varmasti jatkaa?';
+
+  @override
+  String get deleteNow => 'Poista nyt';
+
+  @override
+  String get goBack => 'Palaa takaisin';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Valitse ruutu vahvistaaksesi, että ymmärrät tilin poistamisen olevan pysyvää ja peruuttamatonta.';
+
+  @override
+  String get profile => 'Profiili';
+
+  @override
+  String get name => 'Nimi';
+
+  @override
+  String get email => 'Sähköposti';
+
+  @override
+  String get customVocabulary => 'Mukautettu sanasto';
+
+  @override
+  String get identifyingOthers => 'Muiden tunnistaminen';
+
+  @override
+  String get paymentMethods => 'Maksutavat';
+
+  @override
+  String get conversationDisplay => 'Keskustelunäkymä';
+
+  @override
+  String get dataPrivacy => 'Tiedot ja yksityisyys';
+
+  @override
+  String get userId => 'Käyttäjätunnus';
+
+  @override
+  String get notSet => 'Ei asetettu';
+
+  @override
+  String get userIdCopied => 'Käyttäjätunnus kopioitu leikepöydälle';
+
+  @override
+  String get systemDefault => 'Järjestelmän oletus';
+
+  @override
+  String get planAndUsage => 'Paketti ja käyttö';
+
+  @override
+  String get offlineSync => 'Offline-synkronointi';
+
+  @override
+  String get deviceSettings => 'Laitteen asetukset';
+
+  @override
+  String get chatTools => 'Chat-työkalut';
+
+  @override
+  String get feedbackBug => 'Palaute / Virhe';
+
+  @override
+  String get helpCenter => 'Ohjekeskus';
+
+  @override
+  String get developerSettings => 'Kehittäjäasetukset';
+
+  @override
+  String get getOmiForMac => 'Hanki Omi Macille';
+
+  @override
+  String get referralProgram => 'Suositteluohjelma';
+
+  @override
+  String get signOut => 'Kirjaudu ulos';
+
+  @override
+  String get appAndDeviceCopied => 'Sovelluksen ja laitteen tiedot kopioitu';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Yksityisyytesi, sinun hallinnassasi';
+
+  @override
+  String get privacyIntro =>
+      'Omissa olemme sitoutuneet suojaamaan yksityisyyttäsi. Tämä sivu antaa sinulle mahdollisuuden hallita, miten tietojasi tallennetaan ja käytetään.';
+
+  @override
+  String get learnMore => 'Lue lisää...';
+
+  @override
+  String get dataProtectionLevel => 'Tietosuojataso';
+
+  @override
+  String get dataProtectionDesc =>
+      'Tietosi on oletuksena suojattu vahvalla salauksella. Tarkista asetuksesi ja tulevat yksityisyysvaihtoehdot alla.';
+
+  @override
+  String get appAccess => 'Sovelluspääsy';
+
+  @override
+  String get appAccessDesc =>
+      'Seuraavat sovellukset voivat käyttää tietojasi. Napauta sovellusta hallitaksesi sen käyttöoikeuksia.';
+
+  @override
+  String get noAppsExternalAccess => 'Yhdelläkään asennetulla sovelluksella ei ole ulkoista pääsyä tietoihisi.';
+
+  @override
+  String get deviceName => 'Laitteen nimi';
+
+  @override
+  String get deviceId => 'Laitetunnus';
+
+  @override
+  String get firmware => 'Laiteohjelmisto';
+
+  @override
+  String get sdCardSync => 'SD-kortin synkronointi';
+
+  @override
+  String get hardwareRevision => 'Laitteistoversio';
+
+  @override
+  String get modelNumber => 'Mallinumero';
+
+  @override
+  String get manufacturer => 'Valmistaja';
+
+  @override
+  String get doubleTap => 'Kaksoisnapautus';
+
+  @override
+  String get ledBrightness => 'LED-kirkkaus';
+
+  @override
+  String get micGain => 'Mikrofonin vahvistus';
+
+  @override
+  String get disconnect => 'Katkaise yhteys';
+
+  @override
+  String get forgetDevice => 'Unohda laite';
+
+  @override
+  String get chargingIssues => 'Latausongelmat';
+
+  @override
+  String get disconnectDevice => 'Katkaise laitteen yhteys';
+
+  @override
+  String get unpairDevice => 'Pura laitepari';
+
+  @override
+  String get unpairAndForget => 'Pura laitepari ja unohda laite';
+
+  @override
+  String get deviceDisconnectedMessage => 'Omin yhteys on katkaistu 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Laitepari purettu. Siirry kohtaan Asetukset > Bluetooth ja unohda laite viimeistelläksesi purkamisen.';
+
+  @override
+  String get unpairDialogTitle => 'Pura laitepari';
+
+  @override
+  String get unpairDialogMessage =>
+      'Tämä purkaa laiteparin, jotta se voidaan yhdistää toiseen puhelimeen. Sinun on siirryttävä kohtaan Asetukset > Bluetooth ja unohdettava laite prosessin viimeistelemiseksi.';
+
+  @override
+  String get deviceNotConnected => 'Laitetta ei ole yhdistetty';
+
+  @override
+  String get connectDeviceMessage => 'Yhdistä Omi-laite käyttääksesi\nlaiteasetuksia ja mukautusta';
+
+  @override
+  String get deviceInfoSection => 'Laitteen tiedot';
+
+  @override
+  String get customizationSection => 'Mukautus';
+
+  @override
+  String get hardwareSection => 'Laitteisto';
+
+  @override
+  String get v2Undetected => 'V2 ei havaittu';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Sinulla näyttää olevan V1-laite tai laitteesi ei ole yhdistetty. SD-korttitoiminto on saatavilla vain V2-laitteille.';
+
+  @override
+  String get endConversation => 'Lopeta keskustelu';
+
+  @override
+  String get pauseResume => 'Keskeytä/Jatka';
+
+  @override
+  String get starConversation => 'Merkitse tähdellä';
+
+  @override
+  String get doubleTapAction => 'Kaksoisnapaututstoiminto';
+
+  @override
+  String get endAndProcess => 'Lopeta ja käsittele keskustelu';
+
+  @override
+  String get pauseResumeRecording => 'Keskeytä/Jatka nauhoitusta';
+
+  @override
+  String get starOngoing => 'Merkitse käynnissä oleva keskustelu tähdellä';
+
+  @override
+  String get off => 'Pois';
+
+  @override
+  String get max => 'Maks.';
+
+  @override
+  String get mute => 'Vaimenna';
+
+  @override
+  String get quiet => 'Hiljainen';
+
+  @override
+  String get normal => 'Normaali';
+
+  @override
+  String get high => 'Korkea';
+
+  @override
+  String get micGainDescMuted => 'Mikrofoni on vaimennettu';
+
+  @override
+  String get micGainDescLow => 'Erittäin hiljainen - meluisiin ympäristöihin';
+
+  @override
+  String get micGainDescModerate => 'Hiljainen - kohtalaiseen meluun';
+
+  @override
+  String get micGainDescNeutral => 'Neutraali - tasapainoinen nauhoitus';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Hieman vahvistettu - normaalikäyttö';
+
+  @override
+  String get micGainDescBoosted => 'Vahvistettu - hiljaisiin ympäristöihin';
+
+  @override
+  String get micGainDescHigh => 'Korkea - kaukaisille tai pehmeille äänille';
+
+  @override
+  String get micGainDescVeryHigh => 'Erittäin korkea - erittäin hiljaisille lähteille';
+
+  @override
+  String get micGainDescMax => 'Maksimi - käytä varoen';
+
+  @override
+  String get developerSettingsTitle => 'Kehittäjäasetukset';
+
+  @override
+  String get saving => 'Tallennetaan...';
+
+  @override
+  String get personaConfig => 'Määritä AI-persoonasi';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Litterointi';
+
+  @override
+  String get transcriptionConfig => 'Määritä STT-palveluntarjoaja';
+
+  @override
+  String get conversationTimeout => 'Keskustelun aikakatkaisu';
+
+  @override
+  String get conversationTimeoutConfig => 'Aseta milloin keskustelut päättyvät automaattisesti';
+
+  @override
+  String get importData => 'Tuo tietoja';
+
+  @override
+  String get importDataConfig => 'Tuo tietoja muista lähteistä';
+
+  @override
+  String get debugDiagnostics => 'Vianjäljitys ja diagnostiikka';
+
+  @override
+  String get endpointUrl => 'Päätepisteen URL';
+
+  @override
+  String get noApiKeys => 'Ei vielä API-avaimia';
+
+  @override
+  String get createKeyToStart => 'Luo avain aloittaaksesi';
+
+  @override
+  String get createKey => 'Luo avain';
+
+  @override
+  String get docs => 'Dokumentit';
+
+  @override
+  String get yourOmiInsights => 'Omi-näkemyksesi';
+
+  @override
+  String get today => 'Tänään';
+
+  @override
+  String get thisMonth => 'Tässä kuussa';
+
+  @override
+  String get thisYear => 'Tänä vuonna';
+
+  @override
+  String get allTime => 'Kaikki aika';
+
+  @override
+  String get noActivityYet => 'Ei vielä toimintaa';
+
+  @override
+  String get startConversationToSeeInsights => 'Aloita keskustelu Omin kanssa\nnähdäksesi käyttötietosi täällä.';
+
+  @override
+  String get listening => 'Kuunteleminen';
+
+  @override
+  String get listeningSubtitle => 'Kokonaisaika, jonka Omi on aktiivisesti kuunnellut.';
+
+  @override
+  String get understanding => 'Ymmärtäminen';
+
+  @override
+  String get understandingSubtitle => 'Keskusteluistasi ymmärretyt sanat.';
+
+  @override
+  String get providing => 'Tarjoaminen';
+
+  @override
+  String get providingSubtitle => 'Tehtävät ja muistiinpanot automaattisesti tallennettu.';
+
+  @override
+  String get remembering => 'Muistaminen';
+
+  @override
+  String get rememberingSubtitle => 'Sinulle muistetut faktat ja yksityiskohdat.';
+
+  @override
+  String get unlimitedPlan => 'Rajoittamaton paketti';
+
+  @override
+  String get managePlan => 'Hallitse pakettia';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Pakettisi peruuntuu $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Pakettisi uusiutuu $date.';
+  }
+
+  @override
+  String get basicPlan => 'Ilmaispaketti';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used/$limit min käytetty';
+  }
+
+  @override
+  String get upgrade => 'Päivitä';
+
+  @override
+  String get upgradeToUnlimited => 'Päivitä rajoittamattomaan';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Pakettisi sisältää $limit ilmaisminuuttia kuukaudessa. Päivitä saadaksesi rajoittamattoman.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Jaan Omi-tilastoni! (omi.me - aina päällä oleva tekoälyavustajasi)';
+
+  @override
+  String get sharePeriodToday => 'Tänään omi on:';
+
+  @override
+  String get sharePeriodMonth => 'Tässä kuussa omi on:';
+
+  @override
+  String get sharePeriodYear => 'Tänä vuonna omi on:';
+
+  @override
+  String get sharePeriodAllTime => 'Tähän mennessä omi on:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Kuunnellut $minutes minuuttia';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Ymmärtänyt $words sanaa';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Tarjonnut $count näkemystä';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Muistanut $count muistoa';
+  }
+
+  @override
+  String get debugLogs => 'Vianjäljityslokit';
+
+  @override
+  String get debugLogsAutoDelete => 'Poistetaan automaattisesti 3 päivän kuluttua.';
+
+  @override
+  String get debugLogsDesc => 'Auttaa ongelmien diagnosoinnissa';
+
+  @override
+  String get noLogFilesFound => 'Lokitiedostoja ei löytynyt.';
+
+  @override
+  String get omiDebugLog => 'Omin vianjäljitysloki';
+
+  @override
+  String get logShared => 'Loki jaettu';
+
+  @override
+  String get selectLogFile => 'Valitse lokitiedosto';
+
+  @override
+  String get shareLogs => 'Jaa lokit';
+
+  @override
+  String get debugLogCleared => 'Vianjäljitysloki tyhjennetty';
+
+  @override
+  String get exportStarted => 'Vienti aloitettu. Tämä voi kestää muutaman sekunnin...';
+
+  @override
+  String get exportAllData => 'Vie kaikki tiedot';
+
+  @override
+  String get exportDataDesc => 'Vie keskustelut JSON-tiedostoon';
+
+  @override
+  String get exportedConversations => 'Viedyt keskustelut Omista';
+
+  @override
+  String get exportShared => 'Vienti jaettu';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Poista tietograafi?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Tämä poistaa kaikki johdetut tietograafitiedot (solmut ja yhteydet). Alkuperäiset muistosi pysyvät turvassa. Graafi rakennetaan uudelleen ajan myötä tai seuraavan pyynnön yhteydessä.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Tietograafi poistettu onnistuneesti';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Graafin poisto epäonnistui: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Poista tietograafi';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Tyhjennä kaikki solmut ja yhteydet';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP-palvelin';
+
+  @override
+  String get mcpServerDesc => 'Yhdistä tekoälyavustajat tietoihisi';
+
+  @override
+  String get serverUrl => 'Palvelimen URL';
+
+  @override
+  String get urlCopied => 'URL kopioitu';
+
+  @override
+  String get apiKeyAuth => 'API-avaimen todennus';
+
+  @override
+  String get header => 'Otsikko';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <avain>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Asiakas-ID';
+
+  @override
+  String get clientSecret => 'Asiakassalaisuus';
+
+  @override
+  String get useMcpApiKey => 'Käytä MCP API-avainta';
+
+  @override
+  String get webhooks => 'Webhookit';
+
+  @override
+  String get conversationEvents => 'Keskustelutapahtumat';
+
+  @override
+  String get newConversationCreated => 'Uusi keskustelu luotu';
+
+  @override
+  String get realtimeTranscript => 'Reaaliaikainen litterointi';
+
+  @override
+  String get transcriptReceived => 'Litterointi vastaanotettu';
+
+  @override
+  String get audioBytes => 'Äänitavut';
+
+  @override
+  String get audioDataReceived => 'Ääniaineisto vastaanotettu';
+
+  @override
+  String get intervalSeconds => 'Aikaväli (sekunteina)';
+
+  @override
+  String get daySummary => 'Päivän yhteenveto';
+
+  @override
+  String get summaryGenerated => 'Yhteenveto luotu';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Lisää claude_desktop_config.json-tiedostoon';
+
+  @override
+  String get copyConfig => 'Kopioi kokoonpano';
+
+  @override
+  String get configCopied => 'Kokoonpano kopioitu leikepöydälle';
+
+  @override
+  String get listeningMins => 'Kuunteleminen (min)';
+
+  @override
+  String get understandingWords => 'Ymmärtäminen (sanaa)';
+
+  @override
+  String get insights => 'Näkemykset';
+
+  @override
+  String get memories => 'Muistot';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used/$limit min käytetty tässä kuussa';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used/$limit sanaa käytetty tässä kuussa';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used/$limit näkemystä saavutettu tässä kuussa';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used/$limit muistoa luotu tässä kuussa';
+  }
+
+  @override
+  String get visibility => 'Näkyvyys';
+
+  @override
+  String get visibilitySubtitle => 'Hallitse mitä keskusteluja näkyy luettelossasi';
+
+  @override
+  String get showShortConversations => 'Näytä lyhyet keskustelut';
+
+  @override
+  String get showShortConversationsDesc => 'Näytä kynnysarvoa lyhyemmät keskustelut';
+
+  @override
+  String get showDiscardedConversations => 'Näytä hylätyt keskustelut';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Sisällytä hylätyksi merkityt keskustelut';
+
+  @override
+  String get shortConversationThreshold => 'Lyhyen keskustelun kynnysarvo';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Tätä lyhyemmät keskustelut piilotetaan, ellei niitä ole otettu käyttöön yllä';
+
+  @override
+  String get durationThreshold => 'Kestokynnys';
+
+  @override
+  String get durationThresholdDesc => 'Piilota tätä lyhyemmät keskustelut';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Mukautettu sanasto';
+
+  @override
+  String get addWords => 'Lisää sanoja';
+
+  @override
+  String get addWordsDesc => 'Nimiä, termejä tai harvinaisia sanoja';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Yhdistä';
+
+  @override
+  String get comingSoon => 'Tulossa pian';
+
+  @override
+  String get chatToolsFooter => 'Yhdistä sovelluksesi nähdäksesi tiedot ja mittarit chatissa.';
+
+  @override
+  String get completeAuthInBrowser => 'Viimeistele todennus selaimessasi. Kun olet valmis, palaa sovellukseen.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return '$appName-todennuksen aloitus epäonnistui';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Katkaise yhteys palveluun $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Haluatko varmasti katkaista yhteyden palveluun $appName? Voit yhdistää uudelleen milloin tahansa.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Yhteys katkaistu palveluun $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Yhteyden katkaisu epäonnistui';
+
+  @override
+  String connectTo(String appName) {
+    return 'Yhdistä palveluun $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Sinun on valtuutettava Omi käyttämään $appName-tietojasi. Tämä avaa selaimesi todennusta varten.';
+  }
+
+  @override
+  String get continueAction => 'Jatka';
+
+  @override
+  String get languageTitle => 'Kieli';
+
+  @override
+  String get primaryLanguage => 'Ensisijainen kieli';
+
+  @override
+  String get automaticTranslation => 'Automaattinen käännös';
+
+  @override
+  String get detectLanguages => 'Tunnista yli 10 kieltä';
+
+  @override
+  String get authorizeSavingRecordings => 'Valtuuta nauhoitusten tallentaminen';
+
+  @override
+  String get thanksForAuthorizing => 'Kiitos valtuutuksesta!';
+
+  @override
+  String get needYourPermission => 'Tarvitsemme lupasi';
+
+  @override
+  String get alreadyGavePermission =>
+      'Olet jo antanut meille luvan tallentaa nauhoituksiasi. Tässä muistutus siitä, miksi tarvitsemme sen:';
+
+  @override
+  String get wouldLikePermission => 'Haluaisimme lupasi tallentaa ääninauhoituksesi. Tässä syy:';
+
+  @override
+  String get improveSpeechProfile => 'Paranna puheprofiiliasi';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Käytämme nauhoituksia henkilökohtaisen puheprofiilisi kouluttamiseen ja parantamiseen.';
+
+  @override
+  String get trainFamilyProfiles => 'Kouluta profiileja ystäville ja perheelle';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Nauhoituksesi auttavat meitä tunnistamaan ja luomaan profiileja ystävillesi ja perheellesi.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Paranna litterointitarkkuutta';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Kun mallimme paranee, voimme tarjota parempia litterointituloksia nauhoituksillesi.';
+
+  @override
+  String get legalNotice =>
+      'Oikeudellinen huomautus: Äänidatan nauhoittamisen ja tallentamisen laillisuus voi vaihdella sijaintisi ja tämän ominaisuuden käyttötavan mukaan. Vastaat paikallisten lakien ja määräysten noudattamisesta.';
+
+  @override
+  String get alreadyAuthorized => 'Jo valtuutettu';
+
+  @override
+  String get authorize => 'Valtuuta';
+
+  @override
+  String get revokeAuthorization => 'Peru valtuutus';
+
+  @override
+  String get authorizationSuccessful => 'Valtuutus onnistui!';
+
+  @override
+  String get failedToAuthorize => 'Valtuutus epäonnistui. Yritä uudelleen.';
+
+  @override
+  String get authorizationRevoked => 'Valtuutus peruttu.';
+
+  @override
+  String get recordingsDeleted => 'Nauhoitukset poistettu.';
+
+  @override
+  String get failedToRevoke => 'Valtuutuksen peruutus epäonnistui. Yritä uudelleen.';
+
+  @override
+  String get permissionRevokedTitle => 'Lupa peruttu';
+
+  @override
+  String get permissionRevokedMessage => 'Haluatko meidän poistavan myös kaikki olemassa olevat nauhoituksesi?';
+
+  @override
+  String get yes => 'Kyllä';
+
+  @override
+  String get editName => 'Muokkaa nimeä';
+
+  @override
+  String get howShouldOmiCallYou => 'Miten Omin pitäisi kutsua sinua?';
+
+  @override
+  String get enterYourName => 'Kirjoita nimesi';
+
+  @override
+  String get nameCannotBeEmpty => 'Nimi ei voi olla tyhjä';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Nimi päivitetty onnistuneesti!';
+
+  @override
+  String get calendarSettings => 'Kalenteriasetukset';
+
+  @override
+  String get calendarProviders => 'Kalenteripalvelut';
+
+  @override
+  String get macOsCalendar => 'macOS-kalenteri';
+
+  @override
+  String get connectMacOsCalendar => 'Yhdistä paikallinen macOS-kalenterisi';
+
+  @override
+  String get googleCalendar => 'Google Kalenteri';
+
+  @override
+  String get syncGoogleAccount => 'Synkronoi Google-tilisi kanssa';
+
+  @override
+  String get showMeetingsMenuBar => 'Näytä tulevat kokoukset valikkorivissä';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Näytä seuraava kokouksesi ja aika sen alkuun macOS-valikkorivissä';
+
+  @override
+  String get showEventsNoParticipants => 'Näytä tapahtumat ilman osallistujia';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Kun käytössä, Tulossa näyttää tapahtumat ilman osallistujia tai videolinkkiä.';
+
+  @override
+  String get yourMeetings => 'Kokouksesi';
+
+  @override
+  String get refresh => 'Päivitä';
+
+  @override
+  String get noUpcomingMeetings => 'Tulevia kokouksia ei löytynyt';
+
+  @override
+  String get checkingNextDays => 'Tarkistetaan seuraavat 30 päivää';
+
+  @override
+  String get tomorrow => 'Huomenna';
+
+  @override
+  String get googleCalendarComingSoon => 'Google Kalenteri -integraatio tulossa pian!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Yhdistetty käyttäjänä: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Oletustyötila';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Tehtävät luodaan tähän työtilaan';
+
+  @override
+  String get defaultProjectOptional => 'Oletusprojekti (valinnainen)';
+
+  @override
+  String get leaveUnselectedTasks => 'Jätä valitsematta luodaksesi tehtäviä ilman projektia';
+
+  @override
+  String get noProjectsInWorkspace => 'Projekteja ei löytynyt tästä työtilasta';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Valitse kuinka kauan odotetaan hiljaisuutta ennen keskustelun automaattista päättämistä:';
+
+  @override
+  String get timeout2Minutes => '2 minuuttia';
+
+  @override
+  String get timeout2MinutesDesc => 'Lopeta keskustelu 2 minuutin hiljaisuuden jälkeen';
+
+  @override
+  String get timeout5Minutes => '5 minuuttia';
+
+  @override
+  String get timeout5MinutesDesc => 'Lopeta keskustelu 5 minuutin hiljaisuuden jälkeen';
+
+  @override
+  String get timeout10Minutes => '10 minuuttia';
+
+  @override
+  String get timeout10MinutesDesc => 'Lopeta keskustelu 10 minuutin hiljaisuuden jälkeen';
+
+  @override
+  String get timeout30Minutes => '30 minuuttia';
+
+  @override
+  String get timeout30MinutesDesc => 'Lopeta keskustelu 30 minuutin hiljaisuuden jälkeen';
+
+  @override
+  String get timeout4Hours => '4 tuntia';
+
+  @override
+  String get timeout4HoursDesc => 'Lopeta keskustelu 4 tunnin hiljaisuuden jälkeen';
+
+  @override
+  String get conversationEndAfterHours => 'Keskustelut päättyvät nyt 4 tunnin hiljaisuuden jälkeen';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Keskustelut päättyvät nyt $minutes minuutin hiljaisuuden jälkeen';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Kerro meille ensisijainen kielesi';
+
+  @override
+  String get languageForTranscription => 'Aseta kielesi tarkempaa litterointia ja henkilökohtaista kokemusta varten.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Yhden kielen tila on käytössä. Käännös on poistettu käytöstä paremman tarkkuuden vuoksi.';
+
+  @override
+  String get searchLanguageHint => 'Etsi kieltä nimen tai koodin perusteella';
+
+  @override
+  String get noLanguagesFound => 'Kieliä ei löytynyt';
+
+  @override
+  String get skip => 'Ohita';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Kieleksi asetettu $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Kielen asetus epäonnistui';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName-asetukset';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Katkaise yhteys palveluun $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Tämä poistaa $appName-todennuksesi. Sinun on yhdistettävä uudelleen käyttääksesi sitä uudelleen.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Yhdistetty palveluun $appName';
+  }
+
+  @override
+  String get account => 'Tili';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Tehtäväsi synkronoidaan $appName-tilillesi';
+  }
+
+  @override
+  String get defaultSpace => 'Oletustila';
+
+  @override
+  String get selectSpaceInWorkspace => 'Valitse tila työtilassasi';
+
+  @override
+  String get noSpacesInWorkspace => 'Tiloja ei löytynyt tästä työtilasta';
+
+  @override
+  String get defaultList => 'Oletusluettelo';
+
+  @override
+  String get tasksAddedToList => 'Tehtävät lisätään tähän luetteloon';
+
+  @override
+  String get noListsInSpace => 'Luetteloita ei löytynyt tästä tilasta';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Repositorioiden lataaminen epäonnistui: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Oletusrepositorio tallennettu';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Oletusrepositorion tallentaminen epäonnistui';
+
+  @override
+  String get defaultRepository => 'Oletusrepositorio';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Valitse oletusrepositorio ongelmien luomiseen. Voit silti määrittää eri repositorion ongelmia luodessa.';
+
+  @override
+  String get noReposFound => 'Repositorioita ei löytynyt';
+
+  @override
+  String get private => 'Yksityinen';
+
+  @override
+  String updatedDate(String date) {
+    return 'Päivitetty $date';
+  }
+
+  @override
+  String get yesterday => 'eilen';
+
+  @override
+  String daysAgo(int count) {
+    return '$count päivää sitten';
+  }
+
+  @override
+  String get oneWeekAgo => 'viikko sitten';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count viikkoa sitten';
+  }
+
+  @override
+  String get oneMonthAgo => 'kuukausi sitten';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count kuukautta sitten';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Ongelmat luodaan oletusrepositoriossasi';
+
+  @override
+  String get taskIntegrations => 'Tehtäväintegraatiot';
+
+  @override
+  String get configureSettings => 'Määritä asetukset';
+
+  @override
+  String get completeAuthBrowser => 'Viimeistele todennus selaimessasi. Kun olet valmis, palaa sovellukseen.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return '$appName-todennuksen aloitus epäonnistui';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Yhdistä palveluun $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Sinun on valtuutettava Omi luomaan tehtäviä $appName-tilillesi. Tämä avaa selaimesi todennusta varten.';
+  }
+
+  @override
+  String get continueButton => 'Jatka';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName-integraatio';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integraatio palvelun $appName kanssa tulossa pian! Työskentelemme ahkerasti tuodaksemme sinulle lisää tehtävänhallinnan vaihtoehtoja.';
+  }
+
+  @override
+  String get gotIt => 'Selvä';
+
+  @override
+  String get tasksExportedOneApp => 'Tehtäviä voidaan viedä yhteen sovellukseen kerrallaan';
+
+  @override
+  String get completeYourUpgrade => 'Viimeistele päivityksesi';
+
+  @override
+  String get importConfiguration => 'Tuo kokoonpano';
+
+  @override
+  String get exportConfiguration => 'Vie kokoonpano';
+
+  @override
+  String get bringYourOwn => 'Tuo omasi';
+
+  @override
+  String get payYourSttProvider => 'Käytä omia vapaasti. Maksat vain STT-palveluntarjoajallesi suoraan.';
+
+  @override
+  String get freeMinutesMonth => '1 200 ilmaisminuuttia kuukaudessa mukana. Rajoittamaton ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Isäntä vaaditaan';
+
+  @override
+  String get validPortRequired => 'Kelvollinen portti vaaditaan';
+
+  @override
+  String get validWebsocketUrlRequired => 'Kelvollinen WebSocket-URL vaaditaan (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API-URL vaaditaan';
+
+  @override
+  String get apiKeyRequired => 'API-avain vaaditaan';
+
+  @override
+  String get invalidJsonConfig => 'Virheellinen JSON-kokoonpano';
+
+  @override
+  String errorSaving(String error) {
+    return 'Virhe tallentaessa: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Kokoonpano kopioitu leikepöydälle';
+
+  @override
+  String get pasteJsonConfig => 'Liitä JSON-kokoonpanosi alle:';
+
+  @override
+  String get addApiKeyAfterImport => 'Sinun on lisättävä oma API-avaimesi tuonnin jälkeen';
+
+  @override
+  String get paste => 'Liitä';
+
+  @override
+  String get import => 'Tuo';
+
+  @override
+  String get invalidProviderInConfig => 'Virheellinen palveluntarjoaja kokoonpanossa';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Tuotu $providerName-kokoonpano';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Virheellinen JSON: $error';
+  }
+
+  @override
+  String get provider => 'Palveluntarjoaja';
+
+  @override
+  String get live => 'Live';
+
+  @override
+  String get onDevice => 'Laitteella';
+
+  @override
+  String get apiUrl => 'API-URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Kirjoita STT HTTP -päätepisteesi';
+
+  @override
+  String get websocketUrl => 'WebSocket-URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Kirjoita live-STT WebSocket -päätepisteesi';
+
+  @override
+  String get apiKey => 'API-avain';
+
+  @override
+  String get enterApiKey => 'Kirjoita API-avaimesi';
+
+  @override
+  String get storedLocallyNeverShared => 'Tallennettu paikallisesti, ei koskaan jaettu';
+
+  @override
+  String get host => 'Isäntä';
+
+  @override
+  String get port => 'Portti';
+
+  @override
+  String get advanced => 'Lisäasetukset';
+
+  @override
+  String get configuration => 'Kokoonpano';
+
+  @override
+  String get requestConfiguration => 'Pyyntökokoonpano';
+
+  @override
+  String get responseSchema => 'Vastauskaavio';
+
+  @override
+  String get modified => 'Muokattu';
+
+  @override
+  String get resetRequestConfig => 'Palauta pyyntökokoonpano oletuksiin';
+
+  @override
+  String get logs => 'Lokit';
+
+  @override
+  String get logsCopied => 'Lokit kopioitu';
+
+  @override
+  String get noLogsYet => 'Ei vielä lokeja. Aloita nauhoitus nähdäksesi mukautetun STT-toiminnan.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName käyttää $codecReason. Omia käytetään.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi-litterointi';
+
+  @override
+  String get bestInClassTranscription => 'Paras litterointi ilman asennusta';
+
+  @override
+  String get instantSpeakerLabels => 'Välittömät puhujatunnisteet';
+
+  @override
+  String get languageTranslation => 'Yli 100 kielen käännös';
+
+  @override
+  String get optimizedForConversation => 'Optimoitu keskusteluille';
+
+  @override
+  String get autoLanguageDetection => 'Automaattinen kielentunnistus';
+
+  @override
+  String get highAccuracy => 'Korkea tarkkuus';
+
+  @override
+  String get privacyFirst => 'Yksityisyys ensin';
+
+  @override
+  String get saveChanges => 'Tallenna muutokset';
+
+  @override
+  String get resetToDefault => 'Palauta oletuksiin';
+
+  @override
+  String get viewTemplate => 'Näytä malli';
+
+  @override
+  String get trySomethingLike => 'Kokeile jotain tällaista...';
+
+  @override
+  String get tryIt => 'Kokeile';
+
+  @override
+  String get creatingPlan => 'Luodaan suunnitelmaa';
+
+  @override
+  String get developingLogic => 'Kehitetään logiikkaa';
+
+  @override
+  String get designingApp => 'Suunnitellaan sovellusta';
+
+  @override
+  String get generatingIconStep => 'Luodaan kuvaketta';
+
+  @override
+  String get finalTouches => 'Viimeiset viimeistelyt';
+
+  @override
+  String get processing => 'Käsitellään...';
+
+  @override
+  String get features => 'Ominaisuudet';
+
+  @override
+  String get creatingYourApp => 'Luodaan sovellustasi...';
+
+  @override
+  String get generatingIcon => 'Luodaan kuvaketta...';
+
+  @override
+  String get whatShouldWeMake => 'Mitä meidän pitäisi tehdä?';
+
+  @override
+  String get appName => 'Sovelluksen nimi';
+
+  @override
+  String get description => 'Kuvaus';
+
+  @override
+  String get publicLabel => 'Julkinen';
+
+  @override
+  String get privateLabel => 'Yksityinen';
+
+  @override
+  String get free => 'Ilmainen';
+
+  @override
+  String get perMonth => '/ kuukausi';
+
+  @override
+  String get tailoredConversationSummaries => 'Räätälöidyt keskusteluyhteenvedot';
+
+  @override
+  String get customChatbotPersonality => 'Mukautettu chatbot-persoonallisuus';
+
+  @override
+  String get makePublic => 'Tee julkiseksi';
+
+  @override
+  String get anyoneCanDiscover => 'Kuka tahansa voi löytää sovelluksesi';
+
+  @override
+  String get onlyYouCanUse => 'Vain sinä voit käyttää tätä sovellusta';
+
+  @override
+  String get paidApp => 'Maksullinen sovellus';
+
+  @override
+  String get usersPayToUse => 'Käyttäjät maksavat sovelluksesi käytöstä';
+
+  @override
+  String get freeForEveryone => 'Ilmainen kaikille';
+
+  @override
+  String get perMonthLabel => '/ kuukausi';
+
+  @override
+  String get creating => 'Luodaan...';
+
+  @override
+  String get createApp => 'Luo sovellus';
+
+  @override
+  String get searchingForDevices => 'Etsitään laitteita...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'LAITETTA',
+      one: 'LAITE',
+    );
+    return '$count $_temp0 LÖYDETTY LÄHISTÖLTÄ';
+  }
+
+  @override
+  String get pairingSuccessful => 'PARILIITOS ONNISTUI';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Virhe yhdistettäessä Apple Watchiin: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Älä näytä uudelleen';
+
+  @override
+  String get iUnderstand => 'Ymmärrän';
+
+  @override
+  String get enableBluetooth => 'Ota Bluetooth käyttöön';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi tarvitsee Bluetoothin yhdistääkseen puettavaan laitteeseesi. Ota Bluetooth käyttöön ja yritä uudelleen.';
+
+  @override
+  String get contactSupport => 'Ota yhteyttä tukeen?';
+
+  @override
+  String get connectLater => 'Yhdistä myöhemmin';
+
+  @override
+  String get grantPermissions => 'Myönnä käyttöoikeudet';
+
+  @override
+  String get backgroundActivity => 'Taustatoiminta';
+
+  @override
+  String get backgroundActivityDesc => 'Anna Omin toimia taustalla parempaa vakautta varten';
+
+  @override
+  String get locationAccess => 'Sijaintipääsy';
+
+  @override
+  String get locationAccessDesc => 'Ota taustasijaintisi käyttöön täydelliseen kokemukseen';
+
+  @override
+  String get notifications => 'Ilmoitukset';
+
+  @override
+  String get notificationsDesc => 'Ota ilmoitukset käyttöön pysyäksesi ajan tasalla';
+
+  @override
+  String get locationServiceDisabled => 'Sijaintipalvelu poistettu käytöstä';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Sijaintipalvelu on poistettu käytöstä. Siirry kohtaan Asetukset > Tietosuoja ja turvallisuus > Sijaintipalvelut ja ota se käyttöön';
+
+  @override
+  String get backgroundLocationDenied => 'Taustasijaintipääsy evätty';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Siirry laitteen asetuksiin ja aseta sijaintioikeus asentoon \"Salli aina\"';
+
+  @override
+  String get lovingOmi => 'Pidätkö Omista?';
+
+  @override
+  String get leaveReviewIos =>
+      'Auta meitä tavoittamaan lisää ihmisiä jättämällä arvostelu App Storeen. Palautteesi on meille tärkeää!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Auta meitä tavoittamaan lisää ihmisiä jättämällä arvostelu Google Play -kauppaan. Palautteesi on meille tärkeää!';
+
+  @override
+  String get rateOnAppStore => 'Arvostele App Storessa';
+
+  @override
+  String get rateOnGooglePlay => 'Arvostele Google Playssa';
+
+  @override
+  String get maybeLater => 'Ehkä myöhemmin';
+
+  @override
+  String get speechProfileIntro => 'Omin on opittava tavoitteesi ja äänesi. Voit muokata sitä myöhemmin.';
+
+  @override
+  String get getStarted => 'Aloita';
+
+  @override
+  String get allDone => 'Kaikki valmista!';
+
+  @override
+  String get keepGoing => 'Jatka, teet loistavasti';
+
+  @override
+  String get skipThisQuestion => 'Ohita tämä kysymys';
+
+  @override
+  String get skipForNow => 'Ohita toistaiseksi';
+
+  @override
+  String get connectionError => 'Yhteysvirhe';
+
+  @override
+  String get connectionErrorDesc => 'Yhteys palvelimeen epäonnistui. Tarkista internet-yhteytesi ja yritä uudelleen.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Virheellinen nauhoitus havaittu';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Näyttää siltä, että nauhoituksessa on useita puhujia. Varmista, että olet hiljaisessa paikassa ja yritä uudelleen.';
+
+  @override
+  String get tooShortDesc => 'Puhetta ei havaittu tarpeeksi. Puhu enemmän ja yritä uudelleen.';
+
+  @override
+  String get invalidRecordingDesc => 'Varmista, että puhut vähintään 5 sekuntia ja korkeintaan 90 sekuntia.';
+
+  @override
+  String get areYouThere => 'Oletko siellä?';
+
+  @override
+  String get noSpeechDesc =>
+      'Emme voineet havaita mitään puhetta. Varmista, että puhut vähintään 10 sekuntia ja korkeintaan 3 minuuttia.';
+
+  @override
+  String get connectionLost => 'Yhteys katkesi';
+
+  @override
+  String get connectionLostDesc => 'Yhteys keskeytyi. Tarkista internet-yhteytesi ja yritä uudelleen.';
+
+  @override
+  String get tryAgain => 'Yritä uudelleen';
+
+  @override
+  String get connectOmiOmiGlass => 'Yhdistä Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Jatka ilman laitetta';
+
+  @override
+  String get permissionsRequired => 'Käyttöoikeudet vaaditaan';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Tämä sovellus tarvitsee Bluetooth- ja sijaintioikeudet toimiakseen oikein. Ota ne käyttöön asetuksissa.';
+
+  @override
+  String get openSettings => 'Avaa asetukset';
+
+  @override
+  String get wantDifferentName => 'Haluatko käyttää eri nimeä?';
+
+  @override
+  String get whatsYourName => 'Mikä nimesi on?';
+
+  @override
+  String get speakTranscribeSummarize => 'Puhu. Litteroi. Tee yhteenveto.';
+
+  @override
+  String get signInWithApple => 'Kirjaudu Applella';
+
+  @override
+  String get signInWithGoogle => 'Kirjaudu Googlella';
+
+  @override
+  String get byContinuingAgree => 'Jatkamalla hyväksyt ';
+
+  @override
+  String get termsOfUse => 'Käyttöehdot';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – tekoälykumppanisi';
+
+  @override
+  String get captureEveryMoment =>
+      'Tallenna jokainen hetki. Saat tekoälyn\nluomat yhteenvedot. Älä enää tee muistiinpanoja.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch -asennus';
+
+  @override
+  String get permissionRequestedExclaim => 'Käyttöoikeus pyydetty!';
+
+  @override
+  String get microphonePermission => 'Mikrofonin käyttöoikeus';
+
+  @override
+  String get permissionGrantedNow =>
+      'Käyttöoikeus myönnetty! Nyt:\n\nAvaa Omi-sovellus kellossasi ja napauta \"Jatka\" alla';
+
+  @override
+  String get needMicrophonePermission =>
+      'Tarvitsemme mikrofonin käyttöoikeuden.\n\n1. Napauta \"Myönnä käyttöoikeus\"\n2. Salli iPhonessasi\n3. Kello-sovellus sulkeutuu\n4. Avaa uudelleen ja napauta \"Jatka\"';
+
+  @override
+  String get grantPermissionButton => 'Myönnä käyttöoikeus';
+
+  @override
+  String get needHelp => 'Tarvitsetko apua?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Vianmääritys:\n\n1. Varmista, että Omi on asennettu kelloosi\n2. Avaa Omi-sovellus kellossasi\n3. Etsi käyttöoikeuspyyntö\n4. Napauta \"Salli\" kehotettaessa\n5. Kello-sovellus sulkeutuu - avaa se uudelleen\n6. Palaa ja napauta \"Jatka\" iPhonessasi';
+
+  @override
+  String get recordingStartedSuccessfully => 'Nauhoitus aloitettu onnistuneesti!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Käyttöoikeutta ei ole vielä myönnetty. Varmista, että salloit mikrofonin käytön ja avasit sovelluksen kellossasi uudelleen.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Virhe pyydettäessä käyttöoikeutta: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Virhe nauhoituksen aloittamisessa: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Valitse ensisijainen kielesi';
+
+  @override
+  String get languageBenefits => 'Aseta kielesi tarkempaa litterointia ja henkilökohtaista kokemusta varten';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Mikä on ensisijainen kielesi?';
+
+  @override
+  String get selectYourLanguage => 'Valitse kielesi';
+
+  @override
+  String get personalGrowthJourney => 'Henkilökohtainen kasvumatkasi tekoälyn kanssa, joka kuuntelee jokaista sanaasi.';
+
+  @override
+  String get actionItemsTitle => 'Tehtävät';
+
+  @override
+  String get actionItemsDescription => 'Napauta muokataksesi • Pidä painettuna valitaksesi • Pyyhkäise toiminnoille';
+
+  @override
+  String get tabToDo => 'Tekemättä';
+
+  @override
+  String get tabDone => 'Tehty';
+
+  @override
+  String get tabOld => 'Vanhat';
+
+  @override
+  String get emptyTodoMessage => '🎉 Kaikki hoidettu!\nEi odottavia tehtäviä';
+
+  @override
+  String get emptyDoneMessage => 'Ei vielä suoritettuja kohteita';
+
+  @override
+  String get emptyOldMessage => '✅ Ei vanhoja tehtäviä';
+
+  @override
+  String get noItems => 'Ei kohteita';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Tehtävä merkitty keskeneräiseksi';
+
+  @override
+  String get actionItemCompleted => 'Tehtävä suoritettu';
+
+  @override
+  String get deleteActionItemTitle => 'Poista tehtävä';
+
+  @override
+  String get deleteActionItemMessage => 'Haluatko varmasti poistaa tämän tehtävän?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Poista valitut kohteet';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Haluatko varmasti poistaa $count valittua tehtävää?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Tehtävä \"$description\" poistettu';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count tehtävää poistettu';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Tehtävän poisto epäonnistui';
+
+  @override
+  String get failedToDeleteItems => 'Kohteiden poisto epäonnistui';
+
+  @override
+  String get failedToDeleteSomeItems => 'Joidenkin kohteiden poisto epäonnistui';
+
+  @override
+  String get welcomeActionItemsTitle => 'Valmis tehtäville';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Tekoälysi poimii automaattisesti tehtävät ja to-do-listat keskusteluistasi. Ne näkyvät täällä, kun ne on luotu.';
+
+  @override
+  String get autoExtractionFeature => 'Poimittu automaattisesti keskusteluista';
+
+  @override
+  String get editSwipeFeature => 'Napauta muokataksesi, pyyhkäise suorittaaksesi tai poistaaksesi';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count valittu';
+  }
+
+  @override
+  String get selectAll => 'Valitse kaikki';
+
+  @override
+  String get deleteSelected => 'Poista valitut';
+
+  @override
+  String searchMemories(int count) {
+    return 'Etsi $count muistoa';
+  }
+
+  @override
+  String get memoryDeleted => 'Muisto poistettu.';
+
+  @override
+  String get undo => 'Kumoa';
+
+  @override
+  String get noMemoriesYet => 'Ei vielä muistoja';
+
+  @override
+  String get noAutoMemories => 'Ei vielä automaattisesti poimittuja muistoja';
+
+  @override
+  String get noManualMemories => 'Ei vielä manuaalisia muistoja';
+
+  @override
+  String get noMemoriesInCategories => 'Ei muistoja näissä kategorioissa';
+
+  @override
+  String get noMemoriesFound => 'Muistoja ei löytynyt';
+
+  @override
+  String get addFirstMemory => 'Lisää ensimmäinen muistosi';
+
+  @override
+  String get clearMemoryTitle => 'Tyhjennä Omin muisti';
+
+  @override
+  String get clearMemoryMessage => 'Haluatko varmasti tyhjentää Omin muistin? Tätä toimintoa ei voi perua.';
+
+  @override
+  String get clearMemoryButton => 'Tyhjennä muisti';
+
+  @override
+  String get memoryClearedSuccess => 'Omin muisti sinusta on tyhjennetty';
+
+  @override
+  String get noMemoriesToDelete => 'Ei poistettavia muistoja';
+
+  @override
+  String get createMemoryTooltip => 'Luo uusi muisto';
+
+  @override
+  String get createActionItemTooltip => 'Luo uusi tehtävä';
+
+  @override
+  String get memoryManagement => 'Muistinhallinta';
+
+  @override
+  String get filterMemories => 'Suodata muistoja';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Sinulla on $count muistoa yhteensä';
+  }
+
+  @override
+  String get publicMemories => 'Julkiset muistot';
+
+  @override
+  String get privateMemories => 'Yksityiset muistot';
+
+  @override
+  String get makeAllPrivate => 'Tee kaikki muistot yksityisiksi';
+
+  @override
+  String get makeAllPublic => 'Tee kaikki muistot julkisiksi';
+
+  @override
+  String get deleteAllMemories => 'Poista kaikki muistot';
+
+  @override
+  String get allMemoriesPrivateResult => 'Kaikki muistot ovat nyt yksityisiä';
+
+  @override
+  String get allMemoriesPublicResult => 'Kaikki muistot ovat nyt julkisia';
+
+  @override
+  String get newMemory => 'Uusi muisto';
+
+  @override
+  String get editMemory => 'Muokkaa muistoa';
+
+  @override
+  String get memoryContentHint => 'Pidän jäätelön syömisestä...';
+
+  @override
+  String get failedToSaveMemory => 'Tallennus epäonnistui. Tarkista yhteytesi.';
+
+  @override
+  String get saveMemory => 'Tallenna muisto';
+
+  @override
+  String get retry => 'Yritä uudelleen';
+
+  @override
+  String get createActionItem => 'Luo tehtävä';
+
+  @override
+  String get editActionItem => 'Muokkaa tehtävää';
+
+  @override
+  String get actionItemDescriptionHint => 'Mitä pitää tehdä?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Tehtävän kuvaus ei voi olla tyhjä.';
+
+  @override
+  String get actionItemUpdated => 'Tehtävä päivitetty';
+
+  @override
+  String get failedToUpdateActionItem => 'Tehtävän päivitys epäonnistui';
+
+  @override
+  String get actionItemCreated => 'Tehtävä luotu';
+
+  @override
+  String get failedToCreateActionItem => 'Tehtävän luonti epäonnistui';
+
+  @override
+  String get dueDate => 'Eräpäivä';
+
+  @override
+  String get time => 'Aika';
+
+  @override
+  String get addDueDate => 'Lisää eräpäivä';
+
+  @override
+  String get pressDoneToSave => 'Paina valmis tallentaaksesi';
+
+  @override
+  String get pressDoneToCreate => 'Paina valmis luodaksesi';
+
+  @override
+  String get filterAll => 'Kaikki';
+
+  @override
+  String get filterSystem => 'Tietoja sinusta';
+
+  @override
+  String get filterInteresting => 'Oivallukset';
+
+  @override
+  String get filterManual => 'Manuaalinen';
+
+  @override
+  String get completed => 'Suoritettu';
+
+  @override
+  String get markComplete => 'Merkitse suoritetuksi';
+
+  @override
+  String get actionItemDeleted => 'Tehtävä poistettu';
+
+  @override
+  String get failedToDeleteActionItem => 'Tehtävän poisto epäonnistui';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Poista tehtävä';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Haluatko varmasti poistaa tämän tehtävän?';
+
+  @override
+  String get appLanguage => 'Sovelluksen kieli';
+
+  @override
+  String get appInterfaceSectionTitle => 'SOVELLUKSEN KÄYTTÖLIITTYMÄ';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'PUHE JA LITTEROINTI';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Sovelluksen kieli muuttaa valikkoja ja painikkeita. Puheen kieli vaikuttaa siihen, miten tallenteet litteroidaan.';
+}

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -1,0 +1,2248 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for French (`fr`).
+class AppLocalizationsFr extends AppLocalizations {
+  AppLocalizationsFr([String locale = 'fr']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Conversation';
+
+  @override
+  String get transcriptTab => 'Transcription';
+
+  @override
+  String get actionItemsTab => 'Actions à faire';
+
+  @override
+  String get deleteConversationTitle => 'Supprimer la conversation ?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Êtes-vous sûr de vouloir supprimer cette conversation ? Cette action est irréversible.';
+
+  @override
+  String get confirm => 'Confirmer';
+
+  @override
+  String get cancel => 'Annuler';
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get delete => 'Supprimer';
+
+  @override
+  String get add => 'Ajouter';
+
+  @override
+  String get update => 'Mettre à jour';
+
+  @override
+  String get save => 'Enregistrer';
+
+  @override
+  String get edit => 'Modifier';
+
+  @override
+  String get close => 'Fermer';
+
+  @override
+  String get clear => 'Effacer';
+
+  @override
+  String get copyTranscript => 'Copier la transcription';
+
+  @override
+  String get copySummary => 'Copier le résumé';
+
+  @override
+  String get testPrompt => 'Tester le prompt';
+
+  @override
+  String get reprocessConversation => 'Retraiter la conversation';
+
+  @override
+  String get deleteConversation => 'Supprimer la conversation';
+
+  @override
+  String get contentCopied => 'Contenu copié dans le presse-papiers';
+
+  @override
+  String get failedToUpdateStarred => 'Échec de la mise à jour du statut favori.';
+
+  @override
+  String get conversationUrlNotShared => 'L\'URL de la conversation n\'a pas pu être partagée.';
+
+  @override
+  String get errorProcessingConversation =>
+      'Erreur lors du traitement de la conversation. Veuillez réessayer plus tard.';
+
+  @override
+  String get noInternetConnection => 'Veuillez vérifier votre connexion internet et réessayer.';
+
+  @override
+  String get unableToDeleteConversation => 'Impossible de supprimer la conversation';
+
+  @override
+  String get somethingWentWrong => 'Une erreur s\'est produite ! Veuillez réessayer plus tard.';
+
+  @override
+  String get copyErrorMessage => 'Copier le message d\'erreur';
+
+  @override
+  String get errorCopied => 'Message d\'erreur copié dans le presse-papiers';
+
+  @override
+  String get remaining => 'Restant';
+
+  @override
+  String get loading => 'Chargement...';
+
+  @override
+  String get loadingDuration => 'Chargement de la durée...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count secondes';
+  }
+
+  @override
+  String get people => 'Personnes';
+
+  @override
+  String get addNewPerson => 'Ajouter une nouvelle personne';
+
+  @override
+  String get editPerson => 'Modifier la personne';
+
+  @override
+  String get createPersonHint => 'Créez une nouvelle personne et entraînez Omi à reconnaître sa voix aussi !';
+
+  @override
+  String get speechProfile => 'Profil vocal';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Échantillon $number';
+  }
+
+  @override
+  String get settings => 'Paramètres';
+
+  @override
+  String get language => 'Langue';
+
+  @override
+  String get selectLanguage => 'Sélectionner la langue';
+
+  @override
+  String get deleting => 'Suppression...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
+
+  @override
+  String get failedToStartAuthentication => 'Échec du démarrage de l\'authentification';
+
+  @override
+  String get importStarted => 'Importation démarrée ! Vous serez notifié une fois terminée.';
+
+  @override
+  String get failedToStartImport => 'Échec du démarrage de l\'importation. Veuillez réessayer.';
+
+  @override
+  String get couldNotAccessFile => 'Impossible d\'accéder au fichier sélectionné';
+
+  @override
+  String get askOmi => 'Demander à Omi';
+
+  @override
+  String get done => 'Terminé';
+
+  @override
+  String get disconnected => 'Déconnecté';
+
+  @override
+  String get searching => 'Recherche';
+
+  @override
+  String get connectDevice => 'Connecter l\'appareil';
+
+  @override
+  String get monthlyLimitReached => 'Vous avez atteint votre limite mensuelle.';
+
+  @override
+  String get checkUsage => 'Vérifier l\'utilisation';
+
+  @override
+  String get syncingRecordings => 'Synchronisation des enregistrements';
+
+  @override
+  String get recordingsToSync => 'Enregistrements à synchroniser';
+
+  @override
+  String get allCaughtUp => 'Tout est à jour';
+
+  @override
+  String get sync => 'Synchroniser';
+
+  @override
+  String get pendantUpToDate => 'Le pendentif est à jour';
+
+  @override
+  String get allRecordingsSynced => 'Tous les enregistrements sont synchronisés';
+
+  @override
+  String get syncingInProgress => 'Synchronisation en cours';
+
+  @override
+  String get readyToSync => 'Prêt à synchroniser';
+
+  @override
+  String get tapSyncToStart => 'Appuyez sur Synchroniser pour commencer';
+
+  @override
+  String get pendantNotConnected => 'Pendentif non connecté. Connectez-vous pour synchroniser.';
+
+  @override
+  String get everythingSynced => 'Tout est déjà synchronisé.';
+
+  @override
+  String get recordingsNotSynced => 'Vous avez des enregistrements qui ne sont pas encore synchronisés.';
+
+  @override
+  String get syncingBackground => 'Nous continuerons à synchroniser vos enregistrements en arrière-plan.';
+
+  @override
+  String get noConversationsYet => 'Pas encore de conversations.';
+
+  @override
+  String get noStarredConversations => 'Pas encore de conversations favorites.';
+
+  @override
+  String get starConversationHint =>
+      'Pour marquer une conversation comme favorite, ouvrez-la et appuyez sur l\'icône étoile dans l\'en-tête.';
+
+  @override
+  String get searchConversations => 'Rechercher des conversations';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count sélectionné(s)';
+  }
+
+  @override
+  String get merge => 'Fusionner';
+
+  @override
+  String get mergeConversations => 'Fusionner les conversations';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Cela combinera $count conversations en une seule. Tout le contenu sera fusionné et régénéré.';
+  }
+
+  @override
+  String get mergingInBackground => 'Fusion en cours en arrière-plan. Cela peut prendre un moment.';
+
+  @override
+  String get failedToStartMerge => 'Échec du démarrage de la fusion';
+
+  @override
+  String get askAnything => 'Demandez n\'importe quoi';
+
+  @override
+  String get noMessagesYet => 'Pas encore de messages !\nPourquoi ne pas commencer une conversation ?';
+
+  @override
+  String get deletingMessages => 'Suppression de vos messages de la mémoire d\'Omi...';
+
+  @override
+  String get messageCopied => 'Message copié dans le presse-papiers.';
+
+  @override
+  String get cannotReportOwnMessage => 'Vous ne pouvez pas signaler vos propres messages.';
+
+  @override
+  String get reportMessage => 'Signaler le message';
+
+  @override
+  String get reportMessageConfirm => 'Êtes-vous sûr de vouloir signaler ce message ?';
+
+  @override
+  String get messageReported => 'Message signalé avec succès.';
+
+  @override
+  String get thankYouFeedback => 'Merci pour votre retour !';
+
+  @override
+  String get clearChat => 'Effacer la discussion ?';
+
+  @override
+  String get clearChatConfirm => 'Êtes-vous sûr de vouloir effacer la discussion ? Cette action est irréversible.';
+
+  @override
+  String get maxFilesLimit => 'Vous ne pouvez télécharger que 4 fichiers à la fois';
+
+  @override
+  String get chatWithOmi => 'Discuter avec Omi';
+
+  @override
+  String get apps => 'Applications';
+
+  @override
+  String get noAppsFound => 'Aucune application trouvée';
+
+  @override
+  String get tryAdjustingSearch => 'Essayez d\'ajuster votre recherche ou vos filtres';
+
+  @override
+  String get createYourOwnApp => 'Créez votre propre application';
+
+  @override
+  String get buildAndShareApp => 'Créez et partagez votre application personnalisée';
+
+  @override
+  String get searchApps => 'Rechercher plus de 1500 applications';
+
+  @override
+  String get myApps => 'Mes applications';
+
+  @override
+  String get installedApps => 'Applications installées';
+
+  @override
+  String get unableToFetchApps =>
+      'Impossible de récupérer les applications :(\n\nVeuillez vérifier votre connexion internet et réessayer.';
+
+  @override
+  String get aboutOmi => 'À propos d\'Omi';
+
+  @override
+  String get privacyPolicy => 'Politique de confidentialité';
+
+  @override
+  String get visitWebsite => 'Visiter le site web';
+
+  @override
+  String get helpOrInquiries => 'Aide ou questions ?';
+
+  @override
+  String get joinCommunity => 'Rejoignez la communauté !';
+
+  @override
+  String get membersAndCounting => 'Plus de 8000 membres et ça continue.';
+
+  @override
+  String get deleteAccountTitle => 'Supprimer le compte';
+
+  @override
+  String get deleteAccountConfirm => 'Êtes-vous sûr de vouloir supprimer votre compte ?';
+
+  @override
+  String get cannotBeUndone => 'Cette action est irréversible.';
+
+  @override
+  String get allDataErased => 'Toutes vos mémoires et conversations seront définitivement effacées.';
+
+  @override
+  String get appsDisconnected => 'Vos applications et intégrations seront déconnectées immédiatement.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Vous pouvez exporter vos données avant de supprimer votre compte, mais une fois supprimé, il ne pourra pas être récupéré.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Je comprends que la suppression de mon compte est permanente et que toutes les données, y compris les mémoires et conversations, seront perdues et ne pourront pas être récupérées.';
+
+  @override
+  String get areYouSure => 'Êtes-vous sûr ?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Cette action est irréversible et supprimera définitivement votre compte et toutes les données associées. Êtes-vous sûr de vouloir continuer ?';
+
+  @override
+  String get deleteNow => 'Supprimer maintenant';
+
+  @override
+  String get goBack => 'Retour';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Cochez la case pour confirmer que vous comprenez que la suppression de votre compte est permanente et irréversible.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Nom';
+
+  @override
+  String get email => 'E-mail';
+
+  @override
+  String get customVocabulary => 'Vocabulaire personnalisé';
+
+  @override
+  String get identifyingOthers => 'Identification des autres';
+
+  @override
+  String get paymentMethods => 'Moyens de paiement';
+
+  @override
+  String get conversationDisplay => 'Affichage des conversations';
+
+  @override
+  String get dataPrivacy => 'Données et confidentialité';
+
+  @override
+  String get userId => 'ID utilisateur';
+
+  @override
+  String get notSet => 'Non défini';
+
+  @override
+  String get userIdCopied => 'ID utilisateur copié dans le presse-papiers';
+
+  @override
+  String get systemDefault => 'Par défaut du système';
+
+  @override
+  String get planAndUsage => 'Forfait et utilisation';
+
+  @override
+  String get offlineSync => 'Synchronisation hors ligne';
+
+  @override
+  String get deviceSettings => 'Paramètres de l\'appareil';
+
+  @override
+  String get chatTools => 'Outils de chat';
+
+  @override
+  String get feedbackBug => 'Retour / Bug';
+
+  @override
+  String get helpCenter => 'Centre d\'aide';
+
+  @override
+  String get developerSettings => 'Paramètres développeur';
+
+  @override
+  String get getOmiForMac => 'Obtenir Omi pour Mac';
+
+  @override
+  String get referralProgram => 'Programme de parrainage';
+
+  @override
+  String get signOut => 'Déconnexion';
+
+  @override
+  String get appAndDeviceCopied => 'Détails de l\'application et de l\'appareil copiés';
+
+  @override
+  String get wrapped2025 => 'Rétrospective 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Votre vie privée, votre contrôle';
+
+  @override
+  String get privacyIntro =>
+      'Chez Omi, nous nous engageons à protéger votre vie privée. Cette page vous permet de contrôler la façon dont vos données sont stockées et utilisées.';
+
+  @override
+  String get learnMore => 'En savoir plus...';
+
+  @override
+  String get dataProtectionLevel => 'Niveau de protection des données';
+
+  @override
+  String get dataProtectionDesc =>
+      'Vos données sont sécurisées par défaut avec un cryptage fort. Vérifiez vos paramètres et les futures options de confidentialité ci-dessous.';
+
+  @override
+  String get appAccess => 'Accès des applications';
+
+  @override
+  String get appAccessDesc =>
+      'Les applications suivantes peuvent accéder à vos données. Appuyez sur une application pour gérer ses autorisations.';
+
+  @override
+  String get noAppsExternalAccess => 'Aucune application installée n\'a d\'accès externe à vos données.';
+
+  @override
+  String get deviceName => 'Nom de l\'appareil';
+
+  @override
+  String get deviceId => 'ID de l\'appareil';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'Synchronisation carte SD';
+
+  @override
+  String get hardwareRevision => 'Révision matérielle';
+
+  @override
+  String get modelNumber => 'Numéro de modèle';
+
+  @override
+  String get manufacturer => 'Fabricant';
+
+  @override
+  String get doubleTap => 'Double appui';
+
+  @override
+  String get ledBrightness => 'Luminosité LED';
+
+  @override
+  String get micGain => 'Gain du micro';
+
+  @override
+  String get disconnect => 'Déconnecter';
+
+  @override
+  String get forgetDevice => 'Oublier l\'appareil';
+
+  @override
+  String get chargingIssues => 'Problèmes de charge';
+
+  @override
+  String get disconnectDevice => 'Déconnecter l\'appareil';
+
+  @override
+  String get unpairDevice => 'Dissocier l\'appareil';
+
+  @override
+  String get unpairAndForget => 'Dissocier et oublier l\'appareil';
+
+  @override
+  String get deviceDisconnectedMessage => 'Votre Omi a été déconnecté 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Appareil dissocié. Allez dans Réglages > Bluetooth et oubliez l\'appareil pour terminer la dissociation.';
+
+  @override
+  String get unpairDialogTitle => 'Dissocier l\'appareil';
+
+  @override
+  String get unpairDialogMessage =>
+      'Cela dissociera l\'appareil afin qu\'il puisse être connecté à un autre téléphone. Vous devrez aller dans Réglages > Bluetooth et oublier l\'appareil pour terminer le processus.';
+
+  @override
+  String get deviceNotConnected => 'Appareil non connecté';
+
+  @override
+  String get connectDeviceMessage =>
+      'Connectez votre appareil Omi pour accéder aux\nparamètres et à la personnalisation de l\'appareil';
+
+  @override
+  String get deviceInfoSection => 'Informations sur l\'appareil';
+
+  @override
+  String get customizationSection => 'Personnalisation';
+
+  @override
+  String get hardwareSection => 'Matériel';
+
+  @override
+  String get v2Undetected => 'V2 non détecté';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Nous voyons que vous avez soit un appareil V1, soit votre appareil n\'est pas connecté. La fonctionnalité carte SD n\'est disponible que pour les appareils V2.';
+
+  @override
+  String get endConversation => 'Terminer la conversation';
+
+  @override
+  String get pauseResume => 'Pause/Reprendre';
+
+  @override
+  String get starConversation => 'Marquer la conversation comme favorite';
+
+  @override
+  String get doubleTapAction => 'Action double appui';
+
+  @override
+  String get endAndProcess => 'Terminer et traiter la conversation';
+
+  @override
+  String get pauseResumeRecording => 'Pause/Reprendre l\'enregistrement';
+
+  @override
+  String get starOngoing => 'Marquer la conversation en cours comme favorite';
+
+  @override
+  String get off => 'Désactivé';
+
+  @override
+  String get max => 'Max';
+
+  @override
+  String get mute => 'Muet';
+
+  @override
+  String get quiet => 'Silencieux';
+
+  @override
+  String get normal => 'Normal';
+
+  @override
+  String get high => 'Élevé';
+
+  @override
+  String get micGainDescMuted => 'Le microphone est en sourdine';
+
+  @override
+  String get micGainDescLow => 'Très silencieux - pour les environnements bruyants';
+
+  @override
+  String get micGainDescModerate => 'Silencieux - pour un bruit modéré';
+
+  @override
+  String get micGainDescNeutral => 'Neutre - enregistrement équilibré';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Légèrement amplifié - utilisation normale';
+
+  @override
+  String get micGainDescBoosted => 'Amplifié - pour les environnements calmes';
+
+  @override
+  String get micGainDescHigh => 'Élevé - pour les voix distantes ou douces';
+
+  @override
+  String get micGainDescVeryHigh => 'Très élevé - pour les sources très silencieuses';
+
+  @override
+  String get micGainDescMax => 'Maximum - à utiliser avec précaution';
+
+  @override
+  String get developerSettingsTitle => 'Paramètres développeur';
+
+  @override
+  String get saving => 'Enregistrement...';
+
+  @override
+  String get personaConfig => 'Configurez votre persona IA';
+
+  @override
+  String get beta => 'BÊTA';
+
+  @override
+  String get transcription => 'Transcription';
+
+  @override
+  String get transcriptionConfig => 'Configurer le fournisseur STT';
+
+  @override
+  String get conversationTimeout => 'Délai de conversation';
+
+  @override
+  String get conversationTimeoutConfig => 'Définir quand les conversations se terminent automatiquement';
+
+  @override
+  String get importData => 'Importer des données';
+
+  @override
+  String get importDataConfig => 'Importer des données d\'autres sources';
+
+  @override
+  String get debugDiagnostics => 'Débogage et diagnostics';
+
+  @override
+  String get endpointUrl => 'URL du point de terminaison';
+
+  @override
+  String get noApiKeys => 'Pas encore de clés API';
+
+  @override
+  String get createKeyToStart => 'Créez une clé pour commencer';
+
+  @override
+  String get createKey => 'Créer une clé';
+
+  @override
+  String get docs => 'Documentation';
+
+  @override
+  String get yourOmiInsights => 'Vos statistiques Omi';
+
+  @override
+  String get today => 'Aujourd\'hui';
+
+  @override
+  String get thisMonth => 'Ce mois-ci';
+
+  @override
+  String get thisYear => 'Cette année';
+
+  @override
+  String get allTime => 'Depuis toujours';
+
+  @override
+  String get noActivityYet => 'Pas encore d\'activité';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Commencez une conversation avec Omi\npour voir vos statistiques d\'utilisation ici.';
+
+  @override
+  String get listening => 'Écoute';
+
+  @override
+  String get listeningSubtitle => 'Temps total d\'écoute active d\'Omi.';
+
+  @override
+  String get understanding => 'Compréhension';
+
+  @override
+  String get understandingSubtitle => 'Mots compris de vos conversations.';
+
+  @override
+  String get providing => 'Fourniture';
+
+  @override
+  String get providingSubtitle => 'Actions à faire et notes capturées automatiquement.';
+
+  @override
+  String get remembering => 'Mémorisation';
+
+  @override
+  String get rememberingSubtitle => 'Faits et détails mémorisés pour vous.';
+
+  @override
+  String get unlimitedPlan => 'Forfait illimité';
+
+  @override
+  String get managePlan => 'Gérer le forfait';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Votre forfait sera annulé le $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Votre forfait sera renouvelé le $date.';
+  }
+
+  @override
+  String get basicPlan => 'Forfait gratuit';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used sur $limit min utilisées';
+  }
+
+  @override
+  String get upgrade => 'Mettre à niveau';
+
+  @override
+  String get upgradeToUnlimited => 'Passer à l\'illimité';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Votre forfait comprend $limit minutes gratuites par mois. Passez à l\'illimité.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Je partage mes statistiques Omi ! (omi.me - votre assistant IA toujours actif)';
+
+  @override
+  String get sharePeriodToday => 'Aujourd\'hui, Omi a :';
+
+  @override
+  String get sharePeriodMonth => 'Ce mois-ci, Omi a :';
+
+  @override
+  String get sharePeriodYear => 'Cette année, Omi a :';
+
+  @override
+  String get sharePeriodAllTime => 'Jusqu\'à présent, Omi a :';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Écouté pendant $minutes minutes';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Compris $words mots';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Fourni $count aperçus';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Mémorisé $count souvenirs';
+  }
+
+  @override
+  String get debugLogs => 'Journaux de débogage';
+
+  @override
+  String get debugLogsAutoDelete => 'Suppression automatique après 3 jours.';
+
+  @override
+  String get debugLogsDesc => 'Aide à diagnostiquer les problèmes';
+
+  @override
+  String get noLogFilesFound => 'Aucun fichier journal trouvé.';
+
+  @override
+  String get omiDebugLog => 'Journal de débogage Omi';
+
+  @override
+  String get logShared => 'Journal partagé';
+
+  @override
+  String get selectLogFile => 'Sélectionner un fichier journal';
+
+  @override
+  String get shareLogs => 'Partager les journaux';
+
+  @override
+  String get debugLogCleared => 'Journal de débogage effacé';
+
+  @override
+  String get exportStarted => 'Exportation démarrée. Cela peut prendre quelques secondes...';
+
+  @override
+  String get exportAllData => 'Exporter toutes les données';
+
+  @override
+  String get exportDataDesc => 'Exporter les conversations vers un fichier JSON';
+
+  @override
+  String get exportedConversations => 'Conversations exportées depuis Omi';
+
+  @override
+  String get exportShared => 'Exportation partagée';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Supprimer le graphe de connaissances ?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Cela supprimera toutes les données du graphe de connaissances dérivées (nœuds et connexions). Vos mémoires originales resteront intactes. Le graphe sera reconstruit au fil du temps ou lors de la prochaine demande.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Graphe de connaissances supprimé avec succès';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Échec de la suppression du graphe : $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Supprimer le graphe de connaissances';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Effacer tous les nœuds et connexions';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Serveur MCP';
+
+  @override
+  String get mcpServerDesc => 'Connecter les assistants IA à vos données';
+
+  @override
+  String get serverUrl => 'URL du serveur';
+
+  @override
+  String get urlCopied => 'URL copiée';
+
+  @override
+  String get apiKeyAuth => 'Authentification par clé API';
+
+  @override
+  String get header => 'En-tête';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <clé>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID client';
+
+  @override
+  String get clientSecret => 'Secret client';
+
+  @override
+  String get useMcpApiKey => 'Utilisez votre clé API MCP';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Événements de conversation';
+
+  @override
+  String get newConversationCreated => 'Nouvelle conversation créée';
+
+  @override
+  String get realtimeTranscript => 'Transcription en temps réel';
+
+  @override
+  String get transcriptReceived => 'Transcription reçue';
+
+  @override
+  String get audioBytes => 'Octets audio';
+
+  @override
+  String get audioDataReceived => 'Données audio reçues';
+
+  @override
+  String get intervalSeconds => 'Intervalle (secondes)';
+
+  @override
+  String get daySummary => 'Résumé du jour';
+
+  @override
+  String get summaryGenerated => 'Résumé généré';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Ajouter à claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Copier la configuration';
+
+  @override
+  String get configCopied => 'Configuration copiée dans le presse-papiers';
+
+  @override
+  String get listeningMins => 'Écoute (min)';
+
+  @override
+  String get understandingWords => 'Compréhension (mots)';
+
+  @override
+  String get insights => 'Aperçus';
+
+  @override
+  String get memories => 'Mémoires';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used sur $limit min utilisées ce mois-ci';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used sur $limit mots utilisés ce mois-ci';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used sur $limit aperçus obtenus ce mois-ci';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used sur $limit mémoires créées ce mois-ci';
+  }
+
+  @override
+  String get visibility => 'Visibilité';
+
+  @override
+  String get visibilitySubtitle => 'Contrôlez quelles conversations apparaissent dans votre liste';
+
+  @override
+  String get showShortConversations => 'Afficher les conversations courtes';
+
+  @override
+  String get showShortConversationsDesc => 'Afficher les conversations plus courtes que le seuil';
+
+  @override
+  String get showDiscardedConversations => 'Afficher les conversations ignorées';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Inclure les conversations marquées comme ignorées';
+
+  @override
+  String get shortConversationThreshold => 'Seuil de conversation courte';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Les conversations plus courtes que cela seront masquées sauf si activé ci-dessus';
+
+  @override
+  String get durationThreshold => 'Seuil de durée';
+
+  @override
+  String get durationThresholdDesc => 'Masquer les conversations plus courtes que cela';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Vocabulaire personnalisé';
+
+  @override
+  String get addWords => 'Ajouter des mots';
+
+  @override
+  String get addWordsDesc => 'Noms, termes ou mots inhabituels';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Connecter';
+
+  @override
+  String get comingSoon => 'Bientôt disponible';
+
+  @override
+  String get chatToolsFooter => 'Connectez vos applications pour afficher les données et les métriques dans le chat.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Échec du démarrage de l\'authentification $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Déconnecter $appName ?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Êtes-vous sûr de vouloir vous déconnecter de $appName ? Vous pouvez vous reconnecter à tout moment.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Déconnecté de $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Échec de la déconnexion';
+
+  @override
+  String connectTo(String appName) {
+    return 'Se connecter à $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Vous devrez autoriser Omi à accéder à vos données $appName. Cela ouvrira votre navigateur pour l\'authentification.';
+  }
+
+  @override
+  String get continueAction => 'Continuer';
+
+  @override
+  String get languageTitle => 'Langue';
+
+  @override
+  String get primaryLanguage => 'Langue principale';
+
+  @override
+  String get automaticTranslation => 'Traduction automatique';
+
+  @override
+  String get detectLanguages => 'Détecter plus de 10 langues';
+
+  @override
+  String get authorizeSavingRecordings => 'Autoriser l\'enregistrement des enregistrements';
+
+  @override
+  String get thanksForAuthorizing => 'Merci pour l\'autorisation !';
+
+  @override
+  String get needYourPermission => 'Nous avons besoin de votre permission';
+
+  @override
+  String get alreadyGavePermission =>
+      'Vous nous avez déjà donné la permission d\'enregistrer vos enregistrements. Voici un rappel de pourquoi nous en avons besoin :';
+
+  @override
+  String get wouldLikePermission =>
+      'Nous aimerions avoir votre permission pour sauvegarder vos enregistrements vocaux. Voici pourquoi :';
+
+  @override
+  String get improveSpeechProfile => 'Améliorer votre profil vocal';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Nous utilisons les enregistrements pour entraîner et améliorer davantage votre profil vocal personnel.';
+
+  @override
+  String get trainFamilyProfiles => 'Entraîner des profils pour les amis et la famille';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Vos enregistrements nous aident à reconnaître et créer des profils pour vos amis et votre famille.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Améliorer la précision de la transcription';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'À mesure que notre modèle s\'améliore, nous pouvons fournir de meilleurs résultats de transcription pour vos enregistrements.';
+
+  @override
+  String get legalNotice =>
+      'Avis juridique : La légalité de l\'enregistrement et du stockage des données vocales peut varier selon votre emplacement et la façon dont vous utilisez cette fonctionnalité. Il est de votre responsabilité de vous assurer de la conformité aux lois et réglementations locales.';
+
+  @override
+  String get alreadyAuthorized => 'Déjà autorisé';
+
+  @override
+  String get authorize => 'Autoriser';
+
+  @override
+  String get revokeAuthorization => 'Révoquer l\'autorisation';
+
+  @override
+  String get authorizationSuccessful => 'Autorisation réussie !';
+
+  @override
+  String get failedToAuthorize => 'Échec de l\'autorisation. Veuillez réessayer.';
+
+  @override
+  String get authorizationRevoked => 'Autorisation révoquée.';
+
+  @override
+  String get recordingsDeleted => 'Enregistrements supprimés.';
+
+  @override
+  String get failedToRevoke => 'Échec de la révocation de l\'autorisation. Veuillez réessayer.';
+
+  @override
+  String get permissionRevokedTitle => 'Permission révoquée';
+
+  @override
+  String get permissionRevokedMessage =>
+      'Voulez-vous que nous supprimions également tous vos enregistrements existants ?';
+
+  @override
+  String get yes => 'Oui';
+
+  @override
+  String get editName => 'Modifier le nom';
+
+  @override
+  String get howShouldOmiCallYou => 'Comment Omi devrait-il vous appeler ?';
+
+  @override
+  String get enterYourName => 'Entrez votre nom';
+
+  @override
+  String get nameCannotBeEmpty => 'Le nom ne peut pas être vide';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Nom mis à jour avec succès !';
+
+  @override
+  String get calendarSettings => 'Paramètres du calendrier';
+
+  @override
+  String get calendarProviders => 'Fournisseurs de calendrier';
+
+  @override
+  String get macOsCalendar => 'Calendrier macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Connectez votre calendrier macOS local';
+
+  @override
+  String get googleCalendar => 'Google Agenda';
+
+  @override
+  String get syncGoogleAccount => 'Synchroniser avec votre compte Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Afficher les réunions à venir dans la barre de menus';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'Afficher votre prochaine réunion et le temps restant avant son début dans la barre de menus macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Afficher les événements sans participants';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Lorsque activé, À venir affiche les événements sans participants ou lien vidéo.';
+
+  @override
+  String get yourMeetings => 'Vos réunions';
+
+  @override
+  String get refresh => 'Actualiser';
+
+  @override
+  String get noUpcomingMeetings => 'Aucune réunion à venir trouvée';
+
+  @override
+  String get checkingNextDays => 'Vérification des 30 prochains jours';
+
+  @override
+  String get tomorrow => 'Demain';
+
+  @override
+  String get googleCalendarComingSoon => 'L\'intégration Google Agenda arrive bientôt !';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Connecté en tant qu\'utilisateur : $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Espace de travail par défaut';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Les tâches seront créées dans cet espace de travail';
+
+  @override
+  String get defaultProjectOptional => 'Projet par défaut (facultatif)';
+
+  @override
+  String get leaveUnselectedTasks => 'Laissez non sélectionné pour créer des tâches sans projet';
+
+  @override
+  String get noProjectsInWorkspace => 'Aucun projet trouvé dans cet espace de travail';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Choisissez combien de temps attendre en silence avant de terminer automatiquement une conversation :';
+
+  @override
+  String get timeout2Minutes => '2 minutes';
+
+  @override
+  String get timeout2MinutesDesc => 'Terminer la conversation après 2 minutes de silence';
+
+  @override
+  String get timeout5Minutes => '5 minutes';
+
+  @override
+  String get timeout5MinutesDesc => 'Terminer la conversation après 5 minutes de silence';
+
+  @override
+  String get timeout10Minutes => '10 minutes';
+
+  @override
+  String get timeout10MinutesDesc => 'Terminer la conversation après 10 minutes de silence';
+
+  @override
+  String get timeout30Minutes => '30 minutes';
+
+  @override
+  String get timeout30MinutesDesc => 'Terminer la conversation après 30 minutes de silence';
+
+  @override
+  String get timeout4Hours => '4 heures';
+
+  @override
+  String get timeout4HoursDesc => 'Terminer la conversation après 4 heures de silence';
+
+  @override
+  String get conversationEndAfterHours => 'Les conversations se termineront maintenant après 4 heures de silence';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Les conversations se termineront maintenant après $minutes minute(s) de silence';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Dites-nous votre langue principale';
+
+  @override
+  String get languageForTranscription =>
+      'Définissez votre langue pour des transcriptions plus précises et une expérience personnalisée.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Le mode langue unique est activé. La traduction est désactivée pour une meilleure précision.';
+
+  @override
+  String get searchLanguageHint => 'Rechercher une langue par nom ou code';
+
+  @override
+  String get noLanguagesFound => 'Aucune langue trouvée';
+
+  @override
+  String get skip => 'Passer';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Langue définie sur $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Échec de la définition de la langue';
+
+  @override
+  String appSettings(String appName) {
+    return 'Paramètres de $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Déconnecter de $appName ?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Cela supprimera votre authentification $appName. Vous devrez vous reconnecter pour l\'utiliser à nouveau.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Connecté à $appName';
+  }
+
+  @override
+  String get account => 'Compte';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Vos actions à faire seront synchronisées avec votre compte $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Espace par défaut';
+
+  @override
+  String get selectSpaceInWorkspace => 'Sélectionnez un espace dans votre espace de travail';
+
+  @override
+  String get noSpacesInWorkspace => 'Aucun espace trouvé dans cet espace de travail';
+
+  @override
+  String get defaultList => 'Liste par défaut';
+
+  @override
+  String get tasksAddedToList => 'Les tâches seront ajoutées à cette liste';
+
+  @override
+  String get noListsInSpace => 'Aucune liste trouvée dans cet espace';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Échec du chargement des dépôts : $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Dépôt par défaut enregistré';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Échec de l\'enregistrement du dépôt par défaut';
+
+  @override
+  String get defaultRepository => 'Dépôt par défaut';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Sélectionnez un dépôt par défaut pour créer des issues. Vous pouvez toujours spécifier un autre dépôt lors de la création d\'issues.';
+
+  @override
+  String get noReposFound => 'Aucun dépôt trouvé';
+
+  @override
+  String get private => 'Privé';
+
+  @override
+  String updatedDate(String date) {
+    return 'Mis à jour $date';
+  }
+
+  @override
+  String get yesterday => 'hier';
+
+  @override
+  String daysAgo(int count) {
+    return 'il y a $count jours';
+  }
+
+  @override
+  String get oneWeekAgo => 'il y a 1 semaine';
+
+  @override
+  String weeksAgo(int count) {
+    return 'il y a $count semaines';
+  }
+
+  @override
+  String get oneMonthAgo => 'il y a 1 mois';
+
+  @override
+  String monthsAgo(int count) {
+    return 'il y a $count mois';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Les issues seront créées dans votre dépôt par défaut';
+
+  @override
+  String get taskIntegrations => 'Intégrations de tâches';
+
+  @override
+  String get configureSettings => 'Configurer les paramètres';
+
+  @override
+  String get completeAuthBrowser =>
+      'Veuillez compléter l\'authentification dans votre navigateur. Une fois terminé, revenez à l\'application.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Échec du démarrage de l\'authentification $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Se connecter à $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Vous devrez autoriser Omi à créer des tâches dans votre compte $appName. Cela ouvrira votre navigateur pour l\'authentification.';
+  }
+
+  @override
+  String get continueButton => 'Continuer';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Intégration $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'L\'intégration avec $appName arrive bientôt ! Nous travaillons dur pour vous apporter plus d\'options de gestion des tâches.';
+  }
+
+  @override
+  String get gotIt => 'Compris';
+
+  @override
+  String get tasksExportedOneApp => 'Les tâches peuvent être exportées vers une seule application à la fois.';
+
+  @override
+  String get completeYourUpgrade => 'Complétez votre mise à niveau';
+
+  @override
+  String get importConfiguration => 'Importer la configuration';
+
+  @override
+  String get exportConfiguration => 'Exporter la configuration';
+
+  @override
+  String get bringYourOwn => 'Apportez le vôtre';
+
+  @override
+  String get payYourSttProvider => 'Utilisez Omi librement. Vous ne payez que votre fournisseur STT directement.';
+
+  @override
+  String get freeMinutesMonth => '1 200 minutes gratuites/mois incluses. Illimité avec ';
+
+  @override
+  String get omiUnlimited => 'Omi Illimité';
+
+  @override
+  String get hostRequired => 'L\'hôte est requis';
+
+  @override
+  String get validPortRequired => 'Un port valide est requis';
+
+  @override
+  String get validWebsocketUrlRequired => 'Une URL WebSocket valide est requise (wss://)';
+
+  @override
+  String get apiUrlRequired => 'L\'URL de l\'API est requise';
+
+  @override
+  String get apiKeyRequired => 'La clé API est requise';
+
+  @override
+  String get invalidJsonConfig => 'Configuration JSON invalide';
+
+  @override
+  String errorSaving(String error) {
+    return 'Erreur d\'enregistrement : $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Configuration copiée dans le presse-papiers';
+
+  @override
+  String get pasteJsonConfig => 'Collez votre configuration JSON ci-dessous :';
+
+  @override
+  String get addApiKeyAfterImport => 'Vous devrez ajouter votre propre clé API après l\'importation';
+
+  @override
+  String get paste => 'Coller';
+
+  @override
+  String get import => 'Importer';
+
+  @override
+  String get invalidProviderInConfig => 'Fournisseur invalide dans la configuration';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Configuration $providerName importée';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON invalide : $error';
+  }
+
+  @override
+  String get provider => 'Fournisseur';
+
+  @override
+  String get live => 'En direct';
+
+  @override
+  String get onDevice => 'Sur l\'appareil';
+
+  @override
+  String get apiUrl => 'URL de l\'API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Entrez votre point de terminaison HTTP STT';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Entrez votre point de terminaison WebSocket STT en direct';
+
+  @override
+  String get apiKey => 'Clé API';
+
+  @override
+  String get enterApiKey => 'Entrez votre clé API';
+
+  @override
+  String get storedLocallyNeverShared => 'Stocké localement, jamais partagé';
+
+  @override
+  String get host => 'Hôte';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Avancé';
+
+  @override
+  String get configuration => 'Configuration';
+
+  @override
+  String get requestConfiguration => 'Configuration de la requête';
+
+  @override
+  String get responseSchema => 'Schéma de réponse';
+
+  @override
+  String get modified => 'Modifié';
+
+  @override
+  String get resetRequestConfig => 'Réinitialiser la config de requête par défaut';
+
+  @override
+  String get logs => 'Journaux';
+
+  @override
+  String get logsCopied => 'Journaux copiés';
+
+  @override
+  String get noLogsYet => 'Pas encore de journaux. Commencez à enregistrer pour voir l\'activité STT personnalisée.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName utilise $codecReason. Omi sera utilisé.';
+  }
+
+  @override
+  String get omiTranscription => 'Transcription Omi';
+
+  @override
+  String get bestInClassTranscription => 'Transcription de premier ordre sans configuration';
+
+  @override
+  String get instantSpeakerLabels => 'Étiquettes de locuteur instantanées';
+
+  @override
+  String get languageTranslation => 'Traduction dans plus de 100 langues';
+
+  @override
+  String get optimizedForConversation => 'Optimisé pour la conversation';
+
+  @override
+  String get autoLanguageDetection => 'Détection automatique de la langue';
+
+  @override
+  String get highAccuracy => 'Haute précision';
+
+  @override
+  String get privacyFirst => 'Confidentialité d\'abord';
+
+  @override
+  String get saveChanges => 'Enregistrer les modifications';
+
+  @override
+  String get resetToDefault => 'Réinitialiser par défaut';
+
+  @override
+  String get viewTemplate => 'Voir le modèle';
+
+  @override
+  String get trySomethingLike => 'Essayez quelque chose comme...';
+
+  @override
+  String get tryIt => 'Essayer';
+
+  @override
+  String get creatingPlan => 'Création du plan';
+
+  @override
+  String get developingLogic => 'Développement de la logique';
+
+  @override
+  String get designingApp => 'Conception de l\'application';
+
+  @override
+  String get generatingIconStep => 'Génération de l\'icône';
+
+  @override
+  String get finalTouches => 'Touches finales';
+
+  @override
+  String get processing => 'Traitement...';
+
+  @override
+  String get features => 'Fonctionnalités';
+
+  @override
+  String get creatingYourApp => 'Création de votre application...';
+
+  @override
+  String get generatingIcon => 'Génération de l\'icône...';
+
+  @override
+  String get whatShouldWeMake => 'Que devrions-nous créer ?';
+
+  @override
+  String get appName => 'Nom de l\'application';
+
+  @override
+  String get description => 'Description';
+
+  @override
+  String get publicLabel => 'Public';
+
+  @override
+  String get privateLabel => 'Privé';
+
+  @override
+  String get free => 'Gratuit';
+
+  @override
+  String get perMonth => '/ Mois';
+
+  @override
+  String get tailoredConversationSummaries => 'Résumés de conversation personnalisés';
+
+  @override
+  String get customChatbotPersonality => 'Personnalité de chatbot personnalisée';
+
+  @override
+  String get makePublic => 'Rendre public';
+
+  @override
+  String get anyoneCanDiscover => 'N\'importe qui peut découvrir votre application';
+
+  @override
+  String get onlyYouCanUse => 'Vous seul pouvez utiliser cette application';
+
+  @override
+  String get paidApp => 'Application payante';
+
+  @override
+  String get usersPayToUse => 'Les utilisateurs paient pour utiliser votre application';
+
+  @override
+  String get freeForEveryone => 'Gratuit pour tous';
+
+  @override
+  String get perMonthLabel => '/ mois';
+
+  @override
+  String get creating => 'Création...';
+
+  @override
+  String get createApp => 'Créer l\'application';
+
+  @override
+  String get searchingForDevices => 'Recherche d\'appareils...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'APPAREILS',
+      one: 'APPAREIL',
+    );
+    return '$count $_temp0 TROUVÉ(S) À PROXIMITÉ';
+  }
+
+  @override
+  String get pairingSuccessful => 'APPAIRAGE RÉUSSI';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Erreur de connexion à l\'Apple Watch : $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Ne plus afficher';
+
+  @override
+  String get iUnderstand => 'Je comprends';
+
+  @override
+  String get enableBluetooth => 'Activer le Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi a besoin du Bluetooth pour se connecter à votre wearable. Veuillez activer le Bluetooth et réessayer.';
+
+  @override
+  String get contactSupport => 'Contacter le support ?';
+
+  @override
+  String get connectLater => 'Se connecter plus tard';
+
+  @override
+  String get grantPermissions => 'Accorder les autorisations';
+
+  @override
+  String get backgroundActivity => 'Activité en arrière-plan';
+
+  @override
+  String get backgroundActivityDesc => 'Laissez Omi fonctionner en arrière-plan pour une meilleure stabilité';
+
+  @override
+  String get locationAccess => 'Accès à la localisation';
+
+  @override
+  String get locationAccessDesc => 'Activez la localisation en arrière-plan pour l\'expérience complète';
+
+  @override
+  String get notifications => 'Notifications';
+
+  @override
+  String get notificationsDesc => 'Activez les notifications pour rester informé';
+
+  @override
+  String get locationServiceDisabled => 'Service de localisation désactivé';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Le service de localisation est désactivé. Veuillez aller dans Réglages > Confidentialité et sécurité > Services de localisation et l\'activer';
+
+  @override
+  String get backgroundLocationDenied => 'Accès à la localisation en arrière-plan refusé';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Veuillez aller dans les paramètres de l\'appareil et définir l\'autorisation de localisation sur « Toujours autoriser »';
+
+  @override
+  String get lovingOmi => 'Vous aimez Omi ?';
+
+  @override
+  String get leaveReviewIos =>
+      'Aidez-nous à atteindre plus de personnes en laissant un avis sur l\'App Store. Votre retour compte énormément pour nous !';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Aidez-nous à atteindre plus de personnes en laissant un avis sur le Google Play Store. Votre retour compte énormément pour nous !';
+
+  @override
+  String get rateOnAppStore => 'Noter sur l\'App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Noter sur Google Play';
+
+  @override
+  String get maybeLater => 'Peut-être plus tard';
+
+  @override
+  String get speechProfileIntro =>
+      'Omi doit apprendre vos objectifs et votre voix. Vous pourrez les modifier plus tard.';
+
+  @override
+  String get getStarted => 'Commencer';
+
+  @override
+  String get allDone => 'Terminé !';
+
+  @override
+  String get keepGoing => 'Continuez, vous vous en sortez très bien';
+
+  @override
+  String get skipThisQuestion => 'Passer cette question';
+
+  @override
+  String get skipForNow => 'Passer pour l\'instant';
+
+  @override
+  String get connectionError => 'Erreur de connexion';
+
+  @override
+  String get connectionErrorDesc =>
+      'Échec de la connexion au serveur. Veuillez vérifier votre connexion internet et réessayer.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Enregistrement invalide détecté';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Il semble y avoir plusieurs locuteurs dans l\'enregistrement. Veuillez vous assurer d\'être dans un endroit calme et réessayer.';
+
+  @override
+  String get tooShortDesc => 'Pas assez de parole détectée. Veuillez parler davantage et réessayer.';
+
+  @override
+  String get invalidRecordingDesc => 'Veuillez vous assurer de parler pendant au moins 5 secondes et pas plus de 90.';
+
+  @override
+  String get areYouThere => 'Êtes-vous là ?';
+
+  @override
+  String get noSpeechDesc =>
+      'Nous n\'avons pas pu détecter de parole. Veuillez vous assurer de parler pendant au moins 10 secondes et pas plus de 3 minutes.';
+
+  @override
+  String get connectionLost => 'Connexion perdue';
+
+  @override
+  String get connectionLostDesc =>
+      'La connexion a été interrompue. Veuillez vérifier votre connexion internet et réessayer.';
+
+  @override
+  String get tryAgain => 'Réessayer';
+
+  @override
+  String get connectOmiOmiGlass => 'Connecter Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Continuer sans appareil';
+
+  @override
+  String get permissionsRequired => 'Autorisations requises';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Cette application a besoin des autorisations Bluetooth et Localisation pour fonctionner correctement. Veuillez les activer dans les paramètres.';
+
+  @override
+  String get openSettings => 'Ouvrir les paramètres';
+
+  @override
+  String get wantDifferentName => 'Voulez-vous utiliser un autre nom ?';
+
+  @override
+  String get whatsYourName => 'Comment vous appelez-vous ?';
+
+  @override
+  String get speakTranscribeSummarize => 'Parlez. Transcrivez. Résumez.';
+
+  @override
+  String get signInWithApple => 'Se connecter avec Apple';
+
+  @override
+  String get signInWithGoogle => 'Se connecter avec Google';
+
+  @override
+  String get byContinuingAgree => 'En continuant, vous acceptez notre ';
+
+  @override
+  String get termsOfUse => 'Conditions d\'utilisation';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Votre compagnon IA';
+
+  @override
+  String get captureEveryMoment =>
+      'Capturez chaque moment. Obtenez des résumés\nalimentés par l\'IA. Ne prenez plus jamais de notes.';
+
+  @override
+  String get appleWatchSetup => 'Configuration Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Permission demandée !';
+
+  @override
+  String get microphonePermission => 'Permission du microphone';
+
+  @override
+  String get permissionGrantedNow =>
+      'Permission accordée ! Maintenant :\n\nOuvrez l\'application Omi sur votre montre et appuyez sur « Continuer » ci-dessous';
+
+  @override
+  String get needMicrophonePermission =>
+      'Nous avons besoin de la permission du microphone.\n\n1. Appuyez sur « Accorder la permission »\n2. Autorisez sur votre iPhone\n3. L\'application de la montre se fermera\n4. Rouvrez et appuyez sur « Continuer »';
+
+  @override
+  String get grantPermissionButton => 'Accorder la permission';
+
+  @override
+  String get needHelp => 'Besoin d\'aide ?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Dépannage :\n\n1. Assurez-vous qu\'Omi est installé sur votre montre\n2. Ouvrez l\'application Omi sur votre montre\n3. Recherchez la fenêtre de permission\n4. Appuyez sur « Autoriser » lorsque demandé\n5. L\'application sur votre montre se fermera - rouvrez-la\n6. Revenez et appuyez sur « Continuer » sur votre iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Enregistrement démarré avec succès !';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Permission non encore accordée. Veuillez vous assurer d\'avoir autorisé l\'accès au microphone et rouvert l\'application sur votre montre.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Erreur lors de la demande de permission : $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Erreur lors du démarrage de l\'enregistrement : $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Sélectionnez votre langue principale';
+
+  @override
+  String get languageBenefits =>
+      'Définissez votre langue pour des transcriptions plus précises et une expérience personnalisée';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Quelle est votre langue principale ?';
+
+  @override
+  String get selectYourLanguage => 'Sélectionnez votre langue';
+
+  @override
+  String get personalGrowthJourney =>
+      'Votre parcours de croissance personnelle avec une IA qui écoute chacun de vos mots.';
+
+  @override
+  String get actionItemsTitle => 'À faire';
+
+  @override
+  String get actionItemsDescription =>
+      'Appuyez pour modifier • Appui long pour sélectionner • Glissez pour les actions';
+
+  @override
+  String get tabToDo => 'À faire';
+
+  @override
+  String get tabDone => 'Terminé';
+
+  @override
+  String get tabOld => 'Ancien';
+
+  @override
+  String get emptyTodoMessage => '🎉 Tout est à jour !\nAucune action en attente';
+
+  @override
+  String get emptyDoneMessage => 'Aucun élément terminé pour le moment';
+
+  @override
+  String get emptyOldMessage => '✅ Aucune ancienne tâche';
+
+  @override
+  String get noItems => 'Aucun élément';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Action marquée comme incomplète';
+
+  @override
+  String get actionItemCompleted => 'Action terminée';
+
+  @override
+  String get deleteActionItemTitle => 'Supprimer l\'action';
+
+  @override
+  String get deleteActionItemMessage => 'Êtes-vous sûr de vouloir supprimer cette action ?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Supprimer les éléments sélectionnés';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Êtes-vous sûr de vouloir supprimer $count action(s) sélectionnée(s) ?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Action « $description » supprimée';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count action(s) supprimée(s)';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Échec de la suppression de l\'action';
+
+  @override
+  String get failedToDeleteItems => 'Échec de la suppression des éléments';
+
+  @override
+  String get failedToDeleteSomeItems => 'Échec de la suppression de certains éléments';
+
+  @override
+  String get welcomeActionItemsTitle => 'Prêt pour les actions';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Votre IA extraira automatiquement les tâches et les choses à faire de vos conversations. Elles apparaîtront ici une fois créées.';
+
+  @override
+  String get autoExtractionFeature => 'Extraites automatiquement des conversations';
+
+  @override
+  String get editSwipeFeature => 'Appuyez pour modifier, glissez pour terminer ou supprimer';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count sélectionné(s)';
+  }
+
+  @override
+  String get selectAll => 'Tout sélectionner';
+
+  @override
+  String get deleteSelected => 'Supprimer la sélection';
+
+  @override
+  String searchMemories(int count) {
+    return 'Rechercher $count mémoires';
+  }
+
+  @override
+  String get memoryDeleted => 'Mémoire supprimée.';
+
+  @override
+  String get undo => 'Annuler';
+
+  @override
+  String get noMemoriesYet => 'Pas encore de mémoires';
+
+  @override
+  String get noAutoMemories => 'Pas encore de mémoires extraites automatiquement';
+
+  @override
+  String get noManualMemories => 'Pas encore de mémoires manuelles';
+
+  @override
+  String get noMemoriesInCategories => 'Aucune mémoire dans ces catégories';
+
+  @override
+  String get noMemoriesFound => 'Aucune mémoire trouvée';
+
+  @override
+  String get addFirstMemory => 'Ajoutez votre première mémoire';
+
+  @override
+  String get clearMemoryTitle => 'Effacer la mémoire d\'Omi';
+
+  @override
+  String get clearMemoryMessage =>
+      'Êtes-vous sûr de vouloir effacer la mémoire d\'Omi ? Cette action est irréversible.';
+
+  @override
+  String get clearMemoryButton => 'Effacer la mémoire';
+
+  @override
+  String get memoryClearedSuccess => 'La mémoire d\'Omi vous concernant a été effacée';
+
+  @override
+  String get noMemoriesToDelete => 'Aucune mémoire à supprimer';
+
+  @override
+  String get createMemoryTooltip => 'Créer une nouvelle mémoire';
+
+  @override
+  String get createActionItemTooltip => 'Créer une nouvelle action';
+
+  @override
+  String get memoryManagement => 'Gestion des mémoires';
+
+  @override
+  String get filterMemories => 'Filtrer les mémoires';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Vous avez $count mémoires au total';
+  }
+
+  @override
+  String get publicMemories => 'Mémoires publiques';
+
+  @override
+  String get privateMemories => 'Mémoires privées';
+
+  @override
+  String get makeAllPrivate => 'Rendre toutes les mémoires privées';
+
+  @override
+  String get makeAllPublic => 'Rendre toutes les mémoires publiques';
+
+  @override
+  String get deleteAllMemories => 'Supprimer toutes les mémoires';
+
+  @override
+  String get allMemoriesPrivateResult => 'Toutes les mémoires sont maintenant privées';
+
+  @override
+  String get allMemoriesPublicResult => 'Toutes les mémoires sont maintenant publiques';
+
+  @override
+  String get newMemory => 'Nouvelle mémoire';
+
+  @override
+  String get editMemory => 'Modifier la mémoire';
+
+  @override
+  String get memoryContentHint => 'J\'aime manger des glaces...';
+
+  @override
+  String get failedToSaveMemory => 'Échec de l\'enregistrement. Veuillez vérifier votre connexion.';
+
+  @override
+  String get saveMemory => 'Enregistrer la mémoire';
+
+  @override
+  String get retry => 'Réessayer';
+
+  @override
+  String get createActionItem => 'Créer une action';
+
+  @override
+  String get editActionItem => 'Modifier l\'action';
+
+  @override
+  String get actionItemDescriptionHint => 'Que faut-il faire ?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'La description de l\'action ne peut pas être vide.';
+
+  @override
+  String get actionItemUpdated => 'Action mise à jour';
+
+  @override
+  String get failedToUpdateActionItem => 'Échec de la mise à jour de l\'action';
+
+  @override
+  String get actionItemCreated => 'Action créée';
+
+  @override
+  String get failedToCreateActionItem => 'Échec de la création de l\'action';
+
+  @override
+  String get dueDate => 'Date d\'échéance';
+
+  @override
+  String get time => 'Heure';
+
+  @override
+  String get addDueDate => 'Ajouter une date d\'échéance';
+
+  @override
+  String get pressDoneToSave => 'Appuyez sur Terminé pour enregistrer';
+
+  @override
+  String get pressDoneToCreate => 'Appuyez sur Terminé pour créer';
+
+  @override
+  String get filterAll => 'Tous';
+
+  @override
+  String get filterSystem => 'À propos de vous';
+
+  @override
+  String get filterInteresting => 'Aperçus';
+
+  @override
+  String get filterManual => 'Manuel';
+
+  @override
+  String get completed => 'Terminé';
+
+  @override
+  String get markComplete => 'Marquer comme terminé';
+
+  @override
+  String get actionItemDeleted => 'Action supprimée';
+
+  @override
+  String get failedToDeleteActionItem => 'Échec de la suppression de l\'action';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Supprimer l\'action';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Êtes-vous sûr de vouloir supprimer cette action ?';
+
+  @override
+  String get appLanguage => 'Langue de l\'application';
+
+  @override
+  String get appInterfaceSectionTitle => 'INTERFACE DE L\'APPLICATION';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'VOIX ET TRANSCRIPTION';
+
+  @override
+  String get languageSettingsHelperText =>
+      'La langue de l\'application modifie les menus et les boutons. La langue vocale affecte la transcription de vos enregistrements.';
+}

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -233,7 +233,7 @@ class AppLocalizationsHi extends AppLocalizations {
   String get searchConversations => 'बातचीत खोजें';
 
   @override
-  String selectedCount(int count) {
+  String selectedCount(int count, Object s) {
     return '$count चयनित';
   }
 
@@ -2163,10 +2163,10 @@ class AppLocalizationsHi extends AppLocalizations {
   String get filterAll => 'सभी';
 
   @override
-  String get filterSystem => 'About You';
+  String get filterSystem => 'आपके बारे में';
 
   @override
-  String get filterInteresting => 'Insights';
+  String get filterInteresting => 'अंतर्दृष्टि';
 
   @override
   String get filterManual => 'मैनुअल';
@@ -2191,4 +2191,14 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get appLanguage => 'ऐप भाषा';
+
+  @override
+  String get appInterfaceSectionTitle => 'ऐप इंटरफ़ेस';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'वाणी और ट्रांसक्रिप्शन';
+
+  @override
+  String get languageSettingsHelperText =>
+      'ऐप भाषा मेनू और बटन बदलती है। वाणी भाषा आपकी रिकॉर्डिंग के ट्रांसक्रिप्शन को प्रभावित करती है।';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -1,0 +1,2245 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Hungarian (`hu`).
+class AppLocalizationsHu extends AppLocalizations {
+  AppLocalizationsHu([String locale = 'hu']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Beszélgetés';
+
+  @override
+  String get transcriptTab => 'Átirat';
+
+  @override
+  String get actionItemsTab => 'Teendők';
+
+  @override
+  String get deleteConversationTitle => 'Beszélgetés törlése?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Biztosan törölni szeretnéd ezt a beszélgetést? Ez a művelet nem vonható vissza.';
+
+  @override
+  String get confirm => 'Megerősítés';
+
+  @override
+  String get cancel => 'Mégse';
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get delete => 'Törlés';
+
+  @override
+  String get add => 'Hozzáadás';
+
+  @override
+  String get update => 'Frissítés';
+
+  @override
+  String get save => 'Mentés';
+
+  @override
+  String get edit => 'Szerkesztés';
+
+  @override
+  String get close => 'Bezárás';
+
+  @override
+  String get clear => 'Törlés';
+
+  @override
+  String get copyTranscript => 'Átirat másolása';
+
+  @override
+  String get copySummary => 'Összefoglaló másolása';
+
+  @override
+  String get testPrompt => 'Prompt tesztelése';
+
+  @override
+  String get reprocessConversation => 'Beszélgetés újrafeldolgozása';
+
+  @override
+  String get deleteConversation => 'Beszélgetés törlése';
+
+  @override
+  String get contentCopied => 'Tartalom vágólapra másolva';
+
+  @override
+  String get failedToUpdateStarred => 'A csillagozás frissítése sikertelen.';
+
+  @override
+  String get conversationUrlNotShared => 'A beszélgetés URL-je nem volt megosztható.';
+
+  @override
+  String get errorProcessingConversation =>
+      'Hiba történt a beszélgetés feldolgozása során. Kérlek, próbáld újra később.';
+
+  @override
+  String get noInternetConnection => 'Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
+
+  @override
+  String get unableToDeleteConversation => 'Nem lehet törölni a beszélgetést';
+
+  @override
+  String get somethingWentWrong => 'Valami hiba történt! Kérlek, próbáld újra később.';
+
+  @override
+  String get copyErrorMessage => 'Hibaüzenet másolása';
+
+  @override
+  String get errorCopied => 'Hibaüzenet vágólapra másolva';
+
+  @override
+  String get remaining => 'Hátralévő';
+
+  @override
+  String get loading => 'Betöltés...';
+
+  @override
+  String get loadingDuration => 'Időtartam betöltése...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count másodperc';
+  }
+
+  @override
+  String get people => 'Személyek';
+
+  @override
+  String get addNewPerson => 'Új személy hozzáadása';
+
+  @override
+  String get editPerson => 'Személy szerkesztése';
+
+  @override
+  String get createPersonHint => 'Hozz létre egy új személyt, és tanítsd meg az Omi-t, hogy felismerje a beszédét is!';
+
+  @override
+  String get speechProfile => 'Beszédprofil';
+
+  @override
+  String sampleNumber(int number) {
+    return '$number. minta';
+  }
+
+  @override
+  String get settings => 'Beállítások';
+
+  @override
+  String get language => 'Nyelv';
+
+  @override
+  String get selectLanguage => 'Nyelv kiválasztása';
+
+  @override
+  String get deleting => 'Törlés...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
+
+  @override
+  String get failedToStartAuthentication => 'A hitelesítés indítása sikertelen';
+
+  @override
+  String get importStarted => 'Az importálás elkezdődött! Értesítünk, amikor befejeződik.';
+
+  @override
+  String get failedToStartImport => 'Az importálás indítása sikertelen. Kérlek, próbáld újra.';
+
+  @override
+  String get couldNotAccessFile => 'Nem sikerült hozzáférni a kiválasztott fájlhoz';
+
+  @override
+  String get askOmi => 'Kérdezd Omi-t';
+
+  @override
+  String get done => 'Kész';
+
+  @override
+  String get disconnected => 'Leválasztva';
+
+  @override
+  String get searching => 'Keresés';
+
+  @override
+  String get connectDevice => 'Eszköz csatlakoztatása';
+
+  @override
+  String get monthlyLimitReached => 'Elérted a havi keretet.';
+
+  @override
+  String get checkUsage => 'Használat ellenőrzése';
+
+  @override
+  String get syncingRecordings => 'Felvételek szinkronizálása';
+
+  @override
+  String get recordingsToSync => 'Szinkronizálandó felvételek';
+
+  @override
+  String get allCaughtUp => 'Minden naprakész';
+
+  @override
+  String get sync => 'Szinkronizálás';
+
+  @override
+  String get pendantUpToDate => 'A medál naprakész';
+
+  @override
+  String get allRecordingsSynced => 'Minden felvétel szinkronizálva';
+
+  @override
+  String get syncingInProgress => 'Szinkronizálás folyamatban';
+
+  @override
+  String get readyToSync => 'Készen áll a szinkronizálásra';
+
+  @override
+  String get tapSyncToStart => 'Érintsd meg a Szinkronizálást az indításhoz';
+
+  @override
+  String get pendantNotConnected => 'A medál nincs csatlakoztatva. Csatlakoztasd a szinkronizáláshoz.';
+
+  @override
+  String get everythingSynced => 'Minden már szinkronizálva van.';
+
+  @override
+  String get recordingsNotSynced => 'Vannak még szinkronizálatlan felvételeid.';
+
+  @override
+  String get syncingBackground => 'Folytatjuk a felvételek szinkronizálását a háttérben.';
+
+  @override
+  String get noConversationsYet => 'Még nincsenek beszélgetések.';
+
+  @override
+  String get noStarredConversations => 'Még nincsenek csillagozott beszélgetések.';
+
+  @override
+  String get starConversationHint =>
+      'Beszélgetés csillagozásához nyisd meg, és érintsd meg a csillag ikont a fejlécben.';
+
+  @override
+  String get searchConversations => 'Beszélgetések keresése';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count kiválasztva';
+  }
+
+  @override
+  String get merge => 'Összevonás';
+
+  @override
+  String get mergeConversations => 'Beszélgetések összevonása';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Ez $count beszélgetést egyesít egybe. Minden tartalom összevonásra és újragenerálásra kerül.';
+  }
+
+  @override
+  String get mergingInBackground => 'Összevonás a háttérben. Ez eltarthat egy pillanatig.';
+
+  @override
+  String get failedToStartMerge => 'Az összevonás indítása sikertelen';
+
+  @override
+  String get askAnything => 'Kérdezz bármit';
+
+  @override
+  String get noMessagesYet => 'Még nincsenek üzenetek!\nMiért nem kezdesz egy beszélgetést?';
+
+  @override
+  String get deletingMessages => 'Üzenetek törlése az Omi memóriájából...';
+
+  @override
+  String get messageCopied => 'Üzenet vágólapra másolva.';
+
+  @override
+  String get cannotReportOwnMessage => 'Nem jelentheted be a saját üzeneteidet.';
+
+  @override
+  String get reportMessage => 'Üzenet bejelentése';
+
+  @override
+  String get reportMessageConfirm => 'Biztosan be szeretnéd jelenteni ezt az üzenetet?';
+
+  @override
+  String get messageReported => 'Üzenet sikeresen bejelentve.';
+
+  @override
+  String get thankYouFeedback => 'Köszönjük a visszajelzést!';
+
+  @override
+  String get clearChat => 'Csevegés törlése?';
+
+  @override
+  String get clearChatConfirm => 'Biztosan törölni szeretnéd a csevegést? Ez a művelet nem vonható vissza.';
+
+  @override
+  String get maxFilesLimit => 'Egyszerre csak 4 fájlt tölthetsz fel';
+
+  @override
+  String get chatWithOmi => 'Csevegés Omi-val';
+
+  @override
+  String get apps => 'Alkalmazások';
+
+  @override
+  String get noAppsFound => 'Nem találhatók alkalmazások';
+
+  @override
+  String get tryAdjustingSearch => 'Próbáld módosítani a keresést vagy a szűrőket';
+
+  @override
+  String get createYourOwnApp => 'Saját alkalmazás létrehozása';
+
+  @override
+  String get buildAndShareApp => 'Építsd meg és oszd meg egyedi alkalmazásodat';
+
+  @override
+  String get searchApps => 'Keresés 1500+ alkalmazás között';
+
+  @override
+  String get myApps => 'Saját alkalmazások';
+
+  @override
+  String get installedApps => 'Telepített alkalmazások';
+
+  @override
+  String get unableToFetchApps =>
+      'Nem sikerült betölteni az alkalmazásokat :(\n\nKérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
+
+  @override
+  String get aboutOmi => 'Az Omi-ról';
+
+  @override
+  String get privacyPolicy => 'Adatvédelmi szabályzatot';
+
+  @override
+  String get visitWebsite => 'Weboldal meglátogatása';
+
+  @override
+  String get helpOrInquiries => 'Segítség vagy kérdések?';
+
+  @override
+  String get joinCommunity => 'Csatlakozz a közösséghez!';
+
+  @override
+  String get membersAndCounting => '8000+ tag és még mindig nő.';
+
+  @override
+  String get deleteAccountTitle => 'Fiók törlése';
+
+  @override
+  String get deleteAccountConfirm => 'Biztosan törölni szeretnéd a fiókodat?';
+
+  @override
+  String get cannotBeUndone => 'Ez nem vonható vissza.';
+
+  @override
+  String get allDataErased => 'Minden emléked és beszélgetésed véglegesen törlésre kerül.';
+
+  @override
+  String get appsDisconnected => 'Alkalmazásaid és integrációid azonnal leválasztásra kerülnek.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Exportálhatod az adataidat a fiók törlése előtt, de törlés után nem állítható vissza.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Megértettem, hogy a fiókom törlése végleges, és minden adat, beleértve az emlékeket és beszélgetéseket, elvész és nem állítható vissza.';
+
+  @override
+  String get areYouSure => 'Biztos vagy benne?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Ez a művelet visszafordíthatatlan, és véglegesen törli a fiókodat és minden kapcsolódó adatot. Biztosan folytatni szeretnéd?';
+
+  @override
+  String get deleteNow => 'Törlés most';
+
+  @override
+  String get goBack => 'Vissza';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Jelöld be a négyzetet, hogy megerősítsd, megértetted, hogy a fiókod törlése végleges és visszafordíthatatlan.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Név';
+
+  @override
+  String get email => 'E-mail';
+
+  @override
+  String get customVocabulary => 'Egyedi szókincs';
+
+  @override
+  String get identifyingOthers => 'Mások azonosítása';
+
+  @override
+  String get paymentMethods => 'Fizetési módok';
+
+  @override
+  String get conversationDisplay => 'Beszélgetés megjelenítése';
+
+  @override
+  String get dataPrivacy => 'Adatok és adatvédelem';
+
+  @override
+  String get userId => 'Felhasználói azonosító';
+
+  @override
+  String get notSet => 'Nincs beállítva';
+
+  @override
+  String get userIdCopied => 'Felhasználói azonosító vágólapra másolva';
+
+  @override
+  String get systemDefault => 'Rendszer alapértelmezett';
+
+  @override
+  String get planAndUsage => 'Előfizetés és használat';
+
+  @override
+  String get offlineSync => 'Offline szinkronizálás';
+
+  @override
+  String get deviceSettings => 'Eszköz beállításai';
+
+  @override
+  String get chatTools => 'Csevegés eszközök';
+
+  @override
+  String get feedbackBug => 'Visszajelzés / hiba';
+
+  @override
+  String get helpCenter => 'Súgó központ';
+
+  @override
+  String get developerSettings => 'Fejlesztői beállítások';
+
+  @override
+  String get getOmiForMac => 'Szerezd be az Omi-t Mac-re';
+
+  @override
+  String get referralProgram => 'Ajánlói program';
+
+  @override
+  String get signOut => 'Kijelentkezés';
+
+  @override
+  String get appAndDeviceCopied => 'Alkalmazás és eszköz részletei másolva';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Adatvédelem, saját ellenőrzésed alatt';
+
+  @override
+  String get privacyIntro =>
+      'Az Omi-nál elkötelezettek vagyunk az adatvédelem iránt. Ez az oldal lehetővé teszi az adataid tárolásának és felhasználásának szabályozását.';
+
+  @override
+  String get learnMore => 'További információ...';
+
+  @override
+  String get dataProtectionLevel => 'Adatvédelmi szint';
+
+  @override
+  String get dataProtectionDesc =>
+      'Az adataid alapértelmezetten erős titkosítással védettek. Tekintsd át a beállításaidat és a jövőbeli adatvédelmi lehetőségeket alább.';
+
+  @override
+  String get appAccess => 'Alkalmazás hozzáférés';
+
+  @override
+  String get appAccessDesc =>
+      'A következő alkalmazások férhetnek hozzá az adataidhoz. Érintsd meg az alkalmazást az engedélyek kezeléséhez.';
+
+  @override
+  String get noAppsExternalAccess => 'Egyik telepített alkalmazás sem rendelkezik külső hozzáféréssel az adataidhoz.';
+
+  @override
+  String get deviceName => 'Eszköz neve';
+
+  @override
+  String get deviceId => 'Eszköz azonosító';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'SD kártya szinkronizálás';
+
+  @override
+  String get hardwareRevision => 'Hardver verzió';
+
+  @override
+  String get modelNumber => 'Modellszám';
+
+  @override
+  String get manufacturer => 'Gyártó';
+
+  @override
+  String get doubleTap => 'Dupla érintés';
+
+  @override
+  String get ledBrightness => 'LED fényerő';
+
+  @override
+  String get micGain => 'Mikrofon erősítés';
+
+  @override
+  String get disconnect => 'Leválasztás';
+
+  @override
+  String get forgetDevice => 'Eszköz elfelejtése';
+
+  @override
+  String get chargingIssues => 'Töltési problémák';
+
+  @override
+  String get disconnectDevice => 'Eszköz leválasztása';
+
+  @override
+  String get unpairDevice => 'Eszköz párosításának megszüntetése';
+
+  @override
+  String get unpairAndForget => 'Párosítás megszüntetése és elfelejtés';
+
+  @override
+  String get deviceDisconnectedMessage => 'Az Omi leválasztásra került 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Eszköz párosítása megszüntetve. Menj a Beállítások > Bluetooth menübe, és felejtsd el az eszközt a folyamat befejezéséhez.';
+
+  @override
+  String get unpairDialogTitle => 'Eszköz párosításának megszüntetése';
+
+  @override
+  String get unpairDialogMessage =>
+      'Ez megszünteti az eszköz párosítását, így másik telefonhoz csatlakoztatható. Menned kell a Beállítások > Bluetooth menübe, és el kell felejtened az eszközt a folyamat befejezéséhez.';
+
+  @override
+  String get deviceNotConnected => 'Eszköz nincs csatlakoztatva';
+
+  @override
+  String get connectDeviceMessage =>
+      'Csatlakoztasd az Omi eszközödet az eszköz\nbeállítások és testreszabás eléréséhez';
+
+  @override
+  String get deviceInfoSection => 'Eszköz információk';
+
+  @override
+  String get customizationSection => 'Testreszabás';
+
+  @override
+  String get hardwareSection => 'Hardver';
+
+  @override
+  String get v2Undetected => 'V2 nem észlelhető';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Úgy látjuk, hogy vagy V1 eszközöd van, vagy az eszközöd nincs csatlakoztatva. Az SD kártya funkció csak V2 eszközökön érhető el.';
+
+  @override
+  String get endConversation => 'Beszélgetés befejezése';
+
+  @override
+  String get pauseResume => 'Szünet/folytatás';
+
+  @override
+  String get starConversation => 'Beszélgetés csillagozása';
+
+  @override
+  String get doubleTapAction => 'Dupla érintés művelet';
+
+  @override
+  String get endAndProcess => 'Beszélgetés befejezése és feldolgozása';
+
+  @override
+  String get pauseResumeRecording => 'Felvétel szüneteltetése/folytatása';
+
+  @override
+  String get starOngoing => 'Folyamatban lévő beszélgetés csillagozása';
+
+  @override
+  String get off => 'Ki';
+
+  @override
+  String get max => 'Maximum';
+
+  @override
+  String get mute => 'Némítás';
+
+  @override
+  String get quiet => 'Halk';
+
+  @override
+  String get normal => 'Normál';
+
+  @override
+  String get high => 'Magas';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon némítva';
+
+  @override
+  String get micGainDescLow => 'Nagyon halk - zajos környezethez';
+
+  @override
+  String get micGainDescModerate => 'Halk - közepes zajhoz';
+
+  @override
+  String get micGainDescNeutral => 'Semleges - kiegyensúlyozott felvétel';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Enyhén felerősített - normál használat';
+
+  @override
+  String get micGainDescBoosted => 'Felerősített - csendes környezethez';
+
+  @override
+  String get micGainDescHigh => 'Magas - távoli vagy halk hangokhoz';
+
+  @override
+  String get micGainDescVeryHigh => 'Nagyon magas - nagyon csendes forrásokhoz';
+
+  @override
+  String get micGainDescMax => 'Maximum - óvatosan használd';
+
+  @override
+  String get developerSettingsTitle => 'Fejlesztői beállítások';
+
+  @override
+  String get saving => 'Mentés...';
+
+  @override
+  String get personaConfig => 'AI személyiség beállítása';
+
+  @override
+  String get beta => 'BÉTA';
+
+  @override
+  String get transcription => 'Átírás';
+
+  @override
+  String get transcriptionConfig => 'STT szolgáltató beállítása';
+
+  @override
+  String get conversationTimeout => 'Beszélgetés időkorlátja';
+
+  @override
+  String get conversationTimeoutConfig => 'Beszélgetések automatikus befejezésének beállítása';
+
+  @override
+  String get importData => 'Adatok importálása';
+
+  @override
+  String get importDataConfig => 'Adatok importálása más forrásokból';
+
+  @override
+  String get debugDiagnostics => 'Hibakeresés és diagnosztika';
+
+  @override
+  String get endpointUrl => 'Végpont URL';
+
+  @override
+  String get noApiKeys => 'Még nincsenek API kulcsok';
+
+  @override
+  String get createKeyToStart => 'Hozz létre egy kulcsot a kezdéshez';
+
+  @override
+  String get createKey => 'Kulcs létrehozása';
+
+  @override
+  String get docs => 'Dokumentáció';
+
+  @override
+  String get yourOmiInsights => 'Omi statisztikáid';
+
+  @override
+  String get today => 'Ma';
+
+  @override
+  String get thisMonth => 'Ez a hónap';
+
+  @override
+  String get thisYear => 'Ez az év';
+
+  @override
+  String get allTime => 'Minden idők';
+
+  @override
+  String get noActivityYet => 'Még nincs aktivitás';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Kezdj egy beszélgetést Omi-val,\nhogy itt lásd a használati statisztikáidat.';
+
+  @override
+  String get listening => 'Figyelés';
+
+  @override
+  String get listeningSubtitle => 'Az összes idő, amit az Omi aktívan figyelt.';
+
+  @override
+  String get understanding => 'Megértés';
+
+  @override
+  String get understandingSubtitle => 'A beszélgetéseidből megértett szavak.';
+
+  @override
+  String get providing => 'Nyújtás';
+
+  @override
+  String get providingSubtitle => 'Automatikusan rögzített teendők és jegyzetek.';
+
+  @override
+  String get remembering => 'Emlékezés';
+
+  @override
+  String get rememberingSubtitle => 'Számodra megjegyzett tények és részletek.';
+
+  @override
+  String get unlimitedPlan => 'Korlátlan csomag';
+
+  @override
+  String get managePlan => 'Csomag kezelése';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Előfizetésed $date-án megszűnik.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Előfizetésed $date-án megújul.';
+  }
+
+  @override
+  String get basicPlan => 'Ingyenes csomag';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used / $limit perc felhasználva';
+  }
+
+  @override
+  String get upgrade => 'Frissítés';
+
+  @override
+  String get upgradeToUnlimited => 'Frissítés korlátlanra';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Csomagod $limit ingyenes percet tartalmaz havonta. Frissíts a korlátlan használathoz.';
+  }
+
+  @override
+  String get shareStatsMessage =>
+      'Megosztom az Omi statisztikáimat! (omi.me - mindig rendelkezésre álló AI asszisztensed)';
+
+  @override
+  String get sharePeriodToday => 'Ma az omi:';
+
+  @override
+  String get sharePeriodMonth => 'Ebben a hónapban az omi:';
+
+  @override
+  String get sharePeriodYear => 'Ebben az évben az omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Eddig az omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 $minutes percet figyelt';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 $words szót megértett';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ $count betekintést nyújtott';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 $count emléket jegyzett meg';
+  }
+
+  @override
+  String get debugLogs => 'Hibakeresési naplók';
+
+  @override
+  String get debugLogsAutoDelete => 'Automatikus törlés 3 nap után.';
+
+  @override
+  String get debugLogsDesc => 'Segít a problémák diagnosztizálásában';
+
+  @override
+  String get noLogFilesFound => 'Nem találhatók naplófájlok.';
+
+  @override
+  String get omiDebugLog => 'Omi hibakeresési napló';
+
+  @override
+  String get logShared => 'Napló megosztva';
+
+  @override
+  String get selectLogFile => 'Naplófájl kiválasztása';
+
+  @override
+  String get shareLogs => 'Naplók megosztása';
+
+  @override
+  String get debugLogCleared => 'Hibakeresési napló törölve';
+
+  @override
+  String get exportStarted => 'Exportálás elkezdődött. Ez eltarthat néhány másodpercig...';
+
+  @override
+  String get exportAllData => 'Minden adat exportálása';
+
+  @override
+  String get exportDataDesc => 'Beszélgetések exportálása JSON fájlba';
+
+  @override
+  String get exportedConversations => 'Exportált beszélgetések az Omi-ból';
+
+  @override
+  String get exportShared => 'Exportálás megosztva';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Tudásgráf törlése?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Ez törli az összes származtatott tudásgráf adatot (csomópontok és kapcsolatok). Az eredeti emlékeid biztonságban maradnak. A gráf idővel vagy a következő kérésre újjáépül.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Tudásgráf sikeresen törölve';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Gráf törlése sikertelen: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Tudásgráf törlése';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Összes csomópont és kapcsolat törlése';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP szerver';
+
+  @override
+  String get mcpServerDesc => 'AI asszisztensek csatlakoztatása az adataidhoz';
+
+  @override
+  String get serverUrl => 'Szerver URL';
+
+  @override
+  String get urlCopied => 'URL másolva';
+
+  @override
+  String get apiKeyAuth => 'API kulcs hitelesítés';
+
+  @override
+  String get header => 'Fejléc';
+
+  @override
+  String get authorizationBearer => 'Engedélyezés: Bearer <kulcs>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Kliens azonosító';
+
+  @override
+  String get clientSecret => 'Kliens titok';
+
+  @override
+  String get useMcpApiKey => 'Használd az MCP API kulcsodat';
+
+  @override
+  String get webhooks => 'Webhookok';
+
+  @override
+  String get conversationEvents => 'Beszélgetés események';
+
+  @override
+  String get newConversationCreated => 'Új beszélgetés létrehozva';
+
+  @override
+  String get realtimeTranscript => 'Valós idejű átirat';
+
+  @override
+  String get transcriptReceived => 'Átirat fogadva';
+
+  @override
+  String get audioBytes => 'Hang byte-ok';
+
+  @override
+  String get audioDataReceived => 'Hangadatok fogadva';
+
+  @override
+  String get intervalSeconds => 'Időköz (másodperc)';
+
+  @override
+  String get daySummary => 'Napi összefoglaló';
+
+  @override
+  String get summaryGenerated => 'Összefoglaló generálva';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Hozzáadás claude_desktop_config.json-hoz';
+
+  @override
+  String get copyConfig => 'Konfiguráció másolása';
+
+  @override
+  String get configCopied => 'Konfiguráció vágólapra másolva';
+
+  @override
+  String get listeningMins => 'Figyelés (perc)';
+
+  @override
+  String get understandingWords => 'Megértés (szavak)';
+
+  @override
+  String get insights => 'Betekintések';
+
+  @override
+  String get memories => 'Emlékek';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used / $limit perc felhasználva ebben a hónapban';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used / $limit szó felhasználva ebben a hónapban';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used / $limit betekintés nyerve ebben a hónapban';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used / $limit emlék létrehozva ebben a hónapban';
+  }
+
+  @override
+  String get visibility => 'Láthatóság';
+
+  @override
+  String get visibilitySubtitle => 'Szabályozd, mely beszélgetések jelenjenek meg a listában';
+
+  @override
+  String get showShortConversations => 'Rövid beszélgetések megjelenítése';
+
+  @override
+  String get showShortConversationsDesc => 'Küszöbértéknél rövidebb beszélgetések megjelenítése';
+
+  @override
+  String get showDiscardedConversations => 'Elvetett beszélgetések megjelenítése';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Elvetettként megjelölt beszélgetések hozzáadása';
+
+  @override
+  String get shortConversationThreshold => 'Rövid beszélgetés küszöbérték';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Ennél rövidebb beszélgetések el lesznek rejtve, ha fent nincs engedélyezve';
+
+  @override
+  String get durationThreshold => 'Időtartam küszöbérték';
+
+  @override
+  String get durationThresholdDesc => 'Ennél rövidebb beszélgetések elrejtése';
+
+  @override
+  String minLabel(int count) {
+    return '$count perc';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Egyedi szókincs';
+
+  @override
+  String get addWords => 'Szavak hozzáadása';
+
+  @override
+  String get addWordsDesc => 'Nevek, kifejezések vagy ritka szavak';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Csatlakozás';
+
+  @override
+  String get comingSoon => 'Hamarosan';
+
+  @override
+  String get chatToolsFooter =>
+      'Csatlakoztasd az alkalmazásaidat az adatok és metrikák megjelenítéséhez a csevegésben.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return '$appName hitelesítés indítása sikertelen';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return '$appName leválasztása?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Biztosan leválasztod a(z) $appName-t? Bármikor újracsatlakozthatsz.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return '$appName-től leválasztva';
+  }
+
+  @override
+  String get failedToDisconnect => 'Leválasztás sikertelen';
+
+  @override
+  String connectTo(String appName) {
+    return 'Csatlakozás: $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Engedélyezned kell az Omi-nak, hogy hozzáférjen a(z) $appName adataidhoz. Ez megnyitja a böngésződ a hitelesítéshez.';
+  }
+
+  @override
+  String get continueAction => 'Folytatás';
+
+  @override
+  String get languageTitle => 'Nyelv';
+
+  @override
+  String get primaryLanguage => 'Elsődleges nyelv';
+
+  @override
+  String get automaticTranslation => 'Automatikus fordítás';
+
+  @override
+  String get detectLanguages => '10+ nyelv érzékelése';
+
+  @override
+  String get authorizeSavingRecordings => 'Felvételek mentésének engedélyezése';
+
+  @override
+  String get thanksForAuthorizing => 'Köszönjük az engedélyezést!';
+
+  @override
+  String get needYourPermission => 'Szükségünk van az engedélyedre';
+
+  @override
+  String get alreadyGavePermission =>
+      'Már engedélyezted a felvételeid mentését. Itt egy emlékeztető, hogy miért van erre szükségünk:';
+
+  @override
+  String get wouldLikePermission =>
+      'Szeretnénk az engedélyedet kérni a hangfelvételeid mentéséhez. Itt van, hogy miért:';
+
+  @override
+  String get improveSpeechProfile => 'Beszédprofil fejlesztése';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'A felvételeket használjuk a személyes beszédprofilod további tanítására és fejlesztésére.';
+
+  @override
+  String get trainFamilyProfiles => 'Profilok tanítása barátoknak és családtagoknak';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'A felvételeid segítenek felismerni és profilokat létrehozni a barátaidnak és családtagjaidnak.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Átirat pontosságának növelése';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Ahogy a modellünk fejlődik, jobb átírási eredményeket tudunk biztosítani a felvételeidhez.';
+
+  @override
+  String get legalNotice =>
+      'Jogi közlemény: A hangadatok rögzítésének és tárolásának jogszerűsége a tartózkodási helyedtől és a funkció használatától függően változhat. A helyi törvényeknek és szabályozásoknak való megfelelés a te felelősséged.';
+
+  @override
+  String get alreadyAuthorized => 'Már engedélyezve';
+
+  @override
+  String get authorize => 'Engedélyezés';
+
+  @override
+  String get revokeAuthorization => 'Engedély visszavonása';
+
+  @override
+  String get authorizationSuccessful => 'Engedélyezés sikeres!';
+
+  @override
+  String get failedToAuthorize => 'Engedélyezés sikertelen. Kérlek, próbáld újra.';
+
+  @override
+  String get authorizationRevoked => 'Engedély visszavonva.';
+
+  @override
+  String get recordingsDeleted => 'Felvételek törölve.';
+
+  @override
+  String get failedToRevoke => 'Engedély visszavonása sikertelen. Kérlek, próbáld újra.';
+
+  @override
+  String get permissionRevokedTitle => 'Engedély visszavonva';
+
+  @override
+  String get permissionRevokedMessage => 'Szeretnéd, hogy az összes meglévő felvételedet is töröljük?';
+
+  @override
+  String get yes => 'Igen';
+
+  @override
+  String get editName => 'Név szerkesztése';
+
+  @override
+  String get howShouldOmiCallYou => 'Hogyan szólítson az Omi?';
+
+  @override
+  String get enterYourName => 'Add meg a neved';
+
+  @override
+  String get nameCannotBeEmpty => 'A név nem lehet üres';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Név sikeresen frissítve!';
+
+  @override
+  String get calendarSettings => 'Naptár beállítások';
+
+  @override
+  String get calendarProviders => 'Naptár szolgáltatók';
+
+  @override
+  String get macOsCalendar => 'macOS naptár';
+
+  @override
+  String get connectMacOsCalendar => 'Helyi macOS naptár csatlakoztatása';
+
+  @override
+  String get googleCalendar => 'Google naptár';
+
+  @override
+  String get syncGoogleAccount => 'Szinkronizálás Google fiókoddal';
+
+  @override
+  String get showMeetingsMenuBar => 'Közelgő találkozók megjelenítése a menüsorban';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'A következő találkozód és a kezdésig hátralévő idő megjelenítése a macOS menüsorban';
+
+  @override
+  String get showEventsNoParticipants => 'Résztvevők nélküli események megjelenítése';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Ha engedélyezve van, a Közelgő események résztvevők vagy videó link nélküli eseményeket is mutat.';
+
+  @override
+  String get yourMeetings => 'Találkozóid';
+
+  @override
+  String get refresh => 'Frissítés';
+
+  @override
+  String get noUpcomingMeetings => 'Nem találhatók közelgő találkozók';
+
+  @override
+  String get checkingNextDays => 'Következő 30 nap ellenőrzése';
+
+  @override
+  String get tomorrow => 'Holnap';
+
+  @override
+  String get googleCalendarComingSoon => 'Google naptár integráció hamarosan!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Csatlakozva mint felhasználó: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Alapértelmezett munkaterület';
+
+  @override
+  String get tasksCreatedInWorkspace => 'A feladatok ebben a munkaterületen lesznek létrehozva';
+
+  @override
+  String get defaultProjectOptional => 'Alapértelmezett projekt (opcionális)';
+
+  @override
+  String get leaveUnselectedTasks => 'Hagyd kiválasztatlanul projekt nélküli feladatok létrehozásához';
+
+  @override
+  String get noProjectsInWorkspace => 'Nem találhatók projektek ebben a munkaterületen';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Válaszd ki, mennyi ideig várjon csendben a beszélgetés automatikus befejezése előtt:';
+
+  @override
+  String get timeout2Minutes => '2 perc';
+
+  @override
+  String get timeout2MinutesDesc => 'Beszélgetés befejezése 2 perc csend után';
+
+  @override
+  String get timeout5Minutes => '5 perc';
+
+  @override
+  String get timeout5MinutesDesc => 'Beszélgetés befejezése 5 perc csend után';
+
+  @override
+  String get timeout10Minutes => '10 perc';
+
+  @override
+  String get timeout10MinutesDesc => 'Beszélgetés befejezése 10 perc csend után';
+
+  @override
+  String get timeout30Minutes => '30 perc';
+
+  @override
+  String get timeout30MinutesDesc => 'Beszélgetés befejezése 30 perc csend után';
+
+  @override
+  String get timeout4Hours => '4 óra';
+
+  @override
+  String get timeout4HoursDesc => 'Beszélgetés befejezése 4 óra csend után';
+
+  @override
+  String get conversationEndAfterHours => 'A beszélgetések mostantól 4 óra csend után végződnek';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'A beszélgetések mostantól $minutes perc csend után végződnek';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Add meg az elsődleges nyelvedet';
+
+  @override
+  String get languageForTranscription => 'Állítsd be a nyelvedet a pontosabb átíráshoz és személyre szabott élményhez.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Egynyelvű mód engedélyezve. A fordítás ki van kapcsolva a nagyobb pontosság érdekében.';
+
+  @override
+  String get searchLanguageHint => 'Keress nyelvet név vagy kód alapján';
+
+  @override
+  String get noLanguagesFound => 'Nem találhatók nyelvek';
+
+  @override
+  String get skip => 'Kihagyás';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Nyelv beállítva: $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Nyelv beállítása sikertelen';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName beállítások';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return '$appName leválasztása?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Ez eltávolítja a(z) $appName hitelesítésedet. Újra kell csatlakoznod a használathoz.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Csatlakozva: $appName';
+  }
+
+  @override
+  String get account => 'Fiók';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'A teendőid szinkronizálva lesznek a(z) $appName fiókodhoz';
+  }
+
+  @override
+  String get defaultSpace => 'Alapértelmezett terület';
+
+  @override
+  String get selectSpaceInWorkspace => 'Válassz egy területet a munkaterületen';
+
+  @override
+  String get noSpacesInWorkspace => 'Nem találhatók területek ebben a munkaterületen';
+
+  @override
+  String get defaultList => 'Alapértelmezett lista';
+
+  @override
+  String get tasksAddedToList => 'A feladatok ehhez a listához lesznek hozzáadva';
+
+  @override
+  String get noListsInSpace => 'Nem találhatók listák ezen a területen';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Tárolók betöltése sikertelen: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Alapértelmezett tároló mentve';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Alapértelmezett tároló mentése sikertelen';
+
+  @override
+  String get defaultRepository => 'Alapértelmezett tároló';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Válassz egy alapértelmezett tárolót a problémák létrehozásához. Problémák létrehozásakor továbbra is megadhatsz másik tárolót.';
+
+  @override
+  String get noReposFound => 'Nem találhatók tárolók';
+
+  @override
+  String get private => 'Privát';
+
+  @override
+  String updatedDate(String date) {
+    return 'Frissítve: $date';
+  }
+
+  @override
+  String get yesterday => 'tegnap';
+
+  @override
+  String daysAgo(int count) {
+    return '$count napja';
+  }
+
+  @override
+  String get oneWeekAgo => '1 hete';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count hete';
+  }
+
+  @override
+  String get oneMonthAgo => '1 hónapja';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count hónapja';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'A problémák az alapértelmezett tárolódban lesznek létrehozva';
+
+  @override
+  String get taskIntegrations => 'Feladat integrációk';
+
+  @override
+  String get configureSettings => 'Beállítások konfigurálása';
+
+  @override
+  String get completeAuthBrowser =>
+      'Kérlek, fejezd be a hitelesítést a böngésződben. Ha kész, térj vissza az alkalmazásba.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return '$appName hitelesítés indítása sikertelen';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Csatlakozás: $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Engedélyezned kell az Omi-nak, hogy feladatokat hozzon létre a(z) $appName fiókodban. Ez megnyitja a böngésződ a hitelesítéshez.';
+  }
+
+  @override
+  String get continueButton => 'Folytatás';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName integráció';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'A(z) $appName integrációja hamarosan! Keményen dolgozunk, hogy több feladatkezelési lehetőséget hozzunk.';
+  }
+
+  @override
+  String get gotIt => 'Értem';
+
+  @override
+  String get tasksExportedOneApp => 'A feladatok egyszerre csak egy alkalmazásba exportálhatók.';
+
+  @override
+  String get completeYourUpgrade => 'Fejezd be a frissítést';
+
+  @override
+  String get importConfiguration => 'Konfiguráció importálása';
+
+  @override
+  String get exportConfiguration => 'Konfiguráció exportálása';
+
+  @override
+  String get bringYourOwn => 'Hozd a sajátod';
+
+  @override
+  String get payYourSttProvider => 'Szabadon használd az omi-t. Csak az STT szolgáltatódnak fizetsz közvetlenül.';
+
+  @override
+  String get freeMinutesMonth => '1200 ingyenes perc/hónap tartalmazza. Korlátlan a következővel: ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Host szükséges';
+
+  @override
+  String get validPortRequired => 'Érvényes port szükséges';
+
+  @override
+  String get validWebsocketUrlRequired => 'Érvényes WebSocket URL szükséges (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL szükséges';
+
+  @override
+  String get apiKeyRequired => 'API kulcs szükséges';
+
+  @override
+  String get invalidJsonConfig => 'Érvénytelen JSON konfiguráció';
+
+  @override
+  String errorSaving(String error) {
+    return 'Mentési hiba: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfiguráció vágólapra másolva';
+
+  @override
+  String get pasteJsonConfig => 'Illeszd be a JSON konfigurációdat alább:';
+
+  @override
+  String get addApiKeyAfterImport => 'Importálás után hozzá kell adnod a saját API kulcsodat';
+
+  @override
+  String get paste => 'Beillesztés';
+
+  @override
+  String get import => 'Importálás';
+
+  @override
+  String get invalidProviderInConfig => 'Érvénytelen szolgáltató a konfigurációban';
+
+  @override
+  String importedConfig(String providerName) {
+    return '$providerName konfiguráció importálva';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Érvénytelen JSON: $error';
+  }
+
+  @override
+  String get provider => 'Szolgáltató';
+
+  @override
+  String get live => 'Élő';
+
+  @override
+  String get onDevice => 'Eszközön';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Add meg az STT HTTP végpontodat';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Add meg az élő STT WebSocket végpontodat';
+
+  @override
+  String get apiKey => 'API kulcs';
+
+  @override
+  String get enterApiKey => 'Add meg az API kulcsodat';
+
+  @override
+  String get storedLocallyNeverShared => 'Helyileg tárolva, soha nem megosztott';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Speciális';
+
+  @override
+  String get configuration => 'Konfiguráció';
+
+  @override
+  String get requestConfiguration => 'Kérés konfiguráció';
+
+  @override
+  String get responseSchema => 'Válasz séma';
+
+  @override
+  String get modified => 'Módosítva';
+
+  @override
+  String get resetRequestConfig => 'Kérés konfiguráció alaphelyzetbe állítása';
+
+  @override
+  String get logs => 'Naplók';
+
+  @override
+  String get logsCopied => 'Naplók másolva';
+
+  @override
+  String get noLogsYet => 'Még nincsenek naplók. Kezdj el rögzíteni az egyéni STT aktivitás megtekintéséhez.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName használja: $codecReason. Az Omi-t fogjuk használni.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi átírás';
+
+  @override
+  String get bestInClassTranscription => 'Legjobb átírás a kategóriában, zéró beállítással';
+
+  @override
+  String get instantSpeakerLabels => 'Azonnali beszélő címkék';
+
+  @override
+  String get languageTranslation => '100+ nyelv fordítása';
+
+  @override
+  String get optimizedForConversation => 'Beszélgetésre optimalizált';
+
+  @override
+  String get autoLanguageDetection => 'Automatikus nyelvfelismerés';
+
+  @override
+  String get highAccuracy => 'Nagy pontosság';
+
+  @override
+  String get privacyFirst => 'Adatvédelem az első';
+
+  @override
+  String get saveChanges => 'Változtatások mentése';
+
+  @override
+  String get resetToDefault => 'Alaphelyzetbe állítás';
+
+  @override
+  String get viewTemplate => 'Sablon megtekintése';
+
+  @override
+  String get trySomethingLike => 'Próbálj valami ilyesmit...';
+
+  @override
+  String get tryIt => 'Próbáld ki';
+
+  @override
+  String get creatingPlan => 'Terv készítése';
+
+  @override
+  String get developingLogic => 'Logika fejlesztése';
+
+  @override
+  String get designingApp => 'Alkalmazás tervezése';
+
+  @override
+  String get generatingIconStep => 'Ikon generálása';
+
+  @override
+  String get finalTouches => 'Utolsó simítások';
+
+  @override
+  String get processing => 'Feldolgozás...';
+
+  @override
+  String get features => 'Funkciók';
+
+  @override
+  String get creatingYourApp => 'Alkalmazásod létrehozása...';
+
+  @override
+  String get generatingIcon => 'Ikon generálása...';
+
+  @override
+  String get whatShouldWeMake => 'Mit készítsünk?';
+
+  @override
+  String get appName => 'Alkalmazás neve';
+
+  @override
+  String get description => 'Leírás';
+
+  @override
+  String get publicLabel => 'Nyilvános';
+
+  @override
+  String get privateLabel => 'Privát';
+
+  @override
+  String get free => 'Ingyenes';
+
+  @override
+  String get perMonth => '/ hónap';
+
+  @override
+  String get tailoredConversationSummaries => 'Személyre szabott beszélgetés összefoglalók';
+
+  @override
+  String get customChatbotPersonality => 'Egyéni chatbot személyiség';
+
+  @override
+  String get makePublic => 'Nyilvánossá tétel';
+
+  @override
+  String get anyoneCanDiscover => 'Bárki felfedezheti az alkalmazásodat';
+
+  @override
+  String get onlyYouCanUse => 'Csak te használhatod ezt az alkalmazást';
+
+  @override
+  String get paidApp => 'Fizetős alkalmazás';
+
+  @override
+  String get usersPayToUse => 'A felhasználók fizetnek az alkalmazásod használatáért';
+
+  @override
+  String get freeForEveryone => 'Ingyenes mindenki számára';
+
+  @override
+  String get perMonthLabel => '/ hónap';
+
+  @override
+  String get creating => 'Létrehozás...';
+
+  @override
+  String get createApp => 'Alkalmazás létrehozása';
+
+  @override
+  String get searchingForDevices => 'Eszközök keresése...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ESZKÖZ',
+      one: 'ESZKÖZ',
+    );
+    return '$count $_temp0 TALÁLHATÓ A KÖZELBEN';
+  }
+
+  @override
+  String get pairingSuccessful => 'PÁROSÍTÁS SIKERES';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Hiba az Apple Watch csatlakoztatása során: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Ne mutasd újra';
+
+  @override
+  String get iUnderstand => 'Megértettem';
+
+  @override
+  String get enableBluetooth => 'Bluetooth engedélyezése';
+
+  @override
+  String get bluetoothNeeded =>
+      'Az Omi-nak Bluetoothra van szüksége a viselhető eszközhöz való csatlakozáshoz. Kérlek, engedélyezd a Bluetooth-t, és próbáld újra.';
+
+  @override
+  String get contactSupport => 'Ügyfélszolgálat elérése?';
+
+  @override
+  String get connectLater => 'Csatlakozás később';
+
+  @override
+  String get grantPermissions => 'Engedélyek megadása';
+
+  @override
+  String get backgroundActivity => 'Háttérműködés';
+
+  @override
+  String get backgroundActivityDesc => 'Engedd, hogy az Omi a háttérben fusson a jobb stabilitás érdekében';
+
+  @override
+  String get locationAccess => 'Helymeghatározás';
+
+  @override
+  String get locationAccessDesc => 'Háttérhelymeghatározás engedélyezése a teljes élményhez';
+
+  @override
+  String get notifications => 'Értesítések';
+
+  @override
+  String get notificationsDesc => 'Értesítések engedélyezése tájékozott maradáshoz';
+
+  @override
+  String get locationServiceDisabled => 'Helymeghatározási szolgáltatás letiltva';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'A helymeghatározási szolgáltatás le van tiltva. Kérlek, menj a Beállítások > Adatvédelem és biztonság > Helyszolgáltatások menübe, és engedélyezd';
+
+  @override
+  String get backgroundLocationDenied => 'Háttérhelymeghatározás megtagadva';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Kérlek, menj az eszköz beállításaihoz, és állítsd a helymeghatározási engedélyt \"Mindig engedélyezés\"-re';
+
+  @override
+  String get lovingOmi => 'Tetszik az Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Segíts elérni több embert azzal, hogy értékelést hagysz az App Store-ban. A visszajelzésed sokat jelent nekünk!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Segíts elérni több embert azzal, hogy értékelést hagysz a Google Play Áruházban. A visszajelzésed sokat jelent nekünk!';
+
+  @override
+  String get rateOnAppStore => 'Értékelés az App Store-ban';
+
+  @override
+  String get rateOnGooglePlay => 'Értékelés a Google Play-en';
+
+  @override
+  String get maybeLater => 'Talán később';
+
+  @override
+  String get speechProfileIntro => 'Az Omi-nak meg kell tanulnia a céljaidat és a hangodat. Később módosíthatod.';
+
+  @override
+  String get getStarted => 'Kezdés';
+
+  @override
+  String get allDone => 'Kész!';
+
+  @override
+  String get keepGoing => 'Csak így tovább, nagyszerűen csinálod';
+
+  @override
+  String get skipThisQuestion => 'Kérdés kihagyása';
+
+  @override
+  String get skipForNow => 'Egyelőre kihagyom';
+
+  @override
+  String get connectionError => 'Kapcsolódási hiba';
+
+  @override
+  String get connectionErrorDesc =>
+      'Nem sikerült csatlakozni a szerverhez. Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Érvénytelen felvétel észlelve';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Úgy tűnik, több beszélő van a felvételen. Kérlek, győződj meg róla, hogy csendes helyen vagy, és próbáld újra.';
+
+  @override
+  String get tooShortDesc => 'Nem észlelhető elegendő beszéd. Kérlek, beszélj többet, és próbáld újra.';
+
+  @override
+  String get invalidRecordingDesc =>
+      'Kérlek, győződj meg róla, hogy legalább 5 másodpercig, de legfeljebb 90 másodpercig beszélsz.';
+
+  @override
+  String get areYouThere => 'Ott vagy?';
+
+  @override
+  String get noSpeechDesc =>
+      'Nem tudtunk beszédet észlelni. Kérlek, győződj meg róla, hogy legalább 10 másodpercig, de legfeljebb 3 percig beszélsz.';
+
+  @override
+  String get connectionLost => 'Kapcsolat megszakadt';
+
+  @override
+  String get connectionLostDesc =>
+      'A kapcsolat megszakadt. Kérlek, ellenőrizd az internetkapcsolatot, és próbáld újra.';
+
+  @override
+  String get tryAgain => 'Próbáld újra';
+
+  @override
+  String get connectOmiOmiGlass => 'Omi / OmiGlass csatlakoztatása';
+
+  @override
+  String get continueWithoutDevice => 'Folytatás eszköz nélkül';
+
+  @override
+  String get permissionsRequired => 'Engedélyek szükségesek';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Ez az alkalmazás Bluetooth és helymeghatározási engedélyekre van szüksége a megfelelő működéshez. Kérlek, engedélyezd őket a beállításokban.';
+
+  @override
+  String get openSettings => 'Beállítások megnyitása';
+
+  @override
+  String get wantDifferentName => 'Máshogy szeretnéd, hogy hívjanak?';
+
+  @override
+  String get whatsYourName => 'Mi a neved?';
+
+  @override
+  String get speakTranscribeSummarize => 'Beszélj. Átírás. Összefoglalás.';
+
+  @override
+  String get signInWithApple => 'Bejelentkezés Apple-lel';
+
+  @override
+  String get signInWithGoogle => 'Bejelentkezés Google-lel';
+
+  @override
+  String get byContinuingAgree => 'A folytatással elfogadod az ';
+
+  @override
+  String get termsOfUse => 'Felhasználási feltételeket';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – AI társad';
+
+  @override
+  String get captureEveryMoment =>
+      'Rögzítsd minden pillanatot. Kapj AI-alapú\nösszefoglalókat. Soha többé ne kelljen jegyzetet készítened.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch beállítása';
+
+  @override
+  String get permissionRequestedExclaim => 'Engedély kérve!';
+
+  @override
+  String get microphonePermission => 'Mikrofon engedély';
+
+  @override
+  String get permissionGrantedNow =>
+      'Engedély megadva! Most:\n\nNyisd meg az Omi alkalmazást az órádon, és érintsd meg a \"Folytatás\" gombot alább';
+
+  @override
+  String get needMicrophonePermission =>
+      'Mikrofon engedélyre van szükségünk.\n\n1. Érintsd meg az \"Engedély megadása\" gombot\n2. Engedélyezd az iPhone-odon\n3. Az óra alkalmazás bezárul\n4. Nyisd meg újra, és érintsd meg a \"Folytatás\" gombot';
+
+  @override
+  String get grantPermissionButton => 'Engedély megadása';
+
+  @override
+  String get needHelp => 'Segítség kell?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Hibaelhárítás:\n\n1. Győződj meg róla, hogy az Omi telepítve van az órádon\n2. Nyisd meg az Omi alkalmazást az órádon\n3. Keresd az engedély felugró ablakot\n4. Érintsd meg az \"Engedélyezés\" gombot, amikor megjelenik\n5. Az óra alkalmazás bezárul - nyisd meg újra\n6. Térj vissza, és érintsd meg a \"Folytatás\" gombot az iPhone-odon';
+
+  @override
+  String get recordingStartedSuccessfully => 'Felvétel sikeresen elindult!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Az engedély még nincs megadva. Kérlek, győződj meg róla, hogy engedélyezted a mikrofon hozzáférést, és újra megnyitottad az alkalmazást az órádon.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Hiba az engedély kérésekor: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Hiba a felvétel indításakor: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Válaszd ki az elsődleges nyelvedet';
+
+  @override
+  String get languageBenefits => 'Állítsd be a nyelvedet a pontosabb átíráshoz és személyre szabott élményhez';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Mi az elsődleges nyelved?';
+
+  @override
+  String get selectYourLanguage => 'Válaszd ki a nyelvedet';
+
+  @override
+  String get personalGrowthJourney => 'Személyes fejlődési utad egy AI-val, amely minden szavadat figyeli.';
+
+  @override
+  String get actionItemsTitle => 'Teendők';
+
+  @override
+  String get actionItemsDescription =>
+      'Érintsd meg a szerkesztéshez • Hosszan nyomd a kiválasztáshoz • Húzd a műveletekhez';
+
+  @override
+  String get tabToDo => 'Tennivaló';
+
+  @override
+  String get tabDone => 'Kész';
+
+  @override
+  String get tabOld => 'Régi';
+
+  @override
+  String get emptyTodoMessage => '🎉 Minden naprakész!\nNincsenek függőben lévő teendők';
+
+  @override
+  String get emptyDoneMessage => 'Még nincsenek befejezett elemek';
+
+  @override
+  String get emptyOldMessage => '✅ Nincsenek régi feladatok';
+
+  @override
+  String get noItems => 'Nincsenek elemek';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Teendő befejezetlenként megjelölve';
+
+  @override
+  String get actionItemCompleted => 'Teendő befejezve';
+
+  @override
+  String get deleteActionItemTitle => 'Teendő törlése';
+
+  @override
+  String get deleteActionItemMessage => 'Biztosan törölni szeretnéd ezt a teendőt?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Kiválasztott elemek törlése';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Biztosan törölni szeretnéd a(z) $count kiválasztott teendő${s}t?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return '\"$description\" teendő törölve';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count teendő$s törölve';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Teendő törlése sikertelen';
+
+  @override
+  String get failedToDeleteItems => 'Elemek törlése sikertelen';
+
+  @override
+  String get failedToDeleteSomeItems => 'Néhány elem törlése sikertelen';
+
+  @override
+  String get welcomeActionItemsTitle => 'Készen állsz a teendőkre';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Az AI automatikusan kinyeri a feladatokat és teendőket a beszélgetéseidből. Itt jelennek meg, amikor létrejönnek.';
+
+  @override
+  String get autoExtractionFeature => 'Automatikusan kinyerve a beszélgetésekből';
+
+  @override
+  String get editSwipeFeature => 'Érintsd meg a szerkesztéshez, húzd a befejezéshez vagy törléshez';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count kiválasztva';
+  }
+
+  @override
+  String get selectAll => 'Összes kiválasztása';
+
+  @override
+  String get deleteSelected => 'Kiválasztottak törlése';
+
+  @override
+  String searchMemories(int count) {
+    return '$count emlék keresése';
+  }
+
+  @override
+  String get memoryDeleted => 'Emlék törölve.';
+
+  @override
+  String get undo => 'Visszavonás';
+
+  @override
+  String get noMemoriesYet => 'Még nincsenek emlékek';
+
+  @override
+  String get noAutoMemories => 'Még nincsenek automatikusan kinyert emlékek';
+
+  @override
+  String get noManualMemories => 'Még nincsenek manuális emlékek';
+
+  @override
+  String get noMemoriesInCategories => 'Nincsenek emlékek ezekben a kategóriákban';
+
+  @override
+  String get noMemoriesFound => 'Nem találhatók emlékek';
+
+  @override
+  String get addFirstMemory => 'Add hozzá az első emlékedet';
+
+  @override
+  String get clearMemoryTitle => 'Omi emlékének törlése';
+
+  @override
+  String get clearMemoryMessage => 'Biztosan törölni szeretnéd az Omi emlékét? Ez a művelet nem vonható vissza.';
+
+  @override
+  String get clearMemoryButton => 'Emlék törlése';
+
+  @override
+  String get memoryClearedSuccess => 'Az Omi rólad szóló emléke törölve lett';
+
+  @override
+  String get noMemoriesToDelete => 'Nincsenek törlendő emlékek';
+
+  @override
+  String get createMemoryTooltip => 'Új emlék létrehozása';
+
+  @override
+  String get createActionItemTooltip => 'Új teendő létrehozása';
+
+  @override
+  String get memoryManagement => 'Emlékkezelés';
+
+  @override
+  String get filterMemories => 'Emlékek szűrése';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Összesen $count emléked van';
+  }
+
+  @override
+  String get publicMemories => 'Nyilvános emlékek';
+
+  @override
+  String get privateMemories => 'Privát emlékek';
+
+  @override
+  String get makeAllPrivate => 'Minden emlék priváttá tétele';
+
+  @override
+  String get makeAllPublic => 'Minden emlék nyilvánossá tétele';
+
+  @override
+  String get deleteAllMemories => 'Minden emlék törlése';
+
+  @override
+  String get allMemoriesPrivateResult => 'Minden emlék most privát';
+
+  @override
+  String get allMemoriesPublicResult => 'Minden emlék most nyilvános';
+
+  @override
+  String get newMemory => 'Új emlék';
+
+  @override
+  String get editMemory => 'Emlék szerkesztése';
+
+  @override
+  String get memoryContentHint => 'Szeretek fagyit enni...';
+
+  @override
+  String get failedToSaveMemory => 'Mentés sikertelen. Kérlek, ellenőrizd a kapcsolatot.';
+
+  @override
+  String get saveMemory => 'Emlék mentése';
+
+  @override
+  String get retry => 'Újrapróbálkozás';
+
+  @override
+  String get createActionItem => 'Teendő létrehozása';
+
+  @override
+  String get editActionItem => 'Teendő szerkesztése';
+
+  @override
+  String get actionItemDescriptionHint => 'Mit kell elvégezni?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'A teendő leírása nem lehet üres.';
+
+  @override
+  String get actionItemUpdated => 'Teendő frissítve';
+
+  @override
+  String get failedToUpdateActionItem => 'Teendő frissítése sikertelen';
+
+  @override
+  String get actionItemCreated => 'Teendő létrehozva';
+
+  @override
+  String get failedToCreateActionItem => 'Teendő létrehozása sikertelen';
+
+  @override
+  String get dueDate => 'Határidő';
+
+  @override
+  String get time => 'Idő';
+
+  @override
+  String get addDueDate => 'Határidő hozzáadása';
+
+  @override
+  String get pressDoneToSave => 'Nyomd meg a kész gombot a mentéshez';
+
+  @override
+  String get pressDoneToCreate => 'Nyomd meg a kész gombot a létrehozáshoz';
+
+  @override
+  String get filterAll => 'Összes';
+
+  @override
+  String get filterSystem => 'Rólad';
+
+  @override
+  String get filterInteresting => 'Betekintések';
+
+  @override
+  String get filterManual => 'Manuális';
+
+  @override
+  String get completed => 'Befejezve';
+
+  @override
+  String get markComplete => 'Befejezettként megjelölés';
+
+  @override
+  String get actionItemDeleted => 'Teendő törölve';
+
+  @override
+  String get failedToDeleteActionItem => 'Teendő törlése sikertelen';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Teendő törlése';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Biztosan törölni szeretnéd ezt a teendőt?';
+
+  @override
+  String get appLanguage => 'Alkalmazás nyelve';
+
+  @override
+  String get appInterfaceSectionTitle => 'ALKALMAZÁS FELÜLET';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'BESZÉD ÉS ÁTÍRÁS';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Az alkalmazás nyelve megváltoztatja a menüket és gombokat. A beszéd nyelve befolyásolja, hogyan íródnak át a felvételei.';
+}

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -1,0 +1,2237 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Indonesian (`id`).
+class AppLocalizationsId extends AppLocalizations {
+  AppLocalizationsId([String locale = 'id']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Percakapan';
+
+  @override
+  String get transcriptTab => 'Transkrip';
+
+  @override
+  String get actionItemsTab => 'Item Tindakan';
+
+  @override
+  String get deleteConversationTitle => 'Hapus Percakapan?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Apakah Anda yakin ingin menghapus percakapan ini? Tindakan ini tidak dapat dibatalkan.';
+
+  @override
+  String get confirm => 'Konfirmasi';
+
+  @override
+  String get cancel => 'Batal';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Hapus';
+
+  @override
+  String get add => 'Tambah';
+
+  @override
+  String get update => 'Perbarui';
+
+  @override
+  String get save => 'Simpan';
+
+  @override
+  String get edit => 'Edit';
+
+  @override
+  String get close => 'Tutup';
+
+  @override
+  String get clear => 'Bersihkan';
+
+  @override
+  String get copyTranscript => 'Salin Transkrip';
+
+  @override
+  String get copySummary => 'Salin Ringkasan';
+
+  @override
+  String get testPrompt => 'Uji Prompt';
+
+  @override
+  String get reprocessConversation => 'Proses Ulang Percakapan';
+
+  @override
+  String get deleteConversation => 'Hapus Percakapan';
+
+  @override
+  String get contentCopied => 'Konten disalin ke clipboard';
+
+  @override
+  String get failedToUpdateStarred => 'Gagal memperbarui status bintang.';
+
+  @override
+  String get conversationUrlNotShared => 'URL percakapan tidak dapat dibagikan.';
+
+  @override
+  String get errorProcessingConversation => 'Terjadi kesalahan saat memproses percakapan. Silakan coba lagi nanti.';
+
+  @override
+  String get noInternetConnection => 'Silakan periksa koneksi internet Anda dan coba lagi.';
+
+  @override
+  String get unableToDeleteConversation => 'Tidak Dapat Menghapus Percakapan';
+
+  @override
+  String get somethingWentWrong => 'Terjadi kesalahan! Silakan coba lagi nanti.';
+
+  @override
+  String get copyErrorMessage => 'Salin pesan kesalahan';
+
+  @override
+  String get errorCopied => 'Pesan kesalahan disalin ke clipboard';
+
+  @override
+  String get remaining => 'Tersisa';
+
+  @override
+  String get loading => 'Memuat...';
+
+  @override
+  String get loadingDuration => 'Memuat durasi...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count detik';
+  }
+
+  @override
+  String get people => 'Orang';
+
+  @override
+  String get addNewPerson => 'Tambah Orang Baru';
+
+  @override
+  String get editPerson => 'Edit Orang';
+
+  @override
+  String get createPersonHint => 'Buat orang baru dan latih Omi untuk mengenali suara mereka juga!';
+
+  @override
+  String get speechProfile => 'Profil Suara';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Sampel $number';
+  }
+
+  @override
+  String get settings => 'Pengaturan';
+
+  @override
+  String get language => 'Bahasa';
+
+  @override
+  String get selectLanguage => 'Pilih Bahasa';
+
+  @override
+  String get deleting => 'Menghapus...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
+
+  @override
+  String get failedToStartAuthentication => 'Gagal memulai autentikasi';
+
+  @override
+  String get importStarted => 'Impor dimulai! Anda akan diberi tahu saat selesai.';
+
+  @override
+  String get failedToStartImport => 'Gagal memulai impor. Silakan coba lagi.';
+
+  @override
+  String get couldNotAccessFile => 'Tidak dapat mengakses file yang dipilih';
+
+  @override
+  String get askOmi => 'Tanya Omi';
+
+  @override
+  String get done => 'Selesai';
+
+  @override
+  String get disconnected => 'Terputus';
+
+  @override
+  String get searching => 'Mencari';
+
+  @override
+  String get connectDevice => 'Hubungkan Perangkat';
+
+  @override
+  String get monthlyLimitReached => 'Anda telah mencapai batas bulanan.';
+
+  @override
+  String get checkUsage => 'Periksa Penggunaan';
+
+  @override
+  String get syncingRecordings => 'Menyinkronkan rekaman';
+
+  @override
+  String get recordingsToSync => 'Rekaman untuk disinkronkan';
+
+  @override
+  String get allCaughtUp => 'Semua sudah tersinkronisasi';
+
+  @override
+  String get sync => 'Sinkronkan';
+
+  @override
+  String get pendantUpToDate => 'Pendant sudah terbaru';
+
+  @override
+  String get allRecordingsSynced => 'Semua rekaman sudah tersinkronisasi';
+
+  @override
+  String get syncingInProgress => 'Sinkronisasi sedang berlangsung';
+
+  @override
+  String get readyToSync => 'Siap untuk disinkronkan';
+
+  @override
+  String get tapSyncToStart => 'Ketuk Sinkronkan untuk memulai';
+
+  @override
+  String get pendantNotConnected => 'Pendant tidak terhubung. Hubungkan untuk menyinkronkan.';
+
+  @override
+  String get everythingSynced => 'Semuanya sudah tersinkronisasi.';
+
+  @override
+  String get recordingsNotSynced => 'Anda memiliki rekaman yang belum disinkronkan.';
+
+  @override
+  String get syncingBackground => 'Kami akan terus menyinkronkan rekaman Anda di latar belakang.';
+
+  @override
+  String get noConversationsYet => 'Belum ada percakapan.';
+
+  @override
+  String get noStarredConversations => 'Belum ada percakapan berbintang.';
+
+  @override
+  String get starConversationHint => 'Untuk memberi bintang pada percakapan, buka dan ketuk ikon bintang di header.';
+
+  @override
+  String get searchConversations => 'Cari Percakapan';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count dipilih';
+  }
+
+  @override
+  String get merge => 'Gabungkan';
+
+  @override
+  String get mergeConversations => 'Gabungkan Percakapan';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Ini akan menggabungkan $count percakapan menjadi satu. Semua konten akan digabungkan dan dibuat ulang.';
+  }
+
+  @override
+  String get mergingInBackground => 'Menggabungkan di latar belakang. Ini mungkin memakan waktu sebentar.';
+
+  @override
+  String get failedToStartMerge => 'Gagal memulai penggabungan';
+
+  @override
+  String get askAnything => 'Tanyakan apa saja';
+
+  @override
+  String get noMessagesYet => 'Belum ada pesan!\nMengapa tidak memulai percakapan?';
+
+  @override
+  String get deletingMessages => 'Menghapus pesan Anda dari memori Omi...';
+
+  @override
+  String get messageCopied => 'Pesan disalin ke clipboard.';
+
+  @override
+  String get cannotReportOwnMessage => 'Anda tidak dapat melaporkan pesan Anda sendiri.';
+
+  @override
+  String get reportMessage => 'Laporkan Pesan';
+
+  @override
+  String get reportMessageConfirm => 'Apakah Anda yakin ingin melaporkan pesan ini?';
+
+  @override
+  String get messageReported => 'Pesan berhasil dilaporkan.';
+
+  @override
+  String get thankYouFeedback => 'Terima kasih atas masukan Anda!';
+
+  @override
+  String get clearChat => 'Bersihkan Obrolan?';
+
+  @override
+  String get clearChatConfirm => 'Apakah Anda yakin ingin menghapus obrolan? Tindakan ini tidak dapat dibatalkan.';
+
+  @override
+  String get maxFilesLimit => 'Anda hanya dapat mengunggah 4 file sekaligus';
+
+  @override
+  String get chatWithOmi => 'Obrolan dengan Omi';
+
+  @override
+  String get apps => 'Aplikasi';
+
+  @override
+  String get noAppsFound => 'Tidak ada aplikasi ditemukan';
+
+  @override
+  String get tryAdjustingSearch => 'Coba sesuaikan pencarian atau filter Anda';
+
+  @override
+  String get createYourOwnApp => 'Buat Aplikasi Anda Sendiri';
+
+  @override
+  String get buildAndShareApp => 'Bangun dan bagikan aplikasi kustom Anda';
+
+  @override
+  String get searchApps => 'Cari 1500+ Aplikasi';
+
+  @override
+  String get myApps => 'Aplikasi Saya';
+
+  @override
+  String get installedApps => 'Aplikasi Terinstal';
+
+  @override
+  String get unableToFetchApps =>
+      'Tidak dapat mengambil aplikasi :(\n\nSilakan periksa koneksi internet Anda dan coba lagi.';
+
+  @override
+  String get aboutOmi => 'Tentang Omi';
+
+  @override
+  String get privacyPolicy => 'Kebijakan Privasi';
+
+  @override
+  String get visitWebsite => 'Kunjungi Website';
+
+  @override
+  String get helpOrInquiries => 'Bantuan atau Pertanyaan?';
+
+  @override
+  String get joinCommunity => 'Bergabung dengan komunitas!';
+
+  @override
+  String get membersAndCounting => '8000+ anggota dan terus bertambah.';
+
+  @override
+  String get deleteAccountTitle => 'Hapus Akun';
+
+  @override
+  String get deleteAccountConfirm => 'Apakah Anda yakin ingin menghapus akun Anda?';
+
+  @override
+  String get cannotBeUndone => 'Ini tidak dapat dibatalkan.';
+
+  @override
+  String get allDataErased => 'Semua memori dan percakapan Anda akan dihapus secara permanen.';
+
+  @override
+  String get appsDisconnected => 'Aplikasi dan Integrasi Anda akan segera diputuskan.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Anda dapat mengekspor data Anda sebelum menghapus akun, tetapi setelah dihapus, tidak dapat dipulihkan.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Saya memahami bahwa menghapus akun saya bersifat permanen dan semua data, termasuk memori dan percakapan, akan hilang dan tidak dapat dipulihkan.';
+
+  @override
+  String get areYouSure => 'Apakah Anda yakin?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Tindakan ini tidak dapat dibatalkan dan akan menghapus akun dan semua data terkait secara permanen. Apakah Anda yakin ingin melanjutkan?';
+
+  @override
+  String get deleteNow => 'Hapus Sekarang';
+
+  @override
+  String get goBack => 'Kembali';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Centang kotak untuk mengonfirmasi bahwa Anda memahami penghapusan akun bersifat permanen dan tidak dapat dibatalkan.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Nama';
+
+  @override
+  String get email => 'Email';
+
+  @override
+  String get customVocabulary => 'Kosakata Kustom';
+
+  @override
+  String get identifyingOthers => 'Identifikasi Orang Lain';
+
+  @override
+  String get paymentMethods => 'Metode Pembayaran';
+
+  @override
+  String get conversationDisplay => 'Tampilan Percakapan';
+
+  @override
+  String get dataPrivacy => 'Data & Privasi';
+
+  @override
+  String get userId => 'ID Pengguna';
+
+  @override
+  String get notSet => 'Belum diatur';
+
+  @override
+  String get userIdCopied => 'ID Pengguna disalin ke clipboard';
+
+  @override
+  String get systemDefault => 'Bawaan Sistem';
+
+  @override
+  String get planAndUsage => 'Paket & Penggunaan';
+
+  @override
+  String get offlineSync => 'Sinkronisasi Offline';
+
+  @override
+  String get deviceSettings => 'Pengaturan Perangkat';
+
+  @override
+  String get chatTools => 'Alat Obrolan';
+
+  @override
+  String get feedbackBug => 'Masukan / Bug';
+
+  @override
+  String get helpCenter => 'Pusat Bantuan';
+
+  @override
+  String get developerSettings => 'Pengaturan Pengembang';
+
+  @override
+  String get getOmiForMac => 'Dapatkan Omi untuk Mac';
+
+  @override
+  String get referralProgram => 'Program Rujukan';
+
+  @override
+  String get signOut => 'Keluar';
+
+  @override
+  String get appAndDeviceCopied => 'Detail aplikasi dan perangkat disalin';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Privasi Anda, Kontrol Anda';
+
+  @override
+  String get privacyIntro =>
+      'Di Omi, kami berkomitmen untuk melindungi privasi Anda. Halaman ini memungkinkan Anda mengontrol bagaimana data Anda disimpan dan digunakan.';
+
+  @override
+  String get learnMore => 'Pelajari lebih lanjut...';
+
+  @override
+  String get dataProtectionLevel => 'Tingkat Perlindungan Data';
+
+  @override
+  String get dataProtectionDesc =>
+      'Data Anda diamankan secara default dengan enkripsi yang kuat. Tinjau pengaturan dan opsi privasi Anda di bawah ini.';
+
+  @override
+  String get appAccess => 'Akses Aplikasi';
+
+  @override
+  String get appAccessDesc => 'Aplikasi berikut dapat mengakses data Anda. Ketuk aplikasi untuk mengelola izinnya.';
+
+  @override
+  String get noAppsExternalAccess => 'Tidak ada aplikasi terinstal yang memiliki akses eksternal ke data Anda.';
+
+  @override
+  String get deviceName => 'Nama Perangkat';
+
+  @override
+  String get deviceId => 'ID Perangkat';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'Sinkronisasi Kartu SD';
+
+  @override
+  String get hardwareRevision => 'Revisi Perangkat Keras';
+
+  @override
+  String get modelNumber => 'Nomor Model';
+
+  @override
+  String get manufacturer => 'Produsen';
+
+  @override
+  String get doubleTap => 'Ketuk Ganda';
+
+  @override
+  String get ledBrightness => 'Kecerahan LED';
+
+  @override
+  String get micGain => 'Penguatan Mikrofon';
+
+  @override
+  String get disconnect => 'Putuskan';
+
+  @override
+  String get forgetDevice => 'Lupakan Perangkat';
+
+  @override
+  String get chargingIssues => 'Masalah Pengisian Daya';
+
+  @override
+  String get disconnectDevice => 'Putuskan Perangkat';
+
+  @override
+  String get unpairDevice => 'Batalkan Pasangan Perangkat';
+
+  @override
+  String get unpairAndForget => 'Batalkan Pasangan dan Lupakan Perangkat';
+
+  @override
+  String get deviceDisconnectedMessage => 'Omi Anda telah terputus 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Perangkat tidak terpasang. Buka Pengaturan > Bluetooth dan lupakan perangkat untuk menyelesaikan pembatalan pasangan.';
+
+  @override
+  String get unpairDialogTitle => 'Batalkan Pasangan Perangkat';
+
+  @override
+  String get unpairDialogMessage =>
+      'Ini akan membatalkan pasangan perangkat sehingga dapat dihubungkan ke ponsel lain. Anda perlu pergi ke Pengaturan > Bluetooth dan melupakan perangkat untuk menyelesaikan proses.';
+
+  @override
+  String get deviceNotConnected => 'Perangkat Tidak Terhubung';
+
+  @override
+  String get connectDeviceMessage =>
+      'Hubungkan perangkat Omi Anda untuk mengakses\npengaturan dan kustomisasi perangkat';
+
+  @override
+  String get deviceInfoSection => 'Informasi Perangkat';
+
+  @override
+  String get customizationSection => 'Kustomisasi';
+
+  @override
+  String get hardwareSection => 'Perangkat Keras';
+
+  @override
+  String get v2Undetected => 'V2 tidak terdeteksi';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Kami melihat bahwa Anda memiliki perangkat V1 atau perangkat Anda tidak terhubung. Fungsi Kartu SD hanya tersedia untuk perangkat V2.';
+
+  @override
+  String get endConversation => 'Akhiri Percakapan';
+
+  @override
+  String get pauseResume => 'Jeda/Lanjutkan';
+
+  @override
+  String get starConversation => 'Beri Bintang Percakapan';
+
+  @override
+  String get doubleTapAction => 'Aksi Ketuk Ganda';
+
+  @override
+  String get endAndProcess => 'Akhiri & Proses Percakapan';
+
+  @override
+  String get pauseResumeRecording => 'Jeda/Lanjutkan Perekaman';
+
+  @override
+  String get starOngoing => 'Beri Bintang Percakapan yang Sedang Berlangsung';
+
+  @override
+  String get off => 'Mati';
+
+  @override
+  String get max => 'Maksimal';
+
+  @override
+  String get mute => 'Bisukan';
+
+  @override
+  String get quiet => 'Pelan';
+
+  @override
+  String get normal => 'Normal';
+
+  @override
+  String get high => 'Tinggi';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon dibisukan';
+
+  @override
+  String get micGainDescLow => 'Sangat pelan - untuk lingkungan bising';
+
+  @override
+  String get micGainDescModerate => 'Pelan - untuk kebisingan sedang';
+
+  @override
+  String get micGainDescNeutral => 'Netral - perekaman seimbang';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Sedikit ditingkatkan - penggunaan normal';
+
+  @override
+  String get micGainDescBoosted => 'Ditingkatkan - untuk lingkungan sunyi';
+
+  @override
+  String get micGainDescHigh => 'Tinggi - untuk suara jauh atau lembut';
+
+  @override
+  String get micGainDescVeryHigh => 'Sangat tinggi - untuk sumber sangat sunyi';
+
+  @override
+  String get micGainDescMax => 'Maksimum - gunakan dengan hati-hati';
+
+  @override
+  String get developerSettingsTitle => 'Pengaturan Pengembang';
+
+  @override
+  String get saving => 'Menyimpan...';
+
+  @override
+  String get personaConfig => 'Konfigurasi persona AI Anda';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transkripsi';
+
+  @override
+  String get transcriptionConfig => 'Konfigurasi penyedia STT';
+
+  @override
+  String get conversationTimeout => 'Waktu Tunggu Percakapan';
+
+  @override
+  String get conversationTimeoutConfig => 'Atur kapan percakapan berakhir otomatis';
+
+  @override
+  String get importData => 'Impor Data';
+
+  @override
+  String get importDataConfig => 'Impor data dari sumber lain';
+
+  @override
+  String get debugDiagnostics => 'Debug & Diagnostik';
+
+  @override
+  String get endpointUrl => 'URL Endpoint';
+
+  @override
+  String get noApiKeys => 'Belum ada kunci API';
+
+  @override
+  String get createKeyToStart => 'Buat kunci untuk memulai';
+
+  @override
+  String get createKey => 'Buat Kunci';
+
+  @override
+  String get docs => 'Dokumentasi';
+
+  @override
+  String get yourOmiInsights => 'Wawasan Omi Anda';
+
+  @override
+  String get today => 'Hari Ini';
+
+  @override
+  String get thisMonth => 'Bulan Ini';
+
+  @override
+  String get thisYear => 'Tahun Ini';
+
+  @override
+  String get allTime => 'Sepanjang Waktu';
+
+  @override
+  String get noActivityYet => 'Belum Ada Aktivitas';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Mulai percakapan dengan Omi\nuntuk melihat wawasan penggunaan Anda di sini.';
+
+  @override
+  String get listening => 'Mendengarkan';
+
+  @override
+  String get listeningSubtitle => 'Total waktu Omi mendengarkan secara aktif.';
+
+  @override
+  String get understanding => 'Memahami';
+
+  @override
+  String get understandingSubtitle => 'Kata-kata yang dipahami dari percakapan Anda.';
+
+  @override
+  String get providing => 'Memberikan';
+
+  @override
+  String get providingSubtitle => 'Item tindakan dan catatan yang secara otomatis ditangkap.';
+
+  @override
+  String get remembering => 'Mengingat';
+
+  @override
+  String get rememberingSubtitle => 'Fakta dan detail yang diingat untuk Anda.';
+
+  @override
+  String get unlimitedPlan => 'Paket Tanpa Batas';
+
+  @override
+  String get managePlan => 'Kelola Paket';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Paket Anda akan dibatalkan pada $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Paket Anda diperbarui pada $date.';
+  }
+
+  @override
+  String get basicPlan => 'Paket Gratis';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used dari $limit menit terpakai';
+  }
+
+  @override
+  String get upgrade => 'Tingkatkan';
+
+  @override
+  String get upgradeToUnlimited => 'Tingkatkan ke Tanpa Batas';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Paket Anda mencakup $limit menit gratis per bulan. Tingkatkan untuk tanpa batas.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Membagikan statistik Omi saya! (omi.me - asisten AI yang selalu aktif)';
+
+  @override
+  String get sharePeriodToday => 'Hari ini, omi telah:';
+
+  @override
+  String get sharePeriodMonth => 'Bulan ini, omi telah:';
+
+  @override
+  String get sharePeriodYear => 'Tahun ini, omi telah:';
+
+  @override
+  String get sharePeriodAllTime => 'Sejauh ini, omi telah:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Mendengarkan selama $minutes menit';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Memahami $words kata';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Memberikan $count wawasan';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Mengingat $count memori';
+  }
+
+  @override
+  String get debugLogs => 'Log Debug';
+
+  @override
+  String get debugLogsAutoDelete => 'Otomatis dihapus setelah 3 hari.';
+
+  @override
+  String get debugLogsDesc => 'Membantu mendiagnosis masalah';
+
+  @override
+  String get noLogFilesFound => 'Tidak ada file log ditemukan.';
+
+  @override
+  String get omiDebugLog => 'Log debug Omi';
+
+  @override
+  String get logShared => 'Log dibagikan';
+
+  @override
+  String get selectLogFile => 'Pilih File Log';
+
+  @override
+  String get shareLogs => 'Bagikan Log';
+
+  @override
+  String get debugLogCleared => 'Log debug dibersihkan';
+
+  @override
+  String get exportStarted => 'Ekspor dimulai. Ini mungkin memakan waktu beberapa detik...';
+
+  @override
+  String get exportAllData => 'Ekspor Semua Data';
+
+  @override
+  String get exportDataDesc => 'Ekspor percakapan ke file JSON';
+
+  @override
+  String get exportedConversations => 'Percakapan yang Diekspor dari Omi';
+
+  @override
+  String get exportShared => 'Ekspor dibagikan';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Hapus Grafik Pengetahuan?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Ini akan menghapus semua data grafik pengetahuan turunan (simpul dan koneksi). Memori asli Anda akan tetap aman. Grafik akan dibangun kembali seiring waktu atau pada permintaan berikutnya.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Grafik Pengetahuan berhasil dihapus';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Gagal menghapus grafik: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Hapus Grafik Pengetahuan';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Bersihkan semua simpul dan koneksi';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Server MCP';
+
+  @override
+  String get mcpServerDesc => 'Hubungkan asisten AI ke data Anda';
+
+  @override
+  String get serverUrl => 'URL Server';
+
+  @override
+  String get urlCopied => 'URL disalin';
+
+  @override
+  String get apiKeyAuth => 'Autentikasi Kunci API';
+
+  @override
+  String get header => 'Header';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID Klien';
+
+  @override
+  String get clientSecret => 'Rahasia Klien';
+
+  @override
+  String get useMcpApiKey => 'Gunakan kunci API MCP Anda';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Peristiwa Percakapan';
+
+  @override
+  String get newConversationCreated => 'Percakapan baru dibuat';
+
+  @override
+  String get realtimeTranscript => 'Transkrip Real-time';
+
+  @override
+  String get transcriptReceived => 'Transkrip diterima';
+
+  @override
+  String get audioBytes => 'Byte Audio';
+
+  @override
+  String get audioDataReceived => 'Data audio diterima';
+
+  @override
+  String get intervalSeconds => 'Interval (detik)';
+
+  @override
+  String get daySummary => 'Ringkasan Hari';
+
+  @override
+  String get summaryGenerated => 'Ringkasan dibuat';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Tambahkan ke claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Salin Konfigurasi';
+
+  @override
+  String get configCopied => 'Konfigurasi disalin ke clipboard';
+
+  @override
+  String get listeningMins => 'Mendengarkan (menit)';
+
+  @override
+  String get understandingWords => 'Memahami (kata)';
+
+  @override
+  String get insights => 'Wawasan';
+
+  @override
+  String get memories => 'Memori';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used dari $limit menit terpakai bulan ini';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used dari $limit kata terpakai bulan ini';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used dari $limit wawasan diperoleh bulan ini';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used dari $limit memori dibuat bulan ini';
+  }
+
+  @override
+  String get visibility => 'Visibilitas';
+
+  @override
+  String get visibilitySubtitle => 'Kontrol percakapan mana yang muncul di daftar Anda';
+
+  @override
+  String get showShortConversations => 'Tampilkan Percakapan Pendek';
+
+  @override
+  String get showShortConversationsDesc => 'Tampilkan percakapan yang lebih pendek dari ambang batas';
+
+  @override
+  String get showDiscardedConversations => 'Tampilkan Percakapan yang Dibuang';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Sertakan percakapan yang ditandai sebagai dibuang';
+
+  @override
+  String get shortConversationThreshold => 'Ambang Percakapan Pendek';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Percakapan yang lebih pendek dari ini akan disembunyikan kecuali diaktifkan di atas';
+
+  @override
+  String get durationThreshold => 'Ambang Durasi';
+
+  @override
+  String get durationThresholdDesc => 'Sembunyikan percakapan yang lebih pendek dari ini';
+
+  @override
+  String minLabel(int count) {
+    return '$count menit';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Kosakata Kustom';
+
+  @override
+  String get addWords => 'Tambah Kata';
+
+  @override
+  String get addWordsDesc => 'Nama, istilah, atau kata yang tidak umum';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Hubungkan';
+
+  @override
+  String get comingSoon => 'Segera Hadir';
+
+  @override
+  String get chatToolsFooter => 'Hubungkan aplikasi Anda untuk melihat data dan metrik dalam obrolan.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Gagal memulai autentikasi $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Putuskan $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Apakah Anda yakin ingin memutuskan dari $appName? Anda dapat menyambung kembali kapan saja.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Terputus dari $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Gagal memutuskan';
+
+  @override
+  String connectTo(String appName) {
+    return 'Hubungkan ke $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Anda perlu mengizinkan Omi untuk mengakses data $appName Anda. Ini akan membuka browser Anda untuk autentikasi.';
+  }
+
+  @override
+  String get continueAction => 'Lanjutkan';
+
+  @override
+  String get languageTitle => 'Bahasa';
+
+  @override
+  String get primaryLanguage => 'Bahasa Utama';
+
+  @override
+  String get automaticTranslation => 'Terjemahan Otomatis';
+
+  @override
+  String get detectLanguages => 'Deteksi 10+ bahasa';
+
+  @override
+  String get authorizeSavingRecordings => 'Izinkan Menyimpan Rekaman';
+
+  @override
+  String get thanksForAuthorizing => 'Terima kasih telah mengizinkan!';
+
+  @override
+  String get needYourPermission => 'Kami memerlukan izin Anda';
+
+  @override
+  String get alreadyGavePermission =>
+      'Anda sudah memberi kami izin untuk menyimpan rekaman Anda. Berikut pengingat mengapa kami membutuhkannya:';
+
+  @override
+  String get wouldLikePermission => 'Kami ingin izin Anda untuk menyimpan rekaman suara Anda. Berikut alasannya:';
+
+  @override
+  String get improveSpeechProfile => 'Tingkatkan Profil Suara Anda';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Kami menggunakan rekaman untuk melatih dan meningkatkan profil suara pribadi Anda lebih lanjut.';
+
+  @override
+  String get trainFamilyProfiles => 'Latih Profil untuk Teman dan Keluarga';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Rekaman Anda membantu kami mengenali dan membuat profil untuk teman dan keluarga Anda.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Tingkatkan Akurasi Transkrip';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Seiring model kami meningkat, kami dapat memberikan hasil transkripsi yang lebih baik untuk rekaman Anda.';
+
+  @override
+  String get legalNotice =>
+      'Pemberitahuan Hukum: Legalitas merekam dan menyimpan data suara dapat bervariasi tergantung pada lokasi Anda dan bagaimana Anda menggunakan fitur ini. Ini adalah tanggung jawab Anda untuk memastikan kepatuhan terhadap hukum dan peraturan lokal.';
+
+  @override
+  String get alreadyAuthorized => 'Sudah Diizinkan';
+
+  @override
+  String get authorize => 'Izinkan';
+
+  @override
+  String get revokeAuthorization => 'Cabut Izin';
+
+  @override
+  String get authorizationSuccessful => 'Otorisasi berhasil!';
+
+  @override
+  String get failedToAuthorize => 'Gagal mengotorisasi. Silakan coba lagi.';
+
+  @override
+  String get authorizationRevoked => 'Otorisasi dicabut.';
+
+  @override
+  String get recordingsDeleted => 'Rekaman dihapus.';
+
+  @override
+  String get failedToRevoke => 'Gagal mencabut otorisasi. Silakan coba lagi.';
+
+  @override
+  String get permissionRevokedTitle => 'Izin Dicabut';
+
+  @override
+  String get permissionRevokedMessage => 'Apakah Anda ingin kami menghapus semua rekaman Anda yang ada juga?';
+
+  @override
+  String get yes => 'Ya';
+
+  @override
+  String get editName => 'Edit Nama';
+
+  @override
+  String get howShouldOmiCallYou => 'Bagaimana Omi harus memanggil Anda?';
+
+  @override
+  String get enterYourName => 'Masukkan nama Anda';
+
+  @override
+  String get nameCannotBeEmpty => 'Nama tidak boleh kosong';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Nama berhasil diperbarui!';
+
+  @override
+  String get calendarSettings => 'Pengaturan kalender';
+
+  @override
+  String get calendarProviders => 'Penyedia Kalender';
+
+  @override
+  String get macOsCalendar => 'Kalender macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Hubungkan kalender macOS lokal Anda';
+
+  @override
+  String get googleCalendar => 'Google Calendar';
+
+  @override
+  String get syncGoogleAccount => 'Sinkronkan dengan akun Google Anda';
+
+  @override
+  String get showMeetingsMenuBar => 'Tampilkan rapat mendatang di bilah menu';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Tampilkan rapat berikutnya dan waktu hingga dimulai di bilah menu macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Tampilkan acara tanpa peserta';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Saat diaktifkan, Coming Up menampilkan acara tanpa peserta atau tautan video.';
+
+  @override
+  String get yourMeetings => 'Rapat Anda';
+
+  @override
+  String get refresh => 'Segarkan';
+
+  @override
+  String get noUpcomingMeetings => 'Tidak ada rapat mendatang ditemukan';
+
+  @override
+  String get checkingNextDays => 'Memeriksa 30 hari ke depan';
+
+  @override
+  String get tomorrow => 'Besok';
+
+  @override
+  String get googleCalendarComingSoon => 'Integrasi Google Calendar segera hadir!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Terhubung sebagai pengguna: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Ruang Kerja Default';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Tugas akan dibuat di ruang kerja ini';
+
+  @override
+  String get defaultProjectOptional => 'Proyek Default (Opsional)';
+
+  @override
+  String get leaveUnselectedTasks => 'Biarkan tidak dipilih untuk membuat tugas tanpa proyek';
+
+  @override
+  String get noProjectsInWorkspace => 'Tidak ada proyek ditemukan di ruang kerja ini';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Pilih berapa lama menunggu dalam keheningan sebelum otomatis mengakhiri percakapan:';
+
+  @override
+  String get timeout2Minutes => '2 menit';
+
+  @override
+  String get timeout2MinutesDesc => 'Akhiri percakapan setelah 2 menit keheningan';
+
+  @override
+  String get timeout5Minutes => '5 menit';
+
+  @override
+  String get timeout5MinutesDesc => 'Akhiri percakapan setelah 5 menit keheningan';
+
+  @override
+  String get timeout10Minutes => '10 menit';
+
+  @override
+  String get timeout10MinutesDesc => 'Akhiri percakapan setelah 10 menit keheningan';
+
+  @override
+  String get timeout30Minutes => '30 menit';
+
+  @override
+  String get timeout30MinutesDesc => 'Akhiri percakapan setelah 30 menit keheningan';
+
+  @override
+  String get timeout4Hours => '4 jam';
+
+  @override
+  String get timeout4HoursDesc => 'Akhiri percakapan setelah 4 jam keheningan';
+
+  @override
+  String get conversationEndAfterHours => 'Percakapan sekarang akan berakhir setelah 4 jam keheningan';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Percakapan sekarang akan berakhir setelah $minutes menit keheningan';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Beri tahu kami bahasa utama Anda';
+
+  @override
+  String get languageForTranscription =>
+      'Atur bahasa Anda untuk transkripsi yang lebih tajam dan pengalaman yang dipersonalisasi.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Mode Bahasa Tunggal diaktifkan. Terjemahan dinonaktifkan untuk akurasi yang lebih tinggi.';
+
+  @override
+  String get searchLanguageHint => 'Cari bahasa berdasarkan nama atau kode';
+
+  @override
+  String get noLanguagesFound => 'Tidak ada bahasa ditemukan';
+
+  @override
+  String get skip => 'Lewati';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Bahasa diatur ke $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Gagal mengatur bahasa';
+
+  @override
+  String appSettings(String appName) {
+    return 'Pengaturan $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Putuskan dari $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Ini akan menghapus autentikasi $appName Anda. Anda perlu menyambung kembali untuk menggunakannya lagi.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Terhubung ke $appName';
+  }
+
+  @override
+  String get account => 'Akun';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Item tindakan Anda akan disinkronkan ke akun $appName Anda';
+  }
+
+  @override
+  String get defaultSpace => 'Ruang Default';
+
+  @override
+  String get selectSpaceInWorkspace => 'Pilih ruang di ruang kerja Anda';
+
+  @override
+  String get noSpacesInWorkspace => 'Tidak ada ruang ditemukan di ruang kerja ini';
+
+  @override
+  String get defaultList => 'Daftar Default';
+
+  @override
+  String get tasksAddedToList => 'Tugas akan ditambahkan ke daftar ini';
+
+  @override
+  String get noListsInSpace => 'Tidak ada daftar ditemukan di ruang ini';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Gagal memuat repositori: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Repositori default disimpan';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Gagal menyimpan repositori default';
+
+  @override
+  String get defaultRepository => 'Repositori Default';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Pilih repositori default untuk membuat issue. Anda masih dapat menentukan repositori yang berbeda saat membuat issue.';
+
+  @override
+  String get noReposFound => 'Tidak ada repositori ditemukan';
+
+  @override
+  String get private => 'Pribadi';
+
+  @override
+  String updatedDate(String date) {
+    return 'Diperbarui $date';
+  }
+
+  @override
+  String get yesterday => 'kemarin';
+
+  @override
+  String daysAgo(int count) {
+    return '$count hari yang lalu';
+  }
+
+  @override
+  String get oneWeekAgo => '1 minggu yang lalu';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count minggu yang lalu';
+  }
+
+  @override
+  String get oneMonthAgo => '1 bulan yang lalu';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count bulan yang lalu';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Issue akan dibuat di repositori default Anda';
+
+  @override
+  String get taskIntegrations => 'Integrasi Tugas';
+
+  @override
+  String get configureSettings => 'Konfigurasi Pengaturan';
+
+  @override
+  String get completeAuthBrowser =>
+      'Silakan selesaikan autentikasi di browser Anda. Setelah selesai, kembali ke aplikasi.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Gagal memulai autentikasi $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Hubungkan ke $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Anda perlu mengizinkan Omi untuk membuat tugas di akun $appName Anda. Ini akan membuka browser Anda untuk autentikasi.';
+  }
+
+  @override
+  String get continueButton => 'Lanjutkan';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Integrasi $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integrasi dengan $appName segera hadir! Kami bekerja keras untuk memberikan Anda lebih banyak opsi manajemen tugas.';
+  }
+
+  @override
+  String get gotIt => 'Mengerti';
+
+  @override
+  String get tasksExportedOneApp => 'Tugas dapat diekspor ke satu aplikasi pada satu waktu.';
+
+  @override
+  String get completeYourUpgrade => 'Selesaikan Peningkatan Anda';
+
+  @override
+  String get importConfiguration => 'Impor Konfigurasi';
+
+  @override
+  String get exportConfiguration => 'Ekspor konfigurasi';
+
+  @override
+  String get bringYourOwn => 'Bawa sendiri';
+
+  @override
+  String get payYourSttProvider => 'Gunakan omi secara bebas. Anda hanya membayar penyedia STT Anda secara langsung.';
+
+  @override
+  String get freeMinutesMonth => '1.200 menit gratis/bulan termasuk. Tanpa batas dengan ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Host diperlukan';
+
+  @override
+  String get validPortRequired => 'Port yang valid diperlukan';
+
+  @override
+  String get validWebsocketUrlRequired => 'URL WebSocket yang valid diperlukan (wss://)';
+
+  @override
+  String get apiUrlRequired => 'URL API diperlukan';
+
+  @override
+  String get apiKeyRequired => 'Kunci API diperlukan';
+
+  @override
+  String get invalidJsonConfig => 'Konfigurasi JSON tidak valid';
+
+  @override
+  String errorSaving(String error) {
+    return 'Kesalahan menyimpan: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfigurasi disalin ke clipboard';
+
+  @override
+  String get pasteJsonConfig => 'Tempel konfigurasi JSON Anda di bawah ini:';
+
+  @override
+  String get addApiKeyAfterImport => 'Anda perlu menambahkan kunci API Anda sendiri setelah mengimpor';
+
+  @override
+  String get paste => 'Tempel';
+
+  @override
+  String get import => 'Impor';
+
+  @override
+  String get invalidProviderInConfig => 'Penyedia tidak valid dalam konfigurasi';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Konfigurasi $providerName diimpor';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON tidak valid: $error';
+  }
+
+  @override
+  String get provider => 'Penyedia';
+
+  @override
+  String get live => 'Langsung';
+
+  @override
+  String get onDevice => 'Di Perangkat';
+
+  @override
+  String get apiUrl => 'URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Masukkan endpoint HTTP STT Anda';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Masukkan endpoint WebSocket STT langsung Anda';
+
+  @override
+  String get apiKey => 'Kunci API';
+
+  @override
+  String get enterApiKey => 'Masukkan kunci API Anda';
+
+  @override
+  String get storedLocallyNeverShared => 'Disimpan secara lokal, tidak pernah dibagikan';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Lanjutan';
+
+  @override
+  String get configuration => 'Konfigurasi';
+
+  @override
+  String get requestConfiguration => 'Konfigurasi Permintaan';
+
+  @override
+  String get responseSchema => 'Skema Respons';
+
+  @override
+  String get modified => 'Dimodifikasi';
+
+  @override
+  String get resetRequestConfig => 'Setel ulang konfigurasi permintaan ke default';
+
+  @override
+  String get logs => 'Log';
+
+  @override
+  String get logsCopied => 'Log disalin';
+
+  @override
+  String get noLogsYet => 'Belum ada log. Mulai merekam untuk melihat aktivitas STT kustom.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName menggunakan $codecReason. Omi akan digunakan.';
+  }
+
+  @override
+  String get omiTranscription => 'Transkripsi Omi';
+
+  @override
+  String get bestInClassTranscription => 'Transkripsi terbaik di kelasnya tanpa pengaturan';
+
+  @override
+  String get instantSpeakerLabels => 'Label pembicara instan';
+
+  @override
+  String get languageTranslation => 'Terjemahan 100+ bahasa';
+
+  @override
+  String get optimizedForConversation => 'Dioptimalkan untuk percakapan';
+
+  @override
+  String get autoLanguageDetection => 'Deteksi bahasa otomatis';
+
+  @override
+  String get highAccuracy => 'Akurasi tinggi';
+
+  @override
+  String get privacyFirst => 'Privasi utama';
+
+  @override
+  String get saveChanges => 'Simpan Perubahan';
+
+  @override
+  String get resetToDefault => 'Setel Ulang ke Default';
+
+  @override
+  String get viewTemplate => 'Lihat Template';
+
+  @override
+  String get trySomethingLike => 'Coba sesuatu seperti...';
+
+  @override
+  String get tryIt => 'Coba';
+
+  @override
+  String get creatingPlan => 'Membuat rencana';
+
+  @override
+  String get developingLogic => 'Mengembangkan logika';
+
+  @override
+  String get designingApp => 'Mendesain aplikasi';
+
+  @override
+  String get generatingIconStep => 'Menghasilkan ikon';
+
+  @override
+  String get finalTouches => 'Sentuhan akhir';
+
+  @override
+  String get processing => 'Memproses...';
+
+  @override
+  String get features => 'Fitur';
+
+  @override
+  String get creatingYourApp => 'Membuat aplikasi Anda...';
+
+  @override
+  String get generatingIcon => 'Menghasilkan ikon...';
+
+  @override
+  String get whatShouldWeMake => 'Apa yang harus kita buat?';
+
+  @override
+  String get appName => 'Nama Aplikasi';
+
+  @override
+  String get description => 'Deskripsi';
+
+  @override
+  String get publicLabel => 'Publik';
+
+  @override
+  String get privateLabel => 'Pribadi';
+
+  @override
+  String get free => 'Gratis';
+
+  @override
+  String get perMonth => '/ Bulan';
+
+  @override
+  String get tailoredConversationSummaries => 'Ringkasan Percakapan yang Disesuaikan';
+
+  @override
+  String get customChatbotPersonality => 'Kepribadian Chatbot Kustom';
+
+  @override
+  String get makePublic => 'Buat publik';
+
+  @override
+  String get anyoneCanDiscover => 'Siapa saja dapat menemukan aplikasi Anda';
+
+  @override
+  String get onlyYouCanUse => 'Hanya Anda yang dapat menggunakan aplikasi ini';
+
+  @override
+  String get paidApp => 'Aplikasi berbayar';
+
+  @override
+  String get usersPayToUse => 'Pengguna membayar untuk menggunakan aplikasi Anda';
+
+  @override
+  String get freeForEveryone => 'Gratis untuk semua orang';
+
+  @override
+  String get perMonthLabel => '/ bulan';
+
+  @override
+  String get creating => 'Membuat...';
+
+  @override
+  String get createApp => 'Buat Aplikasi';
+
+  @override
+  String get searchingForDevices => 'Mencari perangkat...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'PERANGKAT',
+      one: 'PERANGKAT',
+    );
+    return '$count $_temp0 DITEMUKAN DI SEKITAR';
+  }
+
+  @override
+  String get pairingSuccessful => 'PASANGAN BERHASIL';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Kesalahan menghubungkan ke Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Jangan tampilkan lagi';
+
+  @override
+  String get iUnderstand => 'Saya Mengerti';
+
+  @override
+  String get enableBluetooth => 'Aktifkan Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi membutuhkan Bluetooth untuk terhubung ke perangkat yang dapat dipakai Anda. Silakan aktifkan Bluetooth dan coba lagi.';
+
+  @override
+  String get contactSupport => 'Hubungi Dukungan?';
+
+  @override
+  String get connectLater => 'Hubungkan Nanti';
+
+  @override
+  String get grantPermissions => 'Berikan izin';
+
+  @override
+  String get backgroundActivity => 'Aktivitas latar belakang';
+
+  @override
+  String get backgroundActivityDesc => 'Biarkan Omi berjalan di latar belakang untuk stabilitas yang lebih baik';
+
+  @override
+  String get locationAccess => 'Akses lokasi';
+
+  @override
+  String get locationAccessDesc => 'Aktifkan lokasi latar belakang untuk pengalaman penuh';
+
+  @override
+  String get notifications => 'Notifikasi';
+
+  @override
+  String get notificationsDesc => 'Aktifkan notifikasi agar tetap mendapat informasi';
+
+  @override
+  String get locationServiceDisabled => 'Layanan Lokasi Dinonaktifkan';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Layanan Lokasi Dinonaktifkan. Silakan buka Pengaturan > Privasi & Keamanan > Layanan Lokasi dan aktifkan';
+
+  @override
+  String get backgroundLocationDenied => 'Akses Lokasi Latar Belakang Ditolak';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Silakan buka pengaturan perangkat dan atur izin lokasi ke \"Selalu Izinkan\"';
+
+  @override
+  String get lovingOmi => 'Menyukai Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Bantu kami menjangkau lebih banyak orang dengan meninggalkan ulasan di App Store. Masukan Anda sangat berarti bagi kami!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Bantu kami menjangkau lebih banyak orang dengan meninggalkan ulasan di Google Play Store. Masukan Anda sangat berarti bagi kami!';
+
+  @override
+  String get rateOnAppStore => 'Beri Nilai di App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Beri Nilai di Google Play';
+
+  @override
+  String get maybeLater => 'Mungkin nanti';
+
+  @override
+  String get speechProfileIntro => 'Omi perlu mempelajari tujuan dan suara Anda. Anda dapat memodifikasinya nanti.';
+
+  @override
+  String get getStarted => 'Mulai';
+
+  @override
+  String get allDone => 'Semua selesai!';
+
+  @override
+  String get keepGoing => 'Terus lanjutkan, Anda melakukannya dengan baik';
+
+  @override
+  String get skipThisQuestion => 'Lewati pertanyaan ini';
+
+  @override
+  String get skipForNow => 'Lewati untuk sekarang';
+
+  @override
+  String get connectionError => 'Kesalahan Koneksi';
+
+  @override
+  String get connectionErrorDesc => 'Gagal terhubung ke server. Silakan periksa koneksi internet Anda dan coba lagi.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Rekaman tidak valid terdeteksi';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Sepertinya ada beberapa pembicara dalam rekaman. Pastikan Anda berada di lokasi yang sunyi dan coba lagi.';
+
+  @override
+  String get tooShortDesc => 'Tidak cukup ucapan terdeteksi. Silakan berbicara lebih banyak dan coba lagi.';
+
+  @override
+  String get invalidRecordingDesc => 'Pastikan Anda berbicara setidaknya selama 5 detik dan tidak lebih dari 90.';
+
+  @override
+  String get areYouThere => 'Apakah Anda di sana?';
+
+  @override
+  String get noSpeechDesc =>
+      'Kami tidak dapat mendeteksi ucapan apa pun. Pastikan untuk berbicara setidaknya selama 10 detik dan tidak lebih dari 3 menit.';
+
+  @override
+  String get connectionLost => 'Koneksi Terputus';
+
+  @override
+  String get connectionLostDesc => 'Koneksi terputus. Silakan periksa koneksi internet Anda dan coba lagi.';
+
+  @override
+  String get tryAgain => 'Coba Lagi';
+
+  @override
+  String get connectOmiOmiGlass => 'Hubungkan Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Lanjutkan Tanpa Perangkat';
+
+  @override
+  String get permissionsRequired => 'Izin Diperlukan';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Aplikasi ini memerlukan izin Bluetooth dan Lokasi agar berfungsi dengan baik. Silakan aktifkan di pengaturan.';
+
+  @override
+  String get openSettings => 'Buka Pengaturan';
+
+  @override
+  String get wantDifferentName => 'Ingin menggunakan nama lain?';
+
+  @override
+  String get whatsYourName => 'Siapa nama Anda?';
+
+  @override
+  String get speakTranscribeSummarize => 'Bicara. Transkripsi. Ringkas.';
+
+  @override
+  String get signInWithApple => 'Masuk dengan Apple';
+
+  @override
+  String get signInWithGoogle => 'Masuk dengan Google';
+
+  @override
+  String get byContinuingAgree => 'Dengan melanjutkan, Anda menyetujui ';
+
+  @override
+  String get termsOfUse => 'Ketentuan Penggunaan';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Pendamping AI Anda';
+
+  @override
+  String get captureEveryMoment =>
+      'Tangkap setiap momen. Dapatkan ringkasan\nbertenaga AI. Jangan pernah mencatat lagi.';
+
+  @override
+  String get appleWatchSetup => 'Pengaturan Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Izin Diminta!';
+
+  @override
+  String get microphonePermission => 'Izin Mikrofon';
+
+  @override
+  String get permissionGrantedNow =>
+      'Izin diberikan! Sekarang:\n\nBuka aplikasi Omi di jam tangan Anda dan ketuk \"Lanjutkan\" di bawah ini';
+
+  @override
+  String get needMicrophonePermission =>
+      'Kami memerlukan izin mikrofon.\n\n1. Ketuk \"Berikan Izin\"\n2. Izinkan di iPhone Anda\n3. Aplikasi jam tangan akan tertutup\n4. Buka kembali dan ketuk \"Lanjutkan\"';
+
+  @override
+  String get grantPermissionButton => 'Berikan Izin';
+
+  @override
+  String get needHelp => 'Butuh Bantuan?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Pemecahan Masalah:\n\n1. Pastikan Omi terinstal di jam tangan Anda\n2. Buka aplikasi Omi di jam tangan Anda\n3. Cari popup izin\n4. Ketuk \"Izinkan\" saat diminta\n5. Aplikasi di jam tangan Anda akan tertutup - buka kembali\n6. Kembali dan ketuk \"Lanjutkan\" di iPhone Anda';
+
+  @override
+  String get recordingStartedSuccessfully => 'Rekaman berhasil dimulai!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Izin belum diberikan. Pastikan Anda telah mengizinkan akses mikrofon dan membuka kembali aplikasi di jam tangan Anda.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Kesalahan meminta izin: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Kesalahan memulai rekaman: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Pilih bahasa utama Anda';
+
+  @override
+  String get languageBenefits =>
+      'Atur bahasa Anda untuk transkripsi yang lebih tajam dan pengalaman yang dipersonalisasi';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Apa bahasa utama Anda?';
+
+  @override
+  String get selectYourLanguage => 'Pilih bahasa Anda';
+
+  @override
+  String get personalGrowthJourney =>
+      'Perjalanan pertumbuhan pribadi Anda dengan AI yang mendengarkan setiap kata Anda.';
+
+  @override
+  String get actionItemsTitle => 'Daftar Tugas';
+
+  @override
+  String get actionItemsDescription => 'Ketuk untuk edit • Tekan lama untuk pilih • Geser untuk aksi';
+
+  @override
+  String get tabToDo => 'Harus Dilakukan';
+
+  @override
+  String get tabDone => 'Selesai';
+
+  @override
+  String get tabOld => 'Lama';
+
+  @override
+  String get emptyTodoMessage => '🎉 Semua selesai!\nTidak ada item tindakan tertunda';
+
+  @override
+  String get emptyDoneMessage => 'Belum ada item yang diselesaikan';
+
+  @override
+  String get emptyOldMessage => '✅ Tidak ada tugas lama';
+
+  @override
+  String get noItems => 'Tidak ada item';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Item tindakan ditandai sebagai belum selesai';
+
+  @override
+  String get actionItemCompleted => 'Item tindakan selesai';
+
+  @override
+  String get deleteActionItemTitle => 'Hapus Item Tindakan';
+
+  @override
+  String get deleteActionItemMessage => 'Apakah Anda yakin ingin menghapus item tindakan ini?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Hapus Item yang Dipilih';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Apakah Anda yakin ingin menghapus $count item tindakan$s yang dipilih?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Item tindakan \"$description\" dihapus';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count item tindakan$s dihapus';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Gagal menghapus item tindakan';
+
+  @override
+  String get failedToDeleteItems => 'Gagal menghapus item';
+
+  @override
+  String get failedToDeleteSomeItems => 'Gagal menghapus beberapa item';
+
+  @override
+  String get welcomeActionItemsTitle => 'Siap untuk Item Tindakan';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'AI Anda akan secara otomatis mengekstrak tugas dan hal-hal yang harus dilakukan dari percakapan Anda. Mereka akan muncul di sini saat dibuat.';
+
+  @override
+  String get autoExtractionFeature => 'Secara otomatis diekstrak dari percakapan';
+
+  @override
+  String get editSwipeFeature => 'Ketuk untuk edit, geser untuk selesaikan atau hapus';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count dipilih';
+  }
+
+  @override
+  String get selectAll => 'Pilih semua';
+
+  @override
+  String get deleteSelected => 'Hapus yang dipilih';
+
+  @override
+  String searchMemories(int count) {
+    return 'Cari $count Memori';
+  }
+
+  @override
+  String get memoryDeleted => 'Memori Dihapus.';
+
+  @override
+  String get undo => 'Batalkan';
+
+  @override
+  String get noMemoriesYet => 'Belum ada memori';
+
+  @override
+  String get noAutoMemories => 'Belum ada memori yang diekstrak otomatis';
+
+  @override
+  String get noManualMemories => 'Belum ada memori manual';
+
+  @override
+  String get noMemoriesInCategories => 'Tidak ada memori dalam kategori ini';
+
+  @override
+  String get noMemoriesFound => 'Tidak ada memori ditemukan';
+
+  @override
+  String get addFirstMemory => 'Tambahkan memori pertama Anda';
+
+  @override
+  String get clearMemoryTitle => 'Hapus Memori Omi';
+
+  @override
+  String get clearMemoryMessage => 'Apakah Anda yakin ingin menghapus memori Omi? Tindakan ini tidak dapat dibatalkan.';
+
+  @override
+  String get clearMemoryButton => 'Hapus Memori';
+
+  @override
+  String get memoryClearedSuccess => 'Memori Omi tentang Anda telah dihapus';
+
+  @override
+  String get noMemoriesToDelete => 'Tidak ada memori untuk dihapus';
+
+  @override
+  String get createMemoryTooltip => 'Buat memori baru';
+
+  @override
+  String get createActionItemTooltip => 'Buat item tindakan baru';
+
+  @override
+  String get memoryManagement => 'Manajemen Memori';
+
+  @override
+  String get filterMemories => 'Filter Memori';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Anda memiliki $count total memori';
+  }
+
+  @override
+  String get publicMemories => 'Memori publik';
+
+  @override
+  String get privateMemories => 'Memori pribadi';
+
+  @override
+  String get makeAllPrivate => 'Jadikan Semua Memori Pribadi';
+
+  @override
+  String get makeAllPublic => 'Jadikan Semua Memori Publik';
+
+  @override
+  String get deleteAllMemories => 'Hapus Semua Memori';
+
+  @override
+  String get allMemoriesPrivateResult => 'Semua memori sekarang pribadi';
+
+  @override
+  String get allMemoriesPublicResult => 'Semua memori sekarang publik';
+
+  @override
+  String get newMemory => 'Memori Baru';
+
+  @override
+  String get editMemory => 'Edit Memori';
+
+  @override
+  String get memoryContentHint => 'Saya suka makan es krim...';
+
+  @override
+  String get failedToSaveMemory => 'Gagal menyimpan. Silakan periksa koneksi Anda.';
+
+  @override
+  String get saveMemory => 'Simpan Memori';
+
+  @override
+  String get retry => 'Coba Lagi';
+
+  @override
+  String get createActionItem => 'Buat Item Tindakan';
+
+  @override
+  String get editActionItem => 'Edit Item Tindakan';
+
+  @override
+  String get actionItemDescriptionHint => 'Apa yang perlu dilakukan?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Deskripsi item tindakan tidak boleh kosong.';
+
+  @override
+  String get actionItemUpdated => 'Item tindakan diperbarui';
+
+  @override
+  String get failedToUpdateActionItem => 'Gagal memperbarui item tindakan';
+
+  @override
+  String get actionItemCreated => 'Item tindakan dibuat';
+
+  @override
+  String get failedToCreateActionItem => 'Gagal membuat item tindakan';
+
+  @override
+  String get dueDate => 'Tenggat Waktu';
+
+  @override
+  String get time => 'Waktu';
+
+  @override
+  String get addDueDate => 'Tambahkan tenggat waktu';
+
+  @override
+  String get pressDoneToSave => 'Tekan selesai untuk menyimpan';
+
+  @override
+  String get pressDoneToCreate => 'Tekan selesai untuk membuat';
+
+  @override
+  String get filterAll => 'Semua';
+
+  @override
+  String get filterSystem => 'Tentang Anda';
+
+  @override
+  String get filterInteresting => 'Wawasan';
+
+  @override
+  String get filterManual => 'Manual';
+
+  @override
+  String get completed => 'Selesai';
+
+  @override
+  String get markComplete => 'Tandai selesai';
+
+  @override
+  String get actionItemDeleted => 'Item tindakan dihapus';
+
+  @override
+  String get failedToDeleteActionItem => 'Gagal menghapus item tindakan';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Hapus Item Tindakan';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Apakah Anda yakin ingin menghapus item tindakan ini?';
+
+  @override
+  String get appLanguage => 'Bahasa Aplikasi';
+
+  @override
+  String get appInterfaceSectionTitle => 'ANTARMUKA APLIKASI';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'UCAPAN & TRANSKRIPSI';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Bahasa Aplikasi mengubah menu dan tombol. Bahasa Ucapan mempengaruhi cara rekaman Anda ditranskripsi.';
+}

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -1,0 +1,2240 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Italian (`it`).
+class AppLocalizationsIt extends AppLocalizations {
+  AppLocalizationsIt([String locale = 'it']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Conversazione';
+
+  @override
+  String get transcriptTab => 'Trascrizione';
+
+  @override
+  String get actionItemsTab => 'Azioni';
+
+  @override
+  String get deleteConversationTitle => 'Eliminare Conversazione?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Sei sicuro di voler eliminare questa conversazione? Questa azione non può essere annullata.';
+
+  @override
+  String get confirm => 'Conferma';
+
+  @override
+  String get cancel => 'Annulla';
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get delete => 'Elimina';
+
+  @override
+  String get add => 'Aggiungi';
+
+  @override
+  String get update => 'Aggiorna';
+
+  @override
+  String get save => 'Salva';
+
+  @override
+  String get edit => 'Modifica';
+
+  @override
+  String get close => 'Chiudi';
+
+  @override
+  String get clear => 'Cancella';
+
+  @override
+  String get copyTranscript => 'Copia Trascrizione';
+
+  @override
+  String get copySummary => 'Copia Riepilogo';
+
+  @override
+  String get testPrompt => 'Prova Prompt';
+
+  @override
+  String get reprocessConversation => 'Rielabora Conversazione';
+
+  @override
+  String get deleteConversation => 'Elimina Conversazione';
+
+  @override
+  String get contentCopied => 'Contenuto copiato negli appunti';
+
+  @override
+  String get failedToUpdateStarred => 'Impossibile aggiornare lo stato preferito.';
+
+  @override
+  String get conversationUrlNotShared => 'L\'URL della conversazione non può essere condiviso.';
+
+  @override
+  String get errorProcessingConversation => 'Errore durante l\'elaborazione della conversazione. Riprova più tardi.';
+
+  @override
+  String get noInternetConnection => 'Controlla la tua connessione internet e riprova.';
+
+  @override
+  String get unableToDeleteConversation => 'Impossibile Eliminare Conversazione';
+
+  @override
+  String get somethingWentWrong => 'Qualcosa è andato storto! Riprova più tardi.';
+
+  @override
+  String get copyErrorMessage => 'Copia messaggio di errore';
+
+  @override
+  String get errorCopied => 'Messaggio di errore copiato negli appunti';
+
+  @override
+  String get remaining => 'Rimanente';
+
+  @override
+  String get loading => 'Caricamento...';
+
+  @override
+  String get loadingDuration => 'Caricamento durata...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count secondi';
+  }
+
+  @override
+  String get people => 'Persone';
+
+  @override
+  String get addNewPerson => 'Aggiungi Nuova Persona';
+
+  @override
+  String get editPerson => 'Modifica Persona';
+
+  @override
+  String get createPersonHint => 'Crea una nuova persona e allena Omi a riconoscere anche il suo modo di parlare!';
+
+  @override
+  String get speechProfile => 'Profilo Vocale';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Campione $number';
+  }
+
+  @override
+  String get settings => 'Impostazioni';
+
+  @override
+  String get language => 'Lingua';
+
+  @override
+  String get selectLanguage => 'Seleziona Lingua';
+
+  @override
+  String get deleting => 'Eliminazione...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Completa l\'autenticazione nel tuo browser. Una volta fatto, torna all\'app.';
+
+  @override
+  String get failedToStartAuthentication => 'Impossibile avviare l\'autenticazione';
+
+  @override
+  String get importStarted => 'Importazione avviata! Riceverai una notifica quando sarà completata.';
+
+  @override
+  String get failedToStartImport => 'Impossibile avviare l\'importazione. Riprova.';
+
+  @override
+  String get couldNotAccessFile => 'Impossibile accedere al file selezionato';
+
+  @override
+  String get askOmi => 'Chiedi a Omi';
+
+  @override
+  String get done => 'Fatto';
+
+  @override
+  String get disconnected => 'Disconnesso';
+
+  @override
+  String get searching => 'Ricerca';
+
+  @override
+  String get connectDevice => 'Connetti Dispositivo';
+
+  @override
+  String get monthlyLimitReached => 'Hai raggiunto il tuo limite mensile.';
+
+  @override
+  String get checkUsage => 'Verifica Utilizzo';
+
+  @override
+  String get syncingRecordings => 'Sincronizzazione registrazioni';
+
+  @override
+  String get recordingsToSync => 'Registrazioni da sincronizzare';
+
+  @override
+  String get allCaughtUp => 'Tutto aggiornato';
+
+  @override
+  String get sync => 'Sincronizza';
+
+  @override
+  String get pendantUpToDate => 'Il pendente è aggiornato';
+
+  @override
+  String get allRecordingsSynced => 'Tutte le registrazioni sono sincronizzate';
+
+  @override
+  String get syncingInProgress => 'Sincronizzazione in corso';
+
+  @override
+  String get readyToSync => 'Pronto per sincronizzare';
+
+  @override
+  String get tapSyncToStart => 'Tocca Sincronizza per iniziare';
+
+  @override
+  String get pendantNotConnected => 'Pendente non connesso. Connettiti per sincronizzare.';
+
+  @override
+  String get everythingSynced => 'Tutto è già sincronizzato.';
+
+  @override
+  String get recordingsNotSynced => 'Hai registrazioni che non sono ancora sincronizzate.';
+
+  @override
+  String get syncingBackground => 'Continueremo a sincronizzare le tue registrazioni in background.';
+
+  @override
+  String get noConversationsYet => 'Nessuna conversazione ancora.';
+
+  @override
+  String get noStarredConversations => 'Nessuna conversazione preferita ancora.';
+
+  @override
+  String get starConversationHint =>
+      'Per aggiungere una conversazione ai preferiti, aprila e tocca l\'icona stella nell\'intestazione.';
+
+  @override
+  String get searchConversations => 'Cerca Conversazioni';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count selezionat$s';
+  }
+
+  @override
+  String get merge => 'Unisci';
+
+  @override
+  String get mergeConversations => 'Unisci Conversazioni';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Questo combinerà $count conversazioni in una. Tutti i contenuti saranno uniti e rigenerati.';
+  }
+
+  @override
+  String get mergingInBackground => 'Unione in background. Potrebbe richiedere un momento.';
+
+  @override
+  String get failedToStartMerge => 'Impossibile avviare l\'unione';
+
+  @override
+  String get askAnything => 'Chiedi qualsiasi cosa';
+
+  @override
+  String get noMessagesYet => 'Nessun messaggio ancora!\nPerché non inizi una conversazione?';
+
+  @override
+  String get deletingMessages => 'Eliminazione dei tuoi messaggi dalla memoria di Omi...';
+
+  @override
+  String get messageCopied => 'Messaggio copiato negli appunti.';
+
+  @override
+  String get cannotReportOwnMessage => 'Non puoi segnalare i tuoi stessi messaggi.';
+
+  @override
+  String get reportMessage => 'Segnala Messaggio';
+
+  @override
+  String get reportMessageConfirm => 'Sei sicuro di voler segnalare questo messaggio?';
+
+  @override
+  String get messageReported => 'Messaggio segnalato con successo.';
+
+  @override
+  String get thankYouFeedback => 'Grazie per il tuo feedback!';
+
+  @override
+  String get clearChat => 'Cancellare Chat?';
+
+  @override
+  String get clearChatConfirm => 'Sei sicuro di voler cancellare la chat? Questa azione non può essere annullata.';
+
+  @override
+  String get maxFilesLimit => 'Puoi caricare solo 4 file alla volta';
+
+  @override
+  String get chatWithOmi => 'Chatta con Omi';
+
+  @override
+  String get apps => 'App';
+
+  @override
+  String get noAppsFound => 'Nessuna app trovata';
+
+  @override
+  String get tryAdjustingSearch => 'Prova a modificare la tua ricerca o i filtri';
+
+  @override
+  String get createYourOwnApp => 'Crea la Tua App';
+
+  @override
+  String get buildAndShareApp => 'Costruisci e condividi la tua app personalizzata';
+
+  @override
+  String get searchApps => 'Cerca tra 1500+ App';
+
+  @override
+  String get myApps => 'Le Mie App';
+
+  @override
+  String get installedApps => 'App Installate';
+
+  @override
+  String get unableToFetchApps =>
+      'Impossibile recuperare le app :(\n\nControlla la tua connessione internet e riprova.';
+
+  @override
+  String get aboutOmi => 'Informazioni su Omi';
+
+  @override
+  String get privacyPolicy => 'Politica sulla Privacy';
+
+  @override
+  String get visitWebsite => 'Visita il Sito Web';
+
+  @override
+  String get helpOrInquiries => 'Aiuto o Richieste?';
+
+  @override
+  String get joinCommunity => 'Unisciti alla community!';
+
+  @override
+  String get membersAndCounting => '8000+ membri e in crescita.';
+
+  @override
+  String get deleteAccountTitle => 'Elimina Account';
+
+  @override
+  String get deleteAccountConfirm => 'Sei sicuro di voler eliminare il tuo account?';
+
+  @override
+  String get cannotBeUndone => 'Questa operazione non può essere annullata.';
+
+  @override
+  String get allDataErased => 'Tutti i tuoi ricordi e conversazioni saranno cancellati permanentemente.';
+
+  @override
+  String get appsDisconnected => 'Le tue App e Integrazioni saranno disconnesse immediatamente.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Puoi esportare i tuoi dati prima di eliminare il tuo account, ma una volta eliminato, non può essere recuperato.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Comprendo che l\'eliminazione del mio account è permanente e tutti i dati, inclusi ricordi e conversazioni, saranno persi e non potranno essere recuperati.';
+
+  @override
+  String get areYouSure => 'Sei sicuro?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Questa azione è irreversibile e eliminerà permanentemente il tuo account e tutti i dati associati. Sei sicuro di voler procedere?';
+
+  @override
+  String get deleteNow => 'Elimina Ora';
+
+  @override
+  String get goBack => 'Indietro';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Seleziona la casella per confermare di aver compreso che l\'eliminazione del tuo account è permanente e irreversibile.';
+
+  @override
+  String get profile => 'Profilo';
+
+  @override
+  String get name => 'Nome';
+
+  @override
+  String get email => 'Email';
+
+  @override
+  String get customVocabulary => 'Vocabolario Personalizzato';
+
+  @override
+  String get identifyingOthers => 'Identificazione Altri';
+
+  @override
+  String get paymentMethods => 'Metodi di Pagamento';
+
+  @override
+  String get conversationDisplay => 'Visualizzazione Conversazioni';
+
+  @override
+  String get dataPrivacy => 'Dati e Privacy';
+
+  @override
+  String get userId => 'ID Utente';
+
+  @override
+  String get notSet => 'Non impostato';
+
+  @override
+  String get userIdCopied => 'ID utente copiato negli appunti';
+
+  @override
+  String get systemDefault => 'Predefinito del Sistema';
+
+  @override
+  String get planAndUsage => 'Piano e Utilizzo';
+
+  @override
+  String get offlineSync => 'Sincronizzazione Offline';
+
+  @override
+  String get deviceSettings => 'Impostazioni Dispositivo';
+
+  @override
+  String get chatTools => 'Strumenti Chat';
+
+  @override
+  String get feedbackBug => 'Feedback / Bug';
+
+  @override
+  String get helpCenter => 'Centro Assistenza';
+
+  @override
+  String get developerSettings => 'Impostazioni Sviluppatore';
+
+  @override
+  String get getOmiForMac => 'Ottieni Omi per Mac';
+
+  @override
+  String get referralProgram => 'Programma di Riferimento';
+
+  @override
+  String get signOut => 'Disconnetti';
+
+  @override
+  String get appAndDeviceCopied => 'Dettagli app e dispositivo copiati';
+
+  @override
+  String get wrapped2025 => 'Resoconto 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'La Tua Privacy, Il Tuo Controllo';
+
+  @override
+  String get privacyIntro =>
+      'In Omi ci impegniamo a proteggere la tua privacy. Questa pagina ti permette di controllare come vengono archiviati e utilizzati i tuoi dati.';
+
+  @override
+  String get learnMore => 'Scopri di più...';
+
+  @override
+  String get dataProtectionLevel => 'Livello di Protezione Dati';
+
+  @override
+  String get dataProtectionDesc =>
+      'I tuoi dati sono protetti di default con crittografia avanzata. Rivedi le tue impostazioni e le future opzioni di privacy qui sotto.';
+
+  @override
+  String get appAccess => 'Accesso App';
+
+  @override
+  String get appAccessDesc =>
+      'Le seguenti app possono accedere ai tuoi dati. Tocca un\'app per gestire i suoi permessi.';
+
+  @override
+  String get noAppsExternalAccess => 'Nessuna app installata ha accesso esterno ai tuoi dati.';
+
+  @override
+  String get deviceName => 'Nome Dispositivo';
+
+  @override
+  String get deviceId => 'ID Dispositivo';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'Sincronizzazione Scheda SD';
+
+  @override
+  String get hardwareRevision => 'Revisione Hardware';
+
+  @override
+  String get modelNumber => 'Numero Modello';
+
+  @override
+  String get manufacturer => 'Produttore';
+
+  @override
+  String get doubleTap => 'Doppio Tocco';
+
+  @override
+  String get ledBrightness => 'Luminosità LED';
+
+  @override
+  String get micGain => 'Guadagno Microfono';
+
+  @override
+  String get disconnect => 'Disconnetti';
+
+  @override
+  String get forgetDevice => 'Dimentica Dispositivo';
+
+  @override
+  String get chargingIssues => 'Problemi di Ricarica';
+
+  @override
+  String get disconnectDevice => 'Disconnetti Dispositivo';
+
+  @override
+  String get unpairDevice => 'Disaccoppia Dispositivo';
+
+  @override
+  String get unpairAndForget => 'Disaccoppia e Dimentica Dispositivo';
+
+  @override
+  String get deviceDisconnectedMessage => 'Il tuo Omi è stato disconnesso 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Dispositivo disaccoppiato. Vai su Impostazioni > Bluetooth e dimentica il dispositivo per completare il disaccoppiamento.';
+
+  @override
+  String get unpairDialogTitle => 'Disaccoppia Dispositivo';
+
+  @override
+  String get unpairDialogMessage =>
+      'Questo disaccoppierà il dispositivo in modo che possa essere connesso a un altro telefono. Dovrai andare su Impostazioni > Bluetooth e dimenticare il dispositivo per completare il processo.';
+
+  @override
+  String get deviceNotConnected => 'Dispositivo Non Connesso';
+
+  @override
+  String get connectDeviceMessage =>
+      'Connetti il tuo dispositivo Omi per accedere\nalle impostazioni e alla personalizzazione del dispositivo';
+
+  @override
+  String get deviceInfoSection => 'Informazioni Dispositivo';
+
+  @override
+  String get customizationSection => 'Personalizzazione';
+
+  @override
+  String get hardwareSection => 'Hardware';
+
+  @override
+  String get v2Undetected => 'V2 non rilevato';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Vediamo che hai un dispositivo V1 o il tuo dispositivo non è connesso. La funzionalità della scheda SD è disponibile solo per i dispositivi V2.';
+
+  @override
+  String get endConversation => 'Termina Conversazione';
+
+  @override
+  String get pauseResume => 'Pausa/Riprendi';
+
+  @override
+  String get starConversation => 'Aggiungi ai Preferiti';
+
+  @override
+  String get doubleTapAction => 'Azione Doppio Tocco';
+
+  @override
+  String get endAndProcess => 'Termina ed Elabora Conversazione';
+
+  @override
+  String get pauseResumeRecording => 'Pausa/Riprendi Registrazione';
+
+  @override
+  String get starOngoing => 'Aggiungi Conversazione in Corso ai Preferiti';
+
+  @override
+  String get off => 'Spento';
+
+  @override
+  String get max => 'Massimo';
+
+  @override
+  String get mute => 'Muto';
+
+  @override
+  String get quiet => 'Silenzioso';
+
+  @override
+  String get normal => 'Normale';
+
+  @override
+  String get high => 'Alto';
+
+  @override
+  String get micGainDescMuted => 'Microfono disattivato';
+
+  @override
+  String get micGainDescLow => 'Molto silenzioso - per ambienti rumorosi';
+
+  @override
+  String get micGainDescModerate => 'Silenzioso - per rumore moderato';
+
+  @override
+  String get micGainDescNeutral => 'Neutrale - registrazione bilanciata';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Leggermente amplificato - uso normale';
+
+  @override
+  String get micGainDescBoosted => 'Amplificato - per ambienti silenziosi';
+
+  @override
+  String get micGainDescHigh => 'Alto - per voci distanti o basse';
+
+  @override
+  String get micGainDescVeryHigh => 'Molto alto - per sorgenti molto silenziose';
+
+  @override
+  String get micGainDescMax => 'Massimo - usare con cautela';
+
+  @override
+  String get developerSettingsTitle => 'Impostazioni Sviluppatore';
+
+  @override
+  String get saving => 'Salvataggio...';
+
+  @override
+  String get personaConfig => 'Configura la tua AI persona';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Trascrizione';
+
+  @override
+  String get transcriptionConfig => 'Configura provider STT';
+
+  @override
+  String get conversationTimeout => 'Timeout Conversazione';
+
+  @override
+  String get conversationTimeoutConfig => 'Imposta quando le conversazioni terminano automaticamente';
+
+  @override
+  String get importData => 'Importa Dati';
+
+  @override
+  String get importDataConfig => 'Importa dati da altre fonti';
+
+  @override
+  String get debugDiagnostics => 'Debug e Diagnostica';
+
+  @override
+  String get endpointUrl => 'URL Endpoint';
+
+  @override
+  String get noApiKeys => 'Nessuna chiave API ancora';
+
+  @override
+  String get createKeyToStart => 'Crea una chiave per iniziare';
+
+  @override
+  String get createKey => 'Crea Chiave';
+
+  @override
+  String get docs => 'Documenti';
+
+  @override
+  String get yourOmiInsights => 'Le Tue Statistiche Omi';
+
+  @override
+  String get today => 'Oggi';
+
+  @override
+  String get thisMonth => 'Questo Mese';
+
+  @override
+  String get thisYear => 'Quest\'Anno';
+
+  @override
+  String get allTime => 'Sempre';
+
+  @override
+  String get noActivityYet => 'Nessuna Attività Ancora';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Inizia una conversazione con Omi\nper vedere le tue statistiche di utilizzo qui.';
+
+  @override
+  String get listening => 'Ascolto';
+
+  @override
+  String get listeningSubtitle => 'Tempo totale in cui Omi ha ascoltato attivamente.';
+
+  @override
+  String get understanding => 'Comprensione';
+
+  @override
+  String get understandingSubtitle => 'Parole comprese dalle tue conversazioni.';
+
+  @override
+  String get providing => 'Fornire';
+
+  @override
+  String get providingSubtitle => 'Azioni e note automaticamente catturate.';
+
+  @override
+  String get remembering => 'Ricordare';
+
+  @override
+  String get rememberingSubtitle => 'Fatti e dettagli ricordati per te.';
+
+  @override
+  String get unlimitedPlan => 'Piano Illimitato';
+
+  @override
+  String get managePlan => 'Gestisci Piano';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Il tuo piano sarà annullato il $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Il tuo piano si rinnova il $date.';
+  }
+
+  @override
+  String get basicPlan => 'Piano Gratuito';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used di $limit min utilizzati';
+  }
+
+  @override
+  String get upgrade => 'Aggiorna';
+
+  @override
+  String get upgradeToUnlimited => 'Passa a Illimitato';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Il tuo piano include $limit minuti gratuiti al mese. Aggiorna per passare a illimitato.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Condivido le mie statistiche Omi! (omi.me - il tuo assistente AI sempre attivo)';
+
+  @override
+  String get sharePeriodToday => 'Oggi, Omi ha:';
+
+  @override
+  String get sharePeriodMonth => 'Questo mese, Omi ha:';
+
+  @override
+  String get sharePeriodYear => 'Quest\'anno, Omi ha:';
+
+  @override
+  String get sharePeriodAllTime => 'Finora, Omi ha:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Ascoltato per $minutes minuti';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Compreso $words parole';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Fornito $count insight';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Ricordato $count ricordi';
+  }
+
+  @override
+  String get debugLogs => 'Log di Debug';
+
+  @override
+  String get debugLogsAutoDelete => 'Eliminazione automatica dopo 3 giorni.';
+
+  @override
+  String get debugLogsDesc => 'Aiuta a diagnosticare i problemi';
+
+  @override
+  String get noLogFilesFound => 'Nessun file di log trovato.';
+
+  @override
+  String get omiDebugLog => 'Log di debug Omi';
+
+  @override
+  String get logShared => 'Log condiviso';
+
+  @override
+  String get selectLogFile => 'Seleziona File di Log';
+
+  @override
+  String get shareLogs => 'Condividi Log';
+
+  @override
+  String get debugLogCleared => 'Log di debug cancellato';
+
+  @override
+  String get exportStarted => 'Esportazione avviata. Potrebbe richiedere alcuni secondi...';
+
+  @override
+  String get exportAllData => 'Esporta Tutti i Dati';
+
+  @override
+  String get exportDataDesc => 'Esporta conversazioni in un file JSON';
+
+  @override
+  String get exportedConversations => 'Conversazioni Esportate da Omi';
+
+  @override
+  String get exportShared => 'Esportazione condivisa';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Eliminare Grafo di Conoscenza?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Questo eliminerà tutti i dati del grafo di conoscenza derivato (nodi e connessioni). I tuoi ricordi originali rimarranno al sicuro. Il grafo sarà ricostruito nel tempo o alla prossima richiesta.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Grafo di Conoscenza eliminato con successo';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Impossibile eliminare il grafo: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Elimina Grafo di Conoscenza';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Cancella tutti i nodi e le connessioni';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Server MCP';
+
+  @override
+  String get mcpServerDesc => 'Connetti assistenti AI ai tuoi dati';
+
+  @override
+  String get serverUrl => 'URL Server';
+
+  @override
+  String get urlCopied => 'URL copiato';
+
+  @override
+  String get apiKeyAuth => 'Autenticazione Chiave API';
+
+  @override
+  String get header => 'Intestazione';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <chiave>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID Cliente';
+
+  @override
+  String get clientSecret => 'Segreto Cliente';
+
+  @override
+  String get useMcpApiKey => 'Usa la tua chiave API MCP';
+
+  @override
+  String get webhooks => 'Webhook';
+
+  @override
+  String get conversationEvents => 'Eventi Conversazione';
+
+  @override
+  String get newConversationCreated => 'Nuova conversazione creata';
+
+  @override
+  String get realtimeTranscript => 'Trascrizione in Tempo Reale';
+
+  @override
+  String get transcriptReceived => 'Trascrizione ricevuta';
+
+  @override
+  String get audioBytes => 'Byte Audio';
+
+  @override
+  String get audioDataReceived => 'Dati audio ricevuti';
+
+  @override
+  String get intervalSeconds => 'Intervallo (secondi)';
+
+  @override
+  String get daySummary => 'Riepilogo Giornaliero';
+
+  @override
+  String get summaryGenerated => 'Riepilogo generato';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Aggiungi a claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Copia Configurazione';
+
+  @override
+  String get configCopied => 'Configurazione copiata negli appunti';
+
+  @override
+  String get listeningMins => 'Ascolto (min)';
+
+  @override
+  String get understandingWords => 'Comprensione (parole)';
+
+  @override
+  String get insights => 'Insight';
+
+  @override
+  String get memories => 'Ricordi';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used di $limit min utilizzati questo mese';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used di $limit parole utilizzate questo mese';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used di $limit insight ottenuti questo mese';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used di $limit ricordi creati questo mese';
+  }
+
+  @override
+  String get visibility => 'Visibilità';
+
+  @override
+  String get visibilitySubtitle => 'Controlla quali conversazioni appaiono nella tua lista';
+
+  @override
+  String get showShortConversations => 'Mostra Conversazioni Brevi';
+
+  @override
+  String get showShortConversationsDesc => 'Visualizza conversazioni più brevi della soglia';
+
+  @override
+  String get showDiscardedConversations => 'Mostra Conversazioni Scartate';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Includi conversazioni contrassegnate come scartate';
+
+  @override
+  String get shortConversationThreshold => 'Soglia Conversazione Breve';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Le conversazioni più brevi di questa soglia saranno nascoste se non abilitate sopra';
+
+  @override
+  String get durationThreshold => 'Soglia Durata';
+
+  @override
+  String get durationThresholdDesc => 'Nascondi conversazioni più brevi di questa soglia';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Vocabolario Personalizzato';
+
+  @override
+  String get addWords => 'Aggiungi Parole';
+
+  @override
+  String get addWordsDesc => 'Nomi, termini o parole non comuni';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Connetti';
+
+  @override
+  String get comingSoon => 'Prossimamente';
+
+  @override
+  String get chatToolsFooter => 'Connetti le tue app per visualizzare dati e metriche nella chat.';
+
+  @override
+  String get completeAuthInBrowser => 'Completa l\'autenticazione nel tuo browser. Una volta fatto, torna all\'app.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Impossibile avviare l\'autenticazione $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Disconnettere $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Sei sicuro di volerti disconnettere da $appName? Puoi riconnetterti in qualsiasi momento.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Disconnesso da $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Impossibile disconnettere';
+
+  @override
+  String connectTo(String appName) {
+    return 'Connetti a $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Dovrai autorizzare Omi ad accedere ai tuoi dati $appName. Questo aprirà il tuo browser per l\'autenticazione.';
+  }
+
+  @override
+  String get continueAction => 'Continua';
+
+  @override
+  String get languageTitle => 'Lingua';
+
+  @override
+  String get primaryLanguage => 'Lingua Principale';
+
+  @override
+  String get automaticTranslation => 'Traduzione Automatica';
+
+  @override
+  String get detectLanguages => 'Rileva oltre 10 lingue';
+
+  @override
+  String get authorizeSavingRecordings => 'Autorizza Salvataggio Registrazioni';
+
+  @override
+  String get thanksForAuthorizing => 'Grazie per aver autorizzato!';
+
+  @override
+  String get needYourPermission => 'Abbiamo bisogno del tuo permesso';
+
+  @override
+  String get alreadyGavePermission =>
+      'Ci hai già dato il permesso di salvare le tue registrazioni. Ecco un promemoria del perché ne abbiamo bisogno:';
+
+  @override
+  String get wouldLikePermission => 'Vorremmo il tuo permesso per salvare le tue registrazioni vocali. Ecco perché:';
+
+  @override
+  String get improveSpeechProfile => 'Migliora il Tuo Profilo Vocale';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Utilizziamo le registrazioni per addestrare e migliorare ulteriormente il tuo profilo vocale personale.';
+
+  @override
+  String get trainFamilyProfiles => 'Addestra Profili per Amici e Famiglia';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Le tue registrazioni ci aiutano a riconoscere e creare profili per i tuoi amici e familiari.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Migliora Precisione Trascrizione';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Man mano che il nostro modello migliora, possiamo fornire risultati di trascrizione migliori per le tue registrazioni.';
+
+  @override
+  String get legalNotice =>
+      'Avviso Legale: La legalità della registrazione e dell\'archiviazione dei dati vocali può variare a seconda della tua posizione e di come utilizzi questa funzione. È tua responsabilità garantire la conformità con le leggi e i regolamenti locali.';
+
+  @override
+  String get alreadyAuthorized => 'Già Autorizzato';
+
+  @override
+  String get authorize => 'Autorizza';
+
+  @override
+  String get revokeAuthorization => 'Revoca Autorizzazione';
+
+  @override
+  String get authorizationSuccessful => 'Autorizzazione riuscita!';
+
+  @override
+  String get failedToAuthorize => 'Impossibile autorizzare. Riprova.';
+
+  @override
+  String get authorizationRevoked => 'Autorizzazione revocata.';
+
+  @override
+  String get recordingsDeleted => 'Registrazioni eliminate.';
+
+  @override
+  String get failedToRevoke => 'Impossibile revocare l\'autorizzazione. Riprova.';
+
+  @override
+  String get permissionRevokedTitle => 'Permesso Revocato';
+
+  @override
+  String get permissionRevokedMessage => 'Vuoi che rimuoviamo anche tutte le tue registrazioni esistenti?';
+
+  @override
+  String get yes => 'Sì';
+
+  @override
+  String get editName => 'Modifica Nome';
+
+  @override
+  String get howShouldOmiCallYou => 'Come dovrebbe chiamarti Omi?';
+
+  @override
+  String get enterYourName => 'Inserisci il tuo nome';
+
+  @override
+  String get nameCannotBeEmpty => 'Il nome non può essere vuoto';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Nome aggiornato con successo!';
+
+  @override
+  String get calendarSettings => 'Impostazioni calendario';
+
+  @override
+  String get calendarProviders => 'Provider Calendario';
+
+  @override
+  String get macOsCalendar => 'Calendario macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Connetti il tuo calendario macOS locale';
+
+  @override
+  String get googleCalendar => 'Google Calendar';
+
+  @override
+  String get syncGoogleAccount => 'Sincronizza con il tuo account Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Mostra riunioni imminenti nella barra dei menu';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'Visualizza la tua prossima riunione e il tempo rimanente nella barra dei menu di macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Mostra eventi senza partecipanti';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Quando abilitato, Prossimi Eventi mostra eventi senza partecipanti o link video.';
+
+  @override
+  String get yourMeetings => 'Le Tue Riunioni';
+
+  @override
+  String get refresh => 'Aggiorna';
+
+  @override
+  String get noUpcomingMeetings => 'Nessuna riunione imminente trovata';
+
+  @override
+  String get checkingNextDays => 'Controllo dei prossimi 30 giorni';
+
+  @override
+  String get tomorrow => 'Domani';
+
+  @override
+  String get googleCalendarComingSoon => 'Integrazione Google Calendar in arrivo!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Connesso come utente: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Area di Lavoro Predefinita';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Le attività saranno create in quest\'area di lavoro';
+
+  @override
+  String get defaultProjectOptional => 'Progetto Predefinito (Facoltativo)';
+
+  @override
+  String get leaveUnselectedTasks => 'Lascia non selezionato per creare attività senza un progetto';
+
+  @override
+  String get noProjectsInWorkspace => 'Nessun progetto trovato in quest\'area di lavoro';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Scegli quanto tempo attendere in silenzio prima di terminare automaticamente una conversazione:';
+
+  @override
+  String get timeout2Minutes => '2 minuti';
+
+  @override
+  String get timeout2MinutesDesc => 'Termina conversazione dopo 2 minuti di silenzio';
+
+  @override
+  String get timeout5Minutes => '5 minuti';
+
+  @override
+  String get timeout5MinutesDesc => 'Termina conversazione dopo 5 minuti di silenzio';
+
+  @override
+  String get timeout10Minutes => '10 minuti';
+
+  @override
+  String get timeout10MinutesDesc => 'Termina conversazione dopo 10 minuti di silenzio';
+
+  @override
+  String get timeout30Minutes => '30 minuti';
+
+  @override
+  String get timeout30MinutesDesc => 'Termina conversazione dopo 30 minuti di silenzio';
+
+  @override
+  String get timeout4Hours => '4 ore';
+
+  @override
+  String get timeout4HoursDesc => 'Termina conversazione dopo 4 ore di silenzio';
+
+  @override
+  String get conversationEndAfterHours => 'Le conversazioni termineranno ora dopo 4 ore di silenzio';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Le conversazioni termineranno ora dopo $minutes minuto/i di silenzio';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Dicci la tua lingua principale';
+
+  @override
+  String get languageForTranscription =>
+      'Imposta la tua lingua per trascrizioni più accurate e un\'esperienza personalizzata.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Modalità Lingua Singola attivata. La traduzione è disabilitata per una maggiore precisione.';
+
+  @override
+  String get searchLanguageHint => 'Cerca lingua per nome o codice';
+
+  @override
+  String get noLanguagesFound => 'Nessuna lingua trovata';
+
+  @override
+  String get skip => 'Salta';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Lingua impostata su $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Impossibile impostare la lingua';
+
+  @override
+  String appSettings(String appName) {
+    return 'Impostazioni $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Disconnettere da $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Questo rimuoverà la tua autenticazione $appName. Dovrai riconnetterti per usarlo di nuovo.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Connesso a $appName';
+  }
+
+  @override
+  String get account => 'Account';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Le tue azioni saranno sincronizzate con il tuo account $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Spazio Predefinito';
+
+  @override
+  String get selectSpaceInWorkspace => 'Seleziona uno spazio nella tua area di lavoro';
+
+  @override
+  String get noSpacesInWorkspace => 'Nessuno spazio trovato in quest\'area di lavoro';
+
+  @override
+  String get defaultList => 'Lista Predefinita';
+
+  @override
+  String get tasksAddedToList => 'Le attività saranno aggiunte a questa lista';
+
+  @override
+  String get noListsInSpace => 'Nessuna lista trovata in questo spazio';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Impossibile caricare i repository: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Repository predefinito salvato';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Impossibile salvare il repository predefinito';
+
+  @override
+  String get defaultRepository => 'Repository Predefinito';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Seleziona un repository predefinito per creare issue. Puoi comunque specificare un repository diverso durante la creazione di issue.';
+
+  @override
+  String get noReposFound => 'Nessun repository trovato';
+
+  @override
+  String get private => 'Privato';
+
+  @override
+  String updatedDate(String date) {
+    return 'Aggiornato $date';
+  }
+
+  @override
+  String get yesterday => 'ieri';
+
+  @override
+  String daysAgo(int count) {
+    return '$count giorni fa';
+  }
+
+  @override
+  String get oneWeekAgo => '1 settimana fa';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count settimane fa';
+  }
+
+  @override
+  String get oneMonthAgo => '1 mese fa';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count mesi fa';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Le issue saranno create nel tuo repository predefinito';
+
+  @override
+  String get taskIntegrations => 'Integrazioni Attività';
+
+  @override
+  String get configureSettings => 'Configura Impostazioni';
+
+  @override
+  String get completeAuthBrowser => 'Completa l\'autenticazione nel tuo browser. Una volta fatto, torna all\'app.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Impossibile avviare l\'autenticazione $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Connetti a $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Dovrai autorizzare Omi a creare attività nel tuo account $appName. Questo aprirà il tuo browser per l\'autenticazione.';
+  }
+
+  @override
+  String get continueButton => 'Continua';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Integrazione $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'L\'integrazione con $appName è in arrivo! Stiamo lavorando sodo per offrirti più opzioni di gestione delle attività.';
+  }
+
+  @override
+  String get gotIt => 'Capito';
+
+  @override
+  String get tasksExportedOneApp => 'Le attività possono essere esportate in un\'app alla volta.';
+
+  @override
+  String get completeYourUpgrade => 'Completa il Tuo Aggiornamento';
+
+  @override
+  String get importConfiguration => 'Importa Configurazione';
+
+  @override
+  String get exportConfiguration => 'Esporta configurazione';
+
+  @override
+  String get bringYourOwn => 'Porta il tuo';
+
+  @override
+  String get payYourSttProvider => 'Usa Omi liberamente. Paghi solo il tuo provider STT direttamente.';
+
+  @override
+  String get freeMinutesMonth => '1.200 minuti gratuiti/mese inclusi. Illimitato con ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'L\'host è richiesto';
+
+  @override
+  String get validPortRequired => 'È richiesta una porta valida';
+
+  @override
+  String get validWebsocketUrlRequired => 'È richiesto un URL WebSocket valido (wss://)';
+
+  @override
+  String get apiUrlRequired => 'L\'URL API è richiesto';
+
+  @override
+  String get apiKeyRequired => 'La chiave API è richiesta';
+
+  @override
+  String get invalidJsonConfig => 'Configurazione JSON non valida';
+
+  @override
+  String errorSaving(String error) {
+    return 'Errore durante il salvataggio: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Configurazione copiata negli appunti';
+
+  @override
+  String get pasteJsonConfig => 'Incolla la tua configurazione JSON qui sotto:';
+
+  @override
+  String get addApiKeyAfterImport => 'Dovrai aggiungere la tua chiave API dopo l\'importazione';
+
+  @override
+  String get paste => 'Incolla';
+
+  @override
+  String get import => 'Importa';
+
+  @override
+  String get invalidProviderInConfig => 'Provider non valido nella configurazione';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Configurazione $providerName importata';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON non valido: $error';
+  }
+
+  @override
+  String get provider => 'Provider';
+
+  @override
+  String get live => 'Live';
+
+  @override
+  String get onDevice => 'Sul Dispositivo';
+
+  @override
+  String get apiUrl => 'URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Inserisci il tuo endpoint HTTP STT';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Inserisci il tuo endpoint WebSocket STT live';
+
+  @override
+  String get apiKey => 'Chiave API';
+
+  @override
+  String get enterApiKey => 'Inserisci la tua chiave API';
+
+  @override
+  String get storedLocallyNeverShared => 'Archiviato localmente, mai condiviso';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Porta';
+
+  @override
+  String get advanced => 'Avanzate';
+
+  @override
+  String get configuration => 'Configurazione';
+
+  @override
+  String get requestConfiguration => 'Configurazione Richiesta';
+
+  @override
+  String get responseSchema => 'Schema Risposta';
+
+  @override
+  String get modified => 'Modificato';
+
+  @override
+  String get resetRequestConfig => 'Ripristina configurazione richiesta predefinita';
+
+  @override
+  String get logs => 'Log';
+
+  @override
+  String get logsCopied => 'Log copiati';
+
+  @override
+  String get noLogsYet => 'Nessun log ancora. Inizia a registrare per vedere l\'attività STT personalizzata.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName usa $codecReason. Verrà utilizzato Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Trascrizione Omi';
+
+  @override
+  String get bestInClassTranscription => 'Trascrizione all\'avanguardia senza configurazione';
+
+  @override
+  String get instantSpeakerLabels => 'Etichette dei parlanti istantanee';
+
+  @override
+  String get languageTranslation => 'Traduzione in oltre 100 lingue';
+
+  @override
+  String get optimizedForConversation => 'Ottimizzato per la conversazione';
+
+  @override
+  String get autoLanguageDetection => 'Rilevamento automatico della lingua';
+
+  @override
+  String get highAccuracy => 'Alta precisione';
+
+  @override
+  String get privacyFirst => 'Privacy al primo posto';
+
+  @override
+  String get saveChanges => 'Salva Modifiche';
+
+  @override
+  String get resetToDefault => 'Ripristina Predefinito';
+
+  @override
+  String get viewTemplate => 'Visualizza Template';
+
+  @override
+  String get trySomethingLike => 'Prova qualcosa come...';
+
+  @override
+  String get tryIt => 'Provalo';
+
+  @override
+  String get creatingPlan => 'Creazione piano';
+
+  @override
+  String get developingLogic => 'Sviluppo logica';
+
+  @override
+  String get designingApp => 'Progettazione app';
+
+  @override
+  String get generatingIconStep => 'Generazione icona';
+
+  @override
+  String get finalTouches => 'Ritocchi finali';
+
+  @override
+  String get processing => 'Elaborazione...';
+
+  @override
+  String get features => 'Funzionalità';
+
+  @override
+  String get creatingYourApp => 'Creazione della tua app...';
+
+  @override
+  String get generatingIcon => 'Generazione icona...';
+
+  @override
+  String get whatShouldWeMake => 'Cosa dovremmo creare?';
+
+  @override
+  String get appName => 'Nome App';
+
+  @override
+  String get description => 'Descrizione';
+
+  @override
+  String get publicLabel => 'Pubblico';
+
+  @override
+  String get privateLabel => 'Privato';
+
+  @override
+  String get free => 'Gratuito';
+
+  @override
+  String get perMonth => '/ Mese';
+
+  @override
+  String get tailoredConversationSummaries => 'Riepiloghi Conversazione Personalizzati';
+
+  @override
+  String get customChatbotPersonality => 'Personalità Chatbot Personalizzata';
+
+  @override
+  String get makePublic => 'Rendi pubblico';
+
+  @override
+  String get anyoneCanDiscover => 'Chiunque può scoprire la tua app';
+
+  @override
+  String get onlyYouCanUse => 'Solo tu puoi usare questa app';
+
+  @override
+  String get paidApp => 'App a pagamento';
+
+  @override
+  String get usersPayToUse => 'Gli utenti pagano per usare la tua app';
+
+  @override
+  String get freeForEveryone => 'Gratuito per tutti';
+
+  @override
+  String get perMonthLabel => '/ mese';
+
+  @override
+  String get creating => 'Creazione...';
+
+  @override
+  String get createApp => 'Crea App';
+
+  @override
+  String get searchingForDevices => 'Ricerca dispositivi...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'DISPOSITIVI',
+      one: 'DISPOSITIVO',
+    );
+    return '$count $_temp0 TROVATO/I NELLE VICINANZE';
+  }
+
+  @override
+  String get pairingSuccessful => 'ACCOPPIAMENTO RIUSCITO';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Errore durante la connessione all\'Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Non mostrare più';
+
+  @override
+  String get iUnderstand => 'Ho Capito';
+
+  @override
+  String get enableBluetooth => 'Abilita Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi ha bisogno del Bluetooth per connettersi al tuo dispositivo indossabile. Abilita il Bluetooth e riprova.';
+
+  @override
+  String get contactSupport => 'Contatta Supporto?';
+
+  @override
+  String get connectLater => 'Connetti Più Tardi';
+
+  @override
+  String get grantPermissions => 'Concedi permessi';
+
+  @override
+  String get backgroundActivity => 'Attività in background';
+
+  @override
+  String get backgroundActivityDesc => 'Consenti a Omi di funzionare in background per una migliore stabilità';
+
+  @override
+  String get locationAccess => 'Accesso posizione';
+
+  @override
+  String get locationAccessDesc => 'Abilita posizione in background per l\'esperienza completa';
+
+  @override
+  String get notifications => 'Notifiche';
+
+  @override
+  String get notificationsDesc => 'Abilita le notifiche per rimanere informato';
+
+  @override
+  String get locationServiceDisabled => 'Servizio di Localizzazione Disabilitato';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Il Servizio di Localizzazione è disabilitato. Vai su Impostazioni > Privacy e Sicurezza > Servizi di Localizzazione e abilitalo';
+
+  @override
+  String get backgroundLocationDenied => 'Accesso Posizione in Background Negato';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Vai nelle impostazioni del dispositivo e imposta il permesso di localizzazione su \"Consenti sempre\"';
+
+  @override
+  String get lovingOmi => 'Ti piace Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Aiutaci a raggiungere più persone lasciando una recensione sull\'App Store. Il tuo feedback è prezioso per noi!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Aiutaci a raggiungere più persone lasciando una recensione sul Google Play Store. Il tuo feedback è prezioso per noi!';
+
+  @override
+  String get rateOnAppStore => 'Valuta su App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Valuta su Google Play';
+
+  @override
+  String get maybeLater => 'Forse più tardi';
+
+  @override
+  String get speechProfileIntro =>
+      'Omi ha bisogno di conoscere i tuoi obiettivi e la tua voce. Potrai modificarli in seguito.';
+
+  @override
+  String get getStarted => 'Inizia';
+
+  @override
+  String get allDone => 'Tutto fatto!';
+
+  @override
+  String get keepGoing => 'Continua così, stai andando alla grande';
+
+  @override
+  String get skipThisQuestion => 'Salta questa domanda';
+
+  @override
+  String get skipForNow => 'Salta per ora';
+
+  @override
+  String get connectionError => 'Errore di Connessione';
+
+  @override
+  String get connectionErrorDesc =>
+      'Impossibile connettersi al server. Controlla la tua connessione internet e riprova.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Registrazione non valida rilevata';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Sembra che ci siano più persone che parlano nella registrazione. Assicurati di essere in un luogo silenzioso e riprova.';
+
+  @override
+  String get tooShortDesc => 'Non è stato rilevato abbastanza parlato. Parla di più e riprova.';
+
+  @override
+  String get invalidRecordingDesc => 'Assicurati di parlare per almeno 5 secondi e non più di 90.';
+
+  @override
+  String get areYouThere => 'Ci sei?';
+
+  @override
+  String get noSpeechDesc =>
+      'Non abbiamo rilevato nessun parlato. Assicurati di parlare per almeno 10 secondi e non più di 3 minuti.';
+
+  @override
+  String get connectionLost => 'Connessione Persa';
+
+  @override
+  String get connectionLostDesc =>
+      'La connessione è stata interrotta. Controlla la tua connessione internet e riprova.';
+
+  @override
+  String get tryAgain => 'Riprova';
+
+  @override
+  String get connectOmiOmiGlass => 'Connetti Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Continua Senza Dispositivo';
+
+  @override
+  String get permissionsRequired => 'Permessi Richiesti';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Questa app ha bisogno dei permessi Bluetooth e Posizione per funzionare correttamente. Abilitali nelle impostazioni.';
+
+  @override
+  String get openSettings => 'Apri Impostazioni';
+
+  @override
+  String get wantDifferentName => 'Vuoi farti chiamare diversamente?';
+
+  @override
+  String get whatsYourName => 'Come ti chiami?';
+
+  @override
+  String get speakTranscribeSummarize => 'Parla. Trascrivi. Riassumi.';
+
+  @override
+  String get signInWithApple => 'Accedi con Apple';
+
+  @override
+  String get signInWithGoogle => 'Accedi con Google';
+
+  @override
+  String get byContinuingAgree => 'Continuando, accetti la nostra ';
+
+  @override
+  String get termsOfUse => 'Condizioni d\'Uso';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Il Tuo Compagno AI';
+
+  @override
+  String get captureEveryMoment =>
+      'Cattura ogni momento. Ottieni riepiloghi\nbasati sull\'AI. Non prendere mai più appunti.';
+
+  @override
+  String get appleWatchSetup => 'Configurazione Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Permesso Richiesto!';
+
+  @override
+  String get microphonePermission => 'Permesso Microfono';
+
+  @override
+  String get permissionGrantedNow =>
+      'Permesso concesso! Ora:\n\nApri l\'app Omi sul tuo watch e tocca \"Continua\" qui sotto';
+
+  @override
+  String get needMicrophonePermission =>
+      'Abbiamo bisogno del permesso microfono.\n\n1. Tocca \"Concedi Permesso\"\n2. Consenti sul tuo iPhone\n3. L\'app Watch si chiuderà\n4. Riaprila e tocca \"Continua\"';
+
+  @override
+  String get grantPermissionButton => 'Concedi Permesso';
+
+  @override
+  String get needHelp => 'Serve Aiuto?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Risoluzione problemi:\n\n1. Assicurati che Omi sia installato sul tuo watch\n2. Apri l\'app Omi sul tuo watch\n3. Cerca il popup di permesso\n4. Tocca \"Consenti\" quando richiesto\n5. L\'app sul watch si chiuderà - riaprila\n6. Torna e tocca \"Continua\" sul tuo iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Registrazione avviata con successo!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Permesso non ancora concesso. Assicurati di aver consentito l\'accesso al microfono e di aver riaperto l\'app sul tuo watch.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Errore durante la richiesta del permesso: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Errore durante l\'avvio della registrazione: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Seleziona la tua lingua principale';
+
+  @override
+  String get languageBenefits => 'Imposta la tua lingua per trascrizioni più accurate e un\'esperienza personalizzata';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Qual è la tua lingua principale?';
+
+  @override
+  String get selectYourLanguage => 'Seleziona la tua lingua';
+
+  @override
+  String get personalGrowthJourney => 'Il tuo percorso di crescita personale con un\'AI che ascolta ogni tua parola.';
+
+  @override
+  String get actionItemsTitle => 'Da Fare';
+
+  @override
+  String get actionItemsDescription => 'Tocca per modificare • Tieni premuto per selezionare • Scorri per azioni';
+
+  @override
+  String get tabToDo => 'Da Fare';
+
+  @override
+  String get tabDone => 'Fatto';
+
+  @override
+  String get tabOld => 'Vecchi';
+
+  @override
+  String get emptyTodoMessage => '🎉 Tutto a posto!\nNessuna azione in sospeso';
+
+  @override
+  String get emptyDoneMessage => 'Nessun elemento completato ancora';
+
+  @override
+  String get emptyOldMessage => '✅ Nessuna attività vecchia';
+
+  @override
+  String get noItems => 'Nessun elemento';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Azione contrassegnata come non completata';
+
+  @override
+  String get actionItemCompleted => 'Azione completata';
+
+  @override
+  String get deleteActionItemTitle => 'Elimina Azione';
+
+  @override
+  String get deleteActionItemMessage => 'Sei sicuro di voler eliminare questa azione?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Elimina Elementi Selezionati';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Sei sicuro di voler eliminare $count azione/i selezionata/e?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Azione \"$description\" eliminata';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count azione/i eliminata/e';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Impossibile eliminare l\'azione';
+
+  @override
+  String get failedToDeleteItems => 'Impossibile eliminare gli elementi';
+
+  @override
+  String get failedToDeleteSomeItems => 'Impossibile eliminare alcuni elementi';
+
+  @override
+  String get welcomeActionItemsTitle => 'Pronto per le Azioni';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'La tua AI estrarrà automaticamente attività e cose da fare dalle tue conversazioni. Appariranno qui quando create.';
+
+  @override
+  String get autoExtractionFeature => 'Estratto automaticamente dalle conversazioni';
+
+  @override
+  String get editSwipeFeature => 'Tocca per modificare, scorri per completare o eliminare';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count selezionati';
+  }
+
+  @override
+  String get selectAll => 'Seleziona tutto';
+
+  @override
+  String get deleteSelected => 'Elimina selezionati';
+
+  @override
+  String searchMemories(int count) {
+    return 'Cerca $count Ricordi';
+  }
+
+  @override
+  String get memoryDeleted => 'Ricordo Eliminato.';
+
+  @override
+  String get undo => 'Annulla';
+
+  @override
+  String get noMemoriesYet => 'Nessun ricordo ancora';
+
+  @override
+  String get noAutoMemories => 'Nessun ricordo auto-estratto ancora';
+
+  @override
+  String get noManualMemories => 'Nessun ricordo manuale ancora';
+
+  @override
+  String get noMemoriesInCategories => 'Nessun ricordo in queste categorie';
+
+  @override
+  String get noMemoriesFound => 'Nessun ricordo trovato';
+
+  @override
+  String get addFirstMemory => 'Aggiungi il tuo primo ricordo';
+
+  @override
+  String get clearMemoryTitle => 'Cancella Memoria di Omi';
+
+  @override
+  String get clearMemoryMessage =>
+      'Sei sicuro di voler cancellare la memoria di Omi? Questa azione non può essere annullata.';
+
+  @override
+  String get clearMemoryButton => 'Cancella Memoria';
+
+  @override
+  String get memoryClearedSuccess => 'La memoria di Omi su di te è stata cancellata';
+
+  @override
+  String get noMemoriesToDelete => 'Nessun ricordo da eliminare';
+
+  @override
+  String get createMemoryTooltip => 'Crea nuovo ricordo';
+
+  @override
+  String get createActionItemTooltip => 'Crea nuova azione';
+
+  @override
+  String get memoryManagement => 'Gestione Ricordi';
+
+  @override
+  String get filterMemories => 'Filtra Ricordi';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Hai $count ricordi totali';
+  }
+
+  @override
+  String get publicMemories => 'Ricordi pubblici';
+
+  @override
+  String get privateMemories => 'Ricordi privati';
+
+  @override
+  String get makeAllPrivate => 'Rendi Tutti i Ricordi Privati';
+
+  @override
+  String get makeAllPublic => 'Rendi Tutti i Ricordi Pubblici';
+
+  @override
+  String get deleteAllMemories => 'Elimina Tutti i Ricordi';
+
+  @override
+  String get allMemoriesPrivateResult => 'Tutti i ricordi sono ora privati';
+
+  @override
+  String get allMemoriesPublicResult => 'Tutti i ricordi sono ora pubblici';
+
+  @override
+  String get newMemory => 'Nuovo Ricordo';
+
+  @override
+  String get editMemory => 'Modifica Ricordo';
+
+  @override
+  String get memoryContentHint => 'Mi piace mangiare il gelato...';
+
+  @override
+  String get failedToSaveMemory => 'Impossibile salvare. Controlla la tua connessione.';
+
+  @override
+  String get saveMemory => 'Salva Ricordo';
+
+  @override
+  String get retry => 'Riprova';
+
+  @override
+  String get createActionItem => 'Crea Azione';
+
+  @override
+  String get editActionItem => 'Modifica Azione';
+
+  @override
+  String get actionItemDescriptionHint => 'Cosa bisogna fare?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'La descrizione dell\'azione non può essere vuota.';
+
+  @override
+  String get actionItemUpdated => 'Azione aggiornata';
+
+  @override
+  String get failedToUpdateActionItem => 'Impossibile aggiornare l\'azione';
+
+  @override
+  String get actionItemCreated => 'Azione creata';
+
+  @override
+  String get failedToCreateActionItem => 'Impossibile creare l\'azione';
+
+  @override
+  String get dueDate => 'Data di Scadenza';
+
+  @override
+  String get time => 'Ora';
+
+  @override
+  String get addDueDate => 'Aggiungi data di scadenza';
+
+  @override
+  String get pressDoneToSave => 'Premi fatto per salvare';
+
+  @override
+  String get pressDoneToCreate => 'Premi fatto per creare';
+
+  @override
+  String get filterAll => 'Tutti';
+
+  @override
+  String get filterSystem => 'Su di Te';
+
+  @override
+  String get filterInteresting => 'Insight';
+
+  @override
+  String get filterManual => 'Manuale';
+
+  @override
+  String get completed => 'Completato';
+
+  @override
+  String get markComplete => 'Segna come completato';
+
+  @override
+  String get actionItemDeleted => 'Azione eliminata';
+
+  @override
+  String get failedToDeleteActionItem => 'Impossibile eliminare l\'azione';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Elimina Azione';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Sei sicuro di voler eliminare questa azione?';
+
+  @override
+  String get appLanguage => 'Lingua App';
+
+  @override
+  String get appInterfaceSectionTitle => 'INTERFACCIA APP';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'VOCE E TRASCRIZIONE';
+
+  @override
+  String get languageSettingsHelperText =>
+      'La lingua dell\'app modifica menu e pulsanti. La lingua vocale influisce su come vengono trascritte le tue registrazioni.';
+}

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -232,7 +232,7 @@ class AppLocalizationsJa extends AppLocalizations {
   String get searchConversations => '会話を検索';
 
   @override
-  String selectedCount(int count) {
+  String selectedCount(int count, Object s) {
     return '$count件選択中';
   }
 
@@ -2150,10 +2150,10 @@ class AppLocalizationsJa extends AppLocalizations {
   String get filterAll => 'すべて';
 
   @override
-  String get filterSystem => 'About You';
+  String get filterSystem => 'あなたについて';
 
   @override
-  String get filterInteresting => 'Insights';
+  String get filterInteresting => 'インサイト';
 
   @override
   String get filterManual => '手動';
@@ -2178,4 +2178,13 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get appLanguage => 'アプリ言語';
+
+  @override
+  String get appInterfaceSectionTitle => 'アプリインターフェース';
+
+  @override
+  String get speechTranscriptionSectionTitle => '音声と文字起こし';
+
+  @override
+  String get languageSettingsHelperText => 'アプリ言語はメニューとボタンを変更します。音声言語は録音の文字起こし方法に影響します。';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -1,0 +1,2190 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Korean (`ko`).
+class AppLocalizationsKo extends AppLocalizations {
+  AppLocalizationsKo([String locale = 'ko']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => '대화';
+
+  @override
+  String get transcriptTab => '녹취록';
+
+  @override
+  String get actionItemsTab => '할 일';
+
+  @override
+  String get deleteConversationTitle => '대화를 삭제하시겠습니까?';
+
+  @override
+  String get deleteConversationMessage => '이 대화를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.';
+
+  @override
+  String get confirm => '확인';
+
+  @override
+  String get cancel => '취소';
+
+  @override
+  String get ok => '확인';
+
+  @override
+  String get delete => '삭제';
+
+  @override
+  String get add => '추가';
+
+  @override
+  String get update => '업데이트';
+
+  @override
+  String get save => '저장';
+
+  @override
+  String get edit => '편집';
+
+  @override
+  String get close => '닫기';
+
+  @override
+  String get clear => '지우기';
+
+  @override
+  String get copyTranscript => '녹취록 복사';
+
+  @override
+  String get copySummary => '요약 복사';
+
+  @override
+  String get testPrompt => '프롬프트 테스트';
+
+  @override
+  String get reprocessConversation => '대화 재처리';
+
+  @override
+  String get deleteConversation => '대화 삭제';
+
+  @override
+  String get contentCopied => '콘텐츠가 클립보드에 복사되었습니다';
+
+  @override
+  String get failedToUpdateStarred => '즐겨찾기 상태 업데이트에 실패했습니다.';
+
+  @override
+  String get conversationUrlNotShared => '대화 URL을 공유할 수 없습니다.';
+
+  @override
+  String get errorProcessingConversation => '대화 처리 중 오류가 발생했습니다. 나중에 다시 시도해 주세요.';
+
+  @override
+  String get noInternetConnection => '인터넷 연결을 확인하고 다시 시도해 주세요.';
+
+  @override
+  String get unableToDeleteConversation => '대화를 삭제할 수 없습니다';
+
+  @override
+  String get somethingWentWrong => '문제가 발생했습니다! 나중에 다시 시도해 주세요.';
+
+  @override
+  String get copyErrorMessage => '오류 메시지 복사';
+
+  @override
+  String get errorCopied => '오류 메시지가 클립보드에 복사되었습니다';
+
+  @override
+  String get remaining => '남은';
+
+  @override
+  String get loading => '로딩 중...';
+
+  @override
+  String get loadingDuration => '지속 시간 로딩 중...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count초';
+  }
+
+  @override
+  String get people => '사람들';
+
+  @override
+  String get addNewPerson => '새로운 사람 추가';
+
+  @override
+  String get editPerson => '사람 편집';
+
+  @override
+  String get createPersonHint => '새로운 사람을 만들고 Omi가 그들의 음성을 인식하도록 학습시키세요!';
+
+  @override
+  String get speechProfile => '음성 프로필';
+
+  @override
+  String sampleNumber(int number) {
+    return '샘플 $number';
+  }
+
+  @override
+  String get settings => '설정';
+
+  @override
+  String get language => '언어';
+
+  @override
+  String get selectLanguage => '언어 선택';
+
+  @override
+  String get deleting => '삭제 중...';
+
+  @override
+  String get pleaseCompleteAuthentication => '브라우저에서 인증을 완료해 주세요. 완료되면 앱으로 돌아가세요.';
+
+  @override
+  String get failedToStartAuthentication => '인증 시작에 실패했습니다';
+
+  @override
+  String get importStarted => '가져오기가 시작되었습니다! 완료되면 알려드리겠습니다.';
+
+  @override
+  String get failedToStartImport => '가져오기 시작에 실패했습니다. 다시 시도해 주세요.';
+
+  @override
+  String get couldNotAccessFile => '선택한 파일에 접근할 수 없습니다';
+
+  @override
+  String get askOmi => 'Omi에게 질문하기';
+
+  @override
+  String get done => '완료';
+
+  @override
+  String get disconnected => '연결 끊김';
+
+  @override
+  String get searching => '검색 중';
+
+  @override
+  String get connectDevice => '기기 연결';
+
+  @override
+  String get monthlyLimitReached => '월간 한도에 도달했습니다.';
+
+  @override
+  String get checkUsage => '사용량 확인';
+
+  @override
+  String get syncingRecordings => '녹음 동기화 중';
+
+  @override
+  String get recordingsToSync => '동기화할 녹음';
+
+  @override
+  String get allCaughtUp => '모두 완료';
+
+  @override
+  String get sync => '동기화';
+
+  @override
+  String get pendantUpToDate => '펜던트가 최신 상태입니다';
+
+  @override
+  String get allRecordingsSynced => '모든 녹음이 동기화되었습니다';
+
+  @override
+  String get syncingInProgress => '동기화 진행 중';
+
+  @override
+  String get readyToSync => '동기화 준비 완료';
+
+  @override
+  String get tapSyncToStart => '동기화를 탭하여 시작하세요';
+
+  @override
+  String get pendantNotConnected => '펜던트가 연결되지 않았습니다. 동기화하려면 연결하세요.';
+
+  @override
+  String get everythingSynced => '모든 항목이 이미 동기화되었습니다.';
+
+  @override
+  String get recordingsNotSynced => '아직 동기화되지 않은 녹음이 있습니다.';
+
+  @override
+  String get syncingBackground => '백그라운드에서 녹음을 계속 동기화하겠습니다.';
+
+  @override
+  String get noConversationsYet => '아직 대화가 없습니다.';
+
+  @override
+  String get noStarredConversations => '아직 즐겨찾기한 대화가 없습니다.';
+
+  @override
+  String get starConversationHint => '대화를 즐겨찾기하려면 대화를 열고 헤더의 별 아이콘을 탭하세요.';
+
+  @override
+  String get searchConversations => '대화 검색';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count개 선택됨';
+  }
+
+  @override
+  String get merge => '병합';
+
+  @override
+  String get mergeConversations => '대화 병합';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return '$count개의 대화를 하나로 결합합니다. 모든 내용이 병합되고 재생성됩니다.';
+  }
+
+  @override
+  String get mergingInBackground => '백그라운드에서 병합 중입니다. 잠시 시간이 걸릴 수 있습니다.';
+
+  @override
+  String get failedToStartMerge => '병합 시작에 실패했습니다';
+
+  @override
+  String get askAnything => '무엇이든 물어보세요';
+
+  @override
+  String get noMessagesYet => '아직 메시지가 없습니다!\n대화를 시작해보는 건 어떨까요?';
+
+  @override
+  String get deletingMessages => 'Omi의 메모리에서 메시지를 삭제하는 중...';
+
+  @override
+  String get messageCopied => '메시지가 클립보드에 복사되었습니다.';
+
+  @override
+  String get cannotReportOwnMessage => '자신의 메시지는 신고할 수 없습니다.';
+
+  @override
+  String get reportMessage => '메시지 신고';
+
+  @override
+  String get reportMessageConfirm => '이 메시지를 신고하시겠습니까?';
+
+  @override
+  String get messageReported => '메시지가 성공적으로 신고되었습니다.';
+
+  @override
+  String get thankYouFeedback => '피드백 감사합니다!';
+
+  @override
+  String get clearChat => '채팅을 지우시겠습니까?';
+
+  @override
+  String get clearChatConfirm => '채팅을 지우시겠습니까? 이 작업은 되돌릴 수 없습니다.';
+
+  @override
+  String get maxFilesLimit => '한 번에 최대 4개의 파일만 업로드할 수 있습니다';
+
+  @override
+  String get chatWithOmi => 'Omi와 채팅하기';
+
+  @override
+  String get apps => '앱';
+
+  @override
+  String get noAppsFound => '앱을 찾을 수 없습니다';
+
+  @override
+  String get tryAdjustingSearch => '검색어나 필터를 조정해 보세요';
+
+  @override
+  String get createYourOwnApp => '나만의 앱 만들기';
+
+  @override
+  String get buildAndShareApp => '맞춤형 앱을 만들고 공유하세요';
+
+  @override
+  String get searchApps => '1500개 이상의 앱 검색';
+
+  @override
+  String get myApps => '내 앱';
+
+  @override
+  String get installedApps => '설치된 앱';
+
+  @override
+  String get unableToFetchApps => '앱을 가져올 수 없습니다 :(\n\n인터넷 연결을 확인하고 다시 시도해 주세요.';
+
+  @override
+  String get aboutOmi => 'Omi 정보';
+
+  @override
+  String get privacyPolicy => '개인정보 처리방침';
+
+  @override
+  String get visitWebsite => '웹사이트 방문';
+
+  @override
+  String get helpOrInquiries => '도움말 또는 문의사항이 있으신가요?';
+
+  @override
+  String get joinCommunity => '커뮤니티에 참여하세요!';
+
+  @override
+  String get membersAndCounting => '8000명 이상의 멤버가 함께하고 있습니다.';
+
+  @override
+  String get deleteAccountTitle => '계정 삭제';
+
+  @override
+  String get deleteAccountConfirm => '계정을 삭제하시겠습니까?';
+
+  @override
+  String get cannotBeUndone => '이 작업은 되돌릴 수 없습니다.';
+
+  @override
+  String get allDataErased => '모든 기억과 대화가 영구적으로 삭제됩니다.';
+
+  @override
+  String get appsDisconnected => '앱 및 통합 기능이 즉시 연결 해제됩니다.';
+
+  @override
+  String get exportBeforeDelete => '계정을 삭제하기 전에 데이터를 내보낼 수 있지만, 삭제된 후에는 복구할 수 없습니다.';
+
+  @override
+  String get deleteAccountCheckbox => '계정 삭제는 영구적이며 기억과 대화를 포함한 모든 데이터가 손실되어 복구할 수 없음을 이해합니다.';
+
+  @override
+  String get areYouSure => '정말 확실하신가요?';
+
+  @override
+  String get deleteAccountFinal => '이 작업은 되돌릴 수 없으며 계정과 관련된 모든 데이터가 영구적으로 삭제됩니다. 계속하시겠습니까?';
+
+  @override
+  String get deleteNow => '지금 삭제';
+
+  @override
+  String get goBack => '돌아가기';
+
+  @override
+  String get checkBoxToConfirm => '계정 삭제가 영구적이고 되돌릴 수 없음을 이해했음을 확인하려면 체크박스를 선택하세요.';
+
+  @override
+  String get profile => '프로필';
+
+  @override
+  String get name => '이름';
+
+  @override
+  String get email => '이메일';
+
+  @override
+  String get customVocabulary => '사용자 지정 어휘';
+
+  @override
+  String get identifyingOthers => '다른 사람 식별';
+
+  @override
+  String get paymentMethods => '결제 수단';
+
+  @override
+  String get conversationDisplay => '대화 표시';
+
+  @override
+  String get dataPrivacy => '데이터 및 개인정보';
+
+  @override
+  String get userId => '사용자 ID';
+
+  @override
+  String get notSet => '설정되지 않음';
+
+  @override
+  String get userIdCopied => '사용자 ID가 클립보드에 복사되었습니다';
+
+  @override
+  String get systemDefault => '시스템 기본값';
+
+  @override
+  String get planAndUsage => '플랜 및 사용량';
+
+  @override
+  String get offlineSync => '오프라인 동기화';
+
+  @override
+  String get deviceSettings => '기기 설정';
+
+  @override
+  String get chatTools => '채팅 도구';
+
+  @override
+  String get feedbackBug => '피드백 / 버그';
+
+  @override
+  String get helpCenter => '고객센터';
+
+  @override
+  String get developerSettings => '개발자 설정';
+
+  @override
+  String get getOmiForMac => 'Mac용 Omi 다운로드';
+
+  @override
+  String get referralProgram => '추천 프로그램';
+
+  @override
+  String get signOut => '로그아웃';
+
+  @override
+  String get appAndDeviceCopied => '앱 및 기기 정보가 복사되었습니다';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => '당신의 개인정보, 당신의 제어';
+
+  @override
+  String get privacyIntro => 'Omi는 귀하의 개인정보 보호에 최선을 다하고 있습니다. 이 페이지에서 데이터 저장 및 사용 방법을 제어할 수 있습니다.';
+
+  @override
+  String get learnMore => '자세히 알아보기...';
+
+  @override
+  String get dataProtectionLevel => '데이터 보호 수준';
+
+  @override
+  String get dataProtectionDesc => '귀하의 데이터는 기본적으로 강력한 암호화로 보호됩니다. 아래에서 설정 및 향후 개인정보 옵션을 검토하세요.';
+
+  @override
+  String get appAccess => '앱 접근';
+
+  @override
+  String get appAccessDesc => '다음 앱이 귀하의 데이터에 접근할 수 있습니다. 앱을 탭하여 권한을 관리하세요.';
+
+  @override
+  String get noAppsExternalAccess => '설치된 앱 중 귀하의 데이터에 외부 접근 권한이 있는 앱이 없습니다.';
+
+  @override
+  String get deviceName => '기기 이름';
+
+  @override
+  String get deviceId => '기기 ID';
+
+  @override
+  String get firmware => '펌웨어';
+
+  @override
+  String get sdCardSync => 'SD 카드 동기화';
+
+  @override
+  String get hardwareRevision => '하드웨어 버전';
+
+  @override
+  String get modelNumber => '모델 번호';
+
+  @override
+  String get manufacturer => '제조사';
+
+  @override
+  String get doubleTap => '더블 탭';
+
+  @override
+  String get ledBrightness => 'LED 밝기';
+
+  @override
+  String get micGain => '마이크 게인';
+
+  @override
+  String get disconnect => '연결 해제';
+
+  @override
+  String get forgetDevice => '기기 삭제';
+
+  @override
+  String get chargingIssues => '충전 문제';
+
+  @override
+  String get disconnectDevice => '기기 연결 해제';
+
+  @override
+  String get unpairDevice => '기기 페어링 해제';
+
+  @override
+  String get unpairAndForget => '기기 페어링 해제 및 삭제';
+
+  @override
+  String get deviceDisconnectedMessage => 'Omi 기기의 연결이 해제되었습니다 😔';
+
+  @override
+  String get deviceUnpairedMessage => '기기 페어링이 해제되었습니다. 페어링 해제를 완료하려면 설정 > 블루투스로 이동하여 기기를 삭제하세요.';
+
+  @override
+  String get unpairDialogTitle => '기기 페어링 해제';
+
+  @override
+  String get unpairDialogMessage => '다른 휴대폰에 연결할 수 있도록 기기의 페어링을 해제합니다. 프로세스를 완료하려면 설정 > 블루투스로 이동하여 기기를 삭제해야 합니다.';
+
+  @override
+  String get deviceNotConnected => '기기가 연결되지 않음';
+
+  @override
+  String get connectDeviceMessage => 'Omi 기기를 연결하여\n기기 설정 및 사용자 지정에 접근하세요';
+
+  @override
+  String get deviceInfoSection => '기기 정보';
+
+  @override
+  String get customizationSection => '사용자 지정';
+
+  @override
+  String get hardwareSection => '하드웨어';
+
+  @override
+  String get v2Undetected => 'V2를 감지할 수 없음';
+
+  @override
+  String get v2UndetectedMessage => 'V1 기기를 사용하고 있거나 기기가 연결되지 않았습니다. SD 카드 기능은 V2 기기에서만 사용할 수 있습니다.';
+
+  @override
+  String get endConversation => '대화 종료';
+
+  @override
+  String get pauseResume => '일시정지/재개';
+
+  @override
+  String get starConversation => '대화 즐겨찾기';
+
+  @override
+  String get doubleTapAction => '더블 탭 동작';
+
+  @override
+  String get endAndProcess => '대화 종료 및 처리';
+
+  @override
+  String get pauseResumeRecording => '녹음 일시정지/재개';
+
+  @override
+  String get starOngoing => '진행 중인 대화 즐겨찾기';
+
+  @override
+  String get off => '끄기';
+
+  @override
+  String get max => '최대';
+
+  @override
+  String get mute => '음소거';
+
+  @override
+  String get quiet => '조용함';
+
+  @override
+  String get normal => '보통';
+
+  @override
+  String get high => '높음';
+
+  @override
+  String get micGainDescMuted => '마이크가 음소거되었습니다';
+
+  @override
+  String get micGainDescLow => '매우 조용함 - 시끄러운 환경용';
+
+  @override
+  String get micGainDescModerate => '조용함 - 보통 소음용';
+
+  @override
+  String get micGainDescNeutral => '중립 - 균형 잡힌 녹음';
+
+  @override
+  String get micGainDescSlightlyBoosted => '약간 증폭 - 일반 사용';
+
+  @override
+  String get micGainDescBoosted => '증폭 - 조용한 환경용';
+
+  @override
+  String get micGainDescHigh => '높음 - 멀리 있거나 부드러운 목소리용';
+
+  @override
+  String get micGainDescVeryHigh => '매우 높음 - 매우 조용한 소스용';
+
+  @override
+  String get micGainDescMax => '최대 - 주의해서 사용';
+
+  @override
+  String get developerSettingsTitle => '개발자 설정';
+
+  @override
+  String get saving => '저장 중...';
+
+  @override
+  String get personaConfig => 'AI 페르소나 구성';
+
+  @override
+  String get beta => '베타';
+
+  @override
+  String get transcription => '음성 변환';
+
+  @override
+  String get transcriptionConfig => 'STT 제공업체 구성';
+
+  @override
+  String get conversationTimeout => '대화 시간 제한';
+
+  @override
+  String get conversationTimeoutConfig => '대화 자동 종료 시간 설정';
+
+  @override
+  String get importData => '데이터 가져오기';
+
+  @override
+  String get importDataConfig => '다른 소스에서 데이터 가져오기';
+
+  @override
+  String get debugDiagnostics => '디버그 및 진단';
+
+  @override
+  String get endpointUrl => '엔드포인트 URL';
+
+  @override
+  String get noApiKeys => '아직 API 키가 없습니다';
+
+  @override
+  String get createKeyToStart => '시작하려면 키를 만드세요';
+
+  @override
+  String get createKey => '키 만들기';
+
+  @override
+  String get docs => '문서';
+
+  @override
+  String get yourOmiInsights => 'Omi 인사이트';
+
+  @override
+  String get today => '오늘';
+
+  @override
+  String get thisMonth => '이번 달';
+
+  @override
+  String get thisYear => '올해';
+
+  @override
+  String get allTime => '전체 기간';
+
+  @override
+  String get noActivityYet => '아직 활동이 없습니다';
+
+  @override
+  String get startConversationToSeeInsights => 'Omi와 대화를 시작하여\n사용량 인사이트를 확인하세요.';
+
+  @override
+  String get listening => '청취';
+
+  @override
+  String get listeningSubtitle => 'Omi가 적극적으로 청취한 총 시간입니다.';
+
+  @override
+  String get understanding => '이해';
+
+  @override
+  String get understandingSubtitle => '대화에서 이해한 단어 수입니다.';
+
+  @override
+  String get providing => '제공';
+
+  @override
+  String get providingSubtitle => '자동으로 캡처된 할 일 및 메모입니다.';
+
+  @override
+  String get remembering => '기억';
+
+  @override
+  String get rememberingSubtitle => '당신을 위해 기억된 사실과 세부 정보입니다.';
+
+  @override
+  String get unlimitedPlan => '무제한 플랜';
+
+  @override
+  String get managePlan => '플랜 관리';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return '플랜이 $date에 취소됩니다.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return '플랜이 $date에 갱신됩니다.';
+  }
+
+  @override
+  String get basicPlan => '무료 플랜';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$limit분 중 $used분 사용';
+  }
+
+  @override
+  String get upgrade => '업그레이드';
+
+  @override
+  String get upgradeToUnlimited => '무제한으로 업그레이드';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return '플랜에는 매월 $limit분의 무료 시간이 포함됩니다. 무제한으로 업그레이드하세요.';
+  }
+
+  @override
+  String get shareStatsMessage => '내 Omi 통계를 공유합니다! (omi.me - 항상 켜져 있는 AI 어시스턴트)';
+
+  @override
+  String get sharePeriodToday => '오늘 Omi는:';
+
+  @override
+  String get sharePeriodMonth => '이번 달 Omi는:';
+
+  @override
+  String get sharePeriodYear => '올해 Omi는:';
+
+  @override
+  String get sharePeriodAllTime => '지금까지 Omi는:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 $minutes분 동안 청취했습니다';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 $words개의 단어를 이해했습니다';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ $count개의 인사이트를 제공했습니다';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 $count개의 기억을 저장했습니다';
+  }
+
+  @override
+  String get debugLogs => '디버그 로그';
+
+  @override
+  String get debugLogsAutoDelete => '3일 후 자동 삭제됩니다.';
+
+  @override
+  String get debugLogsDesc => '문제 진단에 도움이 됩니다';
+
+  @override
+  String get noLogFilesFound => '로그 파일을 찾을 수 없습니다.';
+
+  @override
+  String get omiDebugLog => 'Omi 디버그 로그';
+
+  @override
+  String get logShared => '로그가 공유되었습니다';
+
+  @override
+  String get selectLogFile => '로그 파일 선택';
+
+  @override
+  String get shareLogs => '로그 공유';
+
+  @override
+  String get debugLogCleared => '디버그 로그가 지워졌습니다';
+
+  @override
+  String get exportStarted => '내보내기가 시작되었습니다. 몇 초 정도 걸릴 수 있습니다...';
+
+  @override
+  String get exportAllData => '모든 데이터 내보내기';
+
+  @override
+  String get exportDataDesc => '대화를 JSON 파일로 내보내기';
+
+  @override
+  String get exportedConversations => 'Omi에서 내보낸 대화';
+
+  @override
+  String get exportShared => '내보내기가 공유되었습니다';
+
+  @override
+  String get deleteKnowledgeGraphTitle => '지식 그래프를 삭제하시겠습니까?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      '파생된 모든 지식 그래프 데이터(노드 및 연결)가 삭제됩니다. 원본 기억은 안전하게 유지됩니다. 그래프는 시간이 지나면 다시 구축되거나 다음 요청 시 재구축됩니다.';
+
+  @override
+  String get knowledgeGraphDeleted => '지식 그래프가 성공적으로 삭제되었습니다';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return '그래프 삭제 실패: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => '지식 그래프 삭제';
+
+  @override
+  String get deleteKnowledgeGraphDesc => '모든 노드 및 연결 지우기';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP 서버';
+
+  @override
+  String get mcpServerDesc => 'AI 어시스턴트를 데이터에 연결';
+
+  @override
+  String get serverUrl => '서버 URL';
+
+  @override
+  String get urlCopied => 'URL이 복사되었습니다';
+
+  @override
+  String get apiKeyAuth => 'API 키 인증';
+
+  @override
+  String get header => '헤더';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => '클라이언트 ID';
+
+  @override
+  String get clientSecret => '클라이언트 시크릿';
+
+  @override
+  String get useMcpApiKey => 'MCP API 키 사용';
+
+  @override
+  String get webhooks => '웹훅';
+
+  @override
+  String get conversationEvents => '대화 이벤트';
+
+  @override
+  String get newConversationCreated => '새 대화가 생성됨';
+
+  @override
+  String get realtimeTranscript => '실시간 녹취록';
+
+  @override
+  String get transcriptReceived => '녹취록 수신됨';
+
+  @override
+  String get audioBytes => '오디오 바이트';
+
+  @override
+  String get audioDataReceived => '오디오 데이터 수신됨';
+
+  @override
+  String get intervalSeconds => '간격(초)';
+
+  @override
+  String get daySummary => '일일 요약';
+
+  @override
+  String get summaryGenerated => '요약 생성됨';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'claude_desktop_config.json에 추가';
+
+  @override
+  String get copyConfig => '구성 복사';
+
+  @override
+  String get configCopied => '구성이 클립보드에 복사되었습니다';
+
+  @override
+  String get listeningMins => '청취(분)';
+
+  @override
+  String get understandingWords => '이해(단어)';
+
+  @override
+  String get insights => '인사이트';
+
+  @override
+  String get memories => '기억';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '이번 달 $limit분 중 $used분 사용';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '이번 달 $limit단어 중 $used단어 사용';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '이번 달 $limit개 중 $used개의 인사이트 획득';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '이번 달 $limit개 중 $used개의 기억 생성';
+  }
+
+  @override
+  String get visibility => '가시성';
+
+  @override
+  String get visibilitySubtitle => '목록에 표시할 대화 제어';
+
+  @override
+  String get showShortConversations => '짧은 대화 표시';
+
+  @override
+  String get showShortConversationsDesc => '임계값보다 짧은 대화 표시';
+
+  @override
+  String get showDiscardedConversations => '폐기된 대화 표시';
+
+  @override
+  String get showDiscardedConversationsDesc => '폐기된 것으로 표시된 대화 포함';
+
+  @override
+  String get shortConversationThreshold => '짧은 대화 임계값';
+
+  @override
+  String get shortConversationThresholdSubtitle => '이보다 짧은 대화는 위에서 활성화하지 않는 한 숨겨집니다';
+
+  @override
+  String get durationThreshold => '지속 시간 임계값';
+
+  @override
+  String get durationThresholdDesc => '이보다 짧은 대화 숨기기';
+
+  @override
+  String minLabel(int count) {
+    return '$count분';
+  }
+
+  @override
+  String get customVocabularyTitle => '사용자 지정 어휘';
+
+  @override
+  String get addWords => '단어 추가';
+
+  @override
+  String get addWordsDesc => '이름, 용어 또는 일반적이지 않은 단어';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => '연결';
+
+  @override
+  String get comingSoon => '곧 출시';
+
+  @override
+  String get chatToolsFooter => '채팅에서 데이터 및 지표를 보려면 앱을 연결하세요.';
+
+  @override
+  String get completeAuthInBrowser => '브라우저에서 인증을 완료해 주세요. 완료되면 앱으로 돌아가세요.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return '$appName 인증 시작에 실패했습니다';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return '$appName의 연결을 해제하시겠습니까?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return '$appName과의 연결을 해제하시겠습니까? 언제든지 다시 연결할 수 있습니다.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return '$appName과의 연결이 해제되었습니다';
+  }
+
+  @override
+  String get failedToDisconnect => '연결 해제 실패';
+
+  @override
+  String connectTo(String appName) {
+    return '$appName에 연결';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Omi가 $appName 데이터에 접근하도록 권한을 부여해야 합니다. 인증을 위해 브라우저가 열립니다.';
+  }
+
+  @override
+  String get continueAction => '계속';
+
+  @override
+  String get languageTitle => '언어';
+
+  @override
+  String get primaryLanguage => '기본 언어';
+
+  @override
+  String get automaticTranslation => '자동 번역';
+
+  @override
+  String get detectLanguages => '10개 이상의 언어 감지';
+
+  @override
+  String get authorizeSavingRecordings => '녹음 저장 권한 부여';
+
+  @override
+  String get thanksForAuthorizing => '권한을 부여해 주셔서 감사합니다!';
+
+  @override
+  String get needYourPermission => '귀하의 권한이 필요합니다';
+
+  @override
+  String get alreadyGavePermission => '녹음 저장 권한을 이미 부여하셨습니다. 필요한 이유를 다시 안내드립니다:';
+
+  @override
+  String get wouldLikePermission => '음성 녹음 저장 권한을 부여해 주세요. 그 이유는 다음과 같습니다:';
+
+  @override
+  String get improveSpeechProfile => '음성 프로필 개선';
+
+  @override
+  String get improveSpeechProfileDesc => '녹음을 사용하여 개인 음성 프로필을 추가로 학습하고 향상시킵니다.';
+
+  @override
+  String get trainFamilyProfiles => '친구 및 가족 프로필 학습';
+
+  @override
+  String get trainFamilyProfilesDesc => '녹음은 친구와 가족을 인식하고 프로필을 만드는 데 도움이 됩니다.';
+
+  @override
+  String get enhanceTranscriptAccuracy => '녹취록 정확도 향상';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc => '모델이 개선됨에 따라 녹음에 대한 더 나은 변환 결과를 제공할 수 있습니다.';
+
+  @override
+  String get legalNotice =>
+      '법적 고지: 음성 데이터 녹음 및 저장의 합법성은 위치 및 이 기능 사용 방법에 따라 다를 수 있습니다. 현지 법률 및 규정을 준수하는지 확인하는 것은 귀하의 책임입니다.';
+
+  @override
+  String get alreadyAuthorized => '이미 승인됨';
+
+  @override
+  String get authorize => '권한 부여';
+
+  @override
+  String get revokeAuthorization => '권한 취소';
+
+  @override
+  String get authorizationSuccessful => '권한 부여 성공!';
+
+  @override
+  String get failedToAuthorize => '권한 부여에 실패했습니다. 다시 시도해 주세요.';
+
+  @override
+  String get authorizationRevoked => '권한이 취소되었습니다.';
+
+  @override
+  String get recordingsDeleted => '녹음이 삭제되었습니다.';
+
+  @override
+  String get failedToRevoke => '권한 취소에 실패했습니다. 다시 시도해 주세요.';
+
+  @override
+  String get permissionRevokedTitle => '권한 취소됨';
+
+  @override
+  String get permissionRevokedMessage => '기존 녹음도 모두 삭제하시겠습니까?';
+
+  @override
+  String get yes => '예';
+
+  @override
+  String get editName => '이름 편집';
+
+  @override
+  String get howShouldOmiCallYou => 'Omi가 어떻게 불러드릴까요?';
+
+  @override
+  String get enterYourName => '이름을 입력하세요';
+
+  @override
+  String get nameCannotBeEmpty => '이름은 비워둘 수 없습니다';
+
+  @override
+  String get nameUpdatedSuccessfully => '이름이 성공적으로 업데이트되었습니다!';
+
+  @override
+  String get calendarSettings => '캘린더 설정';
+
+  @override
+  String get calendarProviders => '캘린더 제공업체';
+
+  @override
+  String get macOsCalendar => 'macOS 캘린더';
+
+  @override
+  String get connectMacOsCalendar => '로컬 macOS 캘린더 연결';
+
+  @override
+  String get googleCalendar => 'Google 캘린더';
+
+  @override
+  String get syncGoogleAccount => 'Google 계정과 동기화';
+
+  @override
+  String get showMeetingsMenuBar => '메뉴 바에 예정된 회의 표시';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'macOS 메뉴 바에 다음 회의 및 시작까지의 시간 표시';
+
+  @override
+  String get showEventsNoParticipants => '참가자가 없는 이벤트 표시';
+
+  @override
+  String get showEventsNoParticipantsDesc => '활성화하면 참가자나 비디오 링크가 없는 이벤트가 Coming Up에 표시됩니다.';
+
+  @override
+  String get yourMeetings => '내 회의';
+
+  @override
+  String get refresh => '새로고침';
+
+  @override
+  String get noUpcomingMeetings => '예정된 회의를 찾을 수 없습니다';
+
+  @override
+  String get checkingNextDays => '향후 30일 확인';
+
+  @override
+  String get tomorrow => '내일';
+
+  @override
+  String get googleCalendarComingSoon => 'Google 캘린더 통합이 곧 출시됩니다!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return '다음 사용자로 연결됨: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => '기본 워크스페이스';
+
+  @override
+  String get tasksCreatedInWorkspace => '작업이 이 워크스페이스에 생성됩니다';
+
+  @override
+  String get defaultProjectOptional => '기본 프로젝트(선택 사항)';
+
+  @override
+  String get leaveUnselectedTasks => '프로젝트 없이 작업을 생성하려면 선택하지 마세요';
+
+  @override
+  String get noProjectsInWorkspace => '이 워크스페이스에서 프로젝트를 찾을 수 없습니다';
+
+  @override
+  String get conversationTimeoutDesc => '대화를 자동으로 종료하기 전에 대기할 침묵 시간을 선택하세요:';
+
+  @override
+  String get timeout2Minutes => '2분';
+
+  @override
+  String get timeout2MinutesDesc => '2분간 침묵 후 대화 종료';
+
+  @override
+  String get timeout5Minutes => '5분';
+
+  @override
+  String get timeout5MinutesDesc => '5분간 침묵 후 대화 종료';
+
+  @override
+  String get timeout10Minutes => '10분';
+
+  @override
+  String get timeout10MinutesDesc => '10분간 침묵 후 대화 종료';
+
+  @override
+  String get timeout30Minutes => '30분';
+
+  @override
+  String get timeout30MinutesDesc => '30분간 침묵 후 대화 종료';
+
+  @override
+  String get timeout4Hours => '4시간';
+
+  @override
+  String get timeout4HoursDesc => '4시간 침묵 후 대화 종료';
+
+  @override
+  String get conversationEndAfterHours => '이제 4시간 침묵 후 대화가 종료됩니다';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return '이제 $minutes분 침묵 후 대화가 종료됩니다';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => '기본 언어를 알려주세요';
+
+  @override
+  String get languageForTranscription => '더 정확한 변환과 맞춤형 경험을 위해 언어를 설정하세요.';
+
+  @override
+  String get singleLanguageModeInfo => '단일 언어 모드가 활성화되었습니다. 정확도 향상을 위해 번역이 비활성화됩니다.';
+
+  @override
+  String get searchLanguageHint => '이름 또는 코드로 언어 검색';
+
+  @override
+  String get noLanguagesFound => '언어를 찾을 수 없습니다';
+
+  @override
+  String get skip => '건너뛰기';
+
+  @override
+  String languageSetTo(String language) {
+    return '언어가 $language(으)로 설정되었습니다';
+  }
+
+  @override
+  String get failedToSetLanguage => '언어 설정 실패';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName 설정';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return '$appName과의 연결을 해제하시겠습니까?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return '$appName 인증이 제거됩니다. 다시 사용하려면 다시 연결해야 합니다.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return '$appName에 연결됨';
+  }
+
+  @override
+  String get account => '계정';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return '할 일 항목이 $appName 계정과 동기화됩니다';
+  }
+
+  @override
+  String get defaultSpace => '기본 스페이스';
+
+  @override
+  String get selectSpaceInWorkspace => '워크스페이스에서 스페이스 선택';
+
+  @override
+  String get noSpacesInWorkspace => '이 워크스페이스에서 스페이스를 찾을 수 없습니다';
+
+  @override
+  String get defaultList => '기본 목록';
+
+  @override
+  String get tasksAddedToList => '작업이 이 목록에 추가됩니다';
+
+  @override
+  String get noListsInSpace => '이 스페이스에서 목록을 찾을 수 없습니다';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return '저장소 로드 실패: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => '기본 저장소가 저장되었습니다';
+
+  @override
+  String get failedToSaveDefaultRepo => '기본 저장소 저장 실패';
+
+  @override
+  String get defaultRepository => '기본 저장소';
+
+  @override
+  String get selectDefaultRepoDesc => '이슈 생성을 위한 기본 저장소를 선택하세요. 이슈 생성 시 다른 저장소를 지정할 수도 있습니다.';
+
+  @override
+  String get noReposFound => '저장소를 찾을 수 없습니다';
+
+  @override
+  String get private => '비공개';
+
+  @override
+  String updatedDate(String date) {
+    return '$date 업데이트됨';
+  }
+
+  @override
+  String get yesterday => '어제';
+
+  @override
+  String daysAgo(int count) {
+    return '$count일 전';
+  }
+
+  @override
+  String get oneWeekAgo => '1주일 전';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count주 전';
+  }
+
+  @override
+  String get oneMonthAgo => '1개월 전';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count개월 전';
+  }
+
+  @override
+  String get issuesCreatedInRepo => '이슈가 기본 저장소에 생성됩니다';
+
+  @override
+  String get taskIntegrations => '작업 통합';
+
+  @override
+  String get configureSettings => '설정 구성';
+
+  @override
+  String get completeAuthBrowser => '브라우저에서 인증을 완료해 주세요. 완료되면 앱으로 돌아가세요.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return '$appName 인증 시작에 실패했습니다';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return '$appName에 연결';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return '$appName 계정에서 작업을 생성하도록 Omi에 권한을 부여해야 합니다. 인증을 위해 브라우저가 열립니다.';
+  }
+
+  @override
+  String get continueButton => '계속';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName 통합';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return '$appName과의 통합이 곧 출시됩니다! 더 많은 작업 관리 옵션을 제공하기 위해 열심히 노력하고 있습니다.';
+  }
+
+  @override
+  String get gotIt => '알겠습니다';
+
+  @override
+  String get tasksExportedOneApp => '작업은 한 번에 하나의 앱으로 내보낼 수 있습니다.';
+
+  @override
+  String get completeYourUpgrade => '업그레이드 완료';
+
+  @override
+  String get importConfiguration => '구성 가져오기';
+
+  @override
+  String get exportConfiguration => '구성 내보내기';
+
+  @override
+  String get bringYourOwn => '직접 가져오기';
+
+  @override
+  String get payYourSttProvider => 'Omi를 자유롭게 사용하세요. STT 제공업체에 직접 비용을 지불하기만 하면 됩니다.';
+
+  @override
+  String get freeMinutesMonth => '월 1,200분 무료 포함. ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => '호스트가 필요합니다';
+
+  @override
+  String get validPortRequired => '유효한 포트가 필요합니다';
+
+  @override
+  String get validWebsocketUrlRequired => '유효한 WebSocket URL이 필요합니다(wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL이 필요합니다';
+
+  @override
+  String get apiKeyRequired => 'API 키가 필요합니다';
+
+  @override
+  String get invalidJsonConfig => '잘못된 JSON 구성';
+
+  @override
+  String errorSaving(String error) {
+    return '저장 오류: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => '구성이 클립보드에 복사되었습니다';
+
+  @override
+  String get pasteJsonConfig => '아래에 JSON 구성을 붙여넣으세요:';
+
+  @override
+  String get addApiKeyAfterImport => '가져오기 후 자신의 API 키를 추가해야 합니다';
+
+  @override
+  String get paste => '붙여넣기';
+
+  @override
+  String get import => '가져오기';
+
+  @override
+  String get invalidProviderInConfig => '구성의 제공업체가 잘못되었습니다';
+
+  @override
+  String importedConfig(String providerName) {
+    return '$providerName 구성을 가져왔습니다';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return '잘못된 JSON: $error';
+  }
+
+  @override
+  String get provider => '제공업체';
+
+  @override
+  String get live => '실시간';
+
+  @override
+  String get onDevice => '기기에서';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'STT HTTP 엔드포인트를 입력하세요';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => '실시간 STT WebSocket 엔드포인트를 입력하세요';
+
+  @override
+  String get apiKey => 'API 키';
+
+  @override
+  String get enterApiKey => 'API 키를 입력하세요';
+
+  @override
+  String get storedLocallyNeverShared => '로컬에 저장되며 절대 공유되지 않습니다';
+
+  @override
+  String get host => '호스트';
+
+  @override
+  String get port => '포트';
+
+  @override
+  String get advanced => '고급';
+
+  @override
+  String get configuration => '구성';
+
+  @override
+  String get requestConfiguration => '요청 구성';
+
+  @override
+  String get responseSchema => '응답 스키마';
+
+  @override
+  String get modified => '수정됨';
+
+  @override
+  String get resetRequestConfig => '요청 구성을 기본값으로 재설정';
+
+  @override
+  String get logs => '로그';
+
+  @override
+  String get logsCopied => '로그가 복사되었습니다';
+
+  @override
+  String get noLogsYet => '아직 로그가 없습니다. 녹음을 시작하여 사용자 지정 STT 활동을 확인하세요.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName은(는) $codecReason을(를) 사용합니다. Omi가 사용됩니다.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi 음성 변환';
+
+  @override
+  String get bestInClassTranscription => '설정이 필요 없는 최고 수준의 음성 변환';
+
+  @override
+  String get instantSpeakerLabels => '즉시 화자 레이블 지정';
+
+  @override
+  String get languageTranslation => '100개 이상의 언어 번역';
+
+  @override
+  String get optimizedForConversation => '대화에 최적화';
+
+  @override
+  String get autoLanguageDetection => '자동 언어 감지';
+
+  @override
+  String get highAccuracy => '높은 정확도';
+
+  @override
+  String get privacyFirst => '개인정보 보호 우선';
+
+  @override
+  String get saveChanges => '변경 사항 저장';
+
+  @override
+  String get resetToDefault => '기본값으로 재설정';
+
+  @override
+  String get viewTemplate => '템플릿 보기';
+
+  @override
+  String get trySomethingLike => '다음과 같이 시도해 보세요...';
+
+  @override
+  String get tryIt => '시도해 보기';
+
+  @override
+  String get creatingPlan => '계획 생성 중';
+
+  @override
+  String get developingLogic => '로직 개발 중';
+
+  @override
+  String get designingApp => '앱 디자인 중';
+
+  @override
+  String get generatingIconStep => '아이콘 생성 중';
+
+  @override
+  String get finalTouches => '최종 마무리';
+
+  @override
+  String get processing => '처리 중...';
+
+  @override
+  String get features => '기능';
+
+  @override
+  String get creatingYourApp => '앱을 만드는 중...';
+
+  @override
+  String get generatingIcon => '아이콘 생성 중...';
+
+  @override
+  String get whatShouldWeMake => '무엇을 만들까요?';
+
+  @override
+  String get appName => '앱 이름';
+
+  @override
+  String get description => '설명';
+
+  @override
+  String get publicLabel => '공개';
+
+  @override
+  String get privateLabel => '비공개';
+
+  @override
+  String get free => '무료';
+
+  @override
+  String get perMonth => '/ 월';
+
+  @override
+  String get tailoredConversationSummaries => '맞춤형 대화 요약';
+
+  @override
+  String get customChatbotPersonality => '사용자 지정 챗봇 성격';
+
+  @override
+  String get makePublic => '공개하기';
+
+  @override
+  String get anyoneCanDiscover => '누구나 앱을 찾을 수 있습니다';
+
+  @override
+  String get onlyYouCanUse => '본인만 이 앱을 사용할 수 있습니다';
+
+  @override
+  String get paidApp => '유료 앱';
+
+  @override
+  String get usersPayToUse => '사용자가 앱을 사용하려면 비용을 지불합니다';
+
+  @override
+  String get freeForEveryone => '모두에게 무료';
+
+  @override
+  String get perMonthLabel => '/ 월';
+
+  @override
+  String get creating => '생성 중...';
+
+  @override
+  String get createApp => '앱 만들기';
+
+  @override
+  String get searchingForDevices => '기기 검색 중...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    return '근처에서 $count개의 기기 발견';
+  }
+
+  @override
+  String get pairingSuccessful => '페어링 성공';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Apple Watch 연결 오류: $error';
+  }
+
+  @override
+  String get dontShowAgain => '다시 표시하지 않기';
+
+  @override
+  String get iUnderstand => '이해했습니다';
+
+  @override
+  String get enableBluetooth => '블루투스 활성화';
+
+  @override
+  String get bluetoothNeeded => 'Omi가 웨어러블에 연결하려면 블루투스가 필요합니다. 블루투스를 활성화하고 다시 시도해 주세요.';
+
+  @override
+  String get contactSupport => '지원팀에 문의하시겠습니까?';
+
+  @override
+  String get connectLater => '나중에 연결';
+
+  @override
+  String get grantPermissions => '권한 부여';
+
+  @override
+  String get backgroundActivity => '백그라운드 활동';
+
+  @override
+  String get backgroundActivityDesc => '더 나은 안정성을 위해 Omi가 백그라운드에서 실행되도록 허용';
+
+  @override
+  String get locationAccess => '위치 접근';
+
+  @override
+  String get locationAccessDesc => '완전한 경험을 위해 백그라운드 위치 활성화';
+
+  @override
+  String get notifications => '알림';
+
+  @override
+  String get notificationsDesc => '정보를 받기 위해 알림 활성화';
+
+  @override
+  String get locationServiceDisabled => '위치 서비스 비활성화됨';
+
+  @override
+  String get locationServiceDisabledDesc => '위치 서비스가 비활성화되어 있습니다. 설정 > 개인정보 보호 및 보안 > 위치 서비스로 이동하여 활성화하세요';
+
+  @override
+  String get backgroundLocationDenied => '백그라운드 위치 접근 거부됨';
+
+  @override
+  String get backgroundLocationDeniedDesc => '기기 설정으로 이동하여 위치 권한을 \"항상 허용\"으로 설정하세요';
+
+  @override
+  String get lovingOmi => 'Omi가 마음에 드시나요?';
+
+  @override
+  String get leaveReviewIos => 'App Store에 리뷰를 남겨 더 많은 사람들에게 다가가도록 도와주세요. 귀하의 피드백은 저희에게 큰 의미가 있습니다!';
+
+  @override
+  String get leaveReviewAndroid => 'Google Play 스토어에 리뷰를 남겨 더 많은 사람들에게 다가가도록 도와주세요. 귀하의 피드백은 저희에게 큰 의미가 있습니다!';
+
+  @override
+  String get rateOnAppStore => 'App Store에서 평가하기';
+
+  @override
+  String get rateOnGooglePlay => 'Google Play에서 평가하기';
+
+  @override
+  String get maybeLater => '나중에';
+
+  @override
+  String get speechProfileIntro => 'Omi가 귀하의 목표와 음성을 학습해야 합니다. 나중에 수정할 수 있습니다.';
+
+  @override
+  String get getStarted => '시작하기';
+
+  @override
+  String get allDone => '모두 완료!';
+
+  @override
+  String get keepGoing => '계속하세요, 잘하고 있습니다';
+
+  @override
+  String get skipThisQuestion => '이 질문 건너뛰기';
+
+  @override
+  String get skipForNow => '지금은 건너뛰기';
+
+  @override
+  String get connectionError => '연결 오류';
+
+  @override
+  String get connectionErrorDesc => '서버 연결에 실패했습니다. 인터넷 연결을 확인하고 다시 시도해 주세요.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => '잘못된 녹음 감지됨';
+
+  @override
+  String get multipleSpeakersDesc => '녹음에 여러 명의 화자가 있는 것 같습니다. 조용한 장소에 있는지 확인하고 다시 시도하세요.';
+
+  @override
+  String get tooShortDesc => '음성이 충분히 감지되지 않았습니다. 더 많이 말하고 다시 시도하세요.';
+
+  @override
+  String get invalidRecordingDesc => '최소 5초 이상 90초 이하로 말씀해 주세요.';
+
+  @override
+  String get areYouThere => '계십니까?';
+
+  @override
+  String get noSpeechDesc => '음성을 감지할 수 없습니다. 최소 10초 이상 3분 이하로 말씀해 주세요.';
+
+  @override
+  String get connectionLost => '연결 끊김';
+
+  @override
+  String get connectionLostDesc => '연결이 중단되었습니다. 인터넷 연결을 확인하고 다시 시도해 주세요.';
+
+  @override
+  String get tryAgain => '다시 시도';
+
+  @override
+  String get connectOmiOmiGlass => 'Omi / OmiGlass 연결';
+
+  @override
+  String get continueWithoutDevice => '기기 없이 계속';
+
+  @override
+  String get permissionsRequired => '권한 필요';
+
+  @override
+  String get permissionsRequiredDesc => '이 앱은 제대로 작동하려면 블루투스 및 위치 권한이 필요합니다. 설정에서 활성화하세요.';
+
+  @override
+  String get openSettings => '설정 열기';
+
+  @override
+  String get wantDifferentName => '다른 이름으로 부르시겠습니까?';
+
+  @override
+  String get whatsYourName => '이름이 무엇인가요?';
+
+  @override
+  String get speakTranscribeSummarize => '말하기. 변환. 요약.';
+
+  @override
+  String get signInWithApple => 'Apple로 로그인';
+
+  @override
+  String get signInWithGoogle => 'Google로 로그인';
+
+  @override
+  String get byContinuingAgree => '계속하면 다음에 동의하는 것입니다 ';
+
+  @override
+  String get termsOfUse => '이용약관';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – 당신의 AI 동반자';
+
+  @override
+  String get captureEveryMoment => '모든 순간을 기록하세요. AI 기반\n요약을 받으세요. 더 이상 메모할 필요가 없습니다.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch 설정';
+
+  @override
+  String get permissionRequestedExclaim => '권한 요청됨!';
+
+  @override
+  String get microphonePermission => '마이크 권한';
+
+  @override
+  String get permissionGrantedNow => '권한이 부여되었습니다! 이제:\n\n워치에서 Omi 앱을 열고 아래의 \"계속\"을 탭하세요';
+
+  @override
+  String get needMicrophonePermission =>
+      '마이크 권한이 필요합니다.\n\n1. \"권한 부여\" 탭\n2. iPhone에서 허용\n3. 워치 앱이 닫힙니다\n4. 다시 열고 \"계속\" 탭';
+
+  @override
+  String get grantPermissionButton => '권한 부여';
+
+  @override
+  String get needHelp => '도움이 필요하신가요?';
+
+  @override
+  String get troubleshootingSteps =>
+      '문제 해결:\n\n1. 워치에 Omi가 설치되어 있는지 확인\n2. 워치에서 Omi 앱 열기\n3. 권한 팝업 찾기\n4. 메시지가 나타나면 \"허용\" 탭\n5. 워치의 앱이 닫힙니다 - 다시 열기\n6. 돌아와서 iPhone에서 \"계속\" 탭';
+
+  @override
+  String get recordingStartedSuccessfully => '녹음이 성공적으로 시작되었습니다!';
+
+  @override
+  String get permissionNotGrantedYet => '아직 권한이 부여되지 않았습니다. 마이크 접근을 허용하고 워치에서 앱을 다시 열었는지 확인하세요.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return '권한 요청 오류: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return '녹음 시작 오류: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => '기본 언어 선택';
+
+  @override
+  String get languageBenefits => '더 정확한 변환과 맞춤형 경험을 위해 언어를 설정하세요';
+
+  @override
+  String get whatsYourPrimaryLanguage => '기본 언어가 무엇인가요?';
+
+  @override
+  String get selectYourLanguage => '언어를 선택하세요';
+
+  @override
+  String get personalGrowthJourney => '당신의 모든 말을 듣는 AI와 함께하는 개인 성장 여정.';
+
+  @override
+  String get actionItemsTitle => '할 일';
+
+  @override
+  String get actionItemsDescription => '탭하여 편집 • 길게 눌러 선택 • 스와이프하여 작업';
+
+  @override
+  String get tabToDo => '할 일';
+
+  @override
+  String get tabDone => '완료';
+
+  @override
+  String get tabOld => '이전';
+
+  @override
+  String get emptyTodoMessage => '🎉 모두 완료!\n대기 중인 작업 항목이 없습니다';
+
+  @override
+  String get emptyDoneMessage => '아직 완료된 항목이 없습니다';
+
+  @override
+  String get emptyOldMessage => '✅ 오래된 작업 없음';
+
+  @override
+  String get noItems => '항목 없음';
+
+  @override
+  String get actionItemMarkedIncomplete => '작업 항목이 미완료로 표시되었습니다';
+
+  @override
+  String get actionItemCompleted => '작업 항목이 완료되었습니다';
+
+  @override
+  String get deleteActionItemTitle => '작업 항목 삭제';
+
+  @override
+  String get deleteActionItemMessage => '이 작업 항목을 삭제하시겠습니까?';
+
+  @override
+  String get deleteSelectedItemsTitle => '선택한 항목 삭제';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return '선택한 $count개의 작업 항목$s을(를) 삭제하시겠습니까?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return '작업 항목 \"$description\"이(가) 삭제되었습니다';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count개의 작업 항목$s이(가) 삭제되었습니다';
+  }
+
+  @override
+  String get failedToDeleteItem => '작업 항목 삭제 실패';
+
+  @override
+  String get failedToDeleteItems => '항목 삭제 실패';
+
+  @override
+  String get failedToDeleteSomeItems => '일부 항목 삭제 실패';
+
+  @override
+  String get welcomeActionItemsTitle => '작업 항목 준비 완료';
+
+  @override
+  String get welcomeActionItemsDescription => 'AI가 대화에서 작업과 할 일을 자동으로 추출합니다. 생성되면 여기에 표시됩니다.';
+
+  @override
+  String get autoExtractionFeature => '대화에서 자동 추출';
+
+  @override
+  String get editSwipeFeature => '탭하여 편집, 스와이프하여 완료 또는 삭제';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count개 선택됨';
+  }
+
+  @override
+  String get selectAll => '모두 선택';
+
+  @override
+  String get deleteSelected => '선택 항목 삭제';
+
+  @override
+  String searchMemories(int count) {
+    return '$count개의 기억 검색';
+  }
+
+  @override
+  String get memoryDeleted => '기억이 삭제되었습니다.';
+
+  @override
+  String get undo => '실행 취소';
+
+  @override
+  String get noMemoriesYet => '아직 기억이 없습니다';
+
+  @override
+  String get noAutoMemories => '아직 자동 추출된 기억이 없습니다';
+
+  @override
+  String get noManualMemories => '아직 수동 기억이 없습니다';
+
+  @override
+  String get noMemoriesInCategories => '이 카테고리에 기억이 없습니다';
+
+  @override
+  String get noMemoriesFound => '기억을 찾을 수 없습니다';
+
+  @override
+  String get addFirstMemory => '첫 번째 기억 추가';
+
+  @override
+  String get clearMemoryTitle => 'Omi의 기억 지우기';
+
+  @override
+  String get clearMemoryMessage => 'Omi의 기억을 지우시겠습니까? 이 작업은 되돌릴 수 없습니다.';
+
+  @override
+  String get clearMemoryButton => '기억 지우기';
+
+  @override
+  String get memoryClearedSuccess => 'Omi의 기억이 지워졌습니다';
+
+  @override
+  String get noMemoriesToDelete => '삭제할 기억이 없습니다';
+
+  @override
+  String get createMemoryTooltip => '새 기억 만들기';
+
+  @override
+  String get createActionItemTooltip => '새 작업 항목 만들기';
+
+  @override
+  String get memoryManagement => '기억 관리';
+
+  @override
+  String get filterMemories => '기억 필터링';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return '총 $count개의 기억이 있습니다';
+  }
+
+  @override
+  String get publicMemories => '공개 기억';
+
+  @override
+  String get privateMemories => '비공개 기억';
+
+  @override
+  String get makeAllPrivate => '모든 기억을 비공개로 만들기';
+
+  @override
+  String get makeAllPublic => '모든 기억을 공개로 만들기';
+
+  @override
+  String get deleteAllMemories => '모든 기억 삭제';
+
+  @override
+  String get allMemoriesPrivateResult => '모든 기억이 이제 비공개입니다';
+
+  @override
+  String get allMemoriesPublicResult => '모든 기억이 이제 공개입니다';
+
+  @override
+  String get newMemory => '새 기억';
+
+  @override
+  String get editMemory => '기억 편집';
+
+  @override
+  String get memoryContentHint => '아이스크림 먹는 걸 좋아해요...';
+
+  @override
+  String get failedToSaveMemory => '저장에 실패했습니다. 연결을 확인하세요.';
+
+  @override
+  String get saveMemory => '기억 저장';
+
+  @override
+  String get retry => '다시 시도';
+
+  @override
+  String get createActionItem => '작업 항목 만들기';
+
+  @override
+  String get editActionItem => '작업 항목 편집';
+
+  @override
+  String get actionItemDescriptionHint => '무엇을 해야 하나요?';
+
+  @override
+  String get actionItemDescriptionEmpty => '작업 항목 설명은 비워둘 수 없습니다.';
+
+  @override
+  String get actionItemUpdated => '작업 항목이 업데이트되었습니다';
+
+  @override
+  String get failedToUpdateActionItem => '작업 항목 업데이트 실패';
+
+  @override
+  String get actionItemCreated => '작업 항목이 생성되었습니다';
+
+  @override
+  String get failedToCreateActionItem => '작업 항목 생성 실패';
+
+  @override
+  String get dueDate => '마감일';
+
+  @override
+  String get time => '시간';
+
+  @override
+  String get addDueDate => '마감일 추가';
+
+  @override
+  String get pressDoneToSave => '완료를 눌러 저장하세요';
+
+  @override
+  String get pressDoneToCreate => '완료를 눌러 생성하세요';
+
+  @override
+  String get filterAll => '모두';
+
+  @override
+  String get filterSystem => '본인 정보';
+
+  @override
+  String get filterInteresting => '인사이트';
+
+  @override
+  String get filterManual => '수동';
+
+  @override
+  String get completed => '완료됨';
+
+  @override
+  String get markComplete => '완료로 표시';
+
+  @override
+  String get actionItemDeleted => '작업 항목이 삭제되었습니다';
+
+  @override
+  String get failedToDeleteActionItem => '작업 항목 삭제 실패';
+
+  @override
+  String get deleteActionItemConfirmTitle => '작업 항목 삭제';
+
+  @override
+  String get deleteActionItemConfirmMessage => '이 작업 항목을 삭제하시겠습니까?';
+
+  @override
+  String get appLanguage => '앱 언어';
+
+  @override
+  String get appInterfaceSectionTitle => '앱 인터페이스';
+
+  @override
+  String get speechTranscriptionSectionTitle => '음성 및 전사';
+
+  @override
+  String get languageSettingsHelperText => '앱 언어는 메뉴와 버튼을 변경합니다. 음성 언어는 녹음이 전사되는 방식에 영향을 줍니다.';
+}

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -1,0 +1,2229 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Lithuanian (`lt`).
+class AppLocalizationsLt extends AppLocalizations {
+  AppLocalizationsLt([String locale = 'lt']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Pokalbis';
+
+  @override
+  String get transcriptTab => 'Transkripcija';
+
+  @override
+  String get actionItemsTab => 'Užduotys';
+
+  @override
+  String get deleteConversationTitle => 'Ištrinti pokalbį?';
+
+  @override
+  String get deleteConversationMessage => 'Ar tikrai norite ištrinti šį pokalbį? Šio veiksmo negalima atšaukti.';
+
+  @override
+  String get confirm => 'Patvirtinti';
+
+  @override
+  String get cancel => 'Atšaukti';
+
+  @override
+  String get ok => 'Gerai';
+
+  @override
+  String get delete => 'Ištrinti';
+
+  @override
+  String get add => 'Pridėti';
+
+  @override
+  String get update => 'Atnaujinti';
+
+  @override
+  String get save => 'Išsaugoti';
+
+  @override
+  String get edit => 'Redaguoti';
+
+  @override
+  String get close => 'Uždaryti';
+
+  @override
+  String get clear => 'Išvalyti';
+
+  @override
+  String get copyTranscript => 'Kopijuoti transkripciją';
+
+  @override
+  String get copySummary => 'Kopijuoti santrauką';
+
+  @override
+  String get testPrompt => 'Testuoti užklausą';
+
+  @override
+  String get reprocessConversation => 'Perdoroti pokalbį';
+
+  @override
+  String get deleteConversation => 'Ištrinti pokalbį';
+
+  @override
+  String get contentCopied => 'Turinys nukopijuotas į iškarpinę';
+
+  @override
+  String get failedToUpdateStarred => 'Nepavyko atnaujinti žvaigždutės būsenos.';
+
+  @override
+  String get conversationUrlNotShared => 'Pokalbio nuorodos nepavyko bendrinti.';
+
+  @override
+  String get errorProcessingConversation => 'Klaida dorojant pokalbį. Bandykite dar kartą vėliau.';
+
+  @override
+  String get noInternetConnection => 'Patikrinkite interneto ryšį ir bandykite dar kartą.';
+
+  @override
+  String get unableToDeleteConversation => 'Nepavyko ištrinti pokalbio';
+
+  @override
+  String get somethingWentWrong => 'Kažkas nepavyko! Bandykite dar kartą vėliau.';
+
+  @override
+  String get copyErrorMessage => 'Kopijuoti klaidos pranešimą';
+
+  @override
+  String get errorCopied => 'Klaidos pranešimas nukopijuotas į iškarpinę';
+
+  @override
+  String get remaining => 'Likę';
+
+  @override
+  String get loading => 'Kraunama...';
+
+  @override
+  String get loadingDuration => 'Kraunama trukmė...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sek.';
+  }
+
+  @override
+  String get people => 'Žmonės';
+
+  @override
+  String get addNewPerson => 'Pridėti naują asmenį';
+
+  @override
+  String get editPerson => 'Redaguoti asmenį';
+
+  @override
+  String get createPersonHint => 'Sukurkite naują asmenį ir apmokykite Omi atpažinti jų kalbą!';
+
+  @override
+  String get speechProfile => 'Kalbos profilis';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Pavyzdys $number';
+  }
+
+  @override
+  String get settings => 'Nustatymai';
+
+  @override
+  String get language => 'Kalba';
+
+  @override
+  String get selectLanguage => 'Pasirinkti kalbą';
+
+  @override
+  String get deleting => 'Trinama...';
+
+  @override
+  String get pleaseCompleteAuthentication => 'Užbaikite autentifikaciją naršyklėje. Baigę grįžkite į programą.';
+
+  @override
+  String get failedToStartAuthentication => 'Nepavyko pradėti autentifikacijos';
+
+  @override
+  String get importStarted => 'Importavimas pradėtas! Gausite pranešimą, kai bus baigta.';
+
+  @override
+  String get failedToStartImport => 'Nepavyko pradėti importavimo. Bandykite dar kartą.';
+
+  @override
+  String get couldNotAccessFile => 'Nepavyko pasiekti pasirinkto failo';
+
+  @override
+  String get askOmi => 'Klauskite Omi';
+
+  @override
+  String get done => 'Atlikta';
+
+  @override
+  String get disconnected => 'Atjungta';
+
+  @override
+  String get searching => 'Ieškoma';
+
+  @override
+  String get connectDevice => 'Prijungti įrenginį';
+
+  @override
+  String get monthlyLimitReached => 'Pasiekėte mėnesio limitą.';
+
+  @override
+  String get checkUsage => 'Tikrinti naudojimą';
+
+  @override
+  String get syncingRecordings => 'Sinchronizuojami įrašai';
+
+  @override
+  String get recordingsToSync => 'Įrašai sinchronizavimui';
+
+  @override
+  String get allCaughtUp => 'Viskas atnaujinta';
+
+  @override
+  String get sync => 'Sinchronizuoti';
+
+  @override
+  String get pendantUpToDate => 'Pakabukas atnaujintas';
+
+  @override
+  String get allRecordingsSynced => 'Visi įrašai sinchronizuoti';
+
+  @override
+  String get syncingInProgress => 'Vyksta sinchronizavimas';
+
+  @override
+  String get readyToSync => 'Paruošta sinchronizuoti';
+
+  @override
+  String get tapSyncToStart => 'Paspauskite Sinchronizuoti, kad pradėtumėte';
+
+  @override
+  String get pendantNotConnected => 'Pakabukas neprijungtas. Prijunkite, kad sinchronizuotumėte.';
+
+  @override
+  String get everythingSynced => 'Viskas jau sinchronizuota.';
+
+  @override
+  String get recordingsNotSynced => 'Turite nesinchronizuotų įrašų.';
+
+  @override
+  String get syncingBackground => 'Tęsime įrašų sinchronizavimą fone.';
+
+  @override
+  String get noConversationsYet => 'Kol kas nėra pokalbių.';
+
+  @override
+  String get noStarredConversations => 'Kol kas nėra pažymėtų pokalbių.';
+
+  @override
+  String get starConversationHint =>
+      'Norėdami pažymėti pokalbį, atidarykite jį ir paspauskite žvaigždutės piktogramą antraštėje.';
+
+  @override
+  String get searchConversations => 'Ieškoti pokalbių';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return 'Pasirinkta: $count';
+  }
+
+  @override
+  String get merge => 'Sujungti';
+
+  @override
+  String get mergeConversations => 'Sujungti pokalbius';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Bus sujungti $count pokalbiai į vieną. Visas turinys bus sujungtas ir iš naujo sugeneruotas.';
+  }
+
+  @override
+  String get mergingInBackground => 'Sujungiama fone. Tai gali užtrukti.';
+
+  @override
+  String get failedToStartMerge => 'Nepavyko pradėti sujungimo';
+
+  @override
+  String get askAnything => 'Klauskite bet ko';
+
+  @override
+  String get noMessagesYet => 'Kol kas nėra žinučių!\nKodėl gi nepradėtumėte pokalbio?';
+
+  @override
+  String get deletingMessages => 'Ištrinamos jūsų žinutės iš Omi atminties...';
+
+  @override
+  String get messageCopied => 'Žinutė nukopijuota į iškarpinę.';
+
+  @override
+  String get cannotReportOwnMessage => 'Negalite pranešti apie savo žinutes.';
+
+  @override
+  String get reportMessage => 'Pranešti apie žinutę';
+
+  @override
+  String get reportMessageConfirm => 'Ar tikrai norite pranešti apie šią žinutę?';
+
+  @override
+  String get messageReported => 'Apie žinutę pranešta sėkmingai.';
+
+  @override
+  String get thankYouFeedback => 'Ačiū už jūsų atsiliepimą!';
+
+  @override
+  String get clearChat => 'Išvalyti pokalbį?';
+
+  @override
+  String get clearChatConfirm => 'Ar tikrai norite išvalyti pokalbį? Šio veiksmo negalima atšaukti.';
+
+  @override
+  String get maxFilesLimit => 'Galite įkelti tik 4 failus vienu metu';
+
+  @override
+  String get chatWithOmi => 'Pokalbis su Omi';
+
+  @override
+  String get apps => 'Programėlės';
+
+  @override
+  String get noAppsFound => 'Programėlių nerasta';
+
+  @override
+  String get tryAdjustingSearch => 'Pabandykite pakeisti paiešką arba filtrus';
+
+  @override
+  String get createYourOwnApp => 'Sukurkite savo programėlę';
+
+  @override
+  String get buildAndShareApp => 'Sukurkite ir bendrinkite savo programėlę';
+
+  @override
+  String get searchApps => 'Ieškoti 1500+ programėlių';
+
+  @override
+  String get myApps => 'Mano programėlės';
+
+  @override
+  String get installedApps => 'Įdiegtos programėlės';
+
+  @override
+  String get unableToFetchApps =>
+      'Nepavyko gauti programėlių :(\n\nPatikrinkite interneto ryšį ir bandykite dar kartą.';
+
+  @override
+  String get aboutOmi => 'Apie Omi';
+
+  @override
+  String get privacyPolicy => 'Privatumo politika';
+
+  @override
+  String get visitWebsite => 'Aplankyti svetainę';
+
+  @override
+  String get helpOrInquiries => 'Pagalba ar klausimai?';
+
+  @override
+  String get joinCommunity => 'Prisijunkite prie bendruomenės!';
+
+  @override
+  String get membersAndCounting => '8000+ narių ir vis daugėja.';
+
+  @override
+  String get deleteAccountTitle => 'Ištrinti paskyrą';
+
+  @override
+  String get deleteAccountConfirm => 'Ar tikrai norite ištrinti savo paskyrą?';
+
+  @override
+  String get cannotBeUndone => 'Šio veiksmo negalima atšaukti.';
+
+  @override
+  String get allDataErased => 'Visi jūsų prisiminimai ir pokalbiai bus negrįžtamai ištrinti.';
+
+  @override
+  String get appsDisconnected => 'Jūsų programėlės ir integracijos bus nedelsiant atjungtos.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Prieš ištrindami paskyrą galite eksportuoti duomenis, tačiau ištrynus jų atkurti neįmanoma.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Suprantu, kad mano paskyros ištrynimas yra galutinis ir visi duomenys, įskaitant prisiminimus ir pokalbius, bus prarasti ir jų atkurti nebus įmanoma.';
+
+  @override
+  String get areYouSure => 'Ar tikrai?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Šis veiksmas yra negrįžtamas ir galutinai ištrins jūsų paskyrą ir visus susijusius duomenis. Ar tikrai norite tęsti?';
+
+  @override
+  String get deleteNow => 'Ištrinti dabar';
+
+  @override
+  String get goBack => 'Grįžti atgal';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Pažymėkite langelį, kad patvirtintumėte, jog suprantate, kad paskyros ištrynimas yra galutinis ir negrįžtamas.';
+
+  @override
+  String get profile => 'Profilis';
+
+  @override
+  String get name => 'Vardas';
+
+  @override
+  String get email => 'El. paštas';
+
+  @override
+  String get customVocabulary => 'Pasirinktinis žodynas';
+
+  @override
+  String get identifyingOthers => 'Kitų atpažinimas';
+
+  @override
+  String get paymentMethods => 'Mokėjimo būdai';
+
+  @override
+  String get conversationDisplay => 'Pokalbių rodymas';
+
+  @override
+  String get dataPrivacy => 'Duomenys ir privatumas';
+
+  @override
+  String get userId => 'Naudotojo ID';
+
+  @override
+  String get notSet => 'Nenustatyta';
+
+  @override
+  String get userIdCopied => 'Naudotojo ID nukopijuotas į iškarpinę';
+
+  @override
+  String get systemDefault => 'Sistemos numatytasis';
+
+  @override
+  String get planAndUsage => 'Planas ir naudojimas';
+
+  @override
+  String get offlineSync => 'Autonominė sinchronizacija';
+
+  @override
+  String get deviceSettings => 'Įrenginio nustatymai';
+
+  @override
+  String get chatTools => 'Pokalbių įrankiai';
+
+  @override
+  String get feedbackBug => 'Atsiliepimai / Klaida';
+
+  @override
+  String get helpCenter => 'Pagalbos centras';
+
+  @override
+  String get developerSettings => 'Kūrėjo nustatymai';
+
+  @override
+  String get getOmiForMac => 'Gauti Omi Mac';
+
+  @override
+  String get referralProgram => 'Rekomendacijų programa';
+
+  @override
+  String get signOut => 'Atsijungti';
+
+  @override
+  String get appAndDeviceCopied => 'Programėlės ir įrenginio informacija nukopijuota';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Jūsų privatumas, jūsų kontrolė';
+
+  @override
+  String get privacyIntro =>
+      'Omi įsipareigoja saugoti jūsų privatumą. Šis puslapis leidžia kontroliuoti, kaip jūsų duomenys saugomi ir naudojami.';
+
+  @override
+  String get learnMore => 'Sužinoti daugiau...';
+
+  @override
+  String get dataProtectionLevel => 'Duomenų apsaugos lygis';
+
+  @override
+  String get dataProtectionDesc =>
+      'Jūsų duomenys pagal numatytuosius nustatymus apsaugoti stipriu šifravimu. Peržiūrėkite savo nustatymus ir būsimas privatumo parinktis žemiau.';
+
+  @override
+  String get appAccess => 'Programėlių prieiga';
+
+  @override
+  String get appAccessDesc =>
+      'Šios programėlės gali pasiekti jūsų duomenis. Paspauskite programėlę, kad valdytumėte jos leidimus.';
+
+  @override
+  String get noAppsExternalAccess => 'Jokios įdiegtos programėlės neturi išorinės prieigos prie jūsų duomenų.';
+
+  @override
+  String get deviceName => 'Įrenginio pavadinimas';
+
+  @override
+  String get deviceId => 'Įrenginio ID';
+
+  @override
+  String get firmware => 'Programinė įranga';
+
+  @override
+  String get sdCardSync => 'SD kortelės sinchronizacija';
+
+  @override
+  String get hardwareRevision => 'Aparatinės įrangos versija';
+
+  @override
+  String get modelNumber => 'Modelio numeris';
+
+  @override
+  String get manufacturer => 'Gamintojas';
+
+  @override
+  String get doubleTap => 'Dvigubas bakstelėjimas';
+
+  @override
+  String get ledBrightness => 'LED ryškumas';
+
+  @override
+  String get micGain => 'Mikrofono stiprinimas';
+
+  @override
+  String get disconnect => 'Atjungti';
+
+  @override
+  String get forgetDevice => 'Pamiršti įrenginį';
+
+  @override
+  String get chargingIssues => 'Krovimo problemos';
+
+  @override
+  String get disconnectDevice => 'Atjungti įrenginį';
+
+  @override
+  String get unpairDevice => 'Atjungti įrenginį';
+
+  @override
+  String get unpairAndForget => 'Atjungti ir pamiršti įrenginį';
+
+  @override
+  String get deviceDisconnectedMessage => 'Jūsų Omi buvo atjungtas 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Įrenginys atjungtas. Eikite į Nustatymus > „Bluetooth\" ir pamiršti įrenginį, kad užbaigtumėte atjungimą.';
+
+  @override
+  String get unpairDialogTitle => 'Atjungti įrenginį';
+
+  @override
+  String get unpairDialogMessage =>
+      'Taip atjungsite įrenginį, kad jį būtų galima prijungti prie kito telefono. Norėdami užbaigti procesą, turėsite eiti į Nustatymus > „Bluetooth\" ir pamiršti įrenginį.';
+
+  @override
+  String get deviceNotConnected => 'Įrenginys neprijungtas';
+
+  @override
+  String get connectDeviceMessage => 'Prijunkite Omi įrenginį, kad pasiektumėte\nįrenginio nustatymus ir pritaikymą';
+
+  @override
+  String get deviceInfoSection => 'Įrenginio informacija';
+
+  @override
+  String get customizationSection => 'Pritaikymas';
+
+  @override
+  String get hardwareSection => 'Aparatinė įranga';
+
+  @override
+  String get v2Undetected => 'V2 neaptiktas';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Matome, kad turite V1 įrenginį arba jūsų įrenginys neprijungtas. SD kortelės funkcija prieinama tik V2 įrenginiams.';
+
+  @override
+  String get endConversation => 'Baigti pokalbį';
+
+  @override
+  String get pauseResume => 'Pristabdyti / tęsti';
+
+  @override
+  String get starConversation => 'Pažymėti pokalbį';
+
+  @override
+  String get doubleTapAction => 'Dvigubo bakstelėjimo veiksmas';
+
+  @override
+  String get endAndProcess => 'Baigti ir apdoroti pokalbį';
+
+  @override
+  String get pauseResumeRecording => 'Pristabdyti / tęsti įrašymą';
+
+  @override
+  String get starOngoing => 'Pažymėti vykstantį pokalbį';
+
+  @override
+  String get off => 'Išjungta';
+
+  @override
+  String get max => 'Maksimalus';
+
+  @override
+  String get mute => 'Nutildyti';
+
+  @override
+  String get quiet => 'Tylus';
+
+  @override
+  String get normal => 'Normalus';
+
+  @override
+  String get high => 'Aukštas';
+
+  @override
+  String get micGainDescMuted => 'Mikrofonas nutildytas';
+
+  @override
+  String get micGainDescLow => 'Labai tylus – triukšmingai aplinkai';
+
+  @override
+  String get micGainDescModerate => 'Tylus – vidutiniam triukšmui';
+
+  @override
+  String get micGainDescNeutral => 'Neutralus – subalansuotas įrašymas';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Šiek tiek sustiprintas – įprastam naudojimui';
+
+  @override
+  String get micGainDescBoosted => 'Sustiprintas – tyliai aplinkai';
+
+  @override
+  String get micGainDescHigh => 'Aukštas – tolimam ar tyliam balsui';
+
+  @override
+  String get micGainDescVeryHigh => 'Labai aukštas – labai tyliems šaltiniams';
+
+  @override
+  String get micGainDescMax => 'Maksimalus – naudokite atsargiai';
+
+  @override
+  String get developerSettingsTitle => 'Kūrėjo nustatymai';
+
+  @override
+  String get saving => 'Išsaugoma...';
+
+  @override
+  String get personaConfig => 'Konfigūruokite savo DI asmens charakteristikų';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transkripcija';
+
+  @override
+  String get transcriptionConfig => 'Konfigūruoti STT teikėją';
+
+  @override
+  String get conversationTimeout => 'Pokalbio skirtasis laikas';
+
+  @override
+  String get conversationTimeoutConfig => 'Nustatykite, kada automatiškai baigiami pokalbiai';
+
+  @override
+  String get importData => 'Importuoti duomenis';
+
+  @override
+  String get importDataConfig => 'Importuoti duomenis iš kitų šaltinių';
+
+  @override
+  String get debugDiagnostics => 'Derinimas ir diagnostika';
+
+  @override
+  String get endpointUrl => 'Galinio taško URL';
+
+  @override
+  String get noApiKeys => 'Kol kas nėra API raktų';
+
+  @override
+  String get createKeyToStart => 'Sukurkite raktą, kad pradėtumėte';
+
+  @override
+  String get createKey => 'Sukurti raktą';
+
+  @override
+  String get docs => 'Dokumentai';
+
+  @override
+  String get yourOmiInsights => 'Jūsų Omi įžvalgos';
+
+  @override
+  String get today => 'Šiandien';
+
+  @override
+  String get thisMonth => 'Šį mėnesį';
+
+  @override
+  String get thisYear => 'Šiais metais';
+
+  @override
+  String get allTime => 'Visą laiką';
+
+  @override
+  String get noActivityYet => 'Kol kas nėra veiklos';
+
+  @override
+  String get startConversationToSeeInsights => 'Pradėkite pokalbį su Omi,\nkad čia matytumėte naudojimo įžvalgas.';
+
+  @override
+  String get listening => 'Klausymasis';
+
+  @override
+  String get listeningSubtitle => 'Bendras laikas, kurį Omi aktyviai klausėsi.';
+
+  @override
+  String get understanding => 'Supratimas';
+
+  @override
+  String get understandingSubtitle => 'Žodžiai, suprasti iš jūsų pokalbių.';
+
+  @override
+  String get providing => 'Teikimas';
+
+  @override
+  String get providingSubtitle => 'Automatiškai užfiksuotos užduotys ir pastabos.';
+
+  @override
+  String get remembering => 'Prisiminimas';
+
+  @override
+  String get rememberingSubtitle => 'Faktai ir detalės, prisiminti jums.';
+
+  @override
+  String get unlimitedPlan => 'Neribojamas planas';
+
+  @override
+  String get managePlan => 'Valdyti planą';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Jūsų planas bus atšauktas $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Jūsų planas bus atnaujintas $date.';
+  }
+
+  @override
+  String get basicPlan => 'Nemokamas planas';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return 'Panaudota $used iš $limit min.';
+  }
+
+  @override
+  String get upgrade => 'Atnaujinti';
+
+  @override
+  String get upgradeToUnlimited => 'Atnaujinti į neribotą';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Jūsų planas apima $limit nemokamų minučių per mėnesį. Atnaujinkite, kad gautumėte neribotą.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Dalinu savo Omi statistika! (omi.me – jūsų visada veikiantis DI asistentas)';
+
+  @override
+  String get sharePeriodToday => 'Šiandien omi:';
+
+  @override
+  String get sharePeriodMonth => 'Šį mėnesį omi:';
+
+  @override
+  String get sharePeriodYear => 'Šiais metais omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Iki šiol omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Klausėsi $minutes minučių';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Suprato $words žodžių';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Suteikė $count įžvalgų';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Prisiminė $count prisiminimų';
+  }
+
+  @override
+  String get debugLogs => 'Derinimo žurnalai';
+
+  @override
+  String get debugLogsAutoDelete => 'Automatiškai ištrinami po 3 dienų.';
+
+  @override
+  String get debugLogsDesc => 'Padeda diagnozuoti problemas';
+
+  @override
+  String get noLogFilesFound => 'Žurnalų failų nerasta.';
+
+  @override
+  String get omiDebugLog => 'Omi derinimo žurnalas';
+
+  @override
+  String get logShared => 'Žurnalas bendrintas';
+
+  @override
+  String get selectLogFile => 'Pasirinkti žurnalo failą';
+
+  @override
+  String get shareLogs => 'Bendrinti žurnalus';
+
+  @override
+  String get debugLogCleared => 'Derinimo žurnalas išvalytas';
+
+  @override
+  String get exportStarted => 'Eksportavimas pradėtas. Tai gali užtrukti keletą sekundžių...';
+
+  @override
+  String get exportAllData => 'Eksportuoti visus duomenis';
+
+  @override
+  String get exportDataDesc => 'Eksportuoti pokalbius į JSON failą';
+
+  @override
+  String get exportedConversations => 'Eksportuoti pokalbiai iš Omi';
+
+  @override
+  String get exportShared => 'Eksportas bendrintas';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Ištrinti žinių grafiką?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Taip bus ištrinti visi išvesti žinių grafiko duomenys (mazgai ir ryšiai). Jūsų originalūs prisiminimai liks saugūs. Grafikas bus atstatytas laikui bėgant arba pagal kitą užklausą.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Žinių grafikas sėkmingai ištrintas';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Nepavyko ištrinti grafiko: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Ištrinti žinių grafiką';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Išvalyti visus mazgus ir ryšius';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP serveris';
+
+  @override
+  String get mcpServerDesc => 'Prijunkite DI asistentus prie savo duomenų';
+
+  @override
+  String get serverUrl => 'Serverio URL';
+
+  @override
+  String get urlCopied => 'URL nukopijuotas';
+
+  @override
+  String get apiKeyAuth => 'API rakto autentifikacija';
+
+  @override
+  String get header => 'Antraštė';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Kliento ID';
+
+  @override
+  String get clientSecret => 'Kliento paslaptis';
+
+  @override
+  String get useMcpApiKey => 'Naudokite savo MCP API raktą';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Pokalbių įvykiai';
+
+  @override
+  String get newConversationCreated => 'Sukurtas naujas pokalbis';
+
+  @override
+  String get realtimeTranscript => 'Realaus laiko transkripcija';
+
+  @override
+  String get transcriptReceived => 'Transkripcija gauta';
+
+  @override
+  String get audioBytes => 'Garso baitai';
+
+  @override
+  String get audioDataReceived => 'Garso duomenys gauti';
+
+  @override
+  String get intervalSeconds => 'Intervalas (sekundės)';
+
+  @override
+  String get daySummary => 'Dienos santrauka';
+
+  @override
+  String get summaryGenerated => 'Santrauka sugeneruota';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Pridėti į claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Kopijuoti konfigūraciją';
+
+  @override
+  String get configCopied => 'Konfigūracija nukopijuota į iškarpinę';
+
+  @override
+  String get listeningMins => 'Klausymasis (min.)';
+
+  @override
+  String get understandingWords => 'Supratimas (žodžiai)';
+
+  @override
+  String get insights => 'Įžvalgos';
+
+  @override
+  String get memories => 'Prisiminimai';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return 'Šį mėnesį panaudota $used iš $limit min.';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return 'Šį mėnesį panaudota $used iš $limit žodžių';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return 'Šį mėnesį gauta $used iš $limit įžvalgų';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return 'Šį mėnesį sukurta $used iš $limit prisiminimų';
+  }
+
+  @override
+  String get visibility => 'Matomumas';
+
+  @override
+  String get visibilitySubtitle => 'Kontroliuokite, kurie pokalbiai rodomi jūsų sąraše';
+
+  @override
+  String get showShortConversations => 'Rodyti trumpus pokalbius';
+
+  @override
+  String get showShortConversationsDesc => 'Rodyti pokalbius, trumpesnius už ribą';
+
+  @override
+  String get showDiscardedConversations => 'Rodyti atmestus pokalbius';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Įtraukti pokalbius, pažymėtus kaip atmesti';
+
+  @override
+  String get shortConversationThreshold => 'Trumpo pokalbio riba';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Pokalbiai, trumpesni už šią ribą, bus paslėpti, nebent įjungta aukščiau';
+
+  @override
+  String get durationThreshold => 'Trukmės riba';
+
+  @override
+  String get durationThresholdDesc => 'Slėpti pokalbius, trumpesnius už šią ribą';
+
+  @override
+  String minLabel(int count) {
+    return '$count min.';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Pasirinktinis žodynas';
+
+  @override
+  String get addWords => 'Pridėti žodžių';
+
+  @override
+  String get addWordsDesc => 'Vardai, terminai ar neįprasti žodžiai';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Prisijungti';
+
+  @override
+  String get comingSoon => 'Greitai';
+
+  @override
+  String get chatToolsFooter => 'Prijunkite savo programėles, kad matytumėte duomenis ir metrikas pokalbyje.';
+
+  @override
+  String get completeAuthInBrowser => 'Užbaikite autentifikaciją naršyklėje. Baigę grįžkite į programą.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Nepavyko pradėti $appName autentifikacijos';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Atjungti $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Ar tikrai norite atsijungti nuo $appName? Galite bet kada vėl prisijungti.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Atjungta nuo $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Nepavyko atjungti';
+
+  @override
+  String connectTo(String appName) {
+    return 'Prisijungti prie $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Jums reikės autorizuoti Omi prieigą prie jūsų $appName duomenų. Bus atidaryta naršyklė autentifikacijai.';
+  }
+
+  @override
+  String get continueAction => 'Tęsti';
+
+  @override
+  String get languageTitle => 'Kalba';
+
+  @override
+  String get primaryLanguage => 'Pagrindinė kalba';
+
+  @override
+  String get automaticTranslation => 'Automatinis vertimas';
+
+  @override
+  String get detectLanguages => 'Aptikti 10+ kalbų';
+
+  @override
+  String get authorizeSavingRecordings => 'Leisti išsaugoti įrašus';
+
+  @override
+  String get thanksForAuthorizing => 'Ačiū, kad leidote!';
+
+  @override
+  String get needYourPermission => 'Mums reikia jūsų leidimo';
+
+  @override
+  String get alreadyGavePermission => 'Jau davėte mums leidimą išsaugoti jūsų įrašus. Primename, kodėl mums to reikia:';
+
+  @override
+  String get wouldLikePermission => 'Norėtume jūsų leidimo išsaugoti jūsų balso įrašus. Štai kodėl:';
+
+  @override
+  String get improveSpeechProfile => 'Pagerinti jūsų kalbos profilį';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Naudojame įrašus tolesniam jūsų asmeninio kalbos profilio mokymui ir tobulinimui.';
+
+  @override
+  String get trainFamilyProfiles => 'Mokyti draugų ir šeimos profilius';
+
+  @override
+  String get trainFamilyProfilesDesc => 'Jūsų įrašai padeda atpažinti ir kurti profilius jūsų draugams ir šeimai.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Pagerinti transkripcijos tikslumą';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Mūsų modeliui tobulėjant, galime pateikti geresnius transkripcijos rezultatus jūsų įrašams.';
+
+  @override
+  String get legalNotice =>
+      'Teisinis pranešimas: balso duomenų įrašymo ir saugojimo teisėtumas gali skirtis priklausomai nuo jūsų buvimo vietos ir kaip naudojate šią funkciją. Tai jūsų atsakomybė užtikrinti atitiktį vietiniams įstatymams ir taisyklėms.';
+
+  @override
+  String get alreadyAuthorized => 'Jau autorizuota';
+
+  @override
+  String get authorize => 'Leisti';
+
+  @override
+  String get revokeAuthorization => 'Atšaukti leidimą';
+
+  @override
+  String get authorizationSuccessful => 'Leidimas sėkmingas!';
+
+  @override
+  String get failedToAuthorize => 'Nepavyko autorizuoti. Bandykite dar kartą.';
+
+  @override
+  String get authorizationRevoked => 'Leidimas atšauktas.';
+
+  @override
+  String get recordingsDeleted => 'Įrašai ištrinti.';
+
+  @override
+  String get failedToRevoke => 'Nepavyko atšaukti leidimo. Bandykite dar kartą.';
+
+  @override
+  String get permissionRevokedTitle => 'Leidimas atšauktas';
+
+  @override
+  String get permissionRevokedMessage => 'Ar norite, kad ištrintume visus jūsų esamus įrašus?';
+
+  @override
+  String get yes => 'Taip';
+
+  @override
+  String get editName => 'Redaguoti vardą';
+
+  @override
+  String get howShouldOmiCallYou => 'Kaip Omi turėtų jus vadinti?';
+
+  @override
+  String get enterYourName => 'Įveskite savo vardą';
+
+  @override
+  String get nameCannotBeEmpty => 'Vardas negali būti tuščias';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Vardas sėkmingai atnaujintas!';
+
+  @override
+  String get calendarSettings => 'Kalendoriaus nustatymai';
+
+  @override
+  String get calendarProviders => 'Kalendoriaus teikėjai';
+
+  @override
+  String get macOsCalendar => 'macOS kalendorius';
+
+  @override
+  String get connectMacOsCalendar => 'Prijunkite savo vietinį macOS kalendorių';
+
+  @override
+  String get googleCalendar => 'Google kalendorius';
+
+  @override
+  String get syncGoogleAccount => 'Sinchronizuoti su savo Google paskyra';
+
+  @override
+  String get showMeetingsMenuBar => 'Rodyti būsimus susitikimus meniu juostoje';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Rodyti kitą susitikimą ir laiką iki jo pradžios macOS meniu juostoje';
+
+  @override
+  String get showEventsNoParticipants => 'Rodyti renginius be dalyvių';
+
+  @override
+  String get showEventsNoParticipantsDesc => 'Kai įjungta, „Coming Up\" rodo renginius be dalyvių ar vaizdo nuorodos.';
+
+  @override
+  String get yourMeetings => 'Jūsų susitikimai';
+
+  @override
+  String get refresh => 'Atnaujinti';
+
+  @override
+  String get noUpcomingMeetings => 'Nerasta būsimų susitikimų';
+
+  @override
+  String get checkingNextDays => 'Tikrinama ateinančių 30 dienų';
+
+  @override
+  String get tomorrow => 'Rytoj';
+
+  @override
+  String get googleCalendarComingSoon => 'Google kalendoriaus integracija greitai!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Prisijungta kaip vartotojas: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Numatytoji darbo sritis';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Užduotys bus sukurtos šioje darbo srityje';
+
+  @override
+  String get defaultProjectOptional => 'Numatytasis projektas (nebūtinas)';
+
+  @override
+  String get leaveUnselectedTasks => 'Palikite nepasirinkus, kad sukurtumėte užduotis be projekto';
+
+  @override
+  String get noProjectsInWorkspace => 'Šioje darbo srityje nerasta projektų';
+
+  @override
+  String get conversationTimeoutDesc => 'Pasirinkite, kiek laiko laukti tylos prieš automatiškai baigiant pokalbį:';
+
+  @override
+  String get timeout2Minutes => '2 minutės';
+
+  @override
+  String get timeout2MinutesDesc => 'Baigti pokalbį po 2 minučių tylos';
+
+  @override
+  String get timeout5Minutes => '5 minutės';
+
+  @override
+  String get timeout5MinutesDesc => 'Baigti pokalbį po 5 minučių tylos';
+
+  @override
+  String get timeout10Minutes => '10 minučių';
+
+  @override
+  String get timeout10MinutesDesc => 'Baigti pokalbį po 10 minučių tylos';
+
+  @override
+  String get timeout30Minutes => '30 minučių';
+
+  @override
+  String get timeout30MinutesDesc => 'Baigti pokalbį po 30 minučių tylos';
+
+  @override
+  String get timeout4Hours => '4 valandos';
+
+  @override
+  String get timeout4HoursDesc => 'Baigti pokalbį po 4 valandų tylos';
+
+  @override
+  String get conversationEndAfterHours => 'Pokalbiai dabar bus baigiami po 4 valandų tylos';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Pokalbiai dabar bus baigiami po $minutes minutės(-ių) tylos';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Pasakykite mums savo pagrindinę kalbą';
+
+  @override
+  String get languageForTranscription =>
+      'Nustatykite savo kalbą tikslesnėms transkripcijoms ir individualizuotai patirčiai.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Įjungtas vienos kalbos režimas. Vertimas išjungtas, kad būtų didesnis tikslumas.';
+
+  @override
+  String get searchLanguageHint => 'Ieškoti kalbos pagal pavadinimą ar kodą';
+
+  @override
+  String get noLanguagesFound => 'Kalbų nerasta';
+
+  @override
+  String get skip => 'Praleisti';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Kalba nustatyta į $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Nepavyko nustatyti kalbos';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName nustatymai';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Atjungti nuo $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Bus pašalinta jūsų $appName autentifikacija. Jums reikės vėl prisijungti, kad ją naudotumėte.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Prisijungta prie $appName';
+  }
+
+  @override
+  String get account => 'Paskyra';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Jūsų užduotys bus sinchronizuotos su jūsų $appName paskyra';
+  }
+
+  @override
+  String get defaultSpace => 'Numatytoji erdvė';
+
+  @override
+  String get selectSpaceInWorkspace => 'Pasirinkite erdvę savo darbo srityje';
+
+  @override
+  String get noSpacesInWorkspace => 'Šioje darbo srityje nerasta erdvių';
+
+  @override
+  String get defaultList => 'Numatytasis sąrašas';
+
+  @override
+  String get tasksAddedToList => 'Užduotys bus pridėtos į šį sąrašą';
+
+  @override
+  String get noListsInSpace => 'Šioje erdvėje nerasta sąrašų';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Nepavyko įkelti saugyklų: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Numatytoji saugykla išsaugota';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Nepavyko išsaugoti numatytosios saugyklos';
+
+  @override
+  String get defaultRepository => 'Numatytoji saugykla';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Pasirinkite numatytąją saugyklą problemų kūrimui. Kurdami problemas galite nurodyti kitą saugyklą.';
+
+  @override
+  String get noReposFound => 'Saugyklų nerasta';
+
+  @override
+  String get private => 'Privati';
+
+  @override
+  String updatedDate(String date) {
+    return 'Atnaujinta $date';
+  }
+
+  @override
+  String get yesterday => 'vakar';
+
+  @override
+  String daysAgo(int count) {
+    return 'prieš $count d.';
+  }
+
+  @override
+  String get oneWeekAgo => 'prieš 1 savaitę';
+
+  @override
+  String weeksAgo(int count) {
+    return 'prieš $count sav.';
+  }
+
+  @override
+  String get oneMonthAgo => 'prieš 1 mėnesį';
+
+  @override
+  String monthsAgo(int count) {
+    return 'prieš $count mėn.';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Problemos bus sukurtos jūsų numatytojoje saugykloje';
+
+  @override
+  String get taskIntegrations => 'Užduočių integracijos';
+
+  @override
+  String get configureSettings => 'Konfigūruoti nustatymus';
+
+  @override
+  String get completeAuthBrowser => 'Užbaikite autentifikaciją naršyklėje. Baigę grįžkite į programą.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Nepavyko pradėti $appName autentifikacijos';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Prisijungti prie $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Jums reikės autorizuoti Omi kurti užduotis jūsų $appName paskyroje. Bus atidaryta naršyklė autentifikacijai.';
+  }
+
+  @override
+  String get continueButton => 'Tęsti';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName integracija';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integracija su $appName greitai! Sunkiai dirbame, kad suteiktume daugiau užduočių valdymo parinkčių.';
+  }
+
+  @override
+  String get gotIt => 'Supratau';
+
+  @override
+  String get tasksExportedOneApp => 'Užduotys gali būti eksportuojamos į vieną programėlę vienu metu.';
+
+  @override
+  String get completeYourUpgrade => 'Užbaikite savo atnaujinimą';
+
+  @override
+  String get importConfiguration => 'Importuoti konfigūraciją';
+
+  @override
+  String get exportConfiguration => 'Eksportuoti konfigūraciją';
+
+  @override
+  String get bringYourOwn => 'Naudokite savo';
+
+  @override
+  String get payYourSttProvider => 'Laisvai naudokite omi. Mokate tik savo STT teikėjui tiesiogiai.';
+
+  @override
+  String get freeMinutesMonth => '1 200 nemokamų minučių per mėnesį įtraukta. Neribota su ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Reikalingas pagrindinis kompiuteris';
+
+  @override
+  String get validPortRequired => 'Reikalingas tinkamas prievadas';
+
+  @override
+  String get validWebsocketUrlRequired => 'Reikalingas tinkamas WebSocket URL (wss://)';
+
+  @override
+  String get apiUrlRequired => 'Reikalingas API URL';
+
+  @override
+  String get apiKeyRequired => 'Reikalingas API raktas';
+
+  @override
+  String get invalidJsonConfig => 'Netinkama JSON konfigūracija';
+
+  @override
+  String errorSaving(String error) {
+    return 'Klaida išsaugant: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfigūracija nukopijuota į iškarpinę';
+
+  @override
+  String get pasteJsonConfig => 'Įklijuokite savo JSON konfigūraciją žemiau:';
+
+  @override
+  String get addApiKeyAfterImport => 'Importavę turėsite pridėti savo API raktą';
+
+  @override
+  String get paste => 'Įklijuoti';
+
+  @override
+  String get import => 'Importuoti';
+
+  @override
+  String get invalidProviderInConfig => 'Netinkamas teikėjas konfigūracijoje';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Importuota $providerName konfigūracija';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Netinkamas JSON: $error';
+  }
+
+  @override
+  String get provider => 'Teikėjas';
+
+  @override
+  String get live => 'Tiesioginis';
+
+  @override
+  String get onDevice => 'Įrenginyje';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Įveskite savo STT HTTP galinį tašką';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Įveskite savo tiesioginį STT WebSocket galinį tašką';
+
+  @override
+  String get apiKey => 'API raktas';
+
+  @override
+  String get enterApiKey => 'Įveskite savo API raktą';
+
+  @override
+  String get storedLocallyNeverShared => 'Saugoma vietoje, niekada nebendrinam';
+
+  @override
+  String get host => 'Pagrindinis kompiuteris';
+
+  @override
+  String get port => 'Prievadas';
+
+  @override
+  String get advanced => 'Išplėstiniai';
+
+  @override
+  String get configuration => 'Konfigūracija';
+
+  @override
+  String get requestConfiguration => 'Užklausos konfigūracija';
+
+  @override
+  String get responseSchema => 'Atsakymo schema';
+
+  @override
+  String get modified => 'Pakeista';
+
+  @override
+  String get resetRequestConfig => 'Atkurti užklausos konfigūraciją į numatytąją';
+
+  @override
+  String get logs => 'Žurnalai';
+
+  @override
+  String get logsCopied => 'Žurnalai nukopijuoti';
+
+  @override
+  String get noLogsYet => 'Kol kas nėra žurnalų. Pradėkite įrašinėti, kad matytumėte pasirinktinio STT veiklą.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName naudoja $codecReason. Bus naudojamas Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi transkripcija';
+
+  @override
+  String get bestInClassTranscription => 'Geriausia klasės transkripcija be jokio nustatymo';
+
+  @override
+  String get instantSpeakerLabels => 'Akimirksniu kalbėtojų etiketės';
+
+  @override
+  String get languageTranslation => '100+ kalbų vertimas';
+
+  @override
+  String get optimizedForConversation => 'Optimizuota pokalbiams';
+
+  @override
+  String get autoLanguageDetection => 'Automatinis kalbos aptikimas';
+
+  @override
+  String get highAccuracy => 'Aukštas tikslumas';
+
+  @override
+  String get privacyFirst => 'Pirmiausiai privatumas';
+
+  @override
+  String get saveChanges => 'Išsaugoti pakeitimus';
+
+  @override
+  String get resetToDefault => 'Atkurti į numatytuosius';
+
+  @override
+  String get viewTemplate => 'Peržiūrėti šabloną';
+
+  @override
+  String get trySomethingLike => 'Pabandykite kažką panašaus...';
+
+  @override
+  String get tryIt => 'Išbandykite';
+
+  @override
+  String get creatingPlan => 'Kuriamas planas';
+
+  @override
+  String get developingLogic => 'Kuriama logika';
+
+  @override
+  String get designingApp => 'Projektuojama programėlė';
+
+  @override
+  String get generatingIconStep => 'Generuojama piktograma';
+
+  @override
+  String get finalTouches => 'Paskutiniai patobulinimai';
+
+  @override
+  String get processing => 'Apdorojama...';
+
+  @override
+  String get features => 'Funkcijos';
+
+  @override
+  String get creatingYourApp => 'Kuriama jūsų programėlė...';
+
+  @override
+  String get generatingIcon => 'Generuojama piktograma...';
+
+  @override
+  String get whatShouldWeMake => 'Ką turėtume sukurti?';
+
+  @override
+  String get appName => 'Programėlės pavadinimas';
+
+  @override
+  String get description => 'Aprašymas';
+
+  @override
+  String get publicLabel => 'Vieša';
+
+  @override
+  String get privateLabel => 'Privati';
+
+  @override
+  String get free => 'Nemokai';
+
+  @override
+  String get perMonth => '/ Mėnesį';
+
+  @override
+  String get tailoredConversationSummaries => 'Pritaikytos pokalbių santraukos';
+
+  @override
+  String get customChatbotPersonality => 'Pasirinktinė pokalbių roboto asmenybė';
+
+  @override
+  String get makePublic => 'Padaryti viešą';
+
+  @override
+  String get anyoneCanDiscover => 'Bet kas gali rasti jūsų programėlę';
+
+  @override
+  String get onlyYouCanUse => 'Tik jūs galite naudoti šią programėlę';
+
+  @override
+  String get paidApp => 'Mokama programėlė';
+
+  @override
+  String get usersPayToUse => 'Vartotojai moka, kad naudotų jūsų programėlę';
+
+  @override
+  String get freeForEveryone => 'Nemokamai visiems';
+
+  @override
+  String get perMonthLabel => '/ mėnesį';
+
+  @override
+  String get creating => 'Kuriama...';
+
+  @override
+  String get createApp => 'Sukurti programėlę';
+
+  @override
+  String get searchingForDevices => 'Ieškoma įrenginių...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ĮRENGINIAI',
+      one: 'ĮRENGINYS',
+    );
+    return 'RASTA $count $_temp0 NETOLIESE';
+  }
+
+  @override
+  String get pairingSuccessful => 'SUSIEJIMAS SĖKMINGAS';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Klaida jungiantis prie Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Daugiau nerodyti';
+
+  @override
+  String get iUnderstand => 'Suprantu';
+
+  @override
+  String get enableBluetooth => 'Įjungti Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi reikia Bluetooth, kad prisijungtų prie jūsų nešiojamo įrenginio. Įjunkite Bluetooth ir bandykite dar kartą.';
+
+  @override
+  String get contactSupport => 'Susisiekti su palaikymu?';
+
+  @override
+  String get connectLater => 'Prijungti vėliau';
+
+  @override
+  String get grantPermissions => 'Suteikti leidimus';
+
+  @override
+  String get backgroundActivity => 'Foninė veikla';
+
+  @override
+  String get backgroundActivityDesc => 'Leiskite Omi veikti fone geresniam stabilumui';
+
+  @override
+  String get locationAccess => 'Vietos prieiga';
+
+  @override
+  String get locationAccessDesc => 'Įjunkite foninę vietos nustatymą visapusiškesnei patirčiai';
+
+  @override
+  String get notifications => 'Pranešimai';
+
+  @override
+  String get notificationsDesc => 'Įjunkite pranešimus, kad būtumėte informuoti';
+
+  @override
+  String get locationServiceDisabled => 'Vietos tarnyba išjungta';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Vietos tarnyba išjungta. Eikite į Nustatymus > Privatumas ir sauga > Vietos tarnybos ir įjunkite ją';
+
+  @override
+  String get backgroundLocationDenied => 'Foninės vietos prieiga atmesta';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Eikite į įrenginio nustatymus ir nustatykite vietos leidimą į „Visada leisti\"';
+
+  @override
+  String get lovingOmi => 'Patinka Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Padėkite mums pasiekti daugiau žmonių palikdami atsiliepimą App Store. Jūsų atsiliepimas mums reiškia labai daug!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Padėkite mums pasiekti daugiau žmonių palikdami atsiliepimą „Google Play\" parduotuvėje. Jūsų atsiliepimas mums reiškia labai daug!';
+
+  @override
+  String get rateOnAppStore => 'Įvertinti App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Įvertinti „Google Play\"';
+
+  @override
+  String get maybeLater => 'Galbūt vėliau';
+
+  @override
+  String get speechProfileIntro => 'Omi turi išmokti jūsų tikslų ir jūsų balso. Vėliau galėsite jį keisti.';
+
+  @override
+  String get getStarted => 'Pradėti';
+
+  @override
+  String get allDone => 'Viskas atlikta!';
+
+  @override
+  String get keepGoing => 'Tęskite, jums puikiai sekasi';
+
+  @override
+  String get skipThisQuestion => 'Praleisti šį klausimą';
+
+  @override
+  String get skipForNow => 'Kol kas praleisti';
+
+  @override
+  String get connectionError => 'Ryšio klaida';
+
+  @override
+  String get connectionErrorDesc =>
+      'Nepavyko prisijungti prie serverio. Patikrinkite interneto ryšį ir bandykite dar kartą.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Aptiktas netinkamas įrašas';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Atrodo, kad įraše yra keli kalbėtojai. Įsitikinkite, kad esate tylioje vietoje, ir bandykite dar kartą.';
+
+  @override
+  String get tooShortDesc => 'Neaptikta pakankamai kalbos. Kalbėkite daugiau ir bandykite dar kartą.';
+
+  @override
+  String get invalidRecordingDesc => 'Įsitikinkite, kad kalbate bent 5 sekundes ir ne ilgiau nei 90.';
+
+  @override
+  String get areYouThere => 'Ar jūs čia?';
+
+  @override
+  String get noSpeechDesc =>
+      'Nepavyko aptikti jokios kalbos. Įsitikinkite, kad kalbate bent 10 sekundžių ir ne ilgiau nei 3 minutes.';
+
+  @override
+  String get connectionLost => 'Ryšys prarastas';
+
+  @override
+  String get connectionLostDesc => 'Ryšys buvo nutrauktas. Patikrinkite interneto ryšį ir bandykite dar kartą.';
+
+  @override
+  String get tryAgain => 'Bandyti dar kartą';
+
+  @override
+  String get connectOmiOmiGlass => 'Prijungti Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Tęsti be įrenginio';
+
+  @override
+  String get permissionsRequired => 'Reikalingi leidimai';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Šiai programai reikia Bluetooth ir vietos leidimų, kad tinkamai veiktų. Įjunkite juos nustatymuose.';
+
+  @override
+  String get openSettings => 'Atidaryti nustatymus';
+
+  @override
+  String get wantDifferentName => 'Norite, kad jus vadintų kitaip?';
+
+  @override
+  String get whatsYourName => 'Koks jūsų vardas?';
+
+  @override
+  String get speakTranscribeSummarize => 'Kalbėti. Transkribuoti. Apibendrinti.';
+
+  @override
+  String get signInWithApple => 'Prisijungti su Apple';
+
+  @override
+  String get signInWithGoogle => 'Prisijungti su Google';
+
+  @override
+  String get byContinuingAgree => 'Tęsdami sutinkate su mūsų ';
+
+  @override
+  String get termsOfUse => 'Naudojimo sąlygomis';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – jūsų DI palydovas';
+
+  @override
+  String get captureEveryMoment =>
+      'Užfiksuokite kiekvieną akimirką. Gaukite DI pagrindu\nsukurtas santraukas. Daugiau nebedarykite užrašų.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch sąranka';
+
+  @override
+  String get permissionRequestedExclaim => 'Leidimas paprašytas!';
+
+  @override
+  String get microphonePermission => 'Mikrofono leidimas';
+
+  @override
+  String get permissionGrantedNow =>
+      'Leidimas suteiktas! Dabar:\n\nAtidarykite Omi programą savo laikrodyje ir paspauskite „Tęsti\" žemiau';
+
+  @override
+  String get needMicrophonePermission =>
+      'Mums reikia mikrofono leidimo.\n\n1. Paspauskite „Suteikti leidimą\"\n2. Leiskite savo iPhone\n3. Laikrodžio programėlė užsidarys\n4. Atidarykite iš naujo ir paspauskite „Tęsti\"';
+
+  @override
+  String get grantPermissionButton => 'Suteikti leidimą';
+
+  @override
+  String get needHelp => 'Reikia pagalbos?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Trikčių šalinimas:\n\n1. Įsitikinkite, kad Omi įdiegtas jūsų laikrodyje\n2. Atidarykite Omi programą savo laikrodyje\n3. Ieškokite leidimo iššokančio lango\n4. Paspauskite „Leisti\", kai bus paprašyta\n5. Programėlė jūsų laikrodyje užsidarys – atidarykite ją iš naujo\n6. Grįžkite ir paspauskite „Tęsti\" savo iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Įrašymas pradėtas sėkmingai!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Leidimas dar nesuteiktas. Įsitikinkite, kad leidote prieigą prie mikrofono ir iš naujo atidarėte programą savo laikrodyje.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Klaida prašant leidimo: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Klaida pradedant įrašymą: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Pasirinkite savo pagrindinę kalbą';
+
+  @override
+  String get languageBenefits => 'Nustatykite savo kalbą tikslesnėms transkripcijoms ir individualizuotai patirčiai';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Kokia jūsų pagrindinė kalba?';
+
+  @override
+  String get selectYourLanguage => 'Pasirinkite savo kalbą';
+
+  @override
+  String get personalGrowthJourney => 'Jūsų asmeninio augimo kelionė su DI, kuris klauso kiekvieno jūsų žodžio.';
+
+  @override
+  String get actionItemsTitle => 'Užduotys';
+
+  @override
+  String get actionItemsDescription =>
+      'Bakstelėkite, kad redaguotumėte • Ilgai spauskite, kad pasirinktumėte • Braukite veiksmams';
+
+  @override
+  String get tabToDo => 'Atlikti';
+
+  @override
+  String get tabDone => 'Baigta';
+
+  @override
+  String get tabOld => 'Senos';
+
+  @override
+  String get emptyTodoMessage => '🎉 Viskas atnaujinta!\nNėra laukiančių užduočių';
+
+  @override
+  String get emptyDoneMessage => 'Kol kas nėra baigtų elementų';
+
+  @override
+  String get emptyOldMessage => '✅ Nėra senų užduočių';
+
+  @override
+  String get noItems => 'Nėra elementų';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Užduotis pažymėta kaip nebaigta';
+
+  @override
+  String get actionItemCompleted => 'Užduotis baigta';
+
+  @override
+  String get deleteActionItemTitle => 'Ištrinti užduotį';
+
+  @override
+  String get deleteActionItemMessage => 'Ar tikrai norite ištrinti šią užduotį?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Ištrinti pasirinktus elementus';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Ar tikrai norite ištrinti $count pasirinktą(-s) užduotį(-is)?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Užduotis „$description\" ištrinta';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return 'Ištrinta $count užduotis(-ių)';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Nepavyko ištrinti užduoties';
+
+  @override
+  String get failedToDeleteItems => 'Nepavyko ištrinti elementų';
+
+  @override
+  String get failedToDeleteSomeItems => 'Nepavyko ištrinti kai kurių elementų';
+
+  @override
+  String get welcomeActionItemsTitle => 'Pasiruošę užduotims';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Jūsų DI automatiškai išgaus užduotis iš jūsų pokalbių. Jos atsiras čia, kai bus sukurtos.';
+
+  @override
+  String get autoExtractionFeature => 'Automatiškai išgauta iš pokalbių';
+
+  @override
+  String get editSwipeFeature => 'Bakstelėkite, kad redaguotumėte, braukite, kad baigtumėte ar ištrintumėte';
+
+  @override
+  String itemsSelected(int count) {
+    return 'Pasirinkta: $count';
+  }
+
+  @override
+  String get selectAll => 'Pasirinkti viską';
+
+  @override
+  String get deleteSelected => 'Ištrinti pasirinktus';
+
+  @override
+  String searchMemories(int count) {
+    return 'Ieškoti $count prisiminimų';
+  }
+
+  @override
+  String get memoryDeleted => 'Prisiminimas ištrintas.';
+
+  @override
+  String get undo => 'Atšaukti';
+
+  @override
+  String get noMemoriesYet => 'Kol kas nėra prisiminimų';
+
+  @override
+  String get noAutoMemories => 'Kol kas nėra automatiškai išgautų prisiminimų';
+
+  @override
+  String get noManualMemories => 'Kol kas nėra rankinio prisiminimų';
+
+  @override
+  String get noMemoriesInCategories => 'Šiose kategorijose nėra prisiminimų';
+
+  @override
+  String get noMemoriesFound => 'Prisiminimų nerasta';
+
+  @override
+  String get addFirstMemory => 'Pridėti pirmąjį prisiminimą';
+
+  @override
+  String get clearMemoryTitle => 'Išvalyti Omi atmintį';
+
+  @override
+  String get clearMemoryMessage => 'Ar tikrai norite išvalyti Omi atmintį? Šio veiksmo negalima atšaukti.';
+
+  @override
+  String get clearMemoryButton => 'Išvalyti atmintį';
+
+  @override
+  String get memoryClearedSuccess => 'Omi atmintis apie jus išvalyta';
+
+  @override
+  String get noMemoriesToDelete => 'Nėra prisiminimų trinimui';
+
+  @override
+  String get createMemoryTooltip => 'Sukurti naują prisiminimą';
+
+  @override
+  String get createActionItemTooltip => 'Sukurti naują užduotį';
+
+  @override
+  String get memoryManagement => 'Prisiminimų valdymas';
+
+  @override
+  String get filterMemories => 'Filtruoti prisiminimus';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Turite $count prisiminimų iš viso';
+  }
+
+  @override
+  String get publicMemories => 'Vieši prisiminimai';
+
+  @override
+  String get privateMemories => 'Privatūs prisiminimai';
+
+  @override
+  String get makeAllPrivate => 'Padaryti visus prisiminimus privačius';
+
+  @override
+  String get makeAllPublic => 'Padaryti visus prisiminimus viešus';
+
+  @override
+  String get deleteAllMemories => 'Ištrinti visus prisiminimus';
+
+  @override
+  String get allMemoriesPrivateResult => 'Visi prisiminimai dabar privatūs';
+
+  @override
+  String get allMemoriesPublicResult => 'Visi prisiminimai dabar vieši';
+
+  @override
+  String get newMemory => 'Naujas prisiminimas';
+
+  @override
+  String get editMemory => 'Redaguoti prisiminimą';
+
+  @override
+  String get memoryContentHint => 'Mėgstu valgyti ledus...';
+
+  @override
+  String get failedToSaveMemory => 'Nepavyko išsaugoti. Patikrinkite ryšį.';
+
+  @override
+  String get saveMemory => 'Išsaugoti prisiminimą';
+
+  @override
+  String get retry => 'Bandyti dar kartą';
+
+  @override
+  String get createActionItem => 'Sukurti užduotį';
+
+  @override
+  String get editActionItem => 'Redaguoti užduotį';
+
+  @override
+  String get actionItemDescriptionHint => 'Ką reikia padaryti?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Užduoties aprašymas negali būti tuščias.';
+
+  @override
+  String get actionItemUpdated => 'Užduotis atnaujinta';
+
+  @override
+  String get failedToUpdateActionItem => 'Nepavyko atnaujinti užduoties';
+
+  @override
+  String get actionItemCreated => 'Užduotis sukurta';
+
+  @override
+  String get failedToCreateActionItem => 'Nepavyko sukurti užduoties';
+
+  @override
+  String get dueDate => 'Terminas';
+
+  @override
+  String get time => 'Laikas';
+
+  @override
+  String get addDueDate => 'Pridėti terminą';
+
+  @override
+  String get pressDoneToSave => 'Paspauskite atlikta, kad išsaugotumėte';
+
+  @override
+  String get pressDoneToCreate => 'Paspauskite atlikta, kad sukurtumėte';
+
+  @override
+  String get filterAll => 'Viskas';
+
+  @override
+  String get filterSystem => 'Apie jus';
+
+  @override
+  String get filterInteresting => 'Įžvalgos';
+
+  @override
+  String get filterManual => 'Rankinis';
+
+  @override
+  String get completed => 'Baigta';
+
+  @override
+  String get markComplete => 'Pažymėti kaip baigtą';
+
+  @override
+  String get actionItemDeleted => 'Užduotis ištrinta';
+
+  @override
+  String get failedToDeleteActionItem => 'Nepavyko ištrinti užduoties';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Ištrinti užduotį';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Ar tikrai norite ištrinti šią užduotį?';
+
+  @override
+  String get appLanguage => 'Programėlės kalba';
+
+  @override
+  String get appInterfaceSectionTitle => 'PROGRAMOS SĄSAJA';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'KALBA IR TRANSKRIBAVIMAS';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Programos kalba keičia meniu ir mygtukus. Kalbos kalba įtakoja, kaip transkribuojami jūsų įrašai.';
+}

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -1,0 +1,2235 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Latvian (`lv`).
+class AppLocalizationsLv extends AppLocalizations {
+  AppLocalizationsLv([String locale = 'lv']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Saruna';
+
+  @override
+  String get transcriptTab => 'Transkripcija';
+
+  @override
+  String get actionItemsTab => 'Uzdevumi';
+
+  @override
+  String get deleteConversationTitle => 'Dzēst sarunu?';
+
+  @override
+  String get deleteConversationMessage => 'Vai tiešām vēlaties dzēst šo sarunu? Šo darbību nevar atsaukt.';
+
+  @override
+  String get confirm => 'Apstiprināt';
+
+  @override
+  String get cancel => 'Atcelt';
+
+  @override
+  String get ok => 'Labi';
+
+  @override
+  String get delete => 'Dzēst';
+
+  @override
+  String get add => 'Pievienot';
+
+  @override
+  String get update => 'Atjaunināt';
+
+  @override
+  String get save => 'Saglabāt';
+
+  @override
+  String get edit => 'Rediģēt';
+
+  @override
+  String get close => 'Aizvērt';
+
+  @override
+  String get clear => 'Notīrīt';
+
+  @override
+  String get copyTranscript => 'Kopēt transkripciju';
+
+  @override
+  String get copySummary => 'Kopēt kopsavilkumu';
+
+  @override
+  String get testPrompt => 'Testēt uzvedni';
+
+  @override
+  String get reprocessConversation => 'Pārstrādāt sarunu';
+
+  @override
+  String get deleteConversation => 'Dzēst sarunu';
+
+  @override
+  String get contentCopied => 'Saturs nokopēts starpliktuvē';
+
+  @override
+  String get failedToUpdateStarred => 'Neizdevās atjaunināt zvaigznītes statusu.';
+
+  @override
+  String get conversationUrlNotShared => 'Sarunas URL nevarēja kopīgot.';
+
+  @override
+  String get errorProcessingConversation => 'Kļūda, apstrādājot sarunu. Lūdzu, mēģiniet vēlreiz vēlāk.';
+
+  @override
+  String get noInternetConnection => 'Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
+
+  @override
+  String get unableToDeleteConversation => 'Nevar dzēst sarunu';
+
+  @override
+  String get somethingWentWrong => 'Kaut kas nogāja greizi! Lūdzu, mēģiniet vēlreiz vēlāk.';
+
+  @override
+  String get copyErrorMessage => 'Kopēt kļūdas ziņojumu';
+
+  @override
+  String get errorCopied => 'Kļūdas ziņojums nokopēts starpliktuvē';
+
+  @override
+  String get remaining => 'Atlicis';
+
+  @override
+  String get loading => 'Ielādē...';
+
+  @override
+  String get loadingDuration => 'Ielādē ilgumu...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekundes';
+  }
+
+  @override
+  String get people => 'Cilvēki';
+
+  @override
+  String get addNewPerson => 'Pievienot jaunu personu';
+
+  @override
+  String get editPerson => 'Rediģēt personu';
+
+  @override
+  String get createPersonHint => 'Izveidojiet jaunu personu un apmāciet Omi atpazīt arī viņu runu!';
+
+  @override
+  String get speechProfile => 'Runas profils';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Paraugs $number';
+  }
+
+  @override
+  String get settings => 'Iestatījumi';
+
+  @override
+  String get language => 'Valoda';
+
+  @override
+  String get selectLanguage => 'Izvēlēties valodu';
+
+  @override
+  String get deleting => 'Dzēš...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
+
+  @override
+  String get failedToStartAuthentication => 'Neizdevās sākt autentifikāciju';
+
+  @override
+  String get importStarted => 'Importēšana sākta! Jūs saņemsiet paziņojumu, kad tā būs pabeigta.';
+
+  @override
+  String get failedToStartImport => 'Neizdevās sākt importēšanu. Lūdzu, mēģiniet vēlreiz.';
+
+  @override
+  String get couldNotAccessFile => 'Nevarēja piekļūt atlasītajam failam';
+
+  @override
+  String get askOmi => 'Jautāt Omi';
+
+  @override
+  String get done => 'Gatavs';
+
+  @override
+  String get disconnected => 'Atvienots';
+
+  @override
+  String get searching => 'Meklē';
+
+  @override
+  String get connectDevice => 'Savienot ierīci';
+
+  @override
+  String get monthlyLimitReached => 'Jūs esat sasniedzis mēneša limitu.';
+
+  @override
+  String get checkUsage => 'Pārbaudīt lietojumu';
+
+  @override
+  String get syncingRecordings => 'Sinhronizē ierakstus';
+
+  @override
+  String get recordingsToSync => 'Ieraksti, kas jāsinhronizē';
+
+  @override
+  String get allCaughtUp => 'Viss ir sinhronizēts';
+
+  @override
+  String get sync => 'Sinhronizēt';
+
+  @override
+  String get pendantUpToDate => 'Kulons ir atjaunināts';
+
+  @override
+  String get allRecordingsSynced => 'Visi ieraksti ir sinhronizēti';
+
+  @override
+  String get syncingInProgress => 'Notiek sinhronizācija';
+
+  @override
+  String get readyToSync => 'Gatavs sinhronizācijai';
+
+  @override
+  String get tapSyncToStart => 'Piespiediet Sinhronizēt, lai sāktu';
+
+  @override
+  String get pendantNotConnected => 'Kulons nav savienots. Savienojiet, lai sinhronizētu.';
+
+  @override
+  String get everythingSynced => 'Viss jau ir sinhronizēts.';
+
+  @override
+  String get recordingsNotSynced => 'Jums ir ieraksti, kas vēl nav sinhronizēti.';
+
+  @override
+  String get syncingBackground => 'Mēs turpināsim sinhronizēt jūsu ierakstus fonā.';
+
+  @override
+  String get noConversationsYet => 'Vēl nav sarunu.';
+
+  @override
+  String get noStarredConversations => 'Vēl nav atzīmētu sarunu.';
+
+  @override
+  String get starConversationHint =>
+      'Lai atzīmētu sarunu ar zvaigznīti, atveriet to un piespiediet zvaigznītes ikonu galvenē.';
+
+  @override
+  String get searchConversations => 'Meklēt sarunas';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count atlasīts';
+  }
+
+  @override
+  String get merge => 'Apvienot';
+
+  @override
+  String get mergeConversations => 'Apvienot sarunas';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Tas apvienos $count sarunas vienā. Viss saturs tiks apvienots un ģenerēts no jauna.';
+  }
+
+  @override
+  String get mergingInBackground => 'Apvieno fonā. Tas var aizņemt brīdi.';
+
+  @override
+  String get failedToStartMerge => 'Neizdevās sākt apvienošanu';
+
+  @override
+  String get askAnything => 'Jautājiet jebko';
+
+  @override
+  String get noMessagesYet => 'Vēl nav ziņojumu!\nKāpēc nesākt sarunu?';
+
+  @override
+  String get deletingMessages => 'Dzēš jūsu ziņojumus no Omi atmiņas...';
+
+  @override
+  String get messageCopied => 'Ziņojums nokopēts starpliktuvē.';
+
+  @override
+  String get cannotReportOwnMessage => 'Jūs nevarat ziņot par saviem ziņojumiem.';
+
+  @override
+  String get reportMessage => 'Ziņot par ziņojumu';
+
+  @override
+  String get reportMessageConfirm => 'Vai tiešām vēlaties ziņot par šo ziņojumu?';
+
+  @override
+  String get messageReported => 'Ziņojums veiksmīgi ziņots.';
+
+  @override
+  String get thankYouFeedback => 'Paldies par jūsu atsauksmēm!';
+
+  @override
+  String get clearChat => 'Notīrīt tērzēšanu?';
+
+  @override
+  String get clearChatConfirm => 'Vai tiešām vēlaties notīrīt tērzēšanu? Šo darbību nevar atsaukt.';
+
+  @override
+  String get maxFilesLimit => 'Vienlaikus var augšupielādēt tikai 4 failus';
+
+  @override
+  String get chatWithOmi => 'Tērzēt ar Omi';
+
+  @override
+  String get apps => 'Lietotnes';
+
+  @override
+  String get noAppsFound => 'Lietotnes nav atrastas';
+
+  @override
+  String get tryAdjustingSearch => 'Mēģiniet pielāgot meklēšanu vai filtrus';
+
+  @override
+  String get createYourOwnApp => 'Izveidojiet savu lietotni';
+
+  @override
+  String get buildAndShareApp => 'Izveidojiet un kopīgojiet savu pielāgoto lietotni';
+
+  @override
+  String get searchApps => 'Meklēt 1500+ lietotnes';
+
+  @override
+  String get myApps => 'Manas lietotnes';
+
+  @override
+  String get installedApps => 'Instalētās lietotnes';
+
+  @override
+  String get unableToFetchApps =>
+      'Nevar ielādēt lietotnes :(\n\nLūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
+
+  @override
+  String get aboutOmi => 'Par Omi';
+
+  @override
+  String get privacyPolicy => 'Privātuma politika';
+
+  @override
+  String get visitWebsite => 'Apmeklēt vietni';
+
+  @override
+  String get helpOrInquiries => 'Palīdzība vai jautājumi?';
+
+  @override
+  String get joinCommunity => 'Pievienojieties kopienai!';
+
+  @override
+  String get membersAndCounting => '8000+ biedri un turpina pieaugt.';
+
+  @override
+  String get deleteAccountTitle => 'Dzēst kontu';
+
+  @override
+  String get deleteAccountConfirm => 'Vai tiešām vēlaties dzēst savu kontu?';
+
+  @override
+  String get cannotBeUndone => 'To nevar atsaukt.';
+
+  @override
+  String get allDataErased => 'Visas jūsu atmiņas un sarunas tiks neatgriezeniski dzēstas.';
+
+  @override
+  String get appsDisconnected => 'Jūsu lietotnes un integrācijas tiks atsavi notas nekavējoties.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Jūs varat eksportēt savus datus pirms konta dzēšanas, bet pēc dzēšanas tos vairs nevarēs atjaunot.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Es saprotu, ka konta dzēšana ir neatgriezeniska un visi dati, tostarp atmiņas un sarunas, tiks zaudēti un tos nevarēs atgūt.';
+
+  @override
+  String get areYouSure => 'Vai esat pārliecināts?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Šī darbība ir neatgriezeniska un neatgriezeniski izdzēsīs jūsu kontu un visus saistītos datus. Vai tiešām vēlaties turpināt?';
+
+  @override
+  String get deleteNow => 'Dzēst tagad';
+
+  @override
+  String get goBack => 'Atgriezties';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Atzīmējiet izvēles rūtiņu, lai apstiprinātu, ka saprotat, ka konta dzēšana ir neatgriezeniska un neatceļama.';
+
+  @override
+  String get profile => 'Profils';
+
+  @override
+  String get name => 'Vārds';
+
+  @override
+  String get email => 'E-pasts';
+
+  @override
+  String get customVocabulary => 'Pielāgota vārdnīca';
+
+  @override
+  String get identifyingOthers => 'Citu identificēšana';
+
+  @override
+  String get paymentMethods => 'Maksājumu metodes';
+
+  @override
+  String get conversationDisplay => 'Sarunas attēlojums';
+
+  @override
+  String get dataPrivacy => 'Dati un privātums';
+
+  @override
+  String get userId => 'Lietotāja ID';
+
+  @override
+  String get notSet => 'Nav iestatīts';
+
+  @override
+  String get userIdCopied => 'Lietotāja ID nokopēts starpliktuvē';
+
+  @override
+  String get systemDefault => 'Sistēmas noklusējuma';
+
+  @override
+  String get planAndUsage => 'Plāns un lietojums';
+
+  @override
+  String get offlineSync => 'Bezsaistes sinhronizācija';
+
+  @override
+  String get deviceSettings => 'Ierīces iestatījumi';
+
+  @override
+  String get chatTools => 'Tērzēšanas rīki';
+
+  @override
+  String get feedbackBug => 'Atsauksmes / Kļūda';
+
+  @override
+  String get helpCenter => 'Palīdzības centrs';
+
+  @override
+  String get developerSettings => 'Izstrādātāja iestatījumi';
+
+  @override
+  String get getOmiForMac => 'Iegūt Omi priekš Mac';
+
+  @override
+  String get referralProgram => 'Ieteikšanas programma';
+
+  @override
+  String get signOut => 'Izrakstīties';
+
+  @override
+  String get appAndDeviceCopied => 'Lietotnes un ierīces informācija nokopēta';
+
+  @override
+  String get wrapped2025 => '2025. gada apskats';
+
+  @override
+  String get yourPrivacyYourControl => 'Jūsu privātums, jūsu kontrole';
+
+  @override
+  String get privacyIntro =>
+      'Omi mēs esam apņēmušies aizsargāt jūsu privātumu. Šī lapa ļauj jums kontrolēt, kā jūsu dati tiek uzglabāti un izmantoti.';
+
+  @override
+  String get learnMore => 'Uzzināt vairāk...';
+
+  @override
+  String get dataProtectionLevel => 'Datu aizsardzības līmenis';
+
+  @override
+  String get dataProtectionDesc =>
+      'Jūsu dati pēc noklusējuma ir aizsargāti ar spēcīgu šifrēšanu. Pārskatiet savus iestatījumus un turpmākās privātuma opcijas zemāk.';
+
+  @override
+  String get appAccess => 'Lietotņu piekļuve';
+
+  @override
+  String get appAccessDesc =>
+      'Šādas lietotnes var piekļūt jūsu datiem. Piespiediet uz lietotnes, lai pārvaldītu tās atļaujas.';
+
+  @override
+  String get noAppsExternalAccess => 'Nevienai instalētajai lietotnei nav ārējas piekļuves jūsu datiem.';
+
+  @override
+  String get deviceName => 'Ierīces nosaukums';
+
+  @override
+  String get deviceId => 'Ierīces ID';
+
+  @override
+  String get firmware => 'Programmaparatūra';
+
+  @override
+  String get sdCardSync => 'SD kartes sinhronizācija';
+
+  @override
+  String get hardwareRevision => 'Aparatūras versija';
+
+  @override
+  String get modelNumber => 'Modeļa numurs';
+
+  @override
+  String get manufacturer => 'Ražotājs';
+
+  @override
+  String get doubleTap => 'Dubultklikšķis';
+
+  @override
+  String get ledBrightness => 'LED spilgtums';
+
+  @override
+  String get micGain => 'Mikrofona pastiprinājums';
+
+  @override
+  String get disconnect => 'Atvienot';
+
+  @override
+  String get forgetDevice => 'Aizmirst ierīci';
+
+  @override
+  String get chargingIssues => 'Uzlādes problēmas';
+
+  @override
+  String get disconnectDevice => 'Atvienot ierīci';
+
+  @override
+  String get unpairDevice => 'Atpārošana ierīci';
+
+  @override
+  String get unpairAndForget => 'Atpārošana un aizmirst ierīci';
+
+  @override
+  String get deviceDisconnectedMessage => 'Jūsu Omi ir atvienots 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Ierīce atpārota. Dodieties uz Iestatījumi > Bluetooth un aizmirstiet ierīci, lai pabeigtu atpārošanu.';
+
+  @override
+  String get unpairDialogTitle => 'Atpārošana ierīci';
+
+  @override
+  String get unpairDialogMessage =>
+      'Tas atpāros ierīci, lai to varētu savienot ar citu tālruni. Jums būs jādodas uz Iestatījumi > Bluetooth un jāaizmirst ierīce, lai pabeigtu procesu.';
+
+  @override
+  String get deviceNotConnected => 'Ierīce nav savienota';
+
+  @override
+  String get connectDeviceMessage => 'Savienojiet savu Omi ierīci, lai piekļūtu\nierīces iestatījumiem un pielāgošanai';
+
+  @override
+  String get deviceInfoSection => 'Ierīces informācija';
+
+  @override
+  String get customizationSection => 'Pielāgošana';
+
+  @override
+  String get hardwareSection => 'Aparatūra';
+
+  @override
+  String get v2Undetected => 'V2 nav atklāts';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Redzam, ka jums ir V1 ierīce vai jūsu ierīce nav savienota. SD kartes funkcionalitāte ir pieejama tikai V2 ierīcēm.';
+
+  @override
+  String get endConversation => 'Beigt sarunu';
+
+  @override
+  String get pauseResume => 'Pauze/Atsākt';
+
+  @override
+  String get starConversation => 'Atzīmēt sarunu ar zvaigznīti';
+
+  @override
+  String get doubleTapAction => 'Dubultklikšķa darbība';
+
+  @override
+  String get endAndProcess => 'Beigt un apstrādāt sarunu';
+
+  @override
+  String get pauseResumeRecording => 'Apturēt/atsākt ierakstīšanu';
+
+  @override
+  String get starOngoing => 'Atzīmēt notiekošo sarunu ar zvaigznīti';
+
+  @override
+  String get off => 'Izslēgts';
+
+  @override
+  String get max => 'Maks.';
+
+  @override
+  String get mute => 'Apklusināt';
+
+  @override
+  String get quiet => 'Kluss';
+
+  @override
+  String get normal => 'Normāls';
+
+  @override
+  String get high => 'Augsts';
+
+  @override
+  String get micGainDescMuted => 'Mikrofons ir apklusināts';
+
+  @override
+  String get micGainDescLow => 'Ļoti kluss - skaļām vidēm';
+
+  @override
+  String get micGainDescModerate => 'Kluss - mērenai trokšņu videi';
+
+  @override
+  String get micGainDescNeutral => 'Neitrāls - līdzsvarots ieraksts';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Nedaudz pastiprināts - parastas izmantošanas';
+
+  @override
+  String get micGainDescBoosted => 'Pastiprināts - klusām vidēm';
+
+  @override
+  String get micGainDescHigh => 'Augsts - tālām vai klus ām balsīm';
+
+  @override
+  String get micGainDescVeryHigh => 'Ļoti augsts - ļoti klusiem avotiem';
+
+  @override
+  String get micGainDescMax => 'Maksimālais - lietot piesardzīgi';
+
+  @override
+  String get developerSettingsTitle => 'Izstrādātāja iestatījumi';
+
+  @override
+  String get saving => 'Saglabā...';
+
+  @override
+  String get personaConfig => 'Konfigurēt savu AI personību';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transkripcija';
+
+  @override
+  String get transcriptionConfig => 'Konfigurēt STT pakalpojumu sniedzēju';
+
+  @override
+  String get conversationTimeout => 'Sarunas taimauts';
+
+  @override
+  String get conversationTimeoutConfig => 'Iestatīt, kad sarunas automātiski beidzas';
+
+  @override
+  String get importData => 'Importēt datus';
+
+  @override
+  String get importDataConfig => 'Importēt datus no citiem avotiem';
+
+  @override
+  String get debugDiagnostics => 'Atkļūdošana un diagnostika';
+
+  @override
+  String get endpointUrl => 'Galapunkta URL';
+
+  @override
+  String get noApiKeys => 'Vēl nav API atslēgu';
+
+  @override
+  String get createKeyToStart => 'Izveidojiet atslēgu, lai sāktu';
+
+  @override
+  String get createKey => 'Izveidot atslēgu';
+
+  @override
+  String get docs => 'Dokumentācija';
+
+  @override
+  String get yourOmiInsights => 'Jūsu Omi ieskati';
+
+  @override
+  String get today => 'Šodien';
+
+  @override
+  String get thisMonth => 'Šomēnes';
+
+  @override
+  String get thisYear => 'Šogad';
+
+  @override
+  String get allTime => 'Visu laiku';
+
+  @override
+  String get noActivityYet => 'Vēl nav aktivitātes';
+
+  @override
+  String get startConversationToSeeInsights => 'Sāciet sarunu ar Omi,\nlai šeit redzētu lietošanas statistiku.';
+
+  @override
+  String get listening => 'Klausās';
+
+  @override
+  String get listeningSubtitle => 'Kopējais laiks, ko Omi aktīvi klausījies.';
+
+  @override
+  String get understanding => 'Saprot';
+
+  @override
+  String get understandingSubtitle => 'Vārdi, kas saprasti no jūsu sarunām.';
+
+  @override
+  String get providing => 'Sniedz';
+
+  @override
+  String get providingSubtitle => 'Uzdevumi un piezīmes, kas automātiski fiksēti.';
+
+  @override
+  String get remembering => 'Atceras';
+
+  @override
+  String get rememberingSubtitle => 'Fakti un detaļas, kas atcerētas jums.';
+
+  @override
+  String get unlimitedPlan => 'Neierobežots plāns';
+
+  @override
+  String get managePlan => 'Pārvaldīt plānu';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Jūsu plāns tiks atcelts $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Jūsu plāns atjaunojas $date.';
+  }
+
+  @override
+  String get basicPlan => 'Bezmaksas plāns';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used no $limit min izmantots';
+  }
+
+  @override
+  String get upgrade => 'Jaunināt';
+
+  @override
+  String get upgradeToUnlimited => 'Jaunināt uz neierobežotu';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Jūsu plāns ietver $limit bezmaksas minūtes mēnesī. Jauniniet, lai iegūtu neierobežotu.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Dalījums ar manu Omi statistiku! (omi.me - jūsu vienmēr ieslēgtais AI asistents)';
+
+  @override
+  String get sharePeriodToday => 'Šodien omi ir:';
+
+  @override
+  String get sharePeriodMonth => 'Šomēnes omi ir:';
+
+  @override
+  String get sharePeriodYear => 'Šogad omi ir:';
+
+  @override
+  String get sharePeriodAllTime => 'Līdz šim omi ir:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Klausījies $minutes minūtes';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Sapratis $words vārdus';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Sniedzis $count ieskatus';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Atcerējies $count atmiņas';
+  }
+
+  @override
+  String get debugLogs => 'Atkļūdošanas žurnāli';
+
+  @override
+  String get debugLogsAutoDelete => 'Automātiski izdzēš pēc 3 dienām.';
+
+  @override
+  String get debugLogsDesc => 'Palīdz diagnosticēt problēmas';
+
+  @override
+  String get noLogFilesFound => 'Žurnāla faili nav atrasti.';
+
+  @override
+  String get omiDebugLog => 'Omi atkļūdošanas žurnāls';
+
+  @override
+  String get logShared => 'Žurnāls kopīgots';
+
+  @override
+  String get selectLogFile => 'Izvēlēties žurnāla failu';
+
+  @override
+  String get shareLogs => 'Kopīgot žurnālus';
+
+  @override
+  String get debugLogCleared => 'Atkļūdošanas žurnāls notīrīts';
+
+  @override
+  String get exportStarted => 'Eksports sākts. Tas var aizņemt dažas sekundes...';
+
+  @override
+  String get exportAllData => 'Eksportēt visus datus';
+
+  @override
+  String get exportDataDesc => 'Eksportēt sarunas uz JSON failu';
+
+  @override
+  String get exportedConversations => 'Eksportētās sarunas no Omi';
+
+  @override
+  String get exportShared => 'Eksports kopīgots';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Dzēst zināšanu grafu?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Tas izdzēsīs visus atvasinātos zināšanu grafa datus (mezglus un savienojumus). Jūsu oriģinālās atmiņas paliks drošībā. Grafs tiks atjaunots ar laiku vai pēc nākamā pieprasījuma.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Zināšanu grafs veiksmīgi izdzēsts';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Neizdevās dzēst grafu: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Dzēst zināšanu grafu';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Notīrīt visus mezglus un savienojumus';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP serveris';
+
+  @override
+  String get mcpServerDesc => 'Savienojiet AI asistentus ar jūsu datiem';
+
+  @override
+  String get serverUrl => 'Servera URL';
+
+  @override
+  String get urlCopied => 'URL nokopēts';
+
+  @override
+  String get apiKeyAuth => 'API atslēgas autentifikācija';
+
+  @override
+  String get header => 'Galvene';
+
+  @override
+  String get authorizationBearer => 'Autorizācija: Bearer <atslēga>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Klienta ID';
+
+  @override
+  String get clientSecret => 'Klienta noslēpums';
+
+  @override
+  String get useMcpApiKey => 'Izmantojiet savu MCP API atslēgu';
+
+  @override
+  String get webhooks => 'Tīmekļa āķi';
+
+  @override
+  String get conversationEvents => 'Sarunas notikumi';
+
+  @override
+  String get newConversationCreated => 'Jauna saruna izveidota';
+
+  @override
+  String get realtimeTranscript => 'Reāllaika transkripcija';
+
+  @override
+  String get transcriptReceived => 'Transkripcija saņemta';
+
+  @override
+  String get audioBytes => 'Audio baiti';
+
+  @override
+  String get audioDataReceived => 'Audio dati saņemti';
+
+  @override
+  String get intervalSeconds => 'Intervāls (sekundes)';
+
+  @override
+  String get daySummary => 'Dienas kopsavilkums';
+
+  @override
+  String get summaryGenerated => 'Kopsavilkums izveidots';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Pievienot claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Kopēt konfigurāciju';
+
+  @override
+  String get configCopied => 'Konfigurācija nokopēta starpliktuvē';
+
+  @override
+  String get listeningMins => 'Klausās (min)';
+
+  @override
+  String get understandingWords => 'Saprot (vārdi)';
+
+  @override
+  String get insights => 'Ieskati';
+
+  @override
+  String get memories => 'Atmiņas';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used no $limit min izmantots šomēnes';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used no $limit vārdiem izmantots šomēnes';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used no $limit ieskatiem iegūts šomēnes';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used no $limit atmiņām izveidots šomēnes';
+  }
+
+  @override
+  String get visibility => 'Redzamība';
+
+  @override
+  String get visibilitySubtitle => 'Kontrolējiet, kuras sarunas parādās jūsu sarakstā';
+
+  @override
+  String get showShortConversations => 'Rādīt īsas sarunas';
+
+  @override
+  String get showShortConversationsDesc => 'Attēlot sarunas, kas ir īsākas par slieksni';
+
+  @override
+  String get showDiscardedConversations => 'Rādīt atmestas sarunas';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Iekļaut sarunas, kas atzīmētas kā atmestas';
+
+  @override
+  String get shortConversationThreshold => 'Īsās sarunas slieksnis';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Sarunas, kas ir īsākas par šo, tiks slēptas, ja vien nav iespējotas iepriekš';
+
+  @override
+  String get durationThreshold => 'Ilguma slieksnis';
+
+  @override
+  String get durationThresholdDesc => 'Slēpt sarunas, kas ir īsākas par šo';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Pielāgota vārdnīca';
+
+  @override
+  String get addWords => 'Pievienot vārdus';
+
+  @override
+  String get addWordsDesc => 'Vārdi, termini vai netipiski vārdi';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Savienot';
+
+  @override
+  String get comingSoon => 'Drīzumā';
+
+  @override
+  String get chatToolsFooter => 'Savienojiet savas lietotnes, lai skatītu datus un metriku tērzēšanā.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Neizdevās sākt $appName autentifikāciju';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Atvienot $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Vai tiešām vēlaties atvienot no $appName? Jūs varat atkārtoti izveidot savienojumu jebkurā laikā.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Atvienots no $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Neizdevās atvienot';
+
+  @override
+  String connectTo(String appName) {
+    return 'Savienoties ar $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Jums būs jāautorizē Omi piekļuvei jūsu $appName datiem. Tas atvērs jūsu pārlūkprogrammu autentifikācijai.';
+  }
+
+  @override
+  String get continueAction => 'Turpināt';
+
+  @override
+  String get languageTitle => 'Valoda';
+
+  @override
+  String get primaryLanguage => 'Primārā valoda';
+
+  @override
+  String get automaticTranslation => 'Automātiskais tulkojums';
+
+  @override
+  String get detectLanguages => 'Atklāt 10+ valodas';
+
+  @override
+  String get authorizeSavingRecordings => 'Autorizēt ierakstu saglabāšanu';
+
+  @override
+  String get thanksForAuthorizing => 'Paldies par autorizāciju!';
+
+  @override
+  String get needYourPermission => 'Mums nepieciešama jūsu atļauja';
+
+  @override
+  String get alreadyGavePermission =>
+      'Jūs jau esat devis mums atļauju saglabāt jūsu ierakstus. Šeit ir atgādinājums, kāpēc mums tas ir nepieciešams:';
+
+  @override
+  String get wouldLikePermission => 'Mēs vēlētos jūsu atļauju saglabāt jūsu balss ierakstus. Šeit ir iemesls:';
+
+  @override
+  String get improveSpeechProfile => 'Uzlabot jūsu runas profilu';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Mēs izmantojam ierakstus, lai turpinātu apmācīt un uzlabotu jūsu personīgo runas profilu.';
+
+  @override
+  String get trainFamilyProfiles => 'Apmācīt profilus draugiem un ģimenei';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Jūsu ieraksti palīdz mums atpazīt un izveidot profilus jūsu draugiem un ģimenei.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Uzlabot transkripcijas precizitāti';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Uzlabojoties mūsu modelim, mēs varam sniegt labākus transkripcijas rezultātus jūsu ierakstiem.';
+
+  @override
+  String get legalNotice =>
+      'Juridisks paziņojums: Balss datu ierakstīšanas un uzglabāšanas likumība var atšķirties atkarībā no jūsu atrašanās vietas un tā, kā izmantojat šo funkciju. Ir jūsu atbildība nodrošināt atbilstību vietējiem likumiem un noteikumiem.';
+
+  @override
+  String get alreadyAuthorized => 'Jau autorizēts';
+
+  @override
+  String get authorize => 'Autorizēt';
+
+  @override
+  String get revokeAuthorization => 'Atsaukt autorizāciju';
+
+  @override
+  String get authorizationSuccessful => 'Autorizācija veiksmīga!';
+
+  @override
+  String get failedToAuthorize => 'Neizdevās autorizēt. Lūdzu, mēģiniet vēlreiz.';
+
+  @override
+  String get authorizationRevoked => 'Autorizācija atsaukta.';
+
+  @override
+  String get recordingsDeleted => 'Ieraksti izdzēsti.';
+
+  @override
+  String get failedToRevoke => 'Neizdevās atsaukt autorizāciju. Lūdzu, mēģiniet vēlreiz.';
+
+  @override
+  String get permissionRevokedTitle => 'Atļauja atsaukta';
+
+  @override
+  String get permissionRevokedMessage => 'Vai vēlaties, lai mēs noņemtu arī visus jūsu esošos ierakstus?';
+
+  @override
+  String get yes => 'Jā';
+
+  @override
+  String get editName => 'Rediģēt vārdu';
+
+  @override
+  String get howShouldOmiCallYou => 'Kā Omi jums vajadzētu uzrunāt?';
+
+  @override
+  String get enterYourName => 'Ievadiet savu vārdu';
+
+  @override
+  String get nameCannotBeEmpty => 'Vārds nevar būt tukšs';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Vārds veiksmīgi atjaunināts!';
+
+  @override
+  String get calendarSettings => 'Kalendāra iestatījumi';
+
+  @override
+  String get calendarProviders => 'Kalendāra pakalpojumu sniedzēji';
+
+  @override
+  String get macOsCalendar => 'macOS kalendārs';
+
+  @override
+  String get connectMacOsCalendar => 'Savienojiet savu vietējo macOS kalendāru';
+
+  @override
+  String get googleCalendar => 'Google kalendārs';
+
+  @override
+  String get syncGoogleAccount => 'Sinhronizēt ar savu Google kontu';
+
+  @override
+  String get showMeetingsMenuBar => 'Rādīt tuvākās sanāksmes izvēlnes joslā';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Attēlot jūsu nākamo sanāksmi un laiku līdz tās sākumam macOS izvēlnes joslā';
+
+  @override
+  String get showEventsNoParticipants => 'Rādīt notikumus bez dalībniekiem';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Ja iespējots, Coming Up rāda notikumus bez dalībniekiem vai video saites.';
+
+  @override
+  String get yourMeetings => 'Jūsu sanāksmes';
+
+  @override
+  String get refresh => 'Atsvaidzināt';
+
+  @override
+  String get noUpcomingMeetings => 'Nav atrastas tuvākās sanāksmes';
+
+  @override
+  String get checkingNextDays => 'Pārbauda nākamās 30 dienas';
+
+  @override
+  String get tomorrow => 'Rīt';
+
+  @override
+  String get googleCalendarComingSoon => 'Google Calendar integrācija drīzumā!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Savienots kā lietotājs: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Noklusējuma darba vieta';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Uzdevumi tiks izveidoti šajā darba vietā';
+
+  @override
+  String get defaultProjectOptional => 'Noklusējuma projekts (neobligāts)';
+
+  @override
+  String get leaveUnselectedTasks => 'Atstājiet neizvēlētu, lai izveidotu uzdevumus bez projekta';
+
+  @override
+  String get noProjectsInWorkspace => 'Šajā darba vietā nav atrasti projekti';
+
+  @override
+  String get conversationTimeoutDesc => 'Izvēlieties, cik ilgi gaidīt klusumu, pirms automātiski beidzat sarunu:';
+
+  @override
+  String get timeout2Minutes => '2 minūtes';
+
+  @override
+  String get timeout2MinutesDesc => 'Beigt sarunu pēc 2 minūšu klusuma';
+
+  @override
+  String get timeout5Minutes => '5 minūtes';
+
+  @override
+  String get timeout5MinutesDesc => 'Beigt sarunu pēc 5 minūšu klusuma';
+
+  @override
+  String get timeout10Minutes => '10 minūtes';
+
+  @override
+  String get timeout10MinutesDesc => 'Beigt sarunu pēc 10 minūšu klusuma';
+
+  @override
+  String get timeout30Minutes => '30 minūtes';
+
+  @override
+  String get timeout30MinutesDesc => 'Beigt sarunu pēc 30 minūšu klusuma';
+
+  @override
+  String get timeout4Hours => '4 stundas';
+
+  @override
+  String get timeout4HoursDesc => 'Beigt sarunu pēc 4 stundu klusuma';
+
+  @override
+  String get conversationEndAfterHours => 'Sarunas tagad beigsies pēc 4 stundu klusuma';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Sarunas tagad beigsies pēc $minutes minūtes(-ēm) klusuma';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Pastāstiet mums savu primāro valodu';
+
+  @override
+  String get languageForTranscription => 'Iestatiet savu valodu precīzākai transkripcijai un personalizētai pieredzei.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Vienas valodas režīms ir iespējots. Tulkošana ir atspējota lielākai precizitātei.';
+
+  @override
+  String get searchLanguageHint => 'Meklēt valodu pēc nosaukuma vai koda';
+
+  @override
+  String get noLanguagesFound => 'Valodas nav atrastas';
+
+  @override
+  String get skip => 'Izlaist';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Valoda iestatīta uz $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Neizdevās iestatīt valodu';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName iestatījumi';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Atvienot no $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Tas noņems jūsu $appName autentifikāciju. Jums būs atkārtoti jāizveido savienojums, lai to izmantotu vēlreiz.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Savienots ar $appName';
+  }
+
+  @override
+  String get account => 'Konts';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Jūsu uzdevumi tiks sinhronizēti ar jūsu $appName kontu';
+  }
+
+  @override
+  String get defaultSpace => 'Noklusējuma vieta';
+
+  @override
+  String get selectSpaceInWorkspace => 'Izvēlēties vietu savā darba vietā';
+
+  @override
+  String get noSpacesInWorkspace => 'Šajā darba vietā nav atrastas vietas';
+
+  @override
+  String get defaultList => 'Noklusējuma saraksts';
+
+  @override
+  String get tasksAddedToList => 'Uzdevumi tiks pievienoti šim sarakstam';
+
+  @override
+  String get noListsInSpace => 'Šajā vietā nav atrasti saraksti';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Neizdevās ielādēt repozitorijus: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Noklusējuma repozitorijs saglabāts';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Neizdevās saglabāt noklusējuma repozitoriju';
+
+  @override
+  String get defaultRepository => 'Noklusējuma repozitorijs';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Izvēlieties noklusējuma repozitoriju problēmu izveidošanai. Jūs joprojām varat norādīt citu repozitoriju, veidojot problēmas.';
+
+  @override
+  String get noReposFound => 'Repozitoriji nav atrasti';
+
+  @override
+  String get private => 'Privāts';
+
+  @override
+  String updatedDate(String date) {
+    return 'Atjaunināts $date';
+  }
+
+  @override
+  String get yesterday => 'vakar';
+
+  @override
+  String daysAgo(int count) {
+    return 'pirms $count dienām';
+  }
+
+  @override
+  String get oneWeekAgo => 'pirms 1 nedēļas';
+
+  @override
+  String weeksAgo(int count) {
+    return 'pirms $count nedēļām';
+  }
+
+  @override
+  String get oneMonthAgo => 'pirms 1 mēneša';
+
+  @override
+  String monthsAgo(int count) {
+    return 'pirms $count mēnešiem';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Problēmas tiks izveidotas jūsu noklusējuma repozitorijā';
+
+  @override
+  String get taskIntegrations => 'Uzdevumu integrācijas';
+
+  @override
+  String get configureSettings => 'Konfigurēt iestatījumus';
+
+  @override
+  String get completeAuthBrowser =>
+      'Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Neizdevās sākt $appName autentifikāciju';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Savienoties ar $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Jums būs jāautorizē Omi, lai izveidotu uzdevumus jūsu $appName kontā. Tas atvērs jūsu pārlūkprogrammu autentifikācijai.';
+  }
+
+  @override
+  String get continueButton => 'Turpināt';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName integrācija';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integrācija ar $appName drīzumā! Mēs cītīgi strādājam, lai jums piedāvātu vairāk uzdevumu pārvaldības iespēju.';
+  }
+
+  @override
+  String get gotIt => 'Sapratu';
+
+  @override
+  String get tasksExportedOneApp => 'Uzdevumus var eksportēt uz vienu lietotni vienlaikus.';
+
+  @override
+  String get completeYourUpgrade => 'Pabeidziet savu jaunināšanu';
+
+  @override
+  String get importConfiguration => 'Importēt konfigurāciju';
+
+  @override
+  String get exportConfiguration => 'Eksportēt konfigurāciju';
+
+  @override
+  String get bringYourOwn => 'Atnesiet savu';
+
+  @override
+  String get payYourSttProvider => 'Brīvi izmantojiet omi. Jūs maksājat tikai savam STT pakalpojumu sniedzējam tieši.';
+
+  @override
+  String get freeMinutesMonth => '1200 bezmaksas minūtes/mēnesī iekļautas. Neierobežots ar ';
+
+  @override
+  String get omiUnlimited => 'Omi Neierobežots';
+
+  @override
+  String get hostRequired => 'Resursdators ir nepieciešams';
+
+  @override
+  String get validPortRequired => 'Ir nepieciešams derīgs ports';
+
+  @override
+  String get validWebsocketUrlRequired => 'Ir nepieciešams derīgs WebSocket URL (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL ir nepieciešams';
+
+  @override
+  String get apiKeyRequired => 'API atslēga ir nepieciešama';
+
+  @override
+  String get invalidJsonConfig => 'Nederīga JSON konfigurācija';
+
+  @override
+  String errorSaving(String error) {
+    return 'Kļūda, saglabājot: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfigurācija nokopēta starpliktuvē';
+
+  @override
+  String get pasteJsonConfig => 'Ielīmējiet savu JSON konfigurāciju zemāk:';
+
+  @override
+  String get addApiKeyAfterImport => 'Jums būs jāpievieno sava API atslēga pēc importēšanas';
+
+  @override
+  String get paste => 'Ielīmēt';
+
+  @override
+  String get import => 'Importēt';
+
+  @override
+  String get invalidProviderInConfig => 'Nederīgs pakalpojumu sniedzējs konfigurācijā';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Importēta $providerName konfigurācija';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Nederīgs JSON: $error';
+  }
+
+  @override
+  String get provider => 'Pakalpojumu sniedzējs';
+
+  @override
+  String get live => 'Tiešraide';
+
+  @override
+  String get onDevice => 'Ierīcē';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Ievadiet savu STT HTTP galapunktu';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Ievadiet savu tiešraides STT WebSocket galapunktu';
+
+  @override
+  String get apiKey => 'API atslēga';
+
+  @override
+  String get enterApiKey => 'Ievadiet savu API atslēgu';
+
+  @override
+  String get storedLocallyNeverShared => 'Saglabāts vietēji, nekad nekopīgots';
+
+  @override
+  String get host => 'Resursdators';
+
+  @override
+  String get port => 'Ports';
+
+  @override
+  String get advanced => 'Papildu';
+
+  @override
+  String get configuration => 'Konfigurācija';
+
+  @override
+  String get requestConfiguration => 'Pieprasījuma konfigurācija';
+
+  @override
+  String get responseSchema => 'Atbildes shēma';
+
+  @override
+  String get modified => 'Modificēts';
+
+  @override
+  String get resetRequestConfig => 'Atiestatīt pieprasījuma konfigurāciju uz noklusējumu';
+
+  @override
+  String get logs => 'Žurnāli';
+
+  @override
+  String get logsCopied => 'Žurnāli nokopēti';
+
+  @override
+  String get noLogsYet => 'Vēl nav žurnālu. Sāciet ierakstīšanu, lai redzētu pielāgoto STT aktivitāti.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName izmanto $codecReason. Tiks izmantots Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi transkripcija';
+
+  @override
+  String get bestInClassTranscription => 'Labākā klases transkripcija ar nulli iestatījumiem';
+
+  @override
+  String get instantSpeakerLabels => 'Tūlītējas runātāja etiķetes';
+
+  @override
+  String get languageTranslation => '100+ valodu tulkošana';
+
+  @override
+  String get optimizedForConversation => 'Optimizēts sarunām';
+
+  @override
+  String get autoLanguageDetection => 'Automātiska valodas noteikšana';
+
+  @override
+  String get highAccuracy => 'Augsta precizitāte';
+
+  @override
+  String get privacyFirst => 'Privātums pirmajā vietā';
+
+  @override
+  String get saveChanges => 'Saglabāt izmaiņas';
+
+  @override
+  String get resetToDefault => 'Atiestatīt uz noklusējumu';
+
+  @override
+  String get viewTemplate => 'Skatīt veidni';
+
+  @override
+  String get trySomethingLike => 'Mēģiniet kaut ko līdzīgu...';
+
+  @override
+  String get tryIt => 'Izmēģināt';
+
+  @override
+  String get creatingPlan => 'Izveido plānu';
+
+  @override
+  String get developingLogic => 'Izstrādā loģiku';
+
+  @override
+  String get designingApp => 'Projektē lietotni';
+
+  @override
+  String get generatingIconStep => 'Ģenerē ikonu';
+
+  @override
+  String get finalTouches => 'Pēdējie pieskārieni';
+
+  @override
+  String get processing => 'Apstrādā...';
+
+  @override
+  String get features => 'Funkcijas';
+
+  @override
+  String get creatingYourApp => 'Izveido jūsu lietotni...';
+
+  @override
+  String get generatingIcon => 'Ģenerē ikonu...';
+
+  @override
+  String get whatShouldWeMake => 'Ko mums vajadzētu izveidot?';
+
+  @override
+  String get appName => 'Lietotnes nosaukums';
+
+  @override
+  String get description => 'Apraksts';
+
+  @override
+  String get publicLabel => 'Publisks';
+
+  @override
+  String get privateLabel => 'Privāts';
+
+  @override
+  String get free => 'Bezmaksas';
+
+  @override
+  String get perMonth => '/ Mēnesī';
+
+  @override
+  String get tailoredConversationSummaries => 'Pielāgoti sarunas kopsavilkumi';
+
+  @override
+  String get customChatbotPersonality => 'Pielāgota tērzēšanas robota personība';
+
+  @override
+  String get makePublic => 'Padarīt publisku';
+
+  @override
+  String get anyoneCanDiscover => 'Ikviens var atklāt jūsu lietotni';
+
+  @override
+  String get onlyYouCanUse => 'Tikai jūs varat izmantot šo lietotni';
+
+  @override
+  String get paidApp => 'Maksas lietotne';
+
+  @override
+  String get usersPayToUse => 'Lietotāji maksā, lai izmantotu jūsu lietotni';
+
+  @override
+  String get freeForEveryone => 'Bezmaksas visiem';
+
+  @override
+  String get perMonthLabel => '/ mēnesī';
+
+  @override
+  String get creating => 'Izveido...';
+
+  @override
+  String get createApp => 'Izveidot lietotni';
+
+  @override
+  String get searchingForDevices => 'Meklē ierīces...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'IERĪCES',
+      one: 'IERĪCE',
+    );
+    return '$count $_temp0 ATRASTAS TUVUMĀ';
+  }
+
+  @override
+  String get pairingSuccessful => 'PĀROŠANA VEIKSMĪGA';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Kļūda, savienojoties ar Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Vairs nerādīt';
+
+  @override
+  String get iUnderstand => 'Es saprotu';
+
+  @override
+  String get enableBluetooth => 'Iespējot Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi nepieciešams Bluetooth, lai savienotos ar jūsu valkājamo ierīci. Lūdzu, iespējojiet Bluetooth un mēģiniet vēlreiz.';
+
+  @override
+  String get contactSupport => 'Sazināties ar atbalstu?';
+
+  @override
+  String get connectLater => 'Savienot vēlāk';
+
+  @override
+  String get grantPermissions => 'Piešķirt atļaujas';
+
+  @override
+  String get backgroundActivity => 'Fona aktivitāte';
+
+  @override
+  String get backgroundActivityDesc => 'Ļaujiet Omi darboties fonā labākai stabilitātei';
+
+  @override
+  String get locationAccess => 'Atrašanās vietas piekļuve';
+
+  @override
+  String get locationAccessDesc => 'Iespējojiet fona atrašanās vietu pilnai pieredzei';
+
+  @override
+  String get notifications => 'Paziņojumi';
+
+  @override
+  String get notificationsDesc => 'Iespējojiet paziņojumus, lai būtu informēti';
+
+  @override
+  String get locationServiceDisabled => 'Atrašanās vietas pakalpojums atspējots';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Atrašanās vietas pakalpojums ir atspējots. Lūdzu, dodieties uz Iestatījumi > Privātums un drošība > Atrašanās vietas pakalpojumi un iespējojiet to';
+
+  @override
+  String get backgroundLocationDenied => 'Fona atrašanās vietas piekļuve liegta';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Lūdzu, dodieties uz ierīces iestatījumiem un iestatiet atrašanās vietas atļauju uz \"Vienmēr atļaut\"';
+
+  @override
+  String get lovingOmi => 'Patīk Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Palīdziet mums sasniegt vairāk cilvēku, atstājot atsauksmi App Store. Jūsu atsauksmes mums nozīmē visu!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Palīdziet mums sasniegt vairāk cilvēku, atstājot atsauksmi Google Play Store. Jūsu atsauksmes mums nozīmē visu!';
+
+  @override
+  String get rateOnAppStore => 'Novērtēt App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Novērtēt Google Play';
+
+  @override
+  String get maybeLater => 'Varbūt vēlāk';
+
+  @override
+  String get speechProfileIntro => 'Omi ir jāiemācās jūsu mērķi un jūsu balss. Jūs varēsiet to modificēt vēlāk.';
+
+  @override
+  String get getStarted => 'Sākt';
+
+  @override
+  String get allDone => 'Viss padarīts!';
+
+  @override
+  String get keepGoing => 'Turpiniet, jūs darāt lieliski';
+
+  @override
+  String get skipThisQuestion => 'Izlaist šo jautājumu';
+
+  @override
+  String get skipForNow => 'Izlaist pagaidām';
+
+  @override
+  String get connectionError => 'Savienojuma kļūda';
+
+  @override
+  String get connectionErrorDesc =>
+      'Neizdevās izveidot savienojumu ar serveri. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Atklāts nederīgs ieraksts';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Šķiet, ka ierakstā ir vairāki runātāji. Lūdzu, pārliecinieties, ka atrodaties klusā vietā, un mēģiniet vēlreiz.';
+
+  @override
+  String get tooShortDesc => 'Nav atklāts pietiekami daudz runas. Lūdzu, runājiet vairāk un mēģiniet vēlreiz.';
+
+  @override
+  String get invalidRecordingDesc => 'Lūdzu, pārliecinieties, ka runājat vismaz 5 sekundes un ne vairāk kā 90.';
+
+  @override
+  String get areYouThere => 'Vai jūs esat tur?';
+
+  @override
+  String get noSpeechDesc =>
+      'Mēs nevarējām atklāt nevienu runu. Lūdzu, pārliecinieties, ka runājat vismaz 10 sekundes un ne vairāk kā 3 minūtes.';
+
+  @override
+  String get connectionLost => 'Savienojums zaudēts';
+
+  @override
+  String get connectionLostDesc =>
+      'Savienojums tika pārtraukts. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.';
+
+  @override
+  String get tryAgain => 'Mēģināt vēlreiz';
+
+  @override
+  String get connectOmiOmiGlass => 'Savienot Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Turpināt bez ierīces';
+
+  @override
+  String get permissionsRequired => 'Nepieciešamas atļaujas';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Šai lietotnei ir nepieciešamas Bluetooth un Atrašanās vietas atļaujas, lai darbotos pareizi. Lūdzu, iespējojiet tās iestatījumos.';
+
+  @override
+  String get openSettings => 'Atvērt iestatījumus';
+
+  @override
+  String get wantDifferentName => 'Vēlaties, lai jūs uzrunā citādi?';
+
+  @override
+  String get whatsYourName => 'Kāds ir jūsu vārds?';
+
+  @override
+  String get speakTranscribeSummarize => 'Runāt. Transkribēt. Apkopot.';
+
+  @override
+  String get signInWithApple => 'Pierakstīties ar Apple';
+
+  @override
+  String get signInWithGoogle => 'Pierakstīties ar Google';
+
+  @override
+  String get byContinuingAgree => 'Turpinot, jūs piekrītat mūsu ';
+
+  @override
+  String get termsOfUse => 'Lietošanas noteikumi';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – jūsu AI pavadonis';
+
+  @override
+  String get captureEveryMoment =>
+      'Fiksējiet katru brīdi. Iegūstiet AI\nkopsavilkumus. Nekad vairs nerakstiet piezīmes.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch iestatīšana';
+
+  @override
+  String get permissionRequestedExclaim => 'Atļauja pieprasīta!';
+
+  @override
+  String get microphonePermission => 'Mikrofona atļauja';
+
+  @override
+  String get permissionGrantedNow =>
+      'Atļauja piešķirta! Tagad:\n\nAtveriet Omi lietotni savā pulkstenī un piespiediet \"Turpināt\" zemāk';
+
+  @override
+  String get needMicrophonePermission =>
+      'Mums nepieciešama mikrofona atļauja.\n\n1. Piespiediet \"Piešķirt atļauju\"\n2. Atļaut iPhone\n3. Pulksteņa lietotne aizvērsies\n4. Atkārtoti atveriet un piespiediet \"Turpināt\"';
+
+  @override
+  String get grantPermissionButton => 'Piešķirt atļauju';
+
+  @override
+  String get needHelp => 'Nepieciešama palīdzība?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Problēmu novēršana:\n\n1. Pārliecinieties, ka Omi ir instalēts jūsu pulkstenī\n2. Atveriet Omi lietotni savā pulkstenī\n3. Meklējiet atļaujas uznirstošo logu\n4. Piespiediet \"Atļaut\", kad tiek piedāvāts\n5. Lietotne jūsu pulkstenī aizvērsies - atkārtoti atveriet to\n6. Atgriezieties un piespiediet \"Turpināt\" savā iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Ierakstīšana veiksmīgi sākta!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Atļauja vēl nav piešķirta. Lūdzu, pārliecinieties, ka atļāvāt mikrofona piekļuvi un atkārtoti atvērāt lietotni savā pulkstenī.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Kļūda, pieprasot atļauju: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Kļūda, sākot ierakstīšanu: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Izvēlieties savu primāro valodu';
+
+  @override
+  String get languageBenefits => 'Iestatiet savu valodu precīzākai transkripcijai un personalizētai pieredzei';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Kāda ir jūsu primārā valoda?';
+
+  @override
+  String get selectYourLanguage => 'Izvēlieties savu valodu';
+
+  @override
+  String get personalGrowthJourney => 'Jūsu personīgās izaugsmes ceļojums ar AI, kas klausās katru jūsu vārdu.';
+
+  @override
+  String get actionItemsTitle => 'Darāmie darbi';
+
+  @override
+  String get actionItemsDescription =>
+      'Piespiediet, lai rediģētu • Ilgi turiet, lai atlasītu • Velciet, lai veiktu darbības';
+
+  @override
+  String get tabToDo => 'Darāms';
+
+  @override
+  String get tabDone => 'Padarīts';
+
+  @override
+  String get tabOld => 'Vecs';
+
+  @override
+  String get emptyTodoMessage => '🎉 Viss padarīts!\nNav gaidošu uzdevumu';
+
+  @override
+  String get emptyDoneMessage => 'Vēl nav pabeigtu vienību';
+
+  @override
+  String get emptyOldMessage => '✅ Nav vecu uzdevumu';
+
+  @override
+  String get noItems => 'Nav vienību';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Uzdevums atzīmēts kā nepabeigts';
+
+  @override
+  String get actionItemCompleted => 'Uzdevums pabeigts';
+
+  @override
+  String get deleteActionItemTitle => 'Dzēst uzdevumu';
+
+  @override
+  String get deleteActionItemMessage => 'Vai tiešām vēlaties dzēst šo uzdevumu?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Dzēst atlasītos vienumus';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Vai tiešām vēlaties dzēst $count atlasītos uzdevumus?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Uzdevums \"$description\" izdzēsts';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count uzdevumi izdzēsti';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Neizdevās dzēst uzdevumu';
+
+  @override
+  String get failedToDeleteItems => 'Neizdevās dzēst vienumus';
+
+  @override
+  String get failedToDeleteSomeItems => 'Neizdevās dzēst dažus vienumus';
+
+  @override
+  String get welcomeActionItemsTitle => 'Gatavs uzdevumiem';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Jūsu AI automātiski izvilks uzdevumus no jūsu sarunām. Tie parādīsies šeit, kad tiks izveidoti.';
+
+  @override
+  String get autoExtractionFeature => 'Automātiski izvilkts no sarunām';
+
+  @override
+  String get editSwipeFeature => 'Piespiediet, lai rediģētu, velciet, lai pabeigtu vai dzēstu';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count atlasīts';
+  }
+
+  @override
+  String get selectAll => 'Atlasīt visu';
+
+  @override
+  String get deleteSelected => 'Dzēst atlasītos';
+
+  @override
+  String searchMemories(int count) {
+    return 'Meklēt $count atmiņas';
+  }
+
+  @override
+  String get memoryDeleted => 'Atmiņa izdzēsta.';
+
+  @override
+  String get undo => 'Atsaukt';
+
+  @override
+  String get noMemoriesYet => 'Vēl nav atmiņu';
+
+  @override
+  String get noAutoMemories => 'Vēl nav automātiski izvilktu atmiņu';
+
+  @override
+  String get noManualMemories => 'Vēl nav manuālu atmiņu';
+
+  @override
+  String get noMemoriesInCategories => 'Šajās kategorijās nav atmiņu';
+
+  @override
+  String get noMemoriesFound => 'Atmiņas nav atrastas';
+
+  @override
+  String get addFirstMemory => 'Pievienot savu pirmo atmiņu';
+
+  @override
+  String get clearMemoryTitle => 'Notīrīt Omi atmiņu';
+
+  @override
+  String get clearMemoryMessage => 'Vai tiešām vēlaties notīrīt Omi atmiņu? Šo darbību nevar atsaukt.';
+
+  @override
+  String get clearMemoryButton => 'Notīrīt atmiņu';
+
+  @override
+  String get memoryClearedSuccess => 'Omi atmiņa par jums ir notīrīta';
+
+  @override
+  String get noMemoriesToDelete => 'Nav atmiņu, ko dzēst';
+
+  @override
+  String get createMemoryTooltip => 'Izveidot jaunu atmiņu';
+
+  @override
+  String get createActionItemTooltip => 'Izveidot jaunu uzdevumu';
+
+  @override
+  String get memoryManagement => 'Atmiņas pārvaldība';
+
+  @override
+  String get filterMemories => 'Filtrēt atmiņas';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Jums ir $count kopējās atmiņas';
+  }
+
+  @override
+  String get publicMemories => 'Publiskas atmiņas';
+
+  @override
+  String get privateMemories => 'Privātas atmiņas';
+
+  @override
+  String get makeAllPrivate => 'Padarīt visas atmiņas privātas';
+
+  @override
+  String get makeAllPublic => 'Padarīt visas atmiņas publiskas';
+
+  @override
+  String get deleteAllMemories => 'Dzēst visas atmiņas';
+
+  @override
+  String get allMemoriesPrivateResult => 'Visas atmiņas tagad ir privātas';
+
+  @override
+  String get allMemoriesPublicResult => 'Visas atmiņas tagad ir publiskas';
+
+  @override
+  String get newMemory => 'Jauna atmiņa';
+
+  @override
+  String get editMemory => 'Rediģēt atmiņu';
+
+  @override
+  String get memoryContentHint => 'Man patīk ēst saldējumu...';
+
+  @override
+  String get failedToSaveMemory => 'Neizdevās saglabāt. Lūdzu, pārbaudiet savienojumu.';
+
+  @override
+  String get saveMemory => 'Saglabāt atmiņu';
+
+  @override
+  String get retry => 'Mēģināt vēlreiz';
+
+  @override
+  String get createActionItem => 'Izveidot uzdevumu';
+
+  @override
+  String get editActionItem => 'Rediģēt uzdevumu';
+
+  @override
+  String get actionItemDescriptionHint => 'Kas ir jādara?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Uzdevuma apraksts nevar būt tukšs.';
+
+  @override
+  String get actionItemUpdated => 'Uzdevums atjaunināts';
+
+  @override
+  String get failedToUpdateActionItem => 'Neizdevās atjaunināt uzdevumu';
+
+  @override
+  String get actionItemCreated => 'Uzdevums izveidots';
+
+  @override
+  String get failedToCreateActionItem => 'Neizdevās izveidot uzdevumu';
+
+  @override
+  String get dueDate => 'Termiņš';
+
+  @override
+  String get time => 'Laiks';
+
+  @override
+  String get addDueDate => 'Pievienot termiņu';
+
+  @override
+  String get pressDoneToSave => 'Piespiediet gatavs, lai saglabātu';
+
+  @override
+  String get pressDoneToCreate => 'Piespiediet gatavs, lai izveidotu';
+
+  @override
+  String get filterAll => 'Visi';
+
+  @override
+  String get filterSystem => 'Par jums';
+
+  @override
+  String get filterInteresting => 'Ieskati';
+
+  @override
+  String get filterManual => 'Manuāli';
+
+  @override
+  String get completed => 'Pabeigts';
+
+  @override
+  String get markComplete => 'Atzīmēt kā pabeigtu';
+
+  @override
+  String get actionItemDeleted => 'Uzdevums izdzēsts';
+
+  @override
+  String get failedToDeleteActionItem => 'Neizdevās dzēst uzdevumu';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Dzēst uzdevumu';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Vai tiešām vēlaties dzēst šo uzdevumu?';
+
+  @override
+  String get appLanguage => 'Lietotnes valoda';
+
+  @override
+  String get appInterfaceSectionTitle => 'LIETOJUMPROGRAMMAS INTERFEISS';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'RUNA UN TRANSKRIPCIJA';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Lietojumprogrammas valoda maina izvēlnes un pogas. Runas valoda ietekmē to, kā tiek transkribēti jūsu ieraksti.';
+}

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -1,0 +1,2239 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Malay (`ms`).
+class AppLocalizationsMs extends AppLocalizations {
+  AppLocalizationsMs([String locale = 'ms']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Perbualan';
+
+  @override
+  String get transcriptTab => 'Transkrip';
+
+  @override
+  String get actionItemsTab => 'Item Tindakan';
+
+  @override
+  String get deleteConversationTitle => 'Padam Perbualan?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Adakah anda pasti mahu memadam perbualan ini? Tindakan ini tidak boleh dibatalkan.';
+
+  @override
+  String get confirm => 'Sahkan';
+
+  @override
+  String get cancel => 'Batal';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Padam';
+
+  @override
+  String get add => 'Tambah';
+
+  @override
+  String get update => 'Kemas Kini';
+
+  @override
+  String get save => 'Simpan';
+
+  @override
+  String get edit => 'Edit';
+
+  @override
+  String get close => 'Tutup';
+
+  @override
+  String get clear => 'Kosongkan';
+
+  @override
+  String get copyTranscript => 'Salin Transkrip';
+
+  @override
+  String get copySummary => 'Salin Ringkasan';
+
+  @override
+  String get testPrompt => 'Uji Gesaan';
+
+  @override
+  String get reprocessConversation => 'Proses Semula Perbualan';
+
+  @override
+  String get deleteConversation => 'Padam Perbualan';
+
+  @override
+  String get contentCopied => 'Kandungan disalin ke papan keratan';
+
+  @override
+  String get failedToUpdateStarred => 'Gagal mengemas kini status bintang.';
+
+  @override
+  String get conversationUrlNotShared => 'URL perbualan tidak dapat dikongsi.';
+
+  @override
+  String get errorProcessingConversation => 'Ralat semasa memproses perbualan. Sila cuba lagi kemudian.';
+
+  @override
+  String get noInternetConnection => 'Sila semak sambungan internet anda dan cuba lagi.';
+
+  @override
+  String get unableToDeleteConversation => 'Tidak Dapat Memadam Perbualan';
+
+  @override
+  String get somethingWentWrong => 'Ada yang tidak kena! Sila cuba lagi kemudian.';
+
+  @override
+  String get copyErrorMessage => 'Salin mesej ralat';
+
+  @override
+  String get errorCopied => 'Mesej ralat disalin ke papan keratan';
+
+  @override
+  String get remaining => 'Berbaki';
+
+  @override
+  String get loading => 'Memuatkan...';
+
+  @override
+  String get loadingDuration => 'Memuatkan tempoh...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count saat';
+  }
+
+  @override
+  String get people => 'Orang';
+
+  @override
+  String get addNewPerson => 'Tambah Orang Baharu';
+
+  @override
+  String get editPerson => 'Edit Orang';
+
+  @override
+  String get createPersonHint => 'Cipta orang baharu dan latih Omi untuk mengenali pertuturan mereka juga!';
+
+  @override
+  String get speechProfile => 'Profil Pertuturan';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Sampel $number';
+  }
+
+  @override
+  String get settings => 'Tetapan';
+
+  @override
+  String get language => 'Bahasa';
+
+  @override
+  String get selectLanguage => 'Pilih Bahasa';
+
+  @override
+  String get deleting => 'Memadam...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
+
+  @override
+  String get failedToStartAuthentication => 'Gagal memulakan pengesahan';
+
+  @override
+  String get importStarted => 'Import bermula! Anda akan dimaklumkan apabila selesai.';
+
+  @override
+  String get failedToStartImport => 'Gagal memulakan import. Sila cuba lagi.';
+
+  @override
+  String get couldNotAccessFile => 'Tidak dapat mengakses fail yang dipilih';
+
+  @override
+  String get askOmi => 'Tanya Omi';
+
+  @override
+  String get done => 'Selesai';
+
+  @override
+  String get disconnected => 'Terputus Sambungan';
+
+  @override
+  String get searching => 'Mencari';
+
+  @override
+  String get connectDevice => 'Sambung Peranti';
+
+  @override
+  String get monthlyLimitReached => 'Anda telah mencapai had bulanan anda.';
+
+  @override
+  String get checkUsage => 'Semak Penggunaan';
+
+  @override
+  String get syncingRecordings => 'Menyegerakkan rakaman';
+
+  @override
+  String get recordingsToSync => 'Rakaman untuk disegerakkan';
+
+  @override
+  String get allCaughtUp => 'Semua telah dikemas kini';
+
+  @override
+  String get sync => 'Segerak';
+
+  @override
+  String get pendantUpToDate => 'Pendant adalah terkini';
+
+  @override
+  String get allRecordingsSynced => 'Semua rakaman telah disegerakkan';
+
+  @override
+  String get syncingInProgress => 'Penyegerakan sedang berlangsung';
+
+  @override
+  String get readyToSync => 'Sedia untuk disegerakkan';
+
+  @override
+  String get tapSyncToStart => 'Ketik Segerak untuk mula';
+
+  @override
+  String get pendantNotConnected => 'Pendant tidak disambungkan. Sambung untuk menyegerakkan.';
+
+  @override
+  String get everythingSynced => 'Semua telah disegerakkan.';
+
+  @override
+  String get recordingsNotSynced => 'Anda mempunyai rakaman yang belum disegerakkan lagi.';
+
+  @override
+  String get syncingBackground => 'Kami akan terus menyegerakkan rakaman anda di latar belakang.';
+
+  @override
+  String get noConversationsYet => 'Tiada perbualan lagi.';
+
+  @override
+  String get noStarredConversations => 'Tiada perbualan berbintang lagi.';
+
+  @override
+  String get starConversationHint => 'Untuk membintangkan perbualan, buka dan ketik ikon bintang di pengepala.';
+
+  @override
+  String get searchConversations => 'Cari Perbualan';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count dipilih';
+  }
+
+  @override
+  String get merge => 'Gabung';
+
+  @override
+  String get mergeConversations => 'Gabungkan Perbualan';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Ini akan menggabungkan $count perbualan menjadi satu. Semua kandungan akan digabungkan dan dijana semula.';
+  }
+
+  @override
+  String get mergingInBackground => 'Menggabungkan di latar belakang. Ini mungkin mengambil sedikit masa.';
+
+  @override
+  String get failedToStartMerge => 'Gagal memulakan penggabungan';
+
+  @override
+  String get askAnything => 'Tanya apa sahaja';
+
+  @override
+  String get noMessagesYet => 'Tiada mesej lagi!\nMengapa tidak mulakan perbualan?';
+
+  @override
+  String get deletingMessages => 'Memadam mesej anda daripada ingatan Omi...';
+
+  @override
+  String get messageCopied => 'Mesej disalin ke papan keratan.';
+
+  @override
+  String get cannotReportOwnMessage => 'Anda tidak boleh melaporkan mesej anda sendiri.';
+
+  @override
+  String get reportMessage => 'Laporkan Mesej';
+
+  @override
+  String get reportMessageConfirm => 'Adakah anda pasti mahu melaporkan mesej ini?';
+
+  @override
+  String get messageReported => 'Mesej berjaya dilaporkan.';
+
+  @override
+  String get thankYouFeedback => 'Terima kasih atas maklum balas anda!';
+
+  @override
+  String get clearChat => 'Kosongkan Sembang?';
+
+  @override
+  String get clearChatConfirm => 'Adakah anda pasti mahu mengosongkan sembang? Tindakan ini tidak boleh dibatalkan.';
+
+  @override
+  String get maxFilesLimit => 'Anda hanya boleh memuat naik 4 fail pada satu masa';
+
+  @override
+  String get chatWithOmi => 'Sembang dengan Omi';
+
+  @override
+  String get apps => 'Aplikasi';
+
+  @override
+  String get noAppsFound => 'Tiada aplikasi dijumpai';
+
+  @override
+  String get tryAdjustingSearch => 'Cuba laraskan carian atau penapis anda';
+
+  @override
+  String get createYourOwnApp => 'Cipta Aplikasi Anda Sendiri';
+
+  @override
+  String get buildAndShareApp => 'Bina dan kongsi aplikasi tersuai anda';
+
+  @override
+  String get searchApps => 'Cari 1500+ Aplikasi';
+
+  @override
+  String get myApps => 'Aplikasi Saya';
+
+  @override
+  String get installedApps => 'Aplikasi Dipasang';
+
+  @override
+  String get unableToFetchApps =>
+      'Tidak dapat mendapatkan aplikasi :(\n\nSila semak sambungan internet anda dan cuba lagi.';
+
+  @override
+  String get aboutOmi => 'Tentang Omi';
+
+  @override
+  String get privacyPolicy => 'Dasar Privasi';
+
+  @override
+  String get visitWebsite => 'Lawati Laman Web';
+
+  @override
+  String get helpOrInquiries => 'Bantuan atau Pertanyaan?';
+
+  @override
+  String get joinCommunity => 'Sertai komuniti!';
+
+  @override
+  String get membersAndCounting => '8000+ ahli dan semakin bertambah.';
+
+  @override
+  String get deleteAccountTitle => 'Padam Akaun';
+
+  @override
+  String get deleteAccountConfirm => 'Adakah anda pasti mahu memadam akaun anda?';
+
+  @override
+  String get cannotBeUndone => 'Ini tidak boleh dibatalkan.';
+
+  @override
+  String get allDataErased => 'Semua ingatan dan perbualan anda akan dipadam secara kekal.';
+
+  @override
+  String get appsDisconnected => 'Aplikasi dan Integrasi anda akan diputuskan sambungan dengan serta-merta.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Anda boleh mengeksport data anda sebelum memadam akaun anda, tetapi setelah dipadam, ia tidak boleh dipulihkan.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Saya faham bahawa memadam akaun saya adalah kekal dan semua data, termasuk ingatan dan perbualan, akan hilang dan tidak boleh dipulihkan.';
+
+  @override
+  String get areYouSure => 'Adakah anda pasti?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Tindakan ini tidak boleh diterbalikkan dan akan memadam akaun anda dan semua data berkaitan secara kekal. Adakah anda pasti mahu meneruskan?';
+
+  @override
+  String get deleteNow => 'Padam Sekarang';
+
+  @override
+  String get goBack => 'Kembali';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Tandakan kotak untuk mengesahkan anda faham bahawa memadam akaun anda adalah kekal dan tidak boleh diterbalikkan.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Nama';
+
+  @override
+  String get email => 'E-mel';
+
+  @override
+  String get customVocabulary => 'Perbendaharaan Kata Tersuai';
+
+  @override
+  String get identifyingOthers => 'Mengenal Pasti Orang Lain';
+
+  @override
+  String get paymentMethods => 'Kaedah Pembayaran';
+
+  @override
+  String get conversationDisplay => 'Paparan Perbualan';
+
+  @override
+  String get dataPrivacy => 'Data & Privasi';
+
+  @override
+  String get userId => 'ID Pengguna';
+
+  @override
+  String get notSet => 'Tidak ditetapkan';
+
+  @override
+  String get userIdCopied => 'ID Pengguna disalin ke papan keratan';
+
+  @override
+  String get systemDefault => 'Lalai Sistem';
+
+  @override
+  String get planAndUsage => 'Pelan & Penggunaan';
+
+  @override
+  String get offlineSync => 'Segerak Luar Talian';
+
+  @override
+  String get deviceSettings => 'Tetapan Peranti';
+
+  @override
+  String get chatTools => 'Alat Sembang';
+
+  @override
+  String get feedbackBug => 'Maklum Balas / Pepijat';
+
+  @override
+  String get helpCenter => 'Pusat Bantuan';
+
+  @override
+  String get developerSettings => 'Tetapan Pembangun';
+
+  @override
+  String get getOmiForMac => 'Dapatkan Omi untuk Mac';
+
+  @override
+  String get referralProgram => 'Program Rujukan';
+
+  @override
+  String get signOut => 'Log Keluar';
+
+  @override
+  String get appAndDeviceCopied => 'Butiran aplikasi dan peranti disalin';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Privasi Anda, Kawalan Anda';
+
+  @override
+  String get privacyIntro =>
+      'Di Omi, kami komited untuk melindungi privasi anda. Halaman ini membolehkan anda mengawal cara data anda disimpan dan digunakan.';
+
+  @override
+  String get learnMore => 'Ketahui lebih lanjut...';
+
+  @override
+  String get dataProtectionLevel => 'Tahap Perlindungan Data';
+
+  @override
+  String get dataProtectionDesc =>
+      'Data anda dijamin secara lalai dengan penyulitan yang kukuh. Semak tetapan dan pilihan privasi masa depan anda di bawah.';
+
+  @override
+  String get appAccess => 'Akses Aplikasi';
+
+  @override
+  String get appAccessDesc =>
+      'Aplikasi berikut boleh mengakses data anda. Ketik pada aplikasi untuk mengurus keizinannya.';
+
+  @override
+  String get noAppsExternalAccess => 'Tiada aplikasi yang dipasang mempunyai akses luaran ke data anda.';
+
+  @override
+  String get deviceName => 'Nama Peranti';
+
+  @override
+  String get deviceId => 'ID Peranti';
+
+  @override
+  String get firmware => 'Perisian Tegar';
+
+  @override
+  String get sdCardSync => 'Segerak Kad SD';
+
+  @override
+  String get hardwareRevision => 'Semakan Perkakasan';
+
+  @override
+  String get modelNumber => 'Nombor Model';
+
+  @override
+  String get manufacturer => 'Pengeluar';
+
+  @override
+  String get doubleTap => 'Ketik Dua Kali';
+
+  @override
+  String get ledBrightness => 'Kecerahan LED';
+
+  @override
+  String get micGain => 'Gandaan Mikrofon';
+
+  @override
+  String get disconnect => 'Putuskan Sambungan';
+
+  @override
+  String get forgetDevice => 'Lupakan Peranti';
+
+  @override
+  String get chargingIssues => 'Masalah Pengecasan';
+
+  @override
+  String get disconnectDevice => 'Putuskan Sambungan Peranti';
+
+  @override
+  String get unpairDevice => 'Nyahpasang Peranti';
+
+  @override
+  String get unpairAndForget => 'Nyahpasang dan Lupakan Peranti';
+
+  @override
+  String get deviceDisconnectedMessage => 'Omi anda telah diputuskan sambungan 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Peranti dinyahpasangkan. Pergi ke Tetapan > Bluetooth dan lupakan peranti untuk melengkapkan nyahpasangan.';
+
+  @override
+  String get unpairDialogTitle => 'Nyahpasang Peranti';
+
+  @override
+  String get unpairDialogMessage =>
+      'Ini akan menyahpasangkan peranti supaya ia boleh disambungkan ke telefon lain. Anda perlu pergi ke Tetapan > Bluetooth dan lupakan peranti untuk melengkapkan proses.';
+
+  @override
+  String get deviceNotConnected => 'Peranti Tidak Disambungkan';
+
+  @override
+  String get connectDeviceMessage => 'Sambungkan peranti Omi anda untuk mengakses\ntetapan peranti dan penyesuaian';
+
+  @override
+  String get deviceInfoSection => 'Maklumat Peranti';
+
+  @override
+  String get customizationSection => 'Penyesuaian';
+
+  @override
+  String get hardwareSection => 'Perkakasan';
+
+  @override
+  String get v2Undetected => 'V2 tidak dikesan';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Kami lihat anda sama ada mempunyai peranti V1 atau peranti anda tidak disambungkan. Fungsi Kad SD hanya tersedia untuk peranti V2.';
+
+  @override
+  String get endConversation => 'Tamatkan Perbualan';
+
+  @override
+  String get pauseResume => 'Jeda/Sambung Semula';
+
+  @override
+  String get starConversation => 'Bintangkan Perbualan';
+
+  @override
+  String get doubleTapAction => 'Tindakan Ketik Dua Kali';
+
+  @override
+  String get endAndProcess => 'Tamatkan & Proses Perbualan';
+
+  @override
+  String get pauseResumeRecording => 'Jeda/Sambung Semula Rakaman';
+
+  @override
+  String get starOngoing => 'Bintangkan Perbualan Berterusan';
+
+  @override
+  String get off => 'Mati';
+
+  @override
+  String get max => 'Maksimum';
+
+  @override
+  String get mute => 'Bisukan';
+
+  @override
+  String get quiet => 'Senyap';
+
+  @override
+  String get normal => 'Biasa';
+
+  @override
+  String get high => 'Tinggi';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon dibisukan';
+
+  @override
+  String get micGainDescLow => 'Sangat senyap - untuk persekitaran bising';
+
+  @override
+  String get micGainDescModerate => 'Senyap - untuk bunyi sederhana';
+
+  @override
+  String get micGainDescNeutral => 'Neutral - rakaman seimbang';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Dipertingkat sedikit - penggunaan biasa';
+
+  @override
+  String get micGainDescBoosted => 'Dipertingkat - untuk persekitaran senyap';
+
+  @override
+  String get micGainDescHigh => 'Tinggi - untuk suara jauh atau lembut';
+
+  @override
+  String get micGainDescVeryHigh => 'Sangat tinggi - untuk sumber sangat senyap';
+
+  @override
+  String get micGainDescMax => 'Maksimum - gunakan dengan berhati-hati';
+
+  @override
+  String get developerSettingsTitle => 'Tetapan Pembangun';
+
+  @override
+  String get saving => 'Menyimpan...';
+
+  @override
+  String get personaConfig => 'Konfigurasikan persona AI anda';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transkripsi';
+
+  @override
+  String get transcriptionConfig => 'Konfigurasikan penyedia STT';
+
+  @override
+  String get conversationTimeout => 'Tamat Masa Perbualan';
+
+  @override
+  String get conversationTimeoutConfig => 'Tetapkan bila perbualan tamat secara automatik';
+
+  @override
+  String get importData => 'Import Data';
+
+  @override
+  String get importDataConfig => 'Import data dari sumber lain';
+
+  @override
+  String get debugDiagnostics => 'Nyahpepijat & Diagnostik';
+
+  @override
+  String get endpointUrl => 'URL Titik Akhir';
+
+  @override
+  String get noApiKeys => 'Tiada kunci API lagi';
+
+  @override
+  String get createKeyToStart => 'Cipta kunci untuk bermula';
+
+  @override
+  String get createKey => 'Cipta Kunci';
+
+  @override
+  String get docs => 'Dokumen';
+
+  @override
+  String get yourOmiInsights => 'Wawasan Omi Anda';
+
+  @override
+  String get today => 'Hari Ini';
+
+  @override
+  String get thisMonth => 'Bulan Ini';
+
+  @override
+  String get thisYear => 'Tahun Ini';
+
+  @override
+  String get allTime => 'Sepanjang Masa';
+
+  @override
+  String get noActivityYet => 'Tiada Aktiviti Lagi';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Mulakan perbualan dengan Omi\nuntuk melihat wawasan penggunaan anda di sini.';
+
+  @override
+  String get listening => 'Mendengar';
+
+  @override
+  String get listeningSubtitle => 'Jumlah masa Omi telah mendengar secara aktif.';
+
+  @override
+  String get understanding => 'Memahami';
+
+  @override
+  String get understandingSubtitle => 'Perkataan yang difahami daripada perbualan anda.';
+
+  @override
+  String get providing => 'Menyediakan';
+
+  @override
+  String get providingSubtitle => 'Item tindakan dan nota ditangkap secara automatik.';
+
+  @override
+  String get remembering => 'Mengingati';
+
+  @override
+  String get rememberingSubtitle => 'Fakta dan butiran diingati untuk anda.';
+
+  @override
+  String get unlimitedPlan => 'Pelan Tanpa Had';
+
+  @override
+  String get managePlan => 'Urus Pelan';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Pelan anda akan dibatalkan pada $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Pelan anda diperbaharui pada $date.';
+  }
+
+  @override
+  String get basicPlan => 'Pelan Percuma';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used daripada $limit minit digunakan';
+  }
+
+  @override
+  String get upgrade => 'Naik Taraf';
+
+  @override
+  String get upgradeToUnlimited => 'Naik Taraf ke Tanpa Had';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Pelan anda termasuk $limit minit percuma sebulan. Naik taraf untuk tanpa had.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Berkongsi statistik Omi saya! (omi.me - pembantu AI anda yang sentiasa aktif)';
+
+  @override
+  String get sharePeriodToday => 'Hari ini, omi telah:';
+
+  @override
+  String get sharePeriodMonth => 'Bulan ini, omi telah:';
+
+  @override
+  String get sharePeriodYear => 'Tahun ini, omi telah:';
+
+  @override
+  String get sharePeriodAllTime => 'Setakat ini, omi telah:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Mendengar selama $minutes minit';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Memahami $words perkataan';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Menyediakan $count wawasan';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Mengingati $count ingatan';
+  }
+
+  @override
+  String get debugLogs => 'Log Nyahpepijat';
+
+  @override
+  String get debugLogsAutoDelete => 'Auto-padam selepas 3 hari.';
+
+  @override
+  String get debugLogsDesc => 'Membantu mendiagnosis masalah';
+
+  @override
+  String get noLogFilesFound => 'Tiada fail log dijumpai.';
+
+  @override
+  String get omiDebugLog => 'Log nyahpepijat Omi';
+
+  @override
+  String get logShared => 'Log dikongsi';
+
+  @override
+  String get selectLogFile => 'Pilih Fail Log';
+
+  @override
+  String get shareLogs => 'Kongsi Log';
+
+  @override
+  String get debugLogCleared => 'Log nyahpepijat dikosongkan';
+
+  @override
+  String get exportStarted => 'Eksport bermula. Ini mungkin mengambil beberapa saat...';
+
+  @override
+  String get exportAllData => 'Eksport Semua Data';
+
+  @override
+  String get exportDataDesc => 'Eksport perbualan ke fail JSON';
+
+  @override
+  String get exportedConversations => 'Perbualan Dieksport daripada Omi';
+
+  @override
+  String get exportShared => 'Eksport dikongsi';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Padam Graf Pengetahuan?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Ini akan memadam semua data graf pengetahuan terbitan (nod dan sambungan). Ingatan asal anda akan kekal selamat. Graf akan dibina semula dari semasa ke semasa atau atas permintaan seterusnya.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Graf Pengetahuan berjaya dipadam';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Gagal memadam graf: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Padam Graf Pengetahuan';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Kosongkan semua nod dan sambungan';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Pelayan MCP';
+
+  @override
+  String get mcpServerDesc => 'Sambungkan pembantu AI ke data anda';
+
+  @override
+  String get serverUrl => 'URL Pelayan';
+
+  @override
+  String get urlCopied => 'URL disalin';
+
+  @override
+  String get apiKeyAuth => 'Pengesahan Kunci API';
+
+  @override
+  String get header => 'Pengepala';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID Klien';
+
+  @override
+  String get clientSecret => 'Rahsia Klien';
+
+  @override
+  String get useMcpApiKey => 'Gunakan kunci API MCP anda';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Acara Perbualan';
+
+  @override
+  String get newConversationCreated => 'Perbualan baharu dicipta';
+
+  @override
+  String get realtimeTranscript => 'Transkrip Masa Nyata';
+
+  @override
+  String get transcriptReceived => 'Transkrip diterima';
+
+  @override
+  String get audioBytes => 'Bait Audio';
+
+  @override
+  String get audioDataReceived => 'Data audio diterima';
+
+  @override
+  String get intervalSeconds => 'Selang (saat)';
+
+  @override
+  String get daySummary => 'Ringkasan Hari';
+
+  @override
+  String get summaryGenerated => 'Ringkasan dijana';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Tambah ke claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Salin Konfigurasi';
+
+  @override
+  String get configCopied => 'Konfigurasi disalin ke papan keratan';
+
+  @override
+  String get listeningMins => 'Mendengar (minit)';
+
+  @override
+  String get understandingWords => 'Memahami (perkataan)';
+
+  @override
+  String get insights => 'Wawasan';
+
+  @override
+  String get memories => 'Ingatan';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used daripada $limit minit digunakan bulan ini';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used daripada $limit perkataan digunakan bulan ini';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used daripada $limit wawasan diperoleh bulan ini';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used daripada $limit ingatan dicipta bulan ini';
+  }
+
+  @override
+  String get visibility => 'Keterlihatan';
+
+  @override
+  String get visibilitySubtitle => 'Kawal perbualan mana yang muncul dalam senarai anda';
+
+  @override
+  String get showShortConversations => 'Tunjukkan Perbualan Pendek';
+
+  @override
+  String get showShortConversationsDesc => 'Paparkan perbualan yang lebih pendek daripada ambang';
+
+  @override
+  String get showDiscardedConversations => 'Tunjukkan Perbualan Dibuang';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Sertakan perbualan yang ditandakan sebagai dibuang';
+
+  @override
+  String get shortConversationThreshold => 'Ambang Perbualan Pendek';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Perbualan yang lebih pendek daripada ini akan disembunyikan melainkan didayakan di atas';
+
+  @override
+  String get durationThreshold => 'Ambang Tempoh';
+
+  @override
+  String get durationThresholdDesc => 'Sembunyikan perbualan yang lebih pendek daripada ini';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Perbendaharaan Kata Tersuai';
+
+  @override
+  String get addWords => 'Tambah Perkataan';
+
+  @override
+  String get addWordsDesc => 'Nama, istilah, atau perkataan luar biasa';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Sambung';
+
+  @override
+  String get comingSoon => 'Akan Datang';
+
+  @override
+  String get chatToolsFooter => 'Sambungkan aplikasi anda untuk melihat data dan metrik dalam sembang.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Gagal memulakan pengesahan $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Putuskan sambungan $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Adakah anda pasti mahu memutuskan sambungan dari $appName? Anda boleh menyambung semula bila-bila masa.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Terputus sambungan dari $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Gagal memutuskan sambungan';
+
+  @override
+  String connectTo(String appName) {
+    return 'Sambung ke $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Anda perlu memberi kebenaran kepada Omi untuk mengakses data $appName anda. Ini akan membuka pelayar anda untuk pengesahan.';
+  }
+
+  @override
+  String get continueAction => 'Teruskan';
+
+  @override
+  String get languageTitle => 'Bahasa';
+
+  @override
+  String get primaryLanguage => 'Bahasa Utama';
+
+  @override
+  String get automaticTranslation => 'Terjemahan Automatik';
+
+  @override
+  String get detectLanguages => 'Kesan 10+ bahasa';
+
+  @override
+  String get authorizeSavingRecordings => 'Benarkan Menyimpan Rakaman';
+
+  @override
+  String get thanksForAuthorizing => 'Terima kasih kerana memberi kebenaran!';
+
+  @override
+  String get needYourPermission => 'Kami memerlukan kebenaran anda';
+
+  @override
+  String get alreadyGavePermission =>
+      'Anda telah memberi kami kebenaran untuk menyimpan rakaman anda. Berikut adalah peringatan mengapa kami memerlukannya:';
+
+  @override
+  String get wouldLikePermission => 'Kami ingin kebenaran anda untuk menyimpan rakaman suara anda. Sebabnya:';
+
+  @override
+  String get improveSpeechProfile => 'Tingkatkan Profil Pertuturan Anda';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Kami menggunakan rakaman untuk melatih dan meningkatkan profil pertuturan peribadi anda.';
+
+  @override
+  String get trainFamilyProfiles => 'Latih Profil untuk Rakan dan Keluarga';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Rakaman anda membantu kami mengenali dan mencipta profil untuk rakan dan keluarga anda.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Tingkatkan Ketepatan Transkrip';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Apabila model kami bertambah baik, kami boleh memberikan hasil transkripsi yang lebih baik untuk rakaman anda.';
+
+  @override
+  String get legalNotice =>
+      'Notis Undang-undang: Kesahihan merakam dan menyimpan data suara mungkin berbeza bergantung pada lokasi anda dan cara anda menggunakan ciri ini. Adalah tanggungjawab anda untuk memastikan pematuhan undang-undang dan peraturan tempatan.';
+
+  @override
+  String get alreadyAuthorized => 'Sudah Dibenarkan';
+
+  @override
+  String get authorize => 'Benarkan';
+
+  @override
+  String get revokeAuthorization => 'Batalkan Kebenaran';
+
+  @override
+  String get authorizationSuccessful => 'Kebenaran berjaya!';
+
+  @override
+  String get failedToAuthorize => 'Gagal memberi kebenaran. Sila cuba lagi.';
+
+  @override
+  String get authorizationRevoked => 'Kebenaran dibatalkan.';
+
+  @override
+  String get recordingsDeleted => 'Rakaman dipadam.';
+
+  @override
+  String get failedToRevoke => 'Gagal membatalkan kebenaran. Sila cuba lagi.';
+
+  @override
+  String get permissionRevokedTitle => 'Kebenaran Dibatalkan';
+
+  @override
+  String get permissionRevokedMessage => 'Adakah anda mahu kami membuang semua rakaman sedia ada anda juga?';
+
+  @override
+  String get yes => 'Ya';
+
+  @override
+  String get editName => 'Edit Nama';
+
+  @override
+  String get howShouldOmiCallYou => 'Apa yang Omi patut panggil anda?';
+
+  @override
+  String get enterYourName => 'Masukkan nama anda';
+
+  @override
+  String get nameCannotBeEmpty => 'Nama tidak boleh kosong';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Nama berjaya dikemas kini!';
+
+  @override
+  String get calendarSettings => 'Tetapan kalendar';
+
+  @override
+  String get calendarProviders => 'Penyedia Kalendar';
+
+  @override
+  String get macOsCalendar => 'Kalendar macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Sambungkan kalendar macOS tempatan anda';
+
+  @override
+  String get googleCalendar => 'Google Calendar';
+
+  @override
+  String get syncGoogleAccount => 'Segerakkan dengan akaun Google anda';
+
+  @override
+  String get showMeetingsMenuBar => 'Tunjukkan mesyuarat akan datang di bar menu';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'Paparkan mesyuarat seterusnya anda dan masa sehingga ia bermula di bar menu macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Tunjukkan acara tanpa peserta';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Apabila didayakan, Coming Up menunjukkan acara tanpa peserta atau pautan video.';
+
+  @override
+  String get yourMeetings => 'Mesyuarat Anda';
+
+  @override
+  String get refresh => 'Muat Semula';
+
+  @override
+  String get noUpcomingMeetings => 'Tiada mesyuarat akan datang dijumpai';
+
+  @override
+  String get checkingNextDays => 'Menyemak 30 hari akan datang';
+
+  @override
+  String get tomorrow => 'Esok';
+
+  @override
+  String get googleCalendarComingSoon => 'Integrasi Google Calendar akan datang!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Disambungkan sebagai pengguna: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Ruang Kerja Lalai';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Tugasan akan dicipta dalam ruang kerja ini';
+
+  @override
+  String get defaultProjectOptional => 'Projek Lalai (Pilihan)';
+
+  @override
+  String get leaveUnselectedTasks => 'Biarkan tidak dipilih untuk mencipta tugasan tanpa projek';
+
+  @override
+  String get noProjectsInWorkspace => 'Tiada projek dijumpai dalam ruang kerja ini';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Pilih berapa lama untuk menunggu dalam senyap sebelum menamatkan perbualan secara automatik:';
+
+  @override
+  String get timeout2Minutes => '2 minit';
+
+  @override
+  String get timeout2MinutesDesc => 'Tamatkan perbualan selepas 2 minit senyap';
+
+  @override
+  String get timeout5Minutes => '5 minit';
+
+  @override
+  String get timeout5MinutesDesc => 'Tamatkan perbualan selepas 5 minit senyap';
+
+  @override
+  String get timeout10Minutes => '10 minit';
+
+  @override
+  String get timeout10MinutesDesc => 'Tamatkan perbualan selepas 10 minit senyap';
+
+  @override
+  String get timeout30Minutes => '30 minit';
+
+  @override
+  String get timeout30MinutesDesc => 'Tamatkan perbualan selepas 30 minit senyap';
+
+  @override
+  String get timeout4Hours => '4 jam';
+
+  @override
+  String get timeout4HoursDesc => 'Tamatkan perbualan selepas 4 jam senyap';
+
+  @override
+  String get conversationEndAfterHours => 'Perbualan akan tamat selepas 4 jam senyap';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Perbualan akan tamat selepas $minutes minit senyap';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Beritahu kami bahasa utama anda';
+
+  @override
+  String get languageForTranscription =>
+      'Tetapkan bahasa anda untuk transkripsi yang lebih tajam dan pengalaman yang diperibadikan.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Mod Bahasa Tunggal didayakan. Terjemahan dilumpuhkan untuk ketepatan yang lebih tinggi.';
+
+  @override
+  String get searchLanguageHint => 'Cari bahasa mengikut nama atau kod';
+
+  @override
+  String get noLanguagesFound => 'Tiada bahasa dijumpai';
+
+  @override
+  String get skip => 'Langkau';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Bahasa ditetapkan kepada $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Gagal menetapkan bahasa';
+
+  @override
+  String appSettings(String appName) {
+    return 'Tetapan $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Putuskan sambungan dari $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Ini akan membuang pengesahan $appName anda. Anda perlu menyambung semula untuk menggunakannya lagi.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Disambungkan ke $appName';
+  }
+
+  @override
+  String get account => 'Akaun';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Item tindakan anda akan disegerakkan ke akaun $appName anda';
+  }
+
+  @override
+  String get defaultSpace => 'Ruang Lalai';
+
+  @override
+  String get selectSpaceInWorkspace => 'Pilih ruang dalam ruang kerja anda';
+
+  @override
+  String get noSpacesInWorkspace => 'Tiada ruang dijumpai dalam ruang kerja ini';
+
+  @override
+  String get defaultList => 'Senarai Lalai';
+
+  @override
+  String get tasksAddedToList => 'Tugasan akan ditambah ke senarai ini';
+
+  @override
+  String get noListsInSpace => 'Tiada senarai dijumpai dalam ruang ini';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Gagal memuatkan repositori: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Repositori lalai disimpan';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Gagal menyimpan repositori lalai';
+
+  @override
+  String get defaultRepository => 'Repositori Lalai';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Pilih repositori lalai untuk mencipta isu. Anda masih boleh menyatakan repositori yang berbeza semasa mencipta isu.';
+
+  @override
+  String get noReposFound => 'Tiada repositori dijumpai';
+
+  @override
+  String get private => 'Peribadi';
+
+  @override
+  String updatedDate(String date) {
+    return 'Dikemas kini $date';
+  }
+
+  @override
+  String get yesterday => 'semalam';
+
+  @override
+  String daysAgo(int count) {
+    return '$count hari yang lalu';
+  }
+
+  @override
+  String get oneWeekAgo => '1 minggu yang lalu';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count minggu yang lalu';
+  }
+
+  @override
+  String get oneMonthAgo => '1 bulan yang lalu';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count bulan yang lalu';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Isu akan dicipta dalam repositori lalai anda';
+
+  @override
+  String get taskIntegrations => 'Integrasi Tugasan';
+
+  @override
+  String get configureSettings => 'Konfigurasikan Tetapan';
+
+  @override
+  String get completeAuthBrowser =>
+      'Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Gagal memulakan pengesahan $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Sambung ke $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Anda perlu memberi kebenaran kepada Omi untuk mencipta tugasan dalam akaun $appName anda. Ini akan membuka pelayar anda untuk pengesahan.';
+  }
+
+  @override
+  String get continueButton => 'Teruskan';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Integrasi $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integrasi dengan $appName akan datang! Kami bekerja keras untuk membawa anda lebih banyak pilihan pengurusan tugasan.';
+  }
+
+  @override
+  String get gotIt => 'Faham';
+
+  @override
+  String get tasksExportedOneApp => 'Tugasan boleh dieksport ke satu aplikasi pada satu masa.';
+
+  @override
+  String get completeYourUpgrade => 'Lengkapkan Naik Taraf Anda';
+
+  @override
+  String get importConfiguration => 'Import Konfigurasi';
+
+  @override
+  String get exportConfiguration => 'Eksport konfigurasi';
+
+  @override
+  String get bringYourOwn => 'Bawa milik anda sendiri';
+
+  @override
+  String get payYourSttProvider => 'Gunakan omi secara bebas. Anda hanya membayar penyedia STT anda secara langsung.';
+
+  @override
+  String get freeMinutesMonth => '1,200 minit percuma/bulan disertakan. Tanpa had dengan ';
+
+  @override
+  String get omiUnlimited => 'Omi Tanpa Had';
+
+  @override
+  String get hostRequired => 'Hos diperlukan';
+
+  @override
+  String get validPortRequired => 'Port yang sah diperlukan';
+
+  @override
+  String get validWebsocketUrlRequired => 'URL WebSocket yang sah diperlukan (wss://)';
+
+  @override
+  String get apiUrlRequired => 'URL API diperlukan';
+
+  @override
+  String get apiKeyRequired => 'Kunci API diperlukan';
+
+  @override
+  String get invalidJsonConfig => 'Konfigurasi JSON tidak sah';
+
+  @override
+  String errorSaving(String error) {
+    return 'Ralat menyimpan: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfigurasi disalin ke papan keratan';
+
+  @override
+  String get pasteJsonConfig => 'Tampal konfigurasi JSON anda di bawah:';
+
+  @override
+  String get addApiKeyAfterImport => 'Anda perlu menambah kunci API anda sendiri selepas mengimport';
+
+  @override
+  String get paste => 'Tampal';
+
+  @override
+  String get import => 'Import';
+
+  @override
+  String get invalidProviderInConfig => 'Penyedia tidak sah dalam konfigurasi';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Konfigurasi $providerName diimport';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON tidak sah: $error';
+  }
+
+  @override
+  String get provider => 'Penyedia';
+
+  @override
+  String get live => 'Langsung';
+
+  @override
+  String get onDevice => 'Pada Peranti';
+
+  @override
+  String get apiUrl => 'URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Masukkan titik akhir HTTP STT anda';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Masukkan titik akhir WebSocket STT langsung anda';
+
+  @override
+  String get apiKey => 'Kunci API';
+
+  @override
+  String get enterApiKey => 'Masukkan kunci API anda';
+
+  @override
+  String get storedLocallyNeverShared => 'Disimpan secara tempatan, tidak pernah dikongsi';
+
+  @override
+  String get host => 'Hos';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Lanjutan';
+
+  @override
+  String get configuration => 'Konfigurasi';
+
+  @override
+  String get requestConfiguration => 'Konfigurasi Permintaan';
+
+  @override
+  String get responseSchema => 'Skema Respons';
+
+  @override
+  String get modified => 'Diubah Suai';
+
+  @override
+  String get resetRequestConfig => 'Tetapkan semula konfigurasi permintaan ke lalai';
+
+  @override
+  String get logs => 'Log';
+
+  @override
+  String get logsCopied => 'Log disalin';
+
+  @override
+  String get noLogsYet => 'Tiada log lagi. Mulakan rakaman untuk melihat aktiviti STT tersuai.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName menggunakan $codecReason. Omi akan digunakan.';
+  }
+
+  @override
+  String get omiTranscription => 'Transkripsi Omi';
+
+  @override
+  String get bestInClassTranscription => 'Transkripsi terbaik dalam kelasnya tanpa persediaan';
+
+  @override
+  String get instantSpeakerLabels => 'Label penutur segera';
+
+  @override
+  String get languageTranslation => 'Terjemahan 100+ bahasa';
+
+  @override
+  String get optimizedForConversation => 'Dioptimumkan untuk perbualan';
+
+  @override
+  String get autoLanguageDetection => 'Pengesanan bahasa automatik';
+
+  @override
+  String get highAccuracy => 'Ketepatan tinggi';
+
+  @override
+  String get privacyFirst => 'Privasi utama';
+
+  @override
+  String get saveChanges => 'Simpan Perubahan';
+
+  @override
+  String get resetToDefault => 'Tetapkan Semula ke Lalai';
+
+  @override
+  String get viewTemplate => 'Lihat Templat';
+
+  @override
+  String get trySomethingLike => 'Cuba sesuatu seperti...';
+
+  @override
+  String get tryIt => 'Cuba';
+
+  @override
+  String get creatingPlan => 'Mencipta pelan';
+
+  @override
+  String get developingLogic => 'Membangunkan logik';
+
+  @override
+  String get designingApp => 'Mereka aplikasi';
+
+  @override
+  String get generatingIconStep => 'Menjana ikon';
+
+  @override
+  String get finalTouches => 'Sentuhan akhir';
+
+  @override
+  String get processing => 'Memproses...';
+
+  @override
+  String get features => 'Ciri-ciri';
+
+  @override
+  String get creatingYourApp => 'Mencipta aplikasi anda...';
+
+  @override
+  String get generatingIcon => 'Menjana ikon...';
+
+  @override
+  String get whatShouldWeMake => 'Apa yang patut kita buat?';
+
+  @override
+  String get appName => 'Nama Aplikasi';
+
+  @override
+  String get description => 'Penerangan';
+
+  @override
+  String get publicLabel => 'Awam';
+
+  @override
+  String get privateLabel => 'Peribadi';
+
+  @override
+  String get free => 'Percuma';
+
+  @override
+  String get perMonth => '/ Bulan';
+
+  @override
+  String get tailoredConversationSummaries => 'Ringkasan Perbualan Tersuai';
+
+  @override
+  String get customChatbotPersonality => 'Personaliti Chatbot Tersuai';
+
+  @override
+  String get makePublic => 'Jadikan awam';
+
+  @override
+  String get anyoneCanDiscover => 'Sesiapa sahaja boleh menemui aplikasi anda';
+
+  @override
+  String get onlyYouCanUse => 'Hanya anda boleh menggunakan aplikasi ini';
+
+  @override
+  String get paidApp => 'Aplikasi berbayar';
+
+  @override
+  String get usersPayToUse => 'Pengguna membayar untuk menggunakan aplikasi anda';
+
+  @override
+  String get freeForEveryone => 'Percuma untuk semua';
+
+  @override
+  String get perMonthLabel => '/ bulan';
+
+  @override
+  String get creating => 'Mencipta...';
+
+  @override
+  String get createApp => 'Cipta Aplikasi';
+
+  @override
+  String get searchingForDevices => 'Mencari peranti...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'PERANTI',
+      one: 'PERANTI',
+    );
+    return '$count $_temp0 DIJUMPAI BERDEKATAN';
+  }
+
+  @override
+  String get pairingSuccessful => 'PERPASANGAN BERJAYA';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Ralat menyambung ke Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Jangan tunjukkan lagi';
+
+  @override
+  String get iUnderstand => 'Saya Faham';
+
+  @override
+  String get enableBluetooth => 'Dayakan Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi memerlukan Bluetooth untuk menyambung ke peranti boleh pakai anda. Sila dayakan Bluetooth dan cuba lagi.';
+
+  @override
+  String get contactSupport => 'Hubungi Sokongan?';
+
+  @override
+  String get connectLater => 'Sambung Kemudian';
+
+  @override
+  String get grantPermissions => 'Berikan kebenaran';
+
+  @override
+  String get backgroundActivity => 'Aktiviti latar belakang';
+
+  @override
+  String get backgroundActivityDesc => 'Biarkan Omi berjalan di latar belakang untuk kestabilan yang lebih baik';
+
+  @override
+  String get locationAccess => 'Akses lokasi';
+
+  @override
+  String get locationAccessDesc => 'Dayakan lokasi latar belakang untuk pengalaman penuh';
+
+  @override
+  String get notifications => 'Pemberitahuan';
+
+  @override
+  String get notificationsDesc => 'Dayakan pemberitahuan untuk terus dimaklumkan';
+
+  @override
+  String get locationServiceDisabled => 'Perkhidmatan Lokasi Dilumpuhkan';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Perkhidmatan Lokasi dilumpuhkan. Sila pergi ke Tetapan > Privasi & Keselamatan > Perkhidmatan Lokasi dan dayakannya';
+
+  @override
+  String get backgroundLocationDenied => 'Akses Lokasi Latar Belakang Ditolak';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Sila pergi ke tetapan peranti dan tetapkan kebenaran lokasi kepada \"Sentiasa Benarkan\"';
+
+  @override
+  String get lovingOmi => 'Suka Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Bantu kami menjangkau lebih ramai orang dengan meninggalkan ulasan di App Store. Maklum balas anda sangat bermakna bagi kami!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Bantu kami menjangkau lebih ramai orang dengan meninggalkan ulasan di Google Play Store. Maklum balas anda sangat bermakna bagi kami!';
+
+  @override
+  String get rateOnAppStore => 'Nilai di App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Nilai di Google Play';
+
+  @override
+  String get maybeLater => 'Mungkin kemudian';
+
+  @override
+  String get speechProfileIntro => 'Omi perlu mempelajari matlamat dan suara anda. Anda boleh mengubahnya kemudian.';
+
+  @override
+  String get getStarted => 'Mulakan';
+
+  @override
+  String get allDone => 'Semua selesai!';
+
+  @override
+  String get keepGoing => 'Teruskan, anda buat dengan baik';
+
+  @override
+  String get skipThisQuestion => 'Langkau soalan ini';
+
+  @override
+  String get skipForNow => 'Langkau buat masa ini';
+
+  @override
+  String get connectionError => 'Ralat Sambungan';
+
+  @override
+  String get connectionErrorDesc => 'Gagal menyambung ke pelayan. Sila semak sambungan internet anda dan cuba lagi.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Rakaman tidak sah dikesan';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Nampaknya terdapat beberapa penutur dalam rakaman. Sila pastikan anda berada di lokasi yang senyap dan cuba lagi.';
+
+  @override
+  String get tooShortDesc => 'Tidak cukup pertuturan dikesan. Sila bercakap lebih banyak dan cuba lagi.';
+
+  @override
+  String get invalidRecordingDesc =>
+      'Sila pastikan anda bercakap sekurang-kurangnya 5 saat dan tidak lebih daripada 90.';
+
+  @override
+  String get areYouThere => 'Adakah anda di sana?';
+
+  @override
+  String get noSpeechDesc =>
+      'Kami tidak dapat mengesan sebarang pertuturan. Sila pastikan untuk bercakap sekurang-kurangnya 10 saat dan tidak lebih daripada 3 minit.';
+
+  @override
+  String get connectionLost => 'Sambungan Terputus';
+
+  @override
+  String get connectionLostDesc => 'Sambungan terganggu. Sila semak sambungan internet anda dan cuba lagi.';
+
+  @override
+  String get tryAgain => 'Cuba Lagi';
+
+  @override
+  String get connectOmiOmiGlass => 'Sambung Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Teruskan Tanpa Peranti';
+
+  @override
+  String get permissionsRequired => 'Kebenaran Diperlukan';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Aplikasi ini memerlukan kebenaran Bluetooth dan Lokasi untuk berfungsi dengan betul. Sila dayakannya dalam tetapan.';
+
+  @override
+  String get openSettings => 'Buka Tetapan';
+
+  @override
+  String get wantDifferentName => 'Mahu dipanggil dengan nama lain?';
+
+  @override
+  String get whatsYourName => 'Siapa nama anda?';
+
+  @override
+  String get speakTranscribeSummarize => 'Bercakap. Transkrip. Ringkaskan.';
+
+  @override
+  String get signInWithApple => 'Log masuk dengan Apple';
+
+  @override
+  String get signInWithGoogle => 'Log masuk dengan Google';
+
+  @override
+  String get byContinuingAgree => 'Dengan meneruskan, anda bersetuju dengan ';
+
+  @override
+  String get termsOfUse => 'Terma Penggunaan';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Sahabat AI Anda';
+
+  @override
+  String get captureEveryMoment => 'Tangkap setiap detik. Dapatkan ringkasan dikuasakan AI.\nJangan ambil nota lagi.';
+
+  @override
+  String get appleWatchSetup => 'Persediaan Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Kebenaran Diminta!';
+
+  @override
+  String get microphonePermission => 'Kebenaran Mikrofon';
+
+  @override
+  String get permissionGrantedNow =>
+      'Kebenaran diberikan! Sekarang:\n\nBuka aplikasi Omi pada jam tangan anda dan ketik \"Teruskan\" di bawah';
+
+  @override
+  String get needMicrophonePermission =>
+      'Kami memerlukan kebenaran mikrofon.\n\n1. Ketik \"Berikan Kebenaran\"\n2. Benarkan pada iPhone anda\n3. Aplikasi jam tangan akan ditutup\n4. Buka semula dan ketik \"Teruskan\"';
+
+  @override
+  String get grantPermissionButton => 'Berikan Kebenaran';
+
+  @override
+  String get needHelp => 'Perlukan Bantuan?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Penyelesaian Masalah:\n\n1. Pastikan Omi dipasang pada jam tangan anda\n2. Buka aplikasi Omi pada jam tangan anda\n3. Cari popup kebenaran\n4. Ketik \"Benarkan\" apabila diminta\n5. Aplikasi pada jam tangan anda akan ditutup - buka semula\n6. Kembali dan ketik \"Teruskan\" pada iPhone anda';
+
+  @override
+  String get recordingStartedSuccessfully => 'Rakaman bermula dengan jayanya!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Kebenaran belum diberikan. Sila pastikan anda membenarkan akses mikrofon dan membuka semula aplikasi pada jam tangan anda.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Ralat meminta kebenaran: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Ralat memulakan rakaman: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Pilih bahasa utama anda';
+
+  @override
+  String get languageBenefits =>
+      'Tetapkan bahasa anda untuk transkripsi yang lebih tajam dan pengalaman yang diperibadikan';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Apakah bahasa utama anda?';
+
+  @override
+  String get selectYourLanguage => 'Pilih bahasa anda';
+
+  @override
+  String get personalGrowthJourney =>
+      'Perjalanan pertumbuhan peribadi anda dengan AI yang mendengar setiap perkataan anda.';
+
+  @override
+  String get actionItemsTitle => 'Tugasan';
+
+  @override
+  String get actionItemsDescription => 'Ketik untuk edit • Tekan lama untuk pilih • Leret untuk tindakan';
+
+  @override
+  String get tabToDo => 'Tugasan';
+
+  @override
+  String get tabDone => 'Selesai';
+
+  @override
+  String get tabOld => 'Lama';
+
+  @override
+  String get emptyTodoMessage => '🎉 Semua telah selesai!\nTiada item tindakan tertunda';
+
+  @override
+  String get emptyDoneMessage => 'Tiada item selesai lagi';
+
+  @override
+  String get emptyOldMessage => '✅ Tiada tugasan lama';
+
+  @override
+  String get noItems => 'Tiada item';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Item tindakan ditandakan sebagai tidak lengkap';
+
+  @override
+  String get actionItemCompleted => 'Item tindakan selesai';
+
+  @override
+  String get deleteActionItemTitle => 'Padam Item Tindakan';
+
+  @override
+  String get deleteActionItemMessage => 'Adakah anda pasti mahu memadam item tindakan ini?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Padam Item Terpilih';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Adakah anda pasti mahu memadam $count item tindakan terpilih$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Item tindakan \"$description\" dipadam';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count item tindakan$s dipadam';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Gagal memadam item tindakan';
+
+  @override
+  String get failedToDeleteItems => 'Gagal memadam item';
+
+  @override
+  String get failedToDeleteSomeItems => 'Gagal memadam beberapa item';
+
+  @override
+  String get welcomeActionItemsTitle => 'Sedia untuk Item Tindakan';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'AI anda akan secara automatik mengekstrak tugasan dan perkara-yang-perlu-dilakukan daripada perbualan anda. Ia akan muncul di sini apabila dicipta.';
+
+  @override
+  String get autoExtractionFeature => 'Diekstrak secara automatik daripada perbualan';
+
+  @override
+  String get editSwipeFeature => 'Ketik untuk edit, leret untuk lengkapkan atau padam';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count dipilih';
+  }
+
+  @override
+  String get selectAll => 'Pilih semua';
+
+  @override
+  String get deleteSelected => 'Padam terpilih';
+
+  @override
+  String searchMemories(int count) {
+    return 'Cari $count Ingatan';
+  }
+
+  @override
+  String get memoryDeleted => 'Ingatan Dipadam.';
+
+  @override
+  String get undo => 'Buat Asal';
+
+  @override
+  String get noMemoriesYet => 'Tiada ingatan lagi';
+
+  @override
+  String get noAutoMemories => 'Tiada ingatan auto-ekstrak lagi';
+
+  @override
+  String get noManualMemories => 'Tiada ingatan manual lagi';
+
+  @override
+  String get noMemoriesInCategories => 'Tiada ingatan dalam kategori ini';
+
+  @override
+  String get noMemoriesFound => 'Tiada ingatan dijumpai';
+
+  @override
+  String get addFirstMemory => 'Tambah ingatan pertama anda';
+
+  @override
+  String get clearMemoryTitle => 'Kosongkan Ingatan Omi';
+
+  @override
+  String get clearMemoryMessage =>
+      'Adakah anda pasti mahu mengosongkan ingatan Omi? Tindakan ini tidak boleh dibatalkan.';
+
+  @override
+  String get clearMemoryButton => 'Kosongkan Ingatan';
+
+  @override
+  String get memoryClearedSuccess => 'Ingatan Omi tentang anda telah dikosongkan';
+
+  @override
+  String get noMemoriesToDelete => 'Tiada ingatan untuk dipadam';
+
+  @override
+  String get createMemoryTooltip => 'Cipta ingatan baharu';
+
+  @override
+  String get createActionItemTooltip => 'Cipta item tindakan baharu';
+
+  @override
+  String get memoryManagement => 'Pengurusan Ingatan';
+
+  @override
+  String get filterMemories => 'Tapis Ingatan';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Anda mempunyai $count jumlah ingatan';
+  }
+
+  @override
+  String get publicMemories => 'Ingatan awam';
+
+  @override
+  String get privateMemories => 'Ingatan peribadi';
+
+  @override
+  String get makeAllPrivate => 'Jadikan Semua Ingatan Peribadi';
+
+  @override
+  String get makeAllPublic => 'Jadikan Semua Ingatan Awam';
+
+  @override
+  String get deleteAllMemories => 'Padam Semua Ingatan';
+
+  @override
+  String get allMemoriesPrivateResult => 'Semua ingatan kini peribadi';
+
+  @override
+  String get allMemoriesPublicResult => 'Semua ingatan kini awam';
+
+  @override
+  String get newMemory => 'Ingatan Baharu';
+
+  @override
+  String get editMemory => 'Edit Ingatan';
+
+  @override
+  String get memoryContentHint => 'Saya suka makan ais krim...';
+
+  @override
+  String get failedToSaveMemory => 'Gagal menyimpan. Sila semak sambungan anda.';
+
+  @override
+  String get saveMemory => 'Simpan Ingatan';
+
+  @override
+  String get retry => 'Cuba Semula';
+
+  @override
+  String get createActionItem => 'Cipta Item Tindakan';
+
+  @override
+  String get editActionItem => 'Edit Item Tindakan';
+
+  @override
+  String get actionItemDescriptionHint => 'Apa yang perlu dilakukan?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Penerangan item tindakan tidak boleh kosong.';
+
+  @override
+  String get actionItemUpdated => 'Item tindakan dikemas kini';
+
+  @override
+  String get failedToUpdateActionItem => 'Gagal mengemas kini item tindakan';
+
+  @override
+  String get actionItemCreated => 'Item tindakan dicipta';
+
+  @override
+  String get failedToCreateActionItem => 'Gagal mencipta item tindakan';
+
+  @override
+  String get dueDate => 'Tarikh Akhir';
+
+  @override
+  String get time => 'Masa';
+
+  @override
+  String get addDueDate => 'Tambah tarikh akhir';
+
+  @override
+  String get pressDoneToSave => 'Tekan selesai untuk simpan';
+
+  @override
+  String get pressDoneToCreate => 'Tekan selesai untuk cipta';
+
+  @override
+  String get filterAll => 'Semua';
+
+  @override
+  String get filterSystem => 'Tentang Anda';
+
+  @override
+  String get filterInteresting => 'Wawasan';
+
+  @override
+  String get filterManual => 'Manual';
+
+  @override
+  String get completed => 'Selesai';
+
+  @override
+  String get markComplete => 'Tandakan selesai';
+
+  @override
+  String get actionItemDeleted => 'Item tindakan dipadam';
+
+  @override
+  String get failedToDeleteActionItem => 'Gagal memadam item tindakan';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Padam Item Tindakan';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Adakah anda pasti mahu memadam item tindakan ini?';
+
+  @override
+  String get appLanguage => 'Bahasa Aplikasi';
+
+  @override
+  String get appInterfaceSectionTitle => 'ANTARA MUKA APLIKASI';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'PERTUTURAN & TRANSKRIPSI';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Bahasa Aplikasi menukar menu dan butang. Bahasa Pertuturan mempengaruhi cara rakaman anda ditranskripsi.';
+}

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -1,0 +1,2237 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Dutch Flemish (`nl`).
+class AppLocalizationsNl extends AppLocalizations {
+  AppLocalizationsNl([String locale = 'nl']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Gesprek';
+
+  @override
+  String get transcriptTab => 'Transcript';
+
+  @override
+  String get actionItemsTab => 'Actiepunten';
+
+  @override
+  String get deleteConversationTitle => 'Gesprek verwijderen?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Weet je zeker dat je dit gesprek wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.';
+
+  @override
+  String get confirm => 'Bevestigen';
+
+  @override
+  String get cancel => 'Annuleren';
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get delete => 'Verwijderen';
+
+  @override
+  String get add => 'Toevoegen';
+
+  @override
+  String get update => 'Bijwerken';
+
+  @override
+  String get save => 'Opslaan';
+
+  @override
+  String get edit => 'Bewerken';
+
+  @override
+  String get close => 'Sluiten';
+
+  @override
+  String get clear => 'Wissen';
+
+  @override
+  String get copyTranscript => 'Transcript kopiëren';
+
+  @override
+  String get copySummary => 'Samenvatting kopiëren';
+
+  @override
+  String get testPrompt => 'Prompt testen';
+
+  @override
+  String get reprocessConversation => 'Gesprek opnieuw verwerken';
+
+  @override
+  String get deleteConversation => 'Gesprek verwijderen';
+
+  @override
+  String get contentCopied => 'Inhoud gekopieerd naar klembord';
+
+  @override
+  String get failedToUpdateStarred => 'Kan favorietenstatus niet bijwerken.';
+
+  @override
+  String get conversationUrlNotShared => 'Gesprek-URL kon niet worden gedeeld.';
+
+  @override
+  String get errorProcessingConversation => 'Fout bij het verwerken van gesprek. Probeer het later opnieuw.';
+
+  @override
+  String get noInternetConnection => 'Controleer je internetverbinding en probeer het opnieuw.';
+
+  @override
+  String get unableToDeleteConversation => 'Kan gesprek niet verwijderen';
+
+  @override
+  String get somethingWentWrong => 'Er is iets misgegaan! Probeer het later opnieuw.';
+
+  @override
+  String get copyErrorMessage => 'Foutmelding kopiëren';
+
+  @override
+  String get errorCopied => 'Foutmelding gekopieerd naar klembord';
+
+  @override
+  String get remaining => 'Resterend';
+
+  @override
+  String get loading => 'Laden...';
+
+  @override
+  String get loadingDuration => 'Duur laden...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count seconden';
+  }
+
+  @override
+  String get people => 'Mensen';
+
+  @override
+  String get addNewPerson => 'Nieuwe persoon toevoegen';
+
+  @override
+  String get editPerson => 'Persoon bewerken';
+
+  @override
+  String get createPersonHint => 'Maak een nieuwe persoon aan en train Omi om hun stem te herkennen!';
+
+  @override
+  String get speechProfile => 'Spraakprofiel';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Monster $number';
+  }
+
+  @override
+  String get settings => 'Instellingen';
+
+  @override
+  String get language => 'Taal';
+
+  @override
+  String get selectLanguage => 'Selecteer taal';
+
+  @override
+  String get deleting => 'Verwijderen...';
+
+  @override
+  String get pleaseCompleteAuthentication => 'Voltooi de authenticatie in je browser. Keer daarna terug naar de app.';
+
+  @override
+  String get failedToStartAuthentication => 'Kan authenticatie niet starten';
+
+  @override
+  String get importStarted => 'Import gestart! Je krijgt een melding wanneer het klaar is.';
+
+  @override
+  String get failedToStartImport => 'Kan import niet starten. Probeer het opnieuw.';
+
+  @override
+  String get couldNotAccessFile => 'Kan het geselecteerde bestand niet openen';
+
+  @override
+  String get askOmi => 'Vraag Omi';
+
+  @override
+  String get done => 'Klaar';
+
+  @override
+  String get disconnected => 'Niet verbonden';
+
+  @override
+  String get searching => 'Zoeken';
+
+  @override
+  String get connectDevice => 'Apparaat verbinden';
+
+  @override
+  String get monthlyLimitReached => 'Je hebt je maandelijkse limiet bereikt.';
+
+  @override
+  String get checkUsage => 'Verbruik controleren';
+
+  @override
+  String get syncingRecordings => 'Opnames synchroniseren';
+
+  @override
+  String get recordingsToSync => 'Opnames om te synchroniseren';
+
+  @override
+  String get allCaughtUp => 'Alles is bijgewerkt';
+
+  @override
+  String get sync => 'Synchroniseren';
+
+  @override
+  String get pendantUpToDate => 'Hanger is up-to-date';
+
+  @override
+  String get allRecordingsSynced => 'Alle opnames zijn gesynchroniseerd';
+
+  @override
+  String get syncingInProgress => 'Synchronisatie bezig';
+
+  @override
+  String get readyToSync => 'Klaar om te synchroniseren';
+
+  @override
+  String get tapSyncToStart => 'Tik op Synchroniseren om te starten';
+
+  @override
+  String get pendantNotConnected => 'Hanger niet verbonden. Verbind om te synchroniseren.';
+
+  @override
+  String get everythingSynced => 'Alles is al gesynchroniseerd.';
+
+  @override
+  String get recordingsNotSynced => 'Je hebt opnames die nog niet zijn gesynchroniseerd.';
+
+  @override
+  String get syncingBackground => 'We blijven je opnames op de achtergrond synchroniseren.';
+
+  @override
+  String get noConversationsYet => 'Nog geen gesprekken.';
+
+  @override
+  String get noStarredConversations => 'Nog geen favoriete gesprekken.';
+
+  @override
+  String get starConversationHint =>
+      'Om een gesprek als favoriet te markeren, open het en tik op het stericoon in de header.';
+
+  @override
+  String get searchConversations => 'Gesprekken zoeken';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count geselecteerd';
+  }
+
+  @override
+  String get merge => 'Samenvoegen';
+
+  @override
+  String get mergeConversations => 'Gesprekken samenvoegen';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Dit combineert $count gesprekken tot één. Alle inhoud wordt samengevoegd en opnieuw gegenereerd.';
+  }
+
+  @override
+  String get mergingInBackground => 'Samenvoegen op de achtergrond. Dit kan even duren.';
+
+  @override
+  String get failedToStartMerge => 'Kan samenvoegen niet starten';
+
+  @override
+  String get askAnything => 'Vraag wat je wilt';
+
+  @override
+  String get noMessagesYet => 'Nog geen berichten!\nWaarom begin je geen gesprek?';
+
+  @override
+  String get deletingMessages => 'Je berichten verwijderen uit Omi\'s geheugen...';
+
+  @override
+  String get messageCopied => 'Bericht gekopieerd naar klembord.';
+
+  @override
+  String get cannotReportOwnMessage => 'Je kunt je eigen berichten niet rapporteren.';
+
+  @override
+  String get reportMessage => 'Bericht rapporteren';
+
+  @override
+  String get reportMessageConfirm => 'Weet je zeker dat je dit bericht wilt rapporteren?';
+
+  @override
+  String get messageReported => 'Bericht succesvol gerapporteerd.';
+
+  @override
+  String get thankYouFeedback => 'Bedankt voor je feedback!';
+
+  @override
+  String get clearChat => 'Chat wissen?';
+
+  @override
+  String get clearChatConfirm =>
+      'Weet je zeker dat je de chat wilt wissen? Deze actie kan niet ongedaan worden gemaakt.';
+
+  @override
+  String get maxFilesLimit => 'Je kunt maximaal 4 bestanden tegelijk uploaden';
+
+  @override
+  String get chatWithOmi => 'Chat met Omi';
+
+  @override
+  String get apps => 'Apps';
+
+  @override
+  String get noAppsFound => 'Geen apps gevonden';
+
+  @override
+  String get tryAdjustingSearch => 'Probeer je zoekopdracht of filters aan te passen';
+
+  @override
+  String get createYourOwnApp => 'Maak je eigen app';
+
+  @override
+  String get buildAndShareApp => 'Bouw en deel je aangepaste app';
+
+  @override
+  String get searchApps => 'Zoek in 1500+ apps';
+
+  @override
+  String get myApps => 'Mijn apps';
+
+  @override
+  String get installedApps => 'Geïnstalleerde apps';
+
+  @override
+  String get unableToFetchApps =>
+      'Kan apps niet ophalen :(\n\nControleer je internetverbinding en probeer het opnieuw.';
+
+  @override
+  String get aboutOmi => 'Over Omi';
+
+  @override
+  String get privacyPolicy => 'Privacybeleid';
+
+  @override
+  String get visitWebsite => 'Website bezoeken';
+
+  @override
+  String get helpOrInquiries => 'Hulp of vragen?';
+
+  @override
+  String get joinCommunity => 'Word lid van de community!';
+
+  @override
+  String get membersAndCounting => '8000+ leden en groeiende.';
+
+  @override
+  String get deleteAccountTitle => 'Account verwijderen';
+
+  @override
+  String get deleteAccountConfirm => 'Weet je zeker dat je je account wilt verwijderen?';
+
+  @override
+  String get cannotBeUndone => 'Dit kan niet ongedaan worden gemaakt.';
+
+  @override
+  String get allDataErased => 'Al je herinneringen en gesprekken worden permanent verwijderd.';
+
+  @override
+  String get appsDisconnected => 'Je apps en integraties worden direct losgekoppeld.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Je kunt je gegevens exporteren voordat je je account verwijdert, maar eenmaal verwijderd kan het niet worden hersteld.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Ik begrijp dat het verwijderen van mijn account permanent is en alle gegevens, inclusief herinneringen en gesprekken, verloren gaan en niet kunnen worden hersteld.';
+
+  @override
+  String get areYouSure => 'Weet je het zeker?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Deze actie is onomkeerbaar en verwijdert permanent je account en alle bijbehorende gegevens. Weet je zeker dat je wilt doorgaan?';
+
+  @override
+  String get deleteNow => 'Nu verwijderen';
+
+  @override
+  String get goBack => 'Terug';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Vink het vakje aan om te bevestigen dat je begrijpt dat het verwijderen van je account permanent en onomkeerbaar is.';
+
+  @override
+  String get profile => 'Profiel';
+
+  @override
+  String get name => 'Naam';
+
+  @override
+  String get email => 'E-mail';
+
+  @override
+  String get customVocabulary => 'Aangepaste woordenlijst';
+
+  @override
+  String get identifyingOthers => 'Anderen identificeren';
+
+  @override
+  String get paymentMethods => 'Betaalmethoden';
+
+  @override
+  String get conversationDisplay => 'Gespreksweergave';
+
+  @override
+  String get dataPrivacy => 'Gegevens en privacy';
+
+  @override
+  String get userId => 'Gebruikers-ID';
+
+  @override
+  String get notSet => 'Niet ingesteld';
+
+  @override
+  String get userIdCopied => 'Gebruikers-ID gekopieerd naar klembord';
+
+  @override
+  String get systemDefault => 'Systeemstandaard';
+
+  @override
+  String get planAndUsage => 'Abonnement en gebruik';
+
+  @override
+  String get offlineSync => 'Offline synchronisatie';
+
+  @override
+  String get deviceSettings => 'Apparaatinstellingen';
+
+  @override
+  String get chatTools => 'Chat-tools';
+
+  @override
+  String get feedbackBug => 'Feedback / Bug';
+
+  @override
+  String get helpCenter => 'Helpcentrum';
+
+  @override
+  String get developerSettings => 'Ontwikkelaarsinstellingen';
+
+  @override
+  String get getOmiForMac => 'Omi voor Mac downloaden';
+
+  @override
+  String get referralProgram => 'Doorverwijsprogramma';
+
+  @override
+  String get signOut => 'Uitloggen';
+
+  @override
+  String get appAndDeviceCopied => 'App- en apparaatgegevens gekopieerd';
+
+  @override
+  String get wrapped2025 => 'Terugblik 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Jouw privacy, jouw controle';
+
+  @override
+  String get privacyIntro =>
+      'Bij Omi zijn we toegewijd aan het beschermen van je privacy. Deze pagina stelt je in staat om te bepalen hoe je gegevens worden opgeslagen en gebruikt.';
+
+  @override
+  String get learnMore => 'Meer informatie...';
+
+  @override
+  String get dataProtectionLevel => 'Gegevensbeschermingsniveau';
+
+  @override
+  String get dataProtectionDesc =>
+      'Je gegevens zijn standaard beveiligd met sterke encryptie. Bekijk hieronder je instellingen en toekomstige privacy-opties.';
+
+  @override
+  String get appAccess => 'App-toegang';
+
+  @override
+  String get appAccessDesc =>
+      'De volgende apps hebben toegang tot je gegevens. Tik op een app om de machtigingen te beheren.';
+
+  @override
+  String get noAppsExternalAccess => 'Geen geïnstalleerde apps hebben externe toegang tot je gegevens.';
+
+  @override
+  String get deviceName => 'Apparaatnaam';
+
+  @override
+  String get deviceId => 'Apparaat-ID';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'SD-kaart synchronisatie';
+
+  @override
+  String get hardwareRevision => 'Hardwarerevisie';
+
+  @override
+  String get modelNumber => 'Modelnummer';
+
+  @override
+  String get manufacturer => 'Fabrikant';
+
+  @override
+  String get doubleTap => 'Dubbel tikken';
+
+  @override
+  String get ledBrightness => 'LED-helderheid';
+
+  @override
+  String get micGain => 'Microfoonversterking';
+
+  @override
+  String get disconnect => 'Loskoppelen';
+
+  @override
+  String get forgetDevice => 'Apparaat vergeten';
+
+  @override
+  String get chargingIssues => 'Oplaadproblemen';
+
+  @override
+  String get disconnectDevice => 'Apparaat loskoppelen';
+
+  @override
+  String get unpairDevice => 'Apparaat ontkoppelen';
+
+  @override
+  String get unpairAndForget => 'Apparaat ontkoppelen en vergeten';
+
+  @override
+  String get deviceDisconnectedMessage => 'Je Omi is losgekoppeld 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Apparaat ontkoppeld. Ga naar Instellingen > Bluetooth en vergeet het apparaat om het ontkoppelen te voltooien.';
+
+  @override
+  String get unpairDialogTitle => 'Apparaat ontkoppelen';
+
+  @override
+  String get unpairDialogMessage =>
+      'Dit ontkoppelt het apparaat zodat het met een andere telefoon kan worden verbonden. Je moet naar Instellingen > Bluetooth gaan en het apparaat vergeten om het proces te voltooien.';
+
+  @override
+  String get deviceNotConnected => 'Apparaat niet verbonden';
+
+  @override
+  String get connectDeviceMessage =>
+      'Verbind je Omi-apparaat om toegang te krijgen tot\napparaatinstellingen en aanpassingen';
+
+  @override
+  String get deviceInfoSection => 'Apparaatinformatie';
+
+  @override
+  String get customizationSection => 'Aanpassingen';
+
+  @override
+  String get hardwareSection => 'Hardware';
+
+  @override
+  String get v2Undetected => 'V2 niet gedetecteerd';
+
+  @override
+  String get v2UndetectedMessage =>
+      'We zien dat je een V1-apparaat hebt of je apparaat is niet verbonden. SD-kaartfunctionaliteit is alleen beschikbaar voor V2-apparaten.';
+
+  @override
+  String get endConversation => 'Gesprek beëindigen';
+
+  @override
+  String get pauseResume => 'Pauzeren/Hervatten';
+
+  @override
+  String get starConversation => 'Gesprek als favoriet markeren';
+
+  @override
+  String get doubleTapAction => 'Dubbel tikken actie';
+
+  @override
+  String get endAndProcess => 'Gesprek beëindigen en verwerken';
+
+  @override
+  String get pauseResumeRecording => 'Opname pauzeren/hervatten';
+
+  @override
+  String get starOngoing => 'Lopend gesprek als favoriet markeren';
+
+  @override
+  String get off => 'Uit';
+
+  @override
+  String get max => 'Max';
+
+  @override
+  String get mute => 'Dempen';
+
+  @override
+  String get quiet => 'Stil';
+
+  @override
+  String get normal => 'Normaal';
+
+  @override
+  String get high => 'Hoog';
+
+  @override
+  String get micGainDescMuted => 'Microfoon is gedempt';
+
+  @override
+  String get micGainDescLow => 'Zeer stil - voor luidruchtige omgevingen';
+
+  @override
+  String get micGainDescModerate => 'Stil - voor matig geluid';
+
+  @override
+  String get micGainDescNeutral => 'Neutraal - gebalanceerde opname';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Licht versterkt - normaal gebruik';
+
+  @override
+  String get micGainDescBoosted => 'Versterkt - voor stille omgevingen';
+
+  @override
+  String get micGainDescHigh => 'Hoog - voor verre of zachte stemmen';
+
+  @override
+  String get micGainDescVeryHigh => 'Zeer hoog - voor zeer stille bronnen';
+
+  @override
+  String get micGainDescMax => 'Maximum - gebruik met voorzichtigheid';
+
+  @override
+  String get developerSettingsTitle => 'Ontwikkelaarsinstellingen';
+
+  @override
+  String get saving => 'Opslaan...';
+
+  @override
+  String get personaConfig => 'Configureer je AI-persona';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transcriptie';
+
+  @override
+  String get transcriptionConfig => 'STT-provider configureren';
+
+  @override
+  String get conversationTimeout => 'Gesprekstime-out';
+
+  @override
+  String get conversationTimeoutConfig => 'Instellen wanneer gesprekken automatisch eindigen';
+
+  @override
+  String get importData => 'Gegevens importeren';
+
+  @override
+  String get importDataConfig => 'Gegevens importeren uit andere bronnen';
+
+  @override
+  String get debugDiagnostics => 'Debug en diagnostiek';
+
+  @override
+  String get endpointUrl => 'Endpoint-URL';
+
+  @override
+  String get noApiKeys => 'Nog geen API-sleutels';
+
+  @override
+  String get createKeyToStart => 'Maak een sleutel aan om te beginnen';
+
+  @override
+  String get createKey => 'Sleutel aanmaken';
+
+  @override
+  String get docs => 'Documentatie';
+
+  @override
+  String get yourOmiInsights => 'Je Omi-inzichten';
+
+  @override
+  String get today => 'Vandaag';
+
+  @override
+  String get thisMonth => 'Deze maand';
+
+  @override
+  String get thisYear => 'Dit jaar';
+
+  @override
+  String get allTime => 'Altijd';
+
+  @override
+  String get noActivityYet => 'Nog geen activiteit';
+
+  @override
+  String get startConversationToSeeInsights => 'Start een gesprek met Omi\nom je gebruiksinzichten hier te zien.';
+
+  @override
+  String get listening => 'Luisteren';
+
+  @override
+  String get listeningSubtitle => 'Totale tijd dat Omi actief heeft geluisterd.';
+
+  @override
+  String get understanding => 'Begrijpen';
+
+  @override
+  String get understandingSubtitle => 'Woorden begrepen uit je gesprekken.';
+
+  @override
+  String get providing => 'Leveren';
+
+  @override
+  String get providingSubtitle => 'Actiepunten en notities automatisch vastgelegd.';
+
+  @override
+  String get remembering => 'Onthouden';
+
+  @override
+  String get rememberingSubtitle => 'Feiten en details voor je onthouden.';
+
+  @override
+  String get unlimitedPlan => 'Onbeperkt abonnement';
+
+  @override
+  String get managePlan => 'Abonnement beheren';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Je abonnement wordt geannuleerd op $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Je abonnement wordt verlengd op $date.';
+  }
+
+  @override
+  String get basicPlan => 'Gratis abonnement';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used van $limit min gebruikt';
+  }
+
+  @override
+  String get upgrade => 'Upgraden';
+
+  @override
+  String get upgradeToUnlimited => 'Upgraden naar onbeperkt';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Je abonnement bevat $limit gratis minuten per maand. Upgrade naar onbeperkt.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Ik deel mijn Omi-statistieken! (omi.me - je altijd-aan AI-assistent)';
+
+  @override
+  String get sharePeriodToday => 'Vandaag heeft Omi:';
+
+  @override
+  String get sharePeriodMonth => 'Deze maand heeft Omi:';
+
+  @override
+  String get sharePeriodYear => 'Dit jaar heeft Omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Tot nu toe heeft Omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 $minutes minuten geluisterd';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 $words woorden begrepen';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ $count inzichten gegeven';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 $count herinneringen onthouden';
+  }
+
+  @override
+  String get debugLogs => 'Debug-logboeken';
+
+  @override
+  String get debugLogsAutoDelete => 'Automatisch verwijderd na 3 dagen.';
+
+  @override
+  String get debugLogsDesc => 'Helpt bij het diagnosticeren van problemen';
+
+  @override
+  String get noLogFilesFound => 'Geen logbestanden gevonden.';
+
+  @override
+  String get omiDebugLog => 'Omi debug-log';
+
+  @override
+  String get logShared => 'Log gedeeld';
+
+  @override
+  String get selectLogFile => 'Logbestand selecteren';
+
+  @override
+  String get shareLogs => 'Logboeken delen';
+
+  @override
+  String get debugLogCleared => 'Debug-log gewist';
+
+  @override
+  String get exportStarted => 'Export gestart. Dit kan enkele seconden duren...';
+
+  @override
+  String get exportAllData => 'Alle gegevens exporteren';
+
+  @override
+  String get exportDataDesc => 'Gesprekken exporteren naar een JSON-bestand';
+
+  @override
+  String get exportedConversations => 'Geëxporteerde gesprekken van Omi';
+
+  @override
+  String get exportShared => 'Export gedeeld';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Kennisgraaf verwijderen?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Dit verwijdert alle afgeleide kennisgraafgegevens (knooppunten en verbindingen). Je originele herinneringen blijven veilig. De graaf wordt na verloop van tijd of bij het volgende verzoek opnieuw opgebouwd.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Kennisgraaf succesvol verwijderd';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Verwijderen graaf mislukt: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Kennisgraaf verwijderen';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Alle knooppunten en verbindingen wissen';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP-server';
+
+  @override
+  String get mcpServerDesc => 'AI-assistenten verbinden met je gegevens';
+
+  @override
+  String get serverUrl => 'Server-URL';
+
+  @override
+  String get urlCopied => 'URL gekopieerd';
+
+  @override
+  String get apiKeyAuth => 'API-sleutel authenticatie';
+
+  @override
+  String get header => 'Header';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <sleutel>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Client-ID';
+
+  @override
+  String get clientSecret => 'Client-geheim';
+
+  @override
+  String get useMcpApiKey => 'Gebruik je MCP API-sleutel';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Gespreksgebeurtenissen';
+
+  @override
+  String get newConversationCreated => 'Nieuw gesprek aangemaakt';
+
+  @override
+  String get realtimeTranscript => 'Realtime transcript';
+
+  @override
+  String get transcriptReceived => 'Transcript ontvangen';
+
+  @override
+  String get audioBytes => 'Audiobytes';
+
+  @override
+  String get audioDataReceived => 'Audiogegevens ontvangen';
+
+  @override
+  String get intervalSeconds => 'Interval (seconden)';
+
+  @override
+  String get daySummary => 'Dagsamenvatting';
+
+  @override
+  String get summaryGenerated => 'Samenvatting gegenereerd';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Toevoegen aan claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Configuratie kopiëren';
+
+  @override
+  String get configCopied => 'Configuratie gekopieerd naar klembord';
+
+  @override
+  String get listeningMins => 'Luisteren (min)';
+
+  @override
+  String get understandingWords => 'Begrijpen (woorden)';
+
+  @override
+  String get insights => 'Inzichten';
+
+  @override
+  String get memories => 'Herinneringen';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used van $limit min gebruikt deze maand';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used van $limit woorden gebruikt deze maand';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used van $limit inzichten verkregen deze maand';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used van $limit herinneringen aangemaakt deze maand';
+  }
+
+  @override
+  String get visibility => 'Zichtbaarheid';
+
+  @override
+  String get visibilitySubtitle => 'Bepaal welke gesprekken in je lijst verschijnen';
+
+  @override
+  String get showShortConversations => 'Korte gesprekken tonen';
+
+  @override
+  String get showShortConversationsDesc => 'Gesprekken korter dan de drempel weergeven';
+
+  @override
+  String get showDiscardedConversations => 'Verwijderde gesprekken tonen';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Gesprekken gemarkeerd als verwijderd opnemen';
+
+  @override
+  String get shortConversationThreshold => 'Drempel voor korte gesprekken';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Gesprekken korter dan dit worden verborgen tenzij hierboven ingeschakeld';
+
+  @override
+  String get durationThreshold => 'Duurdrempel';
+
+  @override
+  String get durationThresholdDesc => 'Gesprekken korter dan dit verbergen';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Aangepaste woordenlijst';
+
+  @override
+  String get addWords => 'Woorden toevoegen';
+
+  @override
+  String get addWordsDesc => 'Namen, termen of ongewone woorden';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Verbinden';
+
+  @override
+  String get comingSoon => 'Binnenkort beschikbaar';
+
+  @override
+  String get chatToolsFooter => 'Verbind je apps om gegevens en statistieken in de chat te bekijken.';
+
+  @override
+  String get completeAuthInBrowser => 'Voltooi de authenticatie in je browser. Keer daarna terug naar de app.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Kan $appName-authenticatie niet starten';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return '$appName loskoppelen?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Weet je zeker dat je de verbinding met $appName wilt verbreken? Je kunt altijd opnieuw verbinden.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Losgekoppeld van $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Loskoppelen mislukt';
+
+  @override
+  String connectTo(String appName) {
+    return 'Verbinden met $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Je moet Omi autoriseren om toegang te krijgen tot je $appName-gegevens. Dit opent je browser voor authenticatie.';
+  }
+
+  @override
+  String get continueAction => 'Doorgaan';
+
+  @override
+  String get languageTitle => 'Taal';
+
+  @override
+  String get primaryLanguage => 'Primaire taal';
+
+  @override
+  String get automaticTranslation => 'Automatische vertaling';
+
+  @override
+  String get detectLanguages => 'Detecteer 10+ talen';
+
+  @override
+  String get authorizeSavingRecordings => 'Opnames opslaan autoriseren';
+
+  @override
+  String get thanksForAuthorizing => 'Bedankt voor het autoriseren!';
+
+  @override
+  String get needYourPermission => 'We hebben je toestemming nodig';
+
+  @override
+  String get alreadyGavePermission =>
+      'Je hebt ons al toestemming gegeven om je opnames op te slaan. Hier is een herinnering waarom we het nodig hebben:';
+
+  @override
+  String get wouldLikePermission => 'We willen graag je toestemming om je spraakopnames op te slaan. Dit is waarom:';
+
+  @override
+  String get improveSpeechProfile => 'Verbeter je spraakprofiel';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'We gebruiken opnames om je persoonlijke spraakprofiel verder te trainen en te verbeteren.';
+
+  @override
+  String get trainFamilyProfiles => 'Train profielen voor vrienden en familie';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Je opnames helpen ons om profielen voor je vrienden en familie te herkennen en aan te maken.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Verbeter transcriptnauwkeurigheid';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Naarmate ons model verbetert, kunnen we betere transcriptieresultaten voor je opnames bieden.';
+
+  @override
+  String get legalNotice =>
+      'Juridische kennisgeving: De legaliteit van het opnemen en opslaan van spraakgegevens kan variëren afhankelijk van je locatie en hoe je deze functie gebruikt. Het is jouw verantwoordelijkheid om naleving van lokale wet- en regelgeving te waarborgen.';
+
+  @override
+  String get alreadyAuthorized => 'Al geautoriseerd';
+
+  @override
+  String get authorize => 'Autoriseren';
+
+  @override
+  String get revokeAuthorization => 'Autorisatie intrekken';
+
+  @override
+  String get authorizationSuccessful => 'Autorisatie succesvol!';
+
+  @override
+  String get failedToAuthorize => 'Autorisatie mislukt. Probeer het opnieuw.';
+
+  @override
+  String get authorizationRevoked => 'Autorisatie ingetrokken.';
+
+  @override
+  String get recordingsDeleted => 'Opnames verwijderd.';
+
+  @override
+  String get failedToRevoke => 'Autorisatie intrekken mislukt. Probeer het opnieuw.';
+
+  @override
+  String get permissionRevokedTitle => 'Toestemming ingetrokken';
+
+  @override
+  String get permissionRevokedMessage => 'Wil je dat we ook al je bestaande opnames verwijderen?';
+
+  @override
+  String get yes => 'Ja';
+
+  @override
+  String get editName => 'Naam bewerken';
+
+  @override
+  String get howShouldOmiCallYou => 'Hoe moet Omi je noemen?';
+
+  @override
+  String get enterYourName => 'Voer je naam in';
+
+  @override
+  String get nameCannotBeEmpty => 'Naam mag niet leeg zijn';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Naam succesvol bijgewerkt!';
+
+  @override
+  String get calendarSettings => 'Agenda-instellingen';
+
+  @override
+  String get calendarProviders => 'Agenda-providers';
+
+  @override
+  String get macOsCalendar => 'macOS-agenda';
+
+  @override
+  String get connectMacOsCalendar => 'Verbind je lokale macOS-agenda';
+
+  @override
+  String get googleCalendar => 'Google Agenda';
+
+  @override
+  String get syncGoogleAccount => 'Synchroniseer met je Google-account';
+
+  @override
+  String get showMeetingsMenuBar => 'Toon aankomende vergaderingen in menubalk';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Toon je volgende vergadering en tijd tot deze begint in de macOS-menubalk';
+
+  @override
+  String get showEventsNoParticipants => 'Evenementen zonder deelnemers tonen';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Wanneer ingeschakeld, toont Binnenkort evenementen zonder deelnemers of videolink.';
+
+  @override
+  String get yourMeetings => 'Je vergaderingen';
+
+  @override
+  String get refresh => 'Vernieuwen';
+
+  @override
+  String get noUpcomingMeetings => 'Geen aankomende vergaderingen gevonden';
+
+  @override
+  String get checkingNextDays => 'Volgende 30 dagen controleren';
+
+  @override
+  String get tomorrow => 'Morgen';
+
+  @override
+  String get googleCalendarComingSoon => 'Google Agenda-integratie komt binnenkort!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Verbonden als gebruiker: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Standaard werkruimte';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Taken worden aangemaakt in deze werkruimte';
+
+  @override
+  String get defaultProjectOptional => 'Standaardproject (optioneel)';
+
+  @override
+  String get leaveUnselectedTasks => 'Laat niet geselecteerd om taken zonder project aan te maken';
+
+  @override
+  String get noProjectsInWorkspace => 'Geen projecten gevonden in deze werkruimte';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Kies hoe lang te wachten in stilte voordat een gesprek automatisch wordt beëindigd:';
+
+  @override
+  String get timeout2Minutes => '2 minuten';
+
+  @override
+  String get timeout2MinutesDesc => 'Gesprek beëindigen na 2 minuten stilte';
+
+  @override
+  String get timeout5Minutes => '5 minuten';
+
+  @override
+  String get timeout5MinutesDesc => 'Gesprek beëindigen na 5 minuten stilte';
+
+  @override
+  String get timeout10Minutes => '10 minuten';
+
+  @override
+  String get timeout10MinutesDesc => 'Gesprek beëindigen na 10 minuten stilte';
+
+  @override
+  String get timeout30Minutes => '30 minuten';
+
+  @override
+  String get timeout30MinutesDesc => 'Gesprek beëindigen na 30 minuten stilte';
+
+  @override
+  String get timeout4Hours => '4 uur';
+
+  @override
+  String get timeout4HoursDesc => 'Gesprek beëindigen na 4 uur stilte';
+
+  @override
+  String get conversationEndAfterHours => 'Gesprekken eindigen nu na 4 uur stilte';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Gesprekken eindigen nu na $minutes minuut/minuten stilte';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Vertel ons je primaire taal';
+
+  @override
+  String get languageForTranscription =>
+      'Stel je taal in voor scherpere transcripties en een gepersonaliseerde ervaring.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Enkeltaalmodus is ingeschakeld. Vertaling is uitgeschakeld voor hogere nauwkeurigheid.';
+
+  @override
+  String get searchLanguageHint => 'Zoek taal op naam of code';
+
+  @override
+  String get noLanguagesFound => 'Geen talen gevonden';
+
+  @override
+  String get skip => 'Overslaan';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Taal ingesteld op $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Kan taal niet instellen';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName-instellingen';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Loskoppelen van $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Dit verwijdert je $appName-authenticatie. Je moet opnieuw verbinden om het weer te gebruiken.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Verbonden met $appName';
+  }
+
+  @override
+  String get account => 'Account';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Je actiepunten worden gesynchroniseerd met je $appName-account';
+  }
+
+  @override
+  String get defaultSpace => 'Standaardruimte';
+
+  @override
+  String get selectSpaceInWorkspace => 'Selecteer een ruimte in je werkruimte';
+
+  @override
+  String get noSpacesInWorkspace => 'Geen ruimtes gevonden in deze werkruimte';
+
+  @override
+  String get defaultList => 'Standaardlijst';
+
+  @override
+  String get tasksAddedToList => 'Taken worden toegevoegd aan deze lijst';
+
+  @override
+  String get noListsInSpace => 'Geen lijsten gevonden in deze ruimte';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Laden van repositories mislukt: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Standaard repository opgeslagen';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Opslaan van standaard repository mislukt';
+
+  @override
+  String get defaultRepository => 'Standaard repository';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Selecteer een standaard repository voor het aanmaken van issues. Je kunt nog steeds een andere repository opgeven bij het aanmaken van issues.';
+
+  @override
+  String get noReposFound => 'Geen repositories gevonden';
+
+  @override
+  String get private => 'Privé';
+
+  @override
+  String updatedDate(String date) {
+    return 'Bijgewerkt $date';
+  }
+
+  @override
+  String get yesterday => 'gisteren';
+
+  @override
+  String daysAgo(int count) {
+    return '$count dagen geleden';
+  }
+
+  @override
+  String get oneWeekAgo => '1 week geleden';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count weken geleden';
+  }
+
+  @override
+  String get oneMonthAgo => '1 maand geleden';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count maanden geleden';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Issues worden aangemaakt in je standaard repository';
+
+  @override
+  String get taskIntegrations => 'Taakintegraties';
+
+  @override
+  String get configureSettings => 'Instellingen configureren';
+
+  @override
+  String get completeAuthBrowser => 'Voltooi de authenticatie in je browser. Keer daarna terug naar de app.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Kan $appName-authenticatie niet starten';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Verbinden met $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Je moet Omi autoriseren om taken aan te maken in je $appName-account. Dit opent je browser voor authenticatie.';
+  }
+
+  @override
+  String get continueButton => 'Doorgaan';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName-integratie';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integratie met $appName komt binnenkort! We werken hard om je meer taakbeheeropties te bieden.';
+  }
+
+  @override
+  String get gotIt => 'Begrepen';
+
+  @override
+  String get tasksExportedOneApp => 'Taken kunnen naar één app tegelijk worden geëxporteerd.';
+
+  @override
+  String get completeYourUpgrade => 'Voltooi je upgrade';
+
+  @override
+  String get importConfiguration => 'Configuratie importeren';
+
+  @override
+  String get exportConfiguration => 'Configuratie exporteren';
+
+  @override
+  String get bringYourOwn => 'Breng je eigen mee';
+
+  @override
+  String get payYourSttProvider => 'Gebruik Omi vrij. Je betaalt alleen je STT-provider rechtstreeks.';
+
+  @override
+  String get freeMinutesMonth => '1.200 gratis minuten/maand inbegrepen. Onbeperkt met ';
+
+  @override
+  String get omiUnlimited => 'Omi Onbeperkt';
+
+  @override
+  String get hostRequired => 'Host is vereist';
+
+  @override
+  String get validPortRequired => 'Geldige poort is vereist';
+
+  @override
+  String get validWebsocketUrlRequired => 'Geldige WebSocket-URL is vereist (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API-URL is vereist';
+
+  @override
+  String get apiKeyRequired => 'API-sleutel is vereist';
+
+  @override
+  String get invalidJsonConfig => 'Ongeldige JSON-configuratie';
+
+  @override
+  String errorSaving(String error) {
+    return 'Fout bij opslaan: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Configuratie gekopieerd naar klembord';
+
+  @override
+  String get pasteJsonConfig => 'Plak je JSON-configuratie hieronder:';
+
+  @override
+  String get addApiKeyAfterImport => 'Je moet je eigen API-sleutel toevoegen na het importeren';
+
+  @override
+  String get paste => 'Plakken';
+
+  @override
+  String get import => 'Importeren';
+
+  @override
+  String get invalidProviderInConfig => 'Ongeldige provider in configuratie';
+
+  @override
+  String importedConfig(String providerName) {
+    return '$providerName-configuratie geïmporteerd';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Ongeldige JSON: $error';
+  }
+
+  @override
+  String get provider => 'Provider';
+
+  @override
+  String get live => 'Live';
+
+  @override
+  String get onDevice => 'Op apparaat';
+
+  @override
+  String get apiUrl => 'API-URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Voer je STT HTTP-endpoint in';
+
+  @override
+  String get websocketUrl => 'WebSocket-URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Voer je live STT WebSocket-endpoint in';
+
+  @override
+  String get apiKey => 'API-sleutel';
+
+  @override
+  String get enterApiKey => 'Voer je API-sleutel in';
+
+  @override
+  String get storedLocallyNeverShared => 'Lokaal opgeslagen, nooit gedeeld';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Poort';
+
+  @override
+  String get advanced => 'Geavanceerd';
+
+  @override
+  String get configuration => 'Configuratie';
+
+  @override
+  String get requestConfiguration => 'Verzoek configuratie';
+
+  @override
+  String get responseSchema => 'Response schema';
+
+  @override
+  String get modified => 'Aangepast';
+
+  @override
+  String get resetRequestConfig => 'Verzoekconfiguratie resetten naar standaard';
+
+  @override
+  String get logs => 'Logboeken';
+
+  @override
+  String get logsCopied => 'Logboeken gekopieerd';
+
+  @override
+  String get noLogsYet => 'Nog geen logboeken. Start een opname om aangepaste STT-activiteit te zien.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName gebruikt $codecReason. Omi wordt gebruikt.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi-transcriptie';
+
+  @override
+  String get bestInClassTranscription => 'Beste transcriptie zonder configuratie';
+
+  @override
+  String get instantSpeakerLabels => 'Directe sprekerslabels';
+
+  @override
+  String get languageTranslation => '100+ taalvertaling';
+
+  @override
+  String get optimizedForConversation => 'Geoptimaliseerd voor gesprekken';
+
+  @override
+  String get autoLanguageDetection => 'Automatische taaldetectie';
+
+  @override
+  String get highAccuracy => 'Hoge nauwkeurigheid';
+
+  @override
+  String get privacyFirst => 'Privacy eerst';
+
+  @override
+  String get saveChanges => 'Wijzigingen opslaan';
+
+  @override
+  String get resetToDefault => 'Resetten naar standaard';
+
+  @override
+  String get viewTemplate => 'Template bekijken';
+
+  @override
+  String get trySomethingLike => 'Probeer iets als...';
+
+  @override
+  String get tryIt => 'Probeer het';
+
+  @override
+  String get creatingPlan => 'Plan maken';
+
+  @override
+  String get developingLogic => 'Logica ontwikkelen';
+
+  @override
+  String get designingApp => 'App ontwerpen';
+
+  @override
+  String get generatingIconStep => 'Icoon genereren';
+
+  @override
+  String get finalTouches => 'Laatste aanpassingen';
+
+  @override
+  String get processing => 'Verwerken...';
+
+  @override
+  String get features => 'Functies';
+
+  @override
+  String get creatingYourApp => 'Je app maken...';
+
+  @override
+  String get generatingIcon => 'Icoon genereren...';
+
+  @override
+  String get whatShouldWeMake => 'Wat zullen we maken?';
+
+  @override
+  String get appName => 'App-naam';
+
+  @override
+  String get description => 'Beschrijving';
+
+  @override
+  String get publicLabel => 'Openbaar';
+
+  @override
+  String get privateLabel => 'Privé';
+
+  @override
+  String get free => 'Gratis';
+
+  @override
+  String get perMonth => '/ Maand';
+
+  @override
+  String get tailoredConversationSummaries => 'Op maat gemaakte gesprekssamenvattingen';
+
+  @override
+  String get customChatbotPersonality => 'Aangepaste chatbot-persoonlijkheid';
+
+  @override
+  String get makePublic => 'Openbaar maken';
+
+  @override
+  String get anyoneCanDiscover => 'Iedereen kan je app ontdekken';
+
+  @override
+  String get onlyYouCanUse => 'Alleen jij kunt deze app gebruiken';
+
+  @override
+  String get paidApp => 'Betaalde app';
+
+  @override
+  String get usersPayToUse => 'Gebruikers betalen om je app te gebruiken';
+
+  @override
+  String get freeForEveryone => 'Gratis voor iedereen';
+
+  @override
+  String get perMonthLabel => '/ maand';
+
+  @override
+  String get creating => 'Maken...';
+
+  @override
+  String get createApp => 'App maken';
+
+  @override
+  String get searchingForDevices => 'Zoeken naar apparaten...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'APPARATEN',
+      one: 'APPARAAT',
+    );
+    return '$count $_temp0 GEVONDEN IN DE BUURT';
+  }
+
+  @override
+  String get pairingSuccessful => 'KOPPELEN SUCCESVOL';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Fout bij verbinden met Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Niet meer tonen';
+
+  @override
+  String get iUnderstand => 'Ik begrijp het';
+
+  @override
+  String get enableBluetooth => 'Bluetooth inschakelen';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi heeft Bluetooth nodig om verbinding te maken met je wearable. Schakel Bluetooth in en probeer het opnieuw.';
+
+  @override
+  String get contactSupport => 'Contact opnemen met support?';
+
+  @override
+  String get connectLater => 'Later verbinden';
+
+  @override
+  String get grantPermissions => 'Machtigingen verlenen';
+
+  @override
+  String get backgroundActivity => 'Achtergrondactiviteit';
+
+  @override
+  String get backgroundActivityDesc => 'Laat Omi op de achtergrond draaien voor betere stabiliteit';
+
+  @override
+  String get locationAccess => 'Locatietoegang';
+
+  @override
+  String get locationAccessDesc => 'Schakel achtergrondlocatie in voor de volledige ervaring';
+
+  @override
+  String get notifications => 'Meldingen';
+
+  @override
+  String get notificationsDesc => 'Schakel meldingen in om op de hoogte te blijven';
+
+  @override
+  String get locationServiceDisabled => 'Locatieservice uitgeschakeld';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Locatieservice is uitgeschakeld. Ga naar Instellingen > Privacy en beveiliging > Locatievoorzieningen en schakel deze in';
+
+  @override
+  String get backgroundLocationDenied => 'Achtergrondlocatietoegang geweigerd';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Ga naar apparaatinstellingen en stel locatiemachtiging in op \"Altijd toestaan\"';
+
+  @override
+  String get lovingOmi => 'Ben je blij met Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Help ons meer mensen te bereiken door een review achter te laten in de App Store. Je feedback betekent enorm veel voor ons!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Help ons meer mensen te bereiken door een review achter te laten in de Google Play Store. Je feedback betekent enorm veel voor ons!';
+
+  @override
+  String get rateOnAppStore => 'Beoordelen in App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Beoordelen in Google Play';
+
+  @override
+  String get maybeLater => 'Misschien later';
+
+  @override
+  String get speechProfileIntro => 'Omi moet je doelen en je stem leren. Je kunt dit later aanpassen.';
+
+  @override
+  String get getStarted => 'Aan de slag';
+
+  @override
+  String get allDone => 'Helemaal klaar!';
+
+  @override
+  String get keepGoing => 'Ga zo door, je doet het geweldig';
+
+  @override
+  String get skipThisQuestion => 'Deze vraag overslaan';
+
+  @override
+  String get skipForNow => 'Voorlopig overslaan';
+
+  @override
+  String get connectionError => 'Verbindingsfout';
+
+  @override
+  String get connectionErrorDesc =>
+      'Kan geen verbinding maken met de server. Controleer je internetverbinding en probeer het opnieuw.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Ongeldige opname gedetecteerd';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Het lijkt erop dat er meerdere sprekers in de opname zijn. Zorg ervoor dat je op een rustige locatie bent en probeer het opnieuw.';
+
+  @override
+  String get tooShortDesc => 'Er is niet genoeg spraak gedetecteerd. Spreek meer en probeer het opnieuw.';
+
+  @override
+  String get invalidRecordingDesc => 'Zorg ervoor dat je minimaal 5 seconden en niet meer dan 90 seconden spreekt.';
+
+  @override
+  String get areYouThere => 'Ben je er nog?';
+
+  @override
+  String get noSpeechDesc =>
+      'We konden geen spraak detecteren. Zorg ervoor dat je minimaal 10 seconden en niet meer dan 3 minuten spreekt.';
+
+  @override
+  String get connectionLost => 'Verbinding verbroken';
+
+  @override
+  String get connectionLostDesc =>
+      'De verbinding is onderbroken. Controleer je internetverbinding en probeer het opnieuw.';
+
+  @override
+  String get tryAgain => 'Opnieuw proberen';
+
+  @override
+  String get connectOmiOmiGlass => 'Omi / OmiGlass verbinden';
+
+  @override
+  String get continueWithoutDevice => 'Doorgaan zonder apparaat';
+
+  @override
+  String get permissionsRequired => 'Machtigingen vereist';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Deze app heeft Bluetooth- en locatiemachtigingen nodig om correct te functioneren. Schakel deze in via de instellingen.';
+
+  @override
+  String get openSettings => 'Instellingen openen';
+
+  @override
+  String get wantDifferentName => 'Wil je een andere naam gebruiken?';
+
+  @override
+  String get whatsYourName => 'Hoe heet je?';
+
+  @override
+  String get speakTranscribeSummarize => 'Spreek. Transcribeer. Vat samen.';
+
+  @override
+  String get signInWithApple => 'Inloggen met Apple';
+
+  @override
+  String get signInWithGoogle => 'Inloggen met Google';
+
+  @override
+  String get byContinuingAgree => 'Door verder te gaan, ga je akkoord met ons ';
+
+  @override
+  String get termsOfUse => 'Gebruiksvoorwaarden';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Je AI-metgezel';
+
+  @override
+  String get captureEveryMoment =>
+      'Leg elk moment vast. Krijg AI-aangedreven\nsamenvattingen. Nooit meer notities maken.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch instellen';
+
+  @override
+  String get permissionRequestedExclaim => 'Toestemming gevraagd!';
+
+  @override
+  String get microphonePermission => 'Microfoontoestemming';
+
+  @override
+  String get permissionGrantedNow =>
+      'Toestemming verleend! Nu:\n\nOpen de Omi-app op je horloge en tik hieronder op \"Doorgaan\"';
+
+  @override
+  String get needMicrophonePermission =>
+      'We hebben microfoontoestemming nodig.\n\n1. Tik op \"Toestemming verlenen\"\n2. Sta toe op je iPhone\n3. Horloge-app sluit\n4. Heropen en tik op \"Doorgaan\"';
+
+  @override
+  String get grantPermissionButton => 'Toestemming verlenen';
+
+  @override
+  String get needHelp => 'Hulp nodig?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Probleemoplossing:\n\n1. Zorg dat Omi op je horloge is geïnstalleerd\n2. Open de Omi-app op je horloge\n3. Zoek naar de toestemmingspopup\n4. Tik op \"Toestaan\" wanneer gevraagd\n5. App op je horloge sluit - heropen deze\n6. Kom terug en tik op \"Doorgaan\" op je iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Opname succesvol gestart!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Toestemming nog niet verleend. Zorg dat je microfoontoestemming hebt gegeven en de app op je horloge hebt heropend.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Fout bij het vragen van toestemming: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Fout bij het starten van opname: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Selecteer je primaire taal';
+
+  @override
+  String get languageBenefits => 'Stel je taal in voor scherpere transcripties en een gepersonaliseerde ervaring';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Wat is je primaire taal?';
+
+  @override
+  String get selectYourLanguage => 'Selecteer je taal';
+
+  @override
+  String get personalGrowthJourney => 'Je persoonlijke groeireis met AI die naar elk woord luistert.';
+
+  @override
+  String get actionItemsTitle => 'Taken';
+
+  @override
+  String get actionItemsDescription => 'Tik om te bewerken • Lang indrukken om te selecteren • Veeg voor acties';
+
+  @override
+  String get tabToDo => 'Te doen';
+
+  @override
+  String get tabDone => 'Klaar';
+
+  @override
+  String get tabOld => 'Oud';
+
+  @override
+  String get emptyTodoMessage => '🎉 Alles bijgewerkt!\nGeen openstaande actiepunten';
+
+  @override
+  String get emptyDoneMessage => 'Nog geen voltooide items';
+
+  @override
+  String get emptyOldMessage => '✅ Geen oude taken';
+
+  @override
+  String get noItems => 'Geen items';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Actiepunt gemarkeerd als niet voltooid';
+
+  @override
+  String get actionItemCompleted => 'Actiepunt voltooid';
+
+  @override
+  String get deleteActionItemTitle => 'Actiepunt verwijderen';
+
+  @override
+  String get deleteActionItemMessage => 'Weet je zeker dat je dit actiepunt wilt verwijderen?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Geselecteerde items verwijderen';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Weet je zeker dat je $count geselecteerde actiepunt(en) wilt verwijderen?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Actiepunt \"$description\" verwijderd';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count actiepunt(en) verwijderd';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Kan actiepunt niet verwijderen';
+
+  @override
+  String get failedToDeleteItems => 'Kan items niet verwijderen';
+
+  @override
+  String get failedToDeleteSomeItems => 'Kan sommige items niet verwijderen';
+
+  @override
+  String get welcomeActionItemsTitle => 'Klaar voor actiepunten';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Je AI haalt automatisch taken en to-do\'s uit je gesprekken. Ze verschijnen hier wanneer ze zijn aangemaakt.';
+
+  @override
+  String get autoExtractionFeature => 'Automatisch geëxtraheerd uit gesprekken';
+
+  @override
+  String get editSwipeFeature => 'Tik om te bewerken, veeg om te voltooien of te verwijderen';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count geselecteerd';
+  }
+
+  @override
+  String get selectAll => 'Alles selecteren';
+
+  @override
+  String get deleteSelected => 'Geselecteerde verwijderen';
+
+  @override
+  String searchMemories(int count) {
+    return 'Zoek in $count herinneringen';
+  }
+
+  @override
+  String get memoryDeleted => 'Herinnering verwijderd.';
+
+  @override
+  String get undo => 'Ongedaan maken';
+
+  @override
+  String get noMemoriesYet => 'Nog geen herinneringen';
+
+  @override
+  String get noAutoMemories => 'Nog geen automatisch geëxtraheerde herinneringen';
+
+  @override
+  String get noManualMemories => 'Nog geen handmatige herinneringen';
+
+  @override
+  String get noMemoriesInCategories => 'Geen herinneringen in deze categorieën';
+
+  @override
+  String get noMemoriesFound => 'Geen herinneringen gevonden';
+
+  @override
+  String get addFirstMemory => 'Voeg je eerste herinnering toe';
+
+  @override
+  String get clearMemoryTitle => 'Omi\'s geheugen wissen';
+
+  @override
+  String get clearMemoryMessage =>
+      'Weet je zeker dat je Omi\'s geheugen wilt wissen? Deze actie kan niet ongedaan worden gemaakt.';
+
+  @override
+  String get clearMemoryButton => 'Geheugen wissen';
+
+  @override
+  String get memoryClearedSuccess => 'Omi\'s geheugen over jou is gewist';
+
+  @override
+  String get noMemoriesToDelete => 'Geen herinneringen om te verwijderen';
+
+  @override
+  String get createMemoryTooltip => 'Nieuwe herinnering maken';
+
+  @override
+  String get createActionItemTooltip => 'Nieuw actiepunt maken';
+
+  @override
+  String get memoryManagement => 'Geheugenbeheer';
+
+  @override
+  String get filterMemories => 'Herinneringen filteren';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Je hebt $count herinneringen in totaal';
+  }
+
+  @override
+  String get publicMemories => 'Openbare herinneringen';
+
+  @override
+  String get privateMemories => 'Privé herinneringen';
+
+  @override
+  String get makeAllPrivate => 'Alle herinneringen privé maken';
+
+  @override
+  String get makeAllPublic => 'Alle herinneringen openbaar maken';
+
+  @override
+  String get deleteAllMemories => 'Alle herinneringen verwijderen';
+
+  @override
+  String get allMemoriesPrivateResult => 'Alle herinneringen zijn nu privé';
+
+  @override
+  String get allMemoriesPublicResult => 'Alle herinneringen zijn nu openbaar';
+
+  @override
+  String get newMemory => 'Nieuwe herinnering';
+
+  @override
+  String get editMemory => 'Herinnering bewerken';
+
+  @override
+  String get memoryContentHint => 'Ik hou van ijs eten...';
+
+  @override
+  String get failedToSaveMemory => 'Opslaan mislukt. Controleer je verbinding.';
+
+  @override
+  String get saveMemory => 'Herinnering opslaan';
+
+  @override
+  String get retry => 'Opnieuw proberen';
+
+  @override
+  String get createActionItem => 'Actiepunt maken';
+
+  @override
+  String get editActionItem => 'Actiepunt bewerken';
+
+  @override
+  String get actionItemDescriptionHint => 'Wat moet er gedaan worden?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Actiepuntbeschrijving mag niet leeg zijn.';
+
+  @override
+  String get actionItemUpdated => 'Actiepunt bijgewerkt';
+
+  @override
+  String get failedToUpdateActionItem => 'Kan actiepunt niet bijwerken';
+
+  @override
+  String get actionItemCreated => 'Actiepunt aangemaakt';
+
+  @override
+  String get failedToCreateActionItem => 'Kan actiepunt niet maken';
+
+  @override
+  String get dueDate => 'Vervaldatum';
+
+  @override
+  String get time => 'Tijd';
+
+  @override
+  String get addDueDate => 'Vervaldatum toevoegen';
+
+  @override
+  String get pressDoneToSave => 'Druk op Klaar om op te slaan';
+
+  @override
+  String get pressDoneToCreate => 'Druk op Klaar om aan te maken';
+
+  @override
+  String get filterAll => 'Alle';
+
+  @override
+  String get filterSystem => 'Over jou';
+
+  @override
+  String get filterInteresting => 'Inzichten';
+
+  @override
+  String get filterManual => 'Handmatig';
+
+  @override
+  String get completed => 'Voltooid';
+
+  @override
+  String get markComplete => 'Markeer als voltooid';
+
+  @override
+  String get actionItemDeleted => 'Actiepunt verwijderd';
+
+  @override
+  String get failedToDeleteActionItem => 'Kan actiepunt niet verwijderen';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Actiepunt verwijderen';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Weet je zeker dat je dit actiepunt wilt verwijderen?';
+
+  @override
+  String get appLanguage => 'App-taal';
+
+  @override
+  String get appInterfaceSectionTitle => 'APP-INTERFACE';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'SPRAAK & TRANSCRIPTIE';
+
+  @override
+  String get languageSettingsHelperText =>
+      'App-taal verandert menu\'s en knoppen. Spraaktaal beïnvloedt hoe je opnames worden getranscribeerd.';
+}

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -1,0 +1,2228 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Norwegian (`no`).
+class AppLocalizationsNo extends AppLocalizations {
+  AppLocalizationsNo([String locale = 'no']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Samtale';
+
+  @override
+  String get transcriptTab => 'Transkripsjon';
+
+  @override
+  String get actionItemsTab => 'Handlingspunkter';
+
+  @override
+  String get deleteConversationTitle => 'Slette samtale?';
+
+  @override
+  String get deleteConversationMessage => 'Er du sikker på at du vil slette denne samtalen? Dette kan ikke angres.';
+
+  @override
+  String get confirm => 'Bekreft';
+
+  @override
+  String get cancel => 'Avbryt';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Slett';
+
+  @override
+  String get add => 'Legg til';
+
+  @override
+  String get update => 'Oppdater';
+
+  @override
+  String get save => 'Lagre';
+
+  @override
+  String get edit => 'Rediger';
+
+  @override
+  String get close => 'Lukk';
+
+  @override
+  String get clear => 'Tøm';
+
+  @override
+  String get copyTranscript => 'Kopier transkripsjon';
+
+  @override
+  String get copySummary => 'Kopier sammendrag';
+
+  @override
+  String get testPrompt => 'Test prompt';
+
+  @override
+  String get reprocessConversation => 'Behandle samtale på nytt';
+
+  @override
+  String get deleteConversation => 'Slett samtale';
+
+  @override
+  String get contentCopied => 'Innhold kopiert til utklippstavlen';
+
+  @override
+  String get failedToUpdateStarred => 'Kunne ikke oppdatere favoritt-status.';
+
+  @override
+  String get conversationUrlNotShared => 'Samtale-URL kunne ikke deles.';
+
+  @override
+  String get errorProcessingConversation => 'Feil under behandling av samtale. Prøv igjen senere.';
+
+  @override
+  String get noInternetConnection => 'Sjekk internettforbindelsen din og prøv igjen.';
+
+  @override
+  String get unableToDeleteConversation => 'Kan ikke slette samtale';
+
+  @override
+  String get somethingWentWrong => 'Noe gikk galt! Prøv igjen senere.';
+
+  @override
+  String get copyErrorMessage => 'Kopier feilmelding';
+
+  @override
+  String get errorCopied => 'Feilmelding kopiert til utklippstavlen';
+
+  @override
+  String get remaining => 'Gjenstående';
+
+  @override
+  String get loading => 'Laster...';
+
+  @override
+  String get loadingDuration => 'Laster varighet...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekunder';
+  }
+
+  @override
+  String get people => 'Personer';
+
+  @override
+  String get addNewPerson => 'Legg til ny person';
+
+  @override
+  String get editPerson => 'Rediger person';
+
+  @override
+  String get createPersonHint => 'Opprett en ny person og tren Omi til å gjenkjenne deres tale også!';
+
+  @override
+  String get speechProfile => 'Taleprofil';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Prøve $number';
+  }
+
+  @override
+  String get settings => 'Innstillinger';
+
+  @override
+  String get language => 'Språk';
+
+  @override
+  String get selectLanguage => 'Velg språk';
+
+  @override
+  String get deleting => 'Sletter...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.';
+
+  @override
+  String get failedToStartAuthentication => 'Kunne ikke starte autentisering';
+
+  @override
+  String get importStarted => 'Import startet! Du vil bli varslet når den er fullført.';
+
+  @override
+  String get failedToStartImport => 'Kunne ikke starte import. Prøv igjen.';
+
+  @override
+  String get couldNotAccessFile => 'Kunne ikke åpne den valgte filen';
+
+  @override
+  String get askOmi => 'Spør Omi';
+
+  @override
+  String get done => 'Ferdig';
+
+  @override
+  String get disconnected => 'Frakoblet';
+
+  @override
+  String get searching => 'Søker';
+
+  @override
+  String get connectDevice => 'Koble til enhet';
+
+  @override
+  String get monthlyLimitReached => 'Du har nådd din månedlige grense.';
+
+  @override
+  String get checkUsage => 'Sjekk forbruk';
+
+  @override
+  String get syncingRecordings => 'Synkroniserer opptak';
+
+  @override
+  String get recordingsToSync => 'Opptak å synkronisere';
+
+  @override
+  String get allCaughtUp => 'Alt er oppdatert';
+
+  @override
+  String get sync => 'Synkroniser';
+
+  @override
+  String get pendantUpToDate => 'Anheng er oppdatert';
+
+  @override
+  String get allRecordingsSynced => 'Alle opptak er synkronisert';
+
+  @override
+  String get syncingInProgress => 'Synkronisering pågår';
+
+  @override
+  String get readyToSync => 'Klar til synkronisering';
+
+  @override
+  String get tapSyncToStart => 'Trykk Synkroniser for å starte';
+
+  @override
+  String get pendantNotConnected => 'Anheng ikke tilkoblet. Koble til for å synkronisere.';
+
+  @override
+  String get everythingSynced => 'Alt er allerede synkronisert.';
+
+  @override
+  String get recordingsNotSynced => 'Du har opptak som ikke er synkronisert ennå.';
+
+  @override
+  String get syncingBackground => 'Vi fortsetter å synkronisere opptakene dine i bakgrunnen.';
+
+  @override
+  String get noConversationsYet => 'Ingen samtaler ennå.';
+
+  @override
+  String get noStarredConversations => 'Ingen favorittsamtaler ennå.';
+
+  @override
+  String get starConversationHint =>
+      'For å favorittmarkere en samtale, åpne den og trykk på stjerneikonet i overskriften.';
+
+  @override
+  String get searchConversations => 'Søk i samtaler';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count valgt';
+  }
+
+  @override
+  String get merge => 'Slå sammen';
+
+  @override
+  String get mergeConversations => 'Slå sammen samtaler';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Dette vil kombinere $count samtaler til én. Alt innhold vil bli slått sammen og regenerert.';
+  }
+
+  @override
+  String get mergingInBackground => 'Slår sammen i bakgrunnen. Dette kan ta et øyeblikk.';
+
+  @override
+  String get failedToStartMerge => 'Kunne ikke starte sammenslåing';
+
+  @override
+  String get askAnything => 'Spør om hva som helst';
+
+  @override
+  String get noMessagesYet => 'Ingen meldinger ennå!\nHvorfor ikke starte en samtale?';
+
+  @override
+  String get deletingMessages => 'Sletter meldingene dine fra Omis minne...';
+
+  @override
+  String get messageCopied => 'Melding kopiert til utklippstavlen.';
+
+  @override
+  String get cannotReportOwnMessage => 'Du kan ikke rapportere dine egne meldinger.';
+
+  @override
+  String get reportMessage => 'Rapporter melding';
+
+  @override
+  String get reportMessageConfirm => 'Er du sikker på at du vil rapportere denne meldingen?';
+
+  @override
+  String get messageReported => 'Melding rapportert.';
+
+  @override
+  String get thankYouFeedback => 'Takk for tilbakemeldingen!';
+
+  @override
+  String get clearChat => 'Tøm chat?';
+
+  @override
+  String get clearChatConfirm => 'Er du sikker på at du vil tømme chatten? Dette kan ikke angres.';
+
+  @override
+  String get maxFilesLimit => 'Du kan bare laste opp 4 filer om gangen';
+
+  @override
+  String get chatWithOmi => 'Chat med Omi';
+
+  @override
+  String get apps => 'Apper';
+
+  @override
+  String get noAppsFound => 'Ingen apper funnet';
+
+  @override
+  String get tryAdjustingSearch => 'Prøv å justere søket eller filtrene dine';
+
+  @override
+  String get createYourOwnApp => 'Lag din egen app';
+
+  @override
+  String get buildAndShareApp => 'Bygg og del din egendefinerte app';
+
+  @override
+  String get searchApps => 'Søk i 1500+ apper';
+
+  @override
+  String get myApps => 'Mine apper';
+
+  @override
+  String get installedApps => 'Installerte apper';
+
+  @override
+  String get unableToFetchApps => 'Kan ikke hente apper :(\n\nSjekk internettforbindelsen din og prøv igjen.';
+
+  @override
+  String get aboutOmi => 'Om Omi';
+
+  @override
+  String get privacyPolicy => 'Personvernserklæring';
+
+  @override
+  String get visitWebsite => 'Besøk nettside';
+
+  @override
+  String get helpOrInquiries => 'Hjelp eller henvendelser?';
+
+  @override
+  String get joinCommunity => 'Bli med i fellesskapet!';
+
+  @override
+  String get membersAndCounting => '8000+ medlemmer og flere.';
+
+  @override
+  String get deleteAccountTitle => 'Slett konto';
+
+  @override
+  String get deleteAccountConfirm => 'Er du sikker på at du vil slette kontoen din?';
+
+  @override
+  String get cannotBeUndone => 'Dette kan ikke angres.';
+
+  @override
+  String get allDataErased => 'Alle minnene og samtalene dine vil bli permanent slettet.';
+
+  @override
+  String get appsDisconnected => 'Appene og integrasjonene dine vil bli frakoblet umiddelbart.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Du kan eksportere dataene dine før du sletter kontoen, men når den er slettet, kan den ikke gjenopprettes.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Jeg forstår at sletting av kontoen min er permanent og at alle data, inkludert minner og samtaler, vil gå tapt og ikke kan gjenopprettes.';
+
+  @override
+  String get areYouSure => 'Er du sikker?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Denne handlingen kan ikke angres og vil permanent slette kontoen din og alle tilknyttede data. Er du sikker på at du vil fortsette?';
+
+  @override
+  String get deleteNow => 'Slett nå';
+
+  @override
+  String get goBack => 'Gå tilbake';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Kryss av for å bekrefte at du forstår at sletting av kontoen din er permanent og irreversibel.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Navn';
+
+  @override
+  String get email => 'E-post';
+
+  @override
+  String get customVocabulary => 'Tilpasset ordforråd';
+
+  @override
+  String get identifyingOthers => 'Identifisere andre';
+
+  @override
+  String get paymentMethods => 'Betalingsmetoder';
+
+  @override
+  String get conversationDisplay => 'Samtalevisning';
+
+  @override
+  String get dataPrivacy => 'Data og personvern';
+
+  @override
+  String get userId => 'Bruker-ID';
+
+  @override
+  String get notSet => 'Ikke angitt';
+
+  @override
+  String get userIdCopied => 'Bruker-ID kopiert til utklippstavlen';
+
+  @override
+  String get systemDefault => 'Systemstandard';
+
+  @override
+  String get planAndUsage => 'Abonnement og forbruk';
+
+  @override
+  String get offlineSync => 'Frakoblet synkronisering';
+
+  @override
+  String get deviceSettings => 'Enhetsinnstillinger';
+
+  @override
+  String get chatTools => 'Chatverktøy';
+
+  @override
+  String get feedbackBug => 'Tilbakemelding / Feil';
+
+  @override
+  String get helpCenter => 'Hjelpesenter';
+
+  @override
+  String get developerSettings => 'Utviklerinnstillinger';
+
+  @override
+  String get getOmiForMac => 'Få Omi for Mac';
+
+  @override
+  String get referralProgram => 'Henvisningsprogram';
+
+  @override
+  String get signOut => 'Logg ut';
+
+  @override
+  String get appAndDeviceCopied => 'App- og enhetsdetaljer kopiert';
+
+  @override
+  String get wrapped2025 => 'Oppsummert 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Ditt personvern, din kontroll';
+
+  @override
+  String get privacyIntro =>
+      'Hos Omi er vi opptatt av å beskytte ditt personvern. Denne siden lar deg kontrollere hvordan dataene dine lagres og brukes.';
+
+  @override
+  String get learnMore => 'Lær mer...';
+
+  @override
+  String get dataProtectionLevel => 'Databeskyttelsesnivå';
+
+  @override
+  String get dataProtectionDesc =>
+      'Dataene dine er sikret som standard med sterk kryptering. Se gjennom innstillingene dine og fremtidige personvernalternativer nedenfor.';
+
+  @override
+  String get appAccess => 'Apptilgang';
+
+  @override
+  String get appAccessDesc =>
+      'Følgende apper har tilgang til dataene dine. Trykk på en app for å administrere tillatelsene.';
+
+  @override
+  String get noAppsExternalAccess => 'Ingen installerte apper har ekstern tilgang til dataene dine.';
+
+  @override
+  String get deviceName => 'Enhetsnavn';
+
+  @override
+  String get deviceId => 'Enhets-ID';
+
+  @override
+  String get firmware => 'Fastvare';
+
+  @override
+  String get sdCardSync => 'SD-kortsynkronisering';
+
+  @override
+  String get hardwareRevision => 'Maskinvarerevisjon';
+
+  @override
+  String get modelNumber => 'Modellnummer';
+
+  @override
+  String get manufacturer => 'Produsent';
+
+  @override
+  String get doubleTap => 'Dobbelttrykk';
+
+  @override
+  String get ledBrightness => 'LED-lysstyrke';
+
+  @override
+  String get micGain => 'Mikrofonforsterkning';
+
+  @override
+  String get disconnect => 'Koble fra';
+
+  @override
+  String get forgetDevice => 'Glem enhet';
+
+  @override
+  String get chargingIssues => 'Ladeproblemer';
+
+  @override
+  String get disconnectDevice => 'Koble fra enhet';
+
+  @override
+  String get unpairDevice => 'Fjern paring av enhet';
+
+  @override
+  String get unpairAndForget => 'Fjern paring og glem enhet';
+
+  @override
+  String get deviceDisconnectedMessage => 'Din Omi har blitt frakoblet 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Enhet fjernet fra paring. Gå til Innstillinger > Bluetooth og glem enheten for å fullføre fjerningen.';
+
+  @override
+  String get unpairDialogTitle => 'Fjern paring av enhet';
+
+  @override
+  String get unpairDialogMessage =>
+      'Dette vil fjerne paringen av enheten slik at den kan kobles til en annen telefon. Du må gå til Innstillinger > Bluetooth og glemme enheten for å fullføre prosessen.';
+
+  @override
+  String get deviceNotConnected => 'Enhet ikke tilkoblet';
+
+  @override
+  String get connectDeviceMessage =>
+      'Koble til Omi-enheten din for å få tilgang til\nenhetsinnstillinger og tilpasning';
+
+  @override
+  String get deviceInfoSection => 'Enhetsinformasjon';
+
+  @override
+  String get customizationSection => 'Tilpasning';
+
+  @override
+  String get hardwareSection => 'Maskinvare';
+
+  @override
+  String get v2Undetected => 'V2 ikke oppdaget';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Vi ser at du enten har en V1-enhet eller at enheten din ikke er tilkoblet. SD-kortfunksjonalitet er kun tilgjengelig for V2-enheter.';
+
+  @override
+  String get endConversation => 'Avslutt samtale';
+
+  @override
+  String get pauseResume => 'Pause/Fortsett';
+
+  @override
+  String get starConversation => 'Favorittmerk samtale';
+
+  @override
+  String get doubleTapAction => 'Dobbelttrykk-handling';
+
+  @override
+  String get endAndProcess => 'Avslutt og behandle samtale';
+
+  @override
+  String get pauseResumeRecording => 'Pause/Fortsett opptak';
+
+  @override
+  String get starOngoing => 'Favorittmerk pågående samtale';
+
+  @override
+  String get off => 'Av';
+
+  @override
+  String get max => 'Maks';
+
+  @override
+  String get mute => 'Demp';
+
+  @override
+  String get quiet => 'Stille';
+
+  @override
+  String get normal => 'Normal';
+
+  @override
+  String get high => 'Høy';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon er dempet';
+
+  @override
+  String get micGainDescLow => 'Veldig stille - for høylydte omgivelser';
+
+  @override
+  String get micGainDescModerate => 'Stille - for moderat støy';
+
+  @override
+  String get micGainDescNeutral => 'Nøytral - balansert opptak';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Litt forsterket - normal bruk';
+
+  @override
+  String get micGainDescBoosted => 'Forsterket - for stille omgivelser';
+
+  @override
+  String get micGainDescHigh => 'Høy - for fjerne eller myke stemmer';
+
+  @override
+  String get micGainDescVeryHigh => 'Veldig høy - for veldig stille kilder';
+
+  @override
+  String get micGainDescMax => 'Maksimal - bruk med forsiktighet';
+
+  @override
+  String get developerSettingsTitle => 'Utviklerinnstillinger';
+
+  @override
+  String get saving => 'Lagrer...';
+
+  @override
+  String get personaConfig => 'Konfigurer din AI-persona';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transkripsjon';
+
+  @override
+  String get transcriptionConfig => 'Konfigurer STT-leverandør';
+
+  @override
+  String get conversationTimeout => 'Samtale-timeout';
+
+  @override
+  String get conversationTimeoutConfig => 'Angi når samtaler avsluttes automatisk';
+
+  @override
+  String get importData => 'Importer data';
+
+  @override
+  String get importDataConfig => 'Importer data fra andre kilder';
+
+  @override
+  String get debugDiagnostics => 'Feilsøking og diagnostikk';
+
+  @override
+  String get endpointUrl => 'Endepunkt-URL';
+
+  @override
+  String get noApiKeys => 'Ingen API-nøkler ennå';
+
+  @override
+  String get createKeyToStart => 'Opprett en nøkkel for å komme i gang';
+
+  @override
+  String get createKey => 'Opprett nøkkel';
+
+  @override
+  String get docs => 'Dokumentasjon';
+
+  @override
+  String get yourOmiInsights => 'Dine Omi-innsikter';
+
+  @override
+  String get today => 'I dag';
+
+  @override
+  String get thisMonth => 'Denne måneden';
+
+  @override
+  String get thisYear => 'Dette året';
+
+  @override
+  String get allTime => 'All tid';
+
+  @override
+  String get noActivityYet => 'Ingen aktivitet ennå';
+
+  @override
+  String get startConversationToSeeInsights => 'Start en samtale med Omi\nfor å se forbruksinnsiktene dine her.';
+
+  @override
+  String get listening => 'Lytter';
+
+  @override
+  String get listeningSubtitle => 'Total tid Omi har lyttet aktivt.';
+
+  @override
+  String get understanding => 'Forstår';
+
+  @override
+  String get understandingSubtitle => 'Ord forstått fra samtalene dine.';
+
+  @override
+  String get providing => 'Gir';
+
+  @override
+  String get providingSubtitle => 'Handlingspunkter og notater automatisk registrert.';
+
+  @override
+  String get remembering => 'Husker';
+
+  @override
+  String get rememberingSubtitle => 'Fakta og detaljer husket for deg.';
+
+  @override
+  String get unlimitedPlan => 'Ubegrenset abonnement';
+
+  @override
+  String get managePlan => 'Administrer abonnement';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Abonnementet ditt vil kanselleres $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Abonnementet ditt fornyes $date.';
+  }
+
+  @override
+  String get basicPlan => 'Gratis abonnement';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used av $limit min brukt';
+  }
+
+  @override
+  String get upgrade => 'Oppgrader';
+
+  @override
+  String get upgradeToUnlimited => 'Oppgrader til ubegrenset';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Abonnementet ditt inkluderer $limit gratis minutter per måned. Oppgrader for ubegrenset bruk.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Deler mine Omi-statistikker! (omi.me - din alltid tilgjengelige AI-assistent)';
+
+  @override
+  String get sharePeriodToday => 'I dag har omi:';
+
+  @override
+  String get sharePeriodMonth => 'Denne måneden har omi:';
+
+  @override
+  String get sharePeriodYear => 'Dette året har omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Så langt har omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Lyttet i $minutes minutter';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Forstått $words ord';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Gitt $count innsikter';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Husket $count minner';
+  }
+
+  @override
+  String get debugLogs => 'Feilsøkingslogger';
+
+  @override
+  String get debugLogsAutoDelete => 'Slettes automatisk etter 3 dager.';
+
+  @override
+  String get debugLogsDesc => 'Hjelper med å diagnostisere problemer';
+
+  @override
+  String get noLogFilesFound => 'Ingen loggfiler funnet.';
+
+  @override
+  String get omiDebugLog => 'Omi feilsøkingslogg';
+
+  @override
+  String get logShared => 'Logg delt';
+
+  @override
+  String get selectLogFile => 'Velg loggfil';
+
+  @override
+  String get shareLogs => 'Del logger';
+
+  @override
+  String get debugLogCleared => 'Feilsøkingslogg tømt';
+
+  @override
+  String get exportStarted => 'Eksport startet. Dette kan ta noen sekunder...';
+
+  @override
+  String get exportAllData => 'Eksporter alle data';
+
+  @override
+  String get exportDataDesc => 'Eksporter samtaler til en JSON-fil';
+
+  @override
+  String get exportedConversations => 'Eksporterte samtaler fra Omi';
+
+  @override
+  String get exportShared => 'Eksport delt';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Slette kunnskapsgraf?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Dette vil slette alle utledede kunnskapsdata (noder og forbindelser). De originale minnene dine vil forbli trygge. Grafen vil bli gjenoppbygget over tid eller ved neste forespørsel.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Kunnskapsgraf slettet';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Kunne ikke slette graf: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Slett kunnskapsgraf';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Tøm alle noder og forbindelser';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP-server';
+
+  @override
+  String get mcpServerDesc => 'Koble AI-assistenter til dataene dine';
+
+  @override
+  String get serverUrl => 'Server-URL';
+
+  @override
+  String get urlCopied => 'URL kopiert';
+
+  @override
+  String get apiKeyAuth => 'API-nøkkelautentisering';
+
+  @override
+  String get header => 'Topptekst';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Klient-ID';
+
+  @override
+  String get clientSecret => 'Klienthemmelighet';
+
+  @override
+  String get useMcpApiKey => 'Bruk din MCP API-nøkkel';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Samtalehendelser';
+
+  @override
+  String get newConversationCreated => 'Ny samtale opprettet';
+
+  @override
+  String get realtimeTranscript => 'Sanntidstranskripsjon';
+
+  @override
+  String get transcriptReceived => 'Transkripsjon mottatt';
+
+  @override
+  String get audioBytes => 'Lydbytes';
+
+  @override
+  String get audioDataReceived => 'Lyddata mottatt';
+
+  @override
+  String get intervalSeconds => 'Intervall (sekunder)';
+
+  @override
+  String get daySummary => 'Dagsammendrag';
+
+  @override
+  String get summaryGenerated => 'Sammendrag generert';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Legg til i claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Kopier konfigurasjon';
+
+  @override
+  String get configCopied => 'Konfigurasjon kopiert til utklippstavlen';
+
+  @override
+  String get listeningMins => 'Lytting (min)';
+
+  @override
+  String get understandingWords => 'Forståelse (ord)';
+
+  @override
+  String get insights => 'Innsikter';
+
+  @override
+  String get memories => 'Minner';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used av $limit min brukt denne måneden';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used av $limit ord brukt denne måneden';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used av $limit innsikter fått denne måneden';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used av $limit minner opprettet denne måneden';
+  }
+
+  @override
+  String get visibility => 'Synlighet';
+
+  @override
+  String get visibilitySubtitle => 'Kontroller hvilke samtaler som vises i listen din';
+
+  @override
+  String get showShortConversations => 'Vis korte samtaler';
+
+  @override
+  String get showShortConversationsDesc => 'Vis samtaler kortere enn terskelen';
+
+  @override
+  String get showDiscardedConversations => 'Vis forkastede samtaler';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Inkluder samtaler merket som forkastet';
+
+  @override
+  String get shortConversationThreshold => 'Terskel for korte samtaler';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Samtaler kortere enn dette vil være skjult med mindre aktivert ovenfor';
+
+  @override
+  String get durationThreshold => 'Varighetsterskel';
+
+  @override
+  String get durationThresholdDesc => 'Skjul samtaler kortere enn dette';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Tilpasset ordforråd';
+
+  @override
+  String get addWords => 'Legg til ord';
+
+  @override
+  String get addWordsDesc => 'Navn, termer eller uvanlige ord';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Koble til';
+
+  @override
+  String get comingSoon => 'Kommer snart';
+
+  @override
+  String get chatToolsFooter => 'Koble til appene dine for å se data og måledata i chat.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Kunne ikke starte $appName-autentisering';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Koble fra $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Er du sikker på at du vil koble fra $appName? Du kan koble til igjen når som helst.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Frakoblet fra $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Kunne ikke koble fra';
+
+  @override
+  String connectTo(String appName) {
+    return 'Koble til $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Du må autorisere Omi til å få tilgang til $appName-dataene dine. Dette vil åpne nettleseren din for autentisering.';
+  }
+
+  @override
+  String get continueAction => 'Fortsett';
+
+  @override
+  String get languageTitle => 'Språk';
+
+  @override
+  String get primaryLanguage => 'Hovedspråk';
+
+  @override
+  String get automaticTranslation => 'Automatisk oversettelse';
+
+  @override
+  String get detectLanguages => 'Oppdage 10+ språk';
+
+  @override
+  String get authorizeSavingRecordings => 'Autoriser lagring av opptak';
+
+  @override
+  String get thanksForAuthorizing => 'Takk for at du autoriserte!';
+
+  @override
+  String get needYourPermission => 'Vi trenger din tillatelse';
+
+  @override
+  String get alreadyGavePermission =>
+      'Du har allerede gitt oss tillatelse til å lagre opptakene dine. Her er en påminnelse om hvorfor vi trenger det:';
+
+  @override
+  String get wouldLikePermission => 'Vi vil gjerne ha tillatelse til å lagre stemmeopptakene dine. Her er hvorfor:';
+
+  @override
+  String get improveSpeechProfile => 'Forbedre taleprofilen din';
+
+  @override
+  String get improveSpeechProfileDesc => 'Vi bruker opptak for å videreutvikle og forbedre din personlige taleprofil.';
+
+  @override
+  String get trainFamilyProfiles => 'Tren profiler for venner og familie';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Opptakene dine hjelper oss med å gjenkjenne og opprette profiler for venner og familie.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Forbedre transkripsjonsnøyaktighet';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Etter hvert som modellen vår forbedres, kan vi gi bedre transkripsjon av opptakene dine.';
+
+  @override
+  String get legalNotice =>
+      'Juridisk merknad: Lovligheten av å ta opp og lagre taledata kan variere avhengig av hvor du befinner deg og hvordan du bruker denne funksjonen. Det er ditt ansvar å sikre overholdelse av lokale lover og forskrifter.';
+
+  @override
+  String get alreadyAuthorized => 'Allerede autorisert';
+
+  @override
+  String get authorize => 'Autoriser';
+
+  @override
+  String get revokeAuthorization => 'Tilbakekall autorisasjon';
+
+  @override
+  String get authorizationSuccessful => 'Autorisasjon vellykket!';
+
+  @override
+  String get failedToAuthorize => 'Kunne ikke autorisere. Prøv igjen.';
+
+  @override
+  String get authorizationRevoked => 'Autorisasjon tilbakekalt.';
+
+  @override
+  String get recordingsDeleted => 'Opptak slettet.';
+
+  @override
+  String get failedToRevoke => 'Kunne ikke tilbakekalle autorisasjon. Prøv igjen.';
+
+  @override
+  String get permissionRevokedTitle => 'Tillatelse tilbakekalt';
+
+  @override
+  String get permissionRevokedMessage => 'Vil du at vi skal fjerne alle eksisterende opptak også?';
+
+  @override
+  String get yes => 'Ja';
+
+  @override
+  String get editName => 'Rediger navn';
+
+  @override
+  String get howShouldOmiCallYou => 'Hva skal Omi kalle deg?';
+
+  @override
+  String get enterYourName => 'Skriv inn navnet ditt';
+
+  @override
+  String get nameCannotBeEmpty => 'Navn kan ikke være tomt';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Navn oppdatert!';
+
+  @override
+  String get calendarSettings => 'Kalenderinnstillinger';
+
+  @override
+  String get calendarProviders => 'Kalenderleverandører';
+
+  @override
+  String get macOsCalendar => 'macOS-kalender';
+
+  @override
+  String get connectMacOsCalendar => 'Koble til din lokale macOS-kalender';
+
+  @override
+  String get googleCalendar => 'Google-kalender';
+
+  @override
+  String get syncGoogleAccount => 'Synkroniser med Google-kontoen din';
+
+  @override
+  String get showMeetingsMenuBar => 'Vis kommende møter i menylinje';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Vis neste møte og tid til det starter i macOS-menylinjen';
+
+  @override
+  String get showEventsNoParticipants => 'Vis hendelser uten deltakere';
+
+  @override
+  String get showEventsNoParticipantsDesc => 'Når aktivert, viser Kommende hendelser uten deltakere eller videolenke.';
+
+  @override
+  String get yourMeetings => 'Dine møter';
+
+  @override
+  String get refresh => 'Oppdater';
+
+  @override
+  String get noUpcomingMeetings => 'Ingen kommende møter funnet';
+
+  @override
+  String get checkingNextDays => 'Sjekker neste 30 dager';
+
+  @override
+  String get tomorrow => 'I morgen';
+
+  @override
+  String get googleCalendarComingSoon => 'Google-kalenderintegrasjon kommer snart!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Tilkoblet som bruker: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Standard arbeidsområde';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Oppgaver vil bli opprettet i dette arbeidsområdet';
+
+  @override
+  String get defaultProjectOptional => 'Standard prosjekt (valgfritt)';
+
+  @override
+  String get leaveUnselectedTasks => 'La være uvalgt for å opprette oppgaver uten prosjekt';
+
+  @override
+  String get noProjectsInWorkspace => 'Ingen prosjekter funnet i dette arbeidsområdet';
+
+  @override
+  String get conversationTimeoutDesc => 'Velg hvor lenge du vil vente i stillhet før samtalen avsluttes automatisk:';
+
+  @override
+  String get timeout2Minutes => '2 minutter';
+
+  @override
+  String get timeout2MinutesDesc => 'Avslutt samtale etter 2 minutters stillhet';
+
+  @override
+  String get timeout5Minutes => '5 minutter';
+
+  @override
+  String get timeout5MinutesDesc => 'Avslutt samtale etter 5 minutters stillhet';
+
+  @override
+  String get timeout10Minutes => '10 minutter';
+
+  @override
+  String get timeout10MinutesDesc => 'Avslutt samtale etter 10 minutters stillhet';
+
+  @override
+  String get timeout30Minutes => '30 minutter';
+
+  @override
+  String get timeout30MinutesDesc => 'Avslutt samtale etter 30 minutters stillhet';
+
+  @override
+  String get timeout4Hours => '4 timer';
+
+  @override
+  String get timeout4HoursDesc => 'Avslutt samtale etter 4 timers stillhet';
+
+  @override
+  String get conversationEndAfterHours => 'Samtaler vil nå avsluttes etter 4 timers stillhet';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Samtaler vil nå avsluttes etter $minutes minutt(er) stillhet';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Fortell oss ditt hovedspråk';
+
+  @override
+  String get languageForTranscription => 'Angi språket ditt for skarpere transkripsjoner og en personlig opplevelse.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Enkeltspråkmodus er aktivert. Oversettelse er deaktivert for høyere nøyaktighet.';
+
+  @override
+  String get searchLanguageHint => 'Søk etter språk med navn eller kode';
+
+  @override
+  String get noLanguagesFound => 'Ingen språk funnet';
+
+  @override
+  String get skip => 'Hopp over';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Språk satt til $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Kunne ikke angi språk';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName-innstillinger';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Koble fra $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Dette vil fjerne $appName-autentiseringen din. Du må koble til igjen for å bruke den.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Tilkoblet $appName';
+  }
+
+  @override
+  String get account => 'Konto';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Handlingspunktene dine vil bli synkronisert til $appName-kontoen din';
+  }
+
+  @override
+  String get defaultSpace => 'Standard område';
+
+  @override
+  String get selectSpaceInWorkspace => 'Velg et område i arbeidsområdet ditt';
+
+  @override
+  String get noSpacesInWorkspace => 'Ingen områder funnet i dette arbeidsområdet';
+
+  @override
+  String get defaultList => 'Standard liste';
+
+  @override
+  String get tasksAddedToList => 'Oppgaver vil bli lagt til denne listen';
+
+  @override
+  String get noListsInSpace => 'Ingen lister funnet i dette området';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Kunne ikke laste inn repositorier: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Standard repositorium lagret';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Kunne ikke lagre standard repositorium';
+
+  @override
+  String get defaultRepository => 'Standard repositorium';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Velg et standard repositorium for å opprette problemer. Du kan fortsatt spesifisere et annet repositorium når du oppretter problemer.';
+
+  @override
+  String get noReposFound => 'Ingen repositorier funnet';
+
+  @override
+  String get private => 'Privat';
+
+  @override
+  String updatedDate(String date) {
+    return 'Oppdatert $date';
+  }
+
+  @override
+  String get yesterday => 'i går';
+
+  @override
+  String daysAgo(int count) {
+    return '$count dager siden';
+  }
+
+  @override
+  String get oneWeekAgo => '1 uke siden';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count uker siden';
+  }
+
+  @override
+  String get oneMonthAgo => '1 måned siden';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count måneder siden';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Problemer vil bli opprettet i ditt standard repositorium';
+
+  @override
+  String get taskIntegrations => 'Oppgaveintegrasjoner';
+
+  @override
+  String get configureSettings => 'Konfigurer innstillinger';
+
+  @override
+  String get completeAuthBrowser => 'Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Kunne ikke starte $appName-autentisering';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Koble til $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Du må autorisere Omi til å opprette oppgaver i $appName-kontoen din. Dette vil åpne nettleseren din for autentisering.';
+  }
+
+  @override
+  String get continueButton => 'Fortsett';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName-integrasjon';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integrasjon med $appName kommer snart! Vi jobber hardt for å gi deg flere oppgavebehandlingsalternativer.';
+  }
+
+  @override
+  String get gotIt => 'Skjønner';
+
+  @override
+  String get tasksExportedOneApp => 'Oppgaver kan eksporteres til én app om gangen.';
+
+  @override
+  String get completeYourUpgrade => 'Fullfør oppgraderingen din';
+
+  @override
+  String get importConfiguration => 'Importer konfigurasjon';
+
+  @override
+  String get exportConfiguration => 'Eksporter konfigurasjon';
+
+  @override
+  String get bringYourOwn => 'Ta med din egen';
+
+  @override
+  String get payYourSttProvider => 'Bruk omi fritt. Du betaler bare STT-leverandøren direkte.';
+
+  @override
+  String get freeMinutesMonth => '1 200 gratis minutter/måned inkludert. Ubegrenset med ';
+
+  @override
+  String get omiUnlimited => 'Omi Ubegrenset';
+
+  @override
+  String get hostRequired => 'Vert er påkrevd';
+
+  @override
+  String get validPortRequired => 'Gyldig port er påkrevd';
+
+  @override
+  String get validWebsocketUrlRequired => 'Gyldig WebSocket-URL er påkrevd (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API-URL er påkrevd';
+
+  @override
+  String get apiKeyRequired => 'API-nøkkel er påkrevd';
+
+  @override
+  String get invalidJsonConfig => 'Ugyldig JSON-konfigurasjon';
+
+  @override
+  String errorSaving(String error) {
+    return 'Feil ved lagring: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfigurasjon kopiert til utklippstavlen';
+
+  @override
+  String get pasteJsonConfig => 'Lim inn JSON-konfigurasjonen din nedenfor:';
+
+  @override
+  String get addApiKeyAfterImport => 'Du må legge til din egen API-nøkkel etter import';
+
+  @override
+  String get paste => 'Lim inn';
+
+  @override
+  String get import => 'Importer';
+
+  @override
+  String get invalidProviderInConfig => 'Ugyldig leverandør i konfigurasjon';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Importert $providerName-konfigurasjon';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Ugyldig JSON: $error';
+  }
+
+  @override
+  String get provider => 'Leverandør';
+
+  @override
+  String get live => 'Live';
+
+  @override
+  String get onDevice => 'På enhet';
+
+  @override
+  String get apiUrl => 'API-URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Skriv inn ditt STT HTTP-endepunkt';
+
+  @override
+  String get websocketUrl => 'WebSocket-URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Skriv inn ditt live STT WebSocket-endepunkt';
+
+  @override
+  String get apiKey => 'API-nøkkel';
+
+  @override
+  String get enterApiKey => 'Skriv inn API-nøkkelen din';
+
+  @override
+  String get storedLocallyNeverShared => 'Lagret lokalt, aldri delt';
+
+  @override
+  String get host => 'Vert';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Avansert';
+
+  @override
+  String get configuration => 'Konfigurasjon';
+
+  @override
+  String get requestConfiguration => 'Forespørselskonfigurasjon';
+
+  @override
+  String get responseSchema => 'Responsskjema';
+
+  @override
+  String get modified => 'Endret';
+
+  @override
+  String get resetRequestConfig => 'Tilbakestill forespørselskonfigurasjon til standard';
+
+  @override
+  String get logs => 'Logger';
+
+  @override
+  String get logsCopied => 'Logger kopiert';
+
+  @override
+  String get noLogsYet => 'Ingen logger ennå. Start opptak for å se tilpasset STT-aktivitet.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName bruker $codecReason. Omi vil bli brukt.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi-transkripsjon';
+
+  @override
+  String get bestInClassTranscription => 'Beste transkripsjon i sin klasse uten oppsett';
+
+  @override
+  String get instantSpeakerLabels => 'Øyeblikkelige talermerkinger';
+
+  @override
+  String get languageTranslation => '100+ språkoversettelser';
+
+  @override
+  String get optimizedForConversation => 'Optimalisert for samtaler';
+
+  @override
+  String get autoLanguageDetection => 'Automatisk språkdeteksjon';
+
+  @override
+  String get highAccuracy => 'Høy nøyaktighet';
+
+  @override
+  String get privacyFirst => 'Personvern først';
+
+  @override
+  String get saveChanges => 'Lagre endringer';
+
+  @override
+  String get resetToDefault => 'Tilbakestill til standard';
+
+  @override
+  String get viewTemplate => 'Vis mal';
+
+  @override
+  String get trySomethingLike => 'Prøv noe som...';
+
+  @override
+  String get tryIt => 'Prøv det';
+
+  @override
+  String get creatingPlan => 'Oppretter plan';
+
+  @override
+  String get developingLogic => 'Utvikler logikk';
+
+  @override
+  String get designingApp => 'Designer app';
+
+  @override
+  String get generatingIconStep => 'Genererer ikon';
+
+  @override
+  String get finalTouches => 'Siste finpuss';
+
+  @override
+  String get processing => 'Behandler...';
+
+  @override
+  String get features => 'Funksjoner';
+
+  @override
+  String get creatingYourApp => 'Oppretter appen din...';
+
+  @override
+  String get generatingIcon => 'Genererer ikon...';
+
+  @override
+  String get whatShouldWeMake => 'Hva skal vi lage?';
+
+  @override
+  String get appName => 'Appnavn';
+
+  @override
+  String get description => 'Beskrivelse';
+
+  @override
+  String get publicLabel => 'Offentlig';
+
+  @override
+  String get privateLabel => 'Privat';
+
+  @override
+  String get free => 'Gratis';
+
+  @override
+  String get perMonth => '/ Måned';
+
+  @override
+  String get tailoredConversationSummaries => 'Tilpassede samtalesammendrag';
+
+  @override
+  String get customChatbotPersonality => 'Tilpasset chatbot-personlighet';
+
+  @override
+  String get makePublic => 'Gjør offentlig';
+
+  @override
+  String get anyoneCanDiscover => 'Alle kan oppdage appen din';
+
+  @override
+  String get onlyYouCanUse => 'Bare du kan bruke denne appen';
+
+  @override
+  String get paidApp => 'Betalt app';
+
+  @override
+  String get usersPayToUse => 'Brukere betaler for å bruke appen din';
+
+  @override
+  String get freeForEveryone => 'Gratis for alle';
+
+  @override
+  String get perMonthLabel => '/ måned';
+
+  @override
+  String get creating => 'Oppretter...';
+
+  @override
+  String get createApp => 'Opprett app';
+
+  @override
+  String get searchingForDevices => 'Søker etter enheter...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ENHETER',
+      one: 'ENHET',
+    );
+    return '$count $_temp0 FUNNET I NÆRHETEN';
+  }
+
+  @override
+  String get pairingSuccessful => 'PARING VELLYKKET';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Feil ved tilkobling til Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Ikke vis igjen';
+
+  @override
+  String get iUnderstand => 'Jeg forstår';
+
+  @override
+  String get enableBluetooth => 'Aktiver Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi trenger Bluetooth for å koble til den bærbare enheten din. Aktiver Bluetooth og prøv igjen.';
+
+  @override
+  String get contactSupport => 'Kontakte support?';
+
+  @override
+  String get connectLater => 'Koble til senere';
+
+  @override
+  String get grantPermissions => 'Gi tillatelser';
+
+  @override
+  String get backgroundActivity => 'Bakgrunnsaktivitet';
+
+  @override
+  String get backgroundActivityDesc => 'La Omi kjøre i bakgrunnen for bedre stabilitet';
+
+  @override
+  String get locationAccess => 'Posisjonstilgang';
+
+  @override
+  String get locationAccessDesc => 'Aktiver bakgrunnsposisjon for full opplevelse';
+
+  @override
+  String get notifications => 'Varsler';
+
+  @override
+  String get notificationsDesc => 'Aktiver varsler for å holde deg informert';
+
+  @override
+  String get locationServiceDisabled => 'Posisjonstjeneste deaktivert';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Posisjonstjeneste er deaktivert. Gå til Innstillinger > Personvern og sikkerhet > Posisjonstjenester og aktiver den';
+
+  @override
+  String get backgroundLocationDenied => 'Bakgrunnsposisjonstilgang nektet';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Gå til enhetsinnstillinger og sett posisjonstillatelse til \"Alltid tillat\"';
+
+  @override
+  String get lovingOmi => 'Liker du Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Hjelp oss med å nå flere personer ved å legge igjen en anmeldelse i App Store. Tilbakemeldingen din betyr alt for oss!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Hjelp oss med å nå flere personer ved å legge igjen en anmeldelse i Google Play Store. Tilbakemeldingen din betyr alt for oss!';
+
+  @override
+  String get rateOnAppStore => 'Vurder i App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Vurder i Google Play';
+
+  @override
+  String get maybeLater => 'Kanskje senere';
+
+  @override
+  String get speechProfileIntro => 'Omi må lære målene og stemmen din. Du kan endre det senere.';
+
+  @override
+  String get getStarted => 'Kom i gang';
+
+  @override
+  String get allDone => 'Alt ferdig!';
+
+  @override
+  String get keepGoing => 'Fortsett, du gjør det bra';
+
+  @override
+  String get skipThisQuestion => 'Hopp over dette spørsmålet';
+
+  @override
+  String get skipForNow => 'Hopp over foreløpig';
+
+  @override
+  String get connectionError => 'Tilkoblingsfeil';
+
+  @override
+  String get connectionErrorDesc => 'Kunne ikke koble til serveren. Sjekk internettforbindelsen din og prøv igjen.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Ugyldig opptak oppdaget';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Det ser ut til å være flere talere i opptaket. Pass på at du er på et stille sted og prøv igjen.';
+
+  @override
+  String get tooShortDesc => 'Det er ikke nok tale oppdaget. Snakk mer og prøv igjen.';
+
+  @override
+  String get invalidRecordingDesc => 'Pass på at du snakker i minst 5 sekunder og ikke mer enn 90.';
+
+  @override
+  String get areYouThere => 'Er du der?';
+
+  @override
+  String get noSpeechDesc =>
+      'Vi kunne ikke oppdage noen tale. Pass på å snakke i minst 10 sekunder og ikke mer enn 3 minutter.';
+
+  @override
+  String get connectionLost => 'Tilkobling tapt';
+
+  @override
+  String get connectionLostDesc => 'Tilkoblingen ble avbrutt. Sjekk internettforbindelsen din og prøv igjen.';
+
+  @override
+  String get tryAgain => 'Prøv igjen';
+
+  @override
+  String get connectOmiOmiGlass => 'Koble til Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Fortsett uten enhet';
+
+  @override
+  String get permissionsRequired => 'Tillatelser kreves';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Denne appen trenger Bluetooth- og posisjonstillatelser for å fungere ordentlig. Aktiver dem i innstillingene.';
+
+  @override
+  String get openSettings => 'Åpne innstillinger';
+
+  @override
+  String get wantDifferentName => 'Vil du bli kalt noe annet?';
+
+  @override
+  String get whatsYourName => 'Hva heter du?';
+
+  @override
+  String get speakTranscribeSummarize => 'Snakk. Transkriber. Sammenfatt.';
+
+  @override
+  String get signInWithApple => 'Logg inn med Apple';
+
+  @override
+  String get signInWithGoogle => 'Logg inn med Google';
+
+  @override
+  String get byContinuingAgree => 'Ved å fortsette godtar du vår ';
+
+  @override
+  String get termsOfUse => 'Bruksvilkår';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Din AI-følgesvenn';
+
+  @override
+  String get captureEveryMoment => 'Fang hvert øyeblikk. Få AI-drevne\nsammendrag. Aldri ta notater igjen.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch-oppsett';
+
+  @override
+  String get permissionRequestedExclaim => 'Tillatelse forespurt!';
+
+  @override
+  String get microphonePermission => 'Mikrofontillatelse';
+
+  @override
+  String get permissionGrantedNow =>
+      'Tillatelse gitt! Nå:\n\nÅpne Omi-appen på klokken din og trykk \"Fortsett\" nedenfor';
+
+  @override
+  String get needMicrophonePermission =>
+      'Vi trenger mikrofontillatelse.\n\n1. Trykk \"Gi tillatelse\"\n2. Tillat på iPhone\n3. Klokkeapp vil lukkes\n4. Åpne på nytt og trykk \"Fortsett\"';
+
+  @override
+  String get grantPermissionButton => 'Gi tillatelse';
+
+  @override
+  String get needHelp => 'Trenger du hjelp?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Feilsøking:\n\n1. Sørg for at Omi er installert på klokken din\n2. Åpne Omi-appen på klokken din\n3. Se etter tillatelsespopup\n4. Trykk \"Tillat\" når du blir bedt om det\n5. App på klokken vil lukkes - åpne den på nytt\n6. Kom tilbake og trykk \"Fortsett\" på iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Opptak startet!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Tillatelse ikke gitt ennå. Pass på at du tillot mikrofontilgang og åpnet appen på nytt på klokken din.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Feil ved forespørsel om tillatelse: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Feil ved oppstart av opptak: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Velg hovedspråket ditt';
+
+  @override
+  String get languageBenefits => 'Angi språket ditt for skarpere transkripsjoner og en personlig opplevelse';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Hva er ditt hovedspråk?';
+
+  @override
+  String get selectYourLanguage => 'Velg språket ditt';
+
+  @override
+  String get personalGrowthJourney => 'Din personlige vekstreise med AI som lytter til hvert ord.';
+
+  @override
+  String get actionItemsTitle => 'Gjøremål';
+
+  @override
+  String get actionItemsDescription => 'Trykk for å redigere • Langt trykk for å velge • Sveip for handlinger';
+
+  @override
+  String get tabToDo => 'Å gjøre';
+
+  @override
+  String get tabDone => 'Ferdig';
+
+  @override
+  String get tabOld => 'Gamle';
+
+  @override
+  String get emptyTodoMessage => '🎉 Alt ferdig!\nIngen ventende handlingspunkter';
+
+  @override
+  String get emptyDoneMessage => 'Ingen fullførte elementer ennå';
+
+  @override
+  String get emptyOldMessage => '✅ Ingen gamle oppgaver';
+
+  @override
+  String get noItems => 'Ingen elementer';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Handlingspunkt merket som ufullført';
+
+  @override
+  String get actionItemCompleted => 'Handlingspunkt fullført';
+
+  @override
+  String get deleteActionItemTitle => 'Slette handlingspunkt';
+
+  @override
+  String get deleteActionItemMessage => 'Er du sikker på at du vil slette dette handlingspunktet?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Slette valgte elementer';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Er du sikker på at du vil slette $count valgte handlingspunkt$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Handlingspunkt \"$description\" slettet';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count handlingspunkt$s slettet';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Kunne ikke slette handlingspunkt';
+
+  @override
+  String get failedToDeleteItems => 'Kunne ikke slette elementer';
+
+  @override
+  String get failedToDeleteSomeItems => 'Kunne ikke slette noen elementer';
+
+  @override
+  String get welcomeActionItemsTitle => 'Klar for handlingspunkter';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'AI-en din vil automatisk trekke ut oppgaver og gjøremål fra samtalene dine. De vil dukke opp her når de opprettes.';
+
+  @override
+  String get autoExtractionFeature => 'Automatisk trukket ut fra samtaler';
+
+  @override
+  String get editSwipeFeature => 'Trykk for å redigere, sveip for å fullføre eller slette';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count valgt';
+  }
+
+  @override
+  String get selectAll => 'Velg alle';
+
+  @override
+  String get deleteSelected => 'Slett valgte';
+
+  @override
+  String searchMemories(int count) {
+    return 'Søk i $count minner';
+  }
+
+  @override
+  String get memoryDeleted => 'Minne slettet.';
+
+  @override
+  String get undo => 'Angre';
+
+  @override
+  String get noMemoriesYet => 'Ingen minner ennå';
+
+  @override
+  String get noAutoMemories => 'Ingen automatisk uttrukne minner ennå';
+
+  @override
+  String get noManualMemories => 'Ingen manuelle minner ennå';
+
+  @override
+  String get noMemoriesInCategories => 'Ingen minner i disse kategoriene';
+
+  @override
+  String get noMemoriesFound => 'Ingen minner funnet';
+
+  @override
+  String get addFirstMemory => 'Legg til ditt første minne';
+
+  @override
+  String get clearMemoryTitle => 'Tømme Omis minne';
+
+  @override
+  String get clearMemoryMessage => 'Er du sikker på at du vil tømme Omis minne? Dette kan ikke angres.';
+
+  @override
+  String get clearMemoryButton => 'Tøm minne';
+
+  @override
+  String get memoryClearedSuccess => 'Omis minne om deg har blitt tømt';
+
+  @override
+  String get noMemoriesToDelete => 'Ingen minner å slette';
+
+  @override
+  String get createMemoryTooltip => 'Opprett nytt minne';
+
+  @override
+  String get createActionItemTooltip => 'Opprett nytt handlingspunkt';
+
+  @override
+  String get memoryManagement => 'Minneadministrasjon';
+
+  @override
+  String get filterMemories => 'Filtrer minner';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Du har $count totale minner';
+  }
+
+  @override
+  String get publicMemories => 'Offentlige minner';
+
+  @override
+  String get privateMemories => 'Private minner';
+
+  @override
+  String get makeAllPrivate => 'Gjør alle minner private';
+
+  @override
+  String get makeAllPublic => 'Gjør alle minner offentlige';
+
+  @override
+  String get deleteAllMemories => 'Slett alle minner';
+
+  @override
+  String get allMemoriesPrivateResult => 'Alle minner er nå private';
+
+  @override
+  String get allMemoriesPublicResult => 'Alle minner er nå offentlige';
+
+  @override
+  String get newMemory => 'Nytt minne';
+
+  @override
+  String get editMemory => 'Rediger minne';
+
+  @override
+  String get memoryContentHint => 'Jeg liker å spise iskrem...';
+
+  @override
+  String get failedToSaveMemory => 'Kunne ikke lagre. Sjekk forbindelsen din.';
+
+  @override
+  String get saveMemory => 'Lagre minne';
+
+  @override
+  String get retry => 'Prøv igjen';
+
+  @override
+  String get createActionItem => 'Opprett handlingspunkt';
+
+  @override
+  String get editActionItem => 'Rediger handlingspunkt';
+
+  @override
+  String get actionItemDescriptionHint => 'Hva må gjøres?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Beskrivelse av handlingspunkt kan ikke være tom.';
+
+  @override
+  String get actionItemUpdated => 'Handlingspunkt oppdatert';
+
+  @override
+  String get failedToUpdateActionItem => 'Kunne ikke oppdatere handlingspunkt';
+
+  @override
+  String get actionItemCreated => 'Handlingspunkt opprettet';
+
+  @override
+  String get failedToCreateActionItem => 'Kunne ikke opprette handlingspunkt';
+
+  @override
+  String get dueDate => 'Forfallsdato';
+
+  @override
+  String get time => 'Tid';
+
+  @override
+  String get addDueDate => 'Legg til forfallsdato';
+
+  @override
+  String get pressDoneToSave => 'Trykk ferdig for å lagre';
+
+  @override
+  String get pressDoneToCreate => 'Trykk ferdig for å opprette';
+
+  @override
+  String get filterAll => 'Alle';
+
+  @override
+  String get filterSystem => 'Om deg';
+
+  @override
+  String get filterInteresting => 'Innsikter';
+
+  @override
+  String get filterManual => 'Manuell';
+
+  @override
+  String get completed => 'Fullført';
+
+  @override
+  String get markComplete => 'Merk som fullført';
+
+  @override
+  String get actionItemDeleted => 'Handlingspunkt slettet';
+
+  @override
+  String get failedToDeleteActionItem => 'Kunne ikke slette handlingspunkt';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Slette handlingspunkt';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Er du sikker på at du vil slette dette handlingspunktet?';
+
+  @override
+  String get appLanguage => 'Appspråk';
+
+  @override
+  String get appInterfaceSectionTitle => 'APP-GRENSESNITT';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'TALE OG TRANSKRIPSJON';
+
+  @override
+  String get languageSettingsHelperText =>
+      'App-språk endrer menyer og knapper. Talespråk påvirker hvordan opptakene dine transkriberes.';
+}

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -1,0 +1,2234 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Polish (`pl`).
+class AppLocalizationsPl extends AppLocalizations {
+  AppLocalizationsPl([String locale = 'pl']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Rozmowa';
+
+  @override
+  String get transcriptTab => 'Transkrypcja';
+
+  @override
+  String get actionItemsTab => 'Zadania';
+
+  @override
+  String get deleteConversationTitle => 'Usunąć rozmowę?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Czy na pewno chcesz usunąć tę rozmowę? Ta czynność nie może zostać cofnięta.';
+
+  @override
+  String get confirm => 'Potwierdź';
+
+  @override
+  String get cancel => 'Anuluj';
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get delete => 'Usuń';
+
+  @override
+  String get add => 'Dodaj';
+
+  @override
+  String get update => 'Aktualizuj';
+
+  @override
+  String get save => 'Zapisz';
+
+  @override
+  String get edit => 'Edytuj';
+
+  @override
+  String get close => 'Zamknij';
+
+  @override
+  String get clear => 'Wyczyść';
+
+  @override
+  String get copyTranscript => 'Kopiuj transkrypcję';
+
+  @override
+  String get copySummary => 'Kopiuj podsumowanie';
+
+  @override
+  String get testPrompt => 'Testuj prompt';
+
+  @override
+  String get reprocessConversation => 'Przetwórz ponownie rozmowę';
+
+  @override
+  String get deleteConversation => 'Usuń rozmowę';
+
+  @override
+  String get contentCopied => 'Zawartość skopiowana do schowka';
+
+  @override
+  String get failedToUpdateStarred => 'Nie udało się zaktualizować statusu ulubionego.';
+
+  @override
+  String get conversationUrlNotShared => 'Nie można udostępnić adresu URL rozmowy.';
+
+  @override
+  String get errorProcessingConversation => 'Błąd podczas przetwarzania rozmowy. Spróbuj ponownie później.';
+
+  @override
+  String get noInternetConnection => 'Sprawdź połączenie internetowe i spróbuj ponownie.';
+
+  @override
+  String get unableToDeleteConversation => 'Nie można usunąć rozmowy';
+
+  @override
+  String get somethingWentWrong => 'Coś poszło nie tak! Spróbuj ponownie później.';
+
+  @override
+  String get copyErrorMessage => 'Kopiuj komunikat błędu';
+
+  @override
+  String get errorCopied => 'Komunikat błędu skopiowany do schowka';
+
+  @override
+  String get remaining => 'Pozostało';
+
+  @override
+  String get loading => 'Ładowanie...';
+
+  @override
+  String get loadingDuration => 'Ładowanie czasu trwania...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekund';
+  }
+
+  @override
+  String get people => 'Osoby';
+
+  @override
+  String get addNewPerson => 'Dodaj nową osobę';
+
+  @override
+  String get editPerson => 'Edytuj osobę';
+
+  @override
+  String get createPersonHint => 'Utwórz nową osobę i naucz Omi rozpoznawać jej głos!';
+
+  @override
+  String get speechProfile => 'Profil głosu';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Próbka $number';
+  }
+
+  @override
+  String get settings => 'Ustawienia';
+
+  @override
+  String get language => 'Język';
+
+  @override
+  String get selectLanguage => 'Wybierz język';
+
+  @override
+  String get deleting => 'Usuwanie...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Ukończ uwierzytelnianie w przeglądarce. Po zakończeniu wróć do aplikacji.';
+
+  @override
+  String get failedToStartAuthentication => 'Nie udało się rozpocząć uwierzytelniania';
+
+  @override
+  String get importStarted => 'Import rozpoczęty! Otrzymasz powiadomienie po zakończeniu.';
+
+  @override
+  String get failedToStartImport => 'Nie udało się rozpocząć importu. Spróbuj ponownie.';
+
+  @override
+  String get couldNotAccessFile => 'Nie można uzyskać dostępu do wybranego pliku';
+
+  @override
+  String get askOmi => 'Zapytaj Omi';
+
+  @override
+  String get done => 'Gotowe';
+
+  @override
+  String get disconnected => 'Rozłączono';
+
+  @override
+  String get searching => 'Wyszukiwanie';
+
+  @override
+  String get connectDevice => 'Połącz urządzenie';
+
+  @override
+  String get monthlyLimitReached => 'Osiągnięto miesięczny limit.';
+
+  @override
+  String get checkUsage => 'Sprawdź wykorzystanie';
+
+  @override
+  String get syncingRecordings => 'Synchronizacja nagrań';
+
+  @override
+  String get recordingsToSync => 'Nagrania do synchronizacji';
+
+  @override
+  String get allCaughtUp => 'Wszystko na bieżąco';
+
+  @override
+  String get sync => 'Synchronizuj';
+
+  @override
+  String get pendantUpToDate => 'Pendant jest aktualny';
+
+  @override
+  String get allRecordingsSynced => 'Wszystkie nagrania są zsynchronizowane';
+
+  @override
+  String get syncingInProgress => 'Trwa synchronizacja';
+
+  @override
+  String get readyToSync => 'Gotowe do synchronizacji';
+
+  @override
+  String get tapSyncToStart => 'Dotknij Synchronizuj, aby rozpocząć';
+
+  @override
+  String get pendantNotConnected => 'Pendant nie jest podłączony. Podłącz, aby zsynchronizować.';
+
+  @override
+  String get everythingSynced => 'Wszystko jest już zsynchronizowane.';
+
+  @override
+  String get recordingsNotSynced => 'Masz nagrania, które nie zostały jeszcze zsynchronizowane.';
+
+  @override
+  String get syncingBackground => 'Będziemy synchronizować Twoje nagrania w tle.';
+
+  @override
+  String get noConversationsYet => 'Brak rozmów.';
+
+  @override
+  String get noStarredConversations => 'Brak ulubionych rozmów.';
+
+  @override
+  String get starConversationHint => 'Aby oznaczyć rozmowę gwiazdką, otwórz ją i dotknij ikony gwiazdki w nagłówku.';
+
+  @override
+  String get searchConversations => 'Szukaj rozmów';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return 'Wybrano: $count';
+  }
+
+  @override
+  String get merge => 'Scal';
+
+  @override
+  String get mergeConversations => 'Scal rozmowy';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Spowoduje to połączenie $count rozmów w jedną. Cała zawartość zostanie scalone i wygenerowana ponownie.';
+  }
+
+  @override
+  String get mergingInBackground => 'Scalanie w tle. To może chwilę potrwać.';
+
+  @override
+  String get failedToStartMerge => 'Nie udało się rozpocząć scalania';
+
+  @override
+  String get askAnything => 'Zapytaj o cokolwiek';
+
+  @override
+  String get noMessagesYet => 'Brak wiadomości!\nCzemu nie rozpoczniesz rozmowy?';
+
+  @override
+  String get deletingMessages => 'Usuwanie Twoich wiadomości z pamięci Omi...';
+
+  @override
+  String get messageCopied => 'Wiadomość skopiowana do schowka.';
+
+  @override
+  String get cannotReportOwnMessage => 'Nie możesz zgłosić własnych wiadomości.';
+
+  @override
+  String get reportMessage => 'Zgłoś wiadomość';
+
+  @override
+  String get reportMessageConfirm => 'Czy na pewno chcesz zgłosić tę wiadomość?';
+
+  @override
+  String get messageReported => 'Wiadomość zgłoszona pomyślnie.';
+
+  @override
+  String get thankYouFeedback => 'Dziękujemy za opinię!';
+
+  @override
+  String get clearChat => 'Wyczyścić czat?';
+
+  @override
+  String get clearChatConfirm => 'Czy na pewno chcesz wyczyścić czat? Ta czynność nie może zostać cofnięta.';
+
+  @override
+  String get maxFilesLimit => 'Możesz przesłać maksymalnie 4 pliki naraz';
+
+  @override
+  String get chatWithOmi => 'Czat z Omi';
+
+  @override
+  String get apps => 'Aplikacje';
+
+  @override
+  String get noAppsFound => 'Nie znaleziono aplikacji';
+
+  @override
+  String get tryAdjustingSearch => 'Spróbuj dostosować wyszukiwanie lub filtry';
+
+  @override
+  String get createYourOwnApp => 'Stwórz własną aplikację';
+
+  @override
+  String get buildAndShareApp => 'Zbuduj i udostępnij swoją własną aplikację';
+
+  @override
+  String get searchApps => 'Przeszukaj ponad 1500 aplikacji';
+
+  @override
+  String get myApps => 'Moje aplikacje';
+
+  @override
+  String get installedApps => 'Zainstalowane aplikacje';
+
+  @override
+  String get unableToFetchApps => 'Nie można pobrać aplikacji :(\n\nSprawdź połączenie internetowe i spróbuj ponownie.';
+
+  @override
+  String get aboutOmi => 'O Omi';
+
+  @override
+  String get privacyPolicy => 'Polityką prywatności';
+
+  @override
+  String get visitWebsite => 'Odwiedź stronę';
+
+  @override
+  String get helpOrInquiries => 'Pomoc lub pytania?';
+
+  @override
+  String get joinCommunity => 'Dołącz do społeczności!';
+
+  @override
+  String get membersAndCounting => 'Ponad 8000 członków i wciąż przybywa.';
+
+  @override
+  String get deleteAccountTitle => 'Usuń konto';
+
+  @override
+  String get deleteAccountConfirm => 'Czy na pewno chcesz usunąć swoje konto?';
+
+  @override
+  String get cannotBeUndone => 'Tej operacji nie można cofnąć.';
+
+  @override
+  String get allDataErased => 'Wszystkie Twoje wspomnienia i rozmowy zostaną trwale usunięte.';
+
+  @override
+  String get appsDisconnected => 'Twoje aplikacje i integracje zostaną natychmiast rozłączone.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Możesz wyeksportować swoje dane przed usunięciem konta, ale po usunięciu nie można ich odzyskać.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Rozumiem, że usunięcie mojego konta jest trwałe i wszystkie dane, w tym wspomnienia i rozmowy, zostaną utracone bez możliwości odzyskania.';
+
+  @override
+  String get areYouSure => 'Czy jesteś pewien?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Ta czynność jest nieodwracalna i trwale usunie Twoje konto oraz wszystkie powiązane dane. Czy na pewno chcesz kontynuować?';
+
+  @override
+  String get deleteNow => 'Usuń teraz';
+
+  @override
+  String get goBack => 'Wróć';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Zaznacz pole, aby potwierdzić, że rozumiesz, iż usunięcie konta jest trwałe i nieodwracalne.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Imię';
+
+  @override
+  String get email => 'Email';
+
+  @override
+  String get customVocabulary => 'Własny słownik';
+
+  @override
+  String get identifyingOthers => 'Identyfikacja innych osób';
+
+  @override
+  String get paymentMethods => 'Metody płatności';
+
+  @override
+  String get conversationDisplay => 'Wyświetlanie rozmów';
+
+  @override
+  String get dataPrivacy => 'Dane i prywatność';
+
+  @override
+  String get userId => 'ID użytkownika';
+
+  @override
+  String get notSet => 'Nie ustawiono';
+
+  @override
+  String get userIdCopied => 'ID użytkownika skopiowane do schowka';
+
+  @override
+  String get systemDefault => 'Domyślny systemowy';
+
+  @override
+  String get planAndUsage => 'Plan i wykorzystanie';
+
+  @override
+  String get offlineSync => 'Synchronizacja offline';
+
+  @override
+  String get deviceSettings => 'Ustawienia urządzenia';
+
+  @override
+  String get chatTools => 'Narzędzia czatu';
+
+  @override
+  String get feedbackBug => 'Opinia / Błąd';
+
+  @override
+  String get helpCenter => 'Centrum pomocy';
+
+  @override
+  String get developerSettings => 'Ustawienia programisty';
+
+  @override
+  String get getOmiForMac => 'Pobierz Omi dla Mac';
+
+  @override
+  String get referralProgram => 'Program poleceń';
+
+  @override
+  String get signOut => 'Wyloguj się';
+
+  @override
+  String get appAndDeviceCopied => 'Szczegóły aplikacji i urządzenia skopiowane';
+
+  @override
+  String get wrapped2025 => 'Podsumowanie 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Twoja prywatność, Twoja kontrola';
+
+  @override
+  String get privacyIntro =>
+      'W Omi dbamy o Twoją prywatność. Ta strona pozwala kontrolować sposób przechowywania i wykorzystywania Twoich danych.';
+
+  @override
+  String get learnMore => 'Dowiedz się więcej...';
+
+  @override
+  String get dataProtectionLevel => 'Poziom ochrony danych';
+
+  @override
+  String get dataProtectionDesc =>
+      'Twoje dane są domyślnie zabezpieczone silnym szyfrowaniem. Przejrzyj swoje ustawienia i przyszłe opcje prywatności poniżej.';
+
+  @override
+  String get appAccess => 'Dostęp aplikacji';
+
+  @override
+  String get appAccessDesc =>
+      'Następujące aplikacje mogą uzyskać dostęp do Twoich danych. Dotknij aplikacji, aby zarządzać jej uprawnieniami.';
+
+  @override
+  String get noAppsExternalAccess => 'Żadne zainstalowane aplikacje nie mają zewnętrznego dostępu do Twoich danych.';
+
+  @override
+  String get deviceName => 'Nazwa urządzenia';
+
+  @override
+  String get deviceId => 'ID urządzenia';
+
+  @override
+  String get firmware => 'Oprogramowanie';
+
+  @override
+  String get sdCardSync => 'Synchronizacja karty SD';
+
+  @override
+  String get hardwareRevision => 'Wersja sprzętu';
+
+  @override
+  String get modelNumber => 'Numer modelu';
+
+  @override
+  String get manufacturer => 'Producent';
+
+  @override
+  String get doubleTap => 'Podwójne dotknięcie';
+
+  @override
+  String get ledBrightness => 'Jasność LED';
+
+  @override
+  String get micGain => 'Wzmocnienie mikrofonu';
+
+  @override
+  String get disconnect => 'Rozłącz';
+
+  @override
+  String get forgetDevice => 'Zapomnij urządzenie';
+
+  @override
+  String get chargingIssues => 'Problemy z ładowaniem';
+
+  @override
+  String get disconnectDevice => 'Rozłącz urządzenie';
+
+  @override
+  String get unpairDevice => 'Rozparuj urządzenie';
+
+  @override
+  String get unpairAndForget => 'Rozparuj i zapomnij urządzenie';
+
+  @override
+  String get deviceDisconnectedMessage => 'Twoje Omi zostało rozłączone 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Urządzenie rozparowane. Przejdź do Ustawienia > Bluetooth i zapomnij urządzenie, aby zakończyć parowanie.';
+
+  @override
+  String get unpairDialogTitle => 'Rozparuj urządzenie';
+
+  @override
+  String get unpairDialogMessage =>
+      'Spowoduje to rozparowanie urządzenia, aby można je było podłączyć do innego telefonu. Musisz przejść do Ustawienia > Bluetooth i zapomnieć urządzenie, aby zakończyć proces.';
+
+  @override
+  String get deviceNotConnected => 'Urządzenie nie jest podłączone';
+
+  @override
+  String get connectDeviceMessage =>
+      'Podłącz swoje urządzenie Omi, aby uzyskać dostęp\ndo ustawień urządzenia i personalizacji';
+
+  @override
+  String get deviceInfoSection => 'Informacje o urządzeniu';
+
+  @override
+  String get customizationSection => 'Personalizacja';
+
+  @override
+  String get hardwareSection => 'Sprzęt';
+
+  @override
+  String get v2Undetected => 'Nie wykryto V2';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Widzimy, że masz urządzenie V1 lub Twoje urządzenie nie jest podłączone. Funkcja karty SD jest dostępna tylko dla urządzeń V2.';
+
+  @override
+  String get endConversation => 'Zakończ rozmowę';
+
+  @override
+  String get pauseResume => 'Wstrzymaj/Wznów';
+
+  @override
+  String get starConversation => 'Oznacz rozmowę gwiazdką';
+
+  @override
+  String get doubleTapAction => 'Akcja podwójnego dotknięcia';
+
+  @override
+  String get endAndProcess => 'Zakończ i przetwórz rozmowę';
+
+  @override
+  String get pauseResumeRecording => 'Wstrzymaj/wznów nagrywanie';
+
+  @override
+  String get starOngoing => 'Oznacz bieżącą rozmowę gwiazdką';
+
+  @override
+  String get off => 'Wył.';
+
+  @override
+  String get max => 'Maks.';
+
+  @override
+  String get mute => 'Wycisz';
+
+  @override
+  String get quiet => 'Cicho';
+
+  @override
+  String get normal => 'Normalnie';
+
+  @override
+  String get high => 'Wysoko';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon jest wyciszony';
+
+  @override
+  String get micGainDescLow => 'Bardzo cicho - do głośnych środowisk';
+
+  @override
+  String get micGainDescModerate => 'Cicho - do umiarkowanego hałasu';
+
+  @override
+  String get micGainDescNeutral => 'Neutralnie - zrównoważone nagrywanie';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Lekko wzmocnione - normalne użycie';
+
+  @override
+  String get micGainDescBoosted => 'Wzmocnione - do cichych środowisk';
+
+  @override
+  String get micGainDescHigh => 'Wysokie - do odległych lub cichych głosów';
+
+  @override
+  String get micGainDescVeryHigh => 'Bardzo wysokie - do bardzo cichych źródeł';
+
+  @override
+  String get micGainDescMax => 'Maksymalne - używaj z ostrożnością';
+
+  @override
+  String get developerSettingsTitle => 'Ustawienia programisty';
+
+  @override
+  String get saving => 'Zapisywanie...';
+
+  @override
+  String get personaConfig => 'Skonfiguruj swoją osobowość AI';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transkrypcja';
+
+  @override
+  String get transcriptionConfig => 'Skonfiguruj dostawcę STT';
+
+  @override
+  String get conversationTimeout => 'Limit czasu rozmowy';
+
+  @override
+  String get conversationTimeoutConfig => 'Ustaw, kiedy rozmowy kończą się automatycznie';
+
+  @override
+  String get importData => 'Importuj dane';
+
+  @override
+  String get importDataConfig => 'Importuj dane z innych źródeł';
+
+  @override
+  String get debugDiagnostics => 'Debugowanie i diagnostyka';
+
+  @override
+  String get endpointUrl => 'Adres URL punktu końcowego';
+
+  @override
+  String get noApiKeys => 'Brak kluczy API';
+
+  @override
+  String get createKeyToStart => 'Utwórz klucz, aby rozpocząć';
+
+  @override
+  String get createKey => 'Utwórz klucz';
+
+  @override
+  String get docs => 'Dokumentacja';
+
+  @override
+  String get yourOmiInsights => 'Twoje statystyki Omi';
+
+  @override
+  String get today => 'Dzisiaj';
+
+  @override
+  String get thisMonth => 'W tym miesiącu';
+
+  @override
+  String get thisYear => 'W tym roku';
+
+  @override
+  String get allTime => 'Cały czas';
+
+  @override
+  String get noActivityYet => 'Brak aktywności';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Rozpocznij rozmowę z Omi,\naby zobaczyć tutaj statystyki wykorzystania.';
+
+  @override
+  String get listening => 'Słuchanie';
+
+  @override
+  String get listeningSubtitle => 'Całkowity czas, przez który Omi aktywnie słuchało.';
+
+  @override
+  String get understanding => 'Rozumienie';
+
+  @override
+  String get understandingSubtitle => 'Słowa zrozumiane z Twoich rozmów.';
+
+  @override
+  String get providing => 'Dostarczanie';
+
+  @override
+  String get providingSubtitle => 'Zadania i notatki automatycznie zarejestrowane.';
+
+  @override
+  String get remembering => 'Zapamiętywanie';
+
+  @override
+  String get rememberingSubtitle => 'Fakty i szczegóły zapamiętane dla Ciebie.';
+
+  @override
+  String get unlimitedPlan => 'Plan nieograniczony';
+
+  @override
+  String get managePlan => 'Zarządzaj planem';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Twój plan zostanie anulowany $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Twój plan odnawia się $date.';
+  }
+
+  @override
+  String get basicPlan => 'Plan darmowy';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return 'Wykorzystano $used z $limit min';
+  }
+
+  @override
+  String get upgrade => 'Ulepsz';
+
+  @override
+  String get upgradeToUnlimited => 'Ulepsz do nieograniczonego';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Twój plan obejmuje $limit darmowych minut miesięcznie. Ulepsz, aby uzyskać nielimitowany dostęp.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Udostępniam moje statystyki Omi! (omi.me - Twój asystent AI zawsze dostępny)';
+
+  @override
+  String get sharePeriodToday => 'Dzisiaj Omi:';
+
+  @override
+  String get sharePeriodMonth => 'W tym miesiącu Omi:';
+
+  @override
+  String get sharePeriodYear => 'W tym roku Omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Do tej pory Omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Słuchało przez $minutes minut';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Zrozumiało $words słów';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Dostarczyło $count spostrzeżeń';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Zapamiętało $count wspomnień';
+  }
+
+  @override
+  String get debugLogs => 'Logi debugowania';
+
+  @override
+  String get debugLogsAutoDelete => 'Automatyczne usuwanie po 3 dniach.';
+
+  @override
+  String get debugLogsDesc => 'Pomaga diagnozować problemy';
+
+  @override
+  String get noLogFilesFound => 'Nie znaleziono plików logów.';
+
+  @override
+  String get omiDebugLog => 'Log debugowania Omi';
+
+  @override
+  String get logShared => 'Log udostępniony';
+
+  @override
+  String get selectLogFile => 'Wybierz plik logu';
+
+  @override
+  String get shareLogs => 'Udostępnij logi';
+
+  @override
+  String get debugLogCleared => 'Log debugowania wyczyszczony';
+
+  @override
+  String get exportStarted => 'Eksport rozpoczęty. To może potrwać kilka sekund...';
+
+  @override
+  String get exportAllData => 'Eksportuj wszystkie dane';
+
+  @override
+  String get exportDataDesc => 'Eksportuj rozmowy do pliku JSON';
+
+  @override
+  String get exportedConversations => 'Wyeksportowane rozmowy z Omi';
+
+  @override
+  String get exportShared => 'Eksport udostępniony';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Usunąć graf wiedzy?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Spowoduje to usunięcie wszystkich danych grafu wiedzy (węzłów i połączeń). Twoje oryginalne wspomnienia pozostaną bezpieczne. Graf zostanie odbudowany z czasem lub na następne żądanie.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Graf wiedzy usunięty pomyślnie';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Nie udało się usunąć grafu: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Usuń graf wiedzy';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Wyczyść wszystkie węzły i połączenia';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Serwer MCP';
+
+  @override
+  String get mcpServerDesc => 'Połącz asystentów AI z Twoimi danymi';
+
+  @override
+  String get serverUrl => 'Adres URL serwera';
+
+  @override
+  String get urlCopied => 'Adres URL skopiowany';
+
+  @override
+  String get apiKeyAuth => 'Uwierzytelnianie kluczem API';
+
+  @override
+  String get header => 'Nagłówek';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <klucz>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID klienta';
+
+  @override
+  String get clientSecret => 'Sekret klienta';
+
+  @override
+  String get useMcpApiKey => 'Użyj swojego klucza API MCP';
+
+  @override
+  String get webhooks => 'Webhooki';
+
+  @override
+  String get conversationEvents => 'Zdarzenia rozmowy';
+
+  @override
+  String get newConversationCreated => 'Utworzono nową rozmowę';
+
+  @override
+  String get realtimeTranscript => 'Transkrypcja w czasie rzeczywistym';
+
+  @override
+  String get transcriptReceived => 'Otrzymano transkrypcję';
+
+  @override
+  String get audioBytes => 'Bajty audio';
+
+  @override
+  String get audioDataReceived => 'Otrzymano dane audio';
+
+  @override
+  String get intervalSeconds => 'Interwał (sekundy)';
+
+  @override
+  String get daySummary => 'Podsumowanie dnia';
+
+  @override
+  String get summaryGenerated => 'Wygenerowano podsumowanie';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Dodaj do claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Kopiuj konfigurację';
+
+  @override
+  String get configCopied => 'Konfiguracja skopiowana do schowka';
+
+  @override
+  String get listeningMins => 'Słuchanie (min)';
+
+  @override
+  String get understandingWords => 'Rozumienie (słowa)';
+
+  @override
+  String get insights => 'Spostrzeżenia';
+
+  @override
+  String get memories => 'Wspomnienia';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return 'Wykorzystano $used z $limit min w tym miesiącu';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return 'Wykorzystano $used z $limit słów w tym miesiącu';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return 'Uzyskano $used z $limit spostrzeżeń w tym miesiącu';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return 'Utworzono $used z $limit wspomnień w tym miesiącu';
+  }
+
+  @override
+  String get visibility => 'Widoczność';
+
+  @override
+  String get visibilitySubtitle => 'Kontroluj, które rozmowy pojawiają się na Twojej liście';
+
+  @override
+  String get showShortConversations => 'Pokaż krótkie rozmowy';
+
+  @override
+  String get showShortConversationsDesc => 'Wyświetl rozmowy krótsze niż próg';
+
+  @override
+  String get showDiscardedConversations => 'Pokaż odrzucone rozmowy';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Uwzględnij rozmowy oznaczone jako odrzucone';
+
+  @override
+  String get shortConversationThreshold => 'Próg krótkiej rozmowy';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Rozmowy krótsze niż ten próg będą ukryte, chyba że włączysz powyższą opcję';
+
+  @override
+  String get durationThreshold => 'Próg czasu trwania';
+
+  @override
+  String get durationThresholdDesc => 'Ukryj rozmowy krótsze niż ten próg';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Własny słownik';
+
+  @override
+  String get addWords => 'Dodaj słowa';
+
+  @override
+  String get addWordsDesc => 'Imiona, terminy lub rzadkie słowa';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Połącz';
+
+  @override
+  String get comingSoon => 'Wkrótce';
+
+  @override
+  String get chatToolsFooter => 'Połącz swoje aplikacje, aby wyświetlać dane i metryki w czacie.';
+
+  @override
+  String get completeAuthInBrowser => 'Ukończ uwierzytelnianie w przeglądarce. Po zakończeniu wróć do aplikacji.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Nie udało się rozpocząć uwierzytelniania $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Rozłączyć $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Czy na pewno chcesz rozłączyć się z $appName? Możesz ponownie połączyć w dowolnym momencie.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Rozłączono z $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Nie udało się rozłączyć';
+
+  @override
+  String connectTo(String appName) {
+    return 'Połącz z $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Musisz upoważnić Omi do dostępu do Twoich danych $appName. Otworzy to przeglądarkę w celu uwierzytelnienia.';
+  }
+
+  @override
+  String get continueAction => 'Kontynuuj';
+
+  @override
+  String get languageTitle => 'Język';
+
+  @override
+  String get primaryLanguage => 'Język podstawowy';
+
+  @override
+  String get automaticTranslation => 'Automatyczne tłumaczenie';
+
+  @override
+  String get detectLanguages => 'Wykryj ponad 10 języków';
+
+  @override
+  String get authorizeSavingRecordings => 'Autoryzuj zapisywanie nagrań';
+
+  @override
+  String get thanksForAuthorizing => 'Dziękujemy za autoryzację!';
+
+  @override
+  String get needYourPermission => 'Potrzebujemy Twojego pozwolenia';
+
+  @override
+  String get alreadyGavePermission =>
+      'Już udzieliłeś nam zgody na zapisywanie nagrań. Oto przypomnienie, dlaczego tego potrzebujemy:';
+
+  @override
+  String get wouldLikePermission => 'Chcielibyśmy uzyskać Twoją zgodę na zapisywanie nagrań głosowych. Oto dlaczego:';
+
+  @override
+  String get improveSpeechProfile => 'Popraw swój profil głosu';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Używamy nagrań do dalszego szkolenia i ulepszania Twojego osobistego profilu głosu.';
+
+  @override
+  String get trainFamilyProfiles => 'Trenuj profile dla przyjaciół i rodziny';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Twoje nagrania pomagają nam rozpoznawać i tworzyć profile dla Twoich przyjaciół i rodziny.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Zwiększ dokładność transkrypcji';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'W miarę jak nasz model się poprawia, możemy zapewnić lepsze wyniki transkrypcji Twoich nagrań.';
+
+  @override
+  String get legalNotice =>
+      'Uwaga prawna: Legalność nagrywania i przechowywania danych głosowych może się różnić w zależności od lokalizacji i sposobu korzystania z tej funkcji. Twoim obowiązkiem jest zapewnienie zgodności z lokalnymi przepisami i regulacjami.';
+
+  @override
+  String get alreadyAuthorized => 'Już autoryzowano';
+
+  @override
+  String get authorize => 'Autoryzuj';
+
+  @override
+  String get revokeAuthorization => 'Cofnij autoryzację';
+
+  @override
+  String get authorizationSuccessful => 'Autoryzacja pomyślna!';
+
+  @override
+  String get failedToAuthorize => 'Nie udało się autoryzować. Spróbuj ponownie.';
+
+  @override
+  String get authorizationRevoked => 'Autoryzacja cofnięta.';
+
+  @override
+  String get recordingsDeleted => 'Nagrania usunięte.';
+
+  @override
+  String get failedToRevoke => 'Nie udało się cofnąć autoryzacji. Spróbuj ponownie.';
+
+  @override
+  String get permissionRevokedTitle => 'Cofnięto pozwolenie';
+
+  @override
+  String get permissionRevokedMessage => 'Czy chcesz, abyśmy usunęli również wszystkie Twoje istniejące nagrania?';
+
+  @override
+  String get yes => 'Tak';
+
+  @override
+  String get editName => 'Edytuj imię';
+
+  @override
+  String get howShouldOmiCallYou => 'Jak Omi powinno Cię nazywać?';
+
+  @override
+  String get enterYourName => 'Wprowadź swoje imię';
+
+  @override
+  String get nameCannotBeEmpty => 'Imię nie może być puste';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Imię zaktualizowane pomyślnie!';
+
+  @override
+  String get calendarSettings => 'Ustawienia kalendarza';
+
+  @override
+  String get calendarProviders => 'Dostawcy kalendarza';
+
+  @override
+  String get macOsCalendar => 'Kalendarz macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Połącz swój lokalny kalendarz macOS';
+
+  @override
+  String get googleCalendar => 'Kalendarz Google';
+
+  @override
+  String get syncGoogleAccount => 'Synchronizuj z kontem Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Pokaż nadchodzące spotkania w pasku menu';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Wyświetl następne spotkanie i czas do jego rozpoczęcia w pasku menu macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Pokaż wydarzenia bez uczestników';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Po włączeniu, Nadchodzące pokazuje wydarzenia bez uczestników lub linku wideo.';
+
+  @override
+  String get yourMeetings => 'Twoje spotkania';
+
+  @override
+  String get refresh => 'Odśwież';
+
+  @override
+  String get noUpcomingMeetings => 'Nie znaleziono nadchodzących spotkań';
+
+  @override
+  String get checkingNextDays => 'Sprawdzanie następnych 30 dni';
+
+  @override
+  String get tomorrow => 'Jutro';
+
+  @override
+  String get googleCalendarComingSoon => 'Integracja z Kalendarzem Google wkrótce!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Połączono jako użytkownik: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Domyślny obszar roboczy';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Zadania będą tworzone w tym obszarze roboczym';
+
+  @override
+  String get defaultProjectOptional => 'Domyślny projekt (opcjonalnie)';
+
+  @override
+  String get leaveUnselectedTasks => 'Pozostaw niezaznaczone, aby tworzyć zadania bez projektu';
+
+  @override
+  String get noProjectsInWorkspace => 'Nie znaleziono projektów w tym obszarze roboczym';
+
+  @override
+  String get conversationTimeoutDesc => 'Wybierz, jak długo czekać w ciszy przed automatycznym zakończeniem rozmowy:';
+
+  @override
+  String get timeout2Minutes => '2 minuty';
+
+  @override
+  String get timeout2MinutesDesc => 'Zakończ rozmowę po 2 minutach ciszy';
+
+  @override
+  String get timeout5Minutes => '5 minut';
+
+  @override
+  String get timeout5MinutesDesc => 'Zakończ rozmowę po 5 minutach ciszy';
+
+  @override
+  String get timeout10Minutes => '10 minut';
+
+  @override
+  String get timeout10MinutesDesc => 'Zakończ rozmowę po 10 minutach ciszy';
+
+  @override
+  String get timeout30Minutes => '30 minut';
+
+  @override
+  String get timeout30MinutesDesc => 'Zakończ rozmowę po 30 minutach ciszy';
+
+  @override
+  String get timeout4Hours => '4 godziny';
+
+  @override
+  String get timeout4HoursDesc => 'Zakończ rozmowę po 4 godzinach ciszy';
+
+  @override
+  String get conversationEndAfterHours => 'Rozmowy będą teraz kończyć się po 4 godzinach ciszy';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Rozmowy będą teraz kończyć się po $minutes minutach ciszy';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Podaj nam swój język podstawowy';
+
+  @override
+  String get languageForTranscription =>
+      'Ustaw swój język dla ostrzejszych transkrypcji i spersonalizowanego doświadczenia.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Tryb pojedynczego języka jest włączony. Tłumaczenie jest wyłączone dla większej dokładności.';
+
+  @override
+  String get searchLanguageHint => 'Szukaj języka według nazwy lub kodu';
+
+  @override
+  String get noLanguagesFound => 'Nie znaleziono języków';
+
+  @override
+  String get skip => 'Pomiń';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Język ustawiony na $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Nie udało się ustawić języka';
+
+  @override
+  String appSettings(String appName) {
+    return 'Ustawienia $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Rozłączyć z $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Spowoduje to usunięcie uwierzytelnienia $appName. Będziesz musiał ponownie połączyć, aby użyć go ponownie.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Połączono z $appName';
+  }
+
+  @override
+  String get account => 'Konto';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Twoje zadania będą synchronizowane z Twoim kontem $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Domyślna przestrzeń';
+
+  @override
+  String get selectSpaceInWorkspace => 'Wybierz przestrzeń w swoim obszarze roboczym';
+
+  @override
+  String get noSpacesInWorkspace => 'Nie znaleziono przestrzeni w tym obszarze roboczym';
+
+  @override
+  String get defaultList => 'Domyślna lista';
+
+  @override
+  String get tasksAddedToList => 'Zadania będą dodawane do tej listy';
+
+  @override
+  String get noListsInSpace => 'Nie znaleziono list w tej przestrzeni';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Nie udało się załadować repozytoriów: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Domyślne repozytorium zapisane';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Nie udało się zapisać domyślnego repozytorium';
+
+  @override
+  String get defaultRepository => 'Domyślne repozytorium';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Wybierz domyślne repozytorium do tworzenia problemów. Nadal możesz określić inne repozytorium podczas tworzenia problemów.';
+
+  @override
+  String get noReposFound => 'Nie znaleziono repozytoriów';
+
+  @override
+  String get private => 'Prywatne';
+
+  @override
+  String updatedDate(String date) {
+    return 'Zaktualizowano $date';
+  }
+
+  @override
+  String get yesterday => 'wczoraj';
+
+  @override
+  String daysAgo(int count) {
+    return '$count dni temu';
+  }
+
+  @override
+  String get oneWeekAgo => '1 tydzień temu';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count tygodni temu';
+  }
+
+  @override
+  String get oneMonthAgo => '1 miesiąc temu';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count miesięcy temu';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Problemy będą tworzone w Twoim domyślnym repozytorium';
+
+  @override
+  String get taskIntegrations => 'Integracje zadań';
+
+  @override
+  String get configureSettings => 'Konfiguruj ustawienia';
+
+  @override
+  String get completeAuthBrowser => 'Ukończ uwierzytelnianie w przeglądarce. Po zakończeniu wróć do aplikacji.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Nie udało się rozpocząć uwierzytelniania $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Połącz z $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Musisz upoważnić Omi do tworzenia zadań w Twoim koncie $appName. Otworzy to przeglądarkę w celu uwierzytelnienia.';
+  }
+
+  @override
+  String get continueButton => 'Kontynuuj';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Integracja z $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integracja z $appName wkrótce! Ciężko pracujemy, aby przynieść Ci więcej opcji zarządzania zadaniami.';
+  }
+
+  @override
+  String get gotIt => 'Rozumiem';
+
+  @override
+  String get tasksExportedOneApp => 'Zadania mogą być eksportowane do jednej aplikacji naraz.';
+
+  @override
+  String get completeYourUpgrade => 'Ukończ aktualizację';
+
+  @override
+  String get importConfiguration => 'Importuj konfigurację';
+
+  @override
+  String get exportConfiguration => 'Eksportuj konfigurację';
+
+  @override
+  String get bringYourOwn => 'Przynieś własny';
+
+  @override
+  String get payYourSttProvider => 'Swobodnie korzystaj z Omi. Płacisz tylko swojemu dostawcy STT bezpośrednio.';
+
+  @override
+  String get freeMinutesMonth => '1200 darmowych minut/miesiąc w zestawie. Nieograniczone z ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Host jest wymagany';
+
+  @override
+  String get validPortRequired => 'Wymagany jest prawidłowy port';
+
+  @override
+  String get validWebsocketUrlRequired => 'Wymagany jest prawidłowy adres URL WebSocket (wss://)';
+
+  @override
+  String get apiUrlRequired => 'Adres URL API jest wymagany';
+
+  @override
+  String get apiKeyRequired => 'Klucz API jest wymagany';
+
+  @override
+  String get invalidJsonConfig => 'Nieprawidłowa konfiguracja JSON';
+
+  @override
+  String errorSaving(String error) {
+    return 'Błąd zapisu: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfiguracja skopiowana do schowka';
+
+  @override
+  String get pasteJsonConfig => 'Wklej swoją konfigurację JSON poniżej:';
+
+  @override
+  String get addApiKeyAfterImport => 'Musisz dodać własny klucz API po zaimportowaniu';
+
+  @override
+  String get paste => 'Wklej';
+
+  @override
+  String get import => 'Importuj';
+
+  @override
+  String get invalidProviderInConfig => 'Nieprawidłowy dostawca w konfiguracji';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Zaimportowano konfigurację $providerName';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Nieprawidłowy JSON: $error';
+  }
+
+  @override
+  String get provider => 'Dostawca';
+
+  @override
+  String get live => 'Na żywo';
+
+  @override
+  String get onDevice => 'Na urządzeniu';
+
+  @override
+  String get apiUrl => 'Adres URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Wprowadź swój punkt końcowy HTTP STT';
+
+  @override
+  String get websocketUrl => 'Adres URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Wprowadź swój punkt końcowy WebSocket STT na żywo';
+
+  @override
+  String get apiKey => 'Klucz API';
+
+  @override
+  String get enterApiKey => 'Wprowadź swój klucz API';
+
+  @override
+  String get storedLocallyNeverShared => 'Przechowywane lokalnie, nigdy nie udostępniane';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Zaawansowane';
+
+  @override
+  String get configuration => 'Konfiguracja';
+
+  @override
+  String get requestConfiguration => 'Konfiguracja żądania';
+
+  @override
+  String get responseSchema => 'Schemat odpowiedzi';
+
+  @override
+  String get modified => 'Zmodyfikowano';
+
+  @override
+  String get resetRequestConfig => 'Zresetuj konfigurację żądania do domyślnej';
+
+  @override
+  String get logs => 'Logi';
+
+  @override
+  String get logsCopied => 'Logi skopiowane';
+
+  @override
+  String get noLogsYet => 'Brak logów. Rozpocznij nagrywanie, aby zobaczyć aktywność niestandardowego STT.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName używa $codecReason. Będzie używane Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Transkrypcja Omi';
+
+  @override
+  String get bestInClassTranscription => 'Najlepsza w klasie transkrypcja bez konfiguracji';
+
+  @override
+  String get instantSpeakerLabels => 'Natychmiastowe etykiety mówców';
+
+  @override
+  String get languageTranslation => 'Tłumaczenie na ponad 100 języków';
+
+  @override
+  String get optimizedForConversation => 'Zoptymalizowane pod kątem rozmów';
+
+  @override
+  String get autoLanguageDetection => 'Automatyczne wykrywanie języka';
+
+  @override
+  String get highAccuracy => 'Wysoka dokładność';
+
+  @override
+  String get privacyFirst => 'Prywatność na pierwszym miejscu';
+
+  @override
+  String get saveChanges => 'Zapisz zmiany';
+
+  @override
+  String get resetToDefault => 'Zresetuj do domyślnego';
+
+  @override
+  String get viewTemplate => 'Zobacz szablon';
+
+  @override
+  String get trySomethingLike => 'Spróbuj czegoś takiego...';
+
+  @override
+  String get tryIt => 'Wypróbuj';
+
+  @override
+  String get creatingPlan => 'Tworzenie planu';
+
+  @override
+  String get developingLogic => 'Rozwijanie logiki';
+
+  @override
+  String get designingApp => 'Projektowanie aplikacji';
+
+  @override
+  String get generatingIconStep => 'Generowanie ikony';
+
+  @override
+  String get finalTouches => 'Końcowe poprawki';
+
+  @override
+  String get processing => 'Przetwarzanie...';
+
+  @override
+  String get features => 'Funkcje';
+
+  @override
+  String get creatingYourApp => 'Tworzenie Twojej aplikacji...';
+
+  @override
+  String get generatingIcon => 'Generowanie ikony...';
+
+  @override
+  String get whatShouldWeMake => 'Co powinniśmy stworzyć?';
+
+  @override
+  String get appName => 'Nazwa aplikacji';
+
+  @override
+  String get description => 'Opis';
+
+  @override
+  String get publicLabel => 'Publiczne';
+
+  @override
+  String get privateLabel => 'Prywatne';
+
+  @override
+  String get free => 'Darmowe';
+
+  @override
+  String get perMonth => '/ miesiąc';
+
+  @override
+  String get tailoredConversationSummaries => 'Dostosowane podsumowania rozmów';
+
+  @override
+  String get customChatbotPersonality => 'Niestandardowa osobowość chatbota';
+
+  @override
+  String get makePublic => 'Upublicznij';
+
+  @override
+  String get anyoneCanDiscover => 'Każdy może odkryć Twoją aplikację';
+
+  @override
+  String get onlyYouCanUse => 'Tylko Ty możesz korzystać z tej aplikacji';
+
+  @override
+  String get paidApp => 'Płatna aplikacja';
+
+  @override
+  String get usersPayToUse => 'Użytkownicy płacą za korzystanie z Twojej aplikacji';
+
+  @override
+  String get freeForEveryone => 'Darmowa dla wszystkich';
+
+  @override
+  String get perMonthLabel => '/ miesiąc';
+
+  @override
+  String get creating => 'Tworzenie...';
+
+  @override
+  String get createApp => 'Utwórz aplikację';
+
+  @override
+  String get searchingForDevices => 'Wyszukiwanie urządzeń...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'URZĄDZEŃ',
+      few: 'URZĄDZENIA',
+      one: 'URZĄDZENIE',
+    );
+    return 'ZNALEZIONO $count $_temp0 W POBLIŻU';
+  }
+
+  @override
+  String get pairingSuccessful => 'PAROWANIE UDANE';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Błąd połączenia z Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Nie pokazuj ponownie';
+
+  @override
+  String get iUnderstand => 'Rozumiem';
+
+  @override
+  String get enableBluetooth => 'Włącz Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi potrzebuje Bluetooth, aby połączyć się z Twoim urządzeniem noszonym. Włącz Bluetooth i spróbuj ponownie.';
+
+  @override
+  String get contactSupport => 'Skontaktuj się z pomocą techniczną?';
+
+  @override
+  String get connectLater => 'Połącz później';
+
+  @override
+  String get grantPermissions => 'Przyznaj uprawnienia';
+
+  @override
+  String get backgroundActivity => 'Aktywność w tle';
+
+  @override
+  String get backgroundActivityDesc => 'Pozwól Omi działać w tle dla lepszej stabilności';
+
+  @override
+  String get locationAccess => 'Dostęp do lokalizacji';
+
+  @override
+  String get locationAccessDesc => 'Włącz lokalizację w tle dla pełnego doświadczenia';
+
+  @override
+  String get notifications => 'Powiadomienia';
+
+  @override
+  String get notificationsDesc => 'Włącz powiadomienia, aby być na bieżąco';
+
+  @override
+  String get locationServiceDisabled => 'Usługa lokalizacji wyłączona';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Usługa lokalizacji jest wyłączona. Przejdź do Ustawienia > Prywatność i bezpieczeństwo > Usługi lokalizacji i włącz ją';
+
+  @override
+  String get backgroundLocationDenied => 'Odmowa dostępu do lokalizacji w tle';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Przejdź do ustawień urządzenia i ustaw uprawnienie lokalizacji na \"Zawsze zezwalaj\"';
+
+  @override
+  String get lovingOmi => 'Podoba Ci się Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Pomóż nam dotrzeć do większej liczby osób, zostawiając recenzję w App Store. Twoja opinia wiele dla nas znaczy!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Pomóż nam dotrzeć do większej liczby osób, zostawiając recenzję w Google Play Store. Twoja opinia wiele dla nas znaczy!';
+
+  @override
+  String get rateOnAppStore => 'Oceń w App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Oceń w Google Play';
+
+  @override
+  String get maybeLater => 'Może później';
+
+  @override
+  String get speechProfileIntro => 'Omi musi poznać Twoje cele i Twój głos. Będziesz mógł to później zmodyfikować.';
+
+  @override
+  String get getStarted => 'Rozpocznij';
+
+  @override
+  String get allDone => 'Wszystko gotowe!';
+
+  @override
+  String get keepGoing => 'Dalej tak trzymaj, świetnie Ci idzie';
+
+  @override
+  String get skipThisQuestion => 'Pomiń to pytanie';
+
+  @override
+  String get skipForNow => 'Pomiń na razie';
+
+  @override
+  String get connectionError => 'Błąd połączenia';
+
+  @override
+  String get connectionErrorDesc =>
+      'Nie udało się połączyć z serwerem. Sprawdź połączenie internetowe i spróbuj ponownie.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Wykryto nieprawidłowe nagranie';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Wygląda na to, że w nagraniu jest wielu mówców. Upewnij się, że jesteś w cichym miejscu i spróbuj ponownie.';
+
+  @override
+  String get tooShortDesc => 'Nie wykryto wystarczającej ilości mowy. Mów więcej i spróbuj ponownie.';
+
+  @override
+  String get invalidRecordingDesc => 'Upewnij się, że mówisz przez co najmniej 5 sekund i nie więcej niż 90.';
+
+  @override
+  String get areYouThere => 'Jesteś tam?';
+
+  @override
+  String get noSpeechDesc =>
+      'Nie udało się wykryć żadnej mowy. Upewnij się, że mówisz przez co najmniej 10 sekund i nie więcej niż 3 minuty.';
+
+  @override
+  String get connectionLost => 'Utracono połączenie';
+
+  @override
+  String get connectionLostDesc => 'Połączenie zostało przerwane. Sprawdź połączenie internetowe i spróbuj ponownie.';
+
+  @override
+  String get tryAgain => 'Spróbuj ponownie';
+
+  @override
+  String get connectOmiOmiGlass => 'Połącz Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Kontynuuj bez urządzenia';
+
+  @override
+  String get permissionsRequired => 'Wymagane uprawnienia';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Ta aplikacja wymaga uprawnień Bluetooth i lokalizacji, aby działać prawidłowo. Włącz je w ustawieniach.';
+
+  @override
+  String get openSettings => 'Otwórz ustawienia';
+
+  @override
+  String get wantDifferentName => 'Chcesz być nazywany inaczej?';
+
+  @override
+  String get whatsYourName => 'Jak masz na imię?';
+
+  @override
+  String get speakTranscribeSummarize => 'Mów. Transkrybuj. Podsumuj.';
+
+  @override
+  String get signInWithApple => 'Zaloguj się przez Apple';
+
+  @override
+  String get signInWithGoogle => 'Zaloguj się przez Google';
+
+  @override
+  String get byContinuingAgree => 'Kontynuując, zgadzasz się z naszą ';
+
+  @override
+  String get termsOfUse => 'Warunkami korzystania';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Twój kompan AI';
+
+  @override
+  String get captureEveryMoment =>
+      'Uchwycaj każdą chwilę. Otrzymuj podsumowania\nnapędzane przez AI. Nigdy więcej nie rób notatek.';
+
+  @override
+  String get appleWatchSetup => 'Konfiguracja Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Zażądano uprawnień!';
+
+  @override
+  String get microphonePermission => 'Uprawnienie mikrofonu';
+
+  @override
+  String get permissionGrantedNow =>
+      'Uprawnienie przyznane! Teraz:\n\nOtwórz aplikację Omi na zegarku i dotknij \"Kontynuuj\" poniżej';
+
+  @override
+  String get needMicrophonePermission =>
+      'Potrzebujemy uprawnienia do mikrofonu.\n\n1. Dotknij \"Przyznaj uprawnienie\"\n2. Zezwól na iPhone\n3. Aplikacja na zegarku zostanie zamknięta\n4. Otwórz ponownie i dotknij \"Kontynuuj\"';
+
+  @override
+  String get grantPermissionButton => 'Przyznaj uprawnienie';
+
+  @override
+  String get needHelp => 'Potrzebujesz pomocy?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Rozwiązywanie problemów:\n\n1. Upewnij się, że Omi jest zainstalowane na Twoim zegarku\n2. Otwórz aplikację Omi na zegarku\n3. Poszukaj okna z prośbą o uprawnienie\n4. Dotknij \"Zezwól\" po wyświetleniu monitu\n5. Aplikacja na zegarku zostanie zamknięta - otwórz ją ponownie\n6. Wróć i dotknij \"Kontynuuj\" na iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Nagrywanie rozpoczęte pomyślnie!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Uprawnienie nie zostało jeszcze przyznane. Upewnij się, że zezwoliłeś na dostęp do mikrofonu i ponownie otworzyłeś aplikację na zegarku.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Błąd żądania uprawnień: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Błąd rozpoczęcia nagrywania: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Wybierz swój język podstawowy';
+
+  @override
+  String get languageBenefits => 'Ustaw swój język dla ostrzejszych transkrypcji i spersonalizowanego doświadczenia';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Jaki jest Twój język podstawowy?';
+
+  @override
+  String get selectYourLanguage => 'Wybierz swój język';
+
+  @override
+  String get personalGrowthJourney => 'Twoja osobista podróż rozwoju z AI, który słucha każdego Twojego słowa.';
+
+  @override
+  String get actionItemsTitle => 'Zadania';
+
+  @override
+  String get actionItemsDescription => 'Dotknij, aby edytować • Przytrzymaj, aby wybrać • Przesuń, aby wykonać akcje';
+
+  @override
+  String get tabToDo => 'Do zrobienia';
+
+  @override
+  String get tabDone => 'Zrobione';
+
+  @override
+  String get tabOld => 'Stare';
+
+  @override
+  String get emptyTodoMessage => '🎉 Wszystko na bieżąco!\nBrak oczekujących zadań';
+
+  @override
+  String get emptyDoneMessage => 'Brak ukończonych zadań';
+
+  @override
+  String get emptyOldMessage => '✅ Brak starych zadań';
+
+  @override
+  String get noItems => 'Brak elementów';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Zadanie oznaczone jako nieukończone';
+
+  @override
+  String get actionItemCompleted => 'Zadanie ukończone';
+
+  @override
+  String get deleteActionItemTitle => 'Usuń zadanie';
+
+  @override
+  String get deleteActionItemMessage => 'Czy na pewno chcesz usunąć to zadanie?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Usuń wybrane elementy';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Czy na pewno chcesz usunąć $count wybrane zadani$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Zadanie \"$description\" usunięte';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return 'Usunięto $count zadani$s';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Nie udało się usunąć zadania';
+
+  @override
+  String get failedToDeleteItems => 'Nie udało się usunąć zadań';
+
+  @override
+  String get failedToDeleteSomeItems => 'Nie udało się usunąć niektórych zadań';
+
+  @override
+  String get welcomeActionItemsTitle => 'Gotowe na zadania';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Twoje AI automatycznie wyodrębni zadania z Twoich rozmów. Pojawią się tutaj, gdy zostaną utworzone.';
+
+  @override
+  String get autoExtractionFeature => 'Automatycznie wyodrębniane z rozmów';
+
+  @override
+  String get editSwipeFeature => 'Dotknij, aby edytować, przesuń, aby ukończyć lub usunąć';
+
+  @override
+  String itemsSelected(int count) {
+    return 'Wybrano: $count';
+  }
+
+  @override
+  String get selectAll => 'Zaznacz wszystko';
+
+  @override
+  String get deleteSelected => 'Usuń zaznaczone';
+
+  @override
+  String searchMemories(int count) {
+    return 'Przeszukaj $count wspomnień';
+  }
+
+  @override
+  String get memoryDeleted => 'Wspomnienie usunięte.';
+
+  @override
+  String get undo => 'Cofnij';
+
+  @override
+  String get noMemoriesYet => 'Brak wspomnień';
+
+  @override
+  String get noAutoMemories => 'Brak automatycznie wyodrębnionych wspomnień';
+
+  @override
+  String get noManualMemories => 'Brak ręcznych wspomnień';
+
+  @override
+  String get noMemoriesInCategories => 'Brak wspomnień w tych kategoriach';
+
+  @override
+  String get noMemoriesFound => 'Nie znaleziono wspomnień';
+
+  @override
+  String get addFirstMemory => 'Dodaj swoje pierwsze wspomnienie';
+
+  @override
+  String get clearMemoryTitle => 'Wyczyść pamięć Omi';
+
+  @override
+  String get clearMemoryMessage => 'Czy na pewno chcesz wyczyścić pamięć Omi? Tej czynności nie można cofnąć.';
+
+  @override
+  String get clearMemoryButton => 'Wyczyść pamięć';
+
+  @override
+  String get memoryClearedSuccess => 'Pamięć Omi o Tobie została wyczyszczona';
+
+  @override
+  String get noMemoriesToDelete => 'Brak wspomnień do usunięcia';
+
+  @override
+  String get createMemoryTooltip => 'Utwórz nowe wspomnienie';
+
+  @override
+  String get createActionItemTooltip => 'Utwórz nowe zadanie';
+
+  @override
+  String get memoryManagement => 'Zarządzanie wspomnieniami';
+
+  @override
+  String get filterMemories => 'Filtruj wspomnienia';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Masz $count wspomnień łącznie';
+  }
+
+  @override
+  String get publicMemories => 'Publiczne wspomnienia';
+
+  @override
+  String get privateMemories => 'Prywatne wspomnienia';
+
+  @override
+  String get makeAllPrivate => 'Ustaw wszystkie wspomnienia jako prywatne';
+
+  @override
+  String get makeAllPublic => 'Ustaw wszystkie wspomnienia jako publiczne';
+
+  @override
+  String get deleteAllMemories => 'Usuń wszystkie wspomnienia';
+
+  @override
+  String get allMemoriesPrivateResult => 'Wszystkie wspomnienia są teraz prywatne';
+
+  @override
+  String get allMemoriesPublicResult => 'Wszystkie wspomnienia są teraz publiczne';
+
+  @override
+  String get newMemory => 'Nowe wspomnienie';
+
+  @override
+  String get editMemory => 'Edytuj wspomnienie';
+
+  @override
+  String get memoryContentHint => 'Lubię jeść lody...';
+
+  @override
+  String get failedToSaveMemory => 'Nie udało się zapisać. Sprawdź połączenie.';
+
+  @override
+  String get saveMemory => 'Zapisz wspomnienie';
+
+  @override
+  String get retry => 'Spróbuj ponownie';
+
+  @override
+  String get createActionItem => 'Utwórz zadanie';
+
+  @override
+  String get editActionItem => 'Edytuj zadanie';
+
+  @override
+  String get actionItemDescriptionHint => 'Co trzeba zrobić?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Opis zadania nie może być pusty.';
+
+  @override
+  String get actionItemUpdated => 'Zadanie zaktualizowane';
+
+  @override
+  String get failedToUpdateActionItem => 'Nie udało się zaktualizować zadania';
+
+  @override
+  String get actionItemCreated => 'Zadanie utworzone';
+
+  @override
+  String get failedToCreateActionItem => 'Nie udało się utworzyć zadania';
+
+  @override
+  String get dueDate => 'Termin';
+
+  @override
+  String get time => 'Czas';
+
+  @override
+  String get addDueDate => 'Dodaj termin';
+
+  @override
+  String get pressDoneToSave => 'Naciśnij Gotowe, aby zapisać';
+
+  @override
+  String get pressDoneToCreate => 'Naciśnij Gotowe, aby utworzyć';
+
+  @override
+  String get filterAll => 'Wszystkie';
+
+  @override
+  String get filterSystem => 'O Tobie';
+
+  @override
+  String get filterInteresting => 'Spostrzeżenia';
+
+  @override
+  String get filterManual => 'Ręczne';
+
+  @override
+  String get completed => 'Ukończone';
+
+  @override
+  String get markComplete => 'Oznacz jako ukończone';
+
+  @override
+  String get actionItemDeleted => 'Zadanie usunięte';
+
+  @override
+  String get failedToDeleteActionItem => 'Nie udało się usunąć zadania';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Usuń zadanie';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Czy na pewno chcesz usunąć to zadanie?';
+
+  @override
+  String get appLanguage => 'Język aplikacji';
+
+  @override
+  String get appInterfaceSectionTitle => 'INTERFEJS APLIKACJI';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'MOWA I TRANSKRYPCJA';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Język aplikacji zmienia menu i przyciski. Język mowy wpływa na sposób transkrypcji nagrań.';
+}

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -234,7 +234,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get searchConversations => 'Buscar conversas';
 
   @override
-  String selectedCount(int count) {
+  String selectedCount(int count, Object s) {
     return '$count selecionados';
   }
 
@@ -2162,7 +2162,7 @@ class AppLocalizationsPt extends AppLocalizations {
   String get filterAll => 'Todos';
 
   @override
-  String get filterSystem => 'About You';
+  String get filterSystem => 'Sobre você';
 
   @override
   String get filterInteresting => 'Insights';
@@ -2190,4 +2190,14 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get appLanguage => 'Idioma do App';
+
+  @override
+  String get appInterfaceSectionTitle => 'INTERFACE DO APLICATIVO';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'FALA E TRANSCRIÇÃO';
+
+  @override
+  String get languageSettingsHelperText =>
+      'O idioma do aplicativo altera menus e botões. O idioma de fala afeta como suas gravações são transcritas.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -1,0 +1,2240 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Romanian Moldavian Moldovan (`ro`).
+class AppLocalizationsRo extends AppLocalizations {
+  AppLocalizationsRo([String locale = 'ro']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Conversație';
+
+  @override
+  String get transcriptTab => 'Transcriere';
+
+  @override
+  String get actionItemsTab => 'Sarcini';
+
+  @override
+  String get deleteConversationTitle => 'Ștergi conversația?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Ești sigur că vrei să ștergi această conversație? Această acțiune nu poate fi anulată.';
+
+  @override
+  String get confirm => 'Confirmă';
+
+  @override
+  String get cancel => 'Cancel';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Delete';
+
+  @override
+  String get add => 'Adaugă';
+
+  @override
+  String get update => 'Actualizează';
+
+  @override
+  String get save => 'Salvează';
+
+  @override
+  String get edit => 'Editează';
+
+  @override
+  String get close => 'Închide';
+
+  @override
+  String get clear => 'Șterge';
+
+  @override
+  String get copyTranscript => 'Copiază transcrierea';
+
+  @override
+  String get copySummary => 'Copiază rezumatul';
+
+  @override
+  String get testPrompt => 'Testează promptul';
+
+  @override
+  String get reprocessConversation => 'Reprocesează conversația';
+
+  @override
+  String get deleteConversation => 'Șterge conversația';
+
+  @override
+  String get contentCopied => 'Conținut copiat în clipboard';
+
+  @override
+  String get failedToUpdateStarred => 'Nu s-a putut actualiza starea de favorit.';
+
+  @override
+  String get conversationUrlNotShared => 'URL-ul conversației nu a putut fi partajat.';
+
+  @override
+  String get errorProcessingConversation =>
+      'Eroare la procesarea conversației. Te rugăm să încerci din nou mai târziu.';
+
+  @override
+  String get noInternetConnection => 'Te rugăm să verifici conexiunea la internet și să încerci din nou.';
+
+  @override
+  String get unableToDeleteConversation => 'Nu se poate șterge conversația';
+
+  @override
+  String get somethingWentWrong => 'Ceva nu a mers bine! Te rugăm să încerci din nou mai târziu.';
+
+  @override
+  String get copyErrorMessage => 'Copiază mesajul de eroare';
+
+  @override
+  String get errorCopied => 'Mesaj de eroare copiat în clipboard';
+
+  @override
+  String get remaining => 'Rămas';
+
+  @override
+  String get loading => 'Se încarcă...';
+
+  @override
+  String get loadingDuration => 'Se încarcă durata...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count secunde';
+  }
+
+  @override
+  String get people => 'Persoane';
+
+  @override
+  String get addNewPerson => 'Adaugă persoană nouă';
+
+  @override
+  String get editPerson => 'Editează persoana';
+
+  @override
+  String get createPersonHint => 'Creează o persoană nouă și antrenează Omi să recunoască și vorbirea ei!';
+
+  @override
+  String get speechProfile => 'Profil vocal';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Eșantion $number';
+  }
+
+  @override
+  String get settings => 'Setări';
+
+  @override
+  String get language => 'Limbă';
+
+  @override
+  String get selectLanguage => 'Selectează limba';
+
+  @override
+  String get deleting => 'Se șterge...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
+
+  @override
+  String get failedToStartAuthentication => 'Nu s-a putut inițializa autentificarea';
+
+  @override
+  String get importStarted => 'Import inițiat! Vei fi notificat când se finalizează.';
+
+  @override
+  String get failedToStartImport => 'Nu s-a putut inițializa importul. Te rugăm să încerci din nou.';
+
+  @override
+  String get couldNotAccessFile => 'Nu s-a putut accesa fișierul selectat';
+
+  @override
+  String get askOmi => 'Întreabă Omi';
+
+  @override
+  String get done => 'Done';
+
+  @override
+  String get disconnected => 'Deconectat';
+
+  @override
+  String get searching => 'Se caută';
+
+  @override
+  String get connectDevice => 'Conectează dispozitivul';
+
+  @override
+  String get monthlyLimitReached => 'Ai atins limita lunară.';
+
+  @override
+  String get checkUsage => 'Verifică utilizarea';
+
+  @override
+  String get syncingRecordings => 'Se sincronizează înregistrările';
+
+  @override
+  String get recordingsToSync => 'Înregistrări de sincronizat';
+
+  @override
+  String get allCaughtUp => 'Totul este actualizat';
+
+  @override
+  String get sync => 'Sincronizează';
+
+  @override
+  String get pendantUpToDate => 'Pandantivul este actualizat';
+
+  @override
+  String get allRecordingsSynced => 'Toate înregistrările sunt sincronizate';
+
+  @override
+  String get syncingInProgress => 'Sincronizare în curs';
+
+  @override
+  String get readyToSync => 'Pregătit pentru sincronizare';
+
+  @override
+  String get tapSyncToStart => 'Apasă Sincronizează pentru a începe';
+
+  @override
+  String get pendantNotConnected => 'Pandantivul nu este conectat. Conectează pentru a sincroniza.';
+
+  @override
+  String get everythingSynced => 'Totul este deja sincronizat.';
+
+  @override
+  String get recordingsNotSynced => 'Ai înregistrări care nu sunt încă sincronizate.';
+
+  @override
+  String get syncingBackground => 'Vom continua să sincronizăm înregistrările în fundal.';
+
+  @override
+  String get noConversationsYet => 'Încă nu există conversații.';
+
+  @override
+  String get noStarredConversations => 'Încă nu există conversații favorite.';
+
+  @override
+  String get starConversationHint =>
+      'Pentru a marca o conversație ca favorită, deschide-o și apasă iconița de stea din antet.';
+
+  @override
+  String get searchConversations => 'Caută conversații';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count selectate';
+  }
+
+  @override
+  String get merge => 'Combină';
+
+  @override
+  String get mergeConversations => 'Combină conversațiile';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Aceasta va combina $count conversații într-una singură. Tot conținutul va fi combinat și regenerat.';
+  }
+
+  @override
+  String get mergingInBackground => 'Se combină în fundal. Acest lucru poate dura câteva momente.';
+
+  @override
+  String get failedToStartMerge => 'Nu s-a putut inițializa combinarea';
+
+  @override
+  String get askAnything => 'Întreabă orice';
+
+  @override
+  String get noMessagesYet => 'Încă nu există mesaje!\nDe ce nu începi o conversație?';
+
+  @override
+  String get deletingMessages => 'Se șterg mesajele din memoria Omi...';
+
+  @override
+  String get messageCopied => 'Mesaj copiat în clipboard.';
+
+  @override
+  String get cannotReportOwnMessage => 'Nu poți raporta propriile mesaje.';
+
+  @override
+  String get reportMessage => 'Raportează mesajul';
+
+  @override
+  String get reportMessageConfirm => 'Ești sigur că vrei să raportezi acest mesaj?';
+
+  @override
+  String get messageReported => 'Mesaj raportat cu succes.';
+
+  @override
+  String get thankYouFeedback => 'Mulțumim pentru feedback!';
+
+  @override
+  String get clearChat => 'Ștergi chat-ul?';
+
+  @override
+  String get clearChatConfirm => 'Ești sigur că vrei să ștergi chat-ul? Această acțiune nu poate fi anulată.';
+
+  @override
+  String get maxFilesLimit => 'Poți încărca doar 4 fișiere simultan';
+
+  @override
+  String get chatWithOmi => 'Chat cu Omi';
+
+  @override
+  String get apps => 'Aplicații';
+
+  @override
+  String get noAppsFound => 'Nu s-au găsit aplicații';
+
+  @override
+  String get tryAdjustingSearch => 'Încearcă să ajustezi căutarea sau filtrele';
+
+  @override
+  String get createYourOwnApp => 'Creează-ți propria aplicație';
+
+  @override
+  String get buildAndShareApp => 'Construiește și partajează aplicația ta personalizată';
+
+  @override
+  String get searchApps => 'Caută peste 1500 de aplicații';
+
+  @override
+  String get myApps => 'Aplicațiile mele';
+
+  @override
+  String get installedApps => 'Aplicații instalate';
+
+  @override
+  String get unableToFetchApps =>
+      'Nu s-au putut prelua aplicațiile :(\n\nTe rugăm să verifici conexiunea la internet și să încerci din nou.';
+
+  @override
+  String get aboutOmi => 'Despre Omi';
+
+  @override
+  String get privacyPolicy => 'Privacy Policy';
+
+  @override
+  String get visitWebsite => 'Vizitează site-ul web';
+
+  @override
+  String get helpOrInquiries => 'Ajutor sau întrebări?';
+
+  @override
+  String get joinCommunity => 'Alătură-te comunității!';
+
+  @override
+  String get membersAndCounting => 'Peste 8000 de membri și numărul crește.';
+
+  @override
+  String get deleteAccountTitle => 'Șterge contul';
+
+  @override
+  String get deleteAccountConfirm => 'Ești sigur că vrei să îți ștergi contul?';
+
+  @override
+  String get cannotBeUndone => 'Acest lucru nu poate fi anulat.';
+
+  @override
+  String get allDataErased => 'Toate amintirile și conversațiile tale vor fi șterse permanent.';
+
+  @override
+  String get appsDisconnected => 'Aplicațiile și integrările tale vor fi deconectate imediat.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Poți exporta datele înainte de a-ți șterge contul, dar odată șters, nu poate fi recuperat.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Înțeleg că ștergerea contului meu este permanentă și toate datele, inclusiv amintirile și conversațiile, vor fi pierdute și nu pot fi recuperate.';
+
+  @override
+  String get areYouSure => 'Ești sigur?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Această acțiune este ireversibilă și va șterge permanent contul tău și toate datele asociate. Ești sigur că vrei să continui?';
+
+  @override
+  String get deleteNow => 'Șterge acum';
+
+  @override
+  String get goBack => 'Înapoi';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Bifează caseta pentru a confirma că înțelegi că ștergerea contului este permanentă și ireversibilă.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Nume';
+
+  @override
+  String get email => 'Email';
+
+  @override
+  String get customVocabulary => 'Vocabular personalizat';
+
+  @override
+  String get identifyingOthers => 'Identificarea altora';
+
+  @override
+  String get paymentMethods => 'Metode de plată';
+
+  @override
+  String get conversationDisplay => 'Afișare conversații';
+
+  @override
+  String get dataPrivacy => 'Date și confidențialitate';
+
+  @override
+  String get userId => 'ID utilizator';
+
+  @override
+  String get notSet => 'Nesetat';
+
+  @override
+  String get userIdCopied => 'ID utilizator copiat în clipboard';
+
+  @override
+  String get systemDefault => 'Implicit sistem';
+
+  @override
+  String get planAndUsage => 'Plan și utilizare';
+
+  @override
+  String get offlineSync => 'Sincronizare offline';
+
+  @override
+  String get deviceSettings => 'Setări dispozitiv';
+
+  @override
+  String get chatTools => 'Instrumente chat';
+
+  @override
+  String get feedbackBug => 'Feedback / Bug';
+
+  @override
+  String get helpCenter => 'Centru de asistență';
+
+  @override
+  String get developerSettings => 'Setări dezvoltator';
+
+  @override
+  String get getOmiForMac => 'Obține Omi pentru Mac';
+
+  @override
+  String get referralProgram => 'Program de recomandări';
+
+  @override
+  String get signOut => 'Deconectare';
+
+  @override
+  String get appAndDeviceCopied => 'Detalii aplicație și dispozitiv copiate';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Confidențialitatea ta, sub controlul tău';
+
+  @override
+  String get privacyIntro =>
+      'La Omi, ne angajăm să îți protejăm confidențialitatea. Această pagină îți permite să controlezi modul în care datele tale sunt stocate și utilizate.';
+
+  @override
+  String get learnMore => 'Află mai multe...';
+
+  @override
+  String get dataProtectionLevel => 'Nivel de protecție a datelor';
+
+  @override
+  String get dataProtectionDesc =>
+      'Datele tale sunt securizate implicit cu criptare puternică. Revizuiește setările și opțiunile viitoare de confidențialitate mai jos.';
+
+  @override
+  String get appAccess => 'Acces aplicații';
+
+  @override
+  String get appAccessDesc =>
+      'Următoarele aplicații pot accesa datele tale. Apasă pe o aplicație pentru a-i gestiona permisiunile.';
+
+  @override
+  String get noAppsExternalAccess => 'Nicio aplicație instalată nu are acces extern la datele tale.';
+
+  @override
+  String get deviceName => 'Nume dispozitiv';
+
+  @override
+  String get deviceId => 'ID dispozitiv';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'Sincronizare card SD';
+
+  @override
+  String get hardwareRevision => 'Revizie hardware';
+
+  @override
+  String get modelNumber => 'Număr model';
+
+  @override
+  String get manufacturer => 'Producător';
+
+  @override
+  String get doubleTap => 'Dublă apăsare';
+
+  @override
+  String get ledBrightness => 'Luminozitate LED';
+
+  @override
+  String get micGain => 'Câștig microfon';
+
+  @override
+  String get disconnect => 'Deconectează';
+
+  @override
+  String get forgetDevice => 'Uită dispozitivul';
+
+  @override
+  String get chargingIssues => 'Probleme la încărcare';
+
+  @override
+  String get disconnectDevice => 'Deconectează dispozitivul';
+
+  @override
+  String get unpairDevice => 'Deperechează dispozitivul';
+
+  @override
+  String get unpairAndForget => 'Deperechează și uită dispozitivul';
+
+  @override
+  String get deviceDisconnectedMessage => 'Omi-ul tău a fost deconectat 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Dispozitiv depereche. Mergi la Setări > Bluetooth și uită dispozitivul pentru a finaliza deperecherea.';
+
+  @override
+  String get unpairDialogTitle => 'Deperechează dispozitivul';
+
+  @override
+  String get unpairDialogMessage =>
+      'Acest lucru va deperechia dispozitivul astfel încât să poată fi conectat la alt telefon. Va trebui să mergi la Setări > Bluetooth și să uiți dispozitivul pentru a finaliza procesul.';
+
+  @override
+  String get deviceNotConnected => 'Dispozitiv neconectat';
+
+  @override
+  String get connectDeviceMessage =>
+      'Conectează dispozitivul Omi pentru a accesa\nsetările și personalizarea dispozitivului';
+
+  @override
+  String get deviceInfoSection => 'Informații dispozitiv';
+
+  @override
+  String get customizationSection => 'Personalizare';
+
+  @override
+  String get hardwareSection => 'Hardware';
+
+  @override
+  String get v2Undetected => 'V2 nedetectat';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Vedem că ai fie un dispozitiv V1, fie dispozitivul tău nu este conectat. Funcționalitatea card SD este disponibilă doar pentru dispozitivele V2.';
+
+  @override
+  String get endConversation => 'Încheie conversația';
+
+  @override
+  String get pauseResume => 'Pauză/Reia';
+
+  @override
+  String get starConversation => 'Marchează conversația ca favorită';
+
+  @override
+  String get doubleTapAction => 'Acțiune dublă apăsare';
+
+  @override
+  String get endAndProcess => 'Încheie și procesează conversația';
+
+  @override
+  String get pauseResumeRecording => 'Pauză/Reia înregistrarea';
+
+  @override
+  String get starOngoing => 'Marchează conversația în curs ca favorită';
+
+  @override
+  String get off => 'Oprit';
+
+  @override
+  String get max => 'Maxim';
+
+  @override
+  String get mute => 'Mut';
+
+  @override
+  String get quiet => 'Silențios';
+
+  @override
+  String get normal => 'Normal';
+
+  @override
+  String get high => 'Ridicat';
+
+  @override
+  String get micGainDescMuted => 'Microfonul este mut';
+
+  @override
+  String get micGainDescLow => 'Foarte silențios - pentru medii zgomotoase';
+
+  @override
+  String get micGainDescModerate => 'Silențios - pentru zgomot moderat';
+
+  @override
+  String get micGainDescNeutral => 'Neutru - înregistrare echilibrată';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Ușor amplificat - utilizare normală';
+
+  @override
+  String get micGainDescBoosted => 'Amplificat - pentru medii liniștite';
+
+  @override
+  String get micGainDescHigh => 'Ridicat - pentru voci distante sau line';
+
+  @override
+  String get micGainDescVeryHigh => 'Foarte ridicat - pentru surse foarte liniștite';
+
+  @override
+  String get micGainDescMax => 'Maxim - folosește cu atenție';
+
+  @override
+  String get developerSettingsTitle => 'Setări dezvoltator';
+
+  @override
+  String get saving => 'Se salvează...';
+
+  @override
+  String get personaConfig => 'Configurează personalitatea AI';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transcriere';
+
+  @override
+  String get transcriptionConfig => 'Configurează furnizorul STT';
+
+  @override
+  String get conversationTimeout => 'Timeout conversație';
+
+  @override
+  String get conversationTimeoutConfig => 'Setează când se încheie automat conversațiile';
+
+  @override
+  String get importData => 'Importă date';
+
+  @override
+  String get importDataConfig => 'Importă date din alte surse';
+
+  @override
+  String get debugDiagnostics => 'Depanare și diagnosticare';
+
+  @override
+  String get endpointUrl => 'URL endpoint';
+
+  @override
+  String get noApiKeys => 'Încă nu există chei API';
+
+  @override
+  String get createKeyToStart => 'Creează o cheie pentru a începe';
+
+  @override
+  String get createKey => 'Creează cheie';
+
+  @override
+  String get docs => 'Documente';
+
+  @override
+  String get yourOmiInsights => 'Statisticile tale Omi';
+
+  @override
+  String get today => 'Astăzi';
+
+  @override
+  String get thisMonth => 'Luna aceasta';
+
+  @override
+  String get thisYear => 'Anul acesta';
+
+  @override
+  String get allTime => 'Toate timpurile';
+
+  @override
+  String get noActivityYet => 'Încă nu există activitate';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Începe o conversație cu Omi\npentru a vedea statisticile de utilizare aici.';
+
+  @override
+  String get listening => 'Ascultare';
+
+  @override
+  String get listeningSubtitle => 'Timpul total în care Omi a ascultat activ.';
+
+  @override
+  String get understanding => 'Înțelegere';
+
+  @override
+  String get understandingSubtitle => 'Cuvinte înțelese din conversațiile tale.';
+
+  @override
+  String get providing => 'Furnizare';
+
+  @override
+  String get providingSubtitle => 'Sarcini și notițe capturate automat.';
+
+  @override
+  String get remembering => 'Memorare';
+
+  @override
+  String get rememberingSubtitle => 'Fapte și detalii memorate pentru tine.';
+
+  @override
+  String get unlimitedPlan => 'Plan nelimitat';
+
+  @override
+  String get managePlan => 'Gestionează planul';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Planul tău se va anula pe $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Planul tău se reînnoiește pe $date.';
+  }
+
+  @override
+  String get basicPlan => 'Plan gratuit';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used din $limit minute utilizate';
+  }
+
+  @override
+  String get upgrade => 'Upgrade';
+
+  @override
+  String get upgradeToUnlimited => 'Upgrade la Nelimitat';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Planul tău include $limit minute gratuite pe lună. Fă upgrade pentru a deveni nelimitat.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Împărtășesc statisticile mele Omi! (omi.me - asistentul tău AI mereu activ)';
+
+  @override
+  String get sharePeriodToday => 'Astăzi, Omi a:';
+
+  @override
+  String get sharePeriodMonth => 'Luna aceasta, Omi a:';
+
+  @override
+  String get sharePeriodYear => 'Anul acesta, Omi a:';
+
+  @override
+  String get sharePeriodAllTime => 'Până acum, Omi a:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Ascultat timp de $minutes minute';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Înțeles $words cuvinte';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Furnizat $count perspective';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Memorat $count amintiri';
+  }
+
+  @override
+  String get debugLogs => 'Jurnale de depanare';
+
+  @override
+  String get debugLogsAutoDelete => 'Se șterg automat după 3 zile.';
+
+  @override
+  String get debugLogsDesc => 'Ajută la diagnosticarea problemelor';
+
+  @override
+  String get noLogFilesFound => 'Nu s-au găsit fișiere jurnal.';
+
+  @override
+  String get omiDebugLog => 'Jurnal de depanare Omi';
+
+  @override
+  String get logShared => 'Jurnal partajat';
+
+  @override
+  String get selectLogFile => 'Selectează fișier jurnal';
+
+  @override
+  String get shareLogs => 'Partajează jurnalele';
+
+  @override
+  String get debugLogCleared => 'Jurnal de depanare șters';
+
+  @override
+  String get exportStarted => 'Export inițiat. Acest lucru poate dura câteva secunde...';
+
+  @override
+  String get exportAllData => 'Exportă toate datele';
+
+  @override
+  String get exportDataDesc => 'Exportă conversațiile într-un fișier JSON';
+
+  @override
+  String get exportedConversations => 'Conversații exportate din Omi';
+
+  @override
+  String get exportShared => 'Export partajat';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Ștergi graficul de cunoștințe?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Acest lucru va șterge toate datele derivate din graficul de cunoștințe (noduri și conexiuni). Amintirile tale originale vor rămâne în siguranță. Graficul va fi reconstruit în timp sau la următoarea solicitare.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Grafic de cunoștințe șters cu succes';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Nu s-a putut șterge graficul: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Șterge graficul de cunoștințe';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Șterge toate nodurile și conexiunile';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Server MCP';
+
+  @override
+  String get mcpServerDesc => 'Conectează asistenți AI la datele tale';
+
+  @override
+  String get serverUrl => 'URL server';
+
+  @override
+  String get urlCopied => 'URL copiat';
+
+  @override
+  String get apiKeyAuth => 'Autentificare cheie API';
+
+  @override
+  String get header => 'Antet';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID client';
+
+  @override
+  String get clientSecret => 'Secret client';
+
+  @override
+  String get useMcpApiKey => 'Folosește cheia ta API MCP';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Evenimente conversație';
+
+  @override
+  String get newConversationCreated => 'Conversație nouă creată';
+
+  @override
+  String get realtimeTranscript => 'Transcriere în timp real';
+
+  @override
+  String get transcriptReceived => 'Transcriere primită';
+
+  @override
+  String get audioBytes => 'Bytes audio';
+
+  @override
+  String get audioDataReceived => 'Date audio primite';
+
+  @override
+  String get intervalSeconds => 'Interval (secunde)';
+
+  @override
+  String get daySummary => 'Rezumat zilnic';
+
+  @override
+  String get summaryGenerated => 'Rezumat generat';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Adaugă la claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Copiază configurația';
+
+  @override
+  String get configCopied => 'Configurație copiată în clipboard';
+
+  @override
+  String get listeningMins => 'Ascultare (minute)';
+
+  @override
+  String get understandingWords => 'Înțelegere (cuvinte)';
+
+  @override
+  String get insights => 'Perspective';
+
+  @override
+  String get memories => 'Amintiri';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used din $limit minute utilizate luna aceasta';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used din $limit cuvinte utilizate luna aceasta';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used din $limit perspective obținute luna aceasta';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used din $limit amintiri create luna aceasta';
+  }
+
+  @override
+  String get visibility => 'Vizibilitate';
+
+  @override
+  String get visibilitySubtitle => 'Controlează care conversații apar în lista ta';
+
+  @override
+  String get showShortConversations => 'Afișează conversații scurte';
+
+  @override
+  String get showShortConversationsDesc => 'Afișează conversații mai scurte decât pragul';
+
+  @override
+  String get showDiscardedConversations => 'Afișează conversații eliminate';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Include conversații marcate ca eliminate';
+
+  @override
+  String get shortConversationThreshold => 'Prag conversații scurte';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Conversațiile mai scurte decât aceasta vor fi ascunse dacă nu este activată opțiunea de mai sus';
+
+  @override
+  String get durationThreshold => 'Prag durată';
+
+  @override
+  String get durationThresholdDesc => 'Ascunde conversații mai scurte decât aceasta';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Vocabular personalizat';
+
+  @override
+  String get addWords => 'Adaugă cuvinte';
+
+  @override
+  String get addWordsDesc => 'Nume, termeni sau cuvinte neobișnuite';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Connect';
+
+  @override
+  String get comingSoon => 'În curând';
+
+  @override
+  String get chatToolsFooter => 'Conectează aplicațiile tale pentru a vizualiza date și statistici în chat.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Nu s-a putut inițializa autentificarea $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Deconectezi $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Ești sigur că vrei să te deconectezi de la $appName? Te poți reconecta oricând.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Deconectat de la $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Nu s-a putut deconecta';
+
+  @override
+  String connectTo(String appName) {
+    return 'Conectează-te la $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Va trebui să autorizezi Omi să acceseze datele tale $appName. Aceasta va deschide browser-ul pentru autentificare.';
+  }
+
+  @override
+  String get continueAction => 'Continuă';
+
+  @override
+  String get languageTitle => 'Limbă';
+
+  @override
+  String get primaryLanguage => 'Limbă principală';
+
+  @override
+  String get automaticTranslation => 'Traducere automată';
+
+  @override
+  String get detectLanguages => 'Detectează peste 10 limbi';
+
+  @override
+  String get authorizeSavingRecordings => 'Autorizează salvarea înregistrărilor';
+
+  @override
+  String get thanksForAuthorizing => 'Mulțumim pentru autorizare!';
+
+  @override
+  String get needYourPermission => 'Avem nevoie de permisiunea ta';
+
+  @override
+  String get alreadyGavePermission =>
+      'Ne-ai dat deja permisiunea de a salva înregistrările tale. Iată un memento despre motivul pentru care avem nevoie:';
+
+  @override
+  String get wouldLikePermission => 'Am dori permisiunea ta de a salva înregistrările vocale. Iată de ce:';
+
+  @override
+  String get improveSpeechProfile => 'Îmbunătățește profilul tău vocal';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Folosim înregistrările pentru a antrena și îmbunătăți în continuare profilul tău vocal personal.';
+
+  @override
+  String get trainFamilyProfiles => 'Antrenează profiluri pentru prieteni și familie';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Înregistrările tale ne ajută să recunoaștem și să creăm profiluri pentru prietenii și familia ta.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Îmbunătățește acuratețea transcrierii';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Pe măsură ce modelul nostru se îmbunătățește, putem oferi rezultate de transcriere mai bune pentru înregistrările tale.';
+
+  @override
+  String get legalNotice =>
+      'Notificare legală: Legalitatea înregistrării și stocării datelor vocale poate varia în funcție de locația ta și modul în care folosești această funcție. Este responsabilitatea ta să te asiguri că respecți legile și reglementările locale.';
+
+  @override
+  String get alreadyAuthorized => 'Deja autorizat';
+
+  @override
+  String get authorize => 'Autorizează';
+
+  @override
+  String get revokeAuthorization => 'Revocă autorizarea';
+
+  @override
+  String get authorizationSuccessful => 'Autorizare reușită!';
+
+  @override
+  String get failedToAuthorize => 'Nu s-a putut autoriza. Te rugăm să încerci din nou.';
+
+  @override
+  String get authorizationRevoked => 'Autorizare revocată.';
+
+  @override
+  String get recordingsDeleted => 'Înregistrări șterse.';
+
+  @override
+  String get failedToRevoke => 'Nu s-a putut revoca autorizarea. Te rugăm să încerci din nou.';
+
+  @override
+  String get permissionRevokedTitle => 'Permisiune revocată';
+
+  @override
+  String get permissionRevokedMessage => 'Vrei să ștergem toate înregistrările tale existente?';
+
+  @override
+  String get yes => 'Da';
+
+  @override
+  String get editName => 'Editează numele';
+
+  @override
+  String get howShouldOmiCallYou => 'Cum ar trebui Omi să te numească?';
+
+  @override
+  String get enterYourName => 'Enter your name';
+
+  @override
+  String get nameCannotBeEmpty => 'Numele nu poate fi gol';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Nume actualizat cu succes!';
+
+  @override
+  String get calendarSettings => 'Setări calendar';
+
+  @override
+  String get calendarProviders => 'Furnizori calendar';
+
+  @override
+  String get macOsCalendar => 'Calendar macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Conectează calendarul tău local macOS';
+
+  @override
+  String get googleCalendar => 'Google Calendar';
+
+  @override
+  String get syncGoogleAccount => 'Sincronizează cu contul tău Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Afișează întâlnirile viitoare în bara de meniu';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'Afișează următoarea întâlnire și timpul rămas până începe în bara de meniu macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Afișează evenimente fără participanți';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Când este activat, Coming Up afișează evenimente fără participanți sau link video.';
+
+  @override
+  String get yourMeetings => 'Întâlnirile tale';
+
+  @override
+  String get refresh => 'Reîmprospătează';
+
+  @override
+  String get noUpcomingMeetings => 'Nu s-au găsit întâlniri viitoare';
+
+  @override
+  String get checkingNextDays => 'Se verifică următoarele 30 de zile';
+
+  @override
+  String get tomorrow => 'Mâine';
+
+  @override
+  String get googleCalendarComingSoon => 'Integrarea Google Calendar va fi disponibilă în curând!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Conectat ca utilizator: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Spațiu de lucru implicit';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Sarcinile vor fi create în acest spațiu de lucru';
+
+  @override
+  String get defaultProjectOptional => 'Proiect implicit (opțional)';
+
+  @override
+  String get leaveUnselectedTasks => 'Lasă neselectat pentru a crea sarcini fără proiect';
+
+  @override
+  String get noProjectsInWorkspace => 'Nu s-au găsit proiecte în acest spațiu de lucru';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Alege cât timp să aștepți în tăcere înainte de a încheia automat o conversație:';
+
+  @override
+  String get timeout2Minutes => '2 minute';
+
+  @override
+  String get timeout2MinutesDesc => 'Încheie conversația după 2 minute de tăcere';
+
+  @override
+  String get timeout5Minutes => '5 minute';
+
+  @override
+  String get timeout5MinutesDesc => 'Încheie conversația după 5 minute de tăcere';
+
+  @override
+  String get timeout10Minutes => '10 minute';
+
+  @override
+  String get timeout10MinutesDesc => 'Încheie conversația după 10 minute de tăcere';
+
+  @override
+  String get timeout30Minutes => '30 de minute';
+
+  @override
+  String get timeout30MinutesDesc => 'Încheie conversația după 30 de minute de tăcere';
+
+  @override
+  String get timeout4Hours => '4 ore';
+
+  @override
+  String get timeout4HoursDesc => 'Încheie conversația după 4 ore de tăcere';
+
+  @override
+  String get conversationEndAfterHours => 'Conversațiile se vor încheia acum după 4 ore de tăcere';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Conversațiile se vor încheia acum după $minutes minut(e) de tăcere';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Spune-ne limba ta principală';
+
+  @override
+  String get languageForTranscription => 'Setează limba pentru transcrieri mai precise și o experiență personalizată.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Modul limbă unică este activat. Traducerea este dezactivată pentru o acuratețe mai mare.';
+
+  @override
+  String get searchLanguageHint => 'Search language by name or code';
+
+  @override
+  String get noLanguagesFound => 'No languages found';
+
+  @override
+  String get skip => 'Omite';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Limba setată la $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Nu s-a putut seta limba';
+
+  @override
+  String appSettings(String appName) {
+    return 'Setări $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Deconectezi de la $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Aceasta va elimina autentificarea ta $appName. Va trebui să te reconectezi pentru a o folosi din nou.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Conectat la $appName';
+  }
+
+  @override
+  String get account => 'Cont';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Sarcinile tale vor fi sincronizate cu contul tău $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Spațiu implicit';
+
+  @override
+  String get selectSpaceInWorkspace => 'Selectează un spațiu în spațiul tău de lucru';
+
+  @override
+  String get noSpacesInWorkspace => 'Nu s-au găsit spații în acest spațiu de lucru';
+
+  @override
+  String get defaultList => 'Listă implicită';
+
+  @override
+  String get tasksAddedToList => 'Sarcinile vor fi adăugate la această listă';
+
+  @override
+  String get noListsInSpace => 'Nu s-au găsit liste în acest spațiu';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Nu s-au putut încărca repository-urile: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Repository implicit salvat';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Nu s-a putut salva repository-ul implicit';
+
+  @override
+  String get defaultRepository => 'Repository implicit';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Selectează un repository implicit pentru crearea de issue-uri. Poți specifica totuși un repository diferit când creezi issue-uri.';
+
+  @override
+  String get noReposFound => 'Nu s-au găsit repository-uri';
+
+  @override
+  String get private => 'Privat';
+
+  @override
+  String updatedDate(String date) {
+    return 'Actualizat $date';
+  }
+
+  @override
+  String get yesterday => 'ieri';
+
+  @override
+  String daysAgo(int count) {
+    return 'acum $count zile';
+  }
+
+  @override
+  String get oneWeekAgo => 'acum 1 săptămână';
+
+  @override
+  String weeksAgo(int count) {
+    return 'acum $count săptămâni';
+  }
+
+  @override
+  String get oneMonthAgo => 'acum 1 lună';
+
+  @override
+  String monthsAgo(int count) {
+    return 'acum $count luni';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Issue-urile vor fi create în repository-ul tău implicit';
+
+  @override
+  String get taskIntegrations => 'Integrări sarcini';
+
+  @override
+  String get configureSettings => 'Configurează setările';
+
+  @override
+  String get completeAuthBrowser =>
+      'Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Nu s-a putut inițializa autentificarea $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Conectează-te la $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Va trebui să autorizezi Omi să creeze sarcini în contul tău $appName. Aceasta va deschide browser-ul pentru autentificare.';
+  }
+
+  @override
+  String get continueButton => 'Continue';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Integrare $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integrarea cu $appName va fi disponibilă în curând! Lucrăm din greu pentru a-ți aduce mai multe opțiuni de gestionare a sarcinilor.';
+  }
+
+  @override
+  String get gotIt => 'Got it';
+
+  @override
+  String get tasksExportedOneApp => 'Sarcinile pot fi exportate către o singură aplicație odată.';
+
+  @override
+  String get completeYourUpgrade => 'Finalizează upgrade-ul';
+
+  @override
+  String get importConfiguration => 'Importă configurația';
+
+  @override
+  String get exportConfiguration => 'Exportă configurația';
+
+  @override
+  String get bringYourOwn => 'Folosește propriul tău';
+
+  @override
+  String get payYourSttProvider => 'Folosește Omi liber. Plătești doar furnizorul STT direct.';
+
+  @override
+  String get freeMinutesMonth => '1.200 de minute gratuite/lună incluse. Nelimitat cu ';
+
+  @override
+  String get omiUnlimited => 'Omi Nelimitat';
+
+  @override
+  String get hostRequired => 'Host-ul este necesar';
+
+  @override
+  String get validPortRequired => 'Port valid este necesar';
+
+  @override
+  String get validWebsocketUrlRequired => 'URL WebSocket valid este necesar (wss://)';
+
+  @override
+  String get apiUrlRequired => 'URL API este necesar';
+
+  @override
+  String get apiKeyRequired => 'Cheia API este necesară';
+
+  @override
+  String get invalidJsonConfig => 'Configurație JSON invalidă';
+
+  @override
+  String errorSaving(String error) {
+    return 'Eroare la salvare: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Configurație copiată în clipboard';
+
+  @override
+  String get pasteJsonConfig => 'Lipește configurația JSON mai jos:';
+
+  @override
+  String get addApiKeyAfterImport => 'Va trebui să adaugi propria cheie API după import';
+
+  @override
+  String get paste => 'Lipește';
+
+  @override
+  String get import => 'Importă';
+
+  @override
+  String get invalidProviderInConfig => 'Furnizor invalid în configurație';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Configurație $providerName importată';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON invalid: $error';
+  }
+
+  @override
+  String get provider => 'Furnizor';
+
+  @override
+  String get live => 'Live';
+
+  @override
+  String get onDevice => 'Pe dispozitiv';
+
+  @override
+  String get apiUrl => 'URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Introdu endpoint-ul HTTP STT';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Introdu endpoint-ul WebSocket STT live';
+
+  @override
+  String get apiKey => 'Cheie API';
+
+  @override
+  String get enterApiKey => 'Introdu cheia API';
+
+  @override
+  String get storedLocallyNeverShared => 'Stocat local, niciodată partajat';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Avansat';
+
+  @override
+  String get configuration => 'Configurație';
+
+  @override
+  String get requestConfiguration => 'Configurație cerere';
+
+  @override
+  String get responseSchema => 'Schemă răspuns';
+
+  @override
+  String get modified => 'Modificat';
+
+  @override
+  String get resetRequestConfig => 'Resetează configurația cererii la implicit';
+
+  @override
+  String get logs => 'Jurnale';
+
+  @override
+  String get logsCopied => 'Jurnale copiate';
+
+  @override
+  String get noLogsYet =>
+      'Încă nu există jurnale. Începe să înregistrezi pentru a vedea activitatea STT personalizată.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName folosește $codecReason. Omi va fi folosit.';
+  }
+
+  @override
+  String get omiTranscription => 'Transcriere Omi';
+
+  @override
+  String get bestInClassTranscription => 'Cea mai bună transcriere din clasă fără configurare';
+
+  @override
+  String get instantSpeakerLabels => 'Etichete vorbitor instant';
+
+  @override
+  String get languageTranslation => 'Traducere în peste 100 de limbi';
+
+  @override
+  String get optimizedForConversation => 'Optimizat pentru conversație';
+
+  @override
+  String get autoLanguageDetection => 'Detectare automată a limbii';
+
+  @override
+  String get highAccuracy => 'Acuratețe ridicată';
+
+  @override
+  String get privacyFirst => 'Confidențialitate pe primul loc';
+
+  @override
+  String get saveChanges => 'Salvează modificările';
+
+  @override
+  String get resetToDefault => 'Resetează la implicit';
+
+  @override
+  String get viewTemplate => 'Vezi șablonul';
+
+  @override
+  String get trySomethingLike => 'Încearcă ceva precum...';
+
+  @override
+  String get tryIt => 'Încearcă';
+
+  @override
+  String get creatingPlan => 'Se creează planul';
+
+  @override
+  String get developingLogic => 'Se dezvoltă logica';
+
+  @override
+  String get designingApp => 'Se proiectează aplicația';
+
+  @override
+  String get generatingIconStep => 'Se generează iconița';
+
+  @override
+  String get finalTouches => 'Retușuri finale';
+
+  @override
+  String get processing => 'Se procesează...';
+
+  @override
+  String get features => 'Funcționalități';
+
+  @override
+  String get creatingYourApp => 'Se creează aplicația ta...';
+
+  @override
+  String get generatingIcon => 'Se generează iconița...';
+
+  @override
+  String get whatShouldWeMake => 'Ce ar trebui să facem?';
+
+  @override
+  String get appName => 'Nume aplicație';
+
+  @override
+  String get description => 'Descriere';
+
+  @override
+  String get publicLabel => 'Public';
+
+  @override
+  String get privateLabel => 'Privat';
+
+  @override
+  String get free => 'Gratuit';
+
+  @override
+  String get perMonth => '/ Lună';
+
+  @override
+  String get tailoredConversationSummaries => 'Rezumate de conversație personalizate';
+
+  @override
+  String get customChatbotPersonality => 'Personalitate chatbot personalizată';
+
+  @override
+  String get makePublic => 'Fă publică';
+
+  @override
+  String get anyoneCanDiscover => 'Oricine poate descoperi aplicația ta';
+
+  @override
+  String get onlyYouCanUse => 'Doar tu poți folosi această aplicație';
+
+  @override
+  String get paidApp => 'Aplicație plătită';
+
+  @override
+  String get usersPayToUse => 'Utilizatorii plătesc pentru a folosi aplicația ta';
+
+  @override
+  String get freeForEveryone => 'Gratuit pentru toată lumea';
+
+  @override
+  String get perMonthLabel => '/ lună';
+
+  @override
+  String get creating => 'Se creează...';
+
+  @override
+  String get createApp => 'Creează aplicație';
+
+  @override
+  String get searchingForDevices => 'Searching for devices...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'DEVICES',
+      one: 'DEVICE',
+    );
+    return '$count $_temp0 FOUND NEARBY';
+  }
+
+  @override
+  String get pairingSuccessful => 'PAIRING SUCCESSFUL';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Error connecting to Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Don\'t show it again';
+
+  @override
+  String get iUnderstand => 'I Understand';
+
+  @override
+  String get enableBluetooth => 'Enable Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi needs Bluetooth to connect to your wearable. Please enable Bluetooth and try again.';
+
+  @override
+  String get contactSupport => 'Contact Support?';
+
+  @override
+  String get connectLater => 'Connect Later';
+
+  @override
+  String get grantPermissions => 'Grant permissions';
+
+  @override
+  String get backgroundActivity => 'Background activity';
+
+  @override
+  String get backgroundActivityDesc => 'Let Omi run in the background for better stability';
+
+  @override
+  String get locationAccess => 'Location access';
+
+  @override
+  String get locationAccessDesc => 'Enable background location for the full experience';
+
+  @override
+  String get notifications => 'Notifications';
+
+  @override
+  String get notificationsDesc => 'Enable notifications to stay informed';
+
+  @override
+  String get locationServiceDisabled => 'Location Service Disabled';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Location Service is Disabled. Please go to Settings > Privacy & Security > Location Services and enable it';
+
+  @override
+  String get backgroundLocationDenied => 'Background Location Access Denied';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Please go to device settings and set location permission to \"Always Allow\"';
+
+  @override
+  String get lovingOmi => 'Loving Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Help us reach more people by leaving a review in the App Store. Your feedback means the world to us!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Help us reach more people by leaving a review in the Google Play Store. Your feedback means the world to us!';
+
+  @override
+  String get rateOnAppStore => 'Rate on App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Rate on Google Play';
+
+  @override
+  String get maybeLater => 'Maybe later';
+
+  @override
+  String get speechProfileIntro => 'Omi needs to learn your goals and your voice. You\'ll be able to modify it later.';
+
+  @override
+  String get getStarted => 'Get Started';
+
+  @override
+  String get allDone => 'All done!';
+
+  @override
+  String get keepGoing => 'Keep going, you are doing great';
+
+  @override
+  String get skipThisQuestion => 'Skip this question';
+
+  @override
+  String get skipForNow => 'Skip for now';
+
+  @override
+  String get connectionError => 'Connection Error';
+
+  @override
+  String get connectionErrorDesc =>
+      'Failed to connect to the server. Please check your internet connection and try again.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Invalid recording detected';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.';
+
+  @override
+  String get tooShortDesc => 'There is not enough speech detected. Please speak more and try again.';
+
+  @override
+  String get invalidRecordingDesc => 'Please make sure you speak for at least 5 seconds and not more than 90.';
+
+  @override
+  String get areYouThere => 'Are you there?';
+
+  @override
+  String get noSpeechDesc =>
+      'We could not detect any speech. Please make sure to speak for at least 10 seconds and not more than 3 minutes.';
+
+  @override
+  String get connectionLost => 'Connection Lost';
+
+  @override
+  String get connectionLostDesc =>
+      'The connection was interrupted. Please check your internet connection and try again.';
+
+  @override
+  String get tryAgain => 'Try Again';
+
+  @override
+  String get connectOmiOmiGlass => 'Connect Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Continue Without Device';
+
+  @override
+  String get permissionsRequired => 'Permissions Required';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'This app needs Bluetooth and Location permissions to function properly. Please enable them in the settings.';
+
+  @override
+  String get openSettings => 'Open Settings';
+
+  @override
+  String get wantDifferentName => 'Want to go by something else?';
+
+  @override
+  String get whatsYourName => 'What\'s your name?';
+
+  @override
+  String get speakTranscribeSummarize => 'Speak. Transcribe. Summarize.';
+
+  @override
+  String get signInWithApple => 'Sign in with Apple';
+
+  @override
+  String get signInWithGoogle => 'Sign in with Google';
+
+  @override
+  String get byContinuingAgree => 'By continuing, you agree to our ';
+
+  @override
+  String get termsOfUse => 'Terms of Use';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Your AI Companion';
+
+  @override
+  String get captureEveryMoment => 'Capture every moment. Get AI-powered\nsummaries. Never take notes again.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch Setup';
+
+  @override
+  String get permissionRequestedExclaim => 'Permission Requested!';
+
+  @override
+  String get microphonePermission => 'Microphone Permission';
+
+  @override
+  String get permissionGrantedNow =>
+      'Permission granted! Now:\n\nOpen the Omi app on your watch and tap \"Continue\" below';
+
+  @override
+  String get needMicrophonePermission =>
+      'We need microphone permission.\n\n1. Tap \"Grant Permission\"\n2. Allow on your iPhone\n3. Watch app will close\n4. Reopen and tap \"Continue\"';
+
+  @override
+  String get grantPermissionButton => 'Grant Permission';
+
+  @override
+  String get needHelp => 'Need Help?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Troubleshooting:\n\n1. Ensure Omi is installed on your watch\n2. Open the Omi app on your watch\n3. Look for the permission popup\n4. Tap \"Allow\" when prompted\n5. App on your watch will close - reopen it\n6. Come back and tap \"Continue\" on your iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Recording started successfully!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Permission not granted yet. Please make sure you allowed microphone access and reopened the app on your watch.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Error requesting permission: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Error starting recording: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Select your primary language';
+
+  @override
+  String get languageBenefits => 'Set your language for sharper transcriptions and a personalized experience';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'What\'s your primary language?';
+
+  @override
+  String get selectYourLanguage => 'Select your language';
+
+  @override
+  String get personalGrowthJourney => 'Your personal growth journey with AI that listens to your every word.';
+
+  @override
+  String get actionItemsTitle => 'To-Do\'s';
+
+  @override
+  String get actionItemsDescription => 'Tap to edit • Long press to select • Swipe for actions';
+
+  @override
+  String get tabToDo => 'To Do';
+
+  @override
+  String get tabDone => 'Done';
+
+  @override
+  String get tabOld => 'Old';
+
+  @override
+  String get emptyTodoMessage => '🎉 All caught up!\nNo pending action items';
+
+  @override
+  String get emptyDoneMessage => 'No completed items yet';
+
+  @override
+  String get emptyOldMessage => '✅ No old tasks';
+
+  @override
+  String get noItems => 'No items';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Action item marked as incomplete';
+
+  @override
+  String get actionItemCompleted => 'Action item completed';
+
+  @override
+  String get deleteActionItemTitle => 'Delete Action Item';
+
+  @override
+  String get deleteActionItemMessage => 'Are you sure you want to delete this action item?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Delete Selected Items';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Are you sure you want to delete $count selected action item$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Action item \"$description\" deleted';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count action item$s deleted';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Failed to delete action item';
+
+  @override
+  String get failedToDeleteItems => 'Failed to delete items';
+
+  @override
+  String get failedToDeleteSomeItems => 'Failed to delete some items';
+
+  @override
+  String get welcomeActionItemsTitle => 'Ready for Action Items';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Your AI will automatically extract tasks and to-dos from your conversations. They\'ll appear here when created.';
+
+  @override
+  String get autoExtractionFeature => 'Automatically extracted from conversations';
+
+  @override
+  String get editSwipeFeature => 'Tap to edit, swipe to complete or delete';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count selected';
+  }
+
+  @override
+  String get selectAll => 'Select all';
+
+  @override
+  String get deleteSelected => 'Delete selected';
+
+  @override
+  String searchMemories(int count) {
+    return 'Search $count Memories';
+  }
+
+  @override
+  String get memoryDeleted => 'Memory Deleted.';
+
+  @override
+  String get undo => 'Undo';
+
+  @override
+  String get noMemoriesYet => 'No memories yet';
+
+  @override
+  String get noAutoMemories => 'No auto-extracted memories yet';
+
+  @override
+  String get noManualMemories => 'No manual memories yet';
+
+  @override
+  String get noMemoriesInCategories => 'No memories in these categories';
+
+  @override
+  String get noMemoriesFound => 'No memories found';
+
+  @override
+  String get addFirstMemory => 'Add your first memory';
+
+  @override
+  String get clearMemoryTitle => 'Clear Omi\'s Memory';
+
+  @override
+  String get clearMemoryMessage => 'Are you sure you want to clear Omi\'s memory? This action cannot be undone.';
+
+  @override
+  String get clearMemoryButton => 'Clear Memory';
+
+  @override
+  String get memoryClearedSuccess => 'Omi\'s memory about you has been cleared';
+
+  @override
+  String get noMemoriesToDelete => 'No memories to delete';
+
+  @override
+  String get createMemoryTooltip => 'Create new memory';
+
+  @override
+  String get createActionItemTooltip => 'Create new action item';
+
+  @override
+  String get memoryManagement => 'Memory Management';
+
+  @override
+  String get filterMemories => 'Filter Memories';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'You have $count total memories';
+  }
+
+  @override
+  String get publicMemories => 'Public memories';
+
+  @override
+  String get privateMemories => 'Private memories';
+
+  @override
+  String get makeAllPrivate => 'Make All Memories Private';
+
+  @override
+  String get makeAllPublic => 'Make All Memories Public';
+
+  @override
+  String get deleteAllMemories => 'Delete All Memories';
+
+  @override
+  String get allMemoriesPrivateResult => 'All memories are now private';
+
+  @override
+  String get allMemoriesPublicResult => 'All memories are now public';
+
+  @override
+  String get newMemory => 'New Memory';
+
+  @override
+  String get editMemory => 'Edit Memory';
+
+  @override
+  String get memoryContentHint => 'I like to eat ice cream...';
+
+  @override
+  String get failedToSaveMemory => 'Failed to save. Please check your connection.';
+
+  @override
+  String get saveMemory => 'Save Memory';
+
+  @override
+  String get retry => 'Retry';
+
+  @override
+  String get createActionItem => 'Create Action Item';
+
+  @override
+  String get editActionItem => 'Edit Action Item';
+
+  @override
+  String get actionItemDescriptionHint => 'What needs to be done?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Action item description cannot be empty.';
+
+  @override
+  String get actionItemUpdated => 'Action item updated';
+
+  @override
+  String get failedToUpdateActionItem => 'Failed to update action item';
+
+  @override
+  String get actionItemCreated => 'Action item created';
+
+  @override
+  String get failedToCreateActionItem => 'Failed to create action item';
+
+  @override
+  String get dueDate => 'Due Date';
+
+  @override
+  String get time => 'Time';
+
+  @override
+  String get addDueDate => 'Add due date';
+
+  @override
+  String get pressDoneToSave => 'Press done to save';
+
+  @override
+  String get pressDoneToCreate => 'Press done to create';
+
+  @override
+  String get filterAll => 'All';
+
+  @override
+  String get filterSystem => 'About You';
+
+  @override
+  String get filterInteresting => 'Insights';
+
+  @override
+  String get filterManual => 'Manual';
+
+  @override
+  String get completed => 'Completed';
+
+  @override
+  String get markComplete => 'Mark complete';
+
+  @override
+  String get actionItemDeleted => 'Action item deleted';
+
+  @override
+  String get failedToDeleteActionItem => 'Failed to delete action item';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Delete Action Item';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Are you sure you want to delete this action item?';
+
+  @override
+  String get appLanguage => 'App Language';
+
+  @override
+  String get appInterfaceSectionTitle => 'INTERFAȚĂ APLICAȚIE';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'VORBIRE ȘI TRANSCRIERE';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Limba aplicației schimbă meniurile și butoanele. Limba vorbirii afectează modul în care sunt transcrise înregistrările.';
+}

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -1,0 +1,2238 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Russian (`ru`).
+class AppLocalizationsRu extends AppLocalizations {
+  AppLocalizationsRu([String locale = 'ru']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Разговор';
+
+  @override
+  String get transcriptTab => 'Расшифровка';
+
+  @override
+  String get actionItemsTab => 'Задачи';
+
+  @override
+  String get deleteConversationTitle => 'Удалить разговор?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Вы уверены, что хотите удалить этот разговор? Это действие нельзя будет отменить.';
+
+  @override
+  String get confirm => 'Подтвердить';
+
+  @override
+  String get cancel => 'Отмена';
+
+  @override
+  String get ok => 'Ок';
+
+  @override
+  String get delete => 'Удалить';
+
+  @override
+  String get add => 'Добавить';
+
+  @override
+  String get update => 'Обновить';
+
+  @override
+  String get save => 'Сохранить';
+
+  @override
+  String get edit => 'Редактировать';
+
+  @override
+  String get close => 'Закрыть';
+
+  @override
+  String get clear => 'Очистить';
+
+  @override
+  String get copyTranscript => 'Копировать расшифровку';
+
+  @override
+  String get copySummary => 'Копировать резюме';
+
+  @override
+  String get testPrompt => 'Тестовый запрос';
+
+  @override
+  String get reprocessConversation => 'Переобработать разговор';
+
+  @override
+  String get deleteConversation => 'Удалить разговор';
+
+  @override
+  String get contentCopied => 'Содержимое скопировано в буфер обмена';
+
+  @override
+  String get failedToUpdateStarred => 'Не удалось обновить статус избранного.';
+
+  @override
+  String get conversationUrlNotShared => 'Не удалось поделиться ссылкой на разговор.';
+
+  @override
+  String get errorProcessingConversation => 'Ошибка при обработке разговора. Пожалуйста, попробуйте позже.';
+
+  @override
+  String get noInternetConnection => 'Пожалуйста, проверьте подключение к интернету и попробуйте снова.';
+
+  @override
+  String get unableToDeleteConversation => 'Не удалось удалить разговор';
+
+  @override
+  String get somethingWentWrong => 'Что-то пошло не так! Пожалуйста, попробуйте позже.';
+
+  @override
+  String get copyErrorMessage => 'Копировать сообщение об ошибке';
+
+  @override
+  String get errorCopied => 'Сообщение об ошибке скопировано в буфер обмена';
+
+  @override
+  String get remaining => 'Осталось';
+
+  @override
+  String get loading => 'Загрузка...';
+
+  @override
+  String get loadingDuration => 'Загрузка длительности...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count секунд';
+  }
+
+  @override
+  String get people => 'Люди';
+
+  @override
+  String get addNewPerson => 'Добавить нового человека';
+
+  @override
+  String get editPerson => 'Редактировать человека';
+
+  @override
+  String get createPersonHint => 'Создайте нового человека и обучите Omi распознавать его голос тоже!';
+
+  @override
+  String get speechProfile => 'Голосовой профиль';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Образец $number';
+  }
+
+  @override
+  String get settings => 'Настройки';
+
+  @override
+  String get language => 'Язык';
+
+  @override
+  String get selectLanguage => 'Выберите язык';
+
+  @override
+  String get deleting => 'Удаление...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
+
+  @override
+  String get failedToStartAuthentication => 'Не удалось начать аутентификацию';
+
+  @override
+  String get importStarted => 'Импорт начат! Вы получите уведомление, когда он завершится.';
+
+  @override
+  String get failedToStartImport => 'Не удалось начать импорт. Пожалуйста, попробуйте снова.';
+
+  @override
+  String get couldNotAccessFile => 'Не удалось получить доступ к выбранному файлу';
+
+  @override
+  String get askOmi => 'Спросить Omi';
+
+  @override
+  String get done => 'Готово';
+
+  @override
+  String get disconnected => 'Отключено';
+
+  @override
+  String get searching => 'Поиск';
+
+  @override
+  String get connectDevice => 'Подключить устройство';
+
+  @override
+  String get monthlyLimitReached => 'Вы достигли месячного лимита.';
+
+  @override
+  String get checkUsage => 'Проверить использование';
+
+  @override
+  String get syncingRecordings => 'Синхронизация записей';
+
+  @override
+  String get recordingsToSync => 'Записи для синхронизации';
+
+  @override
+  String get allCaughtUp => 'Всё синхронизировано';
+
+  @override
+  String get sync => 'Синхронизация';
+
+  @override
+  String get pendantUpToDate => 'Кулон обновлён';
+
+  @override
+  String get allRecordingsSynced => 'Все записи синхронизированы';
+
+  @override
+  String get syncingInProgress => 'Идёт синхронизация';
+
+  @override
+  String get readyToSync => 'Готово к синхронизации';
+
+  @override
+  String get tapSyncToStart => 'Нажмите Синхронизация для начала';
+
+  @override
+  String get pendantNotConnected => 'Кулон не подключён. Подключите для синхронизации.';
+
+  @override
+  String get everythingSynced => 'Всё уже синхронизировано.';
+
+  @override
+  String get recordingsNotSynced => 'У вас есть записи, которые ещё не синхронизированы.';
+
+  @override
+  String get syncingBackground => 'Мы продолжим синхронизировать ваши записи в фоновом режиме.';
+
+  @override
+  String get noConversationsYet => 'Разговоров пока нет.';
+
+  @override
+  String get noStarredConversations => 'Избранных разговоров пока нет.';
+
+  @override
+  String get starConversationHint =>
+      'Чтобы добавить разговор в избранное, откройте его и нажмите на значок звезды в заголовке.';
+
+  @override
+  String get searchConversations => 'Поиск разговоров';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return 'Выбрано $count';
+  }
+
+  @override
+  String get merge => 'Объединить';
+
+  @override
+  String get mergeConversations => 'Объединить разговоры';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Это объединит $count разговоров в один. Всё содержимое будет объединено и перегенерировано.';
+  }
+
+  @override
+  String get mergingInBackground => 'Объединение в фоновом режиме. Это может занять некоторое время.';
+
+  @override
+  String get failedToStartMerge => 'Не удалось начать объединение';
+
+  @override
+  String get askAnything => 'Спросите что угодно';
+
+  @override
+  String get noMessagesYet => 'Сообщений пока нет!\nПочему бы не начать разговор?';
+
+  @override
+  String get deletingMessages => 'Удаление ваших сообщений из памяти Omi...';
+
+  @override
+  String get messageCopied => 'Сообщение скопировано в буфер обмена.';
+
+  @override
+  String get cannotReportOwnMessage => 'Вы не можете пожаловаться на свои собственные сообщения.';
+
+  @override
+  String get reportMessage => 'Пожаловаться на сообщение';
+
+  @override
+  String get reportMessageConfirm => 'Вы уверены, что хотите пожаловаться на это сообщение?';
+
+  @override
+  String get messageReported => 'Жалоба на сообщение успешно отправлена.';
+
+  @override
+  String get thankYouFeedback => 'Спасибо за ваш отзыв!';
+
+  @override
+  String get clearChat => 'Очистить чат?';
+
+  @override
+  String get clearChatConfirm => 'Вы уверены, что хотите очистить чат? Это действие нельзя будет отменить.';
+
+  @override
+  String get maxFilesLimit => 'Вы можете загрузить только 4 файла одновременно';
+
+  @override
+  String get chatWithOmi => 'Чат с Omi';
+
+  @override
+  String get apps => 'Приложения';
+
+  @override
+  String get noAppsFound => 'Приложения не найдены';
+
+  @override
+  String get tryAdjustingSearch => 'Попробуйте изменить параметры поиска или фильтры';
+
+  @override
+  String get createYourOwnApp => 'Создайте своё приложение';
+
+  @override
+  String get buildAndShareApp => 'Создавайте и делитесь своим пользовательским приложением';
+
+  @override
+  String get searchApps => 'Поиск среди 1500+ приложений';
+
+  @override
+  String get myApps => 'Мои приложения';
+
+  @override
+  String get installedApps => 'Установленные приложения';
+
+  @override
+  String get unableToFetchApps =>
+      'Не удалось загрузить приложения :(\n\nПожалуйста, проверьте подключение к интернету и попробуйте снова.';
+
+  @override
+  String get aboutOmi => 'О Omi';
+
+  @override
+  String get privacyPolicy => 'Политикой конфиденциальности';
+
+  @override
+  String get visitWebsite => 'Посетить сайт';
+
+  @override
+  String get helpOrInquiries => 'Помощь или вопросы?';
+
+  @override
+  String get joinCommunity => 'Присоединяйтесь к сообществу!';
+
+  @override
+  String get membersAndCounting => 'Более 8000 участников.';
+
+  @override
+  String get deleteAccountTitle => 'Удалить аккаунт';
+
+  @override
+  String get deleteAccountConfirm => 'Вы уверены, что хотите удалить свой аккаунт?';
+
+  @override
+  String get cannotBeUndone => 'Это действие нельзя отменить.';
+
+  @override
+  String get allDataErased => 'Все ваши воспоминания и разговоры будут безвозвратно удалены.';
+
+  @override
+  String get appsDisconnected => 'Ваши приложения и интеграции будут немедленно отключены.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Вы можете экспортировать свои данные перед удалением аккаунта, но после удаления восстановить их будет невозможно.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Я понимаю, что удаление аккаунта необратимо, и все данные, включая воспоминания и разговоры, будут потеряны без возможности восстановления.';
+
+  @override
+  String get areYouSure => 'Вы уверены?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Это действие необратимо и навсегда удалит ваш аккаунт и все связанные с ним данные. Вы уверены, что хотите продолжить?';
+
+  @override
+  String get deleteNow => 'Удалить сейчас';
+
+  @override
+  String get goBack => 'Вернуться назад';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Поставьте галочку, чтобы подтвердить, что вы понимаете: удаление аккаунта необратимо.';
+
+  @override
+  String get profile => 'Профиль';
+
+  @override
+  String get name => 'Имя';
+
+  @override
+  String get email => 'Электронная почта';
+
+  @override
+  String get customVocabulary => 'Пользовательский словарь';
+
+  @override
+  String get identifyingOthers => 'Идентификация других';
+
+  @override
+  String get paymentMethods => 'Способы оплаты';
+
+  @override
+  String get conversationDisplay => 'Отображение разговоров';
+
+  @override
+  String get dataPrivacy => 'Данные и конфиденциальность';
+
+  @override
+  String get userId => 'ID пользователя';
+
+  @override
+  String get notSet => 'Не задано';
+
+  @override
+  String get userIdCopied => 'ID пользователя скопирован в буфер обмена';
+
+  @override
+  String get systemDefault => 'По умолчанию системы';
+
+  @override
+  String get planAndUsage => 'Тариф и использование';
+
+  @override
+  String get offlineSync => 'Оффлайн-синхронизация';
+
+  @override
+  String get deviceSettings => 'Настройки устройства';
+
+  @override
+  String get chatTools => 'Инструменты чата';
+
+  @override
+  String get feedbackBug => 'Отзыв / Ошибка';
+
+  @override
+  String get helpCenter => 'Центр помощи';
+
+  @override
+  String get developerSettings => 'Настройки разработчика';
+
+  @override
+  String get getOmiForMac => 'Получить Omi для Mac';
+
+  @override
+  String get referralProgram => 'Реферальная программа';
+
+  @override
+  String get signOut => 'Выйти';
+
+  @override
+  String get appAndDeviceCopied => 'Информация о приложении и устройстве скопирована';
+
+  @override
+  String get wrapped2025 => 'Итоги 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Ваша конфиденциальность, ваш контроль';
+
+  @override
+  String get privacyIntro =>
+      'В Omi мы стремимся защитить вашу конфиденциальность. Эта страница позволяет вам контролировать, как хранятся и используются ваши данные.';
+
+  @override
+  String get learnMore => 'Узнать больше...';
+
+  @override
+  String get dataProtectionLevel => 'Уровень защиты данных';
+
+  @override
+  String get dataProtectionDesc =>
+      'Ваши данные по умолчанию защищены надёжным шифрованием. Просмотрите ваши настройки и будущие опции конфиденциальности ниже.';
+
+  @override
+  String get appAccess => 'Доступ приложений';
+
+  @override
+  String get appAccessDesc =>
+      'Следующие приложения могут получить доступ к вашим данным. Нажмите на приложение, чтобы управлять его разрешениями.';
+
+  @override
+  String get noAppsExternalAccess => 'Ни одно установленное приложение не имеет внешнего доступа к вашим данным.';
+
+  @override
+  String get deviceName => 'Название устройства';
+
+  @override
+  String get deviceId => 'ID устройства';
+
+  @override
+  String get firmware => 'Прошивка';
+
+  @override
+  String get sdCardSync => 'Синхронизация SD-карты';
+
+  @override
+  String get hardwareRevision => 'Ревизия оборудования';
+
+  @override
+  String get modelNumber => 'Номер модели';
+
+  @override
+  String get manufacturer => 'Производитель';
+
+  @override
+  String get doubleTap => 'Двойное нажатие';
+
+  @override
+  String get ledBrightness => 'Яркость LED';
+
+  @override
+  String get micGain => 'Усиление микрофона';
+
+  @override
+  String get disconnect => 'Отключить';
+
+  @override
+  String get forgetDevice => 'Забыть устройство';
+
+  @override
+  String get chargingIssues => 'Проблемы с зарядкой';
+
+  @override
+  String get disconnectDevice => 'Отключить устройство';
+
+  @override
+  String get unpairDevice => 'Разорвать пару с устройством';
+
+  @override
+  String get unpairAndForget => 'Разорвать пару и забыть устройство';
+
+  @override
+  String get deviceDisconnectedMessage => 'Ваш Omi был отключён 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Пара с устройством разорвана. Перейдите в Настройки > Bluetooth и забудьте устройство для завершения разрыва пары.';
+
+  @override
+  String get unpairDialogTitle => 'Разорвать пару с устройством';
+
+  @override
+  String get unpairDialogMessage =>
+      'Это разорвёт пару с устройством, чтобы оно могло быть подключено к другому телефону. Вам нужно будет перейти в Настройки > Bluetooth и забыть устройство для завершения процесса.';
+
+  @override
+  String get deviceNotConnected => 'Устройство не подключено';
+
+  @override
+  String get connectDeviceMessage => 'Подключите устройство Omi для доступа\nк настройкам устройства и настройке';
+
+  @override
+  String get deviceInfoSection => 'Информация об устройстве';
+
+  @override
+  String get customizationSection => 'Настройка';
+
+  @override
+  String get hardwareSection => 'Оборудование';
+
+  @override
+  String get v2Undetected => 'V2 не обнаружено';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Мы видим, что у вас либо устройство V1, либо ваше устройство не подключено. Функция SD-карты доступна только для устройств V2.';
+
+  @override
+  String get endConversation => 'Завершить разговор';
+
+  @override
+  String get pauseResume => 'Пауза/Возобновить';
+
+  @override
+  String get starConversation => 'Добавить разговор в избранное';
+
+  @override
+  String get doubleTapAction => 'Действие при двойном нажатии';
+
+  @override
+  String get endAndProcess => 'Завершить и обработать разговор';
+
+  @override
+  String get pauseResumeRecording => 'Пауза/Возобновить запись';
+
+  @override
+  String get starOngoing => 'Добавить текущий разговор в избранное';
+
+  @override
+  String get off => 'Выкл';
+
+  @override
+  String get max => 'Макс';
+
+  @override
+  String get mute => 'Без звука';
+
+  @override
+  String get quiet => 'Тихий';
+
+  @override
+  String get normal => 'Обычный';
+
+  @override
+  String get high => 'Высокий';
+
+  @override
+  String get micGainDescMuted => 'Микрофон выключен';
+
+  @override
+  String get micGainDescLow => 'Очень тихий - для шумной обстановки';
+
+  @override
+  String get micGainDescModerate => 'Тихий - для умеренного шума';
+
+  @override
+  String get micGainDescNeutral => 'Нейтральный - сбалансированная запись';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Слегка усиленный - обычное использование';
+
+  @override
+  String get micGainDescBoosted => 'Усиленный - для тихой обстановки';
+
+  @override
+  String get micGainDescHigh => 'Высокий - для отдалённых или тихих голосов';
+
+  @override
+  String get micGainDescVeryHigh => 'Очень высокий - для очень тихих источников';
+
+  @override
+  String get micGainDescMax => 'Максимальный - используйте с осторожностью';
+
+  @override
+  String get developerSettingsTitle => 'Настройки разработчика';
+
+  @override
+  String get saving => 'Сохранение...';
+
+  @override
+  String get personaConfig => 'Настройте вашу AI-персону';
+
+  @override
+  String get beta => 'БЕТА';
+
+  @override
+  String get transcription => 'Расшифровка';
+
+  @override
+  String get transcriptionConfig => 'Настройте провайдера STT';
+
+  @override
+  String get conversationTimeout => 'Тайм-аут разговора';
+
+  @override
+  String get conversationTimeoutConfig => 'Установите, когда разговоры автоматически завершаются';
+
+  @override
+  String get importData => 'Импорт данных';
+
+  @override
+  String get importDataConfig => 'Импортируйте данные из других источников';
+
+  @override
+  String get debugDiagnostics => 'Отладка и диагностика';
+
+  @override
+  String get endpointUrl => 'URL конечной точки';
+
+  @override
+  String get noApiKeys => 'API-ключей пока нет';
+
+  @override
+  String get createKeyToStart => 'Создайте ключ для начала';
+
+  @override
+  String get createKey => 'Создать ключ';
+
+  @override
+  String get docs => 'Документация';
+
+  @override
+  String get yourOmiInsights => 'Ваша статистика Omi';
+
+  @override
+  String get today => 'Сегодня';
+
+  @override
+  String get thisMonth => 'Этот месяц';
+
+  @override
+  String get thisYear => 'Этот год';
+
+  @override
+  String get allTime => 'Всё время';
+
+  @override
+  String get noActivityYet => 'Активности пока нет';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Начните разговор с Omi,\nчтобы увидеть здесь вашу статистику использования.';
+
+  @override
+  String get listening => 'Прослушивание';
+
+  @override
+  String get listeningSubtitle => 'Общее время активного прослушивания Omi.';
+
+  @override
+  String get understanding => 'Понимание';
+
+  @override
+  String get understandingSubtitle => 'Слов понято из ваших разговоров.';
+
+  @override
+  String get providing => 'Предоставление';
+
+  @override
+  String get providingSubtitle => 'Задач и заметок, автоматически зафиксированных.';
+
+  @override
+  String get remembering => 'Запоминание';
+
+  @override
+  String get rememberingSubtitle => 'Фактов и деталей, запомненных для вас.';
+
+  @override
+  String get unlimitedPlan => 'Безлимитный тариф';
+
+  @override
+  String get managePlan => 'Управление тарифом';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Ваш тариф будет отменён $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Ваш тариф продлится $date.';
+  }
+
+  @override
+  String get basicPlan => 'Бесплатный тариф';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return 'Использовано $used из $limit минут';
+  }
+
+  @override
+  String get upgrade => 'Повысить тариф';
+
+  @override
+  String get upgradeToUnlimited => 'Перейти на безлимитный';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Ваш тариф включает $limit бесплатных минут в месяц. Перейдите на безлимитный тариф.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Делюсь статистикой Omi! (omi.me - ваш постоянный AI-помощник)';
+
+  @override
+  String get sharePeriodToday => 'Сегодня omi:';
+
+  @override
+  String get sharePeriodMonth => 'В этом месяце omi:';
+
+  @override
+  String get sharePeriodYear => 'В этом году omi:';
+
+  @override
+  String get sharePeriodAllTime => 'За всё время omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Слушал $minutes минут';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Понял $words слов';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Предоставил $count инсайтов';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Запомнил $count воспоминаний';
+  }
+
+  @override
+  String get debugLogs => 'Журналы отладки';
+
+  @override
+  String get debugLogsAutoDelete => 'Автоматически удаляются через 3 дня.';
+
+  @override
+  String get debugLogsDesc => 'Помогает диагностировать проблемы';
+
+  @override
+  String get noLogFilesFound => 'Файлы журналов не найдены.';
+
+  @override
+  String get omiDebugLog => 'Журнал отладки Omi';
+
+  @override
+  String get logShared => 'Журнал отправлен';
+
+  @override
+  String get selectLogFile => 'Выберите файл журнала';
+
+  @override
+  String get shareLogs => 'Поделиться журналами';
+
+  @override
+  String get debugLogCleared => 'Журнал отладки очищен';
+
+  @override
+  String get exportStarted => 'Экспорт начат. Это может занять несколько секунд...';
+
+  @override
+  String get exportAllData => 'Экспортировать все данные';
+
+  @override
+  String get exportDataDesc => 'Экспортировать разговоры в JSON-файл';
+
+  @override
+  String get exportedConversations => 'Экспортированные разговоры из Omi';
+
+  @override
+  String get exportShared => 'Экспорт отправлен';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Удалить граф знаний?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Это удалит все производные данные графа знаний (узлы и связи). Ваши исходные воспоминания останутся в безопасности. Граф будет восстановлен со временем или при следующем запросе.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Граф знаний успешно удалён';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Не удалось удалить граф: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Удалить граф знаний';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Очистить все узлы и связи';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Сервер MCP';
+
+  @override
+  String get mcpServerDesc => 'Подключите AI-помощников к вашим данным';
+
+  @override
+  String get serverUrl => 'URL сервера';
+
+  @override
+  String get urlCopied => 'URL скопирован';
+
+  @override
+  String get apiKeyAuth => 'Аутентификация по API-ключу';
+
+  @override
+  String get header => 'Заголовок';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <ключ>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID клиента';
+
+  @override
+  String get clientSecret => 'Секрет клиента';
+
+  @override
+  String get useMcpApiKey => 'Используйте ваш MCP API-ключ';
+
+  @override
+  String get webhooks => 'Вебхуки';
+
+  @override
+  String get conversationEvents => 'События разговоров';
+
+  @override
+  String get newConversationCreated => 'Создан новый разговор';
+
+  @override
+  String get realtimeTranscript => 'Расшифровка в реальном времени';
+
+  @override
+  String get transcriptReceived => 'Расшифровка получена';
+
+  @override
+  String get audioBytes => 'Байты аудио';
+
+  @override
+  String get audioDataReceived => 'Данные аудио получены';
+
+  @override
+  String get intervalSeconds => 'Интервал (секунды)';
+
+  @override
+  String get daySummary => 'Сводка дня';
+
+  @override
+  String get summaryGenerated => 'Сводка создана';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Добавить в claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Копировать конфигурацию';
+
+  @override
+  String get configCopied => 'Конфигурация скопирована в буфер обмена';
+
+  @override
+  String get listeningMins => 'Прослушивание (мин)';
+
+  @override
+  String get understandingWords => 'Понимание (слов)';
+
+  @override
+  String get insights => 'Инсайты';
+
+  @override
+  String get memories => 'Воспоминания';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return 'Использовано $used из $limit минут в этом месяце';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return 'Использовано $used из $limit слов в этом месяце';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return 'Получено $used из $limit инсайтов в этом месяце';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return 'Создано $used из $limit воспоминаний в этом месяце';
+  }
+
+  @override
+  String get visibility => 'Видимость';
+
+  @override
+  String get visibilitySubtitle => 'Контролируйте, какие разговоры появляются в вашем списке';
+
+  @override
+  String get showShortConversations => 'Показывать короткие разговоры';
+
+  @override
+  String get showShortConversationsDesc => 'Показывать разговоры короче порогового значения';
+
+  @override
+  String get showDiscardedConversations => 'Показывать отброшенные разговоры';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Включать разговоры, отмеченные как отброшенные';
+
+  @override
+  String get shortConversationThreshold => 'Порог коротких разговоров';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Разговоры короче этого значения будут скрыты, если не включено выше';
+
+  @override
+  String get durationThreshold => 'Порог длительности';
+
+  @override
+  String get durationThresholdDesc => 'Скрыть разговоры короче этого значения';
+
+  @override
+  String minLabel(int count) {
+    return '$count мин';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Пользовательский словарь';
+
+  @override
+  String get addWords => 'Добавить слова';
+
+  @override
+  String get addWordsDesc => 'Имена, термины или редкие слова';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Подключить';
+
+  @override
+  String get comingSoon => 'Скоро';
+
+  @override
+  String get chatToolsFooter => 'Подключите ваши приложения для просмотра данных и метрик в чате.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Не удалось начать аутентификацию $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Отключить $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Вы уверены, что хотите отключиться от $appName? Вы можете переподключиться в любое время.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Отключено от $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Не удалось отключить';
+
+  @override
+  String connectTo(String appName) {
+    return 'Подключиться к $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Вам нужно авторизовать Omi для доступа к вашим данным $appName. Это откроет браузер для аутентификации.';
+  }
+
+  @override
+  String get continueAction => 'Продолжить';
+
+  @override
+  String get languageTitle => 'Язык';
+
+  @override
+  String get primaryLanguage => 'Основной язык';
+
+  @override
+  String get automaticTranslation => 'Автоматический перевод';
+
+  @override
+  String get detectLanguages => 'Определение 10+ языков';
+
+  @override
+  String get authorizeSavingRecordings => 'Разрешить сохранение записей';
+
+  @override
+  String get thanksForAuthorizing => 'Спасибо за разрешение!';
+
+  @override
+  String get needYourPermission => 'Нам нужно ваше разрешение';
+
+  @override
+  String get alreadyGavePermission =>
+      'Вы уже дали нам разрешение на сохранение ваших записей. Напоминаем, зачем нам это нужно:';
+
+  @override
+  String get wouldLikePermission =>
+      'Мы хотели бы получить ваше разрешение на сохранение ваших голосовых записей. Вот почему:';
+
+  @override
+  String get improveSpeechProfile => 'Улучшение вашего голосового профиля';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Мы используем записи для дальнейшего обучения и улучшения вашего персонального голосового профиля.';
+
+  @override
+  String get trainFamilyProfiles => 'Обучение профилей друзей и семьи';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Ваши записи помогают нам распознавать и создавать профили для ваших друзей и семьи.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Повышение точности расшифровки';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'По мере улучшения нашей модели мы сможем предоставлять лучшие результаты расшифровки для ваших записей.';
+
+  @override
+  String get legalNotice =>
+      'Юридическое уведомление: Законность записи и хранения голосовых данных может различаться в зависимости от вашего местоположения и того, как вы используете эту функцию. Вы несёте ответственность за соблюдение местных законов и нормативных актов.';
+
+  @override
+  String get alreadyAuthorized => 'Уже разрешено';
+
+  @override
+  String get authorize => 'Разрешить';
+
+  @override
+  String get revokeAuthorization => 'Отозвать разрешение';
+
+  @override
+  String get authorizationSuccessful => 'Разрешение успешно получено!';
+
+  @override
+  String get failedToAuthorize => 'Не удалось получить разрешение. Пожалуйста, попробуйте снова.';
+
+  @override
+  String get authorizationRevoked => 'Разрешение отозвано.';
+
+  @override
+  String get recordingsDeleted => 'Записи удалены.';
+
+  @override
+  String get failedToRevoke => 'Не удалось отозвать разрешение. Пожалуйста, попробуйте снова.';
+
+  @override
+  String get permissionRevokedTitle => 'Разрешение отозвано';
+
+  @override
+  String get permissionRevokedMessage => 'Хотите, чтобы мы удалили все ваши существующие записи тоже?';
+
+  @override
+  String get yes => 'Да';
+
+  @override
+  String get editName => 'Изменить имя';
+
+  @override
+  String get howShouldOmiCallYou => 'Как Omi должен вас называть?';
+
+  @override
+  String get enterYourName => 'Введите ваше имя';
+
+  @override
+  String get nameCannotBeEmpty => 'Имя не может быть пустым';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Имя успешно обновлено!';
+
+  @override
+  String get calendarSettings => 'Настройки календаря';
+
+  @override
+  String get calendarProviders => 'Провайдеры календаря';
+
+  @override
+  String get macOsCalendar => 'Календарь macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Подключите ваш локальный календарь macOS';
+
+  @override
+  String get googleCalendar => 'Google Календарь';
+
+  @override
+  String get syncGoogleAccount => 'Синхронизация с вашим аккаунтом Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Показывать предстоящие встречи в строке меню';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Отображать вашу следующую встречу и время до её начала в строке меню macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Показывать события без участников';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Когда включено, Coming Up показывает события без участников или видеосвязи.';
+
+  @override
+  String get yourMeetings => 'Ваши встречи';
+
+  @override
+  String get refresh => 'Обновить';
+
+  @override
+  String get noUpcomingMeetings => 'Предстоящих встреч не найдено';
+
+  @override
+  String get checkingNextDays => 'Проверка следующих 30 дней';
+
+  @override
+  String get tomorrow => 'Завтра';
+
+  @override
+  String get googleCalendarComingSoon => 'Интеграция с Google Календарём скоро!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Подключено как пользователь: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Рабочее пространство по умолчанию';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Задачи будут созданы в этом рабочем пространстве';
+
+  @override
+  String get defaultProjectOptional => 'Проект по умолчанию (опционально)';
+
+  @override
+  String get leaveUnselectedTasks => 'Оставьте не выбранным для создания задач без проекта';
+
+  @override
+  String get noProjectsInWorkspace => 'Проекты в этом рабочем пространстве не найдены';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Выберите, сколько времени ждать в тишине перед автоматическим завершением разговора:';
+
+  @override
+  String get timeout2Minutes => '2 минуты';
+
+  @override
+  String get timeout2MinutesDesc => 'Завершить разговор после 2 минут тишины';
+
+  @override
+  String get timeout5Minutes => '5 минут';
+
+  @override
+  String get timeout5MinutesDesc => 'Завершить разговор после 5 минут тишины';
+
+  @override
+  String get timeout10Minutes => '10 минут';
+
+  @override
+  String get timeout10MinutesDesc => 'Завершить разговор после 10 минут тишины';
+
+  @override
+  String get timeout30Minutes => '30 минут';
+
+  @override
+  String get timeout30MinutesDesc => 'Завершить разговор после 30 минут тишины';
+
+  @override
+  String get timeout4Hours => '4 часа';
+
+  @override
+  String get timeout4HoursDesc => 'Завершить разговор после 4 часов тишины';
+
+  @override
+  String get conversationEndAfterHours => 'Разговоры теперь будут завершаться после 4 часов тишины';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Разговоры теперь будут завершаться после $minutes минут тишины';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Укажите ваш основной язык';
+
+  @override
+  String get languageForTranscription =>
+      'Установите ваш язык для более точной расшифровки и персонализированного опыта.';
+
+  @override
+  String get singleLanguageModeInfo => 'Режим одного языка включён. Перевод отключён для повышения точности.';
+
+  @override
+  String get searchLanguageHint => 'Поиск языка по названию или коду';
+
+  @override
+  String get noLanguagesFound => 'Языки не найдены';
+
+  @override
+  String get skip => 'Пропустить';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Язык установлен на $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Не удалось установить язык';
+
+  @override
+  String appSettings(String appName) {
+    return 'Настройки $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Отключиться от $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Это удалит вашу аутентификацию $appName. Вам нужно будет переподключиться для повторного использования.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Подключено к $appName';
+  }
+
+  @override
+  String get account => 'Аккаунт';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Ваши задачи будут синхронизированы с вашим аккаунтом $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Пространство по умолчанию';
+
+  @override
+  String get selectSpaceInWorkspace => 'Выберите пространство в вашем рабочем пространстве';
+
+  @override
+  String get noSpacesInWorkspace => 'Пространства в этом рабочем пространстве не найдены';
+
+  @override
+  String get defaultList => 'Список по умолчанию';
+
+  @override
+  String get tasksAddedToList => 'Задачи будут добавлены в этот список';
+
+  @override
+  String get noListsInSpace => 'Списки в этом пространстве не найдены';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Не удалось загрузить репозитории: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Репозиторий по умолчанию сохранён';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Не удалось сохранить репозиторий по умолчанию';
+
+  @override
+  String get defaultRepository => 'Репозиторий по умолчанию';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Выберите репозиторий по умолчанию для создания задач. Вы все еще можете указать другой репозиторий при создании задач.';
+
+  @override
+  String get noReposFound => 'Репозитории не найдены';
+
+  @override
+  String get private => 'Приватный';
+
+  @override
+  String updatedDate(String date) {
+    return 'Обновлено $date';
+  }
+
+  @override
+  String get yesterday => 'вчера';
+
+  @override
+  String daysAgo(int count) {
+    return '$count дней назад';
+  }
+
+  @override
+  String get oneWeekAgo => '1 неделю назад';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count недель назад';
+  }
+
+  @override
+  String get oneMonthAgo => '1 месяц назад';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count месяцев назад';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Задачи будут создаваться в вашем репозитории по умолчанию';
+
+  @override
+  String get taskIntegrations => 'Интеграции задач';
+
+  @override
+  String get configureSettings => 'Настроить параметры';
+
+  @override
+  String get completeAuthBrowser =>
+      'Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Не удалось начать аутентификацию $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Подключиться к $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Вам нужно авторизовать Omi для создания задач в вашем аккаунте $appName. Это откроет браузер для аутентификации.';
+  }
+
+  @override
+  String get continueButton => 'Продолжить';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Интеграция $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Интеграция с $appName скоро! Мы упорно работаем, чтобы предоставить вам больше вариантов управления задачами.';
+  }
+
+  @override
+  String get gotIt => 'Понятно';
+
+  @override
+  String get tasksExportedOneApp => 'Задачи могут быть экспортированы только в одно приложение за раз.';
+
+  @override
+  String get completeYourUpgrade => 'Завершите обновление';
+
+  @override
+  String get importConfiguration => 'Импорт конфигурации';
+
+  @override
+  String get exportConfiguration => 'Экспорт конфигурации';
+
+  @override
+  String get bringYourOwn => 'Используйте свой';
+
+  @override
+  String get payYourSttProvider => 'Свободно используйте omi. Вы платите только своему провайдеру STT напрямую.';
+
+  @override
+  String get freeMinutesMonth => '1200 бесплатных минут в месяц включено. Безлимитно с ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Требуется хост';
+
+  @override
+  String get validPortRequired => 'Требуется действительный порт';
+
+  @override
+  String get validWebsocketUrlRequired => 'Требуется действительный URL WebSocket (wss://)';
+
+  @override
+  String get apiUrlRequired => 'Требуется URL API';
+
+  @override
+  String get apiKeyRequired => 'Требуется API-ключ';
+
+  @override
+  String get invalidJsonConfig => 'Недействительная конфигурация JSON';
+
+  @override
+  String errorSaving(String error) {
+    return 'Ошибка сохранения: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Конфигурация скопирована в буфер обмена';
+
+  @override
+  String get pasteJsonConfig => 'Вставьте вашу конфигурацию JSON ниже:';
+
+  @override
+  String get addApiKeyAfterImport => 'Вам нужно будет добавить свой API-ключ после импорта';
+
+  @override
+  String get paste => 'Вставить';
+
+  @override
+  String get import => 'Импорт';
+
+  @override
+  String get invalidProviderInConfig => 'Недействительный провайдер в конфигурации';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Импортирована конфигурация $providerName';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Недействительный JSON: $error';
+  }
+
+  @override
+  String get provider => 'Провайдер';
+
+  @override
+  String get live => 'В реальном времени';
+
+  @override
+  String get onDevice => 'На устройстве';
+
+  @override
+  String get apiUrl => 'URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Введите вашу конечную точку STT HTTP';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Введите вашу конечную точку WebSocket для STT в реальном времени';
+
+  @override
+  String get apiKey => 'API-ключ';
+
+  @override
+  String get enterApiKey => 'Введите ваш API-ключ';
+
+  @override
+  String get storedLocallyNeverShared => 'Хранится локально, никогда не передаётся';
+
+  @override
+  String get host => 'Хост';
+
+  @override
+  String get port => 'Порт';
+
+  @override
+  String get advanced => 'Расширенные';
+
+  @override
+  String get configuration => 'Конфигурация';
+
+  @override
+  String get requestConfiguration => 'Конфигурация запроса';
+
+  @override
+  String get responseSchema => 'Схема ответа';
+
+  @override
+  String get modified => 'Изменено';
+
+  @override
+  String get resetRequestConfig => 'Сбросить конфигурацию запроса по умолчанию';
+
+  @override
+  String get logs => 'Журналы';
+
+  @override
+  String get logsCopied => 'Журналы скопированы';
+
+  @override
+  String get noLogsYet => 'Журналов пока нет. Начните запись, чтобы увидеть активность пользовательского STT.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName использует $codecReason. Будет использован Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Расшифровка Omi';
+
+  @override
+  String get bestInClassTranscription => 'Лучшая расшифровка без настройки';
+
+  @override
+  String get instantSpeakerLabels => 'Мгновенные метки спикеров';
+
+  @override
+  String get languageTranslation => 'Перевод на 100+ языков';
+
+  @override
+  String get optimizedForConversation => 'Оптимизировано для разговоров';
+
+  @override
+  String get autoLanguageDetection => 'Автоматическое определение языка';
+
+  @override
+  String get highAccuracy => 'Высокая точность';
+
+  @override
+  String get privacyFirst => 'Конфиденциальность прежде всего';
+
+  @override
+  String get saveChanges => 'Сохранить изменения';
+
+  @override
+  String get resetToDefault => 'Сбросить по умолчанию';
+
+  @override
+  String get viewTemplate => 'Просмотреть шаблон';
+
+  @override
+  String get trySomethingLike => 'Попробуйте что-то вроде...';
+
+  @override
+  String get tryIt => 'Попробовать';
+
+  @override
+  String get creatingPlan => 'Создание плана';
+
+  @override
+  String get developingLogic => 'Разработка логики';
+
+  @override
+  String get designingApp => 'Проектирование приложения';
+
+  @override
+  String get generatingIconStep => 'Генерация иконки';
+
+  @override
+  String get finalTouches => 'Завершающие штрихи';
+
+  @override
+  String get processing => 'Обработка...';
+
+  @override
+  String get features => 'Возможности';
+
+  @override
+  String get creatingYourApp => 'Создание вашего приложения...';
+
+  @override
+  String get generatingIcon => 'Генерация иконки...';
+
+  @override
+  String get whatShouldWeMake => 'Что мы должны создать?';
+
+  @override
+  String get appName => 'Название приложения';
+
+  @override
+  String get description => 'Описание';
+
+  @override
+  String get publicLabel => 'Публичное';
+
+  @override
+  String get privateLabel => 'Приватное';
+
+  @override
+  String get free => 'Бесплатно';
+
+  @override
+  String get perMonth => '/ Месяц';
+
+  @override
+  String get tailoredConversationSummaries => 'Персонализированные резюме разговоров';
+
+  @override
+  String get customChatbotPersonality => 'Пользовательская личность чат-бота';
+
+  @override
+  String get makePublic => 'Сделать публичным';
+
+  @override
+  String get anyoneCanDiscover => 'Любой может найти ваше приложение';
+
+  @override
+  String get onlyYouCanUse => 'Только вы можете использовать это приложение';
+
+  @override
+  String get paidApp => 'Платное приложение';
+
+  @override
+  String get usersPayToUse => 'Пользователи платят за использование вашего приложения';
+
+  @override
+  String get freeForEveryone => 'Бесплатно для всех';
+
+  @override
+  String get perMonthLabel => '/ месяц';
+
+  @override
+  String get creating => 'Создание...';
+
+  @override
+  String get createApp => 'Создать приложение';
+
+  @override
+  String get searchingForDevices => 'Поиск устройств...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'УСТРОЙСТВ',
+      few: 'УСТРОЙСТВА',
+      one: 'УСТРОЙСТВО',
+    );
+    return '$_temp0 НАЙДЕНО РЯДОМ: $count';
+  }
+
+  @override
+  String get pairingSuccessful => 'СОПРЯЖЕНИЕ УСПЕШНО';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Ошибка подключения к Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Больше не показывать';
+
+  @override
+  String get iUnderstand => 'Я понимаю';
+
+  @override
+  String get enableBluetooth => 'Включите Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi требуется Bluetooth для подключения к вашему устройству. Пожалуйста, включите Bluetooth и попробуйте снова.';
+
+  @override
+  String get contactSupport => 'Связаться с поддержкой?';
+
+  @override
+  String get connectLater => 'Подключить позже';
+
+  @override
+  String get grantPermissions => 'Предоставить разрешения';
+
+  @override
+  String get backgroundActivity => 'Фоновая активность';
+
+  @override
+  String get backgroundActivityDesc => 'Позвольте Omi работать в фоновом режиме для лучшей стабильности';
+
+  @override
+  String get locationAccess => 'Доступ к местоположению';
+
+  @override
+  String get locationAccessDesc => 'Включите фоновое определение местоположения для полного опыта';
+
+  @override
+  String get notifications => 'Уведомления';
+
+  @override
+  String get notificationsDesc => 'Включите уведомления, чтобы быть в курсе';
+
+  @override
+  String get locationServiceDisabled => 'Служба определения местоположения отключена';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Служба определения местоположения отключена. Пожалуйста, перейдите в Настройки > Конфиденциальность и безопасность > Службы геолокации и включите её';
+
+  @override
+  String get backgroundLocationDenied => 'Доступ к местоположению в фоновом режиме отклонён';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Пожалуйста, перейдите в настройки устройства и установите разрешение на местоположение как \"Всегда разрешать\"';
+
+  @override
+  String get lovingOmi => 'Нравится Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Помогите нам достичь большего количества людей, оставив отзыв в App Store. Ваш отзыв очень важен для нас!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Помогите нам достичь большего количества людей, оставив отзыв в Google Play Store. Ваш отзыв очень важен для нас!';
+
+  @override
+  String get rateOnAppStore => 'Оценить в App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Оценить в Google Play';
+
+  @override
+  String get maybeLater => 'Может быть, позже';
+
+  @override
+  String get speechProfileIntro => 'Omi нужно узнать ваши цели и ваш голос. Вы сможете изменить это позже.';
+
+  @override
+  String get getStarted => 'Начать';
+
+  @override
+  String get allDone => 'Всё готово!';
+
+  @override
+  String get keepGoing => 'Продолжайте, вы отлично справляетесь';
+
+  @override
+  String get skipThisQuestion => 'Пропустить этот вопрос';
+
+  @override
+  String get skipForNow => 'Пропустить пока';
+
+  @override
+  String get connectionError => 'Ошибка подключения';
+
+  @override
+  String get connectionErrorDesc =>
+      'Не удалось подключиться к серверу. Пожалуйста, проверьте подключение к интернету и попробуйте снова.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Обнаружена недействительная запись';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Похоже, в записи несколько говорящих. Пожалуйста, убедитесь, что вы находитесь в тихом месте, и попробуйте снова.';
+
+  @override
+  String get tooShortDesc => 'Обнаружено недостаточно речи. Пожалуйста, говорите больше и попробуйте снова.';
+
+  @override
+  String get invalidRecordingDesc => 'Пожалуйста, убедитесь, что вы говорите не менее 5 секунд и не более 90.';
+
+  @override
+  String get areYouThere => 'Вы здесь?';
+
+  @override
+  String get noSpeechDesc =>
+      'Мы не смогли обнаружить речь. Пожалуйста, убедитесь, что говорите не менее 10 секунд и не более 3 минут.';
+
+  @override
+  String get connectionLost => 'Соединение потеряно';
+
+  @override
+  String get connectionLostDesc =>
+      'Соединение было прервано. Пожалуйста, проверьте подключение к интернету и попробуйте снова.';
+
+  @override
+  String get tryAgain => 'Попробовать снова';
+
+  @override
+  String get connectOmiOmiGlass => 'Подключить Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Продолжить без устройства';
+
+  @override
+  String get permissionsRequired => 'Требуются разрешения';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Этому приложению нужны разрешения Bluetooth и Местоположение для правильной работы. Пожалуйста, включите их в настройках.';
+
+  @override
+  String get openSettings => 'Открыть настройки';
+
+  @override
+  String get wantDifferentName => 'Хотите использовать другое имя?';
+
+  @override
+  String get whatsYourName => 'Как вас зовут?';
+
+  @override
+  String get speakTranscribeSummarize => 'Говорите. Расшифровывайте. Резюмируйте.';
+
+  @override
+  String get signInWithApple => 'Войти с Apple';
+
+  @override
+  String get signInWithGoogle => 'Войти с Google';
+
+  @override
+  String get byContinuingAgree => 'Продолжая, вы соглашаетесь с нашей ';
+
+  @override
+  String get termsOfUse => 'Условиями использования';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – ваш AI-компаньон';
+
+  @override
+  String get captureEveryMoment => 'Фиксируйте каждый момент. Получайте резюме на основе AI.\nБольше никаких заметок.';
+
+  @override
+  String get appleWatchSetup => 'Настройка Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Разрешение запрошено!';
+
+  @override
+  String get microphonePermission => 'Разрешение на микрофон';
+
+  @override
+  String get permissionGrantedNow =>
+      'Разрешение предоставлено! Теперь:\n\nОткройте приложение Omi на ваших часах и нажмите \"Продолжить\" ниже';
+
+  @override
+  String get needMicrophonePermission =>
+      'Нам нужно разрешение на микрофон.\n\n1. Нажмите \"Предоставить разрешение\"\n2. Разрешите на вашем iPhone\n3. Приложение на часах закроется\n4. Откройте снова и нажмите \"Продолжить\"';
+
+  @override
+  String get grantPermissionButton => 'Предоставить разрешение';
+
+  @override
+  String get needHelp => 'Нужна помощь?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Устранение неполадок:\n\n1. Убедитесь, что Omi установлен на ваших часах\n2. Откройте приложение Omi на ваших часах\n3. Найдите всплывающее окно с разрешением\n4. Нажмите \"Разрешить\" при запросе\n5. Приложение на часах закроется - откройте его снова\n6. Вернитесь и нажмите \"Продолжить\" на вашем iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Запись успешно начата!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Разрешение ещё не предоставлено. Пожалуйста, убедитесь, что вы разрешили доступ к микрофону и открыли приложение на часах заново.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Ошибка при запросе разрешения: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Ошибка при начале записи: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Выберите ваш основной язык';
+
+  @override
+  String get languageBenefits => 'Установите ваш язык для более точной расшифровки и персонализированного опыта';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Какой ваш основной язык?';
+
+  @override
+  String get selectYourLanguage => 'Выберите ваш язык';
+
+  @override
+  String get personalGrowthJourney => 'Ваше личностное развитие с AI, который слушает каждое ваше слово.';
+
+  @override
+  String get actionItemsTitle => 'Задачи';
+
+  @override
+  String get actionItemsDescription => 'Нажмите для редактирования • Удерживайте для выбора • Свайп для действий';
+
+  @override
+  String get tabToDo => 'К выполнению';
+
+  @override
+  String get tabDone => 'Выполнено';
+
+  @override
+  String get tabOld => 'Старые';
+
+  @override
+  String get emptyTodoMessage => '🎉 Всё выполнено!\nНет ожидающих задач';
+
+  @override
+  String get emptyDoneMessage => 'Выполненных задач пока нет';
+
+  @override
+  String get emptyOldMessage => '✅ Нет старых задач';
+
+  @override
+  String get noItems => 'Нет элементов';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Задача отмечена как невыполненная';
+
+  @override
+  String get actionItemCompleted => 'Задача выполнена';
+
+  @override
+  String get deleteActionItemTitle => 'Удалить задачу';
+
+  @override
+  String get deleteActionItemMessage => 'Вы уверены, что хотите удалить эту задачу?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Удалить выбранные элементы';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Вы уверены, что хотите удалить $count выбранных задач$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Задача \"$description\" удалена';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return 'Удалено $count задач$s';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Не удалось удалить задачу';
+
+  @override
+  String get failedToDeleteItems => 'Не удалось удалить элементы';
+
+  @override
+  String get failedToDeleteSomeItems => 'Не удалось удалить некоторые элементы';
+
+  @override
+  String get welcomeActionItemsTitle => 'Готово к задачам';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Ваш AI автоматически извлечёт задачи и дела из ваших разговоров. Они появятся здесь при создании.';
+
+  @override
+  String get autoExtractionFeature => 'Автоматически извлекается из разговоров';
+
+  @override
+  String get editSwipeFeature => 'Нажмите для редактирования, свайп для завершения или удаления';
+
+  @override
+  String itemsSelected(int count) {
+    return 'Выбрано $count';
+  }
+
+  @override
+  String get selectAll => 'Выбрать всё';
+
+  @override
+  String get deleteSelected => 'Удалить выбранное';
+
+  @override
+  String searchMemories(int count) {
+    return 'Поиск среди $count воспоминаний';
+  }
+
+  @override
+  String get memoryDeleted => 'Воспоминание удалено.';
+
+  @override
+  String get undo => 'Отменить';
+
+  @override
+  String get noMemoriesYet => 'Воспоминаний пока нет';
+
+  @override
+  String get noAutoMemories => 'Автоматически извлечённых воспоминаний пока нет';
+
+  @override
+  String get noManualMemories => 'Ручных воспоминаний пока нет';
+
+  @override
+  String get noMemoriesInCategories => 'Нет воспоминаний в этих категориях';
+
+  @override
+  String get noMemoriesFound => 'Воспоминания не найдены';
+
+  @override
+  String get addFirstMemory => 'Добавьте ваше первое воспоминание';
+
+  @override
+  String get clearMemoryTitle => 'Очистить память Omi';
+
+  @override
+  String get clearMemoryMessage => 'Вы уверены, что хотите очистить память Omi? Это действие нельзя отменить.';
+
+  @override
+  String get clearMemoryButton => 'Очистить память';
+
+  @override
+  String get memoryClearedSuccess => 'Память Omi о вас была очищена';
+
+  @override
+  String get noMemoriesToDelete => 'Нет воспоминаний для удаления';
+
+  @override
+  String get createMemoryTooltip => 'Создать новое воспоминание';
+
+  @override
+  String get createActionItemTooltip => 'Создать новую задачу';
+
+  @override
+  String get memoryManagement => 'Управление памятью';
+
+  @override
+  String get filterMemories => 'Фильтр воспоминаний';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'У вас всего $count воспоминаний';
+  }
+
+  @override
+  String get publicMemories => 'Публичные воспоминания';
+
+  @override
+  String get privateMemories => 'Приватные воспоминания';
+
+  @override
+  String get makeAllPrivate => 'Сделать все воспоминания приватными';
+
+  @override
+  String get makeAllPublic => 'Сделать все воспоминания публичными';
+
+  @override
+  String get deleteAllMemories => 'Удалить все воспоминания';
+
+  @override
+  String get allMemoriesPrivateResult => 'Все воспоминания теперь приватные';
+
+  @override
+  String get allMemoriesPublicResult => 'Все воспоминания теперь публичные';
+
+  @override
+  String get newMemory => 'Новое воспоминание';
+
+  @override
+  String get editMemory => 'Редактировать воспоминание';
+
+  @override
+  String get memoryContentHint => 'Я люблю есть мороженое...';
+
+  @override
+  String get failedToSaveMemory => 'Не удалось сохранить. Пожалуйста, проверьте подключение.';
+
+  @override
+  String get saveMemory => 'Сохранить воспоминание';
+
+  @override
+  String get retry => 'Повторить';
+
+  @override
+  String get createActionItem => 'Создать задачу';
+
+  @override
+  String get editActionItem => 'Редактировать задачу';
+
+  @override
+  String get actionItemDescriptionHint => 'Что нужно сделать?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Описание задачи не может быть пустым.';
+
+  @override
+  String get actionItemUpdated => 'Задача обновлена';
+
+  @override
+  String get failedToUpdateActionItem => 'Не удалось обновить задачу';
+
+  @override
+  String get actionItemCreated => 'Задача создана';
+
+  @override
+  String get failedToCreateActionItem => 'Не удалось создать задачу';
+
+  @override
+  String get dueDate => 'Срок выполнения';
+
+  @override
+  String get time => 'Время';
+
+  @override
+  String get addDueDate => 'Добавить срок выполнения';
+
+  @override
+  String get pressDoneToSave => 'Нажмите готово для сохранения';
+
+  @override
+  String get pressDoneToCreate => 'Нажмите готово для создания';
+
+  @override
+  String get filterAll => 'Все';
+
+  @override
+  String get filterSystem => 'О вас';
+
+  @override
+  String get filterInteresting => 'Инсайты';
+
+  @override
+  String get filterManual => 'Ручные';
+
+  @override
+  String get completed => 'Выполнено';
+
+  @override
+  String get markComplete => 'Отметить как выполненное';
+
+  @override
+  String get actionItemDeleted => 'Задача удалена';
+
+  @override
+  String get failedToDeleteActionItem => 'Не удалось удалить задачу';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Удалить задачу';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Вы уверены, что хотите удалить эту задачу?';
+
+  @override
+  String get appLanguage => 'Язык приложения';
+
+  @override
+  String get appInterfaceSectionTitle => 'ИНТЕРФЕЙС ПРИЛОЖЕНИЯ';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'РЕЧЬ И ТРАНСКРИПЦИЯ';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Язык приложения изменяет меню и кнопки. Язык речи влияет на то, как транскрибируются ваши записи.';
+}

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -1,0 +1,2236 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Slovak (`sk`).
+class AppLocalizationsSk extends AppLocalizations {
+  AppLocalizationsSk([String locale = 'sk']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Konverzácia';
+
+  @override
+  String get transcriptTab => 'Prepis';
+
+  @override
+  String get actionItemsTab => 'Úlohy';
+
+  @override
+  String get deleteConversationTitle => 'Odstrániť konverzáciu?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Naozaj chcete odstrániť túto konverzáciu? Túto akciu nie je možné vrátiť späť.';
+
+  @override
+  String get confirm => 'Potvrdiť';
+
+  @override
+  String get cancel => 'Zrušiť';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Odstrániť';
+
+  @override
+  String get add => 'Pridať';
+
+  @override
+  String get update => 'Aktualizovať';
+
+  @override
+  String get save => 'Uložiť';
+
+  @override
+  String get edit => 'Upraviť';
+
+  @override
+  String get close => 'Zavrieť';
+
+  @override
+  String get clear => 'Vymazať';
+
+  @override
+  String get copyTranscript => 'Skopírovať prepis';
+
+  @override
+  String get copySummary => 'Skopírovať zhrnutie';
+
+  @override
+  String get testPrompt => 'Otestovať výzvu';
+
+  @override
+  String get reprocessConversation => 'Znovu spracovať konverzáciu';
+
+  @override
+  String get deleteConversation => 'Odstrániť konverzáciu';
+
+  @override
+  String get contentCopied => 'Obsah bol skopírovaný do schránky';
+
+  @override
+  String get failedToUpdateStarred => 'Nepodarilo sa aktualizovať stav obľúbenej.';
+
+  @override
+  String get conversationUrlNotShared => 'URL konverzácie sa nepodarilo zdieľať.';
+
+  @override
+  String get errorProcessingConversation => 'Chyba pri spracovaní konverzácie. Skúste to prosím neskôr.';
+
+  @override
+  String get noInternetConnection => 'Skontrolujte prosím svoje internetové pripojenie a skúste to znova.';
+
+  @override
+  String get unableToDeleteConversation => 'Nepodarilo sa odstrániť konverzáciu';
+
+  @override
+  String get somethingWentWrong => 'Niečo sa pokazilo! Skúste to prosím neskôr.';
+
+  @override
+  String get copyErrorMessage => 'Skopírovať chybovú správu';
+
+  @override
+  String get errorCopied => 'Chybová správa bola skopírovaná do schránky';
+
+  @override
+  String get remaining => 'Zostáva';
+
+  @override
+  String get loading => 'Načítava sa...';
+
+  @override
+  String get loadingDuration => 'Načítava sa trvanie...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekúnd';
+  }
+
+  @override
+  String get people => 'Ľudia';
+
+  @override
+  String get addNewPerson => 'Pridať novú osobu';
+
+  @override
+  String get editPerson => 'Upraviť osobu';
+
+  @override
+  String get createPersonHint => 'Vytvorte novú osobu a naučte Omi rozpoznávať aj jej hlas!';
+
+  @override
+  String get speechProfile => 'Hlasový profil';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Vzorka $number';
+  }
+
+  @override
+  String get settings => 'Nastavenia';
+
+  @override
+  String get language => 'Jazyk';
+
+  @override
+  String get selectLanguage => 'Vyberte jazyk';
+
+  @override
+  String get deleting => 'Odstraňuje sa...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
+
+  @override
+  String get failedToStartAuthentication => 'Nepodarilo sa spustiť autentifikáciu';
+
+  @override
+  String get importStarted => 'Import bol spustený! Budete upozornení, keď bude dokončený.';
+
+  @override
+  String get failedToStartImport => 'Nepodarilo sa spustiť import. Skúste to prosím znova.';
+
+  @override
+  String get couldNotAccessFile => 'Nepodarilo sa pristúpiť k vybranému súboru';
+
+  @override
+  String get askOmi => 'Spýtať sa Omi';
+
+  @override
+  String get done => 'Hotovo';
+
+  @override
+  String get disconnected => 'Odpojené';
+
+  @override
+  String get searching => 'Vyhľadáva sa';
+
+  @override
+  String get connectDevice => 'Pripojiť zariadenie';
+
+  @override
+  String get monthlyLimitReached => 'Dosiahli ste váš mesačný limit.';
+
+  @override
+  String get checkUsage => 'Skontrolovať využitie';
+
+  @override
+  String get syncingRecordings => 'Synchronizujú sa nahrávky';
+
+  @override
+  String get recordingsToSync => 'Nahrávky na synchronizáciu';
+
+  @override
+  String get allCaughtUp => 'Všetko je aktuálne';
+
+  @override
+  String get sync => 'Synchronizovať';
+
+  @override
+  String get pendantUpToDate => 'Prívesok je aktuálny';
+
+  @override
+  String get allRecordingsSynced => 'Všetky nahrávky sú synchronizované';
+
+  @override
+  String get syncingInProgress => 'Prebieha synchronizácia';
+
+  @override
+  String get readyToSync => 'Pripravené na synchronizáciu';
+
+  @override
+  String get tapSyncToStart => 'Ťuknite na Synchronizovať pre spustenie';
+
+  @override
+  String get pendantNotConnected => 'Prívesok nie je pripojený. Pripojte ho pre synchronizáciu.';
+
+  @override
+  String get everythingSynced => 'Všetko je už synchronizované.';
+
+  @override
+  String get recordingsNotSynced => 'Máte nahrávky, ktoré ešte nie sú synchronizované.';
+
+  @override
+  String get syncingBackground => 'Budeme naďalej synchronizovať vaše nahrávky na pozadí.';
+
+  @override
+  String get noConversationsYet => 'Zatiaľ žiadne konverzácie.';
+
+  @override
+  String get noStarredConversations => 'Zatiaľ žiadne obľúbené konverzácie.';
+
+  @override
+  String get starConversationHint =>
+      'Ak chcete označiť konverzáciu hviezdičkou, otvorte ju a ťuknite na ikonu hviezdy v hlavičke.';
+
+  @override
+  String get searchConversations => 'Hľadať konverzácie';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count vybraných';
+  }
+
+  @override
+  String get merge => 'Zlúčiť';
+
+  @override
+  String get mergeConversations => 'Zlúčiť konverzácie';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Toto zlúči $count konverzácií do jednej. Celý obsah bude zlúčený a znovu vygenerovaný.';
+  }
+
+  @override
+  String get mergingInBackground => 'Zlučovanie prebieha na pozadí. Môže to chvíľu trvať.';
+
+  @override
+  String get failedToStartMerge => 'Nepodarilo sa spustiť zlučovanie';
+
+  @override
+  String get askAnything => 'Spýtajte sa na čokoľvek';
+
+  @override
+  String get noMessagesYet => 'Zatiaľ žiadne správy!\nPrečo nespustíte konverzáciu?';
+
+  @override
+  String get deletingMessages => 'Odstraňujú sa vaše správy z pamäte Omi...';
+
+  @override
+  String get messageCopied => 'Správa bola skopírovaná do schránky.';
+
+  @override
+  String get cannotReportOwnMessage => 'Nemôžete nahlásiť vlastné správy.';
+
+  @override
+  String get reportMessage => 'Nahlásiť správu';
+
+  @override
+  String get reportMessageConfirm => 'Naozaj chcete nahlásiť túto správu?';
+
+  @override
+  String get messageReported => 'Správa bola úspešne nahlásená.';
+
+  @override
+  String get thankYouFeedback => 'Ďakujeme za vašu spätnú väzbu!';
+
+  @override
+  String get clearChat => 'Vymazať chat?';
+
+  @override
+  String get clearChatConfirm => 'Naozaj chcete vymazať chat? Túto akciu nie je možné vrátiť späť.';
+
+  @override
+  String get maxFilesLimit => 'Môžete nahrať maximálne 4 súbory naraz';
+
+  @override
+  String get chatWithOmi => 'Chat s Omi';
+
+  @override
+  String get apps => 'Aplikácie';
+
+  @override
+  String get noAppsFound => 'Neboli nájdené žiadne aplikácie';
+
+  @override
+  String get tryAdjustingSearch => 'Skúste upraviť vyhľadávanie alebo filtre';
+
+  @override
+  String get createYourOwnApp => 'Vytvorte si vlastnú aplikáciu';
+
+  @override
+  String get buildAndShareApp => 'Vytvorte a zdieľajte vlastnú aplikáciu';
+
+  @override
+  String get searchApps => 'Hľadať v 1500+ aplikáciách';
+
+  @override
+  String get myApps => 'Moje aplikácie';
+
+  @override
+  String get installedApps => 'Nainštalované aplikácie';
+
+  @override
+  String get unableToFetchApps =>
+      'Nepodarilo sa načítať aplikácie :(\n\nSkontrolujte prosím svoje internetové pripojenie a skúste to znova.';
+
+  @override
+  String get aboutOmi => 'O aplikácii Omi';
+
+  @override
+  String get privacyPolicy => 'Zásady ochrany osobných údajov';
+
+  @override
+  String get visitWebsite => 'Navštíviť webovú stránku';
+
+  @override
+  String get helpOrInquiries => 'Pomoc alebo otázky?';
+
+  @override
+  String get joinCommunity => 'Pridajte sa ku komunite!';
+
+  @override
+  String get membersAndCounting => 'Viac ako 8000 členov a stále pribúdajú.';
+
+  @override
+  String get deleteAccountTitle => 'Odstrániť účet';
+
+  @override
+  String get deleteAccountConfirm => 'Naozaj chcete odstrániť svoj účet?';
+
+  @override
+  String get cannotBeUndone => 'Túto akciu nie je možné vrátiť späť.';
+
+  @override
+  String get allDataErased => 'Všetky vaše spomienky a konverzácie budú natrvalo odstránené.';
+
+  @override
+  String get appsDisconnected => 'Vaše aplikácie a integrácie budú okamžite odpojené.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Pred odstránením účtu môžete exportovať svoje údaje, ale po odstránení ich nebude možné obnoviť.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Rozumiem, že odstránenie môjho účtu je trvalé a všetky údaje vrátane spomienok a konverzácií budú stratené a nebude ich možné obnoviť.';
+
+  @override
+  String get areYouSure => 'Ste si istí?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Táto akcia je nezvratná a natrvalo odstráni váš účet a všetky súvisiace údaje. Naozaj chcete pokračovať?';
+
+  @override
+  String get deleteNow => 'Odstrániť teraz';
+
+  @override
+  String get goBack => 'Vrátiť sa';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Začiarknite políčko na potvrdenie, že rozumiete, že odstránenie vášho účtu je trvalé a nezvratné.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Meno';
+
+  @override
+  String get email => 'E-mail';
+
+  @override
+  String get customVocabulary => 'Vlastný slovník';
+
+  @override
+  String get identifyingOthers => 'Identifikácia ostatných';
+
+  @override
+  String get paymentMethods => 'Platobné metódy';
+
+  @override
+  String get conversationDisplay => 'Zobrazenie konverzácií';
+
+  @override
+  String get dataPrivacy => 'Údaje a súkromie';
+
+  @override
+  String get userId => 'ID používateľa';
+
+  @override
+  String get notSet => 'Nie je nastavené';
+
+  @override
+  String get userIdCopied => 'ID používateľa bolo skopírované do schránky';
+
+  @override
+  String get systemDefault => 'Predvolené nastavenie systému';
+
+  @override
+  String get planAndUsage => 'Plán a využitie';
+
+  @override
+  String get offlineSync => 'Offline synchronizácia';
+
+  @override
+  String get deviceSettings => 'Nastavenia zariadenia';
+
+  @override
+  String get chatTools => 'Nástroje chatu';
+
+  @override
+  String get feedbackBug => 'Spätná väzba / chyba';
+
+  @override
+  String get helpCenter => 'Centrum pomoci';
+
+  @override
+  String get developerSettings => 'Vývojárske nastavenia';
+
+  @override
+  String get getOmiForMac => 'Získať Omi pre Mac';
+
+  @override
+  String get referralProgram => 'Odporúčací program';
+
+  @override
+  String get signOut => 'Odhlásiť sa';
+
+  @override
+  String get appAndDeviceCopied => 'Podrobnosti o aplikácii a zariadení boli skopírované';
+
+  @override
+  String get wrapped2025 => 'Wrapped 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Vaše súkromie, vaša kontrola';
+
+  @override
+  String get privacyIntro =>
+      'V Omi sa zaväzujeme chrániť vaše súkromie. Táto stránka vám umožňuje kontrolovať, ako sú vaše údaje ukladané a používané.';
+
+  @override
+  String get learnMore => 'Dozvedieť sa viac...';
+
+  @override
+  String get dataProtectionLevel => 'Úroveň ochrany údajov';
+
+  @override
+  String get dataProtectionDesc =>
+      'Vaše údaje sú predvolene zabezpečené silným šifrovaním. Skontrolujte svoje nastavenia a budúce možnosti ochrany súkromia nižšie.';
+
+  @override
+  String get appAccess => 'Prístup aplikácií';
+
+  @override
+  String get appAccessDesc =>
+      'Nasledujúce aplikácie majú prístup k vašim údajom. Ťuknutím na aplikáciu spravujte jej oprávnenia.';
+
+  @override
+  String get noAppsExternalAccess => 'Žiadne nainštalované aplikácie nemajú externý prístup k vašim údajom.';
+
+  @override
+  String get deviceName => 'Názov zariadenia';
+
+  @override
+  String get deviceId => 'ID zariadenia';
+
+  @override
+  String get firmware => 'Firmvér';
+
+  @override
+  String get sdCardSync => 'Synchronizácia SD karty';
+
+  @override
+  String get hardwareRevision => 'Revízia hardvéru';
+
+  @override
+  String get modelNumber => 'Číslo modelu';
+
+  @override
+  String get manufacturer => 'Výrobca';
+
+  @override
+  String get doubleTap => 'Dvojité ťuknutie';
+
+  @override
+  String get ledBrightness => 'Jas LED';
+
+  @override
+  String get micGain => 'Zosilnenie mikrofónu';
+
+  @override
+  String get disconnect => 'Odpojiť';
+
+  @override
+  String get forgetDevice => 'Zabudnúť zariadenie';
+
+  @override
+  String get chargingIssues => 'Problémy s nabíjaním';
+
+  @override
+  String get disconnectDevice => 'Odpojiť zariadenie';
+
+  @override
+  String get unpairDevice => 'Zrušiť párovanie zariadenia';
+
+  @override
+  String get unpairAndForget => 'Zrušiť párovanie a zabudnúť zariadenie';
+
+  @override
+  String get deviceDisconnectedMessage => 'Vaše Omi bolo odpojené 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Párovanie zariadenia bolo zrušené. Prejdite do Nastavenia > Bluetooth a zabudnite zariadenie pre dokončenie.';
+
+  @override
+  String get unpairDialogTitle => 'Zrušiť párovanie zariadenia';
+
+  @override
+  String get unpairDialogMessage =>
+      'Týmto sa zruší párovanie zariadenia, aby sa mohlo pripojiť k inému telefónu. Budete musieť prejsť do Nastavenia > Bluetooth a zabudnúť zariadenie pre dokončenie procesu.';
+
+  @override
+  String get deviceNotConnected => 'Zariadenie nie je pripojené';
+
+  @override
+  String get connectDeviceMessage =>
+      'Pripojte svoje zariadenie Omi pre prístup\nk nastaveniam a prispôsobeniu zariadenia';
+
+  @override
+  String get deviceInfoSection => 'Informácie o zariadení';
+
+  @override
+  String get customizationSection => 'Prispôsobenie';
+
+  @override
+  String get hardwareSection => 'Hardvér';
+
+  @override
+  String get v2Undetected => 'V2 nebolo zistené';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Zistili sme, že máte zariadenie V1 alebo vaše zariadenie nie je pripojené. Funkcia SD karty je dostupná len pre zariadenia V2.';
+
+  @override
+  String get endConversation => 'Ukončiť konverzáciu';
+
+  @override
+  String get pauseResume => 'Pozastaviť/Pokračovať';
+
+  @override
+  String get starConversation => 'Označiť konverzáciu hviezdičkou';
+
+  @override
+  String get doubleTapAction => 'Akcia dvojitého ťuknutia';
+
+  @override
+  String get endAndProcess => 'Ukončiť a spracovať konverzáciu';
+
+  @override
+  String get pauseResumeRecording => 'Pozastaviť/Pokračovať nahrávanie';
+
+  @override
+  String get starOngoing => 'Označiť prebiehajúcu konverzáciu hviezdičkou';
+
+  @override
+  String get off => 'Vypnuté';
+
+  @override
+  String get max => 'Maximum';
+
+  @override
+  String get mute => 'Stlmiť';
+
+  @override
+  String get quiet => 'Tiché';
+
+  @override
+  String get normal => 'Normálne';
+
+  @override
+  String get high => 'Vysoké';
+
+  @override
+  String get micGainDescMuted => 'Mikrofón je stlmený';
+
+  @override
+  String get micGainDescLow => 'Veľmi tiché - pre hlučné prostredia';
+
+  @override
+  String get micGainDescModerate => 'Tiché - pre mierne hlučné prostredie';
+
+  @override
+  String get micGainDescNeutral => 'Neutrálne - vyvážené nahrávanie';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Mierne zosilnené - normálne použitie';
+
+  @override
+  String get micGainDescBoosted => 'Zosilnené - pre tiché prostredia';
+
+  @override
+  String get micGainDescHigh => 'Vysoké - pre vzdialené alebo tiché hlasy';
+
+  @override
+  String get micGainDescVeryHigh => 'Veľmi vysoké - pre veľmi tiché zdroje';
+
+  @override
+  String get micGainDescMax => 'Maximálne - používať opatrne';
+
+  @override
+  String get developerSettingsTitle => 'Vývojárske nastavenia';
+
+  @override
+  String get saving => 'Ukladá sa...';
+
+  @override
+  String get personaConfig => 'Nakonfigurujte svoju AI persónu';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Prepis';
+
+  @override
+  String get transcriptionConfig => 'Nakonfigurovať poskytovateľa STT';
+
+  @override
+  String get conversationTimeout => 'Časový limit konverzácie';
+
+  @override
+  String get conversationTimeoutConfig => 'Nastaviť, kedy sa konverzácie automaticky ukončia';
+
+  @override
+  String get importData => 'Importovať údaje';
+
+  @override
+  String get importDataConfig => 'Importovať údaje z iných zdrojov';
+
+  @override
+  String get debugDiagnostics => 'Ladenie a diagnostika';
+
+  @override
+  String get endpointUrl => 'URL koncového bodu';
+
+  @override
+  String get noApiKeys => 'Zatiaľ žiadne API kľúče';
+
+  @override
+  String get createKeyToStart => 'Vytvorte kľúč pre začiatok';
+
+  @override
+  String get createKey => 'Vytvoriť kľúč';
+
+  @override
+  String get docs => 'Dokumentácia';
+
+  @override
+  String get yourOmiInsights => 'Vaše štatistiky Omi';
+
+  @override
+  String get today => 'Dnes';
+
+  @override
+  String get thisMonth => 'Tento mesiac';
+
+  @override
+  String get thisYear => 'Tento rok';
+
+  @override
+  String get allTime => 'Celkovo';
+
+  @override
+  String get noActivityYet => 'Zatiaľ žiadna aktivita';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Začnite konverzáciu s Omi,\naby ste tu videli svoje štatistiky využitia.';
+
+  @override
+  String get listening => 'Počúvanie';
+
+  @override
+  String get listeningSubtitle => 'Celkový čas, počas ktorého Omi aktívne počúvalo.';
+
+  @override
+  String get understanding => 'Porozumenie';
+
+  @override
+  String get understandingSubtitle => 'Slová pochopené z vašich konverzácií.';
+
+  @override
+  String get providing => 'Poskytovanie';
+
+  @override
+  String get providingSubtitle => 'Úlohy a poznámky automaticky zachytené.';
+
+  @override
+  String get remembering => 'Pamätanie';
+
+  @override
+  String get rememberingSubtitle => 'Fakty a detaily zapamätané pre vás.';
+
+  @override
+  String get unlimitedPlan => 'Neobmedzený plán';
+
+  @override
+  String get managePlan => 'Spravovať plán';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Váš plán bude zrušený $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Váš plán sa obnoví $date.';
+  }
+
+  @override
+  String get basicPlan => 'Bezplatný plán';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used z $limit min použitých';
+  }
+
+  @override
+  String get upgrade => 'Upgradovať';
+
+  @override
+  String get upgradeToUnlimited => 'Upgradovať na neobmedzený';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Váš plán zahŕňa $limit bezplatných minút mesačne. Upgradujte na neobmedzený.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Zdieľam svoje štatistiky Omi! (omi.me - váš AI asistent vždy po ruke)';
+
+  @override
+  String get sharePeriodToday => 'Dnes Omi:';
+
+  @override
+  String get sharePeriodMonth => 'Tento mesiac Omi:';
+
+  @override
+  String get sharePeriodYear => 'Tento rok Omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Doteraz Omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Počúvalo $minutes minút';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Porozumelo $words slovám';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Poskytlo $count postrehov';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Zapamätalo si $count spomienok';
+  }
+
+  @override
+  String get debugLogs => 'Debug logy';
+
+  @override
+  String get debugLogsAutoDelete => 'Automaticky sa odstránia po 3 dňoch.';
+
+  @override
+  String get debugLogsDesc => 'Pomáha diagnostikovať problémy';
+
+  @override
+  String get noLogFilesFound => 'Neboli nájdené žiadne súbory logov.';
+
+  @override
+  String get omiDebugLog => 'Omi debug log';
+
+  @override
+  String get logShared => 'Log bol zdieľaný';
+
+  @override
+  String get selectLogFile => 'Vyberte súbor logu';
+
+  @override
+  String get shareLogs => 'Zdieľať logy';
+
+  @override
+  String get debugLogCleared => 'Debug log bol vymazaný';
+
+  @override
+  String get exportStarted => 'Export bol spustený. Môže to trvať niekoľko sekúnd...';
+
+  @override
+  String get exportAllData => 'Exportovať všetky údaje';
+
+  @override
+  String get exportDataDesc => 'Exportovať konverzácie do JSON súboru';
+
+  @override
+  String get exportedConversations => 'Exportované konverzácie z Omi';
+
+  @override
+  String get exportShared => 'Export bol zdieľaný';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Odstrániť graf znalostí?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Týmto odstránite všetky odvodené údaje grafu znalostí (uzly a prepojenia). Vaše pôvodné spomienky zostanú v bezpečí. Graf bude znovu vytvorený postupom času alebo na ďalšiu požiadavku.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Graf znalostí bol úspešne odstránený';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Nepodarilo sa odstrániť graf: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Odstrániť graf znalostí';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Vymazať všetky uzly a prepojenia';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP server';
+
+  @override
+  String get mcpServerDesc => 'Pripojte AI asistentov k vašim údajom';
+
+  @override
+  String get serverUrl => 'URL servera';
+
+  @override
+  String get urlCopied => 'URL bola skopírovaná';
+
+  @override
+  String get apiKeyAuth => 'Autentifikácia API kľúčom';
+
+  @override
+  String get header => 'Hlavička';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Client ID';
+
+  @override
+  String get clientSecret => 'Client Secret';
+
+  @override
+  String get useMcpApiKey => 'Použite svoj MCP API kľúč';
+
+  @override
+  String get webhooks => 'Webhooky';
+
+  @override
+  String get conversationEvents => 'Udalosti konverzácií';
+
+  @override
+  String get newConversationCreated => 'Nová konverzácia bola vytvorená';
+
+  @override
+  String get realtimeTranscript => 'Prepis v reálnom čase';
+
+  @override
+  String get transcriptReceived => 'Prepis bol prijatý';
+
+  @override
+  String get audioBytes => 'Audio bajty';
+
+  @override
+  String get audioDataReceived => 'Audio dáta boli prijaté';
+
+  @override
+  String get intervalSeconds => 'Interval (sekundy)';
+
+  @override
+  String get daySummary => 'Denné zhrnutie';
+
+  @override
+  String get summaryGenerated => 'Zhrnutie bolo vygenerované';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Pridať do claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Skopírovať konfiguráciu';
+
+  @override
+  String get configCopied => 'Konfigurácia bola skopírovaná do schránky';
+
+  @override
+  String get listeningMins => 'Počúvanie (min)';
+
+  @override
+  String get understandingWords => 'Porozumenie (slová)';
+
+  @override
+  String get insights => 'Postrehy';
+
+  @override
+  String get memories => 'Spomienky';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used z $limit min použitých tento mesiac';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used z $limit slov použitých tento mesiac';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used z $limit postrehov získaných tento mesiac';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used z $limit spomienok vytvorených tento mesiac';
+  }
+
+  @override
+  String get visibility => 'Viditeľnosť';
+
+  @override
+  String get visibilitySubtitle => 'Kontrolujte, ktoré konverzácie sa zobrazia vo vašom zozname';
+
+  @override
+  String get showShortConversations => 'Zobraziť krátke konverzácie';
+
+  @override
+  String get showShortConversationsDesc => 'Zobraziť konverzácie kratšie ako hranica';
+
+  @override
+  String get showDiscardedConversations => 'Zobraziť zahodené konverzácie';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Zahrnúť konverzácie označené ako zahodené';
+
+  @override
+  String get shortConversationThreshold => 'Hranica krátkej konverzácie';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Konverzácie kratšie ako toto budú skryté, pokiaľ nie sú povolené vyššie';
+
+  @override
+  String get durationThreshold => 'Hranica trvania';
+
+  @override
+  String get durationThresholdDesc => 'Skryť konverzácie kratšie ako toto';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Vlastný slovník';
+
+  @override
+  String get addWords => 'Pridať slová';
+
+  @override
+  String get addWordsDesc => 'Mená, výrazy alebo neobvyklé slová';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Pripojiť';
+
+  @override
+  String get comingSoon => 'Čoskoro';
+
+  @override
+  String get chatToolsFooter => 'Pripojte svoje aplikácie na zobrazenie údajov a metrík v chate.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Nepodarilo sa spustiť autentifikáciu $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Odpojiť $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Naozaj chcete odpojiť $appName? Môžete sa znovu pripojiť kedykoľvek.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Odpojené od $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Nepodarilo sa odpojiť';
+
+  @override
+  String connectTo(String appName) {
+    return 'Pripojiť k $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Budete musieť autorizovať Omi na prístup k vašim údajom $appName. Toto otvorí váš prehliadač pre autentifikáciu.';
+  }
+
+  @override
+  String get continueAction => 'Pokračovať';
+
+  @override
+  String get languageTitle => 'Jazyk';
+
+  @override
+  String get primaryLanguage => 'Primárny jazyk';
+
+  @override
+  String get automaticTranslation => 'Automatický preklad';
+
+  @override
+  String get detectLanguages => 'Zistiť 10+ jazykov';
+
+  @override
+  String get authorizeSavingRecordings => 'Autorizovať ukladanie nahrávok';
+
+  @override
+  String get thanksForAuthorizing => 'Ďakujeme za autorizáciu!';
+
+  @override
+  String get needYourPermission => 'Potrebujeme vaše povolenie';
+
+  @override
+  String get alreadyGavePermission =>
+      'Už ste nám dali povolenie uložiť vaše nahrávky. Tu je pripomenutie, prečo ho potrebujeme:';
+
+  @override
+  String get wouldLikePermission => 'Chceli by sme vaše povolenie na uloženie vašich hlasových nahrávok. Tu je dôvod:';
+
+  @override
+  String get improveSpeechProfile => 'Zlepšiť váš hlasový profil';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Používame nahrávky na ďalšie trénovanie a vylepšenie vášho osobného hlasového profilu.';
+
+  @override
+  String get trainFamilyProfiles => 'Trénovať profily pre priateľov a rodinu';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Vaše nahrávky nám pomáhajú rozpoznávať a vytvárať profily pre vašich priateľov a rodinu.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Zlepšiť presnosť prepisu';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Keď sa náš model zlepší, môžeme poskytovať lepšie výsledky prepisu pre vaše nahrávky.';
+
+  @override
+  String get legalNotice =>
+      'Právne upozornenie: Zákonnosť nahrávania a ukladania hlasových dát sa môže líšiť v závislosti od vašej lokality a spôsobu používania tejto funkcie. Je vašou zodpovednosťou zabezpečiť súlad s miestnymi zákonmi a predpismi.';
+
+  @override
+  String get alreadyAuthorized => 'Už autorizované';
+
+  @override
+  String get authorize => 'Autorizovať';
+
+  @override
+  String get revokeAuthorization => 'Zrušiť autorizáciu';
+
+  @override
+  String get authorizationSuccessful => 'Autorizácia bola úspešná!';
+
+  @override
+  String get failedToAuthorize => 'Nepodarilo sa autorizovať. Skúste to prosím znova.';
+
+  @override
+  String get authorizationRevoked => 'Autorizácia bola zrušená.';
+
+  @override
+  String get recordingsDeleted => 'Nahrávky boli odstránené.';
+
+  @override
+  String get failedToRevoke => 'Nepodarilo sa zrušiť autorizáciu. Skúste to prosím znova.';
+
+  @override
+  String get permissionRevokedTitle => 'Povolenie bolo zrušené';
+
+  @override
+  String get permissionRevokedMessage => 'Chcete, aby sme odstránili aj všetky vaše existujúce nahrávky?';
+
+  @override
+  String get yes => 'Áno';
+
+  @override
+  String get editName => 'Upraviť meno';
+
+  @override
+  String get howShouldOmiCallYou => 'Ako by vás malo Omi oslovovať?';
+
+  @override
+  String get enterYourName => 'Zadajte svoje meno';
+
+  @override
+  String get nameCannotBeEmpty => 'Meno nemôže byť prázdne';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Meno bolo úspešne aktualizované!';
+
+  @override
+  String get calendarSettings => 'Nastavenia kalendára';
+
+  @override
+  String get calendarProviders => 'Poskytovatelia kalendára';
+
+  @override
+  String get macOsCalendar => 'macOS kalendár';
+
+  @override
+  String get connectMacOsCalendar => 'Pripojte svoj lokálny macOS kalendár';
+
+  @override
+  String get googleCalendar => 'Google kalendár';
+
+  @override
+  String get syncGoogleAccount => 'Synchronizovať s vaším Google účtom';
+
+  @override
+  String get showMeetingsMenuBar => 'Zobraziť nadchádzajúce stretnutia v paneli ponúk';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Zobraziť vaše ďalšie stretnutie a čas do jeho začiatku v paneli ponúk macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Zobraziť udalosti bez účastníkov';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Keď je povolené, Nadchádzajúce zobrazí udalosti bez účastníkov alebo video odkazu.';
+
+  @override
+  String get yourMeetings => 'Vaše stretnutia';
+
+  @override
+  String get refresh => 'Obnoviť';
+
+  @override
+  String get noUpcomingMeetings => 'Neboli nájdené žiadne nadchádzajúce stretnutia';
+
+  @override
+  String get checkingNextDays => 'Kontrola nasledujúcich 30 dní';
+
+  @override
+  String get tomorrow => 'Zajtra';
+
+  @override
+  String get googleCalendarComingSoon => 'Integrácia Google kalendára čoskoro!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Pripojený ako používateľ: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Predvolený pracovný priestor';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Úlohy budú vytvorené v tomto pracovnom priestore';
+
+  @override
+  String get defaultProjectOptional => 'Predvolený projekt (voliteľné)';
+
+  @override
+  String get leaveUnselectedTasks => 'Nechajte nevybrané pre vytvorenie úloh bez projektu';
+
+  @override
+  String get noProjectsInWorkspace => 'V tomto pracovnom priestore neboli nájdené žiadne projekty';
+
+  @override
+  String get conversationTimeoutDesc => 'Vyberte, ako dlho čakať v tichosti pred automatickým ukončením konverzácie:';
+
+  @override
+  String get timeout2Minutes => '2 minúty';
+
+  @override
+  String get timeout2MinutesDesc => 'Ukončiť konverzáciu po 2 minútach ticha';
+
+  @override
+  String get timeout5Minutes => '5 minút';
+
+  @override
+  String get timeout5MinutesDesc => 'Ukončiť konverzáciu po 5 minútach ticha';
+
+  @override
+  String get timeout10Minutes => '10 minút';
+
+  @override
+  String get timeout10MinutesDesc => 'Ukončiť konverzáciu po 10 minútach ticha';
+
+  @override
+  String get timeout30Minutes => '30 minút';
+
+  @override
+  String get timeout30MinutesDesc => 'Ukončiť konverzáciu po 30 minútach ticha';
+
+  @override
+  String get timeout4Hours => '4 hodiny';
+
+  @override
+  String get timeout4HoursDesc => 'Ukončiť konverzáciu po 4 hodinách ticha';
+
+  @override
+  String get conversationEndAfterHours => 'Konverzácie sa teraz ukončia po 4 hodinách ticha';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Konverzácie sa teraz ukončia po $minutes minúte/minútach ticha';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Povedzte nám váš primárny jazyk';
+
+  @override
+  String get languageForTranscription => 'Nastavte svoj jazyk pre presnejšie prepisy a personalizovaný zážitok.';
+
+  @override
+  String get singleLanguageModeInfo => 'Režim jedného jazyka je povolený. Preklad je vypnutý pre vyššiu presnosť.';
+
+  @override
+  String get searchLanguageHint => 'Hľadať jazyk podľa názvu alebo kódu';
+
+  @override
+  String get noLanguagesFound => 'Neboli nájdené žiadne jazyky';
+
+  @override
+  String get skip => 'Preskočiť';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Jazyk bol nastavený na $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Nepodarilo sa nastaviť jazyk';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName Nastavenia';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Odpojiť od $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Toto odstráni vašu autentifikáciu $appName. Budete sa musieť znovu pripojiť, aby ste ho mohli použiť.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Pripojené k $appName';
+  }
+
+  @override
+  String get account => 'Účet';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Vaše úlohy budú synchronizované s vaším účtom $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Predvolený priestor';
+
+  @override
+  String get selectSpaceInWorkspace => 'Vyberte priestor vo vašom pracovnom priestore';
+
+  @override
+  String get noSpacesInWorkspace => 'V tomto pracovnom priestore neboli nájdené žiadne priestory';
+
+  @override
+  String get defaultList => 'Predvolený zoznam';
+
+  @override
+  String get tasksAddedToList => 'Úlohy budú pridané do tohto zoznamu';
+
+  @override
+  String get noListsInSpace => 'V tomto priestore neboli nájdené žiadne zoznamy';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Nepodarilo sa načítať repozitáre: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Predvolený repozitár bol uložený';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Nepodarilo sa uložiť predvolený repozitár';
+
+  @override
+  String get defaultRepository => 'Predvolený repozitár';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Vyberte predvolený repozitár pre vytváranie problémov. Pri vytváraní problémov môžete stále zadať iný repozitár.';
+
+  @override
+  String get noReposFound => 'Neboli nájdené žiadne repozitáre';
+
+  @override
+  String get private => 'Súkromný';
+
+  @override
+  String updatedDate(String date) {
+    return 'Aktualizované $date';
+  }
+
+  @override
+  String get yesterday => 'včera';
+
+  @override
+  String daysAgo(int count) {
+    return 'pred $count dňami';
+  }
+
+  @override
+  String get oneWeekAgo => 'pred 1 týždňom';
+
+  @override
+  String weeksAgo(int count) {
+    return 'pred $count týždňami';
+  }
+
+  @override
+  String get oneMonthAgo => 'pred 1 mesiacom';
+
+  @override
+  String monthsAgo(int count) {
+    return 'pred $count mesiacmi';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Problémy budú vytvorené vo vašom predvolenom repozitári';
+
+  @override
+  String get taskIntegrations => 'Integrácie úloh';
+
+  @override
+  String get configureSettings => 'Konfigurovať nastavenia';
+
+  @override
+  String get completeAuthBrowser =>
+      'Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Nepodarilo sa spustiť autentifikáciu $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Pripojiť k $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Budete musieť autorizovať Omi na vytváranie úloh vo vašom účte $appName. Toto otvorí váš prehliadač pre autentifikáciu.';
+  }
+
+  @override
+  String get continueButton => 'Pokračovať';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName Integrácia';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integrácia s $appName čoskoro! Usilovne pracujeme na tom, aby sme vám priniesli viac možností správy úloh.';
+  }
+
+  @override
+  String get gotIt => 'Rozumiem';
+
+  @override
+  String get tasksExportedOneApp => 'Úlohy možno exportovať do jednej aplikácie naraz.';
+
+  @override
+  String get completeYourUpgrade => 'Dokončite svoj upgrade';
+
+  @override
+  String get importConfiguration => 'Importovať konfiguráciu';
+
+  @override
+  String get exportConfiguration => 'Exportovať konfiguráciu';
+
+  @override
+  String get bringYourOwn => 'Prineste si vlastný';
+
+  @override
+  String get payYourSttProvider => 'Voľne používajte omi. Platíte len svojmu poskytovateľovi STT priamo.';
+
+  @override
+  String get freeMinutesMonth => '1 200 bezplatných minút/mesiac je zahrnutých. Neobmedzené s ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Hostiteľ je povinný';
+
+  @override
+  String get validPortRequired => 'Platný port je povinný';
+
+  @override
+  String get validWebsocketUrlRequired => 'Platná WebSocket URL je povinná (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL je povinná';
+
+  @override
+  String get apiKeyRequired => 'API kľúč je povinný';
+
+  @override
+  String get invalidJsonConfig => 'Neplatná JSON konfigurácia';
+
+  @override
+  String errorSaving(String error) {
+    return 'Chyba pri ukladaní: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfigurácia bola skopírovaná do schránky';
+
+  @override
+  String get pasteJsonConfig => 'Vložte svoju JSON konfiguráciu nižšie:';
+
+  @override
+  String get addApiKeyAfterImport => 'Po importe budete musieť pridať svoj vlastný API kľúč';
+
+  @override
+  String get paste => 'Vložiť';
+
+  @override
+  String get import => 'Importovať';
+
+  @override
+  String get invalidProviderInConfig => 'Neplatný poskytovateľ v konfigurácii';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Importovaná konfigurácia $providerName';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Neplatný JSON: $error';
+  }
+
+  @override
+  String get provider => 'Poskytovateľ';
+
+  @override
+  String get live => 'Naživo';
+
+  @override
+  String get onDevice => 'Na zariadení';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Zadajte svoj STT HTTP koncový bod';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Zadajte svoj live STT WebSocket koncový bod';
+
+  @override
+  String get apiKey => 'API kľúč';
+
+  @override
+  String get enterApiKey => 'Zadajte svoj API kľúč';
+
+  @override
+  String get storedLocallyNeverShared => 'Uložené lokálne, nikdy nezdieľané';
+
+  @override
+  String get host => 'Hostiteľ';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Pokročilé';
+
+  @override
+  String get configuration => 'Konfigurácia';
+
+  @override
+  String get requestConfiguration => 'Konfigurácia požiadavky';
+
+  @override
+  String get responseSchema => 'Schéma odpovede';
+
+  @override
+  String get modified => 'Zmenené';
+
+  @override
+  String get resetRequestConfig => 'Obnoviť konfiguráciu požiadavky na predvolenú';
+
+  @override
+  String get logs => 'Logy';
+
+  @override
+  String get logsCopied => 'Logy boli skopírované';
+
+  @override
+  String get noLogsYet => 'Zatiaľ žiadne logy. Začnite nahrávanie, aby ste videli vlastnú STT aktivitu.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName používa $codecReason. Omi bude použité.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi Prepis';
+
+  @override
+  String get bestInClassTranscription => 'Najlepší prepis v triede s nulovou konfiguráciou';
+
+  @override
+  String get instantSpeakerLabels => 'Okamžité značky rečníkov';
+
+  @override
+  String get languageTranslation => 'Preklad do 100+ jazykov';
+
+  @override
+  String get optimizedForConversation => 'Optimalizované pre konverzáciu';
+
+  @override
+  String get autoLanguageDetection => 'Automatická detekcia jazyka';
+
+  @override
+  String get highAccuracy => 'Vysoká presnosť';
+
+  @override
+  String get privacyFirst => 'Súkromie na prvom mieste';
+
+  @override
+  String get saveChanges => 'Uložiť zmeny';
+
+  @override
+  String get resetToDefault => 'Obnoviť na predvolené';
+
+  @override
+  String get viewTemplate => 'Zobraziť šablónu';
+
+  @override
+  String get trySomethingLike => 'Skúste niečo ako...';
+
+  @override
+  String get tryIt => 'Vyskúšajte to';
+
+  @override
+  String get creatingPlan => 'Vytváranie plánu';
+
+  @override
+  String get developingLogic => 'Vyvíjanie logiky';
+
+  @override
+  String get designingApp => 'Navrhovanie aplikácie';
+
+  @override
+  String get generatingIconStep => 'Generovanie ikony';
+
+  @override
+  String get finalTouches => 'Záverečné úpravy';
+
+  @override
+  String get processing => 'Spracováva sa...';
+
+  @override
+  String get features => 'Funkcie';
+
+  @override
+  String get creatingYourApp => 'Vytváranie vašej aplikácie...';
+
+  @override
+  String get generatingIcon => 'Generovanie ikony...';
+
+  @override
+  String get whatShouldWeMake => 'Čo by sme mali vytvoriť?';
+
+  @override
+  String get appName => 'Názov aplikácie';
+
+  @override
+  String get description => 'Popis';
+
+  @override
+  String get publicLabel => 'Verejná';
+
+  @override
+  String get privateLabel => 'Súkromná';
+
+  @override
+  String get free => 'Zadarmo';
+
+  @override
+  String get perMonth => '/ Mesiac';
+
+  @override
+  String get tailoredConversationSummaries => 'Prispôsobené zhrnutia konverzácií';
+
+  @override
+  String get customChatbotPersonality => 'Vlastná osobnosť chatbota';
+
+  @override
+  String get makePublic => 'Zverejniť';
+
+  @override
+  String get anyoneCanDiscover => 'Ktokoľvek môže objaviť vašu aplikáciu';
+
+  @override
+  String get onlyYouCanUse => 'Túto aplikáciu môžete používať len vy';
+
+  @override
+  String get paidApp => 'Platená aplikácia';
+
+  @override
+  String get usersPayToUse => 'Používatelia platia za používanie vašej aplikácie';
+
+  @override
+  String get freeForEveryone => 'Bezplatné pre všetkých';
+
+  @override
+  String get perMonthLabel => '/ mesiac';
+
+  @override
+  String get creating => 'Vytvára sa...';
+
+  @override
+  String get createApp => 'Vytvoriť aplikáciu';
+
+  @override
+  String get searchingForDevices => 'Vyhľadávajú sa zariadenia...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ZARIADENIA',
+      one: 'ZARIADENIE',
+    );
+    return '$count $_temp0 NÁJDENÉ V BLÍZKOSTI';
+  }
+
+  @override
+  String get pairingSuccessful => 'PÁROVANIE ÚSPEŠNÉ';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Chyba pri pripájaní Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Znovu to neukazovať';
+
+  @override
+  String get iUnderstand => 'Rozumiem';
+
+  @override
+  String get enableBluetooth => 'Povoliť Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi potrebuje Bluetooth na pripojenie k vášmu nositeľnému zariadeniu. Povoľte prosím Bluetooth a skúste to znova.';
+
+  @override
+  String get contactSupport => 'Kontaktovať podporu?';
+
+  @override
+  String get connectLater => 'Pripojiť neskôr';
+
+  @override
+  String get grantPermissions => 'Udeliť povolenia';
+
+  @override
+  String get backgroundActivity => 'Aktivita na pozadí';
+
+  @override
+  String get backgroundActivityDesc => 'Nechajte Omi bežať na pozadí pre lepšiu stabilitu';
+
+  @override
+  String get locationAccess => 'Prístup k polohe';
+
+  @override
+  String get locationAccessDesc => 'Povoliť polohu na pozadí pre plný zážitok';
+
+  @override
+  String get notifications => 'Upozornenia';
+
+  @override
+  String get notificationsDesc => 'Povoliť upozornenia, aby ste zostali informovaní';
+
+  @override
+  String get locationServiceDisabled => 'Služba polohy je vypnutá';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Služba polohy je vypnutá. Prejdite do Nastavenia > Súkromie a zabezpečenie > Služby polohy a povoľte ju';
+
+  @override
+  String get backgroundLocationDenied => 'Prístup k polohe na pozadí bol zamietnutý';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Prejdite do nastavení zariadenia a nastavte povolenie polohy na \"Vždy povoliť\"';
+
+  @override
+  String get lovingOmi => 'Páči sa vám Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Pomôžte nám osloviť viac ľudí tým, že zanecháte recenziu v App Store. Vaša spätná väzba pre nás znamená celý svet!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Pomôžte nám osloviť viac ľudí tým, že zanecháte recenziu v Google Play Store. Vaša spätná väzba pre nás znamená celý svet!';
+
+  @override
+  String get rateOnAppStore => 'Ohodnotiť v App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Ohodnotiť v Google Play';
+
+  @override
+  String get maybeLater => 'Možno neskôr';
+
+  @override
+  String get speechProfileIntro => 'Omi potrebuje naučiť sa vaše ciele a váš hlas. Neskôr to budete môcť upraviť.';
+
+  @override
+  String get getStarted => 'Začať';
+
+  @override
+  String get allDone => 'Všetko hotové!';
+
+  @override
+  String get keepGoing => 'Pokračujte, darí sa vám to skvele';
+
+  @override
+  String get skipThisQuestion => 'Preskočiť túto otázku';
+
+  @override
+  String get skipForNow => 'Preskočiť zatiaľ';
+
+  @override
+  String get connectionError => 'Chyba pripojenia';
+
+  @override
+  String get connectionErrorDesc =>
+      'Nepodarilo sa pripojiť k serveru. Skontrolujte prosím svoje internetové pripojenie a skúste to znova.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Bola zistená neplatná nahrávka';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Zdá sa, že v nahrávke je viacero rečníkov. Uistite sa, že ste na tichom mieste, a skúste to znova.';
+
+  @override
+  String get tooShortDesc => 'Nezistilo sa dostatok reči. Hovorte viac a skúste to znova.';
+
+  @override
+  String get invalidRecordingDesc => 'Uistite sa, že hovoríte minimálne 5 sekúnd a najviac 90.';
+
+  @override
+  String get areYouThere => 'Ste tam?';
+
+  @override
+  String get noSpeechDesc =>
+      'Nepodarilo sa zistiť žiadnu reč. Uistite sa, že hovoríte minimálne 10 sekúnd a najviac 3 minúty.';
+
+  @override
+  String get connectionLost => 'Pripojenie bolo stratené';
+
+  @override
+  String get connectionLostDesc =>
+      'Pripojenie bolo prerušené. Skontrolujte prosím svoje internetové pripojenie a skúste to znova.';
+
+  @override
+  String get tryAgain => 'Skúsiť znova';
+
+  @override
+  String get connectOmiOmiGlass => 'Pripojiť Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Pokračovať bez zariadenia';
+
+  @override
+  String get permissionsRequired => 'Vyžadujú sa povolenia';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Táto aplikácia potrebuje povolenia Bluetooth a Poloha, aby mohla správne fungovať. Povoľte ich prosím v nastaveniach.';
+
+  @override
+  String get openSettings => 'Otvoriť nastavenia';
+
+  @override
+  String get wantDifferentName => 'Chcete sa volať inak?';
+
+  @override
+  String get whatsYourName => 'Ako sa voláte?';
+
+  @override
+  String get speakTranscribeSummarize => 'Hovoriť. Prepisovať. Sumarizovať.';
+
+  @override
+  String get signInWithApple => 'Prihlásiť sa cez Apple';
+
+  @override
+  String get signInWithGoogle => 'Prihlásiť sa cez Google';
+
+  @override
+  String get byContinuingAgree => 'Pokračovaním súhlasíte s našimi ';
+
+  @override
+  String get termsOfUse => 'Podmienky používania';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Váš AI spoločník';
+
+  @override
+  String get captureEveryMoment =>
+      'Zachyťte každý moment. Získajte zhrnutia\npoháňané AI. Nikdy viac si nerobte poznámky.';
+
+  @override
+  String get appleWatchSetup => 'Nastavenie Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Povolenie bolo vyžiadané!';
+
+  @override
+  String get microphonePermission => 'Povolenie mikrofónu';
+
+  @override
+  String get permissionGrantedNow =>
+      'Povolenie bolo udelené! Teraz:\n\nOtvorte aplikáciu Omi na hodinkách a ťuknite na \"Pokračovať\" nižšie';
+
+  @override
+  String get needMicrophonePermission =>
+      'Potrebujeme povolenie mikrofónu.\n\n1. Ťuknite na \"Udeliť povolenie\"\n2. Povoľte na vašom iPhone\n3. Aplikácia na hodinkách sa zatvorí\n4. Znovu ju otvorte a ťuknite na \"Pokračovať\"';
+
+  @override
+  String get grantPermissionButton => 'Udeliť povolenie';
+
+  @override
+  String get needHelp => 'Potrebujete pomoc?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Riešenie problémov:\n\n1. Uistite sa, že Omi je nainštalované na vašich hodinkách\n2. Otvorte aplikáciu Omi na hodinkách\n3. Hľadajte vyskakovacie okno s povolením\n4. Ťuknite na \"Povoliť\", keď sa zobrazí\n5. Aplikácia na hodinkách sa zatvorí - znovu ju otvorte\n6. Vráťte sa a ťuknite na \"Pokračovať\" na vašom iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Nahrávanie bolo úspešne spustené!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Povolenie ešte nebolo udelené. Uistite sa, že ste povolili prístup k mikrofónu a znovu otvorili aplikáciu na hodinkách.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Chyba pri vyžiadaní povolenia: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Chyba pri spustení nahrávania: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Vyberte svoj primárny jazyk';
+
+  @override
+  String get languageBenefits => 'Nastavte svoj jazyk pre presnejšie prepisy a personalizovaný zážitok';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Aký je váš primárny jazyk?';
+
+  @override
+  String get selectYourLanguage => 'Vyberte svoj jazyk';
+
+  @override
+  String get personalGrowthJourney => 'Vaša cesta osobného rastu s AI, ktorá počúva každé vaše slovo.';
+
+  @override
+  String get actionItemsTitle => 'Úlohy';
+
+  @override
+  String get actionItemsDescription => 'Ťuknite pre úpravu • Dlhé stlačenie pre výber • Potiahnutím pre akcie';
+
+  @override
+  String get tabToDo => 'Urobiť';
+
+  @override
+  String get tabDone => 'Hotové';
+
+  @override
+  String get tabOld => 'Staré';
+
+  @override
+  String get emptyTodoMessage => '🎉 Všetko je aktuálne!\nŽiadne čakajúce úlohy';
+
+  @override
+  String get emptyDoneMessage => 'Zatiaľ žiadne dokončené položky';
+
+  @override
+  String get emptyOldMessage => '✅ Žiadne staré úlohy';
+
+  @override
+  String get noItems => 'Žiadne položky';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Úloha bola označená ako nedokončená';
+
+  @override
+  String get actionItemCompleted => 'Úloha bola dokončená';
+
+  @override
+  String get deleteActionItemTitle => 'Odstrániť úlohu';
+
+  @override
+  String get deleteActionItemMessage => 'Naozaj chcete odstrániť túto úlohu?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Odstrániť vybrané položky';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Naozaj chcete odstrániť $count vybranú úlohu/úlohy$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Úloha \"$description\" bola odstránená';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count úloha/úlohy$s bola odstránená';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Nepodarilo sa odstrániť úlohu';
+
+  @override
+  String get failedToDeleteItems => 'Nepodarilo sa odstrániť položky';
+
+  @override
+  String get failedToDeleteSomeItems => 'Nepodarilo sa odstrániť niektoré položky';
+
+  @override
+  String get welcomeActionItemsTitle => 'Pripravené na úlohy';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Vaša AI automaticky extrahuje úlohy z vašich konverzácií. Objavia sa tu, keď budú vytvorené.';
+
+  @override
+  String get autoExtractionFeature => 'Automaticky extrahované z konverzácií';
+
+  @override
+  String get editSwipeFeature => 'Ťuknite pre úpravu, potiahnutím dokončíte alebo odstránite';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count vybraných';
+  }
+
+  @override
+  String get selectAll => 'Vybrať všetko';
+
+  @override
+  String get deleteSelected => 'Odstrániť vybrané';
+
+  @override
+  String searchMemories(int count) {
+    return 'Hľadať v $count spomienkach';
+  }
+
+  @override
+  String get memoryDeleted => 'Spomienka bola odstránená.';
+
+  @override
+  String get undo => 'Vrátiť späť';
+
+  @override
+  String get noMemoriesYet => 'Zatiaľ žiadne spomienky';
+
+  @override
+  String get noAutoMemories => 'Zatiaľ žiadne automaticky extrahované spomienky';
+
+  @override
+  String get noManualMemories => 'Zatiaľ žiadne manuálne spomienky';
+
+  @override
+  String get noMemoriesInCategories => 'Žiadne spomienky v týchto kategóriách';
+
+  @override
+  String get noMemoriesFound => 'Neboli nájdené žiadne spomienky';
+
+  @override
+  String get addFirstMemory => 'Pridajte svoju prvú spomienku';
+
+  @override
+  String get clearMemoryTitle => 'Vymazať pamäť Omi';
+
+  @override
+  String get clearMemoryMessage => 'Naozaj chcete vymazať pamäť Omi? Túto akciu nie je možné vrátiť späť.';
+
+  @override
+  String get clearMemoryButton => 'Vymazať pamäť';
+
+  @override
+  String get memoryClearedSuccess => 'Pamäť Omi o vás bola vymazaná';
+
+  @override
+  String get noMemoriesToDelete => 'Žiadne spomienky na odstránenie';
+
+  @override
+  String get createMemoryTooltip => 'Vytvoriť novú spomienku';
+
+  @override
+  String get createActionItemTooltip => 'Vytvoriť novú úlohu';
+
+  @override
+  String get memoryManagement => 'Správa pamäte';
+
+  @override
+  String get filterMemories => 'Filtrovať spomienky';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Máte $count spomienok celkom';
+  }
+
+  @override
+  String get publicMemories => 'Verejné spomienky';
+
+  @override
+  String get privateMemories => 'Súkromné spomienky';
+
+  @override
+  String get makeAllPrivate => 'Urobiť všetky spomienky súkromnými';
+
+  @override
+  String get makeAllPublic => 'Urobiť všetky spomienky verejnými';
+
+  @override
+  String get deleteAllMemories => 'Odstrániť všetky spomienky';
+
+  @override
+  String get allMemoriesPrivateResult => 'Všetky spomienky sú teraz súkromné';
+
+  @override
+  String get allMemoriesPublicResult => 'Všetky spomienky sú teraz verejné';
+
+  @override
+  String get newMemory => 'Nová spomienka';
+
+  @override
+  String get editMemory => 'Upraviť spomienku';
+
+  @override
+  String get memoryContentHint => 'Rád jem zmrzlinu...';
+
+  @override
+  String get failedToSaveMemory => 'Nepodarilo sa uložiť. Skontrolujte prosím svoje pripojenie.';
+
+  @override
+  String get saveMemory => 'Uložiť spomienku';
+
+  @override
+  String get retry => 'Skúsiť znova';
+
+  @override
+  String get createActionItem => 'Vytvoriť úlohu';
+
+  @override
+  String get editActionItem => 'Upraviť úlohu';
+
+  @override
+  String get actionItemDescriptionHint => 'Čo je potrebné urobiť?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Popis úlohy nemôže byť prázdny.';
+
+  @override
+  String get actionItemUpdated => 'Úloha bola aktualizovaná';
+
+  @override
+  String get failedToUpdateActionItem => 'Nepodarilo sa aktualizovať úlohu';
+
+  @override
+  String get actionItemCreated => 'Úloha bola vytvorená';
+
+  @override
+  String get failedToCreateActionItem => 'Nepodarilo sa vytvoriť úlohu';
+
+  @override
+  String get dueDate => 'Termín dokončenia';
+
+  @override
+  String get time => 'Čas';
+
+  @override
+  String get addDueDate => 'Pridať termín dokončenia';
+
+  @override
+  String get pressDoneToSave => 'Stlačte hotovo pre uloženie';
+
+  @override
+  String get pressDoneToCreate => 'Stlačte hotovo pre vytvorenie';
+
+  @override
+  String get filterAll => 'Všetko';
+
+  @override
+  String get filterSystem => 'O vás';
+
+  @override
+  String get filterInteresting => 'Postrehy';
+
+  @override
+  String get filterManual => 'Manuálne';
+
+  @override
+  String get completed => 'Dokončené';
+
+  @override
+  String get markComplete => 'Označiť ako dokončené';
+
+  @override
+  String get actionItemDeleted => 'Úloha bola odstránená';
+
+  @override
+  String get failedToDeleteActionItem => 'Nepodarilo sa odstrániť úlohu';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Odstrániť úlohu';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Naozaj chcete odstrániť túto úlohu?';
+
+  @override
+  String get appLanguage => 'Jazyk aplikácie';
+
+  @override
+  String get appInterfaceSectionTitle => 'ROZHRANIE APLIKÁCIE';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'REČ A PREPIS';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Jazyk aplikácie mení ponuky a tlačidlá. Jazyk reči ovplyvňuje spôsob prepisu vašich nahrávok.';
+}

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -1,0 +1,2233 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Swedish (`sv`).
+class AppLocalizationsSv extends AppLocalizations {
+  AppLocalizationsSv([String locale = 'sv']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Konversation';
+
+  @override
+  String get transcriptTab => 'Transkription';
+
+  @override
+  String get actionItemsTab => 'Åtgärder';
+
+  @override
+  String get deleteConversationTitle => 'Ta bort konversation?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Är du säker på att du vill ta bort denna konversation? Detta kan inte ångras.';
+
+  @override
+  String get confirm => 'Bekräfta';
+
+  @override
+  String get cancel => 'Avbryt';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Ta bort';
+
+  @override
+  String get add => 'Lägg till';
+
+  @override
+  String get update => 'Uppdatera';
+
+  @override
+  String get save => 'Spara';
+
+  @override
+  String get edit => 'Redigera';
+
+  @override
+  String get close => 'Stäng';
+
+  @override
+  String get clear => 'Rensa';
+
+  @override
+  String get copyTranscript => 'Kopiera transkription';
+
+  @override
+  String get copySummary => 'Kopiera sammanfattning';
+
+  @override
+  String get testPrompt => 'Testa prompt';
+
+  @override
+  String get reprocessConversation => 'Bearbeta konversation igen';
+
+  @override
+  String get deleteConversation => 'Ta bort konversation';
+
+  @override
+  String get contentCopied => 'Innehåll kopierat till urklipp';
+
+  @override
+  String get failedToUpdateStarred => 'Det gick inte att uppdatera stjärnstatus.';
+
+  @override
+  String get conversationUrlNotShared => 'Konversationens URL kunde inte delas.';
+
+  @override
+  String get errorProcessingConversation => 'Fel vid bearbetning av konversation. Försök igen senare.';
+
+  @override
+  String get noInternetConnection => 'Kontrollera din internetanslutning och försök igen.';
+
+  @override
+  String get unableToDeleteConversation => 'Kan inte ta bort konversation';
+
+  @override
+  String get somethingWentWrong => 'Något gick fel! Försök igen senare.';
+
+  @override
+  String get copyErrorMessage => 'Kopiera felmeddelande';
+
+  @override
+  String get errorCopied => 'Felmeddelande kopierat till urklipp';
+
+  @override
+  String get remaining => 'Återstående';
+
+  @override
+  String get loading => 'Läser in...';
+
+  @override
+  String get loadingDuration => 'Läser in längd...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count sekunder';
+  }
+
+  @override
+  String get people => 'Personer';
+
+  @override
+  String get addNewPerson => 'Lägg till ny person';
+
+  @override
+  String get editPerson => 'Redigera person';
+
+  @override
+  String get createPersonHint => 'Skapa en ny person och träna Omi att känna igen deras röst också!';
+
+  @override
+  String get speechProfile => 'Röstprofil';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Exempel $number';
+  }
+
+  @override
+  String get settings => 'Inställningar';
+
+  @override
+  String get language => 'Språk';
+
+  @override
+  String get selectLanguage => 'Välj språk';
+
+  @override
+  String get deleting => 'Tar bort...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Slutför autentiseringen i din webbläsare. När du är klar, återvänd till appen.';
+
+  @override
+  String get failedToStartAuthentication => 'Det gick inte att starta autentisering';
+
+  @override
+  String get importStarted => 'Import har startat! Du får ett meddelande när den är klar.';
+
+  @override
+  String get failedToStartImport => 'Det gick inte att starta import. Försök igen.';
+
+  @override
+  String get couldNotAccessFile => 'Kunde inte komma åt den valda filen';
+
+  @override
+  String get askOmi => 'Fråga Omi';
+
+  @override
+  String get done => 'Klar';
+
+  @override
+  String get disconnected => 'Frånkopplad';
+
+  @override
+  String get searching => 'Söker';
+
+  @override
+  String get connectDevice => 'Anslut enhet';
+
+  @override
+  String get monthlyLimitReached => 'Du har nått din månatliga gräns.';
+
+  @override
+  String get checkUsage => 'Kontrollera användning';
+
+  @override
+  String get syncingRecordings => 'Synkroniserar inspelningar';
+
+  @override
+  String get recordingsToSync => 'Inspelningar att synkronisera';
+
+  @override
+  String get allCaughtUp => 'Allt är klart';
+
+  @override
+  String get sync => 'Synkronisera';
+
+  @override
+  String get pendantUpToDate => 'Hängsmycket är uppdaterat';
+
+  @override
+  String get allRecordingsSynced => 'Alla inspelningar är synkroniserade';
+
+  @override
+  String get syncingInProgress => 'Synkronisering pågår';
+
+  @override
+  String get readyToSync => 'Redo att synkronisera';
+
+  @override
+  String get tapSyncToStart => 'Tryck på Synkronisera för att starta';
+
+  @override
+  String get pendantNotConnected => 'Hängsmycket är inte anslutet. Anslut för att synkronisera.';
+
+  @override
+  String get everythingSynced => 'Allt är redan synkroniserat.';
+
+  @override
+  String get recordingsNotSynced => 'Du har inspelningar som inte är synkroniserade ännu.';
+
+  @override
+  String get syncingBackground => 'Vi fortsätter synkronisera dina inspelningar i bakgrunden.';
+
+  @override
+  String get noConversationsYet => 'Inga konversationer ännu.';
+
+  @override
+  String get noStarredConversations => 'Inga stjärnmärkta konversationer ännu.';
+
+  @override
+  String get starConversationHint =>
+      'För att stjärnmärka en konversation, öppna den och tryck på stjärnikonen i sidhuvudet.';
+
+  @override
+  String get searchConversations => 'Sök konversationer';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count valda';
+  }
+
+  @override
+  String get merge => 'Slå ihop';
+
+  @override
+  String get mergeConversations => 'Slå ihop konversationer';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Detta kommer att kombinera $count konversationer till en. Allt innehåll kommer att slås ihop och genereras på nytt.';
+  }
+
+  @override
+  String get mergingInBackground => 'Slår ihop i bakgrunden. Detta kan ta en stund.';
+
+  @override
+  String get failedToStartMerge => 'Det gick inte att starta ihopslagning';
+
+  @override
+  String get askAnything => 'Fråga vad som helst';
+
+  @override
+  String get noMessagesYet => 'Inga meddelanden ännu!\nVarför inte starta en konversation?';
+
+  @override
+  String get deletingMessages => 'Tar bort dina meddelanden från Omis minne...';
+
+  @override
+  String get messageCopied => 'Meddelande kopierat till urklipp.';
+
+  @override
+  String get cannotReportOwnMessage => 'Du kan inte rapportera dina egna meddelanden.';
+
+  @override
+  String get reportMessage => 'Rapportera meddelande';
+
+  @override
+  String get reportMessageConfirm => 'Är du säker på att du vill rapportera detta meddelande?';
+
+  @override
+  String get messageReported => 'Meddelande rapporterat.';
+
+  @override
+  String get thankYouFeedback => 'Tack för din återkoppling!';
+
+  @override
+  String get clearChat => 'Rensa chatt?';
+
+  @override
+  String get clearChatConfirm => 'Är du säker på att du vill rensa chatten? Detta kan inte ångras.';
+
+  @override
+  String get maxFilesLimit => 'Du kan bara ladda upp 4 filer åt gången';
+
+  @override
+  String get chatWithOmi => 'Chatta med Omi';
+
+  @override
+  String get apps => 'Appar';
+
+  @override
+  String get noAppsFound => 'Inga appar hittades';
+
+  @override
+  String get tryAdjustingSearch => 'Prova att justera din sökning eller filter';
+
+  @override
+  String get createYourOwnApp => 'Skapa din egen app';
+
+  @override
+  String get buildAndShareApp => 'Bygg och dela din anpassade app';
+
+  @override
+  String get searchApps => 'Sök bland 1500+ appar';
+
+  @override
+  String get myApps => 'Mina appar';
+
+  @override
+  String get installedApps => 'Installerade appar';
+
+  @override
+  String get unableToFetchApps => 'Kunde inte hämta appar :(\n\nKontrollera din internetanslutning och försök igen.';
+
+  @override
+  String get aboutOmi => 'Om Omi';
+
+  @override
+  String get privacyPolicy => 'Integritetspolicy';
+
+  @override
+  String get visitWebsite => 'Besök webbplatsen';
+
+  @override
+  String get helpOrInquiries => 'Hjälp eller frågor?';
+
+  @override
+  String get joinCommunity => 'Gå med i communityn!';
+
+  @override
+  String get membersAndCounting => '8000+ medlemmar och fler tillkommer.';
+
+  @override
+  String get deleteAccountTitle => 'Ta bort konto';
+
+  @override
+  String get deleteAccountConfirm => 'Är du säker på att du vill ta bort ditt konto?';
+
+  @override
+  String get cannotBeUndone => 'Detta kan inte ångras.';
+
+  @override
+  String get allDataErased => 'Alla dina minnen och konversationer kommer att raderas permanent.';
+
+  @override
+  String get appsDisconnected => 'Dina appar och integrationer kommer att kopplas från omedelbart.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Du kan exportera dina data innan du tar bort ditt konto, men när det väl är borttaget kan det inte återställas.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Jag förstår att borttagning av mitt konto är permanent och att all data, inklusive minnen och konversationer, kommer att förloras och inte kan återställas.';
+
+  @override
+  String get areYouSure => 'Är du säker?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Denna åtgärd är oåterkallelig och kommer permanent ta bort ditt konto och all associerad data. Är du säker på att du vill fortsätta?';
+
+  @override
+  String get deleteNow => 'Ta bort nu';
+
+  @override
+  String get goBack => 'Gå tillbaka';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Markera kryssrutan för att bekräfta att du förstår att borttagning av ditt konto är permanent och oåterkalleligt.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'Namn';
+
+  @override
+  String get email => 'E-post';
+
+  @override
+  String get customVocabulary => 'Anpassat ordförråd';
+
+  @override
+  String get identifyingOthers => 'Identifiera andra';
+
+  @override
+  String get paymentMethods => 'Betalningsmetoder';
+
+  @override
+  String get conversationDisplay => 'Konversationsvisning';
+
+  @override
+  String get dataPrivacy => 'Data och integritet';
+
+  @override
+  String get userId => 'Användar-ID';
+
+  @override
+  String get notSet => 'Inte inställt';
+
+  @override
+  String get userIdCopied => 'Användar-ID kopierat till urklipp';
+
+  @override
+  String get systemDefault => 'Systemstandard';
+
+  @override
+  String get planAndUsage => 'Plan och användning';
+
+  @override
+  String get offlineSync => 'Offlinesynkronisering';
+
+  @override
+  String get deviceSettings => 'Enhetsinställningar';
+
+  @override
+  String get chatTools => 'Chattverktyg';
+
+  @override
+  String get feedbackBug => 'Återkoppling / Bugg';
+
+  @override
+  String get helpCenter => 'Hjälpcenter';
+
+  @override
+  String get developerSettings => 'Utvecklarinställningar';
+
+  @override
+  String get getOmiForMac => 'Hämta Omi för Mac';
+
+  @override
+  String get referralProgram => 'Hänvisningsprogram';
+
+  @override
+  String get signOut => 'Logga ut';
+
+  @override
+  String get appAndDeviceCopied => 'App- och enhetsdetaljer kopierade';
+
+  @override
+  String get wrapped2025 => 'Årssummering 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Din integritet, din kontroll';
+
+  @override
+  String get privacyIntro =>
+      'På Omi är vi engagerade i att skydda din integritet. Denna sida låter dig kontrollera hur din data lagras och används.';
+
+  @override
+  String get learnMore => 'Läs mer...';
+
+  @override
+  String get dataProtectionLevel => 'Dataskyddsnivå';
+
+  @override
+  String get dataProtectionDesc =>
+      'Din data är säkrad som standard med stark kryptering. Granska dina inställningar och framtida integritetsalternativ nedan.';
+
+  @override
+  String get appAccess => 'Appåtkomst';
+
+  @override
+  String get appAccessDesc =>
+      'Följande appar kan komma åt din data. Tryck på en app för att hantera dess behörigheter.';
+
+  @override
+  String get noAppsExternalAccess => 'Inga installerade appar har extern åtkomst till din data.';
+
+  @override
+  String get deviceName => 'Enhetsnamn';
+
+  @override
+  String get deviceId => 'Enhets-ID';
+
+  @override
+  String get firmware => 'Firmware';
+
+  @override
+  String get sdCardSync => 'SD-kortssynkronisering';
+
+  @override
+  String get hardwareRevision => 'Hårdvarurevision';
+
+  @override
+  String get modelNumber => 'Modellnummer';
+
+  @override
+  String get manufacturer => 'Tillverkare';
+
+  @override
+  String get doubleTap => 'Dubbeltryck';
+
+  @override
+  String get ledBrightness => 'LED-ljusstyrka';
+
+  @override
+  String get micGain => 'Mikrofonförstärkning';
+
+  @override
+  String get disconnect => 'Koppla från';
+
+  @override
+  String get forgetDevice => 'Glöm enhet';
+
+  @override
+  String get chargingIssues => 'Laddningsproblem';
+
+  @override
+  String get disconnectDevice => 'Koppla från enhet';
+
+  @override
+  String get unpairDevice => 'Koppla bort enhet';
+
+  @override
+  String get unpairAndForget => 'Koppla bort och glöm enhet';
+
+  @override
+  String get deviceDisconnectedMessage => 'Din Omi har kopplats från 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Enhet bortkopplad. Gå till Inställningar > Bluetooth och glöm enheten för att slutföra.';
+
+  @override
+  String get unpairDialogTitle => 'Koppla bort enhet';
+
+  @override
+  String get unpairDialogMessage =>
+      'Detta kommer att koppla bort enheten så att den kan anslutas till en annan telefon. Du behöver gå till Inställningar > Bluetooth och glömma enheten för att slutföra processen.';
+
+  @override
+  String get deviceNotConnected => 'Enheten är inte ansluten';
+
+  @override
+  String get connectDeviceMessage =>
+      'Anslut din Omi-enhet för att få tillgång till\nenhetsinställningar och anpassning';
+
+  @override
+  String get deviceInfoSection => 'Enhetsinformation';
+
+  @override
+  String get customizationSection => 'Anpassning';
+
+  @override
+  String get hardwareSection => 'Hårdvara';
+
+  @override
+  String get v2Undetected => 'V2 ej upptäckt';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Vi ser att du antingen har en V1-enhet eller att din enhet inte är ansluten. SD-kortsfunktionalitet är endast tillgänglig för V2-enheter.';
+
+  @override
+  String get endConversation => 'Avsluta konversation';
+
+  @override
+  String get pauseResume => 'Pausa/Återuppta';
+
+  @override
+  String get starConversation => 'Stjärnmärk konversation';
+
+  @override
+  String get doubleTapAction => 'Dubbeltrycksåtgärd';
+
+  @override
+  String get endAndProcess => 'Avsluta och bearbeta konversation';
+
+  @override
+  String get pauseResumeRecording => 'Pausa/Återuppta inspelning';
+
+  @override
+  String get starOngoing => 'Stjärnmärk pågående konversation';
+
+  @override
+  String get off => 'Av';
+
+  @override
+  String get max => 'Max';
+
+  @override
+  String get mute => 'Tysta';
+
+  @override
+  String get quiet => 'Tyst';
+
+  @override
+  String get normal => 'Normal';
+
+  @override
+  String get high => 'Hög';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon är tystad';
+
+  @override
+  String get micGainDescLow => 'Mycket tyst - för högljudda miljöer';
+
+  @override
+  String get micGainDescModerate => 'Tyst - för måttligt buller';
+
+  @override
+  String get micGainDescNeutral => 'Neutral - balanserad inspelning';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Lätt förstärkt - normal användning';
+
+  @override
+  String get micGainDescBoosted => 'Förstärkt - för tysta miljöer';
+
+  @override
+  String get micGainDescHigh => 'Hög - för avlägsna eller svaga röster';
+
+  @override
+  String get micGainDescVeryHigh => 'Mycket hög - för mycket tysta källor';
+
+  @override
+  String get micGainDescMax => 'Maximum - använd med försiktighet';
+
+  @override
+  String get developerSettingsTitle => 'Utvecklarinställningar';
+
+  @override
+  String get saving => 'Sparar...';
+
+  @override
+  String get personaConfig => 'Konfigurera din AI-persona';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transkription';
+
+  @override
+  String get transcriptionConfig => 'Konfigurera STT-leverantör';
+
+  @override
+  String get conversationTimeout => 'Konversations timeout';
+
+  @override
+  String get conversationTimeoutConfig => 'Ställ in när konversationer avslutas automatiskt';
+
+  @override
+  String get importData => 'Importera data';
+
+  @override
+  String get importDataConfig => 'Importera data från andra källor';
+
+  @override
+  String get debugDiagnostics => 'Felsökning och diagnostik';
+
+  @override
+  String get endpointUrl => 'Endpoint-URL';
+
+  @override
+  String get noApiKeys => 'Inga API-nycklar ännu';
+
+  @override
+  String get createKeyToStart => 'Skapa en nyckel för att komma igång';
+
+  @override
+  String get createKey => 'Skapa nyckel';
+
+  @override
+  String get docs => 'Dokumentation';
+
+  @override
+  String get yourOmiInsights => 'Dina Omi-insikter';
+
+  @override
+  String get today => 'Idag';
+
+  @override
+  String get thisMonth => 'Denna månad';
+
+  @override
+  String get thisYear => 'Detta år';
+
+  @override
+  String get allTime => 'All tid';
+
+  @override
+  String get noActivityYet => 'Ingen aktivitet ännu';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Starta en konversation med Omi\nför att se dina användningsinsikter här.';
+
+  @override
+  String get listening => 'Lyssnar';
+
+  @override
+  String get listeningSubtitle => 'Total tid Omi har aktivt lyssnat.';
+
+  @override
+  String get understanding => 'Förstår';
+
+  @override
+  String get understandingSubtitle => 'Ord förstådda från dina konversationer.';
+
+  @override
+  String get providing => 'Tillhandahåller';
+
+  @override
+  String get providingSubtitle => 'Åtgärder och anteckningar automatiskt fångade.';
+
+  @override
+  String get remembering => 'Kommer ihåg';
+
+  @override
+  String get rememberingSubtitle => 'Fakta och detaljer som kommer ihåg för dig.';
+
+  @override
+  String get unlimitedPlan => 'Obegränsad plan';
+
+  @override
+  String get managePlan => 'Hantera plan';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Din plan kommer att avbrytas den $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Din plan förnyas den $date.';
+  }
+
+  @override
+  String get basicPlan => 'Gratisplan';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used av $limit min använt';
+  }
+
+  @override
+  String get upgrade => 'Uppgradera';
+
+  @override
+  String get upgradeToUnlimited => 'Uppgradera till obegränsat';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Din plan inkluderar $limit gratis minuter per månad. Uppgradera för att få obegränsat.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Delar mina Omi-statistik! (omi.me - din alltid påslagna AI-assistent)';
+
+  @override
+  String get sharePeriodToday => 'Idag har Omi:';
+
+  @override
+  String get sharePeriodMonth => 'Denna månad har Omi:';
+
+  @override
+  String get sharePeriodYear => 'Detta år har Omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Hittills har Omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Lyssnat i $minutes minuter';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Förstått $words ord';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Tillhandahållit $count insikter';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Kommit ihåg $count minnen';
+  }
+
+  @override
+  String get debugLogs => 'Felsökningsloggar';
+
+  @override
+  String get debugLogsAutoDelete => 'Raderas automatiskt efter 3 dagar.';
+
+  @override
+  String get debugLogsDesc => 'Hjälper till att diagnostisera problem';
+
+  @override
+  String get noLogFilesFound => 'Inga loggfiler hittades.';
+
+  @override
+  String get omiDebugLog => 'Omi felsökningslogg';
+
+  @override
+  String get logShared => 'Logg delad';
+
+  @override
+  String get selectLogFile => 'Välj loggfil';
+
+  @override
+  String get shareLogs => 'Dela loggar';
+
+  @override
+  String get debugLogCleared => 'Felsökningslogg rensad';
+
+  @override
+  String get exportStarted => 'Export har startat. Detta kan ta några sekunder...';
+
+  @override
+  String get exportAllData => 'Exportera all data';
+
+  @override
+  String get exportDataDesc => 'Exportera konversationer till en JSON-fil';
+
+  @override
+  String get exportedConversations => 'Exporterade konversationer från Omi';
+
+  @override
+  String get exportShared => 'Export delad';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Ta bort kunskapsgraf?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Detta kommer att ta bort all härledd kunskapsgrafsdata (noder och kopplingar). Dina ursprungliga minnen förblir säkra. Grafen kommer att byggas om över tid eller vid nästa begäran.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Kunskapsgraf borttagen';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Det gick inte att ta bort graf: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Ta bort kunskapsgraf';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Rensa alla noder och kopplingar';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP-server';
+
+  @override
+  String get mcpServerDesc => 'Anslut AI-assistenter till din data';
+
+  @override
+  String get serverUrl => 'Server-URL';
+
+  @override
+  String get urlCopied => 'URL kopierad';
+
+  @override
+  String get apiKeyAuth => 'API-nyckel autentisering';
+
+  @override
+  String get header => 'Header';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Klient-ID';
+
+  @override
+  String get clientSecret => 'Klienthemlighet';
+
+  @override
+  String get useMcpApiKey => 'Använd din MCP API-nyckel';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Konversationshändelser';
+
+  @override
+  String get newConversationCreated => 'Ny konversation skapad';
+
+  @override
+  String get realtimeTranscript => 'Realtidstranskription';
+
+  @override
+  String get transcriptReceived => 'Transkription mottagen';
+
+  @override
+  String get audioBytes => 'Ljudbytes';
+
+  @override
+  String get audioDataReceived => 'Ljuddata mottagen';
+
+  @override
+  String get intervalSeconds => 'Intervall (sekunder)';
+
+  @override
+  String get daySummary => 'Dagsammanfattning';
+
+  @override
+  String get summaryGenerated => 'Sammanfattning genererad';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Lägg till i claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Kopiera konfiguration';
+
+  @override
+  String get configCopied => 'Konfiguration kopierad till urklipp';
+
+  @override
+  String get listeningMins => 'Lyssnar (min)';
+
+  @override
+  String get understandingWords => 'Förstår (ord)';
+
+  @override
+  String get insights => 'Insikter';
+
+  @override
+  String get memories => 'Minnen';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used av $limit min använt denna månad';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used av $limit ord använt denna månad';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used av $limit insikter vunna denna månad';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used av $limit minnen skapade denna månad';
+  }
+
+  @override
+  String get visibility => 'Synlighet';
+
+  @override
+  String get visibilitySubtitle => 'Kontrollera vilka konversationer som visas i din lista';
+
+  @override
+  String get showShortConversations => 'Visa korta konversationer';
+
+  @override
+  String get showShortConversationsDesc => 'Visa konversationer som är kortare än tröskelvärdet';
+
+  @override
+  String get showDiscardedConversations => 'Visa kasserade konversationer';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Inkludera konversationer markerade som kasserade';
+
+  @override
+  String get shortConversationThreshold => 'Kort konversationströskel';
+
+  @override
+  String get shortConversationThresholdSubtitle => 'Konversationer kortare än detta döljs om de inte aktiveras ovan';
+
+  @override
+  String get durationThreshold => 'Varaktighetströskel';
+
+  @override
+  String get durationThresholdDesc => 'Dölj konversationer kortare än detta';
+
+  @override
+  String minLabel(int count) {
+    return '$count min';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Anpassat ordförråd';
+
+  @override
+  String get addWords => 'Lägg till ord';
+
+  @override
+  String get addWordsDesc => 'Namn, termer eller ovanliga ord';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Anslut';
+
+  @override
+  String get comingSoon => 'Kommer snart';
+
+  @override
+  String get chatToolsFooter => 'Anslut dina appar för att visa data och mått i chatten.';
+
+  @override
+  String get completeAuthInBrowser => 'Slutför autentiseringen i din webbläsare. När du är klar, återvänd till appen.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Det gick inte att starta $appName-autentisering';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Koppla från $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Är du säker på att du vill koppla från $appName? Du kan ansluta igen när som helst.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Frånkopplad från $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Det gick inte att koppla från';
+
+  @override
+  String connectTo(String appName) {
+    return 'Anslut till $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Du behöver auktorisera Omi för att komma åt din $appName-data. Detta öppnar din webbläsare för autentisering.';
+  }
+
+  @override
+  String get continueAction => 'Fortsätt';
+
+  @override
+  String get languageTitle => 'Språk';
+
+  @override
+  String get primaryLanguage => 'Primärt språk';
+
+  @override
+  String get automaticTranslation => 'Automatisk översättning';
+
+  @override
+  String get detectLanguages => 'Upptäck 10+ språk';
+
+  @override
+  String get authorizeSavingRecordings => 'Auktorisera lagring av inspelningar';
+
+  @override
+  String get thanksForAuthorizing => 'Tack för auktoriseringen!';
+
+  @override
+  String get needYourPermission => 'Vi behöver ditt tillstånd';
+
+  @override
+  String get alreadyGavePermission =>
+      'Du har redan gett oss tillstånd att spara dina inspelningar. Här är en påminnelse om varför vi behöver det:';
+
+  @override
+  String get wouldLikePermission => 'Vi skulle vilja ha ditt tillstånd att spara dina röstinspelningar. Här är varför:';
+
+  @override
+  String get improveSpeechProfile => 'Förbättra din röstprofil';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Vi använder inspelningar för att ytterligare träna och förbättra din personliga röstprofil.';
+
+  @override
+  String get trainFamilyProfiles => 'Träna profiler för vänner och familj';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Dina inspelningar hjälper oss att känna igen och skapa profiler för dina vänner och familj.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Förbättra transkriptionsnoggrannhet';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'När vår modell förbättras kan vi ge bättre transkriptionsresultat för dina inspelningar.';
+
+  @override
+  String get legalNotice =>
+      'Juridiskt meddelande: Lagligheten av att spela in och lagra röstdata kan variera beroende på var du befinner dig och hur du använder denna funktion. Det är ditt ansvar att säkerställa efterlevnad av lokala lagar och förordningar.';
+
+  @override
+  String get alreadyAuthorized => 'Redan auktoriserad';
+
+  @override
+  String get authorize => 'Auktorisera';
+
+  @override
+  String get revokeAuthorization => 'Återkalla auktorisering';
+
+  @override
+  String get authorizationSuccessful => 'Auktorisering lyckades!';
+
+  @override
+  String get failedToAuthorize => 'Det gick inte att auktorisera. Försök igen.';
+
+  @override
+  String get authorizationRevoked => 'Auktorisering återkallad.';
+
+  @override
+  String get recordingsDeleted => 'Inspelningar raderade.';
+
+  @override
+  String get failedToRevoke => 'Det gick inte att återkalla auktorisering. Försök igen.';
+
+  @override
+  String get permissionRevokedTitle => 'Tillstånd återkallat';
+
+  @override
+  String get permissionRevokedMessage => 'Vill du att vi tar bort alla dina befintliga inspelningar också?';
+
+  @override
+  String get yes => 'Ja';
+
+  @override
+  String get editName => 'Redigera namn';
+
+  @override
+  String get howShouldOmiCallYou => 'Vad ska Omi kalla dig?';
+
+  @override
+  String get enterYourName => 'Ange ditt namn';
+
+  @override
+  String get nameCannotBeEmpty => 'Namnet kan inte vara tomt';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Namnet har uppdaterats!';
+
+  @override
+  String get calendarSettings => 'Kalenderinställningar';
+
+  @override
+  String get calendarProviders => 'Kalenderleverantörer';
+
+  @override
+  String get macOsCalendar => 'macOS Kalender';
+
+  @override
+  String get connectMacOsCalendar => 'Anslut din lokala macOS-kalender';
+
+  @override
+  String get googleCalendar => 'Google Kalender';
+
+  @override
+  String get syncGoogleAccount => 'Synkronisera med ditt Google-konto';
+
+  @override
+  String get showMeetingsMenuBar => 'Visa kommande möten i menyraden';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Visa ditt nästa möte och tid tills det börjar i macOS menyraden';
+
+  @override
+  String get showEventsNoParticipants => 'Visa händelser utan deltagare';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'När det är aktiverat visar Kommande händelser utan deltagare eller en videolänk.';
+
+  @override
+  String get yourMeetings => 'Dina möten';
+
+  @override
+  String get refresh => 'Uppdatera';
+
+  @override
+  String get noUpcomingMeetings => 'Inga kommande möten hittades';
+
+  @override
+  String get checkingNextDays => 'Kontrollerar nästa 30 dagar';
+
+  @override
+  String get tomorrow => 'Imorgon';
+
+  @override
+  String get googleCalendarComingSoon => 'Google Kalender-integration kommer snart!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Ansluten som användare: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Standardarbetsyta';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Uppgifter skapas i denna arbetsyta';
+
+  @override
+  String get defaultProjectOptional => 'Standardprojekt (valfritt)';
+
+  @override
+  String get leaveUnselectedTasks => 'Lämna omarkerad för att skapa uppgifter utan projekt';
+
+  @override
+  String get noProjectsInWorkspace => 'Inga projekt hittades i denna arbetsyta';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Välj hur länge du vill vänta i tystnad innan en konversation avslutas automatiskt:';
+
+  @override
+  String get timeout2Minutes => '2 minuter';
+
+  @override
+  String get timeout2MinutesDesc => 'Avsluta konversation efter 2 minuters tystnad';
+
+  @override
+  String get timeout5Minutes => '5 minuter';
+
+  @override
+  String get timeout5MinutesDesc => 'Avsluta konversation efter 5 minuters tystnad';
+
+  @override
+  String get timeout10Minutes => '10 minuter';
+
+  @override
+  String get timeout10MinutesDesc => 'Avsluta konversation efter 10 minuters tystnad';
+
+  @override
+  String get timeout30Minutes => '30 minuter';
+
+  @override
+  String get timeout30MinutesDesc => 'Avsluta konversation efter 30 minuters tystnad';
+
+  @override
+  String get timeout4Hours => '4 timmar';
+
+  @override
+  String get timeout4HoursDesc => 'Avsluta konversation efter 4 timmars tystnad';
+
+  @override
+  String get conversationEndAfterHours => 'Konversationer avslutas nu efter 4 timmars tystnad';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Konversationer avslutas nu efter $minutes minuters tystnad';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Berätta ditt primära språk';
+
+  @override
+  String get languageForTranscription =>
+      'Ställ in ditt språk för skarpare transkriptioner och en personlig upplevelse.';
+
+  @override
+  String get singleLanguageModeInfo => 'Enspråksläge är aktiverat. Översättning är inaktiverad för högre noggrannhet.';
+
+  @override
+  String get searchLanguageHint => 'Sök språk efter namn eller kod';
+
+  @override
+  String get noLanguagesFound => 'Inga språk hittades';
+
+  @override
+  String get skip => 'Hoppa över';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Språk inställt på $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Det gick inte att ställa in språk';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName-inställningar';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Koppla från $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Detta tar bort din $appName-autentisering. Du måste ansluta igen för att använda den.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Ansluten till $appName';
+  }
+
+  @override
+  String get account => 'Konto';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Dina åtgärder kommer att synkroniseras till ditt $appName-konto';
+  }
+
+  @override
+  String get defaultSpace => 'Standardutrymme';
+
+  @override
+  String get selectSpaceInWorkspace => 'Välj ett utrymme i din arbetsyta';
+
+  @override
+  String get noSpacesInWorkspace => 'Inga utrymmen hittades i denna arbetsyta';
+
+  @override
+  String get defaultList => 'Standardlista';
+
+  @override
+  String get tasksAddedToList => 'Uppgifter läggs till i denna lista';
+
+  @override
+  String get noListsInSpace => 'Inga listor hittades i detta utrymme';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Det gick inte att ladda repositories: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Standardrepository sparad';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Det gick inte att spara standardrepository';
+
+  @override
+  String get defaultRepository => 'Standardrepository';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Välj en standardrepository för att skapa ärenden. Du kan fortfarande ange en annan repository när du skapar ärenden.';
+
+  @override
+  String get noReposFound => 'Inga repositories hittades';
+
+  @override
+  String get private => 'Privat';
+
+  @override
+  String updatedDate(String date) {
+    return 'Uppdaterad $date';
+  }
+
+  @override
+  String get yesterday => 'igår';
+
+  @override
+  String daysAgo(int count) {
+    return '$count dagar sedan';
+  }
+
+  @override
+  String get oneWeekAgo => '1 vecka sedan';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count veckor sedan';
+  }
+
+  @override
+  String get oneMonthAgo => '1 månad sedan';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count månader sedan';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Ärenden skapas i din standardrepository';
+
+  @override
+  String get taskIntegrations => 'Uppgiftsintegrationer';
+
+  @override
+  String get configureSettings => 'Konfigurera inställningar';
+
+  @override
+  String get completeAuthBrowser => 'Slutför autentiseringen i din webbläsare. När du är klar, återvänd till appen.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Det gick inte att starta $appName-autentisering';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Anslut till $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Du behöver auktorisera Omi för att skapa uppgifter i ditt $appName-konto. Detta öppnar din webbläsare för autentisering.';
+  }
+
+  @override
+  String get continueButton => 'Fortsätt';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName-integration';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Integration med $appName kommer snart! Vi arbetar hårt för att ge dig fler alternativ för uppgiftshantering.';
+  }
+
+  @override
+  String get gotIt => 'Förstår';
+
+  @override
+  String get tasksExportedOneApp => 'Uppgifter kan exporteras till en app åt gången.';
+
+  @override
+  String get completeYourUpgrade => 'Slutför din uppgradering';
+
+  @override
+  String get importConfiguration => 'Importera konfiguration';
+
+  @override
+  String get exportConfiguration => 'Exportera konfiguration';
+
+  @override
+  String get bringYourOwn => 'Ta med din egen';
+
+  @override
+  String get payYourSttProvider => 'Använd Omi fritt. Du betalar bara din STT-leverantör direkt.';
+
+  @override
+  String get freeMinutesMonth => '1 200 gratis minuter/månad ingår. Obegränsat med ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Värd krävs';
+
+  @override
+  String get validPortRequired => 'Giltig port krävs';
+
+  @override
+  String get validWebsocketUrlRequired => 'Giltig WebSocket-URL krävs (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API-URL krävs';
+
+  @override
+  String get apiKeyRequired => 'API-nyckel krävs';
+
+  @override
+  String get invalidJsonConfig => 'Ogiltig JSON-konfiguration';
+
+  @override
+  String errorSaving(String error) {
+    return 'Fel vid sparande: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Konfiguration kopierad till urklipp';
+
+  @override
+  String get pasteJsonConfig => 'Klistra in din JSON-konfiguration nedan:';
+
+  @override
+  String get addApiKeyAfterImport => 'Du behöver lägga till din egen API-nyckel efter import';
+
+  @override
+  String get paste => 'Klistra in';
+
+  @override
+  String get import => 'Importera';
+
+  @override
+  String get invalidProviderInConfig => 'Ogiltig leverantör i konfiguration';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Importerad $providerName-konfiguration';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Ogiltig JSON: $error';
+  }
+
+  @override
+  String get provider => 'Leverantör';
+
+  @override
+  String get live => 'Live';
+
+  @override
+  String get onDevice => 'På enhet';
+
+  @override
+  String get apiUrl => 'API-URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Ange din STT HTTP-endpoint';
+
+  @override
+  String get websocketUrl => 'WebSocket-URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Ange din live STT WebSocket-endpoint';
+
+  @override
+  String get apiKey => 'API-nyckel';
+
+  @override
+  String get enterApiKey => 'Ange din API-nyckel';
+
+  @override
+  String get storedLocallyNeverShared => 'Lagras lokalt, delas aldrig';
+
+  @override
+  String get host => 'Värd';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Avancerat';
+
+  @override
+  String get configuration => 'Konfiguration';
+
+  @override
+  String get requestConfiguration => 'Begäran konfiguration';
+
+  @override
+  String get responseSchema => 'Svarsschema';
+
+  @override
+  String get modified => 'Modifierad';
+
+  @override
+  String get resetRequestConfig => 'Återställ begäran konfiguration till standard';
+
+  @override
+  String get logs => 'Loggar';
+
+  @override
+  String get logsCopied => 'Loggar kopierade';
+
+  @override
+  String get noLogsYet => 'Inga loggar ännu. Börja spela in för att se anpassad STT-aktivitet.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName använder $codecReason. Omi kommer att användas.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi-transkription';
+
+  @override
+  String get bestInClassTranscription => 'Bästa i klassen transkription utan konfiguration';
+
+  @override
+  String get instantSpeakerLabels => 'Omedelbara talaretiketter';
+
+  @override
+  String get languageTranslation => '100+ språköversättning';
+
+  @override
+  String get optimizedForConversation => 'Optimerad för konversation';
+
+  @override
+  String get autoLanguageDetection => 'Automatisk språkdetektering';
+
+  @override
+  String get highAccuracy => 'Hög noggrannhet';
+
+  @override
+  String get privacyFirst => 'Integritet först';
+
+  @override
+  String get saveChanges => 'Spara ändringar';
+
+  @override
+  String get resetToDefault => 'Återställ till standard';
+
+  @override
+  String get viewTemplate => 'Visa mall';
+
+  @override
+  String get trySomethingLike => 'Prova något som...';
+
+  @override
+  String get tryIt => 'Prova det';
+
+  @override
+  String get creatingPlan => 'Skapar plan';
+
+  @override
+  String get developingLogic => 'Utvecklar logik';
+
+  @override
+  String get designingApp => 'Designar app';
+
+  @override
+  String get generatingIconStep => 'Genererar ikon';
+
+  @override
+  String get finalTouches => 'Sista finishen';
+
+  @override
+  String get processing => 'Bearbetar...';
+
+  @override
+  String get features => 'Funktioner';
+
+  @override
+  String get creatingYourApp => 'Skapar din app...';
+
+  @override
+  String get generatingIcon => 'Genererar ikon...';
+
+  @override
+  String get whatShouldWeMake => 'Vad ska vi skapa?';
+
+  @override
+  String get appName => 'Appnamn';
+
+  @override
+  String get description => 'Beskrivning';
+
+  @override
+  String get publicLabel => 'Offentlig';
+
+  @override
+  String get privateLabel => 'Privat';
+
+  @override
+  String get free => 'Gratis';
+
+  @override
+  String get perMonth => '/ Månad';
+
+  @override
+  String get tailoredConversationSummaries => 'Skräddarsydda konversationssammanfattningar';
+
+  @override
+  String get customChatbotPersonality => 'Anpassad chatbot-personlighet';
+
+  @override
+  String get makePublic => 'Gör offentlig';
+
+  @override
+  String get anyoneCanDiscover => 'Vem som helst kan upptäcka din app';
+
+  @override
+  String get onlyYouCanUse => 'Endast du kan använda denna app';
+
+  @override
+  String get paidApp => 'Betald app';
+
+  @override
+  String get usersPayToUse => 'Användare betalar för att använda din app';
+
+  @override
+  String get freeForEveryone => 'Gratis för alla';
+
+  @override
+  String get perMonthLabel => '/ månad';
+
+  @override
+  String get creating => 'Skapar...';
+
+  @override
+  String get createApp => 'Skapa app';
+
+  @override
+  String get searchingForDevices => 'Söker efter enheter...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ENHETER',
+      one: 'ENHET',
+    );
+    return '$count $_temp0 HITTAD(E) I NÄRHETEN';
+  }
+
+  @override
+  String get pairingSuccessful => 'PARKOPPLING LYCKADES';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Fel vid anslutning till Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Visa inte igen';
+
+  @override
+  String get iUnderstand => 'Jag förstår';
+
+  @override
+  String get enableBluetooth => 'Aktivera Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi behöver Bluetooth för att ansluta till din bärbara enhet. Aktivera Bluetooth och försök igen.';
+
+  @override
+  String get contactSupport => 'Kontakta support?';
+
+  @override
+  String get connectLater => 'Anslut senare';
+
+  @override
+  String get grantPermissions => 'Bevilja behörigheter';
+
+  @override
+  String get backgroundActivity => 'Bakgrundsaktivitet';
+
+  @override
+  String get backgroundActivityDesc => 'Låt Omi köra i bakgrunden för bättre stabilitet';
+
+  @override
+  String get locationAccess => 'Platsåtkomst';
+
+  @override
+  String get locationAccessDesc => 'Aktivera bakgrundsplats för den fullständiga upplevelsen';
+
+  @override
+  String get notifications => 'Notifieringar';
+
+  @override
+  String get notificationsDesc => 'Aktivera notifieringar för att hålla dig informerad';
+
+  @override
+  String get locationServiceDisabled => 'Platstjänst inaktiverad';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Platstjänsten är inaktiverad. Gå till Inställningar > Integritet och säkerhet > Platstjänster och aktivera den';
+
+  @override
+  String get backgroundLocationDenied => 'Bakgrundsplatsåtkomst nekad';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Gå till enhetsinställningar och ställ in platsbehörighet till \"Tillåt alltid\"';
+
+  @override
+  String get lovingOmi => 'Älskar du Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Hjälp oss att nå fler människor genom att lämna en recension i App Store. Din återkoppling betyder världen för oss!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Hjälp oss att nå fler människor genom att lämna en recension i Google Play Store. Din återkoppling betyder världen för oss!';
+
+  @override
+  String get rateOnAppStore => 'Betygsätt i App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Betygsätt i Google Play';
+
+  @override
+  String get maybeLater => 'Kanske senare';
+
+  @override
+  String get speechProfileIntro => 'Omi behöver lära sig dina mål och din röst. Du kan ändra det senare.';
+
+  @override
+  String get getStarted => 'Kom igång';
+
+  @override
+  String get allDone => 'Allt klart!';
+
+  @override
+  String get keepGoing => 'Fortsätt, du gör det bra';
+
+  @override
+  String get skipThisQuestion => 'Hoppa över denna fråga';
+
+  @override
+  String get skipForNow => 'Hoppa över för tillfället';
+
+  @override
+  String get connectionError => 'Anslutningsfel';
+
+  @override
+  String get connectionErrorDesc =>
+      'Det gick inte att ansluta till servern. Kontrollera din internetanslutning och försök igen.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Ogiltig inspelning upptäckt';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Det verkar som det finns flera talare i inspelningen. Se till att du är på en tyst plats och försök igen.';
+
+  @override
+  String get tooShortDesc => 'Det finns inte tillräckligt med tal upptäckt. Tala mer och försök igen.';
+
+  @override
+  String get invalidRecordingDesc => 'Se till att du talar i minst 5 sekunder och inte mer än 90.';
+
+  @override
+  String get areYouThere => 'Är du där?';
+
+  @override
+  String get noSpeechDesc =>
+      'Vi kunde inte upptäcka något tal. Se till att tala i minst 10 sekunder och inte mer än 3 minuter.';
+
+  @override
+  String get connectionLost => 'Anslutning förlorad';
+
+  @override
+  String get connectionLostDesc => 'Anslutningen avbröts. Kontrollera din internetanslutning och försök igen.';
+
+  @override
+  String get tryAgain => 'Försök igen';
+
+  @override
+  String get connectOmiOmiGlass => 'Anslut Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Fortsätt utan enhet';
+
+  @override
+  String get permissionsRequired => 'Behörigheter krävs';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Denna app behöver Bluetooth- och platsbehörigheter för att fungera korrekt. Aktivera dem i inställningarna.';
+
+  @override
+  String get openSettings => 'Öppna inställningar';
+
+  @override
+  String get wantDifferentName => 'Vill du kallas något annat?';
+
+  @override
+  String get whatsYourName => 'Vad heter du?';
+
+  @override
+  String get speakTranscribeSummarize => 'Tala. Transkribera. Sammanfatta.';
+
+  @override
+  String get signInWithApple => 'Logga in med Apple';
+
+  @override
+  String get signInWithGoogle => 'Logga in med Google';
+
+  @override
+  String get byContinuingAgree => 'Genom att fortsätta godkänner du vår ';
+
+  @override
+  String get termsOfUse => 'Användarvillkor';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Din AI-följeslagare';
+
+  @override
+  String get captureEveryMoment =>
+      'Fånga varje ögonblick. Få AI-drivna\nsammanfattningar. Ta aldrig anteckningar igen.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch-konfiguration';
+
+  @override
+  String get permissionRequestedExclaim => 'Behörighet begärd!';
+
+  @override
+  String get microphonePermission => 'Mikrofonbehörighet';
+
+  @override
+  String get permissionGrantedNow =>
+      'Behörighet beviljad! Nu:\n\nÖppna Omi-appen på din klocka och tryck på \"Fortsätt\" nedan';
+
+  @override
+  String get needMicrophonePermission =>
+      'Vi behöver mikrofonbehörighet.\n\n1. Tryck på \"Bevilja behörighet\"\n2. Tillåt på din iPhone\n3. Klockappen stängs\n4. Öppna igen och tryck på \"Fortsätt\"';
+
+  @override
+  String get grantPermissionButton => 'Bevilja behörighet';
+
+  @override
+  String get needHelp => 'Behöver du hjälp?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Felsökning:\n\n1. Se till att Omi är installerat på din klocka\n2. Öppna Omi-appen på din klocka\n3. Leta efter behörighetspopupen\n4. Tryck på \"Tillåt\" när du uppmanas\n5. Appen på din klocka stängs - öppna den igen\n6. Kom tillbaka och tryck på \"Fortsätt\" på din iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Inspelning startade!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Behörighet har inte beviljats ännu. Se till att du tillät mikrofonåtkomst och öppnade appen igen på din klocka.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Fel vid begäran av behörighet: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Fel vid start av inspelning: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Välj ditt primära språk';
+
+  @override
+  String get languageBenefits => 'Ställ in ditt språk för skarpare transkriptioner och en personlig upplevelse';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Vilket är ditt primära språk?';
+
+  @override
+  String get selectYourLanguage => 'Välj ditt språk';
+
+  @override
+  String get personalGrowthJourney => 'Din personliga utvecklingsresa med AI som lyssnar på varje ord.';
+
+  @override
+  String get actionItemsTitle => 'Att göra';
+
+  @override
+  String get actionItemsDescription => 'Tryck för att redigera • Långtryck för att välja • Svep för åtgärder';
+
+  @override
+  String get tabToDo => 'Att göra';
+
+  @override
+  String get tabDone => 'Klar';
+
+  @override
+  String get tabOld => 'Gamla';
+
+  @override
+  String get emptyTodoMessage => '🎉 Allt klart!\nInga väntande åtgärder';
+
+  @override
+  String get emptyDoneMessage => 'Inga avslutade objekt ännu';
+
+  @override
+  String get emptyOldMessage => '✅ Inga gamla uppgifter';
+
+  @override
+  String get noItems => 'Inga objekt';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Åtgärd markerad som ofullständig';
+
+  @override
+  String get actionItemCompleted => 'Åtgärd slutförd';
+
+  @override
+  String get deleteActionItemTitle => 'Ta bort åtgärd';
+
+  @override
+  String get deleteActionItemMessage => 'Är du säker på att du vill ta bort denna åtgärd?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Ta bort valda objekt';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Är du säker på att du vill ta bort $count vald$s åtgärd$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Åtgärd \"$description\" borttagen';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count åtgärd$s borttagen$s';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Det gick inte att ta bort åtgärd';
+
+  @override
+  String get failedToDeleteItems => 'Det gick inte att ta bort objekt';
+
+  @override
+  String get failedToDeleteSomeItems => 'Det gick inte att ta bort vissa objekt';
+
+  @override
+  String get welcomeActionItemsTitle => 'Redo för åtgärder';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Din AI kommer automatiskt att extrahera uppgifter och att-göra-saker från dina konversationer. De kommer att visas här när de skapas.';
+
+  @override
+  String get autoExtractionFeature => 'Automatiskt extraherat från konversationer';
+
+  @override
+  String get editSwipeFeature => 'Tryck för att redigera, svep för att slutföra eller ta bort';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count valda';
+  }
+
+  @override
+  String get selectAll => 'Välj alla';
+
+  @override
+  String get deleteSelected => 'Ta bort valda';
+
+  @override
+  String searchMemories(int count) {
+    return 'Sök $count minnen';
+  }
+
+  @override
+  String get memoryDeleted => 'Minne borttaget.';
+
+  @override
+  String get undo => 'Ångra';
+
+  @override
+  String get noMemoriesYet => 'Inga minnen ännu';
+
+  @override
+  String get noAutoMemories => 'Inga automatiskt extraherade minnen ännu';
+
+  @override
+  String get noManualMemories => 'Inga manuella minnen ännu';
+
+  @override
+  String get noMemoriesInCategories => 'Inga minnen i dessa kategorier';
+
+  @override
+  String get noMemoriesFound => 'Inga minnen hittades';
+
+  @override
+  String get addFirstMemory => 'Lägg till ditt första minne';
+
+  @override
+  String get clearMemoryTitle => 'Rensa Omis minne';
+
+  @override
+  String get clearMemoryMessage => 'Är du säker på att du vill rensa Omis minne? Detta kan inte ångras.';
+
+  @override
+  String get clearMemoryButton => 'Rensa minne';
+
+  @override
+  String get memoryClearedSuccess => 'Omis minne om dig har rensats';
+
+  @override
+  String get noMemoriesToDelete => 'Inga minnen att ta bort';
+
+  @override
+  String get createMemoryTooltip => 'Skapa nytt minne';
+
+  @override
+  String get createActionItemTooltip => 'Skapa ny åtgärd';
+
+  @override
+  String get memoryManagement => 'Minneshantering';
+
+  @override
+  String get filterMemories => 'Filtrera minnen';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Du har $count totala minnen';
+  }
+
+  @override
+  String get publicMemories => 'Offentliga minnen';
+
+  @override
+  String get privateMemories => 'Privata minnen';
+
+  @override
+  String get makeAllPrivate => 'Gör alla minnen privata';
+
+  @override
+  String get makeAllPublic => 'Gör alla minnen offentliga';
+
+  @override
+  String get deleteAllMemories => 'Ta bort alla minnen';
+
+  @override
+  String get allMemoriesPrivateResult => 'Alla minnen är nu privata';
+
+  @override
+  String get allMemoriesPublicResult => 'Alla minnen är nu offentliga';
+
+  @override
+  String get newMemory => 'Nytt minne';
+
+  @override
+  String get editMemory => 'Redigera minne';
+
+  @override
+  String get memoryContentHint => 'Jag gillar att äta glass...';
+
+  @override
+  String get failedToSaveMemory => 'Det gick inte att spara. Kontrollera din anslutning.';
+
+  @override
+  String get saveMemory => 'Spara minne';
+
+  @override
+  String get retry => 'Försök igen';
+
+  @override
+  String get createActionItem => 'Skapa åtgärd';
+
+  @override
+  String get editActionItem => 'Redigera åtgärd';
+
+  @override
+  String get actionItemDescriptionHint => 'Vad behöver göras?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Åtgärdsbeskrivning kan inte vara tom.';
+
+  @override
+  String get actionItemUpdated => 'Åtgärd uppdaterad';
+
+  @override
+  String get failedToUpdateActionItem => 'Det gick inte att uppdatera åtgärd';
+
+  @override
+  String get actionItemCreated => 'Åtgärd skapad';
+
+  @override
+  String get failedToCreateActionItem => 'Det gick inte att skapa åtgärd';
+
+  @override
+  String get dueDate => 'Förfallodatum';
+
+  @override
+  String get time => 'Tid';
+
+  @override
+  String get addDueDate => 'Lägg till förfallodatum';
+
+  @override
+  String get pressDoneToSave => 'Tryck på klar för att spara';
+
+  @override
+  String get pressDoneToCreate => 'Tryck på klar för att skapa';
+
+  @override
+  String get filterAll => 'Alla';
+
+  @override
+  String get filterSystem => 'Om dig';
+
+  @override
+  String get filterInteresting => 'Insikter';
+
+  @override
+  String get filterManual => 'Manuell';
+
+  @override
+  String get completed => 'Slutförd';
+
+  @override
+  String get markComplete => 'Markera som slutförd';
+
+  @override
+  String get actionItemDeleted => 'Åtgärd borttagen';
+
+  @override
+  String get failedToDeleteActionItem => 'Det gick inte att ta bort åtgärd';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Ta bort åtgärd';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Är du säker på att du vill ta bort denna åtgärd?';
+
+  @override
+  String get appLanguage => 'Appspråk';
+
+  @override
+  String get appInterfaceSectionTitle => 'APPGRÄNSSNITT';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'TAL OCH TRANSKRIPTION';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Appspråk ändrar menyer och knappar. Talspråk påverkar hur dina inspelningar transkriberas.';
+}

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -1,0 +1,2218 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Thai (`th`).
+class AppLocalizationsTh extends AppLocalizations {
+  AppLocalizationsTh([String locale = 'th']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'บทสนทนา';
+
+  @override
+  String get transcriptTab => 'บันทึกเสียง';
+
+  @override
+  String get actionItemsTab => 'รายการสิ่งที่ต้องทำ';
+
+  @override
+  String get deleteConversationTitle => 'ลบบทสนทนา?';
+
+  @override
+  String get deleteConversationMessage => 'คุณแน่ใจหรือไม่ว่าต้องการลบบทสนทนานี้? การดำเนินการนี้ไม่สามารถยกเลิกได้';
+
+  @override
+  String get confirm => 'ยืนยัน';
+
+  @override
+  String get cancel => 'ยกเลิก';
+
+  @override
+  String get ok => 'ตกลง';
+
+  @override
+  String get delete => 'ลบ';
+
+  @override
+  String get add => 'เพิ่ม';
+
+  @override
+  String get update => 'อัปเดต';
+
+  @override
+  String get save => 'บันทึก';
+
+  @override
+  String get edit => 'แก้ไข';
+
+  @override
+  String get close => 'ปิด';
+
+  @override
+  String get clear => 'ล้าง';
+
+  @override
+  String get copyTranscript => 'คัดลอกบันทึกเสียง';
+
+  @override
+  String get copySummary => 'คัดลอกสรุป';
+
+  @override
+  String get testPrompt => 'ทดสอบคำสั่ง';
+
+  @override
+  String get reprocessConversation => 'ประมวลผลบทสนทนาใหม่';
+
+  @override
+  String get deleteConversation => 'ลบบทสนทนา';
+
+  @override
+  String get contentCopied => 'คัดลอกเนื้อหาไปยังคลิปบอร์ดแล้ว';
+
+  @override
+  String get failedToUpdateStarred => 'ไม่สามารถอัปเดตสถานะการติดดาวได้';
+
+  @override
+  String get conversationUrlNotShared => 'ไม่สามารถแชร์ URL บทสนทนาได้';
+
+  @override
+  String get errorProcessingConversation => 'เกิดข้อผิดพลาดขณะประมวลผลบทสนทนา กรุณาลองใหม่ภายหลัง';
+
+  @override
+  String get noInternetConnection => 'กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองใหม่อีกครั้ง';
+
+  @override
+  String get unableToDeleteConversation => 'ไม่สามารถลบบทสนทนาได้';
+
+  @override
+  String get somethingWentWrong => 'เกิดข้อผิดพลาดบางอย่าง! กรุณาลองใหม่ภายหลัง';
+
+  @override
+  String get copyErrorMessage => 'คัดลอกข้อความแสดงข้อผิดพลาด';
+
+  @override
+  String get errorCopied => 'คัดลอกข้อความแสดงข้อผิดพลาดไปยังคลิปบอร์ดแล้ว';
+
+  @override
+  String get remaining => 'เหลืออยู่';
+
+  @override
+  String get loading => 'กำลังโหลด...';
+
+  @override
+  String get loadingDuration => 'กำลังโหลดระยะเวลา...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count วินาที';
+  }
+
+  @override
+  String get people => 'บุคคล';
+
+  @override
+  String get addNewPerson => 'เพิ่มบุคคลใหม่';
+
+  @override
+  String get editPerson => 'แก้ไขบุคคล';
+
+  @override
+  String get createPersonHint => 'สร้างบุคคลใหม่และฝึก Omi ให้รู้จักเสียงพูดของพวกเขาด้วย!';
+
+  @override
+  String get speechProfile => 'โปรไฟล์การพูด';
+
+  @override
+  String sampleNumber(int number) {
+    return 'ตัวอย่างที่ $number';
+  }
+
+  @override
+  String get settings => 'การตั้งค่า';
+
+  @override
+  String get language => 'ภาษา';
+
+  @override
+  String get selectLanguage => 'เลือกภาษา';
+
+  @override
+  String get deleting => 'กำลังลบ...';
+
+  @override
+  String get pleaseCompleteAuthentication => 'กรุณายืนยันตัวตนในเบราว์เซอร์ของคุณ เมื่อเสร็จแล้วกลับมาที่แอป';
+
+  @override
+  String get failedToStartAuthentication => 'ไม่สามารถเริ่มการยืนยันตัวตนได้';
+
+  @override
+  String get importStarted => 'เริ่มการนำเข้าแล้ว! คุณจะได้รับการแจ้งเตือนเมื่อเสร็จสิ้น';
+
+  @override
+  String get failedToStartImport => 'ไม่สามารถเริ่มการนำเข้าได้ กรุณาลองใหม่อีกครั้ง';
+
+  @override
+  String get couldNotAccessFile => 'ไม่สามารถเข้าถึงไฟล์ที่เลือกได้';
+
+  @override
+  String get askOmi => 'ถาม Omi';
+
+  @override
+  String get done => 'เสร็จสิ้น';
+
+  @override
+  String get disconnected => 'ตัดการเชื่อมต่อแล้ว';
+
+  @override
+  String get searching => 'กำลังค้นหา';
+
+  @override
+  String get connectDevice => 'เชื่อมต่ออุปกรณ์';
+
+  @override
+  String get monthlyLimitReached => 'คุณถึงขีดจำกัดรายเดือนแล้ว';
+
+  @override
+  String get checkUsage => 'ตรวจสอบการใช้งาน';
+
+  @override
+  String get syncingRecordings => 'กำลังซิงค์การบันทึก';
+
+  @override
+  String get recordingsToSync => 'การบันทึกที่ต้องซิงค์';
+
+  @override
+  String get allCaughtUp => 'ทำทุกอย่างเรียบร้อยแล้ว';
+
+  @override
+  String get sync => 'ซิงค์';
+
+  @override
+  String get pendantUpToDate => 'จี้อัปเดตแล้ว';
+
+  @override
+  String get allRecordingsSynced => 'ซิงค์การบันทึกทั้งหมดแล้ว';
+
+  @override
+  String get syncingInProgress => 'กำลังดำเนินการซิงค์';
+
+  @override
+  String get readyToSync => 'พร้อมซิงค์';
+
+  @override
+  String get tapSyncToStart => 'แตะซิงค์เพื่อเริ่มต้น';
+
+  @override
+  String get pendantNotConnected => 'ไม่ได้เชื่อมต่อจี้ เชื่อมต่อเพื่อซิงค์';
+
+  @override
+  String get everythingSynced => 'ซิงค์ทุกอย่างเรียบร้อยแล้ว';
+
+  @override
+  String get recordingsNotSynced => 'คุณมีการบันทึกที่ยังไม่ได้ซิงค์';
+
+  @override
+  String get syncingBackground => 'เราจะซิงค์การบันทึกของคุณต่อในเบื้องหลัง';
+
+  @override
+  String get noConversationsYet => 'ยังไม่มีบทสนทนา';
+
+  @override
+  String get noStarredConversations => 'ยังไม่มีบทสนทนาที่ติดดาว';
+
+  @override
+  String get starConversationHint => 'หากต้องการติดดาวบทสนทนา ให้เปิดและแตะไอคอนดาวในส่วนหัว';
+
+  @override
+  String get searchConversations => 'ค้นหาบทสนทนา';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return 'เลือก $count รายการ';
+  }
+
+  @override
+  String get merge => 'รวม';
+
+  @override
+  String get mergeConversations => 'รวมบทสนทนา';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'นี่จะรวม $count บทสนทนาเป็นหนึ่งเดียว เนื้อหาทั้งหมดจะถูกรวมและสร้างใหม่';
+  }
+
+  @override
+  String get mergingInBackground => 'กำลังรวมในเบื้องหลัง อาจใช้เวลาสักครู่';
+
+  @override
+  String get failedToStartMerge => 'ไม่สามารถเริ่มการรวมได้';
+
+  @override
+  String get askAnything => 'ถามอะไรก็ได้';
+
+  @override
+  String get noMessagesYet => 'ยังไม่มีข้อความ!\nลองเริ่มบทสนทนาสิ';
+
+  @override
+  String get deletingMessages => 'กำลังลบข้อความของคุณจากความทรงจำของ Omi...';
+
+  @override
+  String get messageCopied => 'คัดลอกข้อความไปยังคลิปบอร์ดแล้ว';
+
+  @override
+  String get cannotReportOwnMessage => 'คุณไม่สามารถรายงานข้อความของตัวเองได้';
+
+  @override
+  String get reportMessage => 'รายงานข้อความ';
+
+  @override
+  String get reportMessageConfirm => 'คุณแน่ใจหรือไม่ว่าต้องการรายงานข้อความนี้?';
+
+  @override
+  String get messageReported => 'รายงานข้อความสำเร็จแล้ว';
+
+  @override
+  String get thankYouFeedback => 'ขอบคุณสำหรับคำติชมของคุณ!';
+
+  @override
+  String get clearChat => 'ล้างแชท?';
+
+  @override
+  String get clearChatConfirm => 'คุณแน่ใจหรือไม่ว่าต้องการล้างแชท? การดำเนินการนี้ไม่สามารถยกเลิกได้';
+
+  @override
+  String get maxFilesLimit => 'คุณสามารถอัปโหลดได้เพียง 4 ไฟล์ในคราวเดียว';
+
+  @override
+  String get chatWithOmi => 'แชทกับ Omi';
+
+  @override
+  String get apps => 'แอป';
+
+  @override
+  String get noAppsFound => 'ไม่พบแอป';
+
+  @override
+  String get tryAdjustingSearch => 'ลองปรับการค้นหาหรือตัวกรองของคุณ';
+
+  @override
+  String get createYourOwnApp => 'สร้างแอปของคุณเอง';
+
+  @override
+  String get buildAndShareApp => 'สร้างและแชร์แอปที่คุณกำหนดเอง';
+
+  @override
+  String get searchApps => 'ค้นหา 1,500+ แอป';
+
+  @override
+  String get myApps => 'แอปของฉัน';
+
+  @override
+  String get installedApps => 'แอปที่ติดตั้ง';
+
+  @override
+  String get unableToFetchApps =>
+      'ไม่สามารถดึงข้อมูลแอปได้ :(\n\nกรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองใหม่อีกครั้ง';
+
+  @override
+  String get aboutOmi => 'เกี่ยวกับ Omi';
+
+  @override
+  String get privacyPolicy => 'นโยบายความเป็นส่วนตัว';
+
+  @override
+  String get visitWebsite => 'เยี่ยมชมเว็บไซต์';
+
+  @override
+  String get helpOrInquiries => 'ต้องการความช่วยเหลือหรือสอบถามข้อมูล?';
+
+  @override
+  String get joinCommunity => 'เข้าร่วมชุมชน!';
+
+  @override
+  String get membersAndCounting => 'สมาชิก 8,000+ คนและกำลังเพิ่มขึ้น';
+
+  @override
+  String get deleteAccountTitle => 'ลบบัญชี';
+
+  @override
+  String get deleteAccountConfirm => 'คุณแน่ใจหรือไม่ว่าต้องการลบบัญชีของคุณ?';
+
+  @override
+  String get cannotBeUndone => 'การกระทำนี้ไม่สามารถยกเลิกได้';
+
+  @override
+  String get allDataErased => 'ความทรงจำและบทสนทนาทั้งหมดของคุณจะถูกลบอย่างถาวร';
+
+  @override
+  String get appsDisconnected => 'แอปและการเชื่อมต่อของคุณจะถูกตัดการเชื่อมต่อทันที';
+
+  @override
+  String get exportBeforeDelete => 'คุณสามารถส่งออกข้อมูลของคุณก่อนลบบัญชี แต่เมื่อลบแล้วจะไม่สามารถกู้คืนได้';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'ฉันเข้าใจว่าการลบบัญชีของฉันเป็นการถาวรและข้อมูลทั้งหมด รวมถึงความทรงจำและบทสนทนา จะสูญหายและไม่สามารถกู้คืนได้';
+
+  @override
+  String get areYouSure => 'คุณแน่ใจหรือไม่?';
+
+  @override
+  String get deleteAccountFinal =>
+      'การดำเนินการนี้ไม่สามารถย้อนกลับได้และจะลบบัญชีของคุณและข้อมูลที่เกี่ยวข้องทั้งหมดอย่างถาวร คุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?';
+
+  @override
+  String get deleteNow => 'ลบเลย';
+
+  @override
+  String get goBack => 'กลับ';
+
+  @override
+  String get checkBoxToConfirm =>
+      'กาเครื่องหมายในช่องเพื่อยืนยันว่าคุณเข้าใจว่าการลบบัญชีของคุณเป็นการถาวรและไม่สามารถย้อนกลับได้';
+
+  @override
+  String get profile => 'โปรไฟล์';
+
+  @override
+  String get name => 'ชื่อ';
+
+  @override
+  String get email => 'อีเมล';
+
+  @override
+  String get customVocabulary => 'คำศัพท์ที่กำหนดเอง';
+
+  @override
+  String get identifyingOthers => 'การระบุบุคคลอื่น';
+
+  @override
+  String get paymentMethods => 'วิธีการชำระเงิน';
+
+  @override
+  String get conversationDisplay => 'การแสดงผลบทสนทนา';
+
+  @override
+  String get dataPrivacy => 'ข้อมูลและความเป็นส่วนตัว';
+
+  @override
+  String get userId => 'รหัสผู้ใช้';
+
+  @override
+  String get notSet => 'ยังไม่ได้ตั้งค่า';
+
+  @override
+  String get userIdCopied => 'คัดลอกรหัสผู้ใช้ไปยังคลิปบอร์ดแล้ว';
+
+  @override
+  String get systemDefault => 'ค่าเริ่มต้นของระบบ';
+
+  @override
+  String get planAndUsage => 'แผนและการใช้งาน';
+
+  @override
+  String get offlineSync => 'ซิงค์แบบออฟไลน์';
+
+  @override
+  String get deviceSettings => 'การตั้งค่าอุปกรณ์';
+
+  @override
+  String get chatTools => 'เครื่องมือแชท';
+
+  @override
+  String get feedbackBug => 'คำติชม / รายงานข้อผิดพลาด';
+
+  @override
+  String get helpCenter => 'ศูนย์ช่วยเหลือ';
+
+  @override
+  String get developerSettings => 'การตั้งค่านักพัฒนา';
+
+  @override
+  String get getOmiForMac => 'ดาวน์โหลด Omi สำหรับ Mac';
+
+  @override
+  String get referralProgram => 'โปรแกรมแนะนำเพื่อน';
+
+  @override
+  String get signOut => 'ออกจากระบบ';
+
+  @override
+  String get appAndDeviceCopied => 'คัดลอกรายละเอียดแอปและอุปกรณ์แล้ว';
+
+  @override
+  String get wrapped2025 => 'สรุปปี 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'ความเป็นส่วนตัวของคุณ อยู่ในการควบคุมของคุณ';
+
+  @override
+  String get privacyIntro =>
+      'ที่ Omi เรามุ่งมั่นในการปกป้องความเป็นส่วนตัวของคุณ หน้านี้ช่วยให้คุณสามารถควบคุมวิธีการจัดเก็บและใช้ข้อมูลของคุณได้';
+
+  @override
+  String get learnMore => 'เรียนรู้เพิ่มเติม...';
+
+  @override
+  String get dataProtectionLevel => 'ระดับการปกป้องข้อมูล';
+
+  @override
+  String get dataProtectionDesc =>
+      'ข้อมูลของคุณได้รับการรักษาความปลอดภัยโดยค่าเริ่มต้นด้วยการเข้ารหัสที่แข็งแกร่ง ตรวจสอบการตั้งค่าและตัวเลือกความเป็นส่วนตัวในอนาคตด้านล่าง';
+
+  @override
+  String get appAccess => 'การเข้าถึงแอป';
+
+  @override
+  String get appAccessDesc => 'แอปต่อไปนี้สามารถเข้าถึงข้อมูลของคุณได้ แตะที่แอปเพื่อจัดการสิทธิ์';
+
+  @override
+  String get noAppsExternalAccess => 'ไม่มีแอปที่ติดตั้งซึ่งมีการเข้าถึงข้อมูลของคุณจากภายนอก';
+
+  @override
+  String get deviceName => 'ชื่ออุปกรณ์';
+
+  @override
+  String get deviceId => 'รหัสอุปกรณ์';
+
+  @override
+  String get firmware => 'เฟิร์มแวร์';
+
+  @override
+  String get sdCardSync => 'ซิงค์การ์ด SD';
+
+  @override
+  String get hardwareRevision => 'เวอร์ชันฮาร์ดแวร์';
+
+  @override
+  String get modelNumber => 'หมายเลขรุ่น';
+
+  @override
+  String get manufacturer => 'ผู้ผลิต';
+
+  @override
+  String get doubleTap => 'แตะสองครั้ง';
+
+  @override
+  String get ledBrightness => 'ความสว่าง LED';
+
+  @override
+  String get micGain => 'ระดับไมโครโฟน';
+
+  @override
+  String get disconnect => 'ตัดการเชื่อมต่อ';
+
+  @override
+  String get forgetDevice => 'ลืมอุปกรณ์';
+
+  @override
+  String get chargingIssues => 'ปัญหาการชาร์จ';
+
+  @override
+  String get disconnectDevice => 'ตัดการเชื่อมต่ออุปกรณ์';
+
+  @override
+  String get unpairDevice => 'ยกเลิกการจับคู่อุปกรณ์';
+
+  @override
+  String get unpairAndForget => 'ยกเลิกการจับคู่และลืมอุปกรณ์';
+
+  @override
+  String get deviceDisconnectedMessage => 'Omi ของคุณถูกตัดการเชื่อมต่อแล้ว 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'ยกเลิกการจับคู่อุปกรณ์แล้ว ไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำการยกเลิกการจับคู่ให้เสร็จสมบูรณ์';
+
+  @override
+  String get unpairDialogTitle => 'ยกเลิกการจับคู่อุปกรณ์';
+
+  @override
+  String get unpairDialogMessage =>
+      'นี่จะยกเลิกการจับคู่อุปกรณ์เพื่อให้สามารถเชื่อมต่อกับโทรศัพท์เครื่องอื่นได้ คุณจะต้องไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำกระบวนการให้เสร็จสมบูรณ์';
+
+  @override
+  String get deviceNotConnected => 'ไม่ได้เชื่อมต่ออุปกรณ์';
+
+  @override
+  String get connectDeviceMessage => 'เชื่อมต่ออุปกรณ์ Omi ของคุณเพื่อเข้าถึง\nการตั้งค่าและการปรับแต่งอุปกรณ์';
+
+  @override
+  String get deviceInfoSection => 'ข้อมูลอุปกรณ์';
+
+  @override
+  String get customizationSection => 'การปรับแต่ง';
+
+  @override
+  String get hardwareSection => 'ฮาร์ดแวร์';
+
+  @override
+  String get v2Undetected => 'ไม่พบ V2';
+
+  @override
+  String get v2UndetectedMessage =>
+      'เราเห็นว่าคุณมีอุปกรณ์ V1 หรืออุปกรณ์ของคุณไม่ได้เชื่อมต่อ ฟังก์ชัน SD Card จะใช้ได้เฉพาะกับอุปกรณ์ V2 เท่านั้น';
+
+  @override
+  String get endConversation => 'จบบทสนทนา';
+
+  @override
+  String get pauseResume => 'หยุดชั่วคราว/ดำเนินการต่อ';
+
+  @override
+  String get starConversation => 'ติดดาวบทสนทนา';
+
+  @override
+  String get doubleTapAction => 'การดำเนินการแตะสองครั้ง';
+
+  @override
+  String get endAndProcess => 'จบและประมวลผลบทสนทนา';
+
+  @override
+  String get pauseResumeRecording => 'หยุดชั่วคราว/ดำเนินการบันทึกต่อ';
+
+  @override
+  String get starOngoing => 'ติดดาวบทสนทนาที่กำลังดำเนินการ';
+
+  @override
+  String get off => 'ปิด';
+
+  @override
+  String get max => 'สูงสุด';
+
+  @override
+  String get mute => 'ปิดเสียง';
+
+  @override
+  String get quiet => 'เงียบ';
+
+  @override
+  String get normal => 'ปกติ';
+
+  @override
+  String get high => 'สูง';
+
+  @override
+  String get micGainDescMuted => 'ไมโครโฟนถูกปิดเสียง';
+
+  @override
+  String get micGainDescLow => 'เงียบมาก - สำหรับสภาพแวดล้อมที่เสียงดัง';
+
+  @override
+  String get micGainDescModerate => 'เงียบ - สำหรับเสียงรบกวนปานกลาง';
+
+  @override
+  String get micGainDescNeutral => 'กลางๆ - การบันทึกที่สมดุล';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'เพิ่มขึ้นเล็กน้อย - การใช้งานปกติ';
+
+  @override
+  String get micGainDescBoosted => 'เพิ่มขึ้น - สำหรับสภาพแวดล้อมที่เงียบ';
+
+  @override
+  String get micGainDescHigh => 'สูง - สำหรับเสียงที่ไกลหรือเบา';
+
+  @override
+  String get micGainDescVeryHigh => 'สูงมาก - สำหรับแหล่งเสียงที่เงียบมาก';
+
+  @override
+  String get micGainDescMax => 'สูงสุด - ใช้ด้วยความระมัดระวัง';
+
+  @override
+  String get developerSettingsTitle => 'การตั้งค่านักพัฒนา';
+
+  @override
+  String get saving => 'กำลังบันทึก...';
+
+  @override
+  String get personaConfig => 'กำหนดค่าบุคลิก AI ของคุณ';
+
+  @override
+  String get beta => 'เบต้า';
+
+  @override
+  String get transcription => 'การถอดเสียง';
+
+  @override
+  String get transcriptionConfig => 'กำหนดค่าผู้ให้บริการ STT';
+
+  @override
+  String get conversationTimeout => 'หมดเวลาบทสนทนา';
+
+  @override
+  String get conversationTimeoutConfig => 'ตั้งค่าเมื่อบทสนทนาจะจบอัตโนมัติ';
+
+  @override
+  String get importData => 'นำเข้าข้อมูล';
+
+  @override
+  String get importDataConfig => 'นำเข้าข้อมูลจากแหล่งอื่น';
+
+  @override
+  String get debugDiagnostics => 'การแก้ไขจุดบกพร่องและการวินิจฉัย';
+
+  @override
+  String get endpointUrl => 'URL ปลายทาง';
+
+  @override
+  String get noApiKeys => 'ยังไม่มีคีย์ API';
+
+  @override
+  String get createKeyToStart => 'สร้างคีย์เพื่อเริ่มต้น';
+
+  @override
+  String get createKey => 'สร้างคีย์';
+
+  @override
+  String get docs => 'เอกสาร';
+
+  @override
+  String get yourOmiInsights => 'ข้อมูลเชิงลึก Omi ของคุณ';
+
+  @override
+  String get today => 'วันนี้';
+
+  @override
+  String get thisMonth => 'เดือนนี้';
+
+  @override
+  String get thisYear => 'ปีนี้';
+
+  @override
+  String get allTime => 'ตลอดเวลา';
+
+  @override
+  String get noActivityYet => 'ยังไม่มีกิจกรรม';
+
+  @override
+  String get startConversationToSeeInsights => 'เริ่มบทสนทนากับ Omi\nเพื่อดูข้อมูลเชิงลึกการใช้งานของคุณที่นี่';
+
+  @override
+  String get listening => 'การฟัง';
+
+  @override
+  String get listeningSubtitle => 'เวลารวมที่ Omi ฟังอย่างกระตือรือร้น';
+
+  @override
+  String get understanding => 'การเข้าใจ';
+
+  @override
+  String get understandingSubtitle => 'คำที่เข้าใจจากบทสนทนาของคุณ';
+
+  @override
+  String get providing => 'การให้บริการ';
+
+  @override
+  String get providingSubtitle => 'รายการสิ่งที่ต้องทำและบันทึกที่จับได้โดยอัตโนมัติ';
+
+  @override
+  String get remembering => 'การจดจำ';
+
+  @override
+  String get rememberingSubtitle => 'ข้อเท็จจริงและรายละเอียดที่จำไว้ให้คุณ';
+
+  @override
+  String get unlimitedPlan => 'แผนไม่จำกัด';
+
+  @override
+  String get managePlan => 'จัดการแผน';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'แผนของคุณจะยกเลิกในวันที่ $date';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'แผนของคุณจะต่ออายุในวันที่ $date';
+  }
+
+  @override
+  String get basicPlan => 'แผนฟรี';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return 'ใช้ไป $used จาก $limit นาที';
+  }
+
+  @override
+  String get upgrade => 'อัปเกรด';
+
+  @override
+  String get upgradeToUnlimited => 'อัปเกรดเป็นแบบไม่จำกัด';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'แผนของคุณรวม $limit นาทีฟรีต่อเดือน อัปเกรดเพื่อใช้งานแบบไม่จำกัด';
+  }
+
+  @override
+  String get shareStatsMessage => 'แชร์สถิติ Omi ของฉัน! (omi.me - ผู้ช่วย AI ที่เปิดอยู่ตลอดเวลา)';
+
+  @override
+  String get sharePeriodToday => 'วันนี้ omi ได้:';
+
+  @override
+  String get sharePeriodMonth => 'เดือนนี้ omi ได้:';
+
+  @override
+  String get sharePeriodYear => 'ปีนี้ omi ได้:';
+
+  @override
+  String get sharePeriodAllTime => 'จนถึงตอนนี้ omi ได้:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 ฟังเป็นเวลา $minutes นาที';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 เข้าใจ $words คำ';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ ให้ข้อมูลเชิงลึก $count รายการ';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 จำความทรงจำ $count รายการ';
+  }
+
+  @override
+  String get debugLogs => 'บันทึกการแก้ไขจุดบกพร่อง';
+
+  @override
+  String get debugLogsAutoDelete => 'ลบอัตโนมัติหลังจาก 3 วัน';
+
+  @override
+  String get debugLogsDesc => 'ช่วยวินิจฉัยปัญหา';
+
+  @override
+  String get noLogFilesFound => 'ไม่พบไฟล์บันทึก';
+
+  @override
+  String get omiDebugLog => 'บันทึกการแก้ไขจุดบกพร่อง Omi';
+
+  @override
+  String get logShared => 'แชร์บันทึกแล้ว';
+
+  @override
+  String get selectLogFile => 'เลือกไฟล์บันทึก';
+
+  @override
+  String get shareLogs => 'แชร์บันทึก';
+
+  @override
+  String get debugLogCleared => 'ล้างบันทึกการแก้ไขจุดบกพร่องแล้ว';
+
+  @override
+  String get exportStarted => 'เริ่มการส่งออกแล้ว อาจใช้เวลาสักครู่...';
+
+  @override
+  String get exportAllData => 'ส่งออกข้อมูลทั้งหมด';
+
+  @override
+  String get exportDataDesc => 'ส่งออกบทสนทนาเป็นไฟล์ JSON';
+
+  @override
+  String get exportedConversations => 'บทสนทนาที่ส่งออกจาก Omi';
+
+  @override
+  String get exportShared => 'แชร์การส่งออกแล้ว';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'ลบกราฟความรู้?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'นี่จะลบข้อมูลกราฟความรู้ที่สร้างขึ้นทั้งหมด (โหนดและการเชื่อมต่อ) ความทรงจำเดิมของคุณจะยังคงปลอดภัย กราฟจะถูกสร้างขึ้นใหม่เมื่อเวลาผ่านไปหรือเมื่อมีคำขอครั้งถัดไป';
+
+  @override
+  String get knowledgeGraphDeleted => 'ลบกราฟความรู้สำเร็จแล้ว';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'ไม่สามารถลบกราฟ: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'ลบกราฟความรู้';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'ล้างโหนดและการเชื่อมต่อทั้งหมด';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'เซิร์ฟเวอร์ MCP';
+
+  @override
+  String get mcpServerDesc => 'เชื่อมต่อผู้ช่วย AI กับข้อมูลของคุณ';
+
+  @override
+  String get serverUrl => 'URL เซิร์ฟเวอร์';
+
+  @override
+  String get urlCopied => 'คัดลอก URL แล้ว';
+
+  @override
+  String get apiKeyAuth => 'การยืนยันตัวตนด้วยคีย์ API';
+
+  @override
+  String get header => 'ส่วนหัว';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Client ID';
+
+  @override
+  String get clientSecret => 'Client Secret';
+
+  @override
+  String get useMcpApiKey => 'ใช้คีย์ API MCP ของคุณ';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'เหตุการณ์บทสนทนา';
+
+  @override
+  String get newConversationCreated => 'สร้างบทสนทนาใหม่แล้ว';
+
+  @override
+  String get realtimeTranscript => 'บันทึกเสียงแบบเรียลไทม์';
+
+  @override
+  String get transcriptReceived => 'ได้รับบันทึกเสียงแล้ว';
+
+  @override
+  String get audioBytes => 'ไบต์เสียง';
+
+  @override
+  String get audioDataReceived => 'ได้รับข้อมูลเสียงแล้ว';
+
+  @override
+  String get intervalSeconds => 'ช่วงเวลา (วินาที)';
+
+  @override
+  String get daySummary => 'สรุปรายวัน';
+
+  @override
+  String get summaryGenerated => 'สร้างสรุปแล้ว';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'เพิ่มไปยัง claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'คัดลอกการกำหนดค่า';
+
+  @override
+  String get configCopied => 'คัดลอกการกำหนดค่าไปยังคลิปบอร์ดแล้ว';
+
+  @override
+  String get listeningMins => 'การฟัง (นาที)';
+
+  @override
+  String get understandingWords => 'การเข้าใจ (คำ)';
+
+  @override
+  String get insights => 'ข้อมูลเชิงลึก';
+
+  @override
+  String get memories => 'ความทรงจำ';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return 'ใช้ไป $used จาก $limit นาทีในเดือนนี้';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return 'ใช้ไป $used จาก $limit คำในเดือนนี้';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return 'ได้รับข้อมูลเชิงลึก $used จาก $limit รายการในเดือนนี้';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return 'สร้างความทรงจำ $used จาก $limit รายการในเดือนนี้';
+  }
+
+  @override
+  String get visibility => 'การมองเห็น';
+
+  @override
+  String get visibilitySubtitle => 'ควบคุมว่าบทสนทนาใดจะปรากฏในรายการของคุณ';
+
+  @override
+  String get showShortConversations => 'แสดงบทสนทนาสั้น';
+
+  @override
+  String get showShortConversationsDesc => 'แสดงบทสนทนาที่สั้นกว่าเกณฑ์';
+
+  @override
+  String get showDiscardedConversations => 'แสดงบทสนทนาที่ถูกทิ้ง';
+
+  @override
+  String get showDiscardedConversationsDesc => 'รวมบทสนทนาที่ถูกทำเครื่องหมายว่าทิ้ง';
+
+  @override
+  String get shortConversationThreshold => 'เกณฑ์บทสนทนาสั้น';
+
+  @override
+  String get shortConversationThresholdSubtitle => 'บทสนทนาที่สั้นกว่านี้จะถูกซ่อนเว้นแต่จะเปิดใช้งานด้านบน';
+
+  @override
+  String get durationThreshold => 'เกณฑ์ระยะเวลา';
+
+  @override
+  String get durationThresholdDesc => 'ซ่อนบทสนทนาที่สั้นกว่านี้';
+
+  @override
+  String minLabel(int count) {
+    return '$count นาที';
+  }
+
+  @override
+  String get customVocabularyTitle => 'คำศัพท์ที่กำหนดเอง';
+
+  @override
+  String get addWords => 'เพิ่มคำ';
+
+  @override
+  String get addWordsDesc => 'ชื่อ คำศัพท์ หรือคำที่ไม่ธรรมดา';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'เชื่อมต่อ';
+
+  @override
+  String get comingSoon => 'เร็วๆ นี้';
+
+  @override
+  String get chatToolsFooter => 'เชื่อมต่อแอปของคุณเพื่อดูข้อมูลและตัวชี้วัดในแชท';
+
+  @override
+  String get completeAuthInBrowser => 'กรุณายืนยันตัวตนในเบราว์เซอร์ของคุณ เมื่อเสร็จแล้วกลับมาที่แอป';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'ไม่สามารถเริ่มการยืนยันตัวตน $appName ได้';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'ตัดการเชื่อมต่อ $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'คุณแน่ใจหรือไม่ว่าต้องการตัดการเชื่อมต่อจาก $appName? คุณสามารถเชื่อมต่อใหม่ได้ตลอดเวลา';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'ตัดการเชื่อมต่อจาก $appName แล้ว';
+  }
+
+  @override
+  String get failedToDisconnect => 'ตัดการเชื่อมต่อไม่สำเร็จ';
+
+  @override
+  String connectTo(String appName) {
+    return 'เชื่อมต่อกับ $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'คุณต้องอนุญาตให้ Omi เข้าถึงข้อมูล $appName ของคุณ ระบบจะเปิดเบราว์เซอร์เพื่อยืนยันตัวตน';
+  }
+
+  @override
+  String get continueAction => 'ดำเนินการต่อ';
+
+  @override
+  String get languageTitle => 'ภาษา';
+
+  @override
+  String get primaryLanguage => 'ภาษาหลัก';
+
+  @override
+  String get automaticTranslation => 'แปลภาษาอัตโนมัติ';
+
+  @override
+  String get detectLanguages => 'ตรวจจับมากกว่า 10 ภาษา';
+
+  @override
+  String get authorizeSavingRecordings => 'อนุญาตให้บันทึกการอัด';
+
+  @override
+  String get thanksForAuthorizing => 'ขอบคุณสำหรับการอนุญาต!';
+
+  @override
+  String get needYourPermission => 'เราต้องการความยินยอมจากคุณ';
+
+  @override
+  String get alreadyGavePermission => 'คุณได้อนุญาตให้เราบันทึกการอัดของคุณแล้ว นี่คือเหตุผลที่เราต้องการ:';
+
+  @override
+  String get wouldLikePermission => 'เราต้องการความยินยอมในการบันทึกเสียงของคุณ นี่คือเหตุผล:';
+
+  @override
+  String get improveSpeechProfile => 'ปรับปรุงโปรไฟล์เสียงของคุณ';
+
+  @override
+  String get improveSpeechProfileDesc => 'เราใช้การบันทึกเพื่อฝึกและปรับปรุงโปรไฟล์เสียงส่วนบุคคลของคุณ';
+
+  @override
+  String get trainFamilyProfiles => 'ฝึกโปรไฟล์สำหรับเพื่อนและครอบครัว';
+
+  @override
+  String get trainFamilyProfilesDesc => 'การบันทึกของคุณช่วยให้เราจดจำและสร้างโปรไฟล์สำหรับเพื่อนและครอบครัวของคุณ';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'เพิ่มความแม่นยำของการถอดเสียง';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'เมื่อโมเดลของเราดีขึ้น เราสามารถให้ผลการถอดเสียงที่ดีขึ้นสำหรับการบันทึกของคุณ';
+
+  @override
+  String get legalNotice =>
+      'ประกาศทางกฎหมาย: ความถูกต้องตามกฎหมายในการบันทึกและจัดเก็บข้อมูลเสียงอาจแตกต่างกันไปตามสถานที่และวิธีที่คุณใช้ฟีเจอร์นี้ เป็นความรับผิดชอบของคุณที่จะต้องปฏิบัติตามกฎหมายและข้อบังคับในพื้นที่';
+
+  @override
+  String get alreadyAuthorized => 'อนุญาตแล้ว';
+
+  @override
+  String get authorize => 'อนุญาต';
+
+  @override
+  String get revokeAuthorization => 'เพิกถอนการอนุญาต';
+
+  @override
+  String get authorizationSuccessful => 'อนุญาตสำเร็จ!';
+
+  @override
+  String get failedToAuthorize => 'อนุญาตไม่สำเร็จ กรุณาลองอีกครั้ง';
+
+  @override
+  String get authorizationRevoked => 'เพิกถอนการอนุญาตแล้ว';
+
+  @override
+  String get recordingsDeleted => 'ลบการบันทึกแล้ว';
+
+  @override
+  String get failedToRevoke => 'เพิกถอนการอนุญาตไม่สำเร็จ กรุณาลองอีกครั้ง';
+
+  @override
+  String get permissionRevokedTitle => 'เพิกถอนการอนุญาต';
+
+  @override
+  String get permissionRevokedMessage => 'คุณต้องการให้เราลบการบันทึกที่มีอยู่ทั้งหมดของคุณด้วยหรือไม่?';
+
+  @override
+  String get yes => 'ใช่';
+
+  @override
+  String get editName => 'แก้ไขชื่อ';
+
+  @override
+  String get howShouldOmiCallYou => 'Omi ควรเรียกคุณว่าอะไร?';
+
+  @override
+  String get enterYourName => 'ใส่ชื่อของคุณ';
+
+  @override
+  String get nameCannotBeEmpty => 'ชื่อต้องไม่ว่างเปล่า';
+
+  @override
+  String get nameUpdatedSuccessfully => 'อัปเดตชื่อสำเร็จ!';
+
+  @override
+  String get calendarSettings => 'การตั้งค่าปฏิทิน';
+
+  @override
+  String get calendarProviders => 'ผู้ให้บริการปฏิทิน';
+
+  @override
+  String get macOsCalendar => 'ปฏิทิน macOS';
+
+  @override
+  String get connectMacOsCalendar => 'เชื่อมต่อปฏิทิน macOS ในเครื่องของคุณ';
+
+  @override
+  String get googleCalendar => 'ปฏิทิน Google';
+
+  @override
+  String get syncGoogleAccount => 'ซิงค์กับบัญชี Google ของคุณ';
+
+  @override
+  String get showMeetingsMenuBar => 'แสดงการประชุมที่กำลังจะมาถึงในแถบเมนู';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'แสดงการประชุมถัดไปและเวลาที่เหลือก่อนเริ่มในแถบเมนู macOS';
+
+  @override
+  String get showEventsNoParticipants => 'แสดงกิจกรรมที่ไม่มีผู้เข้าร่วม';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'เมื่อเปิดใช้งาน Coming Up จะแสดงกิจกรรมที่ไม่มีผู้เข้าร่วมหรือลิงก์วิดีโอ';
+
+  @override
+  String get yourMeetings => 'การประชุมของคุณ';
+
+  @override
+  String get refresh => 'รีเฟรช';
+
+  @override
+  String get noUpcomingMeetings => 'ไม่พบการประชุมที่กำลังจะมาถึง';
+
+  @override
+  String get checkingNextDays => 'ตรวจสอบ 30 วันถัดไป';
+
+  @override
+  String get tomorrow => 'พรุ่งนี้';
+
+  @override
+  String get googleCalendarComingSoon => 'การผสานรวมปฏิทิน Google เร็วๆ นี้!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'เชื่อมต่อในชื่อผู้ใช้: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'พื้นที่ทำงานเริ่มต้น';
+
+  @override
+  String get tasksCreatedInWorkspace => 'งานจะถูกสร้างในพื้นที่ทำงานนี้';
+
+  @override
+  String get defaultProjectOptional => 'โปรเจกต์เริ่มต้น (ไม่บังคับ)';
+
+  @override
+  String get leaveUnselectedTasks => 'เว้นว่างไว้เพื่อสร้างงานโดยไม่มีโปรเจกต์';
+
+  @override
+  String get noProjectsInWorkspace => 'ไม่พบโปรเจกต์ในพื้นที่ทำงานนี้';
+
+  @override
+  String get conversationTimeoutDesc => 'เลือกระยะเวลาที่จะรอในความเงียบก่อนสิ้นสุดบทสนทนาอัตโนมัติ:';
+
+  @override
+  String get timeout2Minutes => '2 นาที';
+
+  @override
+  String get timeout2MinutesDesc => 'สิ้นสุดบทสนทนาหลังจากเงียบ 2 นาที';
+
+  @override
+  String get timeout5Minutes => '5 นาที';
+
+  @override
+  String get timeout5MinutesDesc => 'สิ้นสุดบทสนทนาหลังจากเงียบ 5 นาที';
+
+  @override
+  String get timeout10Minutes => '10 นาที';
+
+  @override
+  String get timeout10MinutesDesc => 'สิ้นสุดบทสนทนาหลังจากเงียบ 10 นาที';
+
+  @override
+  String get timeout30Minutes => '30 นาที';
+
+  @override
+  String get timeout30MinutesDesc => 'สิ้นสุดบทสนทนาหลังจากเงียบ 30 นาที';
+
+  @override
+  String get timeout4Hours => '4 ชั่วโมง';
+
+  @override
+  String get timeout4HoursDesc => 'สิ้นสุดบทสนทนาหลังจากเงียบ 4 ชั่วโมง';
+
+  @override
+  String get conversationEndAfterHours => 'บทสนทนาจะสิ้นสุดหลังจากเงียบ 4 ชั่วโมง';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'บทสนทนาจะสิ้นสุดหลังจากเงียบ $minutes นาที';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'บอกเราถึงภาษาหลักของคุณ';
+
+  @override
+  String get languageForTranscription => 'ตั้งค่าภาษาของคุณเพื่อการถอดเสียงที่แม่นยำขึ้นและประสบการณ์ที่เป็นส่วนตัว';
+
+  @override
+  String get singleLanguageModeInfo => 'โหมดภาษาเดียวถูกเปิดใช้งาน การแปลภาษาถูกปิดเพื่อความแม่นยำที่สูงขึ้น';
+
+  @override
+  String get searchLanguageHint => 'ค้นหาภาษาตามชื่อหรือรหัส';
+
+  @override
+  String get noLanguagesFound => 'ไม่พบภาษา';
+
+  @override
+  String get skip => 'ข้าม';
+
+  @override
+  String languageSetTo(String language) {
+    return 'ตั้งค่าภาษาเป็น $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'ตั้งค่าภาษาไม่สำเร็จ';
+
+  @override
+  String appSettings(String appName) {
+    return 'การตั้งค่า $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'ตัดการเชื่อมต่อจาก $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'การดำเนินการนี้จะลบการยืนยันตัวตน $appName ของคุณ คุณจะต้องเชื่อมต่อใหม่เพื่อใช้งานอีกครั้ง';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'เชื่อมต่อกับ $appName แล้ว';
+  }
+
+  @override
+  String get account => 'บัญชี';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'รายการสิ่งที่ต้องทำของคุณจะถูกซิงค์ไปยังบัญชี $appName ของคุณ';
+  }
+
+  @override
+  String get defaultSpace => 'พื้นที่เริ่มต้น';
+
+  @override
+  String get selectSpaceInWorkspace => 'เลือกพื้นที่ในพื้นที่ทำงานของคุณ';
+
+  @override
+  String get noSpacesInWorkspace => 'ไม่พบพื้นที่ในพื้นที่ทำงานนี้';
+
+  @override
+  String get defaultList => 'รายการเริ่มต้น';
+
+  @override
+  String get tasksAddedToList => 'งานจะถูกเพิ่มลงในรายการนี้';
+
+  @override
+  String get noListsInSpace => 'ไม่พบรายการในพื้นที่นี้';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'โหลดที่เก็บไม่สำเร็จ: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'บันทึกที่เก็บเริ่มต้นแล้ว';
+
+  @override
+  String get failedToSaveDefaultRepo => 'บันทึกที่เก็บเริ่มต้นไม่สำเร็จ';
+
+  @override
+  String get defaultRepository => 'ที่เก็บเริ่มต้น';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'เลือกที่เก็บเริ่มต้นสำหรับสร้าง issue คุณยังสามารถระบุที่เก็บอื่นได้เมื่อสร้าง issue';
+
+  @override
+  String get noReposFound => 'ไม่พบที่เก็บ';
+
+  @override
+  String get private => 'ส่วนตัว';
+
+  @override
+  String updatedDate(String date) {
+    return 'อัปเดต $date';
+  }
+
+  @override
+  String get yesterday => 'เมื่อวาน';
+
+  @override
+  String daysAgo(int count) {
+    return '$count วันที่แล้ว';
+  }
+
+  @override
+  String get oneWeekAgo => '1 สัปดาห์ที่แล้ว';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count สัปดาห์ที่แล้ว';
+  }
+
+  @override
+  String get oneMonthAgo => '1 เดือนที่แล้ว';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count เดือนที่แล้ว';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Issue จะถูกสร้างในที่เก็บเริ่มต้นของคุณ';
+
+  @override
+  String get taskIntegrations => 'การผสานรวมงาน';
+
+  @override
+  String get configureSettings => 'กำหนดการตั้งค่า';
+
+  @override
+  String get completeAuthBrowser => 'กรุณายืนยันตัวตนในเบราว์เซอร์ของคุณ เมื่อเสร็จแล้วกลับมาที่แอป';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'เริ่มการยืนยันตัวตน $appName ไม่สำเร็จ';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'เชื่อมต่อกับ $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'คุณต้องอนุญาตให้ Omi สร้างงานในบัญชี $appName ของคุณ ระบบจะเปิดเบราว์เซอร์เพื่อยืนยันตัวตน';
+  }
+
+  @override
+  String get continueButton => 'ดำเนินการต่อ';
+
+  @override
+  String appIntegration(String appName) {
+    return 'การผสานรวม $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'การผสานรวมกับ $appName เร็วๆ นี้! เรากำลังพยายามนำตัวเลือกการจัดการงานเพิ่มเติมมาให้คุณ';
+  }
+
+  @override
+  String get gotIt => 'เข้าใจแล้ว';
+
+  @override
+  String get tasksExportedOneApp => 'สามารถส่งออกงานไปยังแอปหนึ่งแอปในแต่ละครั้ง';
+
+  @override
+  String get completeYourUpgrade => 'ดำเนินการอัปเกรดของคุณให้เสร็จสมบูรณ์';
+
+  @override
+  String get importConfiguration => 'นำเข้าการกำหนดค่า';
+
+  @override
+  String get exportConfiguration => 'ส่งออกการกำหนดค่า';
+
+  @override
+  String get bringYourOwn => 'นำของคุณเองมาใช้';
+
+  @override
+  String get payYourSttProvider => 'ใช้ Omi ได้อย่างอิสระ คุณจ่ายเฉพาะผู้ให้บริการ STT ของคุณโดยตรง';
+
+  @override
+  String get freeMinutesMonth => 'รวม 1,200 นาทีฟรี/เดือน ไม่จำกัดด้วย ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'ต้องระบุ Host';
+
+  @override
+  String get validPortRequired => 'ต้องระบุพอร์ตที่ถูกต้อง';
+
+  @override
+  String get validWebsocketUrlRequired => 'ต้องระบุ URL WebSocket ที่ถูกต้อง (wss://)';
+
+  @override
+  String get apiUrlRequired => 'ต้องระบุ API URL';
+
+  @override
+  String get apiKeyRequired => 'ต้องระบุ API key';
+
+  @override
+  String get invalidJsonConfig => 'การกำหนดค่า JSON ไม่ถูกต้อง';
+
+  @override
+  String errorSaving(String error) {
+    return 'ข้อผิดพลาดในการบันทึก: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'คัดลอกการกำหนดค่าไปยังคลิปบอร์ดแล้ว';
+
+  @override
+  String get pasteJsonConfig => 'วางการกำหนดค่า JSON ของคุณด้านล่าง:';
+
+  @override
+  String get addApiKeyAfterImport => 'คุณจะต้องเพิ่ม API key ของคุณเองหลังจากนำเข้า';
+
+  @override
+  String get paste => 'วาง';
+
+  @override
+  String get import => 'นำเข้า';
+
+  @override
+  String get invalidProviderInConfig => 'ผู้ให้บริการในการกำหนดค่าไม่ถูกต้อง';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'นำเข้าการกำหนดค่า $providerName แล้ว';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON ไม่ถูกต้อง: $error';
+  }
+
+  @override
+  String get provider => 'ผู้ให้บริการ';
+
+  @override
+  String get live => 'สด';
+
+  @override
+  String get onDevice => 'บนอุปกรณ์';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'ใส่ endpoint HTTP ของ STT ของคุณ';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'ใส่ endpoint WebSocket ของ STT แบบสดของคุณ';
+
+  @override
+  String get apiKey => 'API Key';
+
+  @override
+  String get enterApiKey => 'ใส่ API key ของคุณ';
+
+  @override
+  String get storedLocallyNeverShared => 'จัดเก็บในเครื่อง ไม่แชร์เลย';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'พอร์ต';
+
+  @override
+  String get advanced => 'ขั้นสูง';
+
+  @override
+  String get configuration => 'การกำหนดค่า';
+
+  @override
+  String get requestConfiguration => 'การกำหนดค่าคำขอ';
+
+  @override
+  String get responseSchema => 'โครงสร้างการตอบกลับ';
+
+  @override
+  String get modified => 'แก้ไขแล้ว';
+
+  @override
+  String get resetRequestConfig => 'รีเซ็ตการกำหนดค่าคำขอเป็นค่าเริ่มต้น';
+
+  @override
+  String get logs => 'บันทึก';
+
+  @override
+  String get logsCopied => 'คัดลอกบันทึกแล้ว';
+
+  @override
+  String get noLogsYet => 'ยังไม่มีบันทึก เริ่มบันทึกเพื่อดูกิจกรรม STT แบบกำหนดเอง';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName ใช้ $codecReason จะใช้ Omi แทน';
+  }
+
+  @override
+  String get omiTranscription => 'การถอดเสียง Omi';
+
+  @override
+  String get bestInClassTranscription => 'การถอดเสียงชั้นนำโดยไม่ต้องตั้งค่า';
+
+  @override
+  String get instantSpeakerLabels => 'ติดป้ายผู้พูดทันที';
+
+  @override
+  String get languageTranslation => 'แปลมากกว่า 100 ภาษา';
+
+  @override
+  String get optimizedForConversation => 'เหมาะสำหรับบทสนทนา';
+
+  @override
+  String get autoLanguageDetection => 'ตรวจจับภาษาอัตโนมัติ';
+
+  @override
+  String get highAccuracy => 'ความแม่นยำสูง';
+
+  @override
+  String get privacyFirst => 'ความเป็นส่วนตัวเป็นอันดับแรก';
+
+  @override
+  String get saveChanges => 'บันทึกการเปลี่ยนแปลง';
+
+  @override
+  String get resetToDefault => 'รีเซ็ตเป็นค่าเริ่มต้น';
+
+  @override
+  String get viewTemplate => 'ดูเทมเพลต';
+
+  @override
+  String get trySomethingLike => 'ลองอะไรแบบนี้...';
+
+  @override
+  String get tryIt => 'ลองดู';
+
+  @override
+  String get creatingPlan => 'กำลังสร้างแผน';
+
+  @override
+  String get developingLogic => 'กำลังพัฒนาตรรกะ';
+
+  @override
+  String get designingApp => 'กำลังออกแบบแอป';
+
+  @override
+  String get generatingIconStep => 'กำลังสร้างไอคอน';
+
+  @override
+  String get finalTouches => 'ตกแต่งขั้นสุดท้าย';
+
+  @override
+  String get processing => 'กำลังประมวลผล...';
+
+  @override
+  String get features => 'ฟีเจอร์';
+
+  @override
+  String get creatingYourApp => 'กำลังสร้างแอปของคุณ...';
+
+  @override
+  String get generatingIcon => 'กำลังสร้างไอคอน...';
+
+  @override
+  String get whatShouldWeMake => 'เราควรสร้างอะไร?';
+
+  @override
+  String get appName => 'ชื่อแอป';
+
+  @override
+  String get description => 'คำอธิบาย';
+
+  @override
+  String get publicLabel => 'สาธารณะ';
+
+  @override
+  String get privateLabel => 'ส่วนตัว';
+
+  @override
+  String get free => 'ฟรี';
+
+  @override
+  String get perMonth => '/ เดือน';
+
+  @override
+  String get tailoredConversationSummaries => 'สรุปบทสนทนาที่ปรับแต่งได้';
+
+  @override
+  String get customChatbotPersonality => 'บุคลิกแชทบอทที่กำหนดเอง';
+
+  @override
+  String get makePublic => 'ทำให้เป็นสาธารณะ';
+
+  @override
+  String get anyoneCanDiscover => 'ทุกคนสามารถค้นพบแอปของคุณได้';
+
+  @override
+  String get onlyYouCanUse => 'เฉพาะคุณเท่านั้นที่สามารถใช้แอปนี้ได้';
+
+  @override
+  String get paidApp => 'แอปแบบชำระเงิน';
+
+  @override
+  String get usersPayToUse => 'ผู้ใช้จ่ายเงินเพื่อใช้แอปของคุณ';
+
+  @override
+  String get freeForEveryone => 'ฟรีสำหรับทุกคน';
+
+  @override
+  String get perMonthLabel => '/ เดือน';
+
+  @override
+  String get creating => 'กำลังสร้าง...';
+
+  @override
+  String get createApp => 'สร้างแอป';
+
+  @override
+  String get searchingForDevices => 'กำลังค้นหาอุปกรณ์...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'อุปกรณ์',
+      one: 'อุปกรณ์',
+    );
+    return 'พบ $count $_temp0 ในบริเวณใกล้เคียง';
+  }
+
+  @override
+  String get pairingSuccessful => 'จับคู่สำเร็จ';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'เชื่อมต่อกับ Apple Watch ไม่สำเร็จ: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'อย่าแสดงอีก';
+
+  @override
+  String get iUnderstand => 'ฉันเข้าใจ';
+
+  @override
+  String get enableBluetooth => 'เปิดใช้งาน Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi ต้องการ Bluetooth เพื่อเชื่อมต่อกับอุปกรณ์สวมใส่ของคุณ กรุณาเปิดใช้งาน Bluetooth แล้วลองอีกครั้ง';
+
+  @override
+  String get contactSupport => 'ติดต่อฝ่ายสนับสนุน?';
+
+  @override
+  String get connectLater => 'เชื่อมต่อภายหลัง';
+
+  @override
+  String get grantPermissions => 'อนุญาตสิทธิ์';
+
+  @override
+  String get backgroundActivity => 'กิจกรรมพื้นหลัง';
+
+  @override
+  String get backgroundActivityDesc => 'ให้ Omi ทำงานในพื้นหลังเพื่อความเสถียรที่ดีขึ้น';
+
+  @override
+  String get locationAccess => 'การเข้าถึงตำแหน่ง';
+
+  @override
+  String get locationAccessDesc => 'เปิดใช้งานตำแหน่งพื้นหลังเพื่อประสบการณ์ที่สมบูรณ์';
+
+  @override
+  String get notifications => 'การแจ้งเตือน';
+
+  @override
+  String get notificationsDesc => 'เปิดใช้งานการแจ้งเตือนเพื่อรับข้อมูล';
+
+  @override
+  String get locationServiceDisabled => 'บริการตำแหน่งถูกปิด';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'บริการตำแหน่งถูกปิด กรุณาไปที่ การตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการตำแหน่ง แล้วเปิดใช้งาน';
+
+  @override
+  String get backgroundLocationDenied => 'การเข้าถึงตำแหน่งพื้นหลังถูกปฏิเสธ';
+
+  @override
+  String get backgroundLocationDeniedDesc => 'กรุณาไปที่การตั้งค่าอุปกรณ์และตั้งค่าสิทธิ์ตำแหน่งเป็น \"อนุญาตเสมอ\"';
+
+  @override
+  String get lovingOmi => 'ชอบ Omi ไหม?';
+
+  @override
+  String get leaveReviewIos =>
+      'ช่วยเราเข้าถึงคนมากขึ้นด้วยการรีวิวใน App Store ความคิดเห็นของคุณมีความหมายมากสำหรับเรา!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'ช่วยเราเข้าถึงคนมากขึ้นด้วยการรีวิวใน Google Play Store ความคิดเห็นของคุณมีความหมายมากสำหรับเรา!';
+
+  @override
+  String get rateOnAppStore => 'ให้คะแนนบน App Store';
+
+  @override
+  String get rateOnGooglePlay => 'ให้คะแนนบน Google Play';
+
+  @override
+  String get maybeLater => 'ทีหลังก็ได้';
+
+  @override
+  String get speechProfileIntro => 'Omi ต้องเรียนรู้เป้าหมายและเสียงของคุณ คุณสามารถแก้ไขได้ในภายหลัง';
+
+  @override
+  String get getStarted => 'เริ่มต้น';
+
+  @override
+  String get allDone => 'เสร็จแล้ว!';
+
+  @override
+  String get keepGoing => 'ทำต่อไป คุณทำได้ดีมาก';
+
+  @override
+  String get skipThisQuestion => 'ข้ามคำถามนี้';
+
+  @override
+  String get skipForNow => 'ข้ามไว้ก่อน';
+
+  @override
+  String get connectionError => 'ข้อผิดพลาดในการเชื่อมต่อ';
+
+  @override
+  String get connectionErrorDesc =>
+      'เชื่อมต่อกับเซิร์ฟเวอร์ไม่สำเร็จ กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'ตรวจพบการบันทึกที่ไม่ถูกต้อง';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'ดูเหมือนว่ามีผู้พูดหลายคนในการบันทึก กรุณาตรวจสอบให้แน่ใจว่าคุณอยู่ในสถานที่เงียบและลองอีกครั้ง';
+
+  @override
+  String get tooShortDesc => 'ตรวจพบคำพูดไม่เพียงพอ กรุณาพูดมากขึ้นและลองอีกครั้ง';
+
+  @override
+  String get invalidRecordingDesc => 'กรุณาตรวจสอบให้แน่ใจว่าคุณพูดอย่างน้อย 5 วินาทีและไม่เกิน 90 วินาที';
+
+  @override
+  String get areYouThere => 'คุณยังอยู่ไหม?';
+
+  @override
+  String get noSpeechDesc => 'เราตรวจไม่พบคำพูดใดๆ กรุณาตรวจสอบให้แน่ใจว่าคุณพูดอย่างน้อย 10 วินาทีและไม่เกิน 3 นาที';
+
+  @override
+  String get connectionLost => 'การเชื่อมต่อขาดหาย';
+
+  @override
+  String get connectionLostDesc => 'การเชื่อมต่อถูกขัดจังหวะ กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง';
+
+  @override
+  String get tryAgain => 'ลองอีกครั้ง';
+
+  @override
+  String get connectOmiOmiGlass => 'เชื่อมต่อ Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'ดำเนินการต่อโดยไม่มีอุปกรณ์';
+
+  @override
+  String get permissionsRequired => 'ต้องการสิทธิ์';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'แอปนี้ต้องการสิทธิ์ Bluetooth และตำแหน่งเพื่อทำงานอย่างถูกต้อง กรุณาเปิดใช้งานในการตั้งค่า';
+
+  @override
+  String get openSettings => 'เปิดการตั้งค่า';
+
+  @override
+  String get wantDifferentName => 'ต้องการใช้ชื่ออื่นไหม?';
+
+  @override
+  String get whatsYourName => 'คุณชื่ออะไร?';
+
+  @override
+  String get speakTranscribeSummarize => 'พูด ถอดเสียง สรุป';
+
+  @override
+  String get signInWithApple => 'ลงชื่อเข้าใช้ด้วย Apple';
+
+  @override
+  String get signInWithGoogle => 'ลงชื่อเข้าใช้ด้วย Google';
+
+  @override
+  String get byContinuingAgree => 'การดำเนินการต่อแสดงว่าคุณยอมรับ ';
+
+  @override
+  String get termsOfUse => 'เงื่อนไขการใช้งาน';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – เพื่อนคู่ใจ AI ของคุณ';
+
+  @override
+  String get captureEveryMoment => 'บันทึกทุกช่วงเวลา รับสรุปโดย AI\nไม่ต้องจดบันทึกอีกต่อไป';
+
+  @override
+  String get appleWatchSetup => 'ตั้งค่า Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'ขอสิทธิ์แล้ว!';
+
+  @override
+  String get microphonePermission => 'สิทธิ์ไมโครโฟน';
+
+  @override
+  String get permissionGrantedNow =>
+      'อนุญาตสิทธิ์แล้ว! ตอนนี้:\n\nเปิดแอป Omi บนนาฬิกาของคุณและแตะ \"ดำเนินการต่อ\" ด้านล่าง';
+
+  @override
+  String get needMicrophonePermission =>
+      'เราต้องการสิทธิ์ไมโครโฟน\n\n1. แตะ \"อนุญาตสิทธิ์\"\n2. อนุญาตบน iPhone ของคุณ\n3. แอปบนนาฬิกาจะปิด\n4. เปิดใหม่และแตะ \"ดำเนินการต่อ\"';
+
+  @override
+  String get grantPermissionButton => 'อนุญาตสิทธิ์';
+
+  @override
+  String get needHelp => 'ต้องการความช่วยเหลือ?';
+
+  @override
+  String get troubleshootingSteps =>
+      'วิธีแก้ปัญหา:\n\n1. ตรวจสอบว่าได้ติดตั้ง Omi บนนาฬิกาแล้ว\n2. เปิดแอป Omi บนนาฬิกาของคุณ\n3. มองหาป๊อปอัปสิทธิ์\n4. แตะ \"อนุญาต\" เมื่อได้รับแจ้ง\n5. แอปบนนาฬิกาจะปิด - เปิดใหม่\n6. กลับมาและแตะ \"ดำเนินการต่อ\" บน iPhone ของคุณ';
+
+  @override
+  String get recordingStartedSuccessfully => 'เริ่มบันทึกสำเร็จ!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'ยังไม่ได้อนุญาตสิทธิ์ กรุณาตรวจสอบให้แน่ใจว่าคุณได้อนุญาตการเข้าถึงไมโครโฟนและเปิดแอปบนนาฬิกาใหม่แล้ว';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'ขอสิทธิ์ไม่สำเร็จ: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'เริ่มบันทึกไม่สำเร็จ: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'เลือกภาษาหลักของคุณ';
+
+  @override
+  String get languageBenefits => 'ตั้งค่าภาษาของคุณเพื่อการถอดเสียงที่แม่นยำขึ้นและประสบการณ์ที่เป็นส่วนตัว';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'ภาษาหลักของคุณคืออะไร?';
+
+  @override
+  String get selectYourLanguage => 'เลือกภาษาของคุณ';
+
+  @override
+  String get personalGrowthJourney => 'เส้นทางการเติบโตส่วนบุคคลของคุณกับ AI ที่ฟังทุกคำพูดของคุณ';
+
+  @override
+  String get actionItemsTitle => 'สิ่งที่ต้องทำ';
+
+  @override
+  String get actionItemsDescription => 'แตะเพื่อแก้ไข • กดค้างเพื่อเลือก • ปัดเพื่อดำเนินการ';
+
+  @override
+  String get tabToDo => 'ต้องทำ';
+
+  @override
+  String get tabDone => 'เสร็จแล้ว';
+
+  @override
+  String get tabOld => 'เก่า';
+
+  @override
+  String get emptyTodoMessage => '🎉 ทำทุกอย่างเสร็จแล้ว!\nไม่มีสิ่งที่ต้องทำที่รอดำเนินการ';
+
+  @override
+  String get emptyDoneMessage => 'ยังไม่มีรายการที่เสร็จสมบูรณ์';
+
+  @override
+  String get emptyOldMessage => '✅ ไม่มีงานเก่า';
+
+  @override
+  String get noItems => 'ไม่มีรายการ';
+
+  @override
+  String get actionItemMarkedIncomplete => 'ทำเครื่องหมายสิ่งที่ต้องทำเป็นยังไม่เสร็จสมบูรณ์';
+
+  @override
+  String get actionItemCompleted => 'ทำสิ่งที่ต้องทำเสร็จแล้ว';
+
+  @override
+  String get deleteActionItemTitle => 'ลบสิ่งที่ต้องทำ';
+
+  @override
+  String get deleteActionItemMessage => 'คุณแน่ใจหรือไม่ว่าต้องการลบสิ่งที่ต้องทำนี้?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'ลบรายการที่เลือก';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'คุณแน่ใจหรือไม่ว่าต้องการลบสิ่งที่ต้องทำที่เลือก $count รายการ$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'ลบสิ่งที่ต้องทำ \"$description\" แล้ว';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return 'ลบสิ่งที่ต้องทำ $count รายการ$sแล้ว';
+  }
+
+  @override
+  String get failedToDeleteItem => 'ลบสิ่งที่ต้องทำไม่สำเร็จ';
+
+  @override
+  String get failedToDeleteItems => 'ลบรายการไม่สำเร็จ';
+
+  @override
+  String get failedToDeleteSomeItems => 'ลบบางรายการไม่สำเร็จ';
+
+  @override
+  String get welcomeActionItemsTitle => 'พร้อมสำหรับสิ่งที่ต้องทำ';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'AI ของคุณจะดึงงานและสิ่งที่ต้องทำจากบทสนทนาโดยอัตโนมัติ รายการจะปรากฏที่นี่เมื่อสร้าง';
+
+  @override
+  String get autoExtractionFeature => 'ดึงจากบทสนทนาอัตโนมัติ';
+
+  @override
+  String get editSwipeFeature => 'แตะเพื่อแก้ไข ปัดเพื่อทำให้เสร็จหรือลบ';
+
+  @override
+  String itemsSelected(int count) {
+    return 'เลือกแล้ว $count รายการ';
+  }
+
+  @override
+  String get selectAll => 'เลือกทั้งหมด';
+
+  @override
+  String get deleteSelected => 'ลบที่เลือก';
+
+  @override
+  String searchMemories(int count) {
+    return 'ค้นหา $count ความทรงจำ';
+  }
+
+  @override
+  String get memoryDeleted => 'ลบความทรงจำแล้ว';
+
+  @override
+  String get undo => 'เลิกทำ';
+
+  @override
+  String get noMemoriesYet => 'ยังไม่มีความทรงจำ';
+
+  @override
+  String get noAutoMemories => 'ยังไม่มีความทรงจำที่ดึงอัตโนมัติ';
+
+  @override
+  String get noManualMemories => 'ยังไม่มีความทรงจำที่สร้างด้วยตนเอง';
+
+  @override
+  String get noMemoriesInCategories => 'ไม่มีความทรงจำในหมวดหมู่เหล่านี้';
+
+  @override
+  String get noMemoriesFound => 'ไม่พบความทรงจำ';
+
+  @override
+  String get addFirstMemory => 'เพิ่มความทรงจำแรกของคุณ';
+
+  @override
+  String get clearMemoryTitle => 'ล้างความทรงจำของ Omi';
+
+  @override
+  String get clearMemoryMessage => 'คุณแน่ใจหรือไม่ว่าต้องการล้างความทรงจำของ Omi? การกระทำนี้ไม่สามารถยกเลิกได้';
+
+  @override
+  String get clearMemoryButton => 'ล้างความทรงจำ';
+
+  @override
+  String get memoryClearedSuccess => 'ล้างความทรงจำของ Omi เกี่ยวกับคุณแล้ว';
+
+  @override
+  String get noMemoriesToDelete => 'ไม่มีความทรงจำที่จะลบ';
+
+  @override
+  String get createMemoryTooltip => 'สร้างความทรงจำใหม่';
+
+  @override
+  String get createActionItemTooltip => 'สร้างสิ่งที่ต้องทำใหม่';
+
+  @override
+  String get memoryManagement => 'การจัดการความทรงจำ';
+
+  @override
+  String get filterMemories => 'กรองความทรงจำ';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'คุณมีความทรงจำทั้งหมด $count รายการ';
+  }
+
+  @override
+  String get publicMemories => 'ความทรงจำสาธารณะ';
+
+  @override
+  String get privateMemories => 'ความทรงจำส่วนตัว';
+
+  @override
+  String get makeAllPrivate => 'ทำให้ความทรงจำทั้งหมดเป็นส่วนตัว';
+
+  @override
+  String get makeAllPublic => 'ทำให้ความทรงจำทั้งหมดเป็นสาธารณะ';
+
+  @override
+  String get deleteAllMemories => 'ลบความทรงจำทั้งหมด';
+
+  @override
+  String get allMemoriesPrivateResult => 'ความทรงจำทั้งหมดเป็นส่วนตัวแล้ว';
+
+  @override
+  String get allMemoriesPublicResult => 'ความทรงจำทั้งหมดเป็นสาธารณะแล้ว';
+
+  @override
+  String get newMemory => 'ความทรงจำใหม่';
+
+  @override
+  String get editMemory => 'แก้ไขความทรงจำ';
+
+  @override
+  String get memoryContentHint => 'ฉันชอบกินไอศกรีม...';
+
+  @override
+  String get failedToSaveMemory => 'บันทึกไม่สำเร็จ กรุณาตรวจสอบการเชื่อมต่อของคุณ';
+
+  @override
+  String get saveMemory => 'บันทึกความทรงจำ';
+
+  @override
+  String get retry => 'ลองใหม่';
+
+  @override
+  String get createActionItem => 'สร้างสิ่งที่ต้องทำ';
+
+  @override
+  String get editActionItem => 'แก้ไขสิ่งที่ต้องทำ';
+
+  @override
+  String get actionItemDescriptionHint => 'ต้องทำอะไร?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'คำอธิบายสิ่งที่ต้องทำต้องไม่ว่างเปล่า';
+
+  @override
+  String get actionItemUpdated => 'อัปเดตสิ่งที่ต้องทำแล้ว';
+
+  @override
+  String get failedToUpdateActionItem => 'อัปเดตสิ่งที่ต้องทำไม่สำเร็จ';
+
+  @override
+  String get actionItemCreated => 'สร้างสิ่งที่ต้องทำแล้ว';
+
+  @override
+  String get failedToCreateActionItem => 'สร้างสิ่งที่ต้องทำไม่สำเร็จ';
+
+  @override
+  String get dueDate => 'วันครบกำหนด';
+
+  @override
+  String get time => 'เวลา';
+
+  @override
+  String get addDueDate => 'เพิ่มวันครบกำหนด';
+
+  @override
+  String get pressDoneToSave => 'กดเสร็จสิ้นเพื่อบันทึก';
+
+  @override
+  String get pressDoneToCreate => 'กดเสร็จสิ้นเพื่อสร้าง';
+
+  @override
+  String get filterAll => 'ทั้งหมด';
+
+  @override
+  String get filterSystem => 'เกี่ยวกับคุณ';
+
+  @override
+  String get filterInteresting => 'ข้อมูลเชิงลึก';
+
+  @override
+  String get filterManual => 'ด้วยตนเอง';
+
+  @override
+  String get completed => 'เสร็จสมบูรณ์';
+
+  @override
+  String get markComplete => 'ทำเครื่องหมายว่าเสร็จสมบูรณ์';
+
+  @override
+  String get actionItemDeleted => 'ลบสิ่งที่ต้องทำแล้ว';
+
+  @override
+  String get failedToDeleteActionItem => 'ลบสิ่งที่ต้องทำไม่สำเร็จ';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'ลบสิ่งที่ต้องทำ';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'คุณแน่ใจหรือไม่ว่าต้องการลบสิ่งที่ต้องทำนี้?';
+
+  @override
+  String get appLanguage => 'ภาษาแอป';
+
+  @override
+  String get appInterfaceSectionTitle => 'อินเทอร์เฟซแอป';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'คำพูดและการถอดเสียง';
+
+  @override
+  String get languageSettingsHelperText => 'ภาษาแอปเปลี่ยนเมนูและปุ่ม ภาษาคำพูดส่งผลต่อวิธีถอดเสียงการบันทึกของคุณ';
+}

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -1,0 +1,2237 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Turkish (`tr`).
+class AppLocalizationsTr extends AppLocalizations {
+  AppLocalizationsTr([String locale = 'tr']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Konuşma';
+
+  @override
+  String get transcriptTab => 'Transkript';
+
+  @override
+  String get actionItemsTab => 'Eylem Öğeleri';
+
+  @override
+  String get deleteConversationTitle => 'Konuşma Silinsin mi?';
+
+  @override
+  String get deleteConversationMessage => 'Bu konuşmayı silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
+
+  @override
+  String get confirm => 'Onayla';
+
+  @override
+  String get cancel => 'İptal';
+
+  @override
+  String get ok => 'Tamam';
+
+  @override
+  String get delete => 'Sil';
+
+  @override
+  String get add => 'Ekle';
+
+  @override
+  String get update => 'Güncelle';
+
+  @override
+  String get save => 'Kaydet';
+
+  @override
+  String get edit => 'Düzenle';
+
+  @override
+  String get close => 'Kapat';
+
+  @override
+  String get clear => 'Temizle';
+
+  @override
+  String get copyTranscript => 'Transkripti Kopyala';
+
+  @override
+  String get copySummary => 'Özeti Kopyala';
+
+  @override
+  String get testPrompt => 'İstemi Test Et';
+
+  @override
+  String get reprocessConversation => 'Konuşmayı Yeniden İşle';
+
+  @override
+  String get deleteConversation => 'Konuşmayı Sil';
+
+  @override
+  String get contentCopied => 'İçerik panoya kopyalandı';
+
+  @override
+  String get failedToUpdateStarred => 'Favorilere ekleme durumu güncellenemedi.';
+
+  @override
+  String get conversationUrlNotShared => 'Konuşma URL\'si paylaşılamadı.';
+
+  @override
+  String get errorProcessingConversation => 'Konuşma işlenirken hata oluştu. Lütfen daha sonra tekrar deneyin.';
+
+  @override
+  String get noInternetConnection => 'Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.';
+
+  @override
+  String get unableToDeleteConversation => 'Konuşma Silinemiyor';
+
+  @override
+  String get somethingWentWrong => 'Bir şeyler ters gitti! Lütfen daha sonra tekrar deneyin.';
+
+  @override
+  String get copyErrorMessage => 'Hata mesajını kopyala';
+
+  @override
+  String get errorCopied => 'Hata mesajı panoya kopyalandı';
+
+  @override
+  String get remaining => 'Kalan';
+
+  @override
+  String get loading => 'Yükleniyor...';
+
+  @override
+  String get loadingDuration => 'Süre yükleniyor...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count saniye';
+  }
+
+  @override
+  String get people => 'Kişiler';
+
+  @override
+  String get addNewPerson => 'Yeni Kişi Ekle';
+
+  @override
+  String get editPerson => 'Kişiyi Düzenle';
+
+  @override
+  String get createPersonHint => 'Yeni bir kişi oluşturun ve Omi\'yi onların konuşmasını da tanımaya eğitin!';
+
+  @override
+  String get speechProfile => 'Konuşma Profili';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Örnek $number';
+  }
+
+  @override
+  String get settings => 'Ayarlar';
+
+  @override
+  String get language => 'Dil';
+
+  @override
+  String get selectLanguage => 'Dil Seç';
+
+  @override
+  String get deleting => 'Siliniyor...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
+
+  @override
+  String get failedToStartAuthentication => 'Kimlik doğrulama başlatılamadı';
+
+  @override
+  String get importStarted => 'İçe aktarma başladı! Tamamlandığında bildirim alacaksınız.';
+
+  @override
+  String get failedToStartImport => 'İçe aktarma başlatılamadı. Lütfen tekrar deneyin.';
+
+  @override
+  String get couldNotAccessFile => 'Seçilen dosyaya erişilemedi';
+
+  @override
+  String get askOmi => 'Omi\'ye Sor';
+
+  @override
+  String get done => 'Bitti';
+
+  @override
+  String get disconnected => 'Bağlantı Kesildi';
+
+  @override
+  String get searching => 'Aranıyor';
+
+  @override
+  String get connectDevice => 'Cihazı Bağla';
+
+  @override
+  String get monthlyLimitReached => 'Aylık limitinize ulaştınız.';
+
+  @override
+  String get checkUsage => 'Kullanımı Kontrol Et';
+
+  @override
+  String get syncingRecordings => 'Kayıtlar senkronize ediliyor';
+
+  @override
+  String get recordingsToSync => 'Senkronize edilecek kayıtlar';
+
+  @override
+  String get allCaughtUp => 'Her şey güncel';
+
+  @override
+  String get sync => 'Senkronize Et';
+
+  @override
+  String get pendantUpToDate => 'Kolye güncel';
+
+  @override
+  String get allRecordingsSynced => 'Tüm kayıtlar senkronize edildi';
+
+  @override
+  String get syncingInProgress => 'Senkronizasyon devam ediyor';
+
+  @override
+  String get readyToSync => 'Senkronize etmeye hazır';
+
+  @override
+  String get tapSyncToStart => 'Başlatmak için Senkronize Et\'e dokunun';
+
+  @override
+  String get pendantNotConnected => 'Kolye bağlı değil. Senkronize etmek için bağlayın.';
+
+  @override
+  String get everythingSynced => 'Her şey zaten senkronize edilmiş.';
+
+  @override
+  String get recordingsNotSynced => 'Henüz senkronize edilmemiş kayıtlarınız var.';
+
+  @override
+  String get syncingBackground => 'Kayıtlarınızı arka planda senkronize etmeye devam edeceğiz.';
+
+  @override
+  String get noConversationsYet => 'Henüz konuşma yok.';
+
+  @override
+  String get noStarredConversations => 'Henüz favorilere eklenmiş konuşma yok.';
+
+  @override
+  String get starConversationHint =>
+      'Bir konuşmayı favorilere eklemek için açın ve üst kısımdaki yıldız simgesine dokunun.';
+
+  @override
+  String get searchConversations => 'Konuşmalarda Ara';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return '$count seçildi';
+  }
+
+  @override
+  String get merge => 'Birleştir';
+
+  @override
+  String get mergeConversations => 'Konuşmaları Birleştir';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Bu işlem $count konuşmayı birleştirecek. Tüm içerik birleştirilecek ve yeniden oluşturulacak.';
+  }
+
+  @override
+  String get mergingInBackground => 'Arka planda birleştiriliyor. Bu biraz zaman alabilir.';
+
+  @override
+  String get failedToStartMerge => 'Birleştirme başlatılamadı';
+
+  @override
+  String get askAnything => 'Her şeyi sor';
+
+  @override
+  String get noMessagesYet => 'Henüz mesaj yok!\nNeden bir konuşma başlatmıyorsunuz?';
+
+  @override
+  String get deletingMessages => 'Mesajlarınız Omi\'nin hafızasından siliniyor...';
+
+  @override
+  String get messageCopied => 'Mesaj panoya kopyalandı.';
+
+  @override
+  String get cannotReportOwnMessage => 'Kendi mesajlarınızı bildiremezsiniz.';
+
+  @override
+  String get reportMessage => 'Mesajı Bildir';
+
+  @override
+  String get reportMessageConfirm => 'Bu mesajı bildirmek istediğinizden emin misiniz?';
+
+  @override
+  String get messageReported => 'Mesaj başarıyla bildirildi.';
+
+  @override
+  String get thankYouFeedback => 'Geri bildiriminiz için teşekkürler!';
+
+  @override
+  String get clearChat => 'Sohbet Temizlensin mi?';
+
+  @override
+  String get clearChatConfirm => 'Sohbeti temizlemek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
+
+  @override
+  String get maxFilesLimit => 'Aynı anda en fazla 4 dosya yükleyebilirsiniz';
+
+  @override
+  String get chatWithOmi => 'Omi ile Sohbet';
+
+  @override
+  String get apps => 'Uygulamalar';
+
+  @override
+  String get noAppsFound => 'Uygulama bulunamadı';
+
+  @override
+  String get tryAdjustingSearch => 'Arama veya filtreleri ayarlamayı deneyin';
+
+  @override
+  String get createYourOwnApp => 'Kendi Uygulamanızı Oluşturun';
+
+  @override
+  String get buildAndShareApp => 'Özel uygulamanızı oluşturun ve paylaşın';
+
+  @override
+  String get searchApps => '1500+ Uygulama Ara';
+
+  @override
+  String get myApps => 'Uygulamalarım';
+
+  @override
+  String get installedApps => 'Yüklü Uygulamalar';
+
+  @override
+  String get unableToFetchApps =>
+      'Uygulamalar alınamadı :(\n\nLütfen internet bağlantınızı kontrol edin ve tekrar deneyin.';
+
+  @override
+  String get aboutOmi => 'Omi Hakkında';
+
+  @override
+  String get privacyPolicy => 'Gizlilik Politikası';
+
+  @override
+  String get visitWebsite => 'Web Sitesini Ziyaret Et';
+
+  @override
+  String get helpOrInquiries => 'Yardım veya Sorular?';
+
+  @override
+  String get joinCommunity => 'Topluluğa katılın!';
+
+  @override
+  String get membersAndCounting => '8000+ üye ve artıyor.';
+
+  @override
+  String get deleteAccountTitle => 'Hesabı Sil';
+
+  @override
+  String get deleteAccountConfirm => 'Hesabınızı silmek istediğinizden emin misiniz?';
+
+  @override
+  String get cannotBeUndone => 'Bu işlem geri alınamaz.';
+
+  @override
+  String get allDataErased => 'Tüm anılarınız ve konuşmalarınız kalıcı olarak silinecek.';
+
+  @override
+  String get appsDisconnected => 'Uygulamalarınız ve Entegrasyonlarınızın bağlantısı derhal kesilecek.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Hesabınızı silmeden önce verilerinizi dışa aktarabilirsiniz, ancak silindikten sonra kurtarılamaz.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Hesabımı silmenin kalıcı olduğunu ve anılar ve konuşmalar dahil tüm verilerin kaybolacağını ve kurtarılamayacağını anlıyorum.';
+
+  @override
+  String get areYouSure => 'Emin misiniz?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Bu işlem geri alınamaz ve hesabınızı ve tüm ilgili verileri kalıcı olarak silecektir. Devam etmek istediğinizden emin misiniz?';
+
+  @override
+  String get deleteNow => 'Şimdi Sil';
+
+  @override
+  String get goBack => 'Geri Dön';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Hesabınızı silmenin kalıcı ve geri alınamaz olduğunu anladığınızı onaylamak için kutucuğu işaretleyin.';
+
+  @override
+  String get profile => 'Profil';
+
+  @override
+  String get name => 'İsim';
+
+  @override
+  String get email => 'E-posta';
+
+  @override
+  String get customVocabulary => 'Özel Kelime Hazinesi';
+
+  @override
+  String get identifyingOthers => 'Diğerlerini Tanımlama';
+
+  @override
+  String get paymentMethods => 'Ödeme Yöntemleri';
+
+  @override
+  String get conversationDisplay => 'Konuşma Görünümü';
+
+  @override
+  String get dataPrivacy => 'Veri ve Gizlilik';
+
+  @override
+  String get userId => 'Kullanıcı Kimliği';
+
+  @override
+  String get notSet => 'Ayarlanmadı';
+
+  @override
+  String get userIdCopied => 'Kullanıcı kimliği panoya kopyalandı';
+
+  @override
+  String get systemDefault => 'Sistem Varsayılanı';
+
+  @override
+  String get planAndUsage => 'Plan ve Kullanım';
+
+  @override
+  String get offlineSync => 'Çevrimdışı Senkronizasyon';
+
+  @override
+  String get deviceSettings => 'Cihaz Ayarları';
+
+  @override
+  String get chatTools => 'Sohbet Araçları';
+
+  @override
+  String get feedbackBug => 'Geri Bildirim / Hata';
+
+  @override
+  String get helpCenter => 'Yardım Merkezi';
+
+  @override
+  String get developerSettings => 'Geliştirici Ayarları';
+
+  @override
+  String get getOmiForMac => 'Mac için Omi\'yi Edinin';
+
+  @override
+  String get referralProgram => 'Yönlendirme Programı';
+
+  @override
+  String get signOut => 'Çıkış Yap';
+
+  @override
+  String get appAndDeviceCopied => 'Uygulama ve cihaz detayları kopyalandı';
+
+  @override
+  String get wrapped2025 => '2025 Özeti';
+
+  @override
+  String get yourPrivacyYourControl => 'Gizliliğiniz, Kontrolünüz';
+
+  @override
+  String get privacyIntro =>
+      'Omi\'de gizliliğinizi korumaya kararlıyız. Bu sayfa verilerinizin nasıl saklandığını ve kullanıldığını kontrol etmenizi sağlar.';
+
+  @override
+  String get learnMore => 'Daha fazla bilgi...';
+
+  @override
+  String get dataProtectionLevel => 'Veri Koruma Seviyesi';
+
+  @override
+  String get dataProtectionDesc =>
+      'Verileriniz varsayılan olarak güçlü şifreleme ile korunmaktadır. Ayarlarınızı ve gelecekteki gizlilik seçeneklerini aşağıda inceleyin.';
+
+  @override
+  String get appAccess => 'Uygulama Erişimi';
+
+  @override
+  String get appAccessDesc =>
+      'Aşağıdaki uygulamalar verilerinize erişebilir. İzinlerini yönetmek için bir uygulamaya dokunun.';
+
+  @override
+  String get noAppsExternalAccess => 'Yüklü hiçbir uygulama verilerinize harici erişime sahip değil.';
+
+  @override
+  String get deviceName => 'Cihaz Adı';
+
+  @override
+  String get deviceId => 'Cihaz Kimliği';
+
+  @override
+  String get firmware => 'Ürün Yazılımı';
+
+  @override
+  String get sdCardSync => 'SD Kart Senkronizasyonu';
+
+  @override
+  String get hardwareRevision => 'Donanım Revizyonu';
+
+  @override
+  String get modelNumber => 'Model Numarası';
+
+  @override
+  String get manufacturer => 'Üretici';
+
+  @override
+  String get doubleTap => 'Çift Dokunma';
+
+  @override
+  String get ledBrightness => 'LED Parlaklığı';
+
+  @override
+  String get micGain => 'Mikrofon Kazancı';
+
+  @override
+  String get disconnect => 'Bağlantıyı Kes';
+
+  @override
+  String get forgetDevice => 'Cihazı Unut';
+
+  @override
+  String get chargingIssues => 'Şarj Sorunları';
+
+  @override
+  String get disconnectDevice => 'Cihazın Bağlantısını Kes';
+
+  @override
+  String get unpairDevice => 'Cihazı Eşleştirmeyi Kaldır';
+
+  @override
+  String get unpairAndForget => 'Eşleştirmeyi Kaldır ve Cihazı Unut';
+
+  @override
+  String get deviceDisconnectedMessage => 'Omi\'nizin bağlantısı kesildi 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Cihazın eşleştirilmesi kaldırıldı. Eşleştirmeyi tamamlamak için Ayarlar > Bluetooth\'a gidin ve cihazı unutun.';
+
+  @override
+  String get unpairDialogTitle => 'Cihazı Eşleştirmeyi Kaldır';
+
+  @override
+  String get unpairDialogMessage =>
+      'Bu, cihazın eşleştirilmesini kaldıracak ve başka bir telefona bağlanabilecek. İşlemi tamamlamak için Ayarlar > Bluetooth\'a gidip cihazı unutmanız gerekecek.';
+
+  @override
+  String get deviceNotConnected => 'Cihaz Bağlı Değil';
+
+  @override
+  String get connectDeviceMessage => 'Cihaz ayarlarına ve özelleştirmeye erişmek için\nOmi cihazınızı bağlayın';
+
+  @override
+  String get deviceInfoSection => 'Cihaz Bilgileri';
+
+  @override
+  String get customizationSection => 'Özelleştirme';
+
+  @override
+  String get hardwareSection => 'Donanım';
+
+  @override
+  String get v2Undetected => 'V2 algılanamadı';
+
+  @override
+  String get v2UndetectedMessage =>
+      'V1 cihazınız olduğunu veya cihazınızın bağlı olmadığını görüyoruz. SD Kart işlevi yalnızca V2 cihazlar için mevcuttur.';
+
+  @override
+  String get endConversation => 'Konuşmayı Sonlandır';
+
+  @override
+  String get pauseResume => 'Duraklat/Devam Et';
+
+  @override
+  String get starConversation => 'Konuşmayı Favorilere Ekle';
+
+  @override
+  String get doubleTapAction => 'Çift Dokunma İşlemi';
+
+  @override
+  String get endAndProcess => 'Konuşmayı Sonlandır ve İşle';
+
+  @override
+  String get pauseResumeRecording => 'Kaydı Duraklat/Devam Ettir';
+
+  @override
+  String get starOngoing => 'Devam Eden Konuşmayı Favorilere Ekle';
+
+  @override
+  String get off => 'Kapalı';
+
+  @override
+  String get max => 'Maksimum';
+
+  @override
+  String get mute => 'Sessiz';
+
+  @override
+  String get quiet => 'Sessiz';
+
+  @override
+  String get normal => 'Normal';
+
+  @override
+  String get high => 'Yüksek';
+
+  @override
+  String get micGainDescMuted => 'Mikrofon sessize alındı';
+
+  @override
+  String get micGainDescLow => 'Çok sessiz - gürültülü ortamlar için';
+
+  @override
+  String get micGainDescModerate => 'Sessiz - orta düzey gürültü için';
+
+  @override
+  String get micGainDescNeutral => 'Nötr - dengeli kayıt';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Hafif artırılmış - normal kullanım';
+
+  @override
+  String get micGainDescBoosted => 'Artırılmış - sessiz ortamlar için';
+
+  @override
+  String get micGainDescHigh => 'Yüksek - uzak veya yumuşak sesler için';
+
+  @override
+  String get micGainDescVeryHigh => 'Çok yüksek - çok sessiz kaynaklar için';
+
+  @override
+  String get micGainDescMax => 'Maksimum - dikkatli kullanın';
+
+  @override
+  String get developerSettingsTitle => 'Geliştirici Ayarları';
+
+  @override
+  String get saving => 'Kaydediliyor...';
+
+  @override
+  String get personaConfig => 'Yapay zeka kişiliğinizi yapılandırın';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Transkripsiyon';
+
+  @override
+  String get transcriptionConfig => 'STT sağlayıcısını yapılandırın';
+
+  @override
+  String get conversationTimeout => 'Konuşma Zaman Aşımı';
+
+  @override
+  String get conversationTimeoutConfig => 'Konuşmaların ne zaman otomatik sonlandırılacağını ayarlayın';
+
+  @override
+  String get importData => 'Veri İçe Aktar';
+
+  @override
+  String get importDataConfig => 'Diğer kaynaklardan veri içe aktarın';
+
+  @override
+  String get debugDiagnostics => 'Hata Ayıklama ve Teşhis';
+
+  @override
+  String get endpointUrl => 'Uç Nokta URL\'si';
+
+  @override
+  String get noApiKeys => 'Henüz API anahtarı yok';
+
+  @override
+  String get createKeyToStart => 'Başlamak için bir anahtar oluşturun';
+
+  @override
+  String get createKey => 'Anahtar Oluştur';
+
+  @override
+  String get docs => 'Dokümanlar';
+
+  @override
+  String get yourOmiInsights => 'Omi İçgörüleriniz';
+
+  @override
+  String get today => 'Bugün';
+
+  @override
+  String get thisMonth => 'Bu Ay';
+
+  @override
+  String get thisYear => 'Bu Yıl';
+
+  @override
+  String get allTime => 'Tüm Zamanlar';
+
+  @override
+  String get noActivityYet => 'Henüz Aktivite Yok';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Kullanım içgörülerinizi burada görmek için\nOmi ile bir konuşma başlatın.';
+
+  @override
+  String get listening => 'Dinleme';
+
+  @override
+  String get listeningSubtitle => 'Omi\'nin aktif olarak dinlediği toplam süre.';
+
+  @override
+  String get understanding => 'Anlama';
+
+  @override
+  String get understandingSubtitle => 'Konuşmalarınızdan anlaşılan kelimeler.';
+
+  @override
+  String get providing => 'Sağlama';
+
+  @override
+  String get providingSubtitle => 'Otomatik olarak yakalanan eylem öğeleri ve notlar.';
+
+  @override
+  String get remembering => 'Hatırlama';
+
+  @override
+  String get rememberingSubtitle => 'Sizin için hatırlanan gerçekler ve detaylar.';
+
+  @override
+  String get unlimitedPlan => 'Sınırsız Plan';
+
+  @override
+  String get managePlan => 'Planı Yönet';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Planınız $date tarihinde iptal edilecek.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Planınız $date tarihinde yenilenecek.';
+  }
+
+  @override
+  String get basicPlan => 'Ücretsiz Plan';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$limit dakikadan $used kullanıldı';
+  }
+
+  @override
+  String get upgrade => 'Yükselt';
+
+  @override
+  String get upgradeToUnlimited => 'Sınırsız\'a Yükselt';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Planınız ayda $limit ücretsiz dakika içerir. Sınırsız kullanım için yükseltin.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Omi istatistiklerimi paylaşıyorum! (omi.me - her zaman açık yapay zeka asistanınız)';
+
+  @override
+  String get sharePeriodToday => 'Bugün, omi:';
+
+  @override
+  String get sharePeriodMonth => 'Bu ay, omi:';
+
+  @override
+  String get sharePeriodYear => 'Bu yıl, omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Şimdiye kadar, omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 $minutes dakika dinledi';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 $words kelime anladı';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ $count içgörü sağladı';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 $count anı hatırladı';
+  }
+
+  @override
+  String get debugLogs => 'Hata Ayıklama Günlükleri';
+
+  @override
+  String get debugLogsAutoDelete => '3 gün sonra otomatik olarak silinir.';
+
+  @override
+  String get debugLogsDesc => 'Sorunların teşhisine yardımcı olur';
+
+  @override
+  String get noLogFilesFound => 'Günlük dosyası bulunamadı.';
+
+  @override
+  String get omiDebugLog => 'Omi hata ayıklama günlüğü';
+
+  @override
+  String get logShared => 'Günlük paylaşıldı';
+
+  @override
+  String get selectLogFile => 'Günlük Dosyası Seç';
+
+  @override
+  String get shareLogs => 'Günlükleri Paylaş';
+
+  @override
+  String get debugLogCleared => 'Hata ayıklama günlüğü temizlendi';
+
+  @override
+  String get exportStarted => 'Dışa aktarma başladı. Bu birkaç saniye sürebilir...';
+
+  @override
+  String get exportAllData => 'Tüm Verileri Dışa Aktar';
+
+  @override
+  String get exportDataDesc => 'Konuşmaları JSON dosyasına aktar';
+
+  @override
+  String get exportedConversations => 'Omi\'den Dışa Aktarılan Konuşmalar';
+
+  @override
+  String get exportShared => 'Dışa aktarma paylaşıldı';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Bilgi Grafiği Silinsin mi?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Bu, tüm türetilmiş bilgi grafiği verilerini (düğümler ve bağlantılar) silecektir. Orijinal anılarınız güvende kalacaktır. Grafik zamanla veya bir sonraki istekte yeniden oluşturulacaktır.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Bilgi Grafiği başarıyla silindi';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Grafik silinemedi: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Bilgi Grafiğini Sil';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Tüm düğümleri ve bağlantıları temizle';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP Sunucusu';
+
+  @override
+  String get mcpServerDesc => 'Yapay zeka asistanlarını verilerinize bağlayın';
+
+  @override
+  String get serverUrl => 'Sunucu URL\'si';
+
+  @override
+  String get urlCopied => 'URL kopyalandı';
+
+  @override
+  String get apiKeyAuth => 'API Anahtar Kimlik Doğrulaması';
+
+  @override
+  String get header => 'Başlık';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'İstemci Kimliği';
+
+  @override
+  String get clientSecret => 'İstemci Gizli Anahtarı';
+
+  @override
+  String get useMcpApiKey => 'MCP API anahtarınızı kullanın';
+
+  @override
+  String get webhooks => 'Web Hook\'ları';
+
+  @override
+  String get conversationEvents => 'Konuşma Olayları';
+
+  @override
+  String get newConversationCreated => 'Yeni konuşma oluşturuldu';
+
+  @override
+  String get realtimeTranscript => 'Gerçek Zamanlı Transkript';
+
+  @override
+  String get transcriptReceived => 'Transkript alındı';
+
+  @override
+  String get audioBytes => 'Ses Baytları';
+
+  @override
+  String get audioDataReceived => 'Ses verisi alındı';
+
+  @override
+  String get intervalSeconds => 'Aralık (saniye)';
+
+  @override
+  String get daySummary => 'Gün Özeti';
+
+  @override
+  String get summaryGenerated => 'Özet oluşturuldu';
+
+  @override
+  String get claudeDesktop => 'Claude Masaüstü';
+
+  @override
+  String get addToClaudeConfig => 'claude_desktop_config.json\'a ekle';
+
+  @override
+  String get copyConfig => 'Yapılandırmayı Kopyala';
+
+  @override
+  String get configCopied => 'Yapılandırma panoya kopyalandı';
+
+  @override
+  String get listeningMins => 'Dinleme (dk)';
+
+  @override
+  String get understandingWords => 'Anlama (kelime)';
+
+  @override
+  String get insights => 'İçgörüler';
+
+  @override
+  String get memories => 'Anılar';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return 'Bu ay $limit dakikadan $used kullanıldı';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return 'Bu ay $limit kelimeden $used kullanıldı';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return 'Bu ay $limit içgörüden $used elde edildi';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return 'Bu ay $limit anıdan $used oluşturuldu';
+  }
+
+  @override
+  String get visibility => 'Görünürlük';
+
+  @override
+  String get visibilitySubtitle => 'Listenizde hangi konuşmaların görüneceğini kontrol edin';
+
+  @override
+  String get showShortConversations => 'Kısa Konuşmaları Göster';
+
+  @override
+  String get showShortConversationsDesc => 'Eşik değerinden kısa konuşmaları göster';
+
+  @override
+  String get showDiscardedConversations => 'Atılan Konuşmaları Göster';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Atılanmış olarak işaretlenmiş konuşmaları dahil et';
+
+  @override
+  String get shortConversationThreshold => 'Kısa Konuşma Eşiği';
+
+  @override
+  String get shortConversationThresholdSubtitle => 'Bundan kısa konuşmalar yukarıda etkinleştirilmedikçe gizlenecek';
+
+  @override
+  String get durationThreshold => 'Süre Eşiği';
+
+  @override
+  String get durationThresholdDesc => 'Bundan kısa konuşmaları gizle';
+
+  @override
+  String minLabel(int count) {
+    return '$count dk';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Özel Kelime Hazinesi';
+
+  @override
+  String get addWords => 'Kelime Ekle';
+
+  @override
+  String get addWordsDesc => 'İsimler, terimler veya yaygın olmayan kelimeler';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Bağlan';
+
+  @override
+  String get comingSoon => 'Yakında';
+
+  @override
+  String get chatToolsFooter => 'Sohbette veri ve metrikleri görmek için uygulamalarınızı bağlayın.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return '$appName kimlik doğrulaması başlatılamadı';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return '$appName Bağlantısı Kesilsin mi?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return '$appName bağlantısını kesmek istediğinizden emin misiniz? İstediğiniz zaman tekrar bağlanabilirsiniz.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return '$appName bağlantısı kesildi';
+  }
+
+  @override
+  String get failedToDisconnect => 'Bağlantı kesilemedi';
+
+  @override
+  String connectTo(String appName) {
+    return '$appName\'e Bağlan';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Omi\'nin $appName verilerinize erişmesine yetki vermeniz gerekecek. Bu, kimlik doğrulama için tarayıcınızı açacaktır.';
+  }
+
+  @override
+  String get continueAction => 'Devam Et';
+
+  @override
+  String get languageTitle => 'Dil';
+
+  @override
+  String get primaryLanguage => 'Ana Dil';
+
+  @override
+  String get automaticTranslation => 'Otomatik Çeviri';
+
+  @override
+  String get detectLanguages => '10+ dil algıla';
+
+  @override
+  String get authorizeSavingRecordings => 'Kayıtların Kaydedilmesine İzin Ver';
+
+  @override
+  String get thanksForAuthorizing => 'İzin verdiğiniz için teşekkürler!';
+
+  @override
+  String get needYourPermission => 'İzninize ihtiyacımız var';
+
+  @override
+  String get alreadyGavePermission =>
+      'Kayıtlarınızı kaydetmemiz için bize zaten izin verdiniz. İşte neden buna ihtiyacımız olduğunun bir hatırlatması:';
+
+  @override
+  String get wouldLikePermission => 'Ses kayıtlarınızı kaydetmek için izninizi istiyoruz. İşte nedeni:';
+
+  @override
+  String get improveSpeechProfile => 'Konuşma Profilinizi Geliştirin';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Kişisel konuşma profilinizi eğitmek ve geliştirmek için kayıtları kullanıyoruz.';
+
+  @override
+  String get trainFamilyProfiles => 'Arkadaşlar ve Aile için Profil Eğitin';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Kayıtlarınız arkadaşlarınızı ve ailenizi tanımamıza ve profil oluşturmamıza yardımcı olur.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Transkript Doğruluğunu Artırın';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Modelimiz geliştikçe, kayıtlarınız için daha iyi transkripsiyon sonuçları sağlayabiliriz.';
+
+  @override
+  String get legalNotice =>
+      'Yasal Uyarı: Ses verilerini kaydetme ve saklama yasallığı bulunduğunuz yere ve bu özelliği nasıl kullandığınıza bağlı olarak değişebilir. Yerel yasalara ve düzenlemelere uyumu sağlamak sizin sorumluluğunuzdur.';
+
+  @override
+  String get alreadyAuthorized => 'Zaten İzin Verildi';
+
+  @override
+  String get authorize => 'İzin Ver';
+
+  @override
+  String get revokeAuthorization => 'İzni Geri Al';
+
+  @override
+  String get authorizationSuccessful => 'İzin verme başarılı!';
+
+  @override
+  String get failedToAuthorize => 'İzin verilemedi. Lütfen tekrar deneyin.';
+
+  @override
+  String get authorizationRevoked => 'İzin geri alındı.';
+
+  @override
+  String get recordingsDeleted => 'Kayıtlar silindi.';
+
+  @override
+  String get failedToRevoke => 'İzin geri alınamadı. Lütfen tekrar deneyin.';
+
+  @override
+  String get permissionRevokedTitle => 'İzin Geri Alındı';
+
+  @override
+  String get permissionRevokedMessage => 'Mevcut tüm kayıtlarınızı da kaldırmamızı ister misiniz?';
+
+  @override
+  String get yes => 'Evet';
+
+  @override
+  String get editName => 'İsmi Düzenle';
+
+  @override
+  String get howShouldOmiCallYou => 'Omi size nasıl hitap etmeli?';
+
+  @override
+  String get enterYourName => 'İsminizi girin';
+
+  @override
+  String get nameCannotBeEmpty => 'İsim boş olamaz';
+
+  @override
+  String get nameUpdatedSuccessfully => 'İsim başarıyla güncellendi!';
+
+  @override
+  String get calendarSettings => 'Takvim ayarları';
+
+  @override
+  String get calendarProviders => 'Takvim Sağlayıcıları';
+
+  @override
+  String get macOsCalendar => 'macOS Takvimi';
+
+  @override
+  String get connectMacOsCalendar => 'Yerel macOS takviminizi bağlayın';
+
+  @override
+  String get googleCalendar => 'Google Takvim';
+
+  @override
+  String get syncGoogleAccount => 'Google hesabınızla senkronize edin';
+
+  @override
+  String get showMeetingsMenuBar => 'Yaklaşan toplantıları menü çubuğunda göster';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'Bir sonraki toplantınızı ve başlamasına kalan süreyi macOS menü çubuğunda gösterin';
+
+  @override
+  String get showEventsNoParticipants => 'Katılımcısı olmayan etkinlikleri göster';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Etkinleştirildiğinde, Yaklaşanlar katılımcısı veya video bağlantısı olmayan etkinlikleri gösterir.';
+
+  @override
+  String get yourMeetings => 'Toplantılarınız';
+
+  @override
+  String get refresh => 'Yenile';
+
+  @override
+  String get noUpcomingMeetings => 'Yaklaşan toplantı bulunamadı';
+
+  @override
+  String get checkingNextDays => 'Sonraki 30 gün kontrol ediliyor';
+
+  @override
+  String get tomorrow => 'Yarın';
+
+  @override
+  String get googleCalendarComingSoon => 'Google Takvim entegrasyonu yakında!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Kullanıcı olarak bağlandı: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Varsayılan Çalışma Alanı';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Görevler bu çalışma alanında oluşturulacak';
+
+  @override
+  String get defaultProjectOptional => 'Varsayılan Proje (İsteğe Bağlı)';
+
+  @override
+  String get leaveUnselectedTasks => 'Görevleri proje olmadan oluşturmak için seçilmemiş bırakın';
+
+  @override
+  String get noProjectsInWorkspace => 'Bu çalışma alanında proje bulunamadı';
+
+  @override
+  String get conversationTimeoutDesc =>
+      'Sessizlikte ne kadar bekledikten sonra konuşmanın otomatik olarak sonlandırılacağını seçin:';
+
+  @override
+  String get timeout2Minutes => '2 dakika';
+
+  @override
+  String get timeout2MinutesDesc => '2 dakika sessizlikten sonra konuşmayı sonlandır';
+
+  @override
+  String get timeout5Minutes => '5 dakika';
+
+  @override
+  String get timeout5MinutesDesc => '5 dakika sessizlikten sonra konuşmayı sonlandır';
+
+  @override
+  String get timeout10Minutes => '10 dakika';
+
+  @override
+  String get timeout10MinutesDesc => '10 dakika sessizlikten sonra konuşmayı sonlandır';
+
+  @override
+  String get timeout30Minutes => '30 dakika';
+
+  @override
+  String get timeout30MinutesDesc => '30 dakika sessizlikten sonra konuşmayı sonlandır';
+
+  @override
+  String get timeout4Hours => '4 saat';
+
+  @override
+  String get timeout4HoursDesc => '4 saat sessizlikten sonra konuşmayı sonlandır';
+
+  @override
+  String get conversationEndAfterHours => 'Konuşmalar artık 4 saat sessizlikten sonra sonlanacak';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Konuşmalar artık $minutes dakika sessizlikten sonra sonlanacak';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Bize ana dilinizi söyleyin';
+
+  @override
+  String get languageForTranscription =>
+      'Daha keskin transkripsiyonlar ve kişiselleştirilmiş bir deneyim için dilinizi ayarlayın.';
+
+  @override
+  String get singleLanguageModeInfo => 'Tek Dil Modu etkin. Daha yüksek doğruluk için çeviri devre dışı.';
+
+  @override
+  String get searchLanguageHint => 'Dili isim veya koda göre arayın';
+
+  @override
+  String get noLanguagesFound => 'Dil bulunamadı';
+
+  @override
+  String get skip => 'Atla';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Dil $language olarak ayarlandı';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Dil ayarlanamadı';
+
+  @override
+  String appSettings(String appName) {
+    return '$appName Ayarları';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return '$appName Bağlantısı Kesilsin mi?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Bu, $appName kimlik doğrulamanızı kaldıracaktır. Tekrar kullanmak için yeniden bağlanmanız gerekecek.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return '$appName\'e bağlandı';
+  }
+
+  @override
+  String get account => 'Hesap';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Eylem öğeleriniz $appName hesabınıza senkronize edilecek';
+  }
+
+  @override
+  String get defaultSpace => 'Varsayılan Alan';
+
+  @override
+  String get selectSpaceInWorkspace => 'Çalışma alanınızda bir alan seçin';
+
+  @override
+  String get noSpacesInWorkspace => 'Bu çalışma alanında alan bulunamadı';
+
+  @override
+  String get defaultList => 'Varsayılan Liste';
+
+  @override
+  String get tasksAddedToList => 'Görevler bu listeye eklenecek';
+
+  @override
+  String get noListsInSpace => 'Bu alanda liste bulunamadı';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Depolar yüklenemedi: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Varsayılan depo kaydedildi';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Varsayılan depo kaydedilemedi';
+
+  @override
+  String get defaultRepository => 'Varsayılan Depo';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Sorun oluşturmak için varsayılan bir depo seçin. Sorun oluştururken farklı bir depo belirtebilirsiniz.';
+
+  @override
+  String get noReposFound => 'Depo bulunamadı';
+
+  @override
+  String get private => 'Özel';
+
+  @override
+  String updatedDate(String date) {
+    return '$date güncellendi';
+  }
+
+  @override
+  String get yesterday => 'dün';
+
+  @override
+  String daysAgo(int count) {
+    return '$count gün önce';
+  }
+
+  @override
+  String get oneWeekAgo => '1 hafta önce';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count hafta önce';
+  }
+
+  @override
+  String get oneMonthAgo => '1 ay önce';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count ay önce';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Sorunlar varsayılan deponuzda oluşturulacak';
+
+  @override
+  String get taskIntegrations => 'Görev Entegrasyonları';
+
+  @override
+  String get configureSettings => 'Ayarları Yapılandır';
+
+  @override
+  String get completeAuthBrowser =>
+      'Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return '$appName kimlik doğrulaması başlatılamadı';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return '$appName\'e Bağlan';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Omi\'nin $appName hesabınızda görev oluşturmasına yetki vermeniz gerekecek. Bu, kimlik doğrulama için tarayıcınızı açacaktır.';
+  }
+
+  @override
+  String get continueButton => 'Devam Et';
+
+  @override
+  String appIntegration(String appName) {
+    return '$appName Entegrasyonu';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return '$appName ile entegrasyon yakında! Size daha fazla görev yönetimi seçeneği sunmak için çok çalışıyoruz.';
+  }
+
+  @override
+  String get gotIt => 'Anladım';
+
+  @override
+  String get tasksExportedOneApp => 'Görevler aynı anda bir uygulamaya aktarılabilir.';
+
+  @override
+  String get completeYourUpgrade => 'Yükseltmenizi Tamamlayın';
+
+  @override
+  String get importConfiguration => 'Yapılandırma İçe Aktar';
+
+  @override
+  String get exportConfiguration => 'Yapılandırmayı dışa aktar';
+
+  @override
+  String get bringYourOwn => 'Kendininkini getir';
+
+  @override
+  String get payYourSttProvider => 'Omi\'yi özgürce kullanın. Sadece STT sağlayıcınıza doğrudan ödeme yaparsınız.';
+
+  @override
+  String get freeMinutesMonth => 'Ayda 1.200 ücretsiz dakika dahildir. ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Host gereklidir';
+
+  @override
+  String get validPortRequired => 'Geçerli port gereklidir';
+
+  @override
+  String get validWebsocketUrlRequired => 'Geçerli WebSocket URL\'si gereklidir (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL\'si gereklidir';
+
+  @override
+  String get apiKeyRequired => 'API anahtarı gereklidir';
+
+  @override
+  String get invalidJsonConfig => 'Geçersiz JSON yapılandırması';
+
+  @override
+  String errorSaving(String error) {
+    return 'Kaydetme hatası: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Yapılandırma panoya kopyalandı';
+
+  @override
+  String get pasteJsonConfig => 'JSON yapılandırmanızı aşağıya yapıştırın:';
+
+  @override
+  String get addApiKeyAfterImport => 'İçe aktardıktan sonra kendi API anahtarınızı eklemeniz gerekecek';
+
+  @override
+  String get paste => 'Yapıştır';
+
+  @override
+  String get import => 'İçe Aktar';
+
+  @override
+  String get invalidProviderInConfig => 'Yapılandırmada geçersiz sağlayıcı';
+
+  @override
+  String importedConfig(String providerName) {
+    return '$providerName yapılandırması içe aktarıldı';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Geçersiz JSON: $error';
+  }
+
+  @override
+  String get provider => 'Sağlayıcı';
+
+  @override
+  String get live => 'Canlı';
+
+  @override
+  String get onDevice => 'Cihazda';
+
+  @override
+  String get apiUrl => 'API URL\'si';
+
+  @override
+  String get enterSttHttpEndpoint => 'STT HTTP uç noktanızı girin';
+
+  @override
+  String get websocketUrl => 'WebSocket URL\'si';
+
+  @override
+  String get enterLiveSttWebsocket => 'Canlı STT WebSocket uç noktanızı girin';
+
+  @override
+  String get apiKey => 'API Anahtarı';
+
+  @override
+  String get enterApiKey => 'API anahtarınızı girin';
+
+  @override
+  String get storedLocallyNeverShared => 'Yerel olarak saklanır, asla paylaşılmaz';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Gelişmiş';
+
+  @override
+  String get configuration => 'Yapılandırma';
+
+  @override
+  String get requestConfiguration => 'İstek Yapılandırması';
+
+  @override
+  String get responseSchema => 'Yanıt Şeması';
+
+  @override
+  String get modified => 'Değiştirildi';
+
+  @override
+  String get resetRequestConfig => 'İstek yapılandırmasını varsayılana sıfırla';
+
+  @override
+  String get logs => 'Günlükler';
+
+  @override
+  String get logsCopied => 'Günlükler kopyalandı';
+
+  @override
+  String get noLogsYet => 'Henüz günlük yok. Özel STT etkinliğini görmek için kayda başlayın.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName $codecReason kullanıyor. Omi kullanılacak.';
+  }
+
+  @override
+  String get omiTranscription => 'Omi Transkripsiyonu';
+
+  @override
+  String get bestInClassTranscription => 'Sıfır kurulum ile sınıfının en iyisi transkripsiyon';
+
+  @override
+  String get instantSpeakerLabels => 'Anında konuşmacı etiketleri';
+
+  @override
+  String get languageTranslation => '100+ dil çevirisi';
+
+  @override
+  String get optimizedForConversation => 'Konuşma için optimize edilmiş';
+
+  @override
+  String get autoLanguageDetection => 'Otomatik dil algılama';
+
+  @override
+  String get highAccuracy => 'Yüksek doğruluk';
+
+  @override
+  String get privacyFirst => 'Önce gizlilik';
+
+  @override
+  String get saveChanges => 'Değişiklikleri Kaydet';
+
+  @override
+  String get resetToDefault => 'Varsayılana Sıfırla';
+
+  @override
+  String get viewTemplate => 'Şablonu Görüntüle';
+
+  @override
+  String get trySomethingLike => 'Şöyle bir şey deneyin...';
+
+  @override
+  String get tryIt => 'Dene';
+
+  @override
+  String get creatingPlan => 'Plan oluşturuluyor';
+
+  @override
+  String get developingLogic => 'Mantık geliştiriliyor';
+
+  @override
+  String get designingApp => 'Uygulama tasarlanıyor';
+
+  @override
+  String get generatingIconStep => 'İkon oluşturuluyor';
+
+  @override
+  String get finalTouches => 'Son dokunuşlar';
+
+  @override
+  String get processing => 'İşleniyor...';
+
+  @override
+  String get features => 'Özellikler';
+
+  @override
+  String get creatingYourApp => 'Uygulamanız oluşturuluyor...';
+
+  @override
+  String get generatingIcon => 'İkon oluşturuluyor...';
+
+  @override
+  String get whatShouldWeMake => 'Ne yapalım?';
+
+  @override
+  String get appName => 'Uygulama Adı';
+
+  @override
+  String get description => 'Açıklama';
+
+  @override
+  String get publicLabel => 'Genel';
+
+  @override
+  String get privateLabel => 'Özel';
+
+  @override
+  String get free => 'Ücretsiz';
+
+  @override
+  String get perMonth => '/ Ay';
+
+  @override
+  String get tailoredConversationSummaries => 'Özelleştirilmiş Konuşma Özetleri';
+
+  @override
+  String get customChatbotPersonality => 'Özel Chatbot Kişiliği';
+
+  @override
+  String get makePublic => 'Herkese açık yap';
+
+  @override
+  String get anyoneCanDiscover => 'Herkes uygulamanızı keşfedebilir';
+
+  @override
+  String get onlyYouCanUse => 'Yalnızca siz bu uygulamayı kullanabilirsiniz';
+
+  @override
+  String get paidApp => 'Ücretli uygulama';
+
+  @override
+  String get usersPayToUse => 'Kullanıcılar uygulamanızı kullanmak için ödeme yapar';
+
+  @override
+  String get freeForEveryone => 'Herkes için ücretsiz';
+
+  @override
+  String get perMonthLabel => '/ ay';
+
+  @override
+  String get creating => 'Oluşturuluyor...';
+
+  @override
+  String get createApp => 'Uygulama Oluştur';
+
+  @override
+  String get searchingForDevices => 'Cihazlar aranıyor...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'CİHAZ',
+      one: 'CİHAZ',
+    );
+    return '$count $_temp0 YAKINLARDA BULUNDU';
+  }
+
+  @override
+  String get pairingSuccessful => 'EŞLEŞTIRME BAŞARILI';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Apple Watch\'a bağlanırken hata: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Bir daha gösterme';
+
+  @override
+  String get iUnderstand => 'Anladım';
+
+  @override
+  String get enableBluetooth => 'Bluetooth\'u Etkinleştir';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi\'nin giyilebilir cihazınıza bağlanması için Bluetooth gereklidir. Lütfen Bluetooth\'u etkinleştirin ve tekrar deneyin.';
+
+  @override
+  String get contactSupport => 'Desteğe Başvur?';
+
+  @override
+  String get connectLater => 'Sonra Bağlan';
+
+  @override
+  String get grantPermissions => 'İzinleri ver';
+
+  @override
+  String get backgroundActivity => 'Arka plan etkinliği';
+
+  @override
+  String get backgroundActivityDesc => 'Daha iyi stabilite için Omi\'nin arka planda çalışmasına izin verin';
+
+  @override
+  String get locationAccess => 'Konum erişimi';
+
+  @override
+  String get locationAccessDesc => 'Tam deneyim için arka plan konumunu etkinleştirin';
+
+  @override
+  String get notifications => 'Bildirimler';
+
+  @override
+  String get notificationsDesc => 'Bilgilendirilmek için bildirimleri etkinleştirin';
+
+  @override
+  String get locationServiceDisabled => 'Konum Servisi Devre Dışı';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Konum Servisi Devre Dışı. Lütfen Ayarlar > Gizlilik ve Güvenlik > Konum Servisleri\'ne gidin ve etkinleştirin';
+
+  @override
+  String get backgroundLocationDenied => 'Arka Plan Konum Erişimi Reddedildi';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Lütfen cihaz ayarlarına gidin ve konum iznini \"Her Zaman İzin Ver\" olarak ayarlayın';
+
+  @override
+  String get lovingOmi => 'Omi\'yi Beğeniyor musunuz?';
+
+  @override
+  String get leaveReviewIos =>
+      'App Store\'da bir yorum bırakarak daha fazla insana ulaşmamıza yardımcı olun. Geri bildiriminiz bizim için çok değerli!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Google Play Store\'da bir yorum bırakarak daha fazla insana ulaşmamıza yardımcı olun. Geri bildiriminiz bizim için çok değerli!';
+
+  @override
+  String get rateOnAppStore => 'App Store\'da Değerlendir';
+
+  @override
+  String get rateOnGooglePlay => 'Google Play\'de Değerlendir';
+
+  @override
+  String get maybeLater => 'Belki sonra';
+
+  @override
+  String get speechProfileIntro =>
+      'Omi\'nin hedeflerinizi ve sesinizi öğrenmesi gerekiyor. Daha sonra değiştirebilirsiniz.';
+
+  @override
+  String get getStarted => 'Başlayın';
+
+  @override
+  String get allDone => 'Hepsi tamam!';
+
+  @override
+  String get keepGoing => 'Devam et, harika gidiyorsun';
+
+  @override
+  String get skipThisQuestion => 'Bu soruyu atla';
+
+  @override
+  String get skipForNow => 'Şimdilik atla';
+
+  @override
+  String get connectionError => 'Bağlantı Hatası';
+
+  @override
+  String get connectionErrorDesc =>
+      'Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Geçersiz kayıt algılandı';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Kayıtta birden fazla konuşmacı var gibi görünüyor. Lütfen sessiz bir yerde olduğunuzdan emin olun ve tekrar deneyin.';
+
+  @override
+  String get tooShortDesc => 'Yeterli konuşma algılanamadı. Lütfen daha fazla konuşun ve tekrar deneyin.';
+
+  @override
+  String get invalidRecordingDesc => 'Lütfen en az 5 saniye, en fazla 90 saniye konuştuğunuzdan emin olun.';
+
+  @override
+  String get areYouThere => 'Orada mısınız?';
+
+  @override
+  String get noSpeechDesc =>
+      'Herhangi bir konuşma algılayamadık. Lütfen en az 10 saniye, en fazla 3 dakika konuştuğunuzdan emin olun.';
+
+  @override
+  String get connectionLost => 'Bağlantı Kesildi';
+
+  @override
+  String get connectionLostDesc => 'Bağlantı kesildi. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.';
+
+  @override
+  String get tryAgain => 'Tekrar Dene';
+
+  @override
+  String get connectOmiOmiGlass => 'Omi / OmiGlass Bağla';
+
+  @override
+  String get continueWithoutDevice => 'Cihaz Olmadan Devam Et';
+
+  @override
+  String get permissionsRequired => 'İzinler Gerekli';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Bu uygulamanın düzgün çalışması için Bluetooth ve Konum izinlerine ihtiyacı var. Lütfen ayarlardan bunları etkinleştirin.';
+
+  @override
+  String get openSettings => 'Ayarları Aç';
+
+  @override
+  String get wantDifferentName => 'Farklı bir isimle mi anılmak istiyorsunuz?';
+
+  @override
+  String get whatsYourName => 'Adınız nedir?';
+
+  @override
+  String get speakTranscribeSummarize => 'Konuş. Transkripsiyonu Oluştur. Özetle.';
+
+  @override
+  String get signInWithApple => 'Apple ile Giriş Yap';
+
+  @override
+  String get signInWithGoogle => 'Google ile Giriş Yap';
+
+  @override
+  String get byContinuingAgree => 'Devam ederek ';
+
+  @override
+  String get termsOfUse => 'Kullanım Koşulları';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Yapay Zeka Yardımcınız';
+
+  @override
+  String get captureEveryMoment => 'Her anı yakalayın. Yapay zeka destekli\nözetler alın. Artık not almayın.';
+
+  @override
+  String get appleWatchSetup => 'Apple Watch Kurulumu';
+
+  @override
+  String get permissionRequestedExclaim => 'İzin İstendi!';
+
+  @override
+  String get microphonePermission => 'Mikrofon İzni';
+
+  @override
+  String get permissionGrantedNow =>
+      'İzin verildi! Şimdi:\n\nSaatinizdeki Omi uygulamasını açın ve aşağıda \"Devam Et\"e dokunun';
+
+  @override
+  String get needMicrophonePermission =>
+      'Mikrofon iznine ihtiyacımız var.\n\n1. \"İzin Ver\"e dokunun\n2. iPhone\'unuzda izin verin\n3. Saat uygulaması kapanacak\n4. Yeniden açın ve \"Devam Et\"e dokunun';
+
+  @override
+  String get grantPermissionButton => 'İzin Ver';
+
+  @override
+  String get needHelp => 'Yardıma mı İhtiyacınız Var?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Sorun giderme:\n\n1. Omi\'nin saatinizde yüklü olduğundan emin olun\n2. Saatinizdeki Omi uygulamasını açın\n3. İzin açılır penceresini arayın\n4. İstendiğinde \"İzin Ver\"e dokunun\n5. Saatinizdeki uygulama kapanacak - yeniden açın\n6. Geri gelin ve iPhone\'unuzda \"Devam Et\"e dokunun';
+
+  @override
+  String get recordingStartedSuccessfully => 'Kayıt başarıyla başladı!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Henüz izin verilmedi. Lütfen mikrofon erişimine izin verdiğinizden ve saatinizdeki uygulamayı yeniden açtığınızdan emin olun.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'İzin isteği hatası: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Kayıt başlatma hatası: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Ana dilinizi seçin';
+
+  @override
+  String get languageBenefits =>
+      'Daha keskin transkripsiyonlar ve kişiselleştirilmiş bir deneyim için dilinizi ayarlayın';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Ana diliniz nedir?';
+
+  @override
+  String get selectYourLanguage => 'Dilinizi seçin';
+
+  @override
+  String get personalGrowthJourney => 'Her kelimenizi dinleyen yapay zeka ile kişisel gelişim yolculuğunuz.';
+
+  @override
+  String get actionItemsTitle => 'Yapılacaklar';
+
+  @override
+  String get actionItemsDescription => 'Düzenlemek için dokunun • Seçmek için uzun basın • Eylemler için kaydırın';
+
+  @override
+  String get tabToDo => 'Yapılacak';
+
+  @override
+  String get tabDone => 'Bitti';
+
+  @override
+  String get tabOld => 'Eski';
+
+  @override
+  String get emptyTodoMessage => '🎉 Her şey güncel!\nBekleyen eylem öğesi yok';
+
+  @override
+  String get emptyDoneMessage => 'Henüz tamamlanmış öğe yok';
+
+  @override
+  String get emptyOldMessage => '✅ Eski görev yok';
+
+  @override
+  String get noItems => 'Öğe yok';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Eylem öğesi tamamlanmamış olarak işaretlendi';
+
+  @override
+  String get actionItemCompleted => 'Eylem öğesi tamamlandı';
+
+  @override
+  String get deleteActionItemTitle => 'Eylem Öğesini Sil';
+
+  @override
+  String get deleteActionItemMessage => 'Bu eylem öğesini silmek istediğinizden emin misiniz?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Seçili Öğeleri Sil';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return '$count seçili eylem öğesini silmek istediğinizden emin misiniz?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Eylem öğesi \"$description\" silindi';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count eylem öğesi silindi';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Eylem öğesi silinemedi';
+
+  @override
+  String get failedToDeleteItems => 'Öğeler silinemedi';
+
+  @override
+  String get failedToDeleteSomeItems => 'Bazı öğeler silinemedi';
+
+  @override
+  String get welcomeActionItemsTitle => 'Eylem Öğeleri için Hazır';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Yapay zekanız konuşmalarınızdan otomatik olarak görevleri ve yapılacakları çıkaracaktır. Oluşturulduklarında burada görünecekler.';
+
+  @override
+  String get autoExtractionFeature => 'Konuşmalardan otomatik olarak çıkarıldı';
+
+  @override
+  String get editSwipeFeature => 'Düzenlemek için dokunun, tamamlamak veya silmek için kaydırın';
+
+  @override
+  String itemsSelected(int count) {
+    return '$count seçildi';
+  }
+
+  @override
+  String get selectAll => 'Tümünü seç';
+
+  @override
+  String get deleteSelected => 'Seçilenleri sil';
+
+  @override
+  String searchMemories(int count) {
+    return '$count Anıda Ara';
+  }
+
+  @override
+  String get memoryDeleted => 'Anı Silindi.';
+
+  @override
+  String get undo => 'Geri Al';
+
+  @override
+  String get noMemoriesYet => 'Henüz anı yok';
+
+  @override
+  String get noAutoMemories => 'Henüz otomatik çıkarılan anı yok';
+
+  @override
+  String get noManualMemories => 'Henüz manuel anı yok';
+
+  @override
+  String get noMemoriesInCategories => 'Bu kategorilerde anı yok';
+
+  @override
+  String get noMemoriesFound => 'Anı bulunamadı';
+
+  @override
+  String get addFirstMemory => 'İlk anınızı ekleyin';
+
+  @override
+  String get clearMemoryTitle => 'Omi\'nin Hafızasını Temizle';
+
+  @override
+  String get clearMemoryMessage =>
+      'Omi\'nin hafızasını temizlemek istediğinizden emin misiniz? Bu işlem geri alınamaz.';
+
+  @override
+  String get clearMemoryButton => 'Hafızayı Temizle';
+
+  @override
+  String get memoryClearedSuccess => 'Omi\'nin sizinle ilgili hafızası temizlendi';
+
+  @override
+  String get noMemoriesToDelete => 'Silinecek anı yok';
+
+  @override
+  String get createMemoryTooltip => 'Yeni anı oluştur';
+
+  @override
+  String get createActionItemTooltip => 'Yeni eylem öğesi oluştur';
+
+  @override
+  String get memoryManagement => 'Anı Yönetimi';
+
+  @override
+  String get filterMemories => 'Anıları Filtrele';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Toplam $count anınız var';
+  }
+
+  @override
+  String get publicMemories => 'Genel anılar';
+
+  @override
+  String get privateMemories => 'Özel anılar';
+
+  @override
+  String get makeAllPrivate => 'Tüm Anıları Özel Yap';
+
+  @override
+  String get makeAllPublic => 'Tüm Anıları Genel Yap';
+
+  @override
+  String get deleteAllMemories => 'Tüm Anıları Sil';
+
+  @override
+  String get allMemoriesPrivateResult => 'Tüm anılar artık özel';
+
+  @override
+  String get allMemoriesPublicResult => 'Tüm anılar artık genel';
+
+  @override
+  String get newMemory => 'Yeni Anı';
+
+  @override
+  String get editMemory => 'Anıyı Düzenle';
+
+  @override
+  String get memoryContentHint => 'Dondurma yemeyi severim...';
+
+  @override
+  String get failedToSaveMemory => 'Kaydedilemedi. Lütfen bağlantınızı kontrol edin.';
+
+  @override
+  String get saveMemory => 'Anıyı Kaydet';
+
+  @override
+  String get retry => 'Tekrar Dene';
+
+  @override
+  String get createActionItem => 'Eylem Öğesi Oluştur';
+
+  @override
+  String get editActionItem => 'Eylem Öğesini Düzenle';
+
+  @override
+  String get actionItemDescriptionHint => 'Ne yapılması gerekiyor?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Eylem öğesi açıklaması boş olamaz.';
+
+  @override
+  String get actionItemUpdated => 'Eylem öğesi güncellendi';
+
+  @override
+  String get failedToUpdateActionItem => 'Eylem öğesi güncellenemedi';
+
+  @override
+  String get actionItemCreated => 'Eylem öğesi oluşturuldu';
+
+  @override
+  String get failedToCreateActionItem => 'Eylem öğesi oluşturulamadı';
+
+  @override
+  String get dueDate => 'Teslim Tarihi';
+
+  @override
+  String get time => 'Saat';
+
+  @override
+  String get addDueDate => 'Teslim tarihi ekle';
+
+  @override
+  String get pressDoneToSave => 'Kaydetmek için bitti\'ye basın';
+
+  @override
+  String get pressDoneToCreate => 'Oluşturmak için bitti\'ye basın';
+
+  @override
+  String get filterAll => 'Tümü';
+
+  @override
+  String get filterSystem => 'Hakkınızda';
+
+  @override
+  String get filterInteresting => 'İçgörüler';
+
+  @override
+  String get filterManual => 'Manuel';
+
+  @override
+  String get completed => 'Tamamlandı';
+
+  @override
+  String get markComplete => 'Tamamlandı olarak işaretle';
+
+  @override
+  String get actionItemDeleted => 'Eylem öğesi silindi';
+
+  @override
+  String get failedToDeleteActionItem => 'Eylem öğesi silinemedi';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Eylem Öğesini Sil';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Bu eylem öğesini silmek istediğinizden emin misiniz?';
+
+  @override
+  String get appLanguage => 'Uygulama Dili';
+
+  @override
+  String get appInterfaceSectionTitle => 'UYGULAMA ARAYÜZÜ';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'KONUŞMA VE TRANSKRİPSİYON';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Uygulama Dili menüleri ve düğmeleri değiştirir. Konuşma Dili, kayıtlarınızın nasıl transkribe edildiğini etkiler.';
+}

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -1,0 +1,2233 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Ukrainian (`uk`).
+class AppLocalizationsUk extends AppLocalizations {
+  AppLocalizationsUk([String locale = 'uk']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Розмова';
+
+  @override
+  String get transcriptTab => 'Транскрипція';
+
+  @override
+  String get actionItemsTab => 'Завдання';
+
+  @override
+  String get deleteConversationTitle => 'Видалити розмову?';
+
+  @override
+  String get deleteConversationMessage => 'Ви впевнені, що хочете видалити цю розмову? Цю дію не можна скасувати.';
+
+  @override
+  String get confirm => 'Підтвердити';
+
+  @override
+  String get cancel => 'Скасувати';
+
+  @override
+  String get ok => 'OK';
+
+  @override
+  String get delete => 'Видалити';
+
+  @override
+  String get add => 'Додати';
+
+  @override
+  String get update => 'Оновити';
+
+  @override
+  String get save => 'Зберегти';
+
+  @override
+  String get edit => 'Редагувати';
+
+  @override
+  String get close => 'Закрити';
+
+  @override
+  String get clear => 'Очистити';
+
+  @override
+  String get copyTranscript => 'Копіювати транскрипцію';
+
+  @override
+  String get copySummary => 'Копіювати підсумок';
+
+  @override
+  String get testPrompt => 'Тестовий запит';
+
+  @override
+  String get reprocessConversation => 'Перепрацювати розмову';
+
+  @override
+  String get deleteConversation => 'Видалити розмову';
+
+  @override
+  String get contentCopied => 'Вміст скопійовано до буфера обміну';
+
+  @override
+  String get failedToUpdateStarred => 'Не вдалося оновити статус обраного.';
+
+  @override
+  String get conversationUrlNotShared => 'Не вдалося поділитися URL розмови.';
+
+  @override
+  String get errorProcessingConversation => 'Помилка під час обробки розмови. Будь ласка, спробуйте пізніше.';
+
+  @override
+  String get noInternetConnection => 'Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
+
+  @override
+  String get unableToDeleteConversation => 'Не вдалося видалити розмову';
+
+  @override
+  String get somethingWentWrong => 'Щось пішло не так! Будь ласка, спробуйте пізніше.';
+
+  @override
+  String get copyErrorMessage => 'Копіювати повідомлення про помилку';
+
+  @override
+  String get errorCopied => 'Повідомлення про помилку скопійовано до буфера обміну';
+
+  @override
+  String get remaining => 'Залишилось';
+
+  @override
+  String get loading => 'Завантаження...';
+
+  @override
+  String get loadingDuration => 'Завантаження тривалості...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count секунд';
+  }
+
+  @override
+  String get people => 'Люди';
+
+  @override
+  String get addNewPerson => 'Додати нову особу';
+
+  @override
+  String get editPerson => 'Редагувати особу';
+
+  @override
+  String get createPersonHint => 'Створіть нову особу та навчіть Omi розпізнавати її мовлення!';
+
+  @override
+  String get speechProfile => 'Мовний профіль';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Зразок $number';
+  }
+
+  @override
+  String get settings => 'Налаштування';
+
+  @override
+  String get language => 'Мова';
+
+  @override
+  String get selectLanguage => 'Вибрати мову';
+
+  @override
+  String get deleting => 'Видалення...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
+
+  @override
+  String get failedToStartAuthentication => 'Не вдалося розпочати автентифікацію';
+
+  @override
+  String get importStarted => 'Імпорт розпочато! Ви отримаєте сповіщення після завершення.';
+
+  @override
+  String get failedToStartImport => 'Не вдалося розпочати імпорт. Будь ласка, спробуйте ще раз.';
+
+  @override
+  String get couldNotAccessFile => 'Не вдалося отримати доступ до вибраного файлу';
+
+  @override
+  String get askOmi => 'Запитати Omi';
+
+  @override
+  String get done => 'Готово';
+
+  @override
+  String get disconnected => 'Відключено';
+
+  @override
+  String get searching => 'Пошук';
+
+  @override
+  String get connectDevice => 'Підключити пристрій';
+
+  @override
+  String get monthlyLimitReached => 'Ви досягли свого місячного ліміту.';
+
+  @override
+  String get checkUsage => 'Перевірити використання';
+
+  @override
+  String get syncingRecordings => 'Синхронізація записів';
+
+  @override
+  String get recordingsToSync => 'Записи для синхронізації';
+
+  @override
+  String get allCaughtUp => 'Все синхронізовано';
+
+  @override
+  String get sync => 'Синхронізувати';
+
+  @override
+  String get pendantUpToDate => 'Підвіска оновлена';
+
+  @override
+  String get allRecordingsSynced => 'Всі записи синхронізовано';
+
+  @override
+  String get syncingInProgress => 'Йде синхронізація';
+
+  @override
+  String get readyToSync => 'Готово до синхронізації';
+
+  @override
+  String get tapSyncToStart => 'Натисніть Синхронізувати, щоб почати';
+
+  @override
+  String get pendantNotConnected => 'Підвіска не підключена. Підключіть для синхронізації.';
+
+  @override
+  String get everythingSynced => 'Все вже синхронізовано.';
+
+  @override
+  String get recordingsNotSynced => 'У вас є записи, які ще не синхронізовано.';
+
+  @override
+  String get syncingBackground => 'Ми продовжимо синхронізацію ваших записів у фоновому режимі.';
+
+  @override
+  String get noConversationsYet => 'Розмов поки немає.';
+
+  @override
+  String get noStarredConversations => 'Обраних розмов поки немає.';
+
+  @override
+  String get starConversationHint =>
+      'Щоб позначити розмову зірочкою, відкрийте її та натисніть іконку зірки в заголовку.';
+
+  @override
+  String get searchConversations => 'Пошук розмов';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return 'Вибрано: $count';
+  }
+
+  @override
+  String get merge => 'Об\'єднати';
+
+  @override
+  String get mergeConversations => 'Об\'єднати розмови';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Це об\'єднає $count розмов в одну. Весь вміст буде об\'єднано та перегенеровано.';
+  }
+
+  @override
+  String get mergingInBackground => 'Об\'єднання у фоновому режимі. Це може зайняти деякий час.';
+
+  @override
+  String get failedToStartMerge => 'Не вдалося розпочати об\'єднання';
+
+  @override
+  String get askAnything => 'Запитайте що завгодно';
+
+  @override
+  String get noMessagesYet => 'Повідомлень поки немає!\nЧому б не почати розмову?';
+
+  @override
+  String get deletingMessages => 'Видалення ваших повідомлень з пам\'яті Omi...';
+
+  @override
+  String get messageCopied => 'Повідомлення скопійовано до буфера обміну.';
+
+  @override
+  String get cannotReportOwnMessage => 'Ви не можете поскаржитись на власні повідомлення.';
+
+  @override
+  String get reportMessage => 'Поскаржитись на повідомлення';
+
+  @override
+  String get reportMessageConfirm => 'Ви впевнені, що хочете поскаржитись на це повідомлення?';
+
+  @override
+  String get messageReported => 'Повідомлення успішно відправлено.';
+
+  @override
+  String get thankYouFeedback => 'Дякуємо за ваш відгук!';
+
+  @override
+  String get clearChat => 'Очистити чат?';
+
+  @override
+  String get clearChatConfirm => 'Ви впевнені, що хочете очистити чат? Цю дію не можна скасувати.';
+
+  @override
+  String get maxFilesLimit => 'Ви можете завантажити лише 4 файли за раз';
+
+  @override
+  String get chatWithOmi => 'Чат з Omi';
+
+  @override
+  String get apps => 'Додатки';
+
+  @override
+  String get noAppsFound => 'Додатки не знайдено';
+
+  @override
+  String get tryAdjustingSearch => 'Спробуйте змінити пошуковий запит або фільтри';
+
+  @override
+  String get createYourOwnApp => 'Створіть власний додаток';
+
+  @override
+  String get buildAndShareApp => 'Створюйте та діліться своїм власним додатком';
+
+  @override
+  String get searchApps => 'Пошук серед 1500+ додатків';
+
+  @override
+  String get myApps => 'Мої додатки';
+
+  @override
+  String get installedApps => 'Встановлені додатки';
+
+  @override
+  String get unableToFetchApps =>
+      'Не вдалося завантажити додатки :(\n\nБудь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
+
+  @override
+  String get aboutOmi => 'Про Omi';
+
+  @override
+  String get privacyPolicy => 'Політикою конфіденційності';
+
+  @override
+  String get visitWebsite => 'Відвідати веб-сайт';
+
+  @override
+  String get helpOrInquiries => 'Допомога або запитання?';
+
+  @override
+  String get joinCommunity => 'Приєднуйтесь до спільноти!';
+
+  @override
+  String get membersAndCounting => 'Понад 8000 учасників.';
+
+  @override
+  String get deleteAccountTitle => 'Видалити обліковий запис';
+
+  @override
+  String get deleteAccountConfirm => 'Ви впевнені, що хочете видалити свій обліковий запис?';
+
+  @override
+  String get cannotBeUndone => 'Це не можна скасувати.';
+
+  @override
+  String get allDataErased => 'Всі ваші спогади та розмови будуть остаточно видалені.';
+
+  @override
+  String get appsDisconnected => 'Ваші додатки та інтеграції будуть негайно відключені.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Ви можете експортувати свої дані перед видаленням облікового запису, але після видалення їх неможливо буде відновити.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Я розумію, що видалення мого облікового запису є остаточним, і всі дані, включно зі спогадами та розмовами, будуть втрачені і не можуть бути відновлені.';
+
+  @override
+  String get areYouSure => 'Ви впевнені?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Ця дія є незворотною та назавжди видалить ваш обліковий запис і всі пов\'язані дані. Ви впевнені, що хочете продовжити?';
+
+  @override
+  String get deleteNow => 'Видалити зараз';
+
+  @override
+  String get goBack => 'Повернутися';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Встановіть прапорець, щоб підтвердити, що ви розумієте, що видалення облікового запису є остаточним і незворотним.';
+
+  @override
+  String get profile => 'Профіль';
+
+  @override
+  String get name => 'Ім\'я';
+
+  @override
+  String get email => 'Електронна пошта';
+
+  @override
+  String get customVocabulary => 'Власний словник';
+
+  @override
+  String get identifyingOthers => 'Ідентифікація інших';
+
+  @override
+  String get paymentMethods => 'Способи оплати';
+
+  @override
+  String get conversationDisplay => 'Відображення розмов';
+
+  @override
+  String get dataPrivacy => 'Дані та конфіденційність';
+
+  @override
+  String get userId => 'ID користувача';
+
+  @override
+  String get notSet => 'Не встановлено';
+
+  @override
+  String get userIdCopied => 'ID користувача скопійовано до буфера обміну';
+
+  @override
+  String get systemDefault => 'За замовчуванням системи';
+
+  @override
+  String get planAndUsage => 'План та використання';
+
+  @override
+  String get offlineSync => 'Офлайн-синхронізація';
+
+  @override
+  String get deviceSettings => 'Налаштування пристрою';
+
+  @override
+  String get chatTools => 'Інструменти чату';
+
+  @override
+  String get feedbackBug => 'Відгук / Помилка';
+
+  @override
+  String get helpCenter => 'Центр допомоги';
+
+  @override
+  String get developerSettings => 'Налаштування розробника';
+
+  @override
+  String get getOmiForMac => 'Отримати Omi для Mac';
+
+  @override
+  String get referralProgram => 'Реферальна програма';
+
+  @override
+  String get signOut => 'Вийти';
+
+  @override
+  String get appAndDeviceCopied => 'Деталі додатка та пристрою скопійовано';
+
+  @override
+  String get wrapped2025 => 'Підсумки 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Ваша конфіденційність, ваш контроль';
+
+  @override
+  String get privacyIntro =>
+      'В Omi ми прагнемо захистити вашу конфіденційність. Ця сторінка дозволяє контролювати, як зберігаються та використовуються ваші дані.';
+
+  @override
+  String get learnMore => 'Дізнатися більше...';
+
+  @override
+  String get dataProtectionLevel => 'Рівень захисту даних';
+
+  @override
+  String get dataProtectionDesc =>
+      'Ваші дані за замовчуванням захищені надійним шифруванням. Перегляньте свої налаштування та майбутні параметри конфіденційності нижче.';
+
+  @override
+  String get appAccess => 'Доступ додатків';
+
+  @override
+  String get appAccessDesc =>
+      'Наступні додатки можуть отримувати доступ до ваших даних. Натисніть на додаток, щоб керувати його дозволами.';
+
+  @override
+  String get noAppsExternalAccess => 'Жоден встановлений додаток не має зовнішнього доступу до ваших даних.';
+
+  @override
+  String get deviceName => 'Назва пристрою';
+
+  @override
+  String get deviceId => 'ID пристрою';
+
+  @override
+  String get firmware => 'Прошивка';
+
+  @override
+  String get sdCardSync => 'Синхронізація SD-карти';
+
+  @override
+  String get hardwareRevision => 'Ревізія апаратного забезпечення';
+
+  @override
+  String get modelNumber => 'Номер моделі';
+
+  @override
+  String get manufacturer => 'Виробник';
+
+  @override
+  String get doubleTap => 'Подвійне натискання';
+
+  @override
+  String get ledBrightness => 'Яскравість світлодіода';
+
+  @override
+  String get micGain => 'Підсилення мікрофона';
+
+  @override
+  String get disconnect => 'Відключити';
+
+  @override
+  String get forgetDevice => 'Забути пристрій';
+
+  @override
+  String get chargingIssues => 'Проблеми із зарядкою';
+
+  @override
+  String get disconnectDevice => 'Відключити пристрій';
+
+  @override
+  String get unpairDevice => 'Роз\'єднати пристрій';
+
+  @override
+  String get unpairAndForget => 'Роз\'єднати та забути пристрій';
+
+  @override
+  String get deviceDisconnectedMessage => 'Ваш Omi було відключено 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Пристрій роз\'єднано. Перейдіть до Налаштування > Bluetooth і забудьте пристрій, щоб завершити роз\'єднання.';
+
+  @override
+  String get unpairDialogTitle => 'Роз\'єднати пристрій';
+
+  @override
+  String get unpairDialogMessage =>
+      'Це роз\'єднає пристрій, щоб його можна було підключити до іншого телефону. Вам потрібно буде перейти до Налаштування > Bluetooth і забути пристрій, щоб завершити процес.';
+
+  @override
+  String get deviceNotConnected => 'Пристрій не підключено';
+
+  @override
+  String get connectDeviceMessage =>
+      'Підключіть свій пристрій Omi для доступу до\nналаштувань пристрою та налаштування';
+
+  @override
+  String get deviceInfoSection => 'Інформація про пристрій';
+
+  @override
+  String get customizationSection => 'Налаштування';
+
+  @override
+  String get hardwareSection => 'Апаратне забезпечення';
+
+  @override
+  String get v2Undetected => 'V2 не виявлено';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Ми бачимо, що у вас або пристрій V1, або ваш пристрій не підключений. Функціонал SD-карти доступний лише для пристроїв V2.';
+
+  @override
+  String get endConversation => 'Завершити розмову';
+
+  @override
+  String get pauseResume => 'Призупинити/Відновити';
+
+  @override
+  String get starConversation => 'Позначити розмову';
+
+  @override
+  String get doubleTapAction => 'Дія подвійного натискання';
+
+  @override
+  String get endAndProcess => 'Завершити та обробити розмову';
+
+  @override
+  String get pauseResumeRecording => 'Призупинити/Відновити запис';
+
+  @override
+  String get starOngoing => 'Позначити поточну розмову';
+
+  @override
+  String get off => 'Вимкнено';
+
+  @override
+  String get max => 'Максимум';
+
+  @override
+  String get mute => 'Без звуку';
+
+  @override
+  String get quiet => 'Тихо';
+
+  @override
+  String get normal => 'Нормально';
+
+  @override
+  String get high => 'Високо';
+
+  @override
+  String get micGainDescMuted => 'Мікрофон вимкнено';
+
+  @override
+  String get micGainDescLow => 'Дуже тихо - для гучного середовища';
+
+  @override
+  String get micGainDescModerate => 'Тихо - для помірного шуму';
+
+  @override
+  String get micGainDescNeutral => 'Нейтрально - збалансований запис';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Трохи посилено - нормальне використання';
+
+  @override
+  String get micGainDescBoosted => 'Посилено - для тихого середовища';
+
+  @override
+  String get micGainDescHigh => 'Високо - для далеких або тихих голосів';
+
+  @override
+  String get micGainDescVeryHigh => 'Дуже високо - для дуже тихих джерел';
+
+  @override
+  String get micGainDescMax => 'Максимум - використовувати обережно';
+
+  @override
+  String get developerSettingsTitle => 'Налаштування розробника';
+
+  @override
+  String get saving => 'Збереження...';
+
+  @override
+  String get personaConfig => 'Налаштуйте свою AI-персону';
+
+  @override
+  String get beta => 'БЕТА';
+
+  @override
+  String get transcription => 'Транскрипція';
+
+  @override
+  String get transcriptionConfig => 'Налаштувати STT-провайдер';
+
+  @override
+  String get conversationTimeout => 'Час очікування розмови';
+
+  @override
+  String get conversationTimeoutConfig => 'Встановіть, коли розмови завершуються автоматично';
+
+  @override
+  String get importData => 'Імпортувати дані';
+
+  @override
+  String get importDataConfig => 'Імпортуйте дані з інших джерел';
+
+  @override
+  String get debugDiagnostics => 'Налагодження та діагностика';
+
+  @override
+  String get endpointUrl => 'URL кінцевої точки';
+
+  @override
+  String get noApiKeys => 'API-ключів поки немає';
+
+  @override
+  String get createKeyToStart => 'Створіть ключ, щоб почати';
+
+  @override
+  String get createKey => 'Створити ключ';
+
+  @override
+  String get docs => 'Документація';
+
+  @override
+  String get yourOmiInsights => 'Ваша статистика Omi';
+
+  @override
+  String get today => 'Сьогодні';
+
+  @override
+  String get thisMonth => 'Цей місяць';
+
+  @override
+  String get thisYear => 'Цей рік';
+
+  @override
+  String get allTime => 'За весь час';
+
+  @override
+  String get noActivityYet => 'Активності поки немає';
+
+  @override
+  String get startConversationToSeeInsights => 'Почніть розмову з Omi,\nщоб побачити статистику використання тут.';
+
+  @override
+  String get listening => 'Прослуховування';
+
+  @override
+  String get listeningSubtitle => 'Загальний час активного прослуховування Omi.';
+
+  @override
+  String get understanding => 'Розуміння';
+
+  @override
+  String get understandingSubtitle => 'Слів зрозуміно з ваших розмов.';
+
+  @override
+  String get providing => 'Надання';
+
+  @override
+  String get providingSubtitle => 'Завдання та нотатки, автоматично зафіксовані.';
+
+  @override
+  String get remembering => 'Запам\'ятовування';
+
+  @override
+  String get rememberingSubtitle => 'Факти та деталі, запам\'ятовані для вас.';
+
+  @override
+  String get unlimitedPlan => 'Необмежений план';
+
+  @override
+  String get managePlan => 'Керувати планом';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Ваш план буде скасовано $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Ваш план поновиться $date.';
+  }
+
+  @override
+  String get basicPlan => 'Безкоштовний план';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return '$used з $limit хв використано';
+  }
+
+  @override
+  String get upgrade => 'Оновити';
+
+  @override
+  String get upgradeToUnlimited => 'Оновити до Необмеженого';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Ваш план включає $limit безкоштовних хвилин на місяць. Оновіть, щоб отримати необмежений доступ.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Ділюся своєю статистикою Omi! (omi.me - ваш завжди активний AI-асистент)';
+
+  @override
+  String get sharePeriodToday => 'Сьогодні omi:';
+
+  @override
+  String get sharePeriodMonth => 'Цього місяця omi:';
+
+  @override
+  String get sharePeriodYear => 'Цього року omi:';
+
+  @override
+  String get sharePeriodAllTime => 'Загалом omi:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Прослухав $minutes хвилин';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Зрозумів $words слів';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Надав $count insights';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Запам\'ятав $count спогадів';
+  }
+
+  @override
+  String get debugLogs => 'Журнали налагодження';
+
+  @override
+  String get debugLogsAutoDelete => 'Автоматичне видалення через 3 дні.';
+
+  @override
+  String get debugLogsDesc => 'Допомагає діагностувати проблеми';
+
+  @override
+  String get noLogFilesFound => 'Файли журналів не знайдено.';
+
+  @override
+  String get omiDebugLog => 'Журнал налагодження Omi';
+
+  @override
+  String get logShared => 'Журнал надіслано';
+
+  @override
+  String get selectLogFile => 'Вибрати файл журналу';
+
+  @override
+  String get shareLogs => 'Поділитися журналами';
+
+  @override
+  String get debugLogCleared => 'Журнал налагодження очищено';
+
+  @override
+  String get exportStarted => 'Експорт розпочато. Це може зайняти кілька секунд...';
+
+  @override
+  String get exportAllData => 'Експортувати всі дані';
+
+  @override
+  String get exportDataDesc => 'Експортувати розмови у файл JSON';
+
+  @override
+  String get exportedConversations => 'Експортовані розмови з Omi';
+
+  @override
+  String get exportShared => 'Експорт надіслано';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Видалити граф знань?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Це видалить всі похідні дані графа знань (вузли та з\'єднання). Ваші оригінальні спогади залишаться в безпеці. Граф буде перебудовано з часом або за наступним запитом.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Граф знань успішно видалено';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Не вдалося видалити граф: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Видалити граф знань';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Очистити всі вузли та з\'єднання';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'MCP-сервер';
+
+  @override
+  String get mcpServerDesc => 'Підключіть AI-асистентів до ваших даних';
+
+  @override
+  String get serverUrl => 'URL сервера';
+
+  @override
+  String get urlCopied => 'URL скопійовано';
+
+  @override
+  String get apiKeyAuth => 'Автентифікація API-ключем';
+
+  @override
+  String get header => 'Заголовок';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'ID клієнта';
+
+  @override
+  String get clientSecret => 'Секрет клієнта';
+
+  @override
+  String get useMcpApiKey => 'Використовуйте свій MCP API-ключ';
+
+  @override
+  String get webhooks => 'Вебхуки';
+
+  @override
+  String get conversationEvents => 'Події розмови';
+
+  @override
+  String get newConversationCreated => 'Створено нову розмову';
+
+  @override
+  String get realtimeTranscript => 'Транскрипція в реальному часі';
+
+  @override
+  String get transcriptReceived => 'Транскрипцію отримано';
+
+  @override
+  String get audioBytes => 'Аудіо байти';
+
+  @override
+  String get audioDataReceived => 'Аудіо дані отримано';
+
+  @override
+  String get intervalSeconds => 'Інтервал (секунди)';
+
+  @override
+  String get daySummary => 'Підсумок дня';
+
+  @override
+  String get summaryGenerated => 'Підсумок згенеровано';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Додати до claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Копіювати конфігурацію';
+
+  @override
+  String get configCopied => 'Конфігурацію скопійовано до буфера обміну';
+
+  @override
+  String get listeningMins => 'Прослуховування (хв)';
+
+  @override
+  String get understandingWords => 'Розуміння (слів)';
+
+  @override
+  String get insights => 'Insights';
+
+  @override
+  String get memories => 'Спогади';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return '$used з $limit хв використано цього місяця';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return '$used з $limit слів використано цього місяця';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return '$used з $limit insights отримано цього місяця';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return '$used з $limit спогадів створено цього місяця';
+  }
+
+  @override
+  String get visibility => 'Видимість';
+
+  @override
+  String get visibilitySubtitle => 'Керуйте тим, які розмови відображаються у вашому списку';
+
+  @override
+  String get showShortConversations => 'Показувати короткі розмови';
+
+  @override
+  String get showShortConversationsDesc => 'Відображати розмови коротші за поріг';
+
+  @override
+  String get showDiscardedConversations => 'Показувати відхилені розмови';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Включати розмови, позначені як відхилені';
+
+  @override
+  String get shortConversationThreshold => 'Поріг коротких розмов';
+
+  @override
+  String get shortConversationThresholdSubtitle =>
+      'Розмови коротші за це значення будуть приховані, якщо не увімкнено вище';
+
+  @override
+  String get durationThreshold => 'Поріг тривалості';
+
+  @override
+  String get durationThresholdDesc => 'Приховувати розмови коротші за це';
+
+  @override
+  String minLabel(int count) {
+    return '$count хв';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Власний словник';
+
+  @override
+  String get addWords => 'Додати слова';
+
+  @override
+  String get addWordsDesc => 'Імена, терміни або незвичні слова';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Підключити';
+
+  @override
+  String get comingSoon => 'Незабаром';
+
+  @override
+  String get chatToolsFooter => 'Підключіть свої додатки для перегляду даних та метрик у чаті.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Не вдалося розпочати автентифікацію $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Відключити $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Ви впевнені, що хочете відключитись від $appName? Ви можете підключитись знову в будь-який час.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Відключено від $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Не вдалося відключитись';
+
+  @override
+  String connectTo(String appName) {
+    return 'Підключитись до $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Вам потрібно авторизувати Omi для доступу до ваших даних $appName. Це відкриє ваш браузер для автентифікації.';
+  }
+
+  @override
+  String get continueAction => 'Продовжити';
+
+  @override
+  String get languageTitle => 'Мова';
+
+  @override
+  String get primaryLanguage => 'Основна мова';
+
+  @override
+  String get automaticTranslation => 'Автоматичний переклад';
+
+  @override
+  String get detectLanguages => 'Виявлення 10+ мов';
+
+  @override
+  String get authorizeSavingRecordings => 'Авторизувати збереження записів';
+
+  @override
+  String get thanksForAuthorizing => 'Дякуємо за авторизацію!';
+
+  @override
+  String get needYourPermission => 'Нам потрібен ваш дозвіл';
+
+  @override
+  String get alreadyGavePermission =>
+      'Ви вже надали нам дозвіл на збереження ваших записів. Нагадуємо, навіщо це потрібно:';
+
+  @override
+  String get wouldLikePermission => 'Ми хотіли б отримати ваш дозвіл на збереження ваших голосових записів. Ось чому:';
+
+  @override
+  String get improveSpeechProfile => 'Покращити ваш мовний профіль';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Ми використовуємо записи для подальшого навчання та покращення вашого особистого мовного профілю.';
+
+  @override
+  String get trainFamilyProfiles => 'Навчити профілі для друзів та родини';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Ваші записи допомагають нам розпізнавати та створювати профілі для ваших друзів та родини.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Покращити точність транскрипції';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'У міру вдосконалення нашої моделі ми можемо надавати кращі результати транскрипції ваших записів.';
+
+  @override
+  String get legalNotice =>
+      'Юридичне повідомлення: Законність запису та зберігання голосових даних може відрізнятися залежно від вашого місцезнаходження та того, як ви використовуєте цю функцію. Ви несете відповідальність за дотримання місцевих законів та правил.';
+
+  @override
+  String get alreadyAuthorized => 'Вже авторизовано';
+
+  @override
+  String get authorize => 'Авторизувати';
+
+  @override
+  String get revokeAuthorization => 'Відкликати авторизацію';
+
+  @override
+  String get authorizationSuccessful => 'Авторизація успішна!';
+
+  @override
+  String get failedToAuthorize => 'Не вдалося авторизувати. Будь ласка, спробуйте ще раз.';
+
+  @override
+  String get authorizationRevoked => 'Авторизацію відкликано.';
+
+  @override
+  String get recordingsDeleted => 'Записи видалено.';
+
+  @override
+  String get failedToRevoke => 'Не вдалося відкликати авторизацію. Будь ласка, спробуйте ще раз.';
+
+  @override
+  String get permissionRevokedTitle => 'Дозвіл відкликано';
+
+  @override
+  String get permissionRevokedMessage => 'Чи хочете ви також видалити всі ваші існуючі записи?';
+
+  @override
+  String get yes => 'Так';
+
+  @override
+  String get editName => 'Редагувати ім\'я';
+
+  @override
+  String get howShouldOmiCallYou => 'Як Omi має до вас звертатися?';
+
+  @override
+  String get enterYourName => 'Введіть своє ім\'я';
+
+  @override
+  String get nameCannotBeEmpty => 'Ім\'я не може бути порожнім';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Ім\'я успішно оновлено!';
+
+  @override
+  String get calendarSettings => 'Налаштування календаря';
+
+  @override
+  String get calendarProviders => 'Провайдери календаря';
+
+  @override
+  String get macOsCalendar => 'Календар macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Підключіть свій локальний календар macOS';
+
+  @override
+  String get googleCalendar => 'Google Календар';
+
+  @override
+  String get syncGoogleAccount => 'Синхронізація з вашим обліковим записом Google';
+
+  @override
+  String get showMeetingsMenuBar => 'Показувати майбутні зустрічі у меню';
+
+  @override
+  String get showMeetingsMenuBarDesc => 'Відображати вашу наступну зустріч та час до її початку у меню macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Показувати події без учасників';
+
+  @override
+  String get showEventsNoParticipantsDesc => 'Коли увімкнено, показує події без учасників або відео-посилання.';
+
+  @override
+  String get yourMeetings => 'Ваші зустрічі';
+
+  @override
+  String get refresh => 'Оновити';
+
+  @override
+  String get noUpcomingMeetings => 'Майбутніх зустрічей не знайдено';
+
+  @override
+  String get checkingNextDays => 'Перевірка наступних 30 днів';
+
+  @override
+  String get tomorrow => 'Завтра';
+
+  @override
+  String get googleCalendarComingSoon => 'Інтеграція з Google Календарем незабаром!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Підключено як користувач: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Робочий простір за замовчуванням';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Завдання будуть створені у цьому робочому просторі';
+
+  @override
+  String get defaultProjectOptional => 'Проект за замовчуванням (необов\'язково)';
+
+  @override
+  String get leaveUnselectedTasks => 'Залиште невибраним для створення завдань без проекту';
+
+  @override
+  String get noProjectsInWorkspace => 'У цьому робочому просторі не знайдено проектів';
+
+  @override
+  String get conversationTimeoutDesc => 'Виберіть, скільки часу чекати в тиші перед автоматичним завершенням розмови:';
+
+  @override
+  String get timeout2Minutes => '2 хвилини';
+
+  @override
+  String get timeout2MinutesDesc => 'Завершити розмову після 2 хвилин тиші';
+
+  @override
+  String get timeout5Minutes => '5 хвилин';
+
+  @override
+  String get timeout5MinutesDesc => 'Завершити розмову після 5 хвилин тиші';
+
+  @override
+  String get timeout10Minutes => '10 хвилин';
+
+  @override
+  String get timeout10MinutesDesc => 'Завершити розмову після 10 хвилин тиші';
+
+  @override
+  String get timeout30Minutes => '30 хвилин';
+
+  @override
+  String get timeout30MinutesDesc => 'Завершити розмову після 30 хвилин тиші';
+
+  @override
+  String get timeout4Hours => '4 години';
+
+  @override
+  String get timeout4HoursDesc => 'Завершити розмову після 4 годин тиші';
+
+  @override
+  String get conversationEndAfterHours => 'Розмови тепер завершуватимуться після 4 годин тиші';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Розмови тепер завершуватимуться після $minutes хвилин тиші';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Вкажіть свою основну мову';
+
+  @override
+  String get languageForTranscription => 'Встановіть свою мову для точнішої транскрипції та персоналізованого досвіду.';
+
+  @override
+  String get singleLanguageModeInfo => 'Режим однієї мови увімкнено. Переклад вимкнено для вищої точності.';
+
+  @override
+  String get searchLanguageHint => 'Шукайте мову за назвою або кодом';
+
+  @override
+  String get noLanguagesFound => 'Мов не знайдено';
+
+  @override
+  String get skip => 'Пропустити';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Мову встановлено на $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Не вдалося встановити мову';
+
+  @override
+  String appSettings(String appName) {
+    return 'Налаштування $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Відключитись від $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Це видалить вашу автентифікацію $appName. Вам потрібно буде підключитися знову, щоб використовувати це.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Підключено до $appName';
+  }
+
+  @override
+  String get account => 'Обліковий запис';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Ваші завдання будуть синхронізовані з вашим обліковим записом $appName';
+  }
+
+  @override
+  String get defaultSpace => 'Простір за замовчуванням';
+
+  @override
+  String get selectSpaceInWorkspace => 'Виберіть простір у вашому робочому просторі';
+
+  @override
+  String get noSpacesInWorkspace => 'У цьому робочому просторі не знайдено просторів';
+
+  @override
+  String get defaultList => 'Список за замовчуванням';
+
+  @override
+  String get tasksAddedToList => 'Завдання будуть додані до цього списку';
+
+  @override
+  String get noListsInSpace => 'У цьому просторі не знайдено списків';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Не вдалося завантажити репозиторії: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Репозиторій за замовчуванням збережено';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Не вдалося зберегти репозиторій за замовчуванням';
+
+  @override
+  String get defaultRepository => 'Репозиторій за замовчуванням';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Виберіть репозиторій за замовчуванням для створення issues. Ви все ще можете вказати інший репозиторій під час створення issues.';
+
+  @override
+  String get noReposFound => 'Репозиторіїв не знайдено';
+
+  @override
+  String get private => 'Приватний';
+
+  @override
+  String updatedDate(String date) {
+    return 'Оновлено $date';
+  }
+
+  @override
+  String get yesterday => 'вчора';
+
+  @override
+  String daysAgo(int count) {
+    return '$count днів тому';
+  }
+
+  @override
+  String get oneWeekAgo => '1 тиждень тому';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count тижнів тому';
+  }
+
+  @override
+  String get oneMonthAgo => '1 місяць тому';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count місяців тому';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Issues будуть створені у вашому репозиторії за замовчуванням';
+
+  @override
+  String get taskIntegrations => 'Інтеграції завдань';
+
+  @override
+  String get configureSettings => 'Налаштувати параметри';
+
+  @override
+  String get completeAuthBrowser =>
+      'Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Не вдалося розпочати автентифікацію $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Підключитися до $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Вам потрібно авторизувати Omi для створення завдань у вашому обліковому записі $appName. Це відкриє ваш браузер для автентифікації.';
+  }
+
+  @override
+  String get continueButton => 'Продовжити';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Інтеграція $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Інтеграція з $appName незабаром! Ми наполегливо працюємо, щоб надати вам більше опцій управління завданнями.';
+  }
+
+  @override
+  String get gotIt => 'Зрозуміло';
+
+  @override
+  String get tasksExportedOneApp => 'Завдання можна експортувати в один додаток за раз.';
+
+  @override
+  String get completeYourUpgrade => 'Завершіть оновлення';
+
+  @override
+  String get importConfiguration => 'Імпортувати конфігурацію';
+
+  @override
+  String get exportConfiguration => 'Експортувати конфігурацію';
+
+  @override
+  String get bringYourOwn => 'Використовуйте власний';
+
+  @override
+  String get payYourSttProvider => 'Вільно користуйтесь omi. Ви платите лише своєму STT-провайдеру безпосередньо.';
+
+  @override
+  String get freeMinutesMonth => '1,200 безкоштовних хвилин/місяць включено. Необмежено з ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Хост обов\'язковий';
+
+  @override
+  String get validPortRequired => 'Потрібен дійсний порт';
+
+  @override
+  String get validWebsocketUrlRequired => 'Потрібен дійсний URL WebSocket (wss://)';
+
+  @override
+  String get apiUrlRequired => 'API URL обов\'язковий';
+
+  @override
+  String get apiKeyRequired => 'API-ключ обов\'язковий';
+
+  @override
+  String get invalidJsonConfig => 'Недійсна конфігурація JSON';
+
+  @override
+  String errorSaving(String error) {
+    return 'Помилка збереження: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Конфігурацію скопійовано до буфера обміну';
+
+  @override
+  String get pasteJsonConfig => 'Вставте свою конфігурацію JSON нижче:';
+
+  @override
+  String get addApiKeyAfterImport => 'Вам потрібно буде додати власний API-ключ після імпорту';
+
+  @override
+  String get paste => 'Вставити';
+
+  @override
+  String get import => 'Імпортувати';
+
+  @override
+  String get invalidProviderInConfig => 'Недійсний провайдер у конфігурації';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Імпортовано конфігурацію $providerName';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'Недійсний JSON: $error';
+  }
+
+  @override
+  String get provider => 'Провайдер';
+
+  @override
+  String get live => 'В реальному часі';
+
+  @override
+  String get onDevice => 'На пристрої';
+
+  @override
+  String get apiUrl => 'API URL';
+
+  @override
+  String get enterSttHttpEndpoint => 'Введіть свою HTTP кінцеву точку STT';
+
+  @override
+  String get websocketUrl => 'WebSocket URL';
+
+  @override
+  String get enterLiveSttWebsocket => 'Введіть свою WebSocket кінцеву точку STT в реальному часі';
+
+  @override
+  String get apiKey => 'API-ключ';
+
+  @override
+  String get enterApiKey => 'Введіть свій API-ключ';
+
+  @override
+  String get storedLocallyNeverShared => 'Зберігається локально, ніколи не передається';
+
+  @override
+  String get host => 'Хост';
+
+  @override
+  String get port => 'Порт';
+
+  @override
+  String get advanced => 'Розширені';
+
+  @override
+  String get configuration => 'Конфігурація';
+
+  @override
+  String get requestConfiguration => 'Конфігурація запиту';
+
+  @override
+  String get responseSchema => 'Схема відповіді';
+
+  @override
+  String get modified => 'Змінено';
+
+  @override
+  String get resetRequestConfig => 'Скинути конфігурацію запиту до значень за замовчуванням';
+
+  @override
+  String get logs => 'Журнали';
+
+  @override
+  String get logsCopied => 'Журнали скопійовано';
+
+  @override
+  String get noLogsYet => 'Журналів поки немає. Почніть запис, щоб побачити активність власного STT.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName використовує $codecReason. Буде використано Omi.';
+  }
+
+  @override
+  String get omiTranscription => 'Транскрипція Omi';
+
+  @override
+  String get bestInClassTranscription => 'Найкраща транскрипція без налаштування';
+
+  @override
+  String get instantSpeakerLabels => 'Миттєві мітки спікерів';
+
+  @override
+  String get languageTranslation => 'Переклад 100+ мов';
+
+  @override
+  String get optimizedForConversation => 'Оптимізовано для розмов';
+
+  @override
+  String get autoLanguageDetection => 'Автоматичне визначення мови';
+
+  @override
+  String get highAccuracy => 'Висока точність';
+
+  @override
+  String get privacyFirst => 'Конфіденційність на першому місці';
+
+  @override
+  String get saveChanges => 'Зберегти зміни';
+
+  @override
+  String get resetToDefault => 'Скинути до значень за замовчуванням';
+
+  @override
+  String get viewTemplate => 'Переглянути шаблон';
+
+  @override
+  String get trySomethingLike => 'Спробуйте щось подібне...';
+
+  @override
+  String get tryIt => 'Спробувати';
+
+  @override
+  String get creatingPlan => 'Створення плану';
+
+  @override
+  String get developingLogic => 'Розробка логіки';
+
+  @override
+  String get designingApp => 'Проектування додатка';
+
+  @override
+  String get generatingIconStep => 'Генерація іконки';
+
+  @override
+  String get finalTouches => 'Фінальні штрихи';
+
+  @override
+  String get processing => 'Обробка...';
+
+  @override
+  String get features => 'Можливості';
+
+  @override
+  String get creatingYourApp => 'Створення вашого додатка...';
+
+  @override
+  String get generatingIcon => 'Генерація іконки...';
+
+  @override
+  String get whatShouldWeMake => 'Що ми повинні створити?';
+
+  @override
+  String get appName => 'Назва додатка';
+
+  @override
+  String get description => 'Опис';
+
+  @override
+  String get publicLabel => 'Публічний';
+
+  @override
+  String get privateLabel => 'Приватний';
+
+  @override
+  String get free => 'Безкоштовно';
+
+  @override
+  String get perMonth => '/ Місяць';
+
+  @override
+  String get tailoredConversationSummaries => 'Персоналізовані підсумки розмов';
+
+  @override
+  String get customChatbotPersonality => 'Налаштована особистість чат-бота';
+
+  @override
+  String get makePublic => 'Зробити публічним';
+
+  @override
+  String get anyoneCanDiscover => 'Будь-хто може знайти ваш додаток';
+
+  @override
+  String get onlyYouCanUse => 'Лише ви можете використовувати цей додаток';
+
+  @override
+  String get paidApp => 'Платний додаток';
+
+  @override
+  String get usersPayToUse => 'Користувачі платять за використання вашого додатка';
+
+  @override
+  String get freeForEveryone => 'Безкоштовно для всіх';
+
+  @override
+  String get perMonthLabel => '/ місяць';
+
+  @override
+  String get creating => 'Створення...';
+
+  @override
+  String get createApp => 'Створити додаток';
+
+  @override
+  String get searchingForDevices => 'Пошук пристроїв...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'ПРИСТРОЇВ',
+      one: 'ПРИСТРІЙ',
+    );
+    return '$count $_temp0 ЗНАЙДЕНО ПОБЛИЗУ';
+  }
+
+  @override
+  String get pairingSuccessful => 'З\'ЄДНАННЯ УСПІШНЕ';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Помилка підключення до Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Не показувати знову';
+
+  @override
+  String get iUnderstand => 'Я розумію';
+
+  @override
+  String get enableBluetooth => 'Увімкнути Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi потребує Bluetooth для підключення до вашого носимого пристрою. Будь ласка, увімкніть Bluetooth та спробуйте ще раз.';
+
+  @override
+  String get contactSupport => 'Зв\'язатися з підтримкою?';
+
+  @override
+  String get connectLater => 'Підключити пізніше';
+
+  @override
+  String get grantPermissions => 'Надати дозволи';
+
+  @override
+  String get backgroundActivity => 'Фонова активність';
+
+  @override
+  String get backgroundActivityDesc => 'Дозвольте Omi працювати у фоновому режимі для кращої стабільності';
+
+  @override
+  String get locationAccess => 'Доступ до місцезнаходження';
+
+  @override
+  String get locationAccessDesc => 'Увімкніть фонове місцезнаходження для повного досвіду';
+
+  @override
+  String get notifications => 'Сповіщення';
+
+  @override
+  String get notificationsDesc => 'Увімкніть сповіщення, щоб бути в курсі';
+
+  @override
+  String get locationServiceDisabled => 'Служба визначення місцезнаходження вимкнена';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Служба визначення місцезнаходження вимкнена. Будь ласка, перейдіть до Налаштування > Конфіденційність і безпека > Служби визначення місцезнаходження та увімкніть її';
+
+  @override
+  String get backgroundLocationDenied => 'Відмовлено в доступі до фонового місцезнаходження';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Будь ласка, перейдіть до налаштувань пристрою та встановіть дозвіл на місцезнаходження на \"Завжди дозволяти\"';
+
+  @override
+  String get lovingOmi => 'Подобається Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Допоможіть нам охопити більше людей, залишивши відгук в App Store. Ваші відгуки дуже важливі для нас!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Допоможіть нам охопити більше людей, залишивши відгук в Google Play Store. Ваші відгуки дуже важливі для нас!';
+
+  @override
+  String get rateOnAppStore => 'Оцінити в App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Оцінити в Google Play';
+
+  @override
+  String get maybeLater => 'Можливо пізніше';
+
+  @override
+  String get speechProfileIntro => 'Omi потрібно дізнатися про ваші цілі та ваш голос. Ви зможете змінити це пізніше.';
+
+  @override
+  String get getStarted => 'Почати';
+
+  @override
+  String get allDone => 'Все готово!';
+
+  @override
+  String get keepGoing => 'Продовжуйте, у вас чудово виходить';
+
+  @override
+  String get skipThisQuestion => 'Пропустити це питання';
+
+  @override
+  String get skipForNow => 'Пропустити зараз';
+
+  @override
+  String get connectionError => 'Помилка підключення';
+
+  @override
+  String get connectionErrorDesc =>
+      'Не вдалося підключитися до сервера. Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Виявлено недійсний запис';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Схоже, що в записі кілька спікерів. Будь ласка, переконайтеся, що ви знаходитесь у тихому місці, та спробуйте ще раз.';
+
+  @override
+  String get tooShortDesc => 'Недостатньо мовлення виявлено. Будь ласка, говоріть більше та спробуйте ще раз.';
+
+  @override
+  String get invalidRecordingDesc => 'Будь ласка, переконайтеся, що ви говорите щонайменше 5 секунд і не більше 90.';
+
+  @override
+  String get areYouThere => 'Ви тут?';
+
+  @override
+  String get noSpeechDesc =>
+      'Ми не змогли виявити жодного мовлення. Будь ласка, переконайтеся, що ви говорите щонайменше 10 секунд і не більше 3 хвилин.';
+
+  @override
+  String get connectionLost => 'З\'єднання втрачено';
+
+  @override
+  String get connectionLostDesc =>
+      'З\'єднання було перервано. Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.';
+
+  @override
+  String get tryAgain => 'Спробувати ще раз';
+
+  @override
+  String get connectOmiOmiGlass => 'Підключити Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Продовжити без пристрою';
+
+  @override
+  String get permissionsRequired => 'Потрібні дозволи';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Цей додаток потребує дозволів Bluetooth та Місцезнаходження для правильної роботи. Будь ласка, увімкніть їх у налаштуваннях.';
+
+  @override
+  String get openSettings => 'Відкрити налаштування';
+
+  @override
+  String get wantDifferentName => 'Хочете, щоб до вас звертались інакше?';
+
+  @override
+  String get whatsYourName => 'Як вас звати?';
+
+  @override
+  String get speakTranscribeSummarize => 'Говоріть. Транскрибуйте. Підсумовуйте.';
+
+  @override
+  String get signInWithApple => 'Увійти через Apple';
+
+  @override
+  String get signInWithGoogle => 'Увійти через Google';
+
+  @override
+  String get byContinuingAgree => 'Продовжуючи, ви погоджуєтесь з нашою ';
+
+  @override
+  String get termsOfUse => 'Умовами використання';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – ваш AI-компаньйон';
+
+  @override
+  String get captureEveryMoment =>
+      'Захопіть кожну мить. Отримуйте підсумки на основі AI.\nНіколи більше не робіть нотатки.';
+
+  @override
+  String get appleWatchSetup => 'Налаштування Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Запит дозволу!';
+
+  @override
+  String get microphonePermission => 'Дозвіл на мікрофон';
+
+  @override
+  String get permissionGrantedNow =>
+      'Дозвіл надано! Тепер:\n\nВідкрийте додаток Omi на вашому годиннику та натисніть \"Продовжити\" нижче';
+
+  @override
+  String get needMicrophonePermission =>
+      'Нам потрібен дозвіл на мікрофон.\n\n1. Натисніть \"Надати дозвіл\"\n2. Дозвольте на вашому iPhone\n3. Додаток на годиннику закриється\n4. Відкрийте знову та натисніть \"Продовжити\"';
+
+  @override
+  String get grantPermissionButton => 'Надати дозвіл';
+
+  @override
+  String get needHelp => 'Потрібна допомога?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Усунення несправностей:\n\n1. Переконайтеся, що Omi встановлено на вашому годиннику\n2. Відкрийте додаток Omi на вашому годиннику\n3. Шукайте спливаюче вікно дозволу\n4. Натисніть \"Дозволити\" при запиті\n5. Додаток на вашому годиннику закриється - відкрийте його знову\n6. Поверніться та натисніть \"Продовжити\" на вашому iPhone';
+
+  @override
+  String get recordingStartedSuccessfully => 'Запис успішно розпочато!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Дозвіл ще не надано. Будь ласка, переконайтеся, що ви дозволили доступ до мікрофона та відкрили додаток на вашому годиннику знову.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Помилка запиту дозволу: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Помилка початку запису: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Виберіть свою основну мову';
+
+  @override
+  String get languageBenefits => 'Встановіть свою мову для точнішої транскрипції та персоналізованого досвіду';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Яка ваша основна мова?';
+
+  @override
+  String get selectYourLanguage => 'Виберіть свою мову';
+
+  @override
+  String get personalGrowthJourney => 'Ваша подорож особистого зростання з AI, який слухає кожне ваше слово.';
+
+  @override
+  String get actionItemsTitle => 'Завдання';
+
+  @override
+  String get actionItemsDescription => 'Торкніться для редагування • Довге натискання для вибору • Проведіть для дій';
+
+  @override
+  String get tabToDo => 'До виконання';
+
+  @override
+  String get tabDone => 'Виконано';
+
+  @override
+  String get tabOld => 'Старі';
+
+  @override
+  String get emptyTodoMessage => '🎉 Все виконано!\nНемає завдань у черзі';
+
+  @override
+  String get emptyDoneMessage => 'Виконаних завдань поки немає';
+
+  @override
+  String get emptyOldMessage => '✅ Немає старих завдань';
+
+  @override
+  String get noItems => 'Немає елементів';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Завдання позначено як невиконане';
+
+  @override
+  String get actionItemCompleted => 'Завдання виконано';
+
+  @override
+  String get deleteActionItemTitle => 'Видалити завдання';
+
+  @override
+  String get deleteActionItemMessage => 'Ви впевнені, що хочете видалити це завдання?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Видалити вибрані елементи';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Ви впевнені, що хочете видалити $count вибраних завдань$s?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Завдання \"$description\" видалено';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return '$count завдань$s видалено';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Не вдалося видалити завдання';
+
+  @override
+  String get failedToDeleteItems => 'Не вдалося видалити елементи';
+
+  @override
+  String get failedToDeleteSomeItems => 'Не вдалося видалити деякі елементи';
+
+  @override
+  String get welcomeActionItemsTitle => 'Готовий до завдань';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'Ваш AI автоматично витягатиме завдання з ваших розмов. Вони з\'являться тут після створення.';
+
+  @override
+  String get autoExtractionFeature => 'Автоматично витягуються з розмов';
+
+  @override
+  String get editSwipeFeature => 'Торкніться для редагування, проведіть для завершення або видалення';
+
+  @override
+  String itemsSelected(int count) {
+    return 'Вибрано: $count';
+  }
+
+  @override
+  String get selectAll => 'Вибрати все';
+
+  @override
+  String get deleteSelected => 'Видалити вибрані';
+
+  @override
+  String searchMemories(int count) {
+    return 'Пошук серед $count спогадів';
+  }
+
+  @override
+  String get memoryDeleted => 'Спогад видалено.';
+
+  @override
+  String get undo => 'Скасувати';
+
+  @override
+  String get noMemoriesYet => 'Спогадів поки немає';
+
+  @override
+  String get noAutoMemories => 'Автоматично витягнутих спогадів поки немає';
+
+  @override
+  String get noManualMemories => 'Власних спогадів поки немає';
+
+  @override
+  String get noMemoriesInCategories => 'Немає спогадів у цих категоріях';
+
+  @override
+  String get noMemoriesFound => 'Спогадів не знайдено';
+
+  @override
+  String get addFirstMemory => 'Додати перший спогад';
+
+  @override
+  String get clearMemoryTitle => 'Очистити пам\'ять Omi';
+
+  @override
+  String get clearMemoryMessage => 'Ви впевнені, що хочете очистити пам\'ять Omi? Цю дію не можна скасувати.';
+
+  @override
+  String get clearMemoryButton => 'Очистити пам\'ять';
+
+  @override
+  String get memoryClearedSuccess => 'Пам\'ять Omi про вас очищено';
+
+  @override
+  String get noMemoriesToDelete => 'Немає спогадів для видалення';
+
+  @override
+  String get createMemoryTooltip => 'Створити новий спогад';
+
+  @override
+  String get createActionItemTooltip => 'Створити нове завдання';
+
+  @override
+  String get memoryManagement => 'Управління спогадами';
+
+  @override
+  String get filterMemories => 'Фільтрувати спогади';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'У вас є $count спогадів загалом';
+  }
+
+  @override
+  String get publicMemories => 'Публічні спогади';
+
+  @override
+  String get privateMemories => 'Приватні спогади';
+
+  @override
+  String get makeAllPrivate => 'Зробити всі спогади приватними';
+
+  @override
+  String get makeAllPublic => 'Зробити всі спогади публічними';
+
+  @override
+  String get deleteAllMemories => 'Видалити всі спогади';
+
+  @override
+  String get allMemoriesPrivateResult => 'Всі спогади тепер приватні';
+
+  @override
+  String get allMemoriesPublicResult => 'Всі спогади тепер публічні';
+
+  @override
+  String get newMemory => 'Новий спогад';
+
+  @override
+  String get editMemory => 'Редагувати спогад';
+
+  @override
+  String get memoryContentHint => 'Мені подобається їсти морозиво...';
+
+  @override
+  String get failedToSaveMemory => 'Не вдалося зберегти. Будь ласка, перевірте підключення.';
+
+  @override
+  String get saveMemory => 'Зберегти спогад';
+
+  @override
+  String get retry => 'Спробувати ще раз';
+
+  @override
+  String get createActionItem => 'Створити завдання';
+
+  @override
+  String get editActionItem => 'Редагувати завдання';
+
+  @override
+  String get actionItemDescriptionHint => 'Що потрібно зробити?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Опис завдання не може бути порожнім.';
+
+  @override
+  String get actionItemUpdated => 'Завдання оновлено';
+
+  @override
+  String get failedToUpdateActionItem => 'Не вдалося оновити завдання';
+
+  @override
+  String get actionItemCreated => 'Завдання створено';
+
+  @override
+  String get failedToCreateActionItem => 'Не вдалося створити завдання';
+
+  @override
+  String get dueDate => 'Термін виконання';
+
+  @override
+  String get time => 'Час';
+
+  @override
+  String get addDueDate => 'Додати термін виконання';
+
+  @override
+  String get pressDoneToSave => 'Натисніть готово для збереження';
+
+  @override
+  String get pressDoneToCreate => 'Натисніть готово для створення';
+
+  @override
+  String get filterAll => 'Всі';
+
+  @override
+  String get filterSystem => 'Про вас';
+
+  @override
+  String get filterInteresting => 'Insights';
+
+  @override
+  String get filterManual => 'Власні';
+
+  @override
+  String get completed => 'Виконано';
+
+  @override
+  String get markComplete => 'Позначити виконаним';
+
+  @override
+  String get actionItemDeleted => 'Завдання видалено';
+
+  @override
+  String get failedToDeleteActionItem => 'Не вдалося видалити завдання';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Видалити завдання';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Ви впевнені, що хочете видалити це завдання?';
+
+  @override
+  String get appLanguage => 'Мова додатка';
+
+  @override
+  String get appInterfaceSectionTitle => 'ІНТЕРФЕЙС ДОДАТКУ';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'МОВЛЕННЯ ТА ТРАНСКРИПЦІЯ';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Мова додатку змінює меню та кнопки. Мова мовлення впливає на те, як транскрибуються ваші записи.';
+}

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -1,0 +1,2234 @@
+// ignore: unused_import
+import 'package:intl/intl.dart' as intl;
+import 'app_localizations.dart';
+
+// ignore_for_file: type=lint
+
+/// The translations for Vietnamese (`vi`).
+class AppLocalizationsVi extends AppLocalizations {
+  AppLocalizationsVi([String locale = 'vi']) : super(locale);
+
+  @override
+  String get appTitle => 'Omi';
+
+  @override
+  String get conversationTab => 'Cuộc trò chuyện';
+
+  @override
+  String get transcriptTab => 'Bản ghi';
+
+  @override
+  String get actionItemsTab => 'Việc cần làm';
+
+  @override
+  String get deleteConversationTitle => 'Xóa cuộc trò chuyện?';
+
+  @override
+  String get deleteConversationMessage =>
+      'Bạn có chắc chắn muốn xóa cuộc trò chuyện này? Hành động này không thể hoàn tác.';
+
+  @override
+  String get confirm => 'Xác nhận';
+
+  @override
+  String get cancel => 'Hủy';
+
+  @override
+  String get ok => 'Ok';
+
+  @override
+  String get delete => 'Xóa';
+
+  @override
+  String get add => 'Thêm';
+
+  @override
+  String get update => 'Cập nhật';
+
+  @override
+  String get save => 'Lưu';
+
+  @override
+  String get edit => 'Sửa';
+
+  @override
+  String get close => 'Đóng';
+
+  @override
+  String get clear => 'Xóa';
+
+  @override
+  String get copyTranscript => 'Sao chép bản ghi';
+
+  @override
+  String get copySummary => 'Sao chép tóm tắt';
+
+  @override
+  String get testPrompt => 'Thử nghiệm';
+
+  @override
+  String get reprocessConversation => 'Xử lý lại cuộc trò chuyện';
+
+  @override
+  String get deleteConversation => 'Xóa cuộc trò chuyện';
+
+  @override
+  String get contentCopied => 'Đã sao chép nội dung vào clipboard';
+
+  @override
+  String get failedToUpdateStarred => 'Không thể cập nhật trạng thái gắn sao.';
+
+  @override
+  String get conversationUrlNotShared => 'Không thể chia sẻ URL cuộc trò chuyện.';
+
+  @override
+  String get errorProcessingConversation => 'Lỗi khi xử lý cuộc trò chuyện. Vui lòng thử lại sau.';
+
+  @override
+  String get noInternetConnection => 'Vui lòng kiểm tra kết nối internet và thử lại.';
+
+  @override
+  String get unableToDeleteConversation => 'Không thể xóa cuộc trò chuyện';
+
+  @override
+  String get somethingWentWrong => 'Đã có lỗi xảy ra! Vui lòng thử lại sau.';
+
+  @override
+  String get copyErrorMessage => 'Sao chép thông báo lỗi';
+
+  @override
+  String get errorCopied => 'Đã sao chép thông báo lỗi vào clipboard';
+
+  @override
+  String get remaining => 'Còn lại';
+
+  @override
+  String get loading => 'Đang tải...';
+
+  @override
+  String get loadingDuration => 'Đang tải thời lượng...';
+
+  @override
+  String secondsCount(int count) {
+    return '$count giây';
+  }
+
+  @override
+  String get people => 'Mọi người';
+
+  @override
+  String get addNewPerson => 'Thêm người mới';
+
+  @override
+  String get editPerson => 'Chỉnh sửa người';
+
+  @override
+  String get createPersonHint => 'Tạo một người mới và huấn luyện Omi để nhận biết giọng nói của họ!';
+
+  @override
+  String get speechProfile => 'Hồ sơ giọng nói';
+
+  @override
+  String sampleNumber(int number) {
+    return 'Mẫu $number';
+  }
+
+  @override
+  String get settings => 'Cài đặt';
+
+  @override
+  String get language => 'Ngôn ngữ';
+
+  @override
+  String get selectLanguage => 'Chọn ngôn ngữ';
+
+  @override
+  String get deleting => 'Đang xóa...';
+
+  @override
+  String get pleaseCompleteAuthentication =>
+      'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
+
+  @override
+  String get failedToStartAuthentication => 'Không thể bắt đầu xác thực';
+
+  @override
+  String get importStarted => 'Đã bắt đầu nhập dữ liệu! Bạn sẽ được thông báo khi hoàn tất.';
+
+  @override
+  String get failedToStartImport => 'Không thể bắt đầu nhập dữ liệu. Vui lòng thử lại.';
+
+  @override
+  String get couldNotAccessFile => 'Không thể truy cập tệp đã chọn';
+
+  @override
+  String get askOmi => 'Hỏi Omi';
+
+  @override
+  String get done => 'Xong';
+
+  @override
+  String get disconnected => 'Đã ngắt kết nối';
+
+  @override
+  String get searching => 'Đang tìm kiếm';
+
+  @override
+  String get connectDevice => 'Kết nối thiết bị';
+
+  @override
+  String get monthlyLimitReached => 'Bạn đã đạt đến giới hạn hàng tháng.';
+
+  @override
+  String get checkUsage => 'Kiểm tra mức sử dụng';
+
+  @override
+  String get syncingRecordings => 'Đang đồng bộ bản ghi âm';
+
+  @override
+  String get recordingsToSync => 'Bản ghi âm cần đồng bộ';
+
+  @override
+  String get allCaughtUp => 'Đã đồng bộ tất cả';
+
+  @override
+  String get sync => 'Đồng bộ';
+
+  @override
+  String get pendantUpToDate => 'Pendant đã được cập nhật';
+
+  @override
+  String get allRecordingsSynced => 'Tất cả bản ghi âm đã được đồng bộ';
+
+  @override
+  String get syncingInProgress => 'Đang đồng bộ';
+
+  @override
+  String get readyToSync => 'Sẵn sàng đồng bộ';
+
+  @override
+  String get tapSyncToStart => 'Nhấn Đồng bộ để bắt đầu';
+
+  @override
+  String get pendantNotConnected => 'Pendant chưa kết nối. Kết nối để đồng bộ.';
+
+  @override
+  String get everythingSynced => 'Mọi thứ đã được đồng bộ.';
+
+  @override
+  String get recordingsNotSynced => 'Bạn có những bản ghi âm chưa được đồng bộ.';
+
+  @override
+  String get syncingBackground => 'Chúng tôi sẽ tiếp tục đồng bộ bản ghi âm của bạn trong nền.';
+
+  @override
+  String get noConversationsYet => 'Chưa có cuộc trò chuyện nào.';
+
+  @override
+  String get noStarredConversations => 'Chưa có cuộc trò chuyện được gắn sao.';
+
+  @override
+  String get starConversationHint =>
+      'Để gắn sao cuộc trò chuyện, hãy mở nó và nhấn vào biểu tượng ngôi sao ở phần đầu.';
+
+  @override
+  String get searchConversations => 'Tìm kiếm cuộc trò chuyện';
+
+  @override
+  String selectedCount(int count, Object s) {
+    return 'Đã chọn $count';
+  }
+
+  @override
+  String get merge => 'Gộp';
+
+  @override
+  String get mergeConversations => 'Gộp cuộc trò chuyện';
+
+  @override
+  String mergeConversationsMessage(int count) {
+    return 'Thao tác này sẽ kết hợp $count cuộc trò chuyện thành một. Tất cả nội dung sẽ được gộp và tạo lại.';
+  }
+
+  @override
+  String get mergingInBackground => 'Đang gộp trong nền. Có thể mất một chút thời gian.';
+
+  @override
+  String get failedToStartMerge => 'Không thể bắt đầu gộp';
+
+  @override
+  String get askAnything => 'Hỏi bất cứ điều gì';
+
+  @override
+  String get noMessagesYet => 'Chưa có tin nhắn nào!\nHãy bắt đầu cuộc trò chuyện nhé?';
+
+  @override
+  String get deletingMessages => 'Đang xóa tin nhắn của bạn khỏi bộ nhớ của Omi...';
+
+  @override
+  String get messageCopied => 'Đã sao chép tin nhắn vào clipboard.';
+
+  @override
+  String get cannotReportOwnMessage => 'Bạn không thể báo cáo tin nhắn của chính mình.';
+
+  @override
+  String get reportMessage => 'Báo cáo tin nhắn';
+
+  @override
+  String get reportMessageConfirm => 'Bạn có chắc chắn muốn báo cáo tin nhắn này?';
+
+  @override
+  String get messageReported => 'Đã báo cáo tin nhắn thành công.';
+
+  @override
+  String get thankYouFeedback => 'Cảm ơn phản hồi của bạn!';
+
+  @override
+  String get clearChat => 'Xóa trò chuyện?';
+
+  @override
+  String get clearChatConfirm => 'Bạn có chắc chắn muốn xóa trò chuyện? Hành động này không thể hoàn tác.';
+
+  @override
+  String get maxFilesLimit => 'Bạn chỉ có thể tải lên tối đa 4 tệp cùng lúc';
+
+  @override
+  String get chatWithOmi => 'Trò chuyện với Omi';
+
+  @override
+  String get apps => 'Ứng dụng';
+
+  @override
+  String get noAppsFound => 'Không tìm thấy ứng dụng';
+
+  @override
+  String get tryAdjustingSearch => 'Thử điều chỉnh tìm kiếm hoặc bộ lọc của bạn';
+
+  @override
+  String get createYourOwnApp => 'Tạo ứng dụng của riêng bạn';
+
+  @override
+  String get buildAndShareApp => 'Xây dựng và chia sẻ ứng dụng tùy chỉnh của bạn';
+
+  @override
+  String get searchApps => 'Tìm kiếm hơn 1500 ứng dụng';
+
+  @override
+  String get myApps => 'Ứng dụng của tôi';
+
+  @override
+  String get installedApps => 'Ứng dụng đã cài đặt';
+
+  @override
+  String get unableToFetchApps => 'Không thể tải ứng dụng :(\n\nVui lòng kiểm tra kết nối internet và thử lại.';
+
+  @override
+  String get aboutOmi => 'Về Omi';
+
+  @override
+  String get privacyPolicy => 'Chính sách bảo mật';
+
+  @override
+  String get visitWebsite => 'Truy cập website';
+
+  @override
+  String get helpOrInquiries => 'Trợ giúp hoặc thắc mắc?';
+
+  @override
+  String get joinCommunity => 'Tham gia cộng đồng!';
+
+  @override
+  String get membersAndCounting => 'Hơn 8000 thành viên và đang tăng.';
+
+  @override
+  String get deleteAccountTitle => 'Xóa tài khoản';
+
+  @override
+  String get deleteAccountConfirm => 'Bạn có chắc chắn muốn xóa tài khoản của mình?';
+
+  @override
+  String get cannotBeUndone => 'Hành động này không thể hoàn tác.';
+
+  @override
+  String get allDataErased => 'Tất cả ký ức và cuộc trò chuyện của bạn sẽ bị xóa vĩnh viễn.';
+
+  @override
+  String get appsDisconnected => 'Các ứng dụng và tích hợp của bạn sẽ bị ngắt kết nối ngay lập tức.';
+
+  @override
+  String get exportBeforeDelete =>
+      'Bạn có thể xuất dữ liệu trước khi xóa tài khoản, nhưng một khi đã xóa, dữ liệu không thể khôi phục.';
+
+  @override
+  String get deleteAccountCheckbox =>
+      'Tôi hiểu rằng việc xóa tài khoản là vĩnh viễn và tất cả dữ liệu, bao gồm ký ức và cuộc trò chuyện, sẽ bị mất và không thể khôi phục.';
+
+  @override
+  String get areYouSure => 'Bạn có chắc chắn?';
+
+  @override
+  String get deleteAccountFinal =>
+      'Hành động này không thể hoàn tác và sẽ xóa vĩnh viễn tài khoản cùng tất cả dữ liệu liên quan. Bạn có chắc chắn muốn tiếp tục?';
+
+  @override
+  String get deleteNow => 'Xóa ngay';
+
+  @override
+  String get goBack => 'Quay lại';
+
+  @override
+  String get checkBoxToConfirm =>
+      'Đánh dấu vào ô để xác nhận bạn hiểu rằng việc xóa tài khoản là vĩnh viễn và không thể hoàn tác.';
+
+  @override
+  String get profile => 'Hồ sơ';
+
+  @override
+  String get name => 'Tên';
+
+  @override
+  String get email => 'Email';
+
+  @override
+  String get customVocabulary => 'Từ vựng tùy chỉnh';
+
+  @override
+  String get identifyingOthers => 'Nhận diện người khác';
+
+  @override
+  String get paymentMethods => 'Phương thức thanh toán';
+
+  @override
+  String get conversationDisplay => 'Hiển thị cuộc trò chuyện';
+
+  @override
+  String get dataPrivacy => 'Dữ liệu & Bảo mật';
+
+  @override
+  String get userId => 'ID người dùng';
+
+  @override
+  String get notSet => 'Chưa đặt';
+
+  @override
+  String get userIdCopied => 'Đã sao chép ID người dùng vào clipboard';
+
+  @override
+  String get systemDefault => 'Mặc định hệ thống';
+
+  @override
+  String get planAndUsage => 'Gói & Mức sử dụng';
+
+  @override
+  String get offlineSync => 'Đồng bộ ngoại tuyến';
+
+  @override
+  String get deviceSettings => 'Cài đặt thiết bị';
+
+  @override
+  String get chatTools => 'Công cụ trò chuyện';
+
+  @override
+  String get feedbackBug => 'Phản hồi / Báo lỗi';
+
+  @override
+  String get helpCenter => 'Trung tâm trợ giúp';
+
+  @override
+  String get developerSettings => 'Cài đặt nhà phát triển';
+
+  @override
+  String get getOmiForMac => 'Tải Omi cho Mac';
+
+  @override
+  String get referralProgram => 'Chương trình giới thiệu';
+
+  @override
+  String get signOut => 'Đăng xuất';
+
+  @override
+  String get appAndDeviceCopied => 'Đã sao chép thông tin ứng dụng và thiết bị';
+
+  @override
+  String get wrapped2025 => 'Tổng kết 2025';
+
+  @override
+  String get yourPrivacyYourControl => 'Quyền riêng tư của bạn, Quyền kiểm soát của bạn';
+
+  @override
+  String get privacyIntro =>
+      'Tại Omi, chúng tôi cam kết bảo vệ quyền riêng tư của bạn. Trang này cho phép bạn kiểm soát cách dữ liệu của bạn được lưu trữ và sử dụng.';
+
+  @override
+  String get learnMore => 'Tìm hiểu thêm...';
+
+  @override
+  String get dataProtectionLevel => 'Mức độ bảo vệ dữ liệu';
+
+  @override
+  String get dataProtectionDesc =>
+      'Dữ liệu của bạn được bảo mật mặc định với mã hóa mạnh. Xem lại cài đặt và các tùy chọn bảo mật trong tương lai bên dưới.';
+
+  @override
+  String get appAccess => 'Quyền truy cập ứng dụng';
+
+  @override
+  String get appAccessDesc =>
+      'Các ứng dụng sau có thể truy cập dữ liệu của bạn. Nhấn vào ứng dụng để quản lý quyền của nó.';
+
+  @override
+  String get noAppsExternalAccess =>
+      'Không có ứng dụng đã cài đặt nào có quyền truy cập bên ngoài vào dữ liệu của bạn.';
+
+  @override
+  String get deviceName => 'Tên thiết bị';
+
+  @override
+  String get deviceId => 'ID thiết bị';
+
+  @override
+  String get firmware => 'Phần mềm';
+
+  @override
+  String get sdCardSync => 'Đồng bộ thẻ SD';
+
+  @override
+  String get hardwareRevision => 'Phiên bản phần cứng';
+
+  @override
+  String get modelNumber => 'Số model';
+
+  @override
+  String get manufacturer => 'Nhà sản xuất';
+
+  @override
+  String get doubleTap => 'Nhấn đúp';
+
+  @override
+  String get ledBrightness => 'Độ sáng đèn LED';
+
+  @override
+  String get micGain => 'Độ tăng micro';
+
+  @override
+  String get disconnect => 'Ngắt kết nối';
+
+  @override
+  String get forgetDevice => 'Xóa thiết bị';
+
+  @override
+  String get chargingIssues => 'Vấn đề sạc pin';
+
+  @override
+  String get disconnectDevice => 'Ngắt kết nối thiết bị';
+
+  @override
+  String get unpairDevice => 'Hủy ghép nối thiết bị';
+
+  @override
+  String get unpairAndForget => 'Hủy ghép nối và xóa thiết bị';
+
+  @override
+  String get deviceDisconnectedMessage => 'Omi của bạn đã bị ngắt kết nối 😔';
+
+  @override
+  String get deviceUnpairedMessage =>
+      'Đã hủy ghép nối thiết bị. Vào Cài đặt > Bluetooth và xóa thiết bị để hoàn tất việc hủy ghép nối.';
+
+  @override
+  String get unpairDialogTitle => 'Hủy ghép nối thiết bị';
+
+  @override
+  String get unpairDialogMessage =>
+      'Thao tác này sẽ hủy ghép nối thiết bị để có thể kết nối với điện thoại khác. Bạn cần vào Cài đặt > Bluetooth và xóa thiết bị để hoàn tất quá trình.';
+
+  @override
+  String get deviceNotConnected => 'Thiết bị chưa kết nối';
+
+  @override
+  String get connectDeviceMessage => 'Kết nối thiết bị Omi của bạn để truy cập\ncài đặt thiết bị và tùy chỉnh';
+
+  @override
+  String get deviceInfoSection => 'Thông tin thiết bị';
+
+  @override
+  String get customizationSection => 'Tùy chỉnh';
+
+  @override
+  String get hardwareSection => 'Phần cứng';
+
+  @override
+  String get v2Undetected => 'Không phát hiện V2';
+
+  @override
+  String get v2UndetectedMessage =>
+      'Chúng tôi thấy rằng bạn có thiết bị V1 hoặc thiết bị của bạn chưa được kết nối. Chức năng thẻ SD chỉ khả dụng cho thiết bị V2.';
+
+  @override
+  String get endConversation => 'Kết thúc cuộc trò chuyện';
+
+  @override
+  String get pauseResume => 'Tạm dừng/Tiếp tục';
+
+  @override
+  String get starConversation => 'Gắn sao cuộc trò chuyện';
+
+  @override
+  String get doubleTapAction => 'Hành động nhấn đúp';
+
+  @override
+  String get endAndProcess => 'Kết thúc & Xử lý cuộc trò chuyện';
+
+  @override
+  String get pauseResumeRecording => 'Tạm dừng/Tiếp tục ghi âm';
+
+  @override
+  String get starOngoing => 'Gắn sao cuộc trò chuyện đang diễn ra';
+
+  @override
+  String get off => 'Tắt';
+
+  @override
+  String get max => 'Tối đa';
+
+  @override
+  String get mute => 'Tắt tiếng';
+
+  @override
+  String get quiet => 'Yên tĩnh';
+
+  @override
+  String get normal => 'Bình thường';
+
+  @override
+  String get high => 'Cao';
+
+  @override
+  String get micGainDescMuted => 'Microphone đã tắt tiếng';
+
+  @override
+  String get micGainDescLow => 'Rất yên tĩnh - cho môi trường ồn ào';
+
+  @override
+  String get micGainDescModerate => 'Yên tĩnh - cho tiếng ồn vừa phải';
+
+  @override
+  String get micGainDescNeutral => 'Trung tính - ghi âm cân bằng';
+
+  @override
+  String get micGainDescSlightlyBoosted => 'Tăng nhẹ - sử dụng thông thường';
+
+  @override
+  String get micGainDescBoosted => 'Tăng cao - cho môi trường yên tĩnh';
+
+  @override
+  String get micGainDescHigh => 'Cao - cho giọng nói xa hoặc nhỏ';
+
+  @override
+  String get micGainDescVeryHigh => 'Rất cao - cho nguồn rất yên tĩnh';
+
+  @override
+  String get micGainDescMax => 'Tối đa - sử dụng cẩn thận';
+
+  @override
+  String get developerSettingsTitle => 'Cài đặt nhà phát triển';
+
+  @override
+  String get saving => 'Đang lưu...';
+
+  @override
+  String get personaConfig => 'Cấu hình nhân cách AI của bạn';
+
+  @override
+  String get beta => 'BETA';
+
+  @override
+  String get transcription => 'Phiên âm';
+
+  @override
+  String get transcriptionConfig => 'Cấu hình nhà cung cấp STT';
+
+  @override
+  String get conversationTimeout => 'Thời gian chờ cuộc trò chuyện';
+
+  @override
+  String get conversationTimeoutConfig => 'Đặt thời gian tự động kết thúc cuộc trò chuyện';
+
+  @override
+  String get importData => 'Nhập dữ liệu';
+
+  @override
+  String get importDataConfig => 'Nhập dữ liệu từ các nguồn khác';
+
+  @override
+  String get debugDiagnostics => 'Gỡ lỗi & Chẩn đoán';
+
+  @override
+  String get endpointUrl => 'URL điểm cuối';
+
+  @override
+  String get noApiKeys => 'Chưa có API key';
+
+  @override
+  String get createKeyToStart => 'Tạo key để bắt đầu';
+
+  @override
+  String get createKey => 'Tạo Key';
+
+  @override
+  String get docs => 'Tài liệu';
+
+  @override
+  String get yourOmiInsights => 'Thông tin chi tiết Omi của bạn';
+
+  @override
+  String get today => 'Hôm nay';
+
+  @override
+  String get thisMonth => 'Tháng này';
+
+  @override
+  String get thisYear => 'Năm nay';
+
+  @override
+  String get allTime => 'Tất cả thời gian';
+
+  @override
+  String get noActivityYet => 'Chưa có hoạt động';
+
+  @override
+  String get startConversationToSeeInsights =>
+      'Bắt đầu cuộc trò chuyện với Omi\nđể xem thông tin chi tiết về mức sử dụng của bạn tại đây.';
+
+  @override
+  String get listening => 'Lắng nghe';
+
+  @override
+  String get listeningSubtitle => 'Tổng thời gian Omi đã lắng nghe tích cực.';
+
+  @override
+  String get understanding => 'Hiểu biết';
+
+  @override
+  String get understandingSubtitle => 'Số từ đã hiểu từ cuộc trò chuyện của bạn.';
+
+  @override
+  String get providing => 'Cung cấp';
+
+  @override
+  String get providingSubtitle => 'Việc cần làm và ghi chú được ghi lại tự động.';
+
+  @override
+  String get remembering => 'Ghi nhớ';
+
+  @override
+  String get rememberingSubtitle => 'Sự kiện và chi tiết được ghi nhớ cho bạn.';
+
+  @override
+  String get unlimitedPlan => 'Gói không giới hạn';
+
+  @override
+  String get managePlan => 'Quản lý gói';
+
+  @override
+  String cancelAtPeriodEnd(String date) {
+    return 'Gói của bạn sẽ bị hủy vào $date.';
+  }
+
+  @override
+  String renewsOn(String date) {
+    return 'Gói của bạn sẽ gia hạn vào $date.';
+  }
+
+  @override
+  String get basicPlan => 'Gói miễn phí';
+
+  @override
+  String usageLimitMessage(String used, int limit) {
+    return 'Đã sử dụng $used trong số $limit phút';
+  }
+
+  @override
+  String get upgrade => 'Nâng cấp';
+
+  @override
+  String get upgradeToUnlimited => 'Nâng cấp lên không giới hạn';
+
+  @override
+  String basicPlanDesc(int limit) {
+    return 'Gói của bạn bao gồm $limit phút miễn phí mỗi tháng. Nâng cấp để sử dụng không giới hạn.';
+  }
+
+  @override
+  String get shareStatsMessage => 'Chia sẻ thống kê Omi của tôi! (omi.me - trợ lý AI luôn bên bạn)';
+
+  @override
+  String get sharePeriodToday => 'Hôm nay, omi đã:';
+
+  @override
+  String get sharePeriodMonth => 'Tháng này, omi đã:';
+
+  @override
+  String get sharePeriodYear => 'Năm nay, omi đã:';
+
+  @override
+  String get sharePeriodAllTime => 'Cho đến nay, omi đã:';
+
+  @override
+  String shareStatsListened(String minutes) {
+    return '🎧 Đã lắng nghe trong $minutes phút';
+  }
+
+  @override
+  String shareStatsWords(String words) {
+    return '🧠 Đã hiểu $words từ';
+  }
+
+  @override
+  String shareStatsInsights(String count) {
+    return '✨ Đã cung cấp $count thông tin chi tiết';
+  }
+
+  @override
+  String shareStatsMemories(String count) {
+    return '📚 Đã ghi nhớ $count ký ức';
+  }
+
+  @override
+  String get debugLogs => 'Nhật ký gỡ lỗi';
+
+  @override
+  String get debugLogsAutoDelete => 'Tự động xóa sau 3 ngày.';
+
+  @override
+  String get debugLogsDesc => 'Giúp chẩn đoán các vấn đề';
+
+  @override
+  String get noLogFilesFound => 'Không tìm thấy tệp nhật ký.';
+
+  @override
+  String get omiDebugLog => 'Nhật ký gỡ lỗi Omi';
+
+  @override
+  String get logShared => 'Đã chia sẻ nhật ký';
+
+  @override
+  String get selectLogFile => 'Chọn tệp nhật ký';
+
+  @override
+  String get shareLogs => 'Chia sẻ nhật ký';
+
+  @override
+  String get debugLogCleared => 'Đã xóa nhật ký gỡ lỗi';
+
+  @override
+  String get exportStarted => 'Đã bắt đầu xuất dữ liệu. Có thể mất vài giây...';
+
+  @override
+  String get exportAllData => 'Xuất tất cả dữ liệu';
+
+  @override
+  String get exportDataDesc => 'Xuất cuộc trò chuyện sang tệp JSON';
+
+  @override
+  String get exportedConversations => 'Cuộc trò chuyện đã xuất từ Omi';
+
+  @override
+  String get exportShared => 'Đã chia sẻ bản xuất';
+
+  @override
+  String get deleteKnowledgeGraphTitle => 'Xóa biểu đồ tri thức?';
+
+  @override
+  String get deleteKnowledgeGraphMessage =>
+      'Thao tác này sẽ xóa tất cả dữ liệu biểu đồ tri thức được tạo ra (nút và kết nối). Ký ức gốc của bạn sẽ vẫn an toàn. Biểu đồ sẽ được xây dựng lại theo thời gian hoặc khi có yêu cầu tiếp theo.';
+
+  @override
+  String get knowledgeGraphDeleted => 'Đã xóa biểu đồ tri thức thành công';
+
+  @override
+  String deleteGraphFailed(String error) {
+    return 'Không thể xóa biểu đồ: $error';
+  }
+
+  @override
+  String get deleteKnowledgeGraph => 'Xóa biểu đồ tri thức';
+
+  @override
+  String get deleteKnowledgeGraphDesc => 'Xóa tất cả nút và kết nối';
+
+  @override
+  String get mcp => 'MCP';
+
+  @override
+  String get mcpServer => 'Máy chủ MCP';
+
+  @override
+  String get mcpServerDesc => 'Kết nối trợ lý AI với dữ liệu của bạn';
+
+  @override
+  String get serverUrl => 'URL máy chủ';
+
+  @override
+  String get urlCopied => 'Đã sao chép URL';
+
+  @override
+  String get apiKeyAuth => 'Xác thực API Key';
+
+  @override
+  String get header => 'Header';
+
+  @override
+  String get authorizationBearer => 'Authorization: Bearer <key>';
+
+  @override
+  String get oauth => 'OAuth';
+
+  @override
+  String get clientId => 'Client ID';
+
+  @override
+  String get clientSecret => 'Client Secret';
+
+  @override
+  String get useMcpApiKey => 'Sử dụng API key MCP của bạn';
+
+  @override
+  String get webhooks => 'Webhooks';
+
+  @override
+  String get conversationEvents => 'Sự kiện cuộc trò chuyện';
+
+  @override
+  String get newConversationCreated => 'Đã tạo cuộc trò chuyện mới';
+
+  @override
+  String get realtimeTranscript => 'Bản ghi thời gian thực';
+
+  @override
+  String get transcriptReceived => 'Đã nhận bản ghi';
+
+  @override
+  String get audioBytes => 'Dữ liệu âm thanh';
+
+  @override
+  String get audioDataReceived => 'Đã nhận dữ liệu âm thanh';
+
+  @override
+  String get intervalSeconds => 'Khoảng thời gian (giây)';
+
+  @override
+  String get daySummary => 'Tóm tắt ngày';
+
+  @override
+  String get summaryGenerated => 'Đã tạo tóm tắt';
+
+  @override
+  String get claudeDesktop => 'Claude Desktop';
+
+  @override
+  String get addToClaudeConfig => 'Thêm vào claude_desktop_config.json';
+
+  @override
+  String get copyConfig => 'Sao chép cấu hình';
+
+  @override
+  String get configCopied => 'Đã sao chép cấu hình vào clipboard';
+
+  @override
+  String get listeningMins => 'Lắng nghe (phút)';
+
+  @override
+  String get understandingWords => 'Hiểu biết (từ)';
+
+  @override
+  String get insights => 'Thông tin chi tiết';
+
+  @override
+  String get memories => 'Ký ức';
+
+  @override
+  String minsUsedThisMonth(String used, int limit) {
+    return 'Đã sử dụng $used trong số $limit phút trong tháng này';
+  }
+
+  @override
+  String wordsUsedThisMonth(String used, String limit) {
+    return 'Đã sử dụng $used trong số $limit từ trong tháng này';
+  }
+
+  @override
+  String insightsUsedThisMonth(String used, String limit) {
+    return 'Đã thu được $used trong số $limit thông tin chi tiết trong tháng này';
+  }
+
+  @override
+  String memoriesUsedThisMonth(String used, String limit) {
+    return 'Đã tạo $used trong số $limit ký ức trong tháng này';
+  }
+
+  @override
+  String get visibility => 'Hiển thị';
+
+  @override
+  String get visibilitySubtitle => 'Kiểm soát cuộc trò chuyện nào xuất hiện trong danh sách của bạn';
+
+  @override
+  String get showShortConversations => 'Hiển thị cuộc trò chuyện ngắn';
+
+  @override
+  String get showShortConversationsDesc => 'Hiển thị cuộc trò chuyện ngắn hơn ngưỡng';
+
+  @override
+  String get showDiscardedConversations => 'Hiển thị cuộc trò chuyện đã hủy';
+
+  @override
+  String get showDiscardedConversationsDesc => 'Bao gồm cuộc trò chuyện được đánh dấu là đã hủy';
+
+  @override
+  String get shortConversationThreshold => 'Ngưỡng cuộc trò chuyện ngắn';
+
+  @override
+  String get shortConversationThresholdSubtitle => 'Cuộc trò chuyện ngắn hơn sẽ bị ẩn trừ khi được bật ở trên';
+
+  @override
+  String get durationThreshold => 'Ngưỡng thời lượng';
+
+  @override
+  String get durationThresholdDesc => 'Ẩn cuộc trò chuyện ngắn hơn';
+
+  @override
+  String minLabel(int count) {
+    return '$count phút';
+  }
+
+  @override
+  String get customVocabularyTitle => 'Từ vựng tùy chỉnh';
+
+  @override
+  String get addWords => 'Thêm từ';
+
+  @override
+  String get addWordsDesc => 'Tên, thuật ngữ hoặc từ không phổ biến';
+
+  @override
+  String get vocabularyHint => 'Omi, Callie, OpenAI';
+
+  @override
+  String get connect => 'Kết nối';
+
+  @override
+  String get comingSoon => 'Sắp ra mắt';
+
+  @override
+  String get chatToolsFooter => 'Kết nối ứng dụng của bạn để xem dữ liệu và số liệu trong trò chuyện.';
+
+  @override
+  String get completeAuthInBrowser =>
+      'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
+
+  @override
+  String failedToStartAuth(String appName) {
+    return 'Không thể bắt đầu xác thực $appName';
+  }
+
+  @override
+  String disconnectAppTitle(String appName) {
+    return 'Ngắt kết nối $appName?';
+  }
+
+  @override
+  String disconnectAppMessage(String appName) {
+    return 'Bạn có chắc chắn muốn ngắt kết nối khỏi $appName? Bạn có thể kết nối lại bất kỳ lúc nào.';
+  }
+
+  @override
+  String disconnectedFrom(String appName) {
+    return 'Đã ngắt kết nối khỏi $appName';
+  }
+
+  @override
+  String get failedToDisconnect => 'Không thể ngắt kết nối';
+
+  @override
+  String connectTo(String appName) {
+    return 'Kết nối với $appName';
+  }
+
+  @override
+  String authAccessMessage(String appName) {
+    return 'Bạn cần cho phép Omi truy cập dữ liệu $appName của bạn. Thao tác này sẽ mở trình duyệt để xác thực.';
+  }
+
+  @override
+  String get continueAction => 'Tiếp tục';
+
+  @override
+  String get languageTitle => 'Ngôn ngữ';
+
+  @override
+  String get primaryLanguage => 'Ngôn ngữ chính';
+
+  @override
+  String get automaticTranslation => 'Dịch tự động';
+
+  @override
+  String get detectLanguages => 'Phát hiện hơn 10 ngôn ngữ';
+
+  @override
+  String get authorizeSavingRecordings => 'Cho phép lưu bản ghi âm';
+
+  @override
+  String get thanksForAuthorizing => 'Cảm ơn bạn đã cho phép!';
+
+  @override
+  String get needYourPermission => 'Chúng tôi cần sự cho phép của bạn';
+
+  @override
+  String get alreadyGavePermission =>
+      'Bạn đã cho phép chúng tôi lưu bản ghi âm của bạn. Đây là lời nhắc nhở về lý do chúng tôi cần:';
+
+  @override
+  String get wouldLikePermission => 'Chúng tôi muốn được phép lưu bản ghi âm giọng nói của bạn. Đây là lý do:';
+
+  @override
+  String get improveSpeechProfile => 'Cải thiện hồ sơ giọng nói của bạn';
+
+  @override
+  String get improveSpeechProfileDesc =>
+      'Chúng tôi sử dụng bản ghi âm để huấn luyện và nâng cao hồ sơ giọng nói cá nhân của bạn.';
+
+  @override
+  String get trainFamilyProfiles => 'Huấn luyện hồ sơ cho bạn bè và gia đình';
+
+  @override
+  String get trainFamilyProfilesDesc =>
+      'Bản ghi âm của bạn giúp chúng tôi nhận dạng và tạo hồ sơ cho bạn bè và gia đình của bạn.';
+
+  @override
+  String get enhanceTranscriptAccuracy => 'Tăng độ chính xác bản ghi';
+
+  @override
+  String get enhanceTranscriptAccuracyDesc =>
+      'Khi mô hình của chúng tôi được cải thiện, chúng tôi có thể cung cấp kết quả phiên âm tốt hơn cho bản ghi âm của bạn.';
+
+  @override
+  String get legalNotice =>
+      'Thông báo pháp lý: Tính hợp pháp của việc ghi âm và lưu trữ dữ liệu giọng nói có thể khác nhau tùy thuộc vào vị trí của bạn và cách bạn sử dụng tính năng này. Bạn có trách nhiệm đảm bảo tuân thủ luật pháp và quy định địa phương.';
+
+  @override
+  String get alreadyAuthorized => 'Đã cho phép';
+
+  @override
+  String get authorize => 'Cho phép';
+
+  @override
+  String get revokeAuthorization => 'Thu hồi quyền';
+
+  @override
+  String get authorizationSuccessful => 'Cho phép thành công!';
+
+  @override
+  String get failedToAuthorize => 'Không thể cho phép. Vui lòng thử lại.';
+
+  @override
+  String get authorizationRevoked => 'Đã thu hồi quyền.';
+
+  @override
+  String get recordingsDeleted => 'Đã xóa bản ghi âm.';
+
+  @override
+  String get failedToRevoke => 'Không thể thu hồi quyền. Vui lòng thử lại.';
+
+  @override
+  String get permissionRevokedTitle => 'Đã thu hồi quyền';
+
+  @override
+  String get permissionRevokedMessage => 'Bạn có muốn chúng tôi xóa tất cả bản ghi âm hiện có của bạn không?';
+
+  @override
+  String get yes => 'Có';
+
+  @override
+  String get editName => 'Chỉnh sửa tên';
+
+  @override
+  String get howShouldOmiCallYou => 'Omi nên gọi bạn như thế nào?';
+
+  @override
+  String get enterYourName => 'Nhập tên của bạn';
+
+  @override
+  String get nameCannotBeEmpty => 'Tên không được để trống';
+
+  @override
+  String get nameUpdatedSuccessfully => 'Đã cập nhật tên thành công!';
+
+  @override
+  String get calendarSettings => 'Cài đặt lịch';
+
+  @override
+  String get calendarProviders => 'Nhà cung cấp lịch';
+
+  @override
+  String get macOsCalendar => 'Lịch macOS';
+
+  @override
+  String get connectMacOsCalendar => 'Kết nối lịch macOS cục bộ của bạn';
+
+  @override
+  String get googleCalendar => 'Google Calendar';
+
+  @override
+  String get syncGoogleAccount => 'Đồng bộ với tài khoản Google của bạn';
+
+  @override
+  String get showMeetingsMenuBar => 'Hiển thị cuộc họp sắp tới trên thanh menu';
+
+  @override
+  String get showMeetingsMenuBarDesc =>
+      'Hiển thị cuộc họp tiếp theo và thời gian cho đến khi nó bắt đầu trên thanh menu macOS';
+
+  @override
+  String get showEventsNoParticipants => 'Hiển thị sự kiện không có người tham gia';
+
+  @override
+  String get showEventsNoParticipantsDesc =>
+      'Khi được bật, Coming Up hiển thị các sự kiện không có người tham gia hoặc liên kết video.';
+
+  @override
+  String get yourMeetings => 'Cuộc họp của bạn';
+
+  @override
+  String get refresh => 'Làm mới';
+
+  @override
+  String get noUpcomingMeetings => 'Không tìm thấy cuộc họp sắp tới';
+
+  @override
+  String get checkingNextDays => 'Kiểm tra 30 ngày tiếp theo';
+
+  @override
+  String get tomorrow => 'Ngày mai';
+
+  @override
+  String get googleCalendarComingSoon => 'Tích hợp Google Calendar sắp ra mắt!';
+
+  @override
+  String connectedAsUser(String userId) {
+    return 'Đã kết nối với tư cách người dùng: $userId';
+  }
+
+  @override
+  String get defaultWorkspace => 'Workspace mặc định';
+
+  @override
+  String get tasksCreatedInWorkspace => 'Nhiệm vụ sẽ được tạo trong workspace này';
+
+  @override
+  String get defaultProjectOptional => 'Dự án mặc định (Tùy chọn)';
+
+  @override
+  String get leaveUnselectedTasks => 'Bỏ trống để tạo nhiệm vụ không có dự án';
+
+  @override
+  String get noProjectsInWorkspace => 'Không tìm thấy dự án trong workspace này';
+
+  @override
+  String get conversationTimeoutDesc => 'Chọn thời gian chờ im lặng trước khi tự động kết thúc cuộc trò chuyện:';
+
+  @override
+  String get timeout2Minutes => '2 phút';
+
+  @override
+  String get timeout2MinutesDesc => 'Kết thúc cuộc trò chuyện sau 2 phút im lặng';
+
+  @override
+  String get timeout5Minutes => '5 phút';
+
+  @override
+  String get timeout5MinutesDesc => 'Kết thúc cuộc trò chuyện sau 5 phút im lặng';
+
+  @override
+  String get timeout10Minutes => '10 phút';
+
+  @override
+  String get timeout10MinutesDesc => 'Kết thúc cuộc trò chuyện sau 10 phút im lặng';
+
+  @override
+  String get timeout30Minutes => '30 phút';
+
+  @override
+  String get timeout30MinutesDesc => 'Kết thúc cuộc trò chuyện sau 30 phút im lặng';
+
+  @override
+  String get timeout4Hours => '4 giờ';
+
+  @override
+  String get timeout4HoursDesc => 'Kết thúc cuộc trò chuyện sau 4 giờ im lặng';
+
+  @override
+  String get conversationEndAfterHours => 'Cuộc trò chuyện bây giờ sẽ kết thúc sau 4 giờ im lặng';
+
+  @override
+  String conversationEndAfterMinutes(int minutes) {
+    return 'Cuộc trò chuyện bây giờ sẽ kết thúc sau $minutes phút im lặng';
+  }
+
+  @override
+  String get tellUsPrimaryLanguage => 'Cho chúng tôi biết ngôn ngữ chính của bạn';
+
+  @override
+  String get languageForTranscription =>
+      'Đặt ngôn ngữ của bạn để có phiên âm chính xác hơn và trải nghiệm được cá nhân hóa.';
+
+  @override
+  String get singleLanguageModeInfo =>
+      'Chế độ đơn ngôn ngữ đã được bật. Dịch bị vô hiệu hóa để có độ chính xác cao hơn.';
+
+  @override
+  String get searchLanguageHint => 'Tìm kiếm ngôn ngữ theo tên hoặc mã';
+
+  @override
+  String get noLanguagesFound => 'Không tìm thấy ngôn ngữ';
+
+  @override
+  String get skip => 'Bỏ qua';
+
+  @override
+  String languageSetTo(String language) {
+    return 'Đã đặt ngôn ngữ thành $language';
+  }
+
+  @override
+  String get failedToSetLanguage => 'Không thể đặt ngôn ngữ';
+
+  @override
+  String appSettings(String appName) {
+    return 'Cài đặt $appName';
+  }
+
+  @override
+  String disconnectFromApp(String appName) {
+    return 'Ngắt kết nối khỏi $appName?';
+  }
+
+  @override
+  String disconnectFromAppDesc(String appName) {
+    return 'Thao tác này sẽ xóa xác thực $appName của bạn. Bạn sẽ cần kết nối lại để sử dụng.';
+  }
+
+  @override
+  String connectedToApp(String appName) {
+    return 'Đã kết nối với $appName';
+  }
+
+  @override
+  String get account => 'Tài khoản';
+
+  @override
+  String actionItemsSyncedTo(String appName) {
+    return 'Việc cần làm của bạn sẽ được đồng bộ với tài khoản $appName của bạn';
+  }
+
+  @override
+  String get defaultSpace => 'Space mặc định';
+
+  @override
+  String get selectSpaceInWorkspace => 'Chọn một space trong workspace của bạn';
+
+  @override
+  String get noSpacesInWorkspace => 'Không tìm thấy space trong workspace này';
+
+  @override
+  String get defaultList => 'Danh sách mặc định';
+
+  @override
+  String get tasksAddedToList => 'Nhiệm vụ sẽ được thêm vào danh sách này';
+
+  @override
+  String get noListsInSpace => 'Không tìm thấy danh sách trong space này';
+
+  @override
+  String failedToLoadRepos(String error) {
+    return 'Không thể tải kho lưu trữ: $error';
+  }
+
+  @override
+  String get defaultRepoSaved => 'Đã lưu kho lưu trữ mặc định';
+
+  @override
+  String get failedToSaveDefaultRepo => 'Không thể lưu kho lưu trữ mặc định';
+
+  @override
+  String get defaultRepository => 'Kho lưu trữ mặc định';
+
+  @override
+  String get selectDefaultRepoDesc =>
+      'Chọn một kho lưu trữ mặc định để tạo issue. Bạn vẫn có thể chỉ định kho lưu trữ khác khi tạo issue.';
+
+  @override
+  String get noReposFound => 'Không tìm thấy kho lưu trữ';
+
+  @override
+  String get private => 'Riêng tư';
+
+  @override
+  String updatedDate(String date) {
+    return 'Đã cập nhật $date';
+  }
+
+  @override
+  String get yesterday => 'hôm qua';
+
+  @override
+  String daysAgo(int count) {
+    return '$count ngày trước';
+  }
+
+  @override
+  String get oneWeekAgo => '1 tuần trước';
+
+  @override
+  String weeksAgo(int count) {
+    return '$count tuần trước';
+  }
+
+  @override
+  String get oneMonthAgo => '1 tháng trước';
+
+  @override
+  String monthsAgo(int count) {
+    return '$count tháng trước';
+  }
+
+  @override
+  String get issuesCreatedInRepo => 'Issue sẽ được tạo trong kho lưu trữ mặc định của bạn';
+
+  @override
+  String get taskIntegrations => 'Tích hợp nhiệm vụ';
+
+  @override
+  String get configureSettings => 'Cấu hình cài đặt';
+
+  @override
+  String get completeAuthBrowser =>
+      'Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.';
+
+  @override
+  String failedToStartAppAuth(String appName) {
+    return 'Không thể bắt đầu xác thực $appName';
+  }
+
+  @override
+  String connectToAppTitle(String appName) {
+    return 'Kết nối với $appName';
+  }
+
+  @override
+  String authorizeOmiForTasks(String appName) {
+    return 'Bạn cần cho phép Omi tạo nhiệm vụ trong tài khoản $appName của bạn. Thao tác này sẽ mở trình duyệt để xác thực.';
+  }
+
+  @override
+  String get continueButton => 'Tiếp tục';
+
+  @override
+  String appIntegration(String appName) {
+    return 'Tích hợp $appName';
+  }
+
+  @override
+  String integrationComingSoon(String appName) {
+    return 'Tích hợp với $appName sắp ra mắt! Chúng tôi đang nỗ lực để mang đến cho bạn nhiều tùy chọn quản lý nhiệm vụ hơn.';
+  }
+
+  @override
+  String get gotIt => 'Đã hiểu';
+
+  @override
+  String get tasksExportedOneApp => 'Nhiệm vụ có thể được xuất sang một ứng dụng tại một thời điểm.';
+
+  @override
+  String get completeYourUpgrade => 'Hoàn tất nâng cấp của bạn';
+
+  @override
+  String get importConfiguration => 'Nhập cấu hình';
+
+  @override
+  String get exportConfiguration => 'Xuất cấu hình';
+
+  @override
+  String get bringYourOwn => 'Mang của riêng bạn';
+
+  @override
+  String get payYourSttProvider => 'Sử dụng omi tự do. Bạn chỉ trả tiền cho nhà cung cấp STT trực tiếp.';
+
+  @override
+  String get freeMinutesMonth => '1.200 phút miễn phí/tháng được bao gồm. Không giới hạn với ';
+
+  @override
+  String get omiUnlimited => 'Omi Unlimited';
+
+  @override
+  String get hostRequired => 'Bắt buộc có host';
+
+  @override
+  String get validPortRequired => 'Bắt buộc có port hợp lệ';
+
+  @override
+  String get validWebsocketUrlRequired => 'Bắt buộc có URL WebSocket hợp lệ (wss://)';
+
+  @override
+  String get apiUrlRequired => 'Bắt buộc có URL API';
+
+  @override
+  String get apiKeyRequired => 'Bắt buộc có API key';
+
+  @override
+  String get invalidJsonConfig => 'Cấu hình JSON không hợp lệ';
+
+  @override
+  String errorSaving(String error) {
+    return 'Lỗi khi lưu: $error';
+  }
+
+  @override
+  String get configCopiedToClipboard => 'Đã sao chép cấu hình vào clipboard';
+
+  @override
+  String get pasteJsonConfig => 'Dán cấu hình JSON của bạn bên dưới:';
+
+  @override
+  String get addApiKeyAfterImport => 'Bạn cần thêm API key của riêng mình sau khi nhập';
+
+  @override
+  String get paste => 'Dán';
+
+  @override
+  String get import => 'Nhập';
+
+  @override
+  String get invalidProviderInConfig => 'Nhà cung cấp không hợp lệ trong cấu hình';
+
+  @override
+  String importedConfig(String providerName) {
+    return 'Đã nhập cấu hình $providerName';
+  }
+
+  @override
+  String invalidJson(String error) {
+    return 'JSON không hợp lệ: $error';
+  }
+
+  @override
+  String get provider => 'Nhà cung cấp';
+
+  @override
+  String get live => 'Trực tiếp';
+
+  @override
+  String get onDevice => 'Trên thiết bị';
+
+  @override
+  String get apiUrl => 'URL API';
+
+  @override
+  String get enterSttHttpEndpoint => 'Nhập điểm cuối HTTP STT của bạn';
+
+  @override
+  String get websocketUrl => 'URL WebSocket';
+
+  @override
+  String get enterLiveSttWebsocket => 'Nhập điểm cuối WebSocket STT trực tiếp của bạn';
+
+  @override
+  String get apiKey => 'API Key';
+
+  @override
+  String get enterApiKey => 'Nhập API key của bạn';
+
+  @override
+  String get storedLocallyNeverShared => 'Lưu trữ cục bộ, không bao giờ chia sẻ';
+
+  @override
+  String get host => 'Host';
+
+  @override
+  String get port => 'Port';
+
+  @override
+  String get advanced => 'Nâng cao';
+
+  @override
+  String get configuration => 'Cấu hình';
+
+  @override
+  String get requestConfiguration => 'Cấu hình yêu cầu';
+
+  @override
+  String get responseSchema => 'Schema phản hồi';
+
+  @override
+  String get modified => 'Đã sửa đổi';
+
+  @override
+  String get resetRequestConfig => 'Đặt lại cấu hình yêu cầu về mặc định';
+
+  @override
+  String get logs => 'Nhật ký';
+
+  @override
+  String get logsCopied => 'Đã sao chép nhật ký';
+
+  @override
+  String get noLogsYet => 'Chưa có nhật ký. Bắt đầu ghi âm để xem hoạt động STT tùy chỉnh.';
+
+  @override
+  String deviceUsesCodec(String deviceName, String codecReason) {
+    return '$deviceName sử dụng $codecReason. Omi sẽ được sử dụng.';
+  }
+
+  @override
+  String get omiTranscription => 'Phiên âm Omi';
+
+  @override
+  String get bestInClassTranscription => 'Phiên âm tốt nhất với cài đặt bằng không';
+
+  @override
+  String get instantSpeakerLabels => 'Nhãn người nói tức thì';
+
+  @override
+  String get languageTranslation => 'Dịch hơn 100 ngôn ngữ';
+
+  @override
+  String get optimizedForConversation => 'Được tối ưu hóa cho cuộc trò chuyện';
+
+  @override
+  String get autoLanguageDetection => 'Tự động phát hiện ngôn ngữ';
+
+  @override
+  String get highAccuracy => 'Độ chính xác cao';
+
+  @override
+  String get privacyFirst => 'Ưu tiên bảo mật';
+
+  @override
+  String get saveChanges => 'Lưu thay đổi';
+
+  @override
+  String get resetToDefault => 'Đặt lại về mặc định';
+
+  @override
+  String get viewTemplate => 'Xem mẫu';
+
+  @override
+  String get trySomethingLike => 'Thử một cái gì đó như...';
+
+  @override
+  String get tryIt => 'Thử ngay';
+
+  @override
+  String get creatingPlan => 'Đang tạo kế hoạch';
+
+  @override
+  String get developingLogic => 'Đang phát triển logic';
+
+  @override
+  String get designingApp => 'Đang thiết kế ứng dụng';
+
+  @override
+  String get generatingIconStep => 'Đang tạo biểu tượng';
+
+  @override
+  String get finalTouches => 'Hoàn thiện cuối cùng';
+
+  @override
+  String get processing => 'Đang xử lý...';
+
+  @override
+  String get features => 'Tính năng';
+
+  @override
+  String get creatingYourApp => 'Đang tạo ứng dụng của bạn...';
+
+  @override
+  String get generatingIcon => 'Đang tạo biểu tượng...';
+
+  @override
+  String get whatShouldWeMake => 'Chúng ta nên tạo gì?';
+
+  @override
+  String get appName => 'Tên ứng dụng';
+
+  @override
+  String get description => 'Mô tả';
+
+  @override
+  String get publicLabel => 'Công khai';
+
+  @override
+  String get privateLabel => 'Riêng tư';
+
+  @override
+  String get free => 'Miễn phí';
+
+  @override
+  String get perMonth => '/ Tháng';
+
+  @override
+  String get tailoredConversationSummaries => 'Tóm tắt cuộc trò chuyện được tùy chỉnh';
+
+  @override
+  String get customChatbotPersonality => 'Tính cách chatbot tùy chỉnh';
+
+  @override
+  String get makePublic => 'Công khai';
+
+  @override
+  String get anyoneCanDiscover => 'Bất kỳ ai cũng có thể khám phá ứng dụng của bạn';
+
+  @override
+  String get onlyYouCanUse => 'Chỉ bạn mới có thể sử dụng ứng dụng này';
+
+  @override
+  String get paidApp => 'Ứng dụng trả phí';
+
+  @override
+  String get usersPayToUse => 'Người dùng trả tiền để sử dụng ứng dụng của bạn';
+
+  @override
+  String get freeForEveryone => 'Miễn phí cho tất cả mọi người';
+
+  @override
+  String get perMonthLabel => '/ tháng';
+
+  @override
+  String get creating => 'Đang tạo...';
+
+  @override
+  String get createApp => 'Tạo ứng dụng';
+
+  @override
+  String get searchingForDevices => 'Đang tìm kiếm thiết bị...';
+
+  @override
+  String devicesFoundNearby(int count) {
+    String _temp0 = intl.Intl.pluralLogic(
+      count,
+      locale: localeName,
+      other: 'THIẾT BỊ',
+      one: 'THIẾT BỊ',
+    );
+    return 'ĐÃ TÌM THẤY $count $_temp0 GẦN ĐÂY';
+  }
+
+  @override
+  String get pairingSuccessful => 'GHÉP NỐI THÀNH CÔNG';
+
+  @override
+  String errorConnectingAppleWatch(String error) {
+    return 'Lỗi khi kết nối với Apple Watch: $error';
+  }
+
+  @override
+  String get dontShowAgain => 'Không hiển thị lại';
+
+  @override
+  String get iUnderstand => 'Tôi hiểu';
+
+  @override
+  String get enableBluetooth => 'Bật Bluetooth';
+
+  @override
+  String get bluetoothNeeded =>
+      'Omi cần Bluetooth để kết nối với thiết bị đeo của bạn. Vui lòng bật Bluetooth và thử lại.';
+
+  @override
+  String get contactSupport => 'Liên hệ hỗ trợ?';
+
+  @override
+  String get connectLater => 'Kết nối sau';
+
+  @override
+  String get grantPermissions => 'Cấp quyền';
+
+  @override
+  String get backgroundActivity => 'Hoạt động nền';
+
+  @override
+  String get backgroundActivityDesc => 'Cho phép Omi chạy trong nền để ổn định hơn';
+
+  @override
+  String get locationAccess => 'Truy cập vị trí';
+
+  @override
+  String get locationAccessDesc => 'Bật vị trí nền để có trải nghiệm đầy đủ';
+
+  @override
+  String get notifications => 'Thông báo';
+
+  @override
+  String get notificationsDesc => 'Bật thông báo để luôn được thông tin';
+
+  @override
+  String get locationServiceDisabled => 'Dịch vụ vị trí đã bị tắt';
+
+  @override
+  String get locationServiceDisabledDesc =>
+      'Dịch vụ vị trí đã bị tắt. Vui lòng vào Cài đặt > Quyền riêng tư & Bảo mật > Dịch vụ vị trí và bật nó';
+
+  @override
+  String get backgroundLocationDenied => 'Quyền truy cập vị trí nền bị từ chối';
+
+  @override
+  String get backgroundLocationDeniedDesc =>
+      'Vui lòng vào cài đặt thiết bị và đặt quyền vị trí thành \"Luôn cho phép\"';
+
+  @override
+  String get lovingOmi => 'Bạn thích Omi?';
+
+  @override
+  String get leaveReviewIos =>
+      'Giúp chúng tôi tiếp cận nhiều người hơn bằng cách để lại đánh giá trên App Store. Phản hồi của bạn có ý nghĩa rất lớn với chúng tôi!';
+
+  @override
+  String get leaveReviewAndroid =>
+      'Giúp chúng tôi tiếp cận nhiều người hơn bằng cách để lại đánh giá trên Google Play Store. Phản hồi của bạn có ý nghĩa rất lớn với chúng tôi!';
+
+  @override
+  String get rateOnAppStore => 'Đánh giá trên App Store';
+
+  @override
+  String get rateOnGooglePlay => 'Đánh giá trên Google Play';
+
+  @override
+  String get maybeLater => 'Có thể sau';
+
+  @override
+  String get speechProfileIntro => 'Omi cần học hỏi mục tiêu và giọng nói của bạn. Bạn có thể sửa đổi nó sau.';
+
+  @override
+  String get getStarted => 'Bắt đầu';
+
+  @override
+  String get allDone => 'Hoàn tất!';
+
+  @override
+  String get keepGoing => 'Tiếp tục, bạn đang làm rất tốt';
+
+  @override
+  String get skipThisQuestion => 'Bỏ qua câu hỏi này';
+
+  @override
+  String get skipForNow => 'Bỏ qua bây giờ';
+
+  @override
+  String get connectionError => 'Lỗi kết nối';
+
+  @override
+  String get connectionErrorDesc => 'Không thể kết nối với máy chủ. Vui lòng kiểm tra kết nối internet và thử lại.';
+
+  @override
+  String get invalidRecordingMultipleSpeakers => 'Phát hiện bản ghi âm không hợp lệ';
+
+  @override
+  String get multipleSpeakersDesc =>
+      'Có vẻ như có nhiều người nói trong bản ghi âm. Vui lòng đảm bảo bạn ở nơi yên tĩnh và thử lại.';
+
+  @override
+  String get tooShortDesc => 'Không phát hiện đủ giọng nói. Vui lòng nói nhiều hơn và thử lại.';
+
+  @override
+  String get invalidRecordingDesc => 'Vui lòng đảm bảo bạn nói ít nhất 5 giây và không quá 90 giây.';
+
+  @override
+  String get areYouThere => 'Bạn có ở đó không?';
+
+  @override
+  String get noSpeechDesc =>
+      'Chúng tôi không thể phát hiện giọng nói nào. Vui lòng đảm bảo nói ít nhất 10 giây và không quá 3 phút.';
+
+  @override
+  String get connectionLost => 'Mất kết nối';
+
+  @override
+  String get connectionLostDesc => 'Kết nối đã bị gián đoạn. Vui lòng kiểm tra kết nối internet và thử lại.';
+
+  @override
+  String get tryAgain => 'Thử lại';
+
+  @override
+  String get connectOmiOmiGlass => 'Kết nối Omi / OmiGlass';
+
+  @override
+  String get continueWithoutDevice => 'Tiếp tục không có thiết bị';
+
+  @override
+  String get permissionsRequired => 'Yêu cầu quyền';
+
+  @override
+  String get permissionsRequiredDesc =>
+      'Ứng dụng này cần quyền Bluetooth và Vị trí để hoạt động đúng cách. Vui lòng bật chúng trong cài đặt.';
+
+  @override
+  String get openSettings => 'Mở cài đặt';
+
+  @override
+  String get wantDifferentName => 'Muốn được gọi bằng tên khác?';
+
+  @override
+  String get whatsYourName => 'Bạn tên gì?';
+
+  @override
+  String get speakTranscribeSummarize => 'Nói. Phiên âm. Tóm tắt.';
+
+  @override
+  String get signInWithApple => 'Đăng nhập bằng Apple';
+
+  @override
+  String get signInWithGoogle => 'Đăng nhập bằng Google';
+
+  @override
+  String get byContinuingAgree => 'Bằng cách tiếp tục, bạn đồng ý với ';
+
+  @override
+  String get termsOfUse => 'Điều khoản sử dụng';
+
+  @override
+  String get omiYourAiCompanion => 'Omi – Trợ lý AI của bạn';
+
+  @override
+  String get captureEveryMoment => 'Ghi lại mọi khoảnh khắc. Nhận tóm tắt\nbằng AI. Không bao giờ phải ghi chú lại.';
+
+  @override
+  String get appleWatchSetup => 'Thiết lập Apple Watch';
+
+  @override
+  String get permissionRequestedExclaim => 'Đã yêu cầu quyền!';
+
+  @override
+  String get microphonePermission => 'Quyền microphone';
+
+  @override
+  String get permissionGrantedNow =>
+      'Đã cấp quyền! Bây giờ:\n\nMở ứng dụng Omi trên đồng hồ của bạn và nhấn \"Tiếp tục\" bên dưới';
+
+  @override
+  String get needMicrophonePermission =>
+      'Chúng tôi cần quyền microphone.\n\n1. Nhấn \"Cấp quyền\"\n2. Cho phép trên iPhone của bạn\n3. Ứng dụng đồng hồ sẽ đóng\n4. Mở lại và nhấn \"Tiếp tục\"';
+
+  @override
+  String get grantPermissionButton => 'Cấp quyền';
+
+  @override
+  String get needHelp => 'Cần trợ giúp?';
+
+  @override
+  String get troubleshootingSteps =>
+      'Khắc phục sự cố:\n\n1. Đảm bảo Omi được cài đặt trên đồng hồ của bạn\n2. Mở ứng dụng Omi trên đồng hồ của bạn\n3. Tìm cửa sổ bật lên yêu cầu quyền\n4. Nhấn \"Cho phép\" khi được nhắc\n5. Ứng dụng trên đồng hồ của bạn sẽ đóng - mở lại\n6. Quay lại và nhấn \"Tiếp tục\" trên iPhone của bạn';
+
+  @override
+  String get recordingStartedSuccessfully => 'Đã bắt đầu ghi âm thành công!';
+
+  @override
+  String get permissionNotGrantedYet =>
+      'Quyền chưa được cấp. Vui lòng đảm bảo bạn đã cho phép quyền microphone và mở lại ứng dụng trên đồng hồ của bạn.';
+
+  @override
+  String errorRequestingPermission(String error) {
+    return 'Lỗi khi yêu cầu quyền: $error';
+  }
+
+  @override
+  String errorStartingRecording(String error) {
+    return 'Lỗi khi bắt đầu ghi âm: $error';
+  }
+
+  @override
+  String get selectPrimaryLanguage => 'Chọn ngôn ngữ chính của bạn';
+
+  @override
+  String get languageBenefits => 'Đặt ngôn ngữ của bạn để có phiên âm chính xác hơn và trải nghiệm được cá nhân hóa';
+
+  @override
+  String get whatsYourPrimaryLanguage => 'Ngôn ngữ chính của bạn là gì?';
+
+  @override
+  String get selectYourLanguage => 'Chọn ngôn ngữ của bạn';
+
+  @override
+  String get personalGrowthJourney => 'Hành trình phát triển cá nhân của bạn với AI lắng nghe mọi lời nói của bạn.';
+
+  @override
+  String get actionItemsTitle => 'Việc cần làm';
+
+  @override
+  String get actionItemsDescription => 'Nhấn để sửa • Nhấn giữ để chọn • Vuốt để thực hiện hành động';
+
+  @override
+  String get tabToDo => 'Cần làm';
+
+  @override
+  String get tabDone => 'Đã xong';
+
+  @override
+  String get tabOld => 'Cũ';
+
+  @override
+  String get emptyTodoMessage => '🎉 Đã hoàn tất tất cả!\nKhông còn việc cần làm';
+
+  @override
+  String get emptyDoneMessage => 'Chưa có mục nào hoàn thành';
+
+  @override
+  String get emptyOldMessage => '✅ Không có nhiệm vụ cũ';
+
+  @override
+  String get noItems => 'Không có mục nào';
+
+  @override
+  String get actionItemMarkedIncomplete => 'Đã đánh dấu việc cần làm là chưa hoàn thành';
+
+  @override
+  String get actionItemCompleted => 'Đã hoàn thành việc cần làm';
+
+  @override
+  String get deleteActionItemTitle => 'Xóa việc cần làm';
+
+  @override
+  String get deleteActionItemMessage => 'Bạn có chắc chắn muốn xóa việc cần làm này?';
+
+  @override
+  String get deleteSelectedItemsTitle => 'Xóa các mục đã chọn';
+
+  @override
+  String deleteSelectedItemsMessage(int count, String s) {
+    return 'Bạn có chắc chắn muốn xóa $count việc cần làm$s đã chọn?';
+  }
+
+  @override
+  String actionItemDeletedResult(String description) {
+    return 'Đã xóa việc cần làm \"$description\"';
+  }
+
+  @override
+  String itemsDeletedResult(int count, String s) {
+    return 'Đã xóa $count việc cần làm$s';
+  }
+
+  @override
+  String get failedToDeleteItem => 'Không thể xóa việc cần làm';
+
+  @override
+  String get failedToDeleteItems => 'Không thể xóa các mục';
+
+  @override
+  String get failedToDeleteSomeItems => 'Không thể xóa một số mục';
+
+  @override
+  String get welcomeActionItemsTitle => 'Sẵn sàng cho việc cần làm';
+
+  @override
+  String get welcomeActionItemsDescription =>
+      'AI của bạn sẽ tự động trích xuất nhiệm vụ và việc cần làm từ cuộc trò chuyện của bạn. Chúng sẽ xuất hiện ở đây khi được tạo.';
+
+  @override
+  String get autoExtractionFeature => 'Tự động trích xuất từ cuộc trò chuyện';
+
+  @override
+  String get editSwipeFeature => 'Nhấn để sửa, vuốt để hoàn thành hoặc xóa';
+
+  @override
+  String itemsSelected(int count) {
+    return 'Đã chọn $count';
+  }
+
+  @override
+  String get selectAll => 'Chọn tất cả';
+
+  @override
+  String get deleteSelected => 'Xóa đã chọn';
+
+  @override
+  String searchMemories(int count) {
+    return 'Tìm kiếm $count ký ức';
+  }
+
+  @override
+  String get memoryDeleted => 'Đã xóa ký ức.';
+
+  @override
+  String get undo => 'Hoàn tác';
+
+  @override
+  String get noMemoriesYet => 'Chưa có ký ức';
+
+  @override
+  String get noAutoMemories => 'Chưa có ký ức tự động trích xuất';
+
+  @override
+  String get noManualMemories => 'Chưa có ký ức thủ công';
+
+  @override
+  String get noMemoriesInCategories => 'Không có ký ức trong các danh mục này';
+
+  @override
+  String get noMemoriesFound => 'Không tìm thấy ký ức';
+
+  @override
+  String get addFirstMemory => 'Thêm ký ức đầu tiên của bạn';
+
+  @override
+  String get clearMemoryTitle => 'Xóa bộ nhớ của Omi';
+
+  @override
+  String get clearMemoryMessage => 'Bạn có chắc chắn muốn xóa bộ nhớ của Omi? Hành động này không thể hoàn tác.';
+
+  @override
+  String get clearMemoryButton => 'Xóa bộ nhớ';
+
+  @override
+  String get memoryClearedSuccess => 'Đã xóa bộ nhớ của Omi về bạn';
+
+  @override
+  String get noMemoriesToDelete => 'Không có ký ức để xóa';
+
+  @override
+  String get createMemoryTooltip => 'Tạo ký ức mới';
+
+  @override
+  String get createActionItemTooltip => 'Tạo việc cần làm mới';
+
+  @override
+  String get memoryManagement => 'Quản lý ký ức';
+
+  @override
+  String get filterMemories => 'Lọc ký ức';
+
+  @override
+  String totalMemoriesCount(int count) {
+    return 'Bạn có tổng cộng $count ký ức';
+  }
+
+  @override
+  String get publicMemories => 'Ký ức công khai';
+
+  @override
+  String get privateMemories => 'Ký ức riêng tư';
+
+  @override
+  String get makeAllPrivate => 'Đặt tất cả ký ức thành riêng tư';
+
+  @override
+  String get makeAllPublic => 'Đặt tất cả ký ức thành công khai';
+
+  @override
+  String get deleteAllMemories => 'Xóa tất cả ký ức';
+
+  @override
+  String get allMemoriesPrivateResult => 'Tất cả ký ức hiện là riêng tư';
+
+  @override
+  String get allMemoriesPublicResult => 'Tất cả ký ức hiện là công khai';
+
+  @override
+  String get newMemory => 'Ký ức mới';
+
+  @override
+  String get editMemory => 'Chỉnh sửa ký ức';
+
+  @override
+  String get memoryContentHint => 'Tôi thích ăn kem...';
+
+  @override
+  String get failedToSaveMemory => 'Không thể lưu. Vui lòng kiểm tra kết nối của bạn.';
+
+  @override
+  String get saveMemory => 'Lưu ký ức';
+
+  @override
+  String get retry => 'Thử lại';
+
+  @override
+  String get createActionItem => 'Tạo việc cần làm';
+
+  @override
+  String get editActionItem => 'Chỉnh sửa việc cần làm';
+
+  @override
+  String get actionItemDescriptionHint => 'Cần làm gì?';
+
+  @override
+  String get actionItemDescriptionEmpty => 'Mô tả việc cần làm không được để trống.';
+
+  @override
+  String get actionItemUpdated => 'Đã cập nhật việc cần làm';
+
+  @override
+  String get failedToUpdateActionItem => 'Không thể cập nhật việc cần làm';
+
+  @override
+  String get actionItemCreated => 'Đã tạo việc cần làm';
+
+  @override
+  String get failedToCreateActionItem => 'Không thể tạo việc cần làm';
+
+  @override
+  String get dueDate => 'Ngày đến hạn';
+
+  @override
+  String get time => 'Thời gian';
+
+  @override
+  String get addDueDate => 'Thêm ngày đến hạn';
+
+  @override
+  String get pressDoneToSave => 'Nhấn xong để lưu';
+
+  @override
+  String get pressDoneToCreate => 'Nhấn xong để tạo';
+
+  @override
+  String get filterAll => 'Tất cả';
+
+  @override
+  String get filterSystem => 'Về bạn';
+
+  @override
+  String get filterInteresting => 'Thông tin chi tiết';
+
+  @override
+  String get filterManual => 'Thủ công';
+
+  @override
+  String get completed => 'Đã hoàn thành';
+
+  @override
+  String get markComplete => 'Đánh dấu hoàn thành';
+
+  @override
+  String get actionItemDeleted => 'Đã xóa việc cần làm';
+
+  @override
+  String get failedToDeleteActionItem => 'Không thể xóa việc cần làm';
+
+  @override
+  String get deleteActionItemConfirmTitle => 'Xóa việc cần làm';
+
+  @override
+  String get deleteActionItemConfirmMessage => 'Bạn có chắc chắn muốn xóa việc cần làm này?';
+
+  @override
+  String get appLanguage => 'Ngôn ngữ ứng dụng';
+
+  @override
+  String get appInterfaceSectionTitle => 'GIAO DIỆN ỨNG DỤNG';
+
+  @override
+  String get speechTranscriptionSectionTitle => 'GIỌNG NÓI & PHIÊN ÂM';
+
+  @override
+  String get languageSettingsHelperText =>
+      'Ngôn ngữ Ứng dụng thay đổi menu và nút. Ngôn ngữ Giọng nói ảnh hưởng đến cách bản ghi âm của bạn được phiên âm.';
+}

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -232,7 +232,7 @@ class AppLocalizationsZh extends AppLocalizations {
   String get searchConversations => '搜索对话';
 
   @override
-  String selectedCount(int count) {
+  String selectedCount(int count, Object s) {
     return '已选择 $count 项';
   }
 
@@ -2146,10 +2146,10 @@ class AppLocalizationsZh extends AppLocalizations {
   String get filterAll => '全部';
 
   @override
-  String get filterSystem => 'About You';
+  String get filterSystem => '关于你';
 
   @override
-  String get filterInteresting => 'Insights';
+  String get filterInteresting => '见解';
 
   @override
   String get filterManual => '手动';
@@ -2174,4 +2174,13 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get appLanguage => '应用语言';
+
+  @override
+  String get appInterfaceSectionTitle => '应用界面';
+
+  @override
+  String get speechTranscriptionSectionTitle => '语音与转录';
+
+  @override
+  String get languageSettingsHelperText => '应用语言更改菜单和按钮。语音语言影响录音的转录方式。';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -1,0 +1,2299 @@
+{
+  "@@locale": "lt",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Pokalbis",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkripcija",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Užduotys",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Ištrinti pokalbį?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Ar tikrai norite ištrinti šį pokalbį? Šio veiksmo negalima atšaukti.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Patvirtinti",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Atšaukti",
+  "@cancel": {
+    "description": "Cancel button label"
+  },
+  "ok": "Gerai",
+  "@ok": {
+    "description": "OK button label"
+  },
+  "delete": "Ištrinti",
+  "@delete": {
+    "description": "Delete button/action label"
+  },
+  "add": "Pridėti",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Atnaujinti",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Išsaugoti",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Redaguoti",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Uždaryti",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Išvalyti",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopijuoti transkripciją",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopijuoti santrauką",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Testuoti užklausą",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Perdoroti pokalbį",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Ištrinti pokalbį",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Turinys nukopijuotas į iškarpinę",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Nepavyko atnaujinti žvaigždutės būsenos.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Pokalbio nuorodos nepavyko bendrinti.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Klaida dorojant pokalbį. Bandykite dar kartą vėliau.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Patikrinkite interneto ryšį ir bandykite dar kartą.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Nepavyko ištrinti pokalbio",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Kažkas nepavyko! Bandykite dar kartą vėliau.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopijuoti klaidos pranešimą",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Klaidos pranešimas nukopijuotas į iškarpinę",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Likę",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Kraunama...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Kraunama trukmė...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sek.",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Žmonės",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Pridėti naują asmenį",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Redaguoti asmenį",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Sukurkite naują asmenį ir apmokykite Omi atpažinti jų kalbą!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Kalbos profilis",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Pavyzdys {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Nustatymai",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Kalba",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Pasirinkti kalbą",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Trinama...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Užbaikite autentifikaciją naršyklėje. Baigę grįžkite į programą.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Nepavyko pradėti autentifikacijos",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Importavimas pradėtas! Gausite pranešimą, kai bus baigta.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Nepavyko pradėti importavimo. Bandykite dar kartą.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Nepavyko pasiekti pasirinkto failo",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Klauskite Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Atlikta",
+  "@done": {
+    "description": "Done button label"
+  },
+  "disconnected": "Atjungta",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Ieškoma",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Prijungti įrenginį",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Pasiekėte mėnesio limitą.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Tikrinti naudojimą",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Sinchronizuojami įrašai",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Įrašai sinchronizavimui",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Viskas atnaujinta",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Sinchronizuoti",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Pakabukas atnaujintas",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Visi įrašai sinchronizuoti",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Vyksta sinchronizavimas",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Paruošta sinchronizuoti",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Paspauskite Sinchronizuoti, kad pradėtumėte",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Pakabukas neprijungtas. Prijunkite, kad sinchronizuotumėte.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Viskas jau sinchronizuota.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Turite nesinchronizuotų įrašų.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Tęsime įrašų sinchronizavimą fone.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Kol kas nėra pokalbių.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Kol kas nėra pažymėtų pokalbių.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Norėdami pažymėti pokalbį, atidarykite jį ir paspauskite žvaigždutės piktogramą antraštėje.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Ieškoti pokalbių",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "Pasirinkta: {count}",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Sujungti",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Sujungti pokalbius",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Bus sujungti {count} pokalbiai į vieną. Visas turinys bus sujungtas ir iš naujo sugeneruotas.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Sujungiama fone. Tai gali užtrukti.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Nepavyko pradėti sujungimo",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Klauskite bet ko",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Kol kas nėra žinučių!\nKodėl gi nepradėtumėte pokalbio?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Ištrinamos jūsų žinutės iš Omi atminties...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Žinutė nukopijuota į iškarpinę.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Negalite pranešti apie savo žinutes.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Pranešti apie žinutę",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Ar tikrai norite pranešti apie šią žinutę?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Apie žinutę pranešta sėkmingai.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Ačiū už jūsų atsiliepimą!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Išvalyti pokalbį?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Ar tikrai norite išvalyti pokalbį? Šio veiksmo negalima atšaukti.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Galite įkelti tik 4 failus vienu metu",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Pokalbis su Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Programėlės",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Programėlių nerasta",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Pabandykite pakeisti paiešką arba filtrus",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Sukurkite savo programėlę",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Sukurkite ir bendrinkite savo programėlę",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Ieškoti 1500+ programėlių",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Mano programėlės",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Įdiegtos programėlės",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Nepavyko gauti programėlių :(\n\nPatikrinkite interneto ryšį ir bandykite dar kartą.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Apie Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Privatumo politika",
+  "@privacyPolicy": {
+    "description": "Privacy policy link"
+  },
+  "visitWebsite": "Aplankyti svetainę",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Pagalba ar klausimai?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Prisijunkite prie bendruomenės!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ narių ir vis daugėja.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Ištrinti paskyrą",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Ar tikrai norite ištrinti savo paskyrą?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Šio veiksmo negalima atšaukti.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Visi jūsų prisiminimai ir pokalbiai bus negrįžtamai ištrinti.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Jūsų programėlės ir integracijos bus nedelsiant atjungtos.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Prieš ištrindami paskyrą galite eksportuoti duomenis, tačiau ištrynus jų atkurti neįmanoma.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Suprantu, kad mano paskyros ištrynimas yra galutinis ir visi duomenys, įskaitant prisiminimus ir pokalbius, bus prarasti ir jų atkurti nebus įmanoma.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Ar tikrai?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Šis veiksmas yra negrįžtamas ir galutinai ištrins jūsų paskyrą ir visus susijusius duomenis. Ar tikrai norite tęsti?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Ištrinti dabar",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Grįžti atgal",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Pažymėkite langelį, kad patvirtintumėte, jog suprantate, kad paskyros ištrynimas yra galutinis ir negrįžtamas.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profilis",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Vardas",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "El. paštas",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Pasirinktinis žodynas",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Kitų atpažinimas",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Mokėjimo būdai",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Pokalbių rodymas",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Duomenys ir privatumas",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Naudotojo ID",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Nenustatyta",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Naudotojo ID nukopijuotas į iškarpinę",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Sistemos numatytasis",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Planas ir naudojimas",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Autonominė sinchronizacija",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Įrenginio nustatymai",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Pokalbių įrankiai",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Atsiliepimai / Klaida",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Pagalbos centras",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Kūrėjo nustatymai",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Gauti Omi Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Rekomendacijų programa",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Atsijungti",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Programėlės ir įrenginio informacija nukopijuota",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Jūsų privatumas, jūsų kontrolė",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Omi įsipareigoja saugoti jūsų privatumą. Šis puslapis leidžia kontroliuoti, kaip jūsų duomenys saugomi ir naudojami.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Sužinoti daugiau...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Duomenų apsaugos lygis",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Jūsų duomenys pagal numatytuosius nustatymus apsaugoti stipriu šifravimu. Peržiūrėkite savo nustatymus ir būsimas privatumo parinktis žemiau.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Programėlių prieiga",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Šios programėlės gali pasiekti jūsų duomenis. Paspauskite programėlę, kad valdytumėte jos leidimus.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Jokios įdiegtos programėlės neturi išorinės prieigos prie jūsų duomenų.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Įrenginio pavadinimas",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Įrenginio ID",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Programinė įranga",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD kortelės sinchronizacija",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Aparatinės įrangos versija",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Modelio numeris",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Gamintojas",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dvigubas bakstelėjimas",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED ryškumas",
+  "@ledBrightness": {
+    "description": "LED brightness label"
+  },
+  "micGain": "Mikrofono stiprinimas",
+  "@micGain": {
+    "description": "Microphone gain label"
+  },
+  "disconnect": "Atjungti",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Pamiršti įrenginį",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Krovimo problemos",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Atjungti įrenginį",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Atjungti įrenginį",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Atjungti ir pamiršti įrenginį",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Jūsų Omi buvo atjungtas 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Įrenginys atjungtas. Eikite į Nustatymus > „Bluetooth\" ir pamiršti įrenginį, kad užbaigtumėte atjungimą.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Atjungti įrenginį",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Taip atjungsite įrenginį, kad jį būtų galima prijungti prie kito telefono. Norėdami užbaigti procesą, turėsite eiti į Nustatymus > „Bluetooth\" ir pamiršti įrenginį.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Įrenginys neprijungtas",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Prijunkite Omi įrenginį, kad pasiektumėte\nįrenginio nustatymus ir pritaikymą",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Įrenginio informacija",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Pritaikymas",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Aparatinė įranga",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 neaptiktas",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Matome, kad turite V1 įrenginį arba jūsų įrenginys neprijungtas. SD kortelės funkcija prieinama tik V2 įrenginiams.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Baigti pokalbį",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pristabdyti / tęsti",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Pažymėti pokalbį",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Dvigubo bakstelėjimo veiksmas",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Baigti ir apdoroti pokalbį",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pristabdyti / tęsti įrašymą",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Pažymėti vykstantį pokalbį",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Išjungta",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maksimalus",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Nutildyti",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Tylus",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normalus",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Aukštas",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofonas nutildytas",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Labai tylus – triukšmingai aplinkai",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Tylus – vidutiniam triukšmui",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutralus – subalansuotas įrašymas",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Šiek tiek sustiprintas – įprastam naudojimui",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Sustiprintas – tyliai aplinkai",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Aukštas – tolimam ar tyliam balsui",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Labai aukštas – labai tyliems šaltiniams",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimalus – naudokite atsargiai",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Kūrėjo nustatymai",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Išsaugoma...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Konfigūruokite savo DI asmens charakteristikų",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkripcija",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Konfigūruoti STT teikėją",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Pokalbio skirtasis laikas",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Nustatykite, kada automatiškai baigiami pokalbiai",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importuoti duomenis",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importuoti duomenis iš kitų šaltinių",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Derinimas ir diagnostika",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Galinio taško URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Kol kas nėra API raktų",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Sukurkite raktą, kad pradėtumėte",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Sukurti raktą",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentai",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Jūsų Omi įžvalgos",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Šiandien",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Šį mėnesį",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Šiais metais",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Visą laiką",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Kol kas nėra veiklos",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Pradėkite pokalbį su Omi,\nkad čia matytumėte naudojimo įžvalgas.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Klausymasis",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Bendras laikas, kurį Omi aktyviai klausėsi.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Supratimas",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Žodžiai, suprasti iš jūsų pokalbių.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Teikimas",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Automatiškai užfiksuotos užduotys ir pastabos.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Prisiminimas",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Faktai ir detalės, prisiminti jums.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Neribojamas planas",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Valdyti planą",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Jūsų planas bus atšauktas {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Jūsų planas bus atnaujintas {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Nemokamas planas",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "Panaudota {used} iš {limit} min.",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Atnaujinti",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Atnaujinti į neribotą",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Jūsų planas apima {limit} nemokamų minučių per mėnesį. Atnaujinkite, kad gautumėte neribotą.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Dalinu savo Omi statistika! (omi.me – jūsų visada veikiantis DI asistentas)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Šiandien omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Šį mėnesį omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Šiais metais omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Iki šiol omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Klausėsi {minutes} minučių",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Suprato {words} žodžių",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Suteikė {count} įžvalgų",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Prisiminė {count} prisiminimų",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Derinimo žurnalai",
+  "debugLogsAutoDelete": "Automatiškai ištrinami po 3 dienų.",
+  "debugLogsDesc": "Padeda diagnozuoti problemas",
+  "noLogFilesFound": "Žurnalų failų nerasta.",
+  "omiDebugLog": "Omi derinimo žurnalas",
+  "logShared": "Žurnalas bendrintas",
+  "selectLogFile": "Pasirinkti žurnalo failą",
+  "shareLogs": "Bendrinti žurnalus",
+  "debugLogCleared": "Derinimo žurnalas išvalytas",
+  "exportStarted": "Eksportavimas pradėtas. Tai gali užtrukti keletą sekundžių...",
+  "exportAllData": "Eksportuoti visus duomenis",
+  "exportDataDesc": "Eksportuoti pokalbius į JSON failą",
+  "exportedConversations": "Eksportuoti pokalbiai iš Omi",
+  "exportShared": "Eksportas bendrintas",
+  "deleteKnowledgeGraphTitle": "Ištrinti žinių grafiką?",
+  "deleteKnowledgeGraphMessage": "Taip bus ištrinti visi išvesti žinių grafiko duomenys (mazgai ir ryšiai). Jūsų originalūs prisiminimai liks saugūs. Grafikas bus atstatytas laikui bėgant arba pagal kitą užklausą.",
+  "knowledgeGraphDeleted": "Žinių grafikas sėkmingai ištrintas",
+  "deleteGraphFailed": "Nepavyko ištrinti grafiko: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Ištrinti žinių grafiką",
+  "deleteKnowledgeGraphDesc": "Išvalyti visus mazgus ir ryšius",
+  "mcp": "MCP",
+  "mcpServer": "MCP serveris",
+  "mcpServerDesc": "Prijunkite DI asistentus prie savo duomenų",
+  "serverUrl": "Serverio URL",
+  "urlCopied": "URL nukopijuotas",
+  "apiKeyAuth": "API rakto autentifikacija",
+  "header": "Antraštė",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Kliento ID",
+  "clientSecret": "Kliento paslaptis",
+  "useMcpApiKey": "Naudokite savo MCP API raktą",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Pokalbių įvykiai",
+  "newConversationCreated": "Sukurtas naujas pokalbis",
+  "realtimeTranscript": "Realaus laiko transkripcija",
+  "transcriptReceived": "Transkripcija gauta",
+  "audioBytes": "Garso baitai",
+  "audioDataReceived": "Garso duomenys gauti",
+  "intervalSeconds": "Intervalas (sekundės)",
+  "daySummary": "Dienos santrauka",
+  "summaryGenerated": "Santrauka sugeneruota",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Pridėti į claude_desktop_config.json",
+  "copyConfig": "Kopijuoti konfigūraciją",
+  "configCopied": "Konfigūracija nukopijuota į iškarpinę",
+  "listeningMins": "Klausymasis (min.)",
+  "understandingWords": "Supratimas (žodžiai)",
+  "insights": "Įžvalgos",
+  "memories": "Prisiminimai",
+  "minsUsedThisMonth": "Šį mėnesį panaudota {used} iš {limit} min.",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "Šį mėnesį panaudota {used} iš {limit} žodžių",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "Šį mėnesį gauta {used} iš {limit} įžvalgų",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "Šį mėnesį sukurta {used} iš {limit} prisiminimų",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Matomumas",
+  "visibilitySubtitle": "Kontroliuokite, kurie pokalbiai rodomi jūsų sąraše",
+  "showShortConversations": "Rodyti trumpus pokalbius",
+  "showShortConversationsDesc": "Rodyti pokalbius, trumpesnius už ribą",
+  "showDiscardedConversations": "Rodyti atmestus pokalbius",
+  "showDiscardedConversationsDesc": "Įtraukti pokalbius, pažymėtus kaip atmesti",
+  "shortConversationThreshold": "Trumpo pokalbio riba",
+  "shortConversationThresholdSubtitle": "Pokalbiai, trumpesni už šią ribą, bus paslėpti, nebent įjungta aukščiau",
+  "durationThreshold": "Trukmės riba",
+  "durationThresholdDesc": "Slėpti pokalbius, trumpesnius už šią ribą",
+  "minLabel": "{count} min.",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Pasirinktinis žodynas",
+  "addWords": "Pridėti žodžių",
+  "addWordsDesc": "Vardai, terminai ar neįprasti žodžiai",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Prisijungti",
+  "comingSoon": "Greitai",
+  "chatToolsFooter": "Prijunkite savo programėles, kad matytumėte duomenis ir metrikas pokalbyje.",
+  "completeAuthInBrowser": "Užbaikite autentifikaciją naršyklėje. Baigę grįžkite į programą.",
+  "failedToStartAuth": "Nepavyko pradėti {appName} autentifikacijos",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Atjungti {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Ar tikrai norite atsijungti nuo {appName}? Galite bet kada vėl prisijungti.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Atjungta nuo {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Nepavyko atjungti",
+  "connectTo": "Prisijungti prie {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Jums reikės autorizuoti Omi prieigą prie jūsų {appName} duomenų. Bus atidaryta naršyklė autentifikacijai.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Tęsti",
+  "languageTitle": "Kalba",
+  "primaryLanguage": "Pagrindinė kalba",
+  "automaticTranslation": "Automatinis vertimas",
+  "detectLanguages": "Aptikti 10+ kalbų",
+  "authorizeSavingRecordings": "Leisti išsaugoti įrašus",
+  "thanksForAuthorizing": "Ačiū, kad leidote!",
+  "needYourPermission": "Mums reikia jūsų leidimo",
+  "alreadyGavePermission": "Jau davėte mums leidimą išsaugoti jūsų įrašus. Primename, kodėl mums to reikia:",
+  "wouldLikePermission": "Norėtume jūsų leidimo išsaugoti jūsų balso įrašus. Štai kodėl:",
+  "improveSpeechProfile": "Pagerinti jūsų kalbos profilį",
+  "improveSpeechProfileDesc": "Naudojame įrašus tolesniam jūsų asmeninio kalbos profilio mokymui ir tobulinimui.",
+  "trainFamilyProfiles": "Mokyti draugų ir šeimos profilius",
+  "trainFamilyProfilesDesc": "Jūsų įrašai padeda atpažinti ir kurti profilius jūsų draugams ir šeimai.",
+  "enhanceTranscriptAccuracy": "Pagerinti transkripcijos tikslumą",
+  "enhanceTranscriptAccuracyDesc": "Mūsų modeliui tobulėjant, galime pateikti geresnius transkripcijos rezultatus jūsų įrašams.",
+  "legalNotice": "Teisinis pranešimas: balso duomenų įrašymo ir saugojimo teisėtumas gali skirtis priklausomai nuo jūsų buvimo vietos ir kaip naudojate šią funkciją. Tai jūsų atsakomybė užtikrinti atitiktį vietiniams įstatymams ir taisyklėms.",
+  "alreadyAuthorized": "Jau autorizuota",
+  "authorize": "Leisti",
+  "revokeAuthorization": "Atšaukti leidimą",
+  "authorizationSuccessful": "Leidimas sėkmingas!",
+  "failedToAuthorize": "Nepavyko autorizuoti. Bandykite dar kartą.",
+  "authorizationRevoked": "Leidimas atšauktas.",
+  "recordingsDeleted": "Įrašai ištrinti.",
+  "failedToRevoke": "Nepavyko atšaukti leidimo. Bandykite dar kartą.",
+  "permissionRevokedTitle": "Leidimas atšauktas",
+  "permissionRevokedMessage": "Ar norite, kad ištrintume visus jūsų esamus įrašus?",
+  "yes": "Taip",
+  "editName": "Redaguoti vardą",
+  "howShouldOmiCallYou": "Kaip Omi turėtų jus vadinti?",
+  "enterYourName": "Įveskite savo vardą",
+  "nameCannotBeEmpty": "Vardas negali būti tuščias",
+  "nameUpdatedSuccessfully": "Vardas sėkmingai atnaujintas!",
+  "calendarSettings": "Kalendoriaus nustatymai",
+  "calendarProviders": "Kalendoriaus teikėjai",
+  "macOsCalendar": "macOS kalendorius",
+  "connectMacOsCalendar": "Prijunkite savo vietinį macOS kalendorių",
+  "googleCalendar": "Google kalendorius",
+  "syncGoogleAccount": "Sinchronizuoti su savo Google paskyra",
+  "showMeetingsMenuBar": "Rodyti būsimus susitikimus meniu juostoje",
+  "showMeetingsMenuBarDesc": "Rodyti kitą susitikimą ir laiką iki jo pradžios macOS meniu juostoje",
+  "showEventsNoParticipants": "Rodyti renginius be dalyvių",
+  "showEventsNoParticipantsDesc": "Kai įjungta, „Coming Up\" rodo renginius be dalyvių ar vaizdo nuorodos.",
+  "yourMeetings": "Jūsų susitikimai",
+  "refresh": "Atnaujinti",
+  "noUpcomingMeetings": "Nerasta būsimų susitikimų",
+  "checkingNextDays": "Tikrinama ateinančių 30 dienų",
+  "tomorrow": "Rytoj",
+  "googleCalendarComingSoon": "Google kalendoriaus integracija greitai!",
+  "connectedAsUser": "Prisijungta kaip vartotojas: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Numatytoji darbo sritis",
+  "tasksCreatedInWorkspace": "Užduotys bus sukurtos šioje darbo srityje",
+  "defaultProjectOptional": "Numatytasis projektas (nebūtinas)",
+  "leaveUnselectedTasks": "Palikite nepasirinkus, kad sukurtumėte užduotis be projekto",
+  "noProjectsInWorkspace": "Šioje darbo srityje nerasta projektų",
+  "conversationTimeoutDesc": "Pasirinkite, kiek laiko laukti tylos prieš automatiškai baigiant pokalbį:",
+  "timeout2Minutes": "2 minutės",
+  "timeout2MinutesDesc": "Baigti pokalbį po 2 minučių tylos",
+  "timeout5Minutes": "5 minutės",
+  "timeout5MinutesDesc": "Baigti pokalbį po 5 minučių tylos",
+  "timeout10Minutes": "10 minučių",
+  "timeout10MinutesDesc": "Baigti pokalbį po 10 minučių tylos",
+  "timeout30Minutes": "30 minučių",
+  "timeout30MinutesDesc": "Baigti pokalbį po 30 minučių tylos",
+  "timeout4Hours": "4 valandos",
+  "timeout4HoursDesc": "Baigti pokalbį po 4 valandų tylos",
+  "conversationEndAfterHours": "Pokalbiai dabar bus baigiami po 4 valandų tylos",
+  "conversationEndAfterMinutes": "Pokalbiai dabar bus baigiami po {minutes} minutės(-ių) tylos",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Pasakykite mums savo pagrindinę kalbą",
+  "languageForTranscription": "Nustatykite savo kalbą tikslesnėms transkripcijoms ir individualizuotai patirčiai.",
+  "singleLanguageModeInfo": "Įjungtas vienos kalbos režimas. Vertimas išjungtas, kad būtų didesnis tikslumas.",
+  "searchLanguageHint": "Ieškoti kalbos pagal pavadinimą ar kodą",
+  "noLanguagesFound": "Kalbų nerasta",
+  "skip": "Praleisti",
+  "languageSetTo": "Kalba nustatyta į {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Nepavyko nustatyti kalbos",
+  "appSettings": "{appName} nustatymai",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Atjungti nuo {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Bus pašalinta jūsų {appName} autentifikacija. Jums reikės vėl prisijungti, kad ją naudotumėte.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Prisijungta prie {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Paskyra",
+  "actionItemsSyncedTo": "Jūsų užduotys bus sinchronizuotos su jūsų {appName} paskyra",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Numatytoji erdvė",
+  "selectSpaceInWorkspace": "Pasirinkite erdvę savo darbo srityje",
+  "noSpacesInWorkspace": "Šioje darbo srityje nerasta erdvių",
+  "defaultList": "Numatytasis sąrašas",
+  "tasksAddedToList": "Užduotys bus pridėtos į šį sąrašą",
+  "noListsInSpace": "Šioje erdvėje nerasta sąrašų",
+  "failedToLoadRepos": "Nepavyko įkelti saugyklų: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Numatytoji saugykla išsaugota",
+  "failedToSaveDefaultRepo": "Nepavyko išsaugoti numatytosios saugyklos",
+  "defaultRepository": "Numatytoji saugykla",
+  "selectDefaultRepoDesc": "Pasirinkite numatytąją saugyklą problemų kūrimui. Kurdami problemas galite nurodyti kitą saugyklą.",
+  "noReposFound": "Saugyklų nerasta",
+  "private": "Privati",
+  "updatedDate": "Atnaujinta {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "vakar",
+  "daysAgo": "prieš {count} d.",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "prieš 1 savaitę",
+  "weeksAgo": "prieš {count} sav.",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "prieš 1 mėnesį",
+  "monthsAgo": "prieš {count} mėn.",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Problemos bus sukurtos jūsų numatytojoje saugykloje",
+  "taskIntegrations": "Užduočių integracijos",
+  "configureSettings": "Konfigūruoti nustatymus",
+  "completeAuthBrowser": "Užbaikite autentifikaciją naršyklėje. Baigę grįžkite į programą.",
+  "failedToStartAppAuth": "Nepavyko pradėti {appName} autentifikacijos",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Prisijungti prie {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Jums reikės autorizuoti Omi kurti užduotis jūsų {appName} paskyroje. Bus atidaryta naršyklė autentifikacijai.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Tęsti",
+  "appIntegration": "{appName} integracija",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integracija su {appName} greitai! Sunkiai dirbame, kad suteiktume daugiau užduočių valdymo parinkčių.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Supratau",
+  "tasksExportedOneApp": "Užduotys gali būti eksportuojamos į vieną programėlę vienu metu.",
+  "completeYourUpgrade": "Užbaikite savo atnaujinimą",
+  "importConfiguration": "Importuoti konfigūraciją",
+  "exportConfiguration": "Eksportuoti konfigūraciją",
+  "bringYourOwn": "Naudokite savo",
+  "payYourSttProvider": "Laisvai naudokite omi. Mokate tik savo STT teikėjui tiesiogiai.",
+  "freeMinutesMonth": "1 200 nemokamų minučių per mėnesį įtraukta. Neribota su ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Reikalingas pagrindinis kompiuteris",
+  "validPortRequired": "Reikalingas tinkamas prievadas",
+  "validWebsocketUrlRequired": "Reikalingas tinkamas WebSocket URL (wss://)",
+  "apiUrlRequired": "Reikalingas API URL",
+  "apiKeyRequired": "Reikalingas API raktas",
+  "invalidJsonConfig": "Netinkama JSON konfigūracija",
+  "errorSaving": "Klaida išsaugant: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfigūracija nukopijuota į iškarpinę",
+  "pasteJsonConfig": "Įklijuokite savo JSON konfigūraciją žemiau:",
+  "addApiKeyAfterImport": "Importavę turėsite pridėti savo API raktą",
+  "paste": "Įklijuoti",
+  "import": "Importuoti",
+  "invalidProviderInConfig": "Netinkamas teikėjas konfigūracijoje",
+  "importedConfig": "Importuota {providerName} konfigūracija",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Netinkamas JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Teikėjas",
+  "live": "Tiesioginis",
+  "onDevice": "Įrenginyje",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "Įveskite savo STT HTTP galinį tašką",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "Įveskite savo tiesioginį STT WebSocket galinį tašką",
+  "apiKey": "API raktas",
+  "enterApiKey": "Įveskite savo API raktą",
+  "storedLocallyNeverShared": "Saugoma vietoje, niekada nebendrinam",
+  "host": "Pagrindinis kompiuteris",
+  "port": "Prievadas",
+  "advanced": "Išplėstiniai",
+  "configuration": "Konfigūracija",
+  "requestConfiguration": "Užklausos konfigūracija",
+  "responseSchema": "Atsakymo schema",
+  "modified": "Pakeista",
+  "resetRequestConfig": "Atkurti užklausos konfigūraciją į numatytąją",
+  "logs": "Žurnalai",
+  "logsCopied": "Žurnalai nukopijuoti",
+  "noLogsYet": "Kol kas nėra žurnalų. Pradėkite įrašinėti, kad matytumėte pasirinktinio STT veiklą.",
+  "deviceUsesCodec": "{deviceName} naudoja {codecReason}. Bus naudojamas Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi transkripcija",
+  "bestInClassTranscription": "Geriausia klasės transkripcija be jokio nustatymo",
+  "instantSpeakerLabels": "Akimirksniu kalbėtojų etiketės",
+  "languageTranslation": "100+ kalbų vertimas",
+  "optimizedForConversation": "Optimizuota pokalbiams",
+  "autoLanguageDetection": "Automatinis kalbos aptikimas",
+  "highAccuracy": "Aukštas tikslumas",
+  "privacyFirst": "Pirmiausiai privatumas",
+  "saveChanges": "Išsaugoti pakeitimus",
+  "resetToDefault": "Atkurti į numatytuosius",
+  "viewTemplate": "Peržiūrėti šabloną",
+  "trySomethingLike": "Pabandykite kažką panašaus...",
+  "tryIt": "Išbandykite",
+  "creatingPlan": "Kuriamas planas",
+  "developingLogic": "Kuriama logika",
+  "designingApp": "Projektuojama programėlė",
+  "generatingIconStep": "Generuojama piktograma",
+  "finalTouches": "Paskutiniai patobulinimai",
+  "processing": "Apdorojama...",
+  "features": "Funkcijos",
+  "creatingYourApp": "Kuriama jūsų programėlė...",
+  "generatingIcon": "Generuojama piktograma...",
+  "whatShouldWeMake": "Ką turėtume sukurti?",
+  "appName": "Programėlės pavadinimas",
+  "description": "Aprašymas",
+  "publicLabel": "Vieša",
+  "privateLabel": "Privati",
+  "free": "Nemokai",
+  "perMonth": "/ Mėnesį",
+  "tailoredConversationSummaries": "Pritaikytos pokalbių santraukos",
+  "customChatbotPersonality": "Pasirinktinė pokalbių roboto asmenybė",
+  "makePublic": "Padaryti viešą",
+  "anyoneCanDiscover": "Bet kas gali rasti jūsų programėlę",
+  "onlyYouCanUse": "Tik jūs galite naudoti šią programėlę",
+  "paidApp": "Mokama programėlė",
+  "usersPayToUse": "Vartotojai moka, kad naudotų jūsų programėlę",
+  "freeForEveryone": "Nemokamai visiems",
+  "perMonthLabel": "/ mėnesį",
+  "creating": "Kuriama...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Sukurti programėlę",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "searchingForDevices": "Ieškoma įrenginių...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "RASTA {count} {count, plural, =1{ĮRENGINYS} other{ĮRENGINIAI}} NETOLIESE",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "SUSIEJIMAS SĖKMINGAS",
+  "errorConnectingAppleWatch": "Klaida jungiantis prie Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Daugiau nerodyti",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Suprantu",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Įjungti Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi reikia Bluetooth, kad prisijungtų prie jūsų nešiojamo įrenginio. Įjunkite Bluetooth ir bandykite dar kartą.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Susisiekti su palaikymu?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Prijungti vėliau",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Suteikti leidimus",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Foninė veikla",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Leiskite Omi veikti fone geresniam stabilumui",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Vietos prieiga",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Įjunkite foninę vietos nustatymą visapusiškesnei patirčiai",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Pranešimai",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Įjunkite pranešimus, kad būtumėte informuoti",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "locationServiceDisabled": "Vietos tarnyba išjungta",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Vietos tarnyba išjungta. Eikite į Nustatymus > Privatumas ir sauga > Vietos tarnybos ir įjunkite ją",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Foninės vietos prieiga atmesta",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Eikite į įrenginio nustatymus ir nustatykite vietos leidimą į „Visada leisti\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Patinka Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Padėkite mums pasiekti daugiau žmonių palikdami atsiliepimą App Store. Jūsų atsiliepimas mums reiškia labai daug!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Padėkite mums pasiekti daugiau žmonių palikdami atsiliepimą „Google Play\" parduotuvėje. Jūsų atsiliepimas mums reiškia labai daug!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Įvertinti App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Įvertinti „Google Play\"",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Galbūt vėliau",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi turi išmokti jūsų tikslų ir jūsų balso. Vėliau galėsite jį keisti.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Pradėti",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Viskas atlikta!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Tęskite, jums puikiai sekasi",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Praleisti šį klausimą",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Kol kas praleisti",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Ryšio klaida",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Nepavyko prisijungti prie serverio. Patikrinkite interneto ryšį ir bandykite dar kartą.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Aptiktas netinkamas įrašas",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Atrodo, kad įraše yra keli kalbėtojai. Įsitikinkite, kad esate tylioje vietoje, ir bandykite dar kartą.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Neaptikta pakankamai kalbos. Kalbėkite daugiau ir bandykite dar kartą.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Įsitikinkite, kad kalbate bent 5 sekundes ir ne ilgiau nei 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Ar jūs čia?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Nepavyko aptikti jokios kalbos. Įsitikinkite, kad kalbate bent 10 sekundžių ir ne ilgiau nei 3 minutes.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Ryšys prarastas",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Ryšys buvo nutrauktas. Patikrinkite interneto ryšį ir bandykite dar kartą.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Bandyti dar kartą",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Prijungti Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Tęsti be įrenginio",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Reikalingi leidimai",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Šiai programai reikia Bluetooth ir vietos leidimų, kad tinkamai veiktų. Įjunkite juos nustatymuose.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Atidaryti nustatymus",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Norite, kad jus vadintų kitaip?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Koks jūsų vardas?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "speakTranscribeSummarize": "Kalbėti. Transkribuoti. Apibendrinti.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Prisijungti su Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Prisijungti su Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Tęsdami sutinkate su mūsų ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Naudojimo sąlygomis",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – jūsų DI palydovas",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Užfiksuokite kiekvieną akimirką. Gaukite DI pagrindu\nsukurtas santraukas. Daugiau nebedarykite užrašų.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch sąranka",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Leidimas paprašytas!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Mikrofono leidimas",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Leidimas suteiktas! Dabar:\n\nAtidarykite Omi programą savo laikrodyje ir paspauskite „Tęsti\" žemiau",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Mums reikia mikrofono leidimo.\n\n1. Paspauskite „Suteikti leidimą\"\n2. Leiskite savo iPhone\n3. Laikrodžio programėlė užsidarys\n4. Atidarykite iš naujo ir paspauskite „Tęsti\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Suteikti leidimą",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Reikia pagalbos?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Trikčių šalinimas:\n\n1. Įsitikinkite, kad Omi įdiegtas jūsų laikrodyje\n2. Atidarykite Omi programą savo laikrodyje\n3. Ieškokite leidimo iššokančio lango\n4. Paspauskite „Leisti\", kai bus paprašyta\n5. Programėlė jūsų laikrodyje užsidarys – atidarykite ją iš naujo\n6. Grįžkite ir paspauskite „Tęsti\" savo iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "recordingStartedSuccessfully": "Įrašymas pradėtas sėkmingai!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Leidimas dar nesuteiktas. Įsitikinkite, kad leidote prieigą prie mikrofono ir iš naujo atidarėte programą savo laikrodyje.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Klaida prašant leidimo: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Klaida pradedant įrašymą: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Pasirinkite savo pagrindinę kalbą",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Nustatykite savo kalbą tikslesnėms transkripcijoms ir individualizuotai patirčiai",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "whatsYourPrimaryLanguage": "Kokia jūsų pagrindinė kalba?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Pasirinkite savo kalbą",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Jūsų asmeninio augimo kelionė su DI, kuris klauso kiekvieno jūsų žodžio.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Užduotys",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Bakstelėkite, kad redaguotumėte • Ilgai spauskite, kad pasirinktumėte • Braukite veiksmams",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Atlikti",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Baigta",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Senos",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Viskas atnaujinta!\nNėra laukiančių užduočių",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Kol kas nėra baigtų elementų",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Nėra senų užduočių",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Nėra elementų",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Užduotis pažymėta kaip nebaigta",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Užduotis baigta",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Ištrinti užduotį",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Ar tikrai norite ištrinti šią užduotį?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Ištrinti pasirinktus elementus",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Ar tikrai norite ištrinti {count} pasirinktą(-s) užduotį(-is)?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Užduotis „{description}\" ištrinta",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "Ištrinta {count} užduotis(-ių)",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Nepavyko ištrinti užduoties",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Nepavyko ištrinti elementų",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Nepavyko ištrinti kai kurių elementų",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Pasiruošę užduotims",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Jūsų DI automatiškai išgaus užduotis iš jūsų pokalbių. Jos atsiras čia, kai bus sukurtos.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automatiškai išgauta iš pokalbių",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Bakstelėkite, kad redaguotumėte, braukite, kad baigtumėte ar ištrintumėte",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "Pasirinkta: {count}",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Pasirinkti viską",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Ištrinti pasirinktus",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Ieškoti {count} prisiminimų",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Prisiminimas ištrintas.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Atšaukti",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Kol kas nėra prisiminimų",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Kol kas nėra automatiškai išgautų prisiminimų",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Kol kas nėra rankinio prisiminimų",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Šiose kategorijose nėra prisiminimų",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Prisiminimų nerasta",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Pridėti pirmąjį prisiminimą",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Išvalyti Omi atmintį",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Ar tikrai norite išvalyti Omi atmintį? Šio veiksmo negalima atšaukti.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Išvalyti atmintį",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omi atmintis apie jus išvalyta",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Nėra prisiminimų trinimui",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Sukurti naują prisiminimą",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Sukurti naują užduotį",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Prisiminimų valdymas",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtruoti prisiminimus",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Turite {count} prisiminimų iš viso",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Vieši prisiminimai",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Privatūs prisiminimai",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Padaryti visus prisiminimus privačius",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Padaryti visus prisiminimus viešus",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Ištrinti visus prisiminimus",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Visi prisiminimai dabar privatūs",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Visi prisiminimai dabar vieši",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Naujas prisiminimas",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Redaguoti prisiminimą",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Mėgstu valgyti ledus...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Nepavyko išsaugoti. Patikrinkite ryšį.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Išsaugoti prisiminimą",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Bandyti dar kartą",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Sukurti užduotį",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Redaguoti užduotį",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Ką reikia padaryti?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Užduoties aprašymas negali būti tuščias.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Užduotis atnaujinta",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Nepavyko atnaujinti užduoties",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Užduotis sukurta",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Nepavyko sukurti užduoties",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Terminas",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Laikas",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Pridėti terminą",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Paspauskite atlikta, kad išsaugotumėte",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Paspauskite atlikta, kad sukurtumėte",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Viskas",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Apie jus",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Įžvalgos",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Rankinis",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Baigta",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Pažymėti kaip baigtą",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Užduotis ištrinta",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Nepavyko ištrinti užduoties",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Ištrinti užduotį",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Ar tikrai norite ištrinti šią užduotį?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Programėlės kalba",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "PROGRAMOS SĄSAJA",
+  "speechTranscriptionSectionTitle": "KALBA IR TRANSKRIBAVIMAS",
+  "languageSettingsHelperText": "Programos kalba keičia meniu ir mygtukus. Kalbos kalba įtakoja, kaip transkribuojami jūsų įrašai."
+}

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "lv",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Saruna",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkripcija",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Uzdevumi",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Dzēst sarunu?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Vai tiešām vēlaties dzēst šo sarunu? Šo darbību nevar atsaukt.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Apstiprināt",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Atcelt",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Labi",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Dzēst",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Pievienot",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Atjaunināt",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Saglabāt",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Rediģēt",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Aizvērt",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Notīrīt",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopēt transkripciju",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopēt kopsavilkumu",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Testēt uzvedni",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Pārstrādāt sarunu",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Dzēst sarunu",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Saturs nokopēts starpliktuvē",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Neizdevās atjaunināt zvaigznītes statusu.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Sarunas URL nevarēja kopīgot.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Kļūda, apstrādājot sarunu. Lūdzu, mēģiniet vēlreiz vēlāk.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Nevar dzēst sarunu",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Kaut kas nogāja greizi! Lūdzu, mēģiniet vēlreiz vēlāk.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopēt kļūdas ziņojumu",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Kļūdas ziņojums nokopēts starpliktuvē",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Atlicis",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Ielādē...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Ielādē ilgumu...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekundes",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Cilvēki",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Pievienot jaunu personu",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Rediģēt personu",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Izveidojiet jaunu personu un apmāciet Omi atpazīt arī viņu runu!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Runas profils",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Paraugs {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Iestatījumi",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Valoda",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Izvēlēties valodu",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Dzēš...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Neizdevās sākt autentifikāciju",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Importēšana sākta! Jūs saņemsiet paziņojumu, kad tā būs pabeigta.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Neizdevās sākt importēšanu. Lūdzu, mēģiniet vēlreiz.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Nevarēja piekļūt atlasītajam failam",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Jautāt Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Gatavs",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Atvienots",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Meklē",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Savienot ierīci",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Jūs esat sasniedzis mēneša limitu.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Pārbaudīt lietojumu",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Sinhronizē ierakstus",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Ieraksti, kas jāsinhronizē",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Viss ir sinhronizēts",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Sinhronizēt",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Kulons ir atjaunināts",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Visi ieraksti ir sinhronizēti",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Notiek sinhronizācija",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Gatavs sinhronizācijai",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Piespiediet Sinhronizēt, lai sāktu",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Kulons nav savienots. Savienojiet, lai sinhronizētu.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Viss jau ir sinhronizēts.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Jums ir ieraksti, kas vēl nav sinhronizēti.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Mēs turpināsim sinhronizēt jūsu ierakstus fonā.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Vēl nav sarunu.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Vēl nav atzīmētu sarunu.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Lai atzīmētu sarunu ar zvaigznīti, atveriet to un piespiediet zvaigznītes ikonu galvenē.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Meklēt sarunas",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} atlasīts",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Apvienot",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Apvienot sarunas",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Tas apvienos {count} sarunas vienā. Viss saturs tiks apvienots un ģenerēts no jauna.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Apvieno fonā. Tas var aizņemt brīdi.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Neizdevās sākt apvienošanu",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Jautājiet jebko",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Vēl nav ziņojumu!\nKāpēc nesākt sarunu?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Dzēš jūsu ziņojumus no Omi atmiņas...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Ziņojums nokopēts starpliktuvē.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Jūs nevarat ziņot par saviem ziņojumiem.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Ziņot par ziņojumu",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Vai tiešām vēlaties ziņot par šo ziņojumu?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Ziņojums veiksmīgi ziņots.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Paldies par jūsu atsauksmēm!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Notīrīt tērzēšanu?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Vai tiešām vēlaties notīrīt tērzēšanu? Šo darbību nevar atsaukt.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Vienlaikus var augšupielādēt tikai 4 failus",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Tērzēt ar Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Lietotnes",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Lietotnes nav atrastas",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Mēģiniet pielāgot meklēšanu vai filtrus",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Izveidojiet savu lietotni",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Izveidojiet un kopīgojiet savu pielāgoto lietotni",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Meklēt 1500+ lietotnes",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Manas lietotnes",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Instalētās lietotnes",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Nevar ielādēt lietotnes :(\n\nLūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Par Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Privātuma politika",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Apmeklēt vietni",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Palīdzība vai jautājumi?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Pievienojieties kopienai!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ biedri un turpina pieaugt.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Dzēst kontu",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Vai tiešām vēlaties dzēst savu kontu?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "To nevar atsaukt.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Visas jūsu atmiņas un sarunas tiks neatgriezeniski dzēstas.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Jūsu lietotnes un integrācijas tiks atsavi notas nekavējoties.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Jūs varat eksportēt savus datus pirms konta dzēšanas, bet pēc dzēšanas tos vairs nevarēs atjaunot.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Es saprotu, ka konta dzēšana ir neatgriezeniska un visi dati, tostarp atmiņas un sarunas, tiks zaudēti un tos nevarēs atgūt.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Vai esat pārliecināts?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Šī darbība ir neatgriezeniska un neatgriezeniski izdzēsīs jūsu kontu un visus saistītos datus. Vai tiešām vēlaties turpināt?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Dzēst tagad",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Atgriezties",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Atzīmējiet izvēles rūtiņu, lai apstiprinātu, ka saprotat, ka konta dzēšana ir neatgriezeniska un neatceļama.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profils",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Vārds",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-pasts",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Pielāgota vārdnīca",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Citu identificēšana",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Maksājumu metodes",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Sarunas attēlojums",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Dati un privātums",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Lietotāja ID",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Nav iestatīts",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Lietotāja ID nokopēts starpliktuvē",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Sistēmas noklusējuma",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plāns un lietojums",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Bezsaistes sinhronizācija",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Ierīces iestatījumi",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Tērzēšanas rīki",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Atsauksmes / Kļūda",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Palīdzības centrs",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Izstrādātāja iestatījumi",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Iegūt Omi priekš Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Ieteikšanas programma",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Izrakstīties",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Lietotnes un ierīces informācija nokopēta",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "2025. gada apskats",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Jūsu privātums, jūsu kontrole",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Omi mēs esam apņēmušies aizsargāt jūsu privātumu. Šī lapa ļauj jums kontrolēt, kā jūsu dati tiek uzglabāti un izmantoti.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Uzzināt vairāk...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Datu aizsardzības līmenis",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Jūsu dati pēc noklusējuma ir aizsargāti ar spēcīgu šifrēšanu. Pārskatiet savus iestatījumus un turpmākās privātuma opcijas zemāk.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Lietotņu piekļuve",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Šādas lietotnes var piekļūt jūsu datiem. Piespiediet uz lietotnes, lai pārvaldītu tās atļaujas.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Nevienai instalētajai lietotnei nav ārējas piekļuves jūsu datiem.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Ierīces nosaukums",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Ierīces ID",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Programmaparatūra",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD kartes sinhronizācija",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Aparatūras versija",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Modeļa numurs",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Ražotājs",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dubultklikšķis",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED spilgtums",
+  "@ledBrightness": {
+    "description": "LED brightness label"
+  },
+  "micGain": "Mikrofona pastiprinājums",
+  "@micGain": {
+    "description": "Microphone gain label"
+  },
+  "disconnect": "Atvienot",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Aizmirst ierīci",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Uzlādes problēmas",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Atvienot ierīci",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Atpārošana ierīci",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Atpārošana un aizmirst ierīci",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Jūsu Omi ir atvienots 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Ierīce atpārota. Dodieties uz Iestatījumi > Bluetooth un aizmirstiet ierīci, lai pabeigtu atpārošanu.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Atpārošana ierīci",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Tas atpāros ierīci, lai to varētu savienot ar citu tālruni. Jums būs jādodas uz Iestatījumi > Bluetooth un jāaizmirst ierīce, lai pabeigtu procesu.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Ierīce nav savienota",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Savienojiet savu Omi ierīci, lai piekļūtu\nierīces iestatījumiem un pielāgošanai",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Ierīces informācija",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Pielāgošana",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Aparatūra",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 nav atklāts",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Redzam, ka jums ir V1 ierīce vai jūsu ierīce nav savienota. SD kartes funkcionalitāte ir pieejama tikai V2 ierīcēm.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Beigt sarunu",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pauze/Atsākt",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Atzīmēt sarunu ar zvaigznīti",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Dubultklikšķa darbība",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Beigt un apstrādāt sarunu",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Apturēt/atsākt ierakstīšanu",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Atzīmēt notiekošo sarunu ar zvaigznīti",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Izslēgts",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maks.",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Apklusināt",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Kluss",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normāls",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Augsts",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofons ir apklusināts",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Ļoti kluss - skaļām vidēm",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Kluss - mērenai trokšņu videi",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neitrāls - līdzsvarots ieraksts",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Nedaudz pastiprināts - parastas izmantošanas",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Pastiprināts - klusām vidēm",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Augsts - tālām vai klus ām balsīm",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Ļoti augsts - ļoti klusiem avotiem",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimālais - lietot piesardzīgi",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Izstrādātāja iestatījumi",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Saglabā...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Konfigurēt savu AI personību",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkripcija",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Konfigurēt STT pakalpojumu sniedzēju",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Sarunas taimauts",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Iestatīt, kad sarunas automātiski beidzas",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importēt datus",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importēt datus no citiem avotiem",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Atkļūdošana un diagnostika",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Galapunkta URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Vēl nav API atslēgu",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Izveidojiet atslēgu, lai sāktu",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Izveidot atslēgu",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentācija",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Jūsu Omi ieskati",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Šodien",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Šomēnes",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Šogad",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Visu laiku",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Vēl nav aktivitātes",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Sāciet sarunu ar Omi,\nlai šeit redzētu lietošanas statistiku.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Klausās",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Kopējais laiks, ko Omi aktīvi klausījies.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Saprot",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Vārdi, kas saprasti no jūsu sarunām.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Sniedz",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Uzdevumi un piezīmes, kas automātiski fiksēti.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Atceras",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakti un detaļas, kas atcerētas jums.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Neierobežots plāns",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Pārvaldīt plānu",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Jūsu plāns tiks atcelts {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Jūsu plāns atjaunojas {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Bezmaksas plāns",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} no {limit} min izmantots",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Jaunināt",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Jaunināt uz neierobežotu",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Jūsu plāns ietver {limit} bezmaksas minūtes mēnesī. Jauniniet, lai iegūtu neierobežotu.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Dalījums ar manu Omi statistiku! (omi.me - jūsu vienmēr ieslēgtais AI asistents)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Šodien omi ir:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Šomēnes omi ir:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Šogad omi ir:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Līdz šim omi ir:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Klausījies {minutes} minūtes",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Sapratis {words} vārdus",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Sniedzis {count} ieskatus",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Atcerējies {count} atmiņas",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Atkļūdošanas žurnāli",
+  "debugLogsAutoDelete": "Automātiski izdzēš pēc 3 dienām.",
+  "debugLogsDesc": "Palīdz diagnosticēt problēmas",
+  "noLogFilesFound": "Žurnāla faili nav atrasti.",
+  "omiDebugLog": "Omi atkļūdošanas žurnāls",
+  "logShared": "Žurnāls kopīgots",
+  "selectLogFile": "Izvēlēties žurnāla failu",
+  "shareLogs": "Kopīgot žurnālus",
+  "debugLogCleared": "Atkļūdošanas žurnāls notīrīts",
+  "exportStarted": "Eksports sākts. Tas var aizņemt dažas sekundes...",
+  "exportAllData": "Eksportēt visus datus",
+  "exportDataDesc": "Eksportēt sarunas uz JSON failu",
+  "exportedConversations": "Eksportētās sarunas no Omi",
+  "exportShared": "Eksports kopīgots",
+  "deleteKnowledgeGraphTitle": "Dzēst zināšanu grafu?",
+  "deleteKnowledgeGraphMessage": "Tas izdzēsīs visus atvasinātos zināšanu grafa datus (mezglus un savienojumus). Jūsu oriģinālās atmiņas paliks drošībā. Grafs tiks atjaunots ar laiku vai pēc nākamā pieprasījuma.",
+  "knowledgeGraphDeleted": "Zināšanu grafs veiksmīgi izdzēsts",
+  "deleteGraphFailed": "Neizdevās dzēst grafu: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Dzēst zināšanu grafu",
+  "deleteKnowledgeGraphDesc": "Notīrīt visus mezglus un savienojumus",
+  "mcp": "MCP",
+  "mcpServer": "MCP serveris",
+  "mcpServerDesc": "Savienojiet AI asistentus ar jūsu datiem",
+  "serverUrl": "Servera URL",
+  "urlCopied": "URL nokopēts",
+  "apiKeyAuth": "API atslēgas autentifikācija",
+  "header": "Galvene",
+  "authorizationBearer": "Autorizācija: Bearer <atslēga>",
+  "oauth": "OAuth",
+  "clientId": "Klienta ID",
+  "clientSecret": "Klienta noslēpums",
+  "useMcpApiKey": "Izmantojiet savu MCP API atslēgu",
+  "webhooks": "Tīmekļa āķi",
+  "conversationEvents": "Sarunas notikumi",
+  "newConversationCreated": "Jauna saruna izveidota",
+  "realtimeTranscript": "Reāllaika transkripcija",
+  "transcriptReceived": "Transkripcija saņemta",
+  "audioBytes": "Audio baiti",
+  "audioDataReceived": "Audio dati saņemti",
+  "intervalSeconds": "Intervāls (sekundes)",
+  "daySummary": "Dienas kopsavilkums",
+  "summaryGenerated": "Kopsavilkums izveidots",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Pievienot claude_desktop_config.json",
+  "copyConfig": "Kopēt konfigurāciju",
+  "configCopied": "Konfigurācija nokopēta starpliktuvē",
+  "listeningMins": "Klausās (min)",
+  "understandingWords": "Saprot (vārdi)",
+  "insights": "Ieskati",
+  "memories": "Atmiņas",
+  "minsUsedThisMonth": "{used} no {limit} min izmantots šomēnes",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} no {limit} vārdiem izmantots šomēnes",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} no {limit} ieskatiem iegūts šomēnes",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} no {limit} atmiņām izveidots šomēnes",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Redzamība",
+  "visibilitySubtitle": "Kontrolējiet, kuras sarunas parādās jūsu sarakstā",
+  "showShortConversations": "Rādīt īsas sarunas",
+  "showShortConversationsDesc": "Attēlot sarunas, kas ir īsākas par slieksni",
+  "showDiscardedConversations": "Rādīt atmestas sarunas",
+  "showDiscardedConversationsDesc": "Iekļaut sarunas, kas atzīmētas kā atmestas",
+  "shortConversationThreshold": "Īsās sarunas slieksnis",
+  "shortConversationThresholdSubtitle": "Sarunas, kas ir īsākas par šo, tiks slēptas, ja vien nav iespējotas iepriekš",
+  "durationThreshold": "Ilguma slieksnis",
+  "durationThresholdDesc": "Slēpt sarunas, kas ir īsākas par šo",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Pielāgota vārdnīca",
+  "addWords": "Pievienot vārdus",
+  "addWordsDesc": "Vārdi, termini vai netipiski vārdi",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Savienot",
+  "comingSoon": "Drīzumā",
+  "chatToolsFooter": "Savienojiet savas lietotnes, lai skatītu datus un metriku tērzēšanā.",
+  "completeAuthInBrowser": "Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.",
+  "failedToStartAuth": "Neizdevās sākt {appName} autentifikāciju",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Atvienot {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Vai tiešām vēlaties atvienot no {appName}? Jūs varat atkārtoti izveidot savienojumu jebkurā laikā.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Atvienots no {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Neizdevās atvienot",
+  "connectTo": "Savienoties ar {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Jums būs jāautorizē Omi piekļuvei jūsu {appName} datiem. Tas atvērs jūsu pārlūkprogrammu autentifikācijai.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Turpināt",
+  "languageTitle": "Valoda",
+  "primaryLanguage": "Primārā valoda",
+  "automaticTranslation": "Automātiskais tulkojums",
+  "detectLanguages": "Atklāt 10+ valodas",
+  "authorizeSavingRecordings": "Autorizēt ierakstu saglabāšanu",
+  "thanksForAuthorizing": "Paldies par autorizāciju!",
+  "needYourPermission": "Mums nepieciešama jūsu atļauja",
+  "alreadyGavePermission": "Jūs jau esat devis mums atļauju saglabāt jūsu ierakstus. Šeit ir atgādinājums, kāpēc mums tas ir nepieciešams:",
+  "wouldLikePermission": "Mēs vēlētos jūsu atļauju saglabāt jūsu balss ierakstus. Šeit ir iemesls:",
+  "improveSpeechProfile": "Uzlabot jūsu runas profilu",
+  "improveSpeechProfileDesc": "Mēs izmantojam ierakstus, lai turpinātu apmācīt un uzlabotu jūsu personīgo runas profilu.",
+  "trainFamilyProfiles": "Apmācīt profilus draugiem un ģimenei",
+  "trainFamilyProfilesDesc": "Jūsu ieraksti palīdz mums atpazīt un izveidot profilus jūsu draugiem un ģimenei.",
+  "enhanceTranscriptAccuracy": "Uzlabot transkripcijas precizitāti",
+  "enhanceTranscriptAccuracyDesc": "Uzlabojoties mūsu modelim, mēs varam sniegt labākus transkripcijas rezultātus jūsu ierakstiem.",
+  "legalNotice": "Juridisks paziņojums: Balss datu ierakstīšanas un uzglabāšanas likumība var atšķirties atkarībā no jūsu atrašanās vietas un tā, kā izmantojat šo funkciju. Ir jūsu atbildība nodrošināt atbilstību vietējiem likumiem un noteikumiem.",
+  "alreadyAuthorized": "Jau autorizēts",
+  "authorize": "Autorizēt",
+  "revokeAuthorization": "Atsaukt autorizāciju",
+  "authorizationSuccessful": "Autorizācija veiksmīga!",
+  "failedToAuthorize": "Neizdevās autorizēt. Lūdzu, mēģiniet vēlreiz.",
+  "authorizationRevoked": "Autorizācija atsaukta.",
+  "recordingsDeleted": "Ieraksti izdzēsti.",
+  "failedToRevoke": "Neizdevās atsaukt autorizāciju. Lūdzu, mēģiniet vēlreiz.",
+  "permissionRevokedTitle": "Atļauja atsaukta",
+  "permissionRevokedMessage": "Vai vēlaties, lai mēs noņemtu arī visus jūsu esošos ierakstus?",
+  "yes": "Jā",
+  "editName": "Rediģēt vārdu",
+  "howShouldOmiCallYou": "Kā Omi jums vajadzētu uzrunāt?",
+  "enterYourName": "Ievadiet savu vārdu",
+  "nameCannotBeEmpty": "Vārds nevar būt tukšs",
+  "nameUpdatedSuccessfully": "Vārds veiksmīgi atjaunināts!",
+  "calendarSettings": "Kalendāra iestatījumi",
+  "calendarProviders": "Kalendāra pakalpojumu sniedzēji",
+  "macOsCalendar": "macOS kalendārs",
+  "connectMacOsCalendar": "Savienojiet savu vietējo macOS kalendāru",
+  "googleCalendar": "Google kalendārs",
+  "syncGoogleAccount": "Sinhronizēt ar savu Google kontu",
+  "showMeetingsMenuBar": "Rādīt tuvākās sanāksmes izvēlnes joslā",
+  "showMeetingsMenuBarDesc": "Attēlot jūsu nākamo sanāksmi un laiku līdz tās sākumam macOS izvēlnes joslā",
+  "showEventsNoParticipants": "Rādīt notikumus bez dalībniekiem",
+  "showEventsNoParticipantsDesc": "Ja iespējots, Coming Up rāda notikumus bez dalībniekiem vai video saites.",
+  "yourMeetings": "Jūsu sanāksmes",
+  "refresh": "Atsvaidzināt",
+  "noUpcomingMeetings": "Nav atrastas tuvākās sanāksmes",
+  "checkingNextDays": "Pārbauda nākamās 30 dienas",
+  "tomorrow": "Rīt",
+  "googleCalendarComingSoon": "Google Calendar integrācija drīzumā!",
+  "connectedAsUser": "Savienots kā lietotājs: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Noklusējuma darba vieta",
+  "tasksCreatedInWorkspace": "Uzdevumi tiks izveidoti šajā darba vietā",
+  "defaultProjectOptional": "Noklusējuma projekts (neobligāts)",
+  "leaveUnselectedTasks": "Atstājiet neizvēlētu, lai izveidotu uzdevumus bez projekta",
+  "noProjectsInWorkspace": "Šajā darba vietā nav atrasti projekti",
+  "conversationTimeoutDesc": "Izvēlieties, cik ilgi gaidīt klusumu, pirms automātiski beidzat sarunu:",
+  "timeout2Minutes": "2 minūtes",
+  "timeout2MinutesDesc": "Beigt sarunu pēc 2 minūšu klusuma",
+  "timeout5Minutes": "5 minūtes",
+  "timeout5MinutesDesc": "Beigt sarunu pēc 5 minūšu klusuma",
+  "timeout10Minutes": "10 minūtes",
+  "timeout10MinutesDesc": "Beigt sarunu pēc 10 minūšu klusuma",
+  "timeout30Minutes": "30 minūtes",
+  "timeout30MinutesDesc": "Beigt sarunu pēc 30 minūšu klusuma",
+  "timeout4Hours": "4 stundas",
+  "timeout4HoursDesc": "Beigt sarunu pēc 4 stundu klusuma",
+  "conversationEndAfterHours": "Sarunas tagad beigsies pēc 4 stundu klusuma",
+  "conversationEndAfterMinutes": "Sarunas tagad beigsies pēc {minutes} minūtes(-ēm) klusuma",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Pastāstiet mums savu primāro valodu",
+  "languageForTranscription": "Iestatiet savu valodu precīzākai transkripcijai un personalizētai pieredzei.",
+  "singleLanguageModeInfo": "Vienas valodas režīms ir iespējots. Tulkošana ir atspējota lielākai precizitātei.",
+  "searchLanguageHint": "Meklēt valodu pēc nosaukuma vai koda",
+  "noLanguagesFound": "Valodas nav atrastas",
+  "skip": "Izlaist",
+  "languageSetTo": "Valoda iestatīta uz {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Neizdevās iestatīt valodu",
+  "appSettings": "{appName} iestatījumi",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Atvienot no {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Tas noņems jūsu {appName} autentifikāciju. Jums būs atkārtoti jāizveido savienojums, lai to izmantotu vēlreiz.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Savienots ar {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Konts",
+  "actionItemsSyncedTo": "Jūsu uzdevumi tiks sinhronizēti ar jūsu {appName} kontu",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Noklusējuma vieta",
+  "selectSpaceInWorkspace": "Izvēlēties vietu savā darba vietā",
+  "noSpacesInWorkspace": "Šajā darba vietā nav atrastas vietas",
+  "defaultList": "Noklusējuma saraksts",
+  "tasksAddedToList": "Uzdevumi tiks pievienoti šim sarakstam",
+  "noListsInSpace": "Šajā vietā nav atrasti saraksti",
+  "failedToLoadRepos": "Neizdevās ielādēt repozitorijus: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Noklusējuma repozitorijs saglabāts",
+  "failedToSaveDefaultRepo": "Neizdevās saglabāt noklusējuma repozitoriju",
+  "defaultRepository": "Noklusējuma repozitorijs",
+  "selectDefaultRepoDesc": "Izvēlieties noklusējuma repozitoriju problēmu izveidošanai. Jūs joprojām varat norādīt citu repozitoriju, veidojot problēmas.",
+  "noReposFound": "Repozitoriji nav atrasti",
+  "private": "Privāts",
+  "updatedDate": "Atjaunināts {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "vakar",
+  "daysAgo": "pirms {count} dienām",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "pirms 1 nedēļas",
+  "weeksAgo": "pirms {count} nedēļām",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "pirms 1 mēneša",
+  "monthsAgo": "pirms {count} mēnešiem",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Problēmas tiks izveidotas jūsu noklusējuma repozitorijā",
+  "taskIntegrations": "Uzdevumu integrācijas",
+  "configureSettings": "Konfigurēt iestatījumus",
+  "completeAuthBrowser": "Lūdzu, pabeidziet autentifikāciju savā pārlūkprogrammā. Kad esat pabeidzis, atgriezieties lietotnē.",
+  "failedToStartAppAuth": "Neizdevās sākt {appName} autentifikāciju",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Savienoties ar {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Jums būs jāautorizē Omi, lai izveidotu uzdevumus jūsu {appName} kontā. Tas atvērs jūsu pārlūkprogrammu autentifikācijai.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Turpināt",
+  "appIntegration": "{appName} integrācija",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integrācija ar {appName} drīzumā! Mēs cītīgi strādājam, lai jums piedāvātu vairāk uzdevumu pārvaldības iespēju.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Sapratu",
+  "tasksExportedOneApp": "Uzdevumus var eksportēt uz vienu lietotni vienlaikus.",
+  "completeYourUpgrade": "Pabeidziet savu jaunināšanu",
+  "importConfiguration": "Importēt konfigurāciju",
+  "exportConfiguration": "Eksportēt konfigurāciju",
+  "bringYourOwn": "Atnesiet savu",
+  "payYourSttProvider": "Brīvi izmantojiet omi. Jūs maksājat tikai savam STT pakalpojumu sniedzējam tieši.",
+  "freeMinutesMonth": "1200 bezmaksas minūtes/mēnesī iekļautas. Neierobežots ar ",
+  "omiUnlimited": "Omi Neierobežots",
+  "hostRequired": "Resursdators ir nepieciešams",
+  "validPortRequired": "Ir nepieciešams derīgs ports",
+  "validWebsocketUrlRequired": "Ir nepieciešams derīgs WebSocket URL (wss://)",
+  "apiUrlRequired": "API URL ir nepieciešams",
+  "apiKeyRequired": "API atslēga ir nepieciešama",
+  "invalidJsonConfig": "Nederīga JSON konfigurācija",
+  "errorSaving": "Kļūda, saglabājot: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfigurācija nokopēta starpliktuvē",
+  "pasteJsonConfig": "Ielīmējiet savu JSON konfigurāciju zemāk:",
+  "addApiKeyAfterImport": "Jums būs jāpievieno sava API atslēga pēc importēšanas",
+  "paste": "Ielīmēt",
+  "import": "Importēt",
+  "invalidProviderInConfig": "Nederīgs pakalpojumu sniedzējs konfigurācijā",
+  "importedConfig": "Importēta {providerName} konfigurācija",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Nederīgs JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Pakalpojumu sniedzējs",
+  "live": "Tiešraide",
+  "onDevice": "Ierīcē",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "Ievadiet savu STT HTTP galapunktu",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "Ievadiet savu tiešraides STT WebSocket galapunktu",
+  "apiKey": "API atslēga",
+  "enterApiKey": "Ievadiet savu API atslēgu",
+  "storedLocallyNeverShared": "Saglabāts vietēji, nekad nekopīgots",
+  "host": "Resursdators",
+  "port": "Ports",
+  "advanced": "Papildu",
+  "configuration": "Konfigurācija",
+  "requestConfiguration": "Pieprasījuma konfigurācija",
+  "responseSchema": "Atbildes shēma",
+  "modified": "Modificēts",
+  "resetRequestConfig": "Atiestatīt pieprasījuma konfigurāciju uz noklusējumu",
+  "logs": "Žurnāli",
+  "logsCopied": "Žurnāli nokopēti",
+  "noLogsYet": "Vēl nav žurnālu. Sāciet ierakstīšanu, lai redzētu pielāgoto STT aktivitāti.",
+  "deviceUsesCodec": "{deviceName} izmanto {codecReason}. Tiks izmantots Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi transkripcija",
+  "bestInClassTranscription": "Labākā klases transkripcija ar nulli iestatījumiem",
+  "instantSpeakerLabels": "Tūlītējas runātāja etiķetes",
+  "languageTranslation": "100+ valodu tulkošana",
+  "optimizedForConversation": "Optimizēts sarunām",
+  "autoLanguageDetection": "Automātiska valodas noteikšana",
+  "highAccuracy": "Augsta precizitāte",
+  "privacyFirst": "Privātums pirmajā vietā",
+  "saveChanges": "Saglabāt izmaiņas",
+  "resetToDefault": "Atiestatīt uz noklusējumu",
+  "viewTemplate": "Skatīt veidni",
+  "trySomethingLike": "Mēģiniet kaut ko līdzīgu...",
+  "tryIt": "Izmēģināt",
+  "creatingPlan": "Izveido plānu",
+  "developingLogic": "Izstrādā loģiku",
+  "designingApp": "Projektē lietotni",
+  "generatingIconStep": "Ģenerē ikonu",
+  "finalTouches": "Pēdējie pieskārieni",
+  "processing": "Apstrādā...",
+  "features": "Funkcijas",
+  "creatingYourApp": "Izveido jūsu lietotni...",
+  "generatingIcon": "Ģenerē ikonu...",
+  "whatShouldWeMake": "Ko mums vajadzētu izveidot?",
+  "appName": "Lietotnes nosaukums",
+  "description": "Apraksts",
+  "publicLabel": "Publisks",
+  "privateLabel": "Privāts",
+  "free": "Bezmaksas",
+  "perMonth": "/ Mēnesī",
+  "tailoredConversationSummaries": "Pielāgoti sarunas kopsavilkumi",
+  "customChatbotPersonality": "Pielāgota tērzēšanas robota personība",
+  "makePublic": "Padarīt publisku",
+  "anyoneCanDiscover": "Ikviens var atklāt jūsu lietotni",
+  "onlyYouCanUse": "Tikai jūs varat izmantot šo lietotni",
+  "paidApp": "Maksas lietotne",
+  "usersPayToUse": "Lietotāji maksā, lai izmantotu jūsu lietotni",
+  "freeForEveryone": "Bezmaksas visiem",
+  "perMonthLabel": "/ mēnesī",
+  "creating": "Izveido...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Izveidot lietotni",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Meklē ierīces...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{IERĪCE} other{IERĪCES}} ATRASTAS TUVUMĀ",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PĀROŠANA VEIKSMĪGA",
+  "errorConnectingAppleWatch": "Kļūda, savienojoties ar Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Vairs nerādīt",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Es saprotu",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Iespējot Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi nepieciešams Bluetooth, lai savienotos ar jūsu valkājamo ierīci. Lūdzu, iespējojiet Bluetooth un mēģiniet vēlreiz.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Sazināties ar atbalstu?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Savienot vēlāk",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Piešķirt atļaujas",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Fona aktivitāte",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Ļaujiet Omi darboties fonā labākai stabilitātei",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Atrašanās vietas piekļuve",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Iespējojiet fona atrašanās vietu pilnai pieredzei",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Paziņojumi",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Iespējojiet paziņojumus, lai būtu informēti",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Atrašanās vietas pakalpojums atspējots",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Atrašanās vietas pakalpojums ir atspējots. Lūdzu, dodieties uz Iestatījumi > Privātums un drošība > Atrašanās vietas pakalpojumi un iespējojiet to",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Fona atrašanās vietas piekļuve liegta",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Lūdzu, dodieties uz ierīces iestatījumiem un iestatiet atrašanās vietas atļauju uz \"Vienmēr atļaut\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Patīk Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Palīdziet mums sasniegt vairāk cilvēku, atstājot atsauksmi App Store. Jūsu atsauksmes mums nozīmē visu!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Palīdziet mums sasniegt vairāk cilvēku, atstājot atsauksmi Google Play Store. Jūsu atsauksmes mums nozīmē visu!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Novērtēt App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Novērtēt Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Varbūt vēlāk",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi ir jāiemācās jūsu mērķi un jūsu balss. Jūs varēsiet to modificēt vēlāk.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Sākt",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Viss padarīts!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Turpiniet, jūs darāt lieliski",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Izlaist šo jautājumu",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Izlaist pagaidām",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Savienojuma kļūda",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Neizdevās izveidot savienojumu ar serveri. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Atklāts nederīgs ieraksts",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Šķiet, ka ierakstā ir vairāki runātāji. Lūdzu, pārliecinieties, ka atrodaties klusā vietā, un mēģiniet vēlreiz.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Nav atklāts pietiekami daudz runas. Lūdzu, runājiet vairāk un mēģiniet vēlreiz.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Lūdzu, pārliecinieties, ka runājat vismaz 5 sekundes un ne vairāk kā 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Vai jūs esat tur?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Mēs nevarējām atklāt nevienu runu. Lūdzu, pārliecinieties, ka runājat vismaz 10 sekundes un ne vairāk kā 3 minūtes.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Savienojums zaudēts",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Savienojums tika pārtraukts. Lūdzu, pārbaudiet interneta savienojumu un mēģiniet vēlreiz.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Mēģināt vēlreiz",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Savienot Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Turpināt bez ierīces",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Nepieciešamas atļaujas",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Šai lietotnei ir nepieciešamas Bluetooth un Atrašanās vietas atļaujas, lai darbotos pareizi. Lūdzu, iespējojiet tās iestatījumos.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Atvērt iestatījumus",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Vēlaties, lai jūs uzrunā citādi?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Kāds ir jūsu vārds?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Runāt. Transkribēt. Apkopot.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Pierakstīties ar Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Pierakstīties ar Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Turpinot, jūs piekrītat mūsu ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Lietošanas noteikumi",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – jūsu AI pavadonis",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Fiksējiet katru brīdi. Iegūstiet AI\nkopsavilkumus. Nekad vairs nerakstiet piezīmes.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch iestatīšana",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Atļauja pieprasīta!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Mikrofona atļauja",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Atļauja piešķirta! Tagad:\n\nAtveriet Omi lietotni savā pulkstenī un piespiediet \"Turpināt\" zemāk",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Mums nepieciešama mikrofona atļauja.\n\n1. Piespiediet \"Piešķirt atļauju\"\n2. Atļaut iPhone\n3. Pulksteņa lietotne aizvērsies\n4. Atkārtoti atveriet un piespiediet \"Turpināt\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Piešķirt atļauju",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Nepieciešama palīdzība?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Problēmu novēršana:\n\n1. Pārliecinieties, ka Omi ir instalēts jūsu pulkstenī\n2. Atveriet Omi lietotni savā pulkstenī\n3. Meklējiet atļaujas uznirstošo logu\n4. Piespiediet \"Atļaut\", kad tiek piedāvāts\n5. Lietotne jūsu pulkstenī aizvērsies - atkārtoti atveriet to\n6. Atgriezieties un piespiediet \"Turpināt\" savā iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Ierakstīšana veiksmīgi sākta!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Atļauja vēl nav piešķirta. Lūdzu, pārliecinieties, ka atļāvāt mikrofona piekļuvi un atkārtoti atvērāt lietotni savā pulkstenī.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Kļūda, pieprasot atļauju: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Kļūda, sākot ierakstīšanu: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Izvēlieties savu primāro valodu",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Iestatiet savu valodu precīzākai transkripcijai un personalizētai pieredzei",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Kāda ir jūsu primārā valoda?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Izvēlieties savu valodu",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Jūsu personīgās izaugsmes ceļojums ar AI, kas klausās katru jūsu vārdu.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Darāmie darbi",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Piespiediet, lai rediģētu • Ilgi turiet, lai atlasītu • Velciet, lai veiktu darbības",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Darāms",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Padarīts",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Vecs",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Viss padarīts!\nNav gaidošu uzdevumu",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Vēl nav pabeigtu vienību",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Nav vecu uzdevumu",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Nav vienību",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Uzdevums atzīmēts kā nepabeigts",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Uzdevums pabeigts",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Dzēst uzdevumu",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Vai tiešām vēlaties dzēst šo uzdevumu?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Dzēst atlasītos vienumus",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Vai tiešām vēlaties dzēst {count} atlasītos uzdevumus?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Uzdevums \"{description}\" izdzēsts",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} uzdevumi izdzēsti",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Neizdevās dzēst uzdevumu",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Neizdevās dzēst vienumus",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Neizdevās dzēst dažus vienumus",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Gatavs uzdevumiem",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Jūsu AI automātiski izvilks uzdevumus no jūsu sarunām. Tie parādīsies šeit, kad tiks izveidoti.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automātiski izvilkts no sarunām",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Piespiediet, lai rediģētu, velciet, lai pabeigtu vai dzēstu",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} atlasīts",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Atlasīt visu",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Dzēst atlasītos",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Meklēt {count} atmiņas",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Atmiņa izdzēsta.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Atsaukt",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Vēl nav atmiņu",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Vēl nav automātiski izvilktu atmiņu",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Vēl nav manuālu atmiņu",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Šajās kategorijās nav atmiņu",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Atmiņas nav atrastas",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Pievienot savu pirmo atmiņu",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Notīrīt Omi atmiņu",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Vai tiešām vēlaties notīrīt Omi atmiņu? Šo darbību nevar atsaukt.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Notīrīt atmiņu",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omi atmiņa par jums ir notīrīta",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Nav atmiņu, ko dzēst",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Izveidot jaunu atmiņu",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Izveidot jaunu uzdevumu",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Atmiņas pārvaldība",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtrēt atmiņas",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Jums ir {count} kopējās atmiņas",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Publiskas atmiņas",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Privātas atmiņas",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Padarīt visas atmiņas privātas",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Padarīt visas atmiņas publiskas",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Dzēst visas atmiņas",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Visas atmiņas tagad ir privātas",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Visas atmiņas tagad ir publiskas",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Jauna atmiņa",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Rediģēt atmiņu",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Man patīk ēst saldējumu...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Neizdevās saglabāt. Lūdzu, pārbaudiet savienojumu.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Saglabāt atmiņu",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Mēģināt vēlreiz",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Izveidot uzdevumu",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Rediģēt uzdevumu",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Kas ir jādara?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Uzdevuma apraksts nevar būt tukšs.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Uzdevums atjaunināts",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Neizdevās atjaunināt uzdevumu",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Uzdevums izveidots",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Neizdevās izveidot uzdevumu",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Termiņš",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Laiks",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Pievienot termiņu",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Piespiediet gatavs, lai saglabātu",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Piespiediet gatavs, lai izveidotu",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Visi",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Par jums",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Ieskati",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuāli",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Pabeigts",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Atzīmēt kā pabeigtu",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Uzdevums izdzēsts",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Neizdevās dzēst uzdevumu",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Dzēst uzdevumu",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Vai tiešām vēlaties dzēst šo uzdevumu?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Lietotnes valoda",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "LIETOJUMPROGRAMMAS INTERFEISS",
+  "speechTranscriptionSectionTitle": "RUNA UN TRANSKRIPCIJA",
+  "languageSettingsHelperText": "Lietojumprogrammas valoda maina izvēlnes un pogas. Runas valoda ietekmē to, kā tiek transkribēti jūsu ieraksti."
+}

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "ms",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Perbualan",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkrip",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Item Tindakan",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Padam Perbualan?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Adakah anda pasti mahu memadam perbualan ini? Tindakan ini tidak boleh dibatalkan.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Sahkan",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Batal",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Padam",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Tambah",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Kemas Kini",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Simpan",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Edit",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Tutup",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Kosongkan",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Salin Transkrip",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Salin Ringkasan",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Uji Gesaan",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Proses Semula Perbualan",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Padam Perbualan",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Kandungan disalin ke papan keratan",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Gagal mengemas kini status bintang.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "URL perbualan tidak dapat dikongsi.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Ralat semasa memproses perbualan. Sila cuba lagi kemudian.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Sila semak sambungan internet anda dan cuba lagi.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Tidak Dapat Memadam Perbualan",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Ada yang tidak kena! Sila cuba lagi kemudian.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Salin mesej ralat",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Mesej ralat disalin ke papan keratan",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Berbaki",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Memuatkan...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Memuatkan tempoh...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} saat",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Orang",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Tambah Orang Baharu",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Edit Orang",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Cipta orang baharu dan latih Omi untuk mengenali pertuturan mereka juga!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Profil Pertuturan",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Sampel {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Tetapan",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Bahasa",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Pilih Bahasa",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Memadam...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Gagal memulakan pengesahan",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import bermula! Anda akan dimaklumkan apabila selesai.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Gagal memulakan import. Sila cuba lagi.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Tidak dapat mengakses fail yang dipilih",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Tanya Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Selesai",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Terputus Sambungan",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Mencari",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Sambung Peranti",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Anda telah mencapai had bulanan anda.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Semak Penggunaan",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Menyegerakkan rakaman",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Rakaman untuk disegerakkan",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Semua telah dikemas kini",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Segerak",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Pendant adalah terkini",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Semua rakaman telah disegerakkan",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Penyegerakan sedang berlangsung",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Sedia untuk disegerakkan",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Ketik Segerak untuk mula",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Pendant tidak disambungkan. Sambung untuk menyegerakkan.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Semua telah disegerakkan.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Anda mempunyai rakaman yang belum disegerakkan lagi.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Kami akan terus menyegerakkan rakaman anda di latar belakang.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Tiada perbualan lagi.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Tiada perbualan berbintang lagi.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Untuk membintangkan perbualan, buka dan ketik ikon bintang di pengepala.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Cari Perbualan",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} dipilih",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Gabung",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Gabungkan Perbualan",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Ini akan menggabungkan {count} perbualan menjadi satu. Semua kandungan akan digabungkan dan dijana semula.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Menggabungkan di latar belakang. Ini mungkin mengambil sedikit masa.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Gagal memulakan penggabungan",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Tanya apa sahaja",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Tiada mesej lagi!\nMengapa tidak mulakan perbualan?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Memadam mesej anda daripada ingatan Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Mesej disalin ke papan keratan.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Anda tidak boleh melaporkan mesej anda sendiri.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Laporkan Mesej",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Adakah anda pasti mahu melaporkan mesej ini?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Mesej berjaya dilaporkan.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Terima kasih atas maklum balas anda!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Kosongkan Sembang?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Adakah anda pasti mahu mengosongkan sembang? Tindakan ini tidak boleh dibatalkan.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Anda hanya boleh memuat naik 4 fail pada satu masa",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Sembang dengan Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Aplikasi",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Tiada aplikasi dijumpai",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Cuba laraskan carian atau penapis anda",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Cipta Aplikasi Anda Sendiri",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Bina dan kongsi aplikasi tersuai anda",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Cari 1500+ Aplikasi",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Aplikasi Saya",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Aplikasi Dipasang",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Tidak dapat mendapatkan aplikasi :(\n\nSila semak sambungan internet anda dan cuba lagi.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Tentang Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Dasar Privasi",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Lawati Laman Web",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Bantuan atau Pertanyaan?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Sertai komuniti!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ ahli dan semakin bertambah.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Padam Akaun",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Adakah anda pasti mahu memadam akaun anda?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Ini tidak boleh dibatalkan.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Semua ingatan dan perbualan anda akan dipadam secara kekal.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Aplikasi dan Integrasi anda akan diputuskan sambungan dengan serta-merta.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Anda boleh mengeksport data anda sebelum memadam akaun anda, tetapi setelah dipadam, ia tidak boleh dipulihkan.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Saya faham bahawa memadam akaun saya adalah kekal dan semua data, termasuk ingatan dan perbualan, akan hilang dan tidak boleh dipulihkan.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Adakah anda pasti?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Tindakan ini tidak boleh diterbalikkan dan akan memadam akaun anda dan semua data berkaitan secara kekal. Adakah anda pasti mahu meneruskan?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Padam Sekarang",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Kembali",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Tandakan kotak untuk mengesahkan anda faham bahawa memadam akaun anda adalah kekal dan tidak boleh diterbalikkan.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Nama",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-mel",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Perbendaharaan Kata Tersuai",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Mengenal Pasti Orang Lain",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Kaedah Pembayaran",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Paparan Perbualan",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Data & Privasi",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID Pengguna",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Tidak ditetapkan",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID Pengguna disalin ke papan keratan",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Lalai Sistem",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Pelan & Penggunaan",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Segerak Luar Talian",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Tetapan Peranti",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Alat Sembang",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Maklum Balas / Pepijat",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Pusat Bantuan",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Tetapan Pembangun",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Dapatkan Omi untuk Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Program Rujukan",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Log Keluar",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Butiran aplikasi dan peranti disalin",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Privasi Anda, Kawalan Anda",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Di Omi, kami komited untuk melindungi privasi anda. Halaman ini membolehkan anda mengawal cara data anda disimpan dan digunakan.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Ketahui lebih lanjut...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Tahap Perlindungan Data",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Data anda dijamin secara lalai dengan penyulitan yang kukuh. Semak tetapan dan pilihan privasi masa depan anda di bawah.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Akses Aplikasi",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Aplikasi berikut boleh mengakses data anda. Ketik pada aplikasi untuk mengurus keizinannya.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Tiada aplikasi yang dipasang mempunyai akses luaran ke data anda.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Nama Peranti",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID Peranti",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Perisian Tegar",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Segerak Kad SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Semakan Perkakasan",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Nombor Model",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Pengeluar",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Ketik Dua Kali",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Kecerahan LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Gandaan Mikrofon",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Putuskan Sambungan",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Lupakan Peranti",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Masalah Pengecasan",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Putuskan Sambungan Peranti",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Nyahpasang Peranti",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Nyahpasang dan Lupakan Peranti",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Omi anda telah diputuskan sambungan 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Peranti dinyahpasangkan. Pergi ke Tetapan > Bluetooth dan lupakan peranti untuk melengkapkan nyahpasangan.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Nyahpasang Peranti",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Ini akan menyahpasangkan peranti supaya ia boleh disambungkan ke telefon lain. Anda perlu pergi ke Tetapan > Bluetooth dan lupakan peranti untuk melengkapkan proses.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Peranti Tidak Disambungkan",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Sambungkan peranti Omi anda untuk mengakses\ntetapan peranti dan penyesuaian",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Maklumat Peranti",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Penyesuaian",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Perkakasan",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 tidak dikesan",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Kami lihat anda sama ada mempunyai peranti V1 atau peranti anda tidak disambungkan. Fungsi Kad SD hanya tersedia untuk peranti V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Tamatkan Perbualan",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Jeda/Sambung Semula",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Bintangkan Perbualan",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Tindakan Ketik Dua Kali",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Tamatkan & Proses Perbualan",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Jeda/Sambung Semula Rakaman",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Bintangkan Perbualan Berterusan",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Mati",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maksimum",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Bisukan",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Senyap",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Biasa",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Tinggi",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon dibisukan",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Sangat senyap - untuk persekitaran bising",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Senyap - untuk bunyi sederhana",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutral - rakaman seimbang",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Dipertingkat sedikit - penggunaan biasa",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Dipertingkat - untuk persekitaran senyap",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Tinggi - untuk suara jauh atau lembut",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Sangat tinggi - untuk sumber sangat senyap",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimum - gunakan dengan berhati-hati",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Tetapan Pembangun",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Menyimpan...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Konfigurasikan persona AI anda",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkripsi",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Konfigurasikan penyedia STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Tamat Masa Perbualan",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Tetapkan bila perbualan tamat secara automatik",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Import Data",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Import data dari sumber lain",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Nyahpepijat & Diagnostik",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL Titik Akhir",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Tiada kunci API lagi",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Cipta kunci untuk bermula",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Cipta Kunci",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumen",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Wawasan Omi Anda",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Hari Ini",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Bulan Ini",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Tahun Ini",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Sepanjang Masa",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Tiada Aktiviti Lagi",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Mulakan perbualan dengan Omi\nuntuk melihat wawasan penggunaan anda di sini.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Mendengar",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Jumlah masa Omi telah mendengar secara aktif.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Memahami",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Perkataan yang difahami daripada perbualan anda.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Menyediakan",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Item tindakan dan nota ditangkap secara automatik.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Mengingati",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakta dan butiran diingati untuk anda.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Pelan Tanpa Had",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Urus Pelan",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Pelan anda akan dibatalkan pada {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Pelan anda diperbaharui pada {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Pelan Percuma",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} daripada {limit} minit digunakan",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Naik Taraf",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Naik Taraf ke Tanpa Had",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Pelan anda termasuk {limit} minit percuma sebulan. Naik taraf untuk tanpa had.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Berkongsi statistik Omi saya! (omi.me - pembantu AI anda yang sentiasa aktif)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Hari ini, omi telah:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Bulan ini, omi telah:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Tahun ini, omi telah:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Setakat ini, omi telah:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Mendengar selama {minutes} minit",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Memahami {words} perkataan",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Menyediakan {count} wawasan",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Mengingati {count} ingatan",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Log Nyahpepijat",
+  "debugLogsAutoDelete": "Auto-padam selepas 3 hari.",
+  "debugLogsDesc": "Membantu mendiagnosis masalah",
+  "noLogFilesFound": "Tiada fail log dijumpai.",
+  "omiDebugLog": "Log nyahpepijat Omi",
+  "logShared": "Log dikongsi",
+  "selectLogFile": "Pilih Fail Log",
+  "shareLogs": "Kongsi Log",
+  "debugLogCleared": "Log nyahpepijat dikosongkan",
+  "exportStarted": "Eksport bermula. Ini mungkin mengambil beberapa saat...",
+  "exportAllData": "Eksport Semua Data",
+  "exportDataDesc": "Eksport perbualan ke fail JSON",
+  "exportedConversations": "Perbualan Dieksport daripada Omi",
+  "exportShared": "Eksport dikongsi",
+  "deleteKnowledgeGraphTitle": "Padam Graf Pengetahuan?",
+  "deleteKnowledgeGraphMessage": "Ini akan memadam semua data graf pengetahuan terbitan (nod dan sambungan). Ingatan asal anda akan kekal selamat. Graf akan dibina semula dari semasa ke semasa atau atas permintaan seterusnya.",
+  "knowledgeGraphDeleted": "Graf Pengetahuan berjaya dipadam",
+  "deleteGraphFailed": "Gagal memadam graf: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Padam Graf Pengetahuan",
+  "deleteKnowledgeGraphDesc": "Kosongkan semua nod dan sambungan",
+  "mcp": "MCP",
+  "mcpServer": "Pelayan MCP",
+  "mcpServerDesc": "Sambungkan pembantu AI ke data anda",
+  "serverUrl": "URL Pelayan",
+  "urlCopied": "URL disalin",
+  "apiKeyAuth": "Pengesahan Kunci API",
+  "header": "Pengepala",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "ID Klien",
+  "clientSecret": "Rahsia Klien",
+  "useMcpApiKey": "Gunakan kunci API MCP anda",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Acara Perbualan",
+  "newConversationCreated": "Perbualan baharu dicipta",
+  "realtimeTranscript": "Transkrip Masa Nyata",
+  "transcriptReceived": "Transkrip diterima",
+  "audioBytes": "Bait Audio",
+  "audioDataReceived": "Data audio diterima",
+  "intervalSeconds": "Selang (saat)",
+  "daySummary": "Ringkasan Hari",
+  "summaryGenerated": "Ringkasan dijana",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Tambah ke claude_desktop_config.json",
+  "copyConfig": "Salin Konfigurasi",
+  "configCopied": "Konfigurasi disalin ke papan keratan",
+  "listeningMins": "Mendengar (minit)",
+  "understandingWords": "Memahami (perkataan)",
+  "insights": "Wawasan",
+  "memories": "Ingatan",
+  "minsUsedThisMonth": "{used} daripada {limit} minit digunakan bulan ini",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} daripada {limit} perkataan digunakan bulan ini",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} daripada {limit} wawasan diperoleh bulan ini",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} daripada {limit} ingatan dicipta bulan ini",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Keterlihatan",
+  "visibilitySubtitle": "Kawal perbualan mana yang muncul dalam senarai anda",
+  "showShortConversations": "Tunjukkan Perbualan Pendek",
+  "showShortConversationsDesc": "Paparkan perbualan yang lebih pendek daripada ambang",
+  "showDiscardedConversations": "Tunjukkan Perbualan Dibuang",
+  "showDiscardedConversationsDesc": "Sertakan perbualan yang ditandakan sebagai dibuang",
+  "shortConversationThreshold": "Ambang Perbualan Pendek",
+  "shortConversationThresholdSubtitle": "Perbualan yang lebih pendek daripada ini akan disembunyikan melainkan didayakan di atas",
+  "durationThreshold": "Ambang Tempoh",
+  "durationThresholdDesc": "Sembunyikan perbualan yang lebih pendek daripada ini",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Perbendaharaan Kata Tersuai",
+  "addWords": "Tambah Perkataan",
+  "addWordsDesc": "Nama, istilah, atau perkataan luar biasa",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Sambung",
+  "comingSoon": "Akan Datang",
+  "chatToolsFooter": "Sambungkan aplikasi anda untuk melihat data dan metrik dalam sembang.",
+  "completeAuthInBrowser": "Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.",
+  "failedToStartAuth": "Gagal memulakan pengesahan {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Putuskan sambungan {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Adakah anda pasti mahu memutuskan sambungan dari {appName}? Anda boleh menyambung semula bila-bila masa.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Terputus sambungan dari {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Gagal memutuskan sambungan",
+  "connectTo": "Sambung ke {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Anda perlu memberi kebenaran kepada Omi untuk mengakses data {appName} anda. Ini akan membuka pelayar anda untuk pengesahan.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Teruskan",
+  "languageTitle": "Bahasa",
+  "primaryLanguage": "Bahasa Utama",
+  "automaticTranslation": "Terjemahan Automatik",
+  "detectLanguages": "Kesan 10+ bahasa",
+  "authorizeSavingRecordings": "Benarkan Menyimpan Rakaman",
+  "thanksForAuthorizing": "Terima kasih kerana memberi kebenaran!",
+  "needYourPermission": "Kami memerlukan kebenaran anda",
+  "alreadyGavePermission": "Anda telah memberi kami kebenaran untuk menyimpan rakaman anda. Berikut adalah peringatan mengapa kami memerlukannya:",
+  "wouldLikePermission": "Kami ingin kebenaran anda untuk menyimpan rakaman suara anda. Sebabnya:",
+  "improveSpeechProfile": "Tingkatkan Profil Pertuturan Anda",
+  "improveSpeechProfileDesc": "Kami menggunakan rakaman untuk melatih dan meningkatkan profil pertuturan peribadi anda.",
+  "trainFamilyProfiles": "Latih Profil untuk Rakan dan Keluarga",
+  "trainFamilyProfilesDesc": "Rakaman anda membantu kami mengenali dan mencipta profil untuk rakan dan keluarga anda.",
+  "enhanceTranscriptAccuracy": "Tingkatkan Ketepatan Transkrip",
+  "enhanceTranscriptAccuracyDesc": "Apabila model kami bertambah baik, kami boleh memberikan hasil transkripsi yang lebih baik untuk rakaman anda.",
+  "legalNotice": "Notis Undang-undang: Kesahihan merakam dan menyimpan data suara mungkin berbeza bergantung pada lokasi anda dan cara anda menggunakan ciri ini. Adalah tanggungjawab anda untuk memastikan pematuhan undang-undang dan peraturan tempatan.",
+  "alreadyAuthorized": "Sudah Dibenarkan",
+  "authorize": "Benarkan",
+  "revokeAuthorization": "Batalkan Kebenaran",
+  "authorizationSuccessful": "Kebenaran berjaya!",
+  "failedToAuthorize": "Gagal memberi kebenaran. Sila cuba lagi.",
+  "authorizationRevoked": "Kebenaran dibatalkan.",
+  "recordingsDeleted": "Rakaman dipadam.",
+  "failedToRevoke": "Gagal membatalkan kebenaran. Sila cuba lagi.",
+  "permissionRevokedTitle": "Kebenaran Dibatalkan",
+  "permissionRevokedMessage": "Adakah anda mahu kami membuang semua rakaman sedia ada anda juga?",
+  "yes": "Ya",
+  "editName": "Edit Nama",
+  "howShouldOmiCallYou": "Apa yang Omi patut panggil anda?",
+  "enterYourName": "Masukkan nama anda",
+  "nameCannotBeEmpty": "Nama tidak boleh kosong",
+  "nameUpdatedSuccessfully": "Nama berjaya dikemas kini!",
+  "calendarSettings": "Tetapan kalendar",
+  "calendarProviders": "Penyedia Kalendar",
+  "macOsCalendar": "Kalendar macOS",
+  "connectMacOsCalendar": "Sambungkan kalendar macOS tempatan anda",
+  "googleCalendar": "Google Calendar",
+  "syncGoogleAccount": "Segerakkan dengan akaun Google anda",
+  "showMeetingsMenuBar": "Tunjukkan mesyuarat akan datang di bar menu",
+  "showMeetingsMenuBarDesc": "Paparkan mesyuarat seterusnya anda dan masa sehingga ia bermula di bar menu macOS",
+  "showEventsNoParticipants": "Tunjukkan acara tanpa peserta",
+  "showEventsNoParticipantsDesc": "Apabila didayakan, Coming Up menunjukkan acara tanpa peserta atau pautan video.",
+  "yourMeetings": "Mesyuarat Anda",
+  "refresh": "Muat Semula",
+  "noUpcomingMeetings": "Tiada mesyuarat akan datang dijumpai",
+  "checkingNextDays": "Menyemak 30 hari akan datang",
+  "tomorrow": "Esok",
+  "googleCalendarComingSoon": "Integrasi Google Calendar akan datang!",
+  "connectedAsUser": "Disambungkan sebagai pengguna: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Ruang Kerja Lalai",
+  "tasksCreatedInWorkspace": "Tugasan akan dicipta dalam ruang kerja ini",
+  "defaultProjectOptional": "Projek Lalai (Pilihan)",
+  "leaveUnselectedTasks": "Biarkan tidak dipilih untuk mencipta tugasan tanpa projek",
+  "noProjectsInWorkspace": "Tiada projek dijumpai dalam ruang kerja ini",
+  "conversationTimeoutDesc": "Pilih berapa lama untuk menunggu dalam senyap sebelum menamatkan perbualan secara automatik:",
+  "timeout2Minutes": "2 minit",
+  "timeout2MinutesDesc": "Tamatkan perbualan selepas 2 minit senyap",
+  "timeout5Minutes": "5 minit",
+  "timeout5MinutesDesc": "Tamatkan perbualan selepas 5 minit senyap",
+  "timeout10Minutes": "10 minit",
+  "timeout10MinutesDesc": "Tamatkan perbualan selepas 10 minit senyap",
+  "timeout30Minutes": "30 minit",
+  "timeout30MinutesDesc": "Tamatkan perbualan selepas 30 minit senyap",
+  "timeout4Hours": "4 jam",
+  "timeout4HoursDesc": "Tamatkan perbualan selepas 4 jam senyap",
+  "conversationEndAfterHours": "Perbualan akan tamat selepas 4 jam senyap",
+  "conversationEndAfterMinutes": "Perbualan akan tamat selepas {minutes} minit senyap",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Beritahu kami bahasa utama anda",
+  "languageForTranscription": "Tetapkan bahasa anda untuk transkripsi yang lebih tajam dan pengalaman yang diperibadikan.",
+  "singleLanguageModeInfo": "Mod Bahasa Tunggal didayakan. Terjemahan dilumpuhkan untuk ketepatan yang lebih tinggi.",
+  "searchLanguageHint": "Cari bahasa mengikut nama atau kod",
+  "noLanguagesFound": "Tiada bahasa dijumpai",
+  "skip": "Langkau",
+  "languageSetTo": "Bahasa ditetapkan kepada {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Gagal menetapkan bahasa",
+  "appSettings": "Tetapan {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Putuskan sambungan dari {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Ini akan membuang pengesahan {appName} anda. Anda perlu menyambung semula untuk menggunakannya lagi.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Disambungkan ke {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Akaun",
+  "actionItemsSyncedTo": "Item tindakan anda akan disegerakkan ke akaun {appName} anda",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Ruang Lalai",
+  "selectSpaceInWorkspace": "Pilih ruang dalam ruang kerja anda",
+  "noSpacesInWorkspace": "Tiada ruang dijumpai dalam ruang kerja ini",
+  "defaultList": "Senarai Lalai",
+  "tasksAddedToList": "Tugasan akan ditambah ke senarai ini",
+  "noListsInSpace": "Tiada senarai dijumpai dalam ruang ini",
+  "failedToLoadRepos": "Gagal memuatkan repositori: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Repositori lalai disimpan",
+  "failedToSaveDefaultRepo": "Gagal menyimpan repositori lalai",
+  "defaultRepository": "Repositori Lalai",
+  "selectDefaultRepoDesc": "Pilih repositori lalai untuk mencipta isu. Anda masih boleh menyatakan repositori yang berbeza semasa mencipta isu.",
+  "noReposFound": "Tiada repositori dijumpai",
+  "private": "Peribadi",
+  "updatedDate": "Dikemas kini {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "semalam",
+  "daysAgo": "{count} hari yang lalu",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 minggu yang lalu",
+  "weeksAgo": "{count} minggu yang lalu",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 bulan yang lalu",
+  "monthsAgo": "{count} bulan yang lalu",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Isu akan dicipta dalam repositori lalai anda",
+  "taskIntegrations": "Integrasi Tugasan",
+  "configureSettings": "Konfigurasikan Tetapan",
+  "completeAuthBrowser": "Sila lengkapkan pengesahan dalam pelayar anda. Selepas selesai, kembali ke aplikasi.",
+  "failedToStartAppAuth": "Gagal memulakan pengesahan {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Sambung ke {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Anda perlu memberi kebenaran kepada Omi untuk mencipta tugasan dalam akaun {appName} anda. Ini akan membuka pelayar anda untuk pengesahan.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Teruskan",
+  "appIntegration": "Integrasi {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integrasi dengan {appName} akan datang! Kami bekerja keras untuk membawa anda lebih banyak pilihan pengurusan tugasan.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Faham",
+  "tasksExportedOneApp": "Tugasan boleh dieksport ke satu aplikasi pada satu masa.",
+  "completeYourUpgrade": "Lengkapkan Naik Taraf Anda",
+  "importConfiguration": "Import Konfigurasi",
+  "exportConfiguration": "Eksport konfigurasi",
+  "bringYourOwn": "Bawa milik anda sendiri",
+  "payYourSttProvider": "Gunakan omi secara bebas. Anda hanya membayar penyedia STT anda secara langsung.",
+  "freeMinutesMonth": "1,200 minit percuma/bulan disertakan. Tanpa had dengan ",
+  "omiUnlimited": "Omi Tanpa Had",
+  "hostRequired": "Hos diperlukan",
+  "validPortRequired": "Port yang sah diperlukan",
+  "validWebsocketUrlRequired": "URL WebSocket yang sah diperlukan (wss://)",
+  "apiUrlRequired": "URL API diperlukan",
+  "apiKeyRequired": "Kunci API diperlukan",
+  "invalidJsonConfig": "Konfigurasi JSON tidak sah",
+  "errorSaving": "Ralat menyimpan: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfigurasi disalin ke papan keratan",
+  "pasteJsonConfig": "Tampal konfigurasi JSON anda di bawah:",
+  "addApiKeyAfterImport": "Anda perlu menambah kunci API anda sendiri selepas mengimport",
+  "paste": "Tampal",
+  "import": "Import",
+  "invalidProviderInConfig": "Penyedia tidak sah dalam konfigurasi",
+  "importedConfig": "Konfigurasi {providerName} diimport",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON tidak sah: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Penyedia",
+  "live": "Langsung",
+  "onDevice": "Pada Peranti",
+  "apiUrl": "URL API",
+  "enterSttHttpEndpoint": "Masukkan titik akhir HTTP STT anda",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Masukkan titik akhir WebSocket STT langsung anda",
+  "apiKey": "Kunci API",
+  "enterApiKey": "Masukkan kunci API anda",
+  "storedLocallyNeverShared": "Disimpan secara tempatan, tidak pernah dikongsi",
+  "host": "Hos",
+  "port": "Port",
+  "advanced": "Lanjutan",
+  "configuration": "Konfigurasi",
+  "requestConfiguration": "Konfigurasi Permintaan",
+  "responseSchema": "Skema Respons",
+  "modified": "Diubah Suai",
+  "resetRequestConfig": "Tetapkan semula konfigurasi permintaan ke lalai",
+  "logs": "Log",
+  "logsCopied": "Log disalin",
+  "noLogsYet": "Tiada log lagi. Mulakan rakaman untuk melihat aktiviti STT tersuai.",
+  "deviceUsesCodec": "{deviceName} menggunakan {codecReason}. Omi akan digunakan.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Transkripsi Omi",
+  "bestInClassTranscription": "Transkripsi terbaik dalam kelasnya tanpa persediaan",
+  "instantSpeakerLabels": "Label penutur segera",
+  "languageTranslation": "Terjemahan 100+ bahasa",
+  "optimizedForConversation": "Dioptimumkan untuk perbualan",
+  "autoLanguageDetection": "Pengesanan bahasa automatik",
+  "highAccuracy": "Ketepatan tinggi",
+  "privacyFirst": "Privasi utama",
+  "saveChanges": "Simpan Perubahan",
+  "resetToDefault": "Tetapkan Semula ke Lalai",
+  "viewTemplate": "Lihat Templat",
+  "trySomethingLike": "Cuba sesuatu seperti...",
+  "tryIt": "Cuba",
+  "creatingPlan": "Mencipta pelan",
+  "developingLogic": "Membangunkan logik",
+  "designingApp": "Mereka aplikasi",
+  "generatingIconStep": "Menjana ikon",
+  "finalTouches": "Sentuhan akhir",
+  "processing": "Memproses...",
+  "features": "Ciri-ciri",
+  "creatingYourApp": "Mencipta aplikasi anda...",
+  "generatingIcon": "Menjana ikon...",
+  "whatShouldWeMake": "Apa yang patut kita buat?",
+  "appName": "Nama Aplikasi",
+  "description": "Penerangan",
+  "publicLabel": "Awam",
+  "privateLabel": "Peribadi",
+  "free": "Percuma",
+  "perMonth": "/ Bulan",
+  "tailoredConversationSummaries": "Ringkasan Perbualan Tersuai",
+  "customChatbotPersonality": "Personaliti Chatbot Tersuai",
+  "makePublic": "Jadikan awam",
+  "anyoneCanDiscover": "Sesiapa sahaja boleh menemui aplikasi anda",
+  "onlyYouCanUse": "Hanya anda boleh menggunakan aplikasi ini",
+  "paidApp": "Aplikasi berbayar",
+  "usersPayToUse": "Pengguna membayar untuk menggunakan aplikasi anda",
+  "freeForEveryone": "Percuma untuk semua",
+  "perMonthLabel": "/ bulan",
+  "creating": "Mencipta...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Cipta Aplikasi",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Mencari peranti...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{PERANTI} other{PERANTI}} DIJUMPAI BERDEKATAN",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PERPASANGAN BERJAYA",
+  "errorConnectingAppleWatch": "Ralat menyambung ke Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Jangan tunjukkan lagi",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Saya Faham",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Dayakan Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi memerlukan Bluetooth untuk menyambung ke peranti boleh pakai anda. Sila dayakan Bluetooth dan cuba lagi.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Hubungi Sokongan?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Sambung Kemudian",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Berikan kebenaran",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Aktiviti latar belakang",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Biarkan Omi berjalan di latar belakang untuk kestabilan yang lebih baik",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Akses lokasi",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Dayakan lokasi latar belakang untuk pengalaman penuh",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Pemberitahuan",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Dayakan pemberitahuan untuk terus dimaklumkan",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Perkhidmatan Lokasi Dilumpuhkan",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Perkhidmatan Lokasi dilumpuhkan. Sila pergi ke Tetapan > Privasi & Keselamatan > Perkhidmatan Lokasi dan dayakannya",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Akses Lokasi Latar Belakang Ditolak",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Sila pergi ke tetapan peranti dan tetapkan kebenaran lokasi kepada \"Sentiasa Benarkan\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Suka Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Bantu kami menjangkau lebih ramai orang dengan meninggalkan ulasan di App Store. Maklum balas anda sangat bermakna bagi kami!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Bantu kami menjangkau lebih ramai orang dengan meninggalkan ulasan di Google Play Store. Maklum balas anda sangat bermakna bagi kami!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Nilai di App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Nilai di Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Mungkin kemudian",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi perlu mempelajari matlamat dan suara anda. Anda boleh mengubahnya kemudian.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Mulakan",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Semua selesai!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Teruskan, anda buat dengan baik",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Langkau soalan ini",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Langkau buat masa ini",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Ralat Sambungan",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Gagal menyambung ke pelayan. Sila semak sambungan internet anda dan cuba lagi.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Rakaman tidak sah dikesan",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Nampaknya terdapat beberapa penutur dalam rakaman. Sila pastikan anda berada di lokasi yang senyap dan cuba lagi.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Tidak cukup pertuturan dikesan. Sila bercakap lebih banyak dan cuba lagi.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Sila pastikan anda bercakap sekurang-kurangnya 5 saat dan tidak lebih daripada 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Adakah anda di sana?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Kami tidak dapat mengesan sebarang pertuturan. Sila pastikan untuk bercakap sekurang-kurangnya 10 saat dan tidak lebih daripada 3 minit.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Sambungan Terputus",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Sambungan terganggu. Sila semak sambungan internet anda dan cuba lagi.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Cuba Lagi",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Sambung Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Teruskan Tanpa Peranti",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Kebenaran Diperlukan",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Aplikasi ini memerlukan kebenaran Bluetooth dan Lokasi untuk berfungsi dengan betul. Sila dayakannya dalam tetapan.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Buka Tetapan",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Mahu dipanggil dengan nama lain?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Siapa nama anda?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Bercakap. Transkrip. Ringkaskan.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Log masuk dengan Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Log masuk dengan Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Dengan meneruskan, anda bersetuju dengan ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Terma Penggunaan",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Sahabat AI Anda",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Tangkap setiap detik. Dapatkan ringkasan dikuasakan AI.\nJangan ambil nota lagi.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Persediaan Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Kebenaran Diminta!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Kebenaran Mikrofon",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Kebenaran diberikan! Sekarang:\n\nBuka aplikasi Omi pada jam tangan anda dan ketik \"Teruskan\" di bawah",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Kami memerlukan kebenaran mikrofon.\n\n1. Ketik \"Berikan Kebenaran\"\n2. Benarkan pada iPhone anda\n3. Aplikasi jam tangan akan ditutup\n4. Buka semula dan ketik \"Teruskan\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Berikan Kebenaran",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Perlukan Bantuan?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Penyelesaian Masalah:\n\n1. Pastikan Omi dipasang pada jam tangan anda\n2. Buka aplikasi Omi pada jam tangan anda\n3. Cari popup kebenaran\n4. Ketik \"Benarkan\" apabila diminta\n5. Aplikasi pada jam tangan anda akan ditutup - buka semula\n6. Kembali dan ketik \"Teruskan\" pada iPhone anda",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Rakaman bermula dengan jayanya!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Kebenaran belum diberikan. Sila pastikan anda membenarkan akses mikrofon dan membuka semula aplikasi pada jam tangan anda.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Ralat meminta kebenaran: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Ralat memulakan rakaman: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Pilih bahasa utama anda",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Tetapkan bahasa anda untuk transkripsi yang lebih tajam dan pengalaman yang diperibadikan",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Apakah bahasa utama anda?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Pilih bahasa anda",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Perjalanan pertumbuhan peribadi anda dengan AI yang mendengar setiap perkataan anda.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Tugasan",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Ketik untuk edit • Tekan lama untuk pilih • Leret untuk tindakan",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Tugasan",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Selesai",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Lama",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Semua telah selesai!\nTiada item tindakan tertunda",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Tiada item selesai lagi",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Tiada tugasan lama",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Tiada item",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Item tindakan ditandakan sebagai tidak lengkap",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Item tindakan selesai",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Padam Item Tindakan",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Adakah anda pasti mahu memadam item tindakan ini?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Padam Item Terpilih",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Adakah anda pasti mahu memadam {count} item tindakan terpilih{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Item tindakan \"{description}\" dipadam",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} item tindakan{s} dipadam",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Gagal memadam item tindakan",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Gagal memadam item",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Gagal memadam beberapa item",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Sedia untuk Item Tindakan",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "AI anda akan secara automatik mengekstrak tugasan dan perkara-yang-perlu-dilakukan daripada perbualan anda. Ia akan muncul di sini apabila dicipta.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Diekstrak secara automatik daripada perbualan",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Ketik untuk edit, leret untuk lengkapkan atau padam",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} dipilih",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Pilih semua",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Padam terpilih",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Cari {count} Ingatan",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Ingatan Dipadam.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Buat Asal",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Tiada ingatan lagi",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Tiada ingatan auto-ekstrak lagi",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Tiada ingatan manual lagi",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Tiada ingatan dalam kategori ini",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Tiada ingatan dijumpai",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Tambah ingatan pertama anda",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Kosongkan Ingatan Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Adakah anda pasti mahu mengosongkan ingatan Omi? Tindakan ini tidak boleh dibatalkan.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Kosongkan Ingatan",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Ingatan Omi tentang anda telah dikosongkan",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Tiada ingatan untuk dipadam",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Cipta ingatan baharu",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Cipta item tindakan baharu",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Pengurusan Ingatan",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Tapis Ingatan",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Anda mempunyai {count} jumlah ingatan",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Ingatan awam",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Ingatan peribadi",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Jadikan Semua Ingatan Peribadi",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Jadikan Semua Ingatan Awam",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Padam Semua Ingatan",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Semua ingatan kini peribadi",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Semua ingatan kini awam",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Ingatan Baharu",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Edit Ingatan",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Saya suka makan ais krim...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Gagal menyimpan. Sila semak sambungan anda.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Simpan Ingatan",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Cuba Semula",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Cipta Item Tindakan",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Edit Item Tindakan",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Apa yang perlu dilakukan?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Penerangan item tindakan tidak boleh kosong.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Item tindakan dikemas kini",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Gagal mengemas kini item tindakan",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Item tindakan dicipta",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Gagal mencipta item tindakan",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Tarikh Akhir",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Masa",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Tambah tarikh akhir",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Tekan selesai untuk simpan",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Tekan selesai untuk cipta",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Semua",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Tentang Anda",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Wawasan",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manual",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Selesai",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Tandakan selesai",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Item tindakan dipadam",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Gagal memadam item tindakan",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Padam Item Tindakan",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Adakah anda pasti mahu memadam item tindakan ini?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Bahasa Aplikasi",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ANTARA MUKA APLIKASI",
+  "speechTranscriptionSectionTitle": "PERTUTURAN & TRANSKRIPSI",
+  "languageSettingsHelperText": "Bahasa Aplikasi menukar menu dan butang. Bahasa Pertuturan mempengaruhi cara rakaman anda ditranskripsi."
+}

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -1,0 +1,1119 @@
+{
+  "@@locale": "nl",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "conversationTab": "Gesprek",
+  "transcriptTab": "Transcript",
+  "actionItemsTab": "Actiepunten",
+  "deleteConversationTitle": "Gesprek verwijderen?",
+  "deleteConversationMessage": "Weet je zeker dat je dit gesprek wilt verwijderen? Deze actie kan niet ongedaan worden gemaakt.",
+  "confirm": "Bevestigen",
+  "cancel": "Annuleren",
+  "ok": "OK",
+  "delete": "Verwijderen",
+  "add": "Toevoegen",
+  "update": "Bijwerken",
+  "save": "Opslaan",
+  "edit": "Bewerken",
+  "close": "Sluiten",
+  "clear": "Wissen",
+  "copyTranscript": "Transcript kopiëren",
+  "copySummary": "Samenvatting kopiëren",
+  "testPrompt": "Prompt testen",
+  "reprocessConversation": "Gesprek opnieuw verwerken",
+  "deleteConversation": "Gesprek verwijderen",
+  "contentCopied": "Inhoud gekopieerd naar klembord",
+  "failedToUpdateStarred": "Kan favorietenstatus niet bijwerken.",
+  "conversationUrlNotShared": "Gesprek-URL kon niet worden gedeeld.",
+  "errorProcessingConversation": "Fout bij het verwerken van gesprek. Probeer het later opnieuw.",
+  "noInternetConnection": "Controleer je internetverbinding en probeer het opnieuw.",
+  "unableToDeleteConversation": "Kan gesprek niet verwijderen",
+  "somethingWentWrong": "Er is iets misgegaan! Probeer het later opnieuw.",
+  "copyErrorMessage": "Foutmelding kopiëren",
+  "errorCopied": "Foutmelding gekopieerd naar klembord",
+  "remaining": "Resterend",
+  "loading": "Laden...",
+  "loadingDuration": "Duur laden...",
+  "secondsCount": "{count} seconden",
+  "@secondsCount": {
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Mensen",
+  "addNewPerson": "Nieuwe persoon toevoegen",
+  "editPerson": "Persoon bewerken",
+  "createPersonHint": "Maak een nieuwe persoon aan en train Omi om hun stem te herkennen!",
+  "speechProfile": "Spraakprofiel",
+  "sampleNumber": "Monster {number}",
+  "@sampleNumber": {
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Instellingen",
+  "language": "Taal",
+  "selectLanguage": "Selecteer taal",
+  "deleting": "Verwijderen...",
+  "pleaseCompleteAuthentication": "Voltooi de authenticatie in je browser. Keer daarna terug naar de app.",
+  "failedToStartAuthentication": "Kan authenticatie niet starten",
+  "importStarted": "Import gestart! Je krijgt een melding wanneer het klaar is.",
+  "failedToStartImport": "Kan import niet starten. Probeer het opnieuw.",
+  "couldNotAccessFile": "Kan het geselecteerde bestand niet openen",
+  "askOmi": "Vraag Omi",
+  "done": "Klaar",
+  "disconnected": "Niet verbonden",
+  "searching": "Zoeken",
+  "connectDevice": "Apparaat verbinden",
+  "monthlyLimitReached": "Je hebt je maandelijkse limiet bereikt.",
+  "checkUsage": "Verbruik controleren",
+  "syncingRecordings": "Opnames synchroniseren",
+  "recordingsToSync": "Opnames om te synchroniseren",
+  "allCaughtUp": "Alles is bijgewerkt",
+  "sync": "Synchroniseren",
+  "pendantUpToDate": "Hanger is up-to-date",
+  "allRecordingsSynced": "Alle opnames zijn gesynchroniseerd",
+  "syncingInProgress": "Synchronisatie bezig",
+  "readyToSync": "Klaar om te synchroniseren",
+  "tapSyncToStart": "Tik op Synchroniseren om te starten",
+  "pendantNotConnected": "Hanger niet verbonden. Verbind om te synchroniseren.",
+  "everythingSynced": "Alles is al gesynchroniseerd.",
+  "recordingsNotSynced": "Je hebt opnames die nog niet zijn gesynchroniseerd.",
+  "syncingBackground": "We blijven je opnames op de achtergrond synchroniseren.",
+  "noConversationsYet": "Nog geen gesprekken.",
+  "noStarredConversations": "Nog geen favoriete gesprekken.",
+  "starConversationHint": "Om een gesprek als favoriet te markeren, open het en tik op het stericoon in de header.",
+  "searchConversations": "Gesprekken zoeken",
+  "selectedCount": "{count} geselecteerd",
+  "@selectedCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Samenvoegen",
+  "mergeConversations": "Gesprekken samenvoegen",
+  "mergeConversationsMessage": "Dit combineert {count} gesprekken tot één. Alle inhoud wordt samengevoegd en opnieuw gegenereerd.",
+  "@mergeConversationsMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Samenvoegen op de achtergrond. Dit kan even duren.",
+  "failedToStartMerge": "Kan samenvoegen niet starten",
+  "askAnything": "Vraag wat je wilt",
+  "noMessagesYet": "Nog geen berichten!\nWaarom begin je geen gesprek?",
+  "deletingMessages": "Je berichten verwijderen uit Omi's geheugen...",
+  "messageCopied": "Bericht gekopieerd naar klembord.",
+  "cannotReportOwnMessage": "Je kunt je eigen berichten niet rapporteren.",
+  "reportMessage": "Bericht rapporteren",
+  "reportMessageConfirm": "Weet je zeker dat je dit bericht wilt rapporteren?",
+  "messageReported": "Bericht succesvol gerapporteerd.",
+  "thankYouFeedback": "Bedankt voor je feedback!",
+  "clearChat": "Chat wissen?",
+  "clearChatConfirm": "Weet je zeker dat je de chat wilt wissen? Deze actie kan niet ongedaan worden gemaakt.",
+  "maxFilesLimit": "Je kunt maximaal 4 bestanden tegelijk uploaden",
+  "chatWithOmi": "Chat met Omi",
+  "apps": "Apps",
+  "noAppsFound": "Geen apps gevonden",
+  "tryAdjustingSearch": "Probeer je zoekopdracht of filters aan te passen",
+  "createYourOwnApp": "Maak je eigen app",
+  "buildAndShareApp": "Bouw en deel je aangepaste app",
+  "searchApps": "Zoek in 1500+ apps",
+  "myApps": "Mijn apps",
+  "installedApps": "Geïnstalleerde apps",
+  "unableToFetchApps": "Kan apps niet ophalen :(\n\nControleer je internetverbinding en probeer het opnieuw.",
+  "aboutOmi": "Over Omi",
+  "privacyPolicy": "Privacybeleid",
+  "visitWebsite": "Website bezoeken",
+  "helpOrInquiries": "Hulp of vragen?",
+  "joinCommunity": "Word lid van de community!",
+  "membersAndCounting": "8000+ leden en groeiende.",
+  "deleteAccountTitle": "Account verwijderen",
+  "deleteAccountConfirm": "Weet je zeker dat je je account wilt verwijderen?",
+  "cannotBeUndone": "Dit kan niet ongedaan worden gemaakt.",
+  "allDataErased": "Al je herinneringen en gesprekken worden permanent verwijderd.",
+  "appsDisconnected": "Je apps en integraties worden direct losgekoppeld.",
+  "exportBeforeDelete": "Je kunt je gegevens exporteren voordat je je account verwijdert, maar eenmaal verwijderd kan het niet worden hersteld.",
+  "deleteAccountCheckbox": "Ik begrijp dat het verwijderen van mijn account permanent is en alle gegevens, inclusief herinneringen en gesprekken, verloren gaan en niet kunnen worden hersteld.",
+  "areYouSure": "Weet je het zeker?",
+  "deleteAccountFinal": "Deze actie is onomkeerbaar en verwijdert permanent je account en alle bijbehorende gegevens. Weet je zeker dat je wilt doorgaan?",
+  "deleteNow": "Nu verwijderen",
+  "goBack": "Terug",
+  "checkBoxToConfirm": "Vink het vakje aan om te bevestigen dat je begrijpt dat het verwijderen van je account permanent en onomkeerbaar is.",
+  "profile": "Profiel",
+  "name": "Naam",
+  "email": "E-mail",
+  "customVocabulary": "Aangepaste woordenlijst",
+  "identifyingOthers": "Anderen identificeren",
+  "paymentMethods": "Betaalmethoden",
+  "conversationDisplay": "Gespreksweergave",
+  "dataPrivacy": "Gegevens en privacy",
+  "userId": "Gebruikers-ID",
+  "notSet": "Niet ingesteld",
+  "userIdCopied": "Gebruikers-ID gekopieerd naar klembord",
+  "systemDefault": "Systeemstandaard",
+  "planAndUsage": "Abonnement en gebruik",
+  "offlineSync": "Offline synchronisatie",
+  "deviceSettings": "Apparaatinstellingen",
+  "chatTools": "Chat-tools",
+  "feedbackBug": "Feedback / Bug",
+  "helpCenter": "Helpcentrum",
+  "developerSettings": "Ontwikkelaarsinstellingen",
+  "getOmiForMac": "Omi voor Mac downloaden",
+  "referralProgram": "Doorverwijsprogramma",
+  "signOut": "Uitloggen",
+  "appAndDeviceCopied": "App- en apparaatgegevens gekopieerd",
+  "wrapped2025": "Terugblik 2025",
+  "yourPrivacyYourControl": "Jouw privacy, jouw controle",
+  "privacyIntro": "Bij Omi zijn we toegewijd aan het beschermen van je privacy. Deze pagina stelt je in staat om te bepalen hoe je gegevens worden opgeslagen en gebruikt.",
+  "learnMore": "Meer informatie...",
+  "dataProtectionLevel": "Gegevensbeschermingsniveau",
+  "dataProtectionDesc": "Je gegevens zijn standaard beveiligd met sterke encryptie. Bekijk hieronder je instellingen en toekomstige privacy-opties.",
+  "appAccess": "App-toegang",
+  "appAccessDesc": "De volgende apps hebben toegang tot je gegevens. Tik op een app om de machtigingen te beheren.",
+  "noAppsExternalAccess": "Geen geïnstalleerde apps hebben externe toegang tot je gegevens.",
+  "deviceName": "Apparaatnaam",
+  "deviceId": "Apparaat-ID",
+  "firmware": "Firmware",
+  "sdCardSync": "SD-kaart synchronisatie",
+  "hardwareRevision": "Hardwarerevisie",
+  "modelNumber": "Modelnummer",
+  "manufacturer": "Fabrikant",
+  "doubleTap": "Dubbel tikken",
+  "ledBrightness": "LED-helderheid",
+  "micGain": "Microfoonversterking",
+  "disconnect": "Loskoppelen",
+  "forgetDevice": "Apparaat vergeten",
+  "chargingIssues": "Oplaadproblemen",
+  "disconnectDevice": "Apparaat loskoppelen",
+  "unpairDevice": "Apparaat ontkoppelen",
+  "unpairAndForget": "Apparaat ontkoppelen en vergeten",
+  "deviceDisconnectedMessage": "Je Omi is losgekoppeld 😔",
+  "deviceUnpairedMessage": "Apparaat ontkoppeld. Ga naar Instellingen > Bluetooth en vergeet het apparaat om het ontkoppelen te voltooien.",
+  "unpairDialogTitle": "Apparaat ontkoppelen",
+  "unpairDialogMessage": "Dit ontkoppelt het apparaat zodat het met een andere telefoon kan worden verbonden. Je moet naar Instellingen > Bluetooth gaan en het apparaat vergeten om het proces te voltooien.",
+  "deviceNotConnected": "Apparaat niet verbonden",
+  "connectDeviceMessage": "Verbind je Omi-apparaat om toegang te krijgen tot\napparaatinstellingen en aanpassingen",
+  "deviceInfoSection": "Apparaatinformatie",
+  "customizationSection": "Aanpassingen",
+  "hardwareSection": "Hardware",
+  "v2Undetected": "V2 niet gedetecteerd",
+  "v2UndetectedMessage": "We zien dat je een V1-apparaat hebt of je apparaat is niet verbonden. SD-kaartfunctionaliteit is alleen beschikbaar voor V2-apparaten.",
+  "endConversation": "Gesprek beëindigen",
+  "pauseResume": "Pauzeren/Hervatten",
+  "starConversation": "Gesprek als favoriet markeren",
+  "doubleTapAction": "Dubbel tikken actie",
+  "endAndProcess": "Gesprek beëindigen en verwerken",
+  "pauseResumeRecording": "Opname pauzeren/hervatten",
+  "starOngoing": "Lopend gesprek als favoriet markeren",
+  "off": "Uit",
+  "max": "Max",
+  "mute": "Dempen",
+  "quiet": "Stil",
+  "normal": "Normaal",
+  "high": "Hoog",
+  "micGainDescMuted": "Microfoon is gedempt",
+  "micGainDescLow": "Zeer stil - voor luidruchtige omgevingen",
+  "micGainDescModerate": "Stil - voor matig geluid",
+  "micGainDescNeutral": "Neutraal - gebalanceerde opname",
+  "micGainDescSlightlyBoosted": "Licht versterkt - normaal gebruik",
+  "micGainDescBoosted": "Versterkt - voor stille omgevingen",
+  "micGainDescHigh": "Hoog - voor verre of zachte stemmen",
+  "micGainDescVeryHigh": "Zeer hoog - voor zeer stille bronnen",
+  "micGainDescMax": "Maximum - gebruik met voorzichtigheid",
+  "developerSettingsTitle": "Ontwikkelaarsinstellingen",
+  "saving": "Opslaan...",
+  "personaConfig": "Configureer je AI-persona",
+  "beta": "BETA",
+  "transcription": "Transcriptie",
+  "transcriptionConfig": "STT-provider configureren",
+  "conversationTimeout": "Gesprekstime-out",
+  "conversationTimeoutConfig": "Instellen wanneer gesprekken automatisch eindigen",
+  "importData": "Gegevens importeren",
+  "importDataConfig": "Gegevens importeren uit andere bronnen",
+  "debugDiagnostics": "Debug en diagnostiek",
+  "endpointUrl": "Endpoint-URL",
+  "noApiKeys": "Nog geen API-sleutels",
+  "createKeyToStart": "Maak een sleutel aan om te beginnen",
+  "createKey": "Sleutel aanmaken",
+  "docs": "Documentatie",
+  "yourOmiInsights": "Je Omi-inzichten",
+  "today": "Vandaag",
+  "thisMonth": "Deze maand",
+  "thisYear": "Dit jaar",
+  "allTime": "Altijd",
+  "noActivityYet": "Nog geen activiteit",
+  "startConversationToSeeInsights": "Start een gesprek met Omi\nom je gebruiksinzichten hier te zien.",
+  "listening": "Luisteren",
+  "listeningSubtitle": "Totale tijd dat Omi actief heeft geluisterd.",
+  "understanding": "Begrijpen",
+  "understandingSubtitle": "Woorden begrepen uit je gesprekken.",
+  "providing": "Leveren",
+  "providingSubtitle": "Actiepunten en notities automatisch vastgelegd.",
+  "remembering": "Onthouden",
+  "rememberingSubtitle": "Feiten en details voor je onthouden.",
+  "unlimitedPlan": "Onbeperkt abonnement",
+  "managePlan": "Abonnement beheren",
+  "cancelAtPeriodEnd": "Je abonnement wordt geannuleerd op {date}.",
+  "@cancelAtPeriodEnd": {
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "1 jan 2026"
+      }
+    }
+  },
+  "renewsOn": "Je abonnement wordt verlengd op {date}.",
+  "@renewsOn": {
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "1 jan 2026"
+      }
+    }
+  },
+  "basicPlan": "Gratis abonnement",
+  "usageLimitMessage": "{used} van {limit} min gebruikt",
+  "@usageLimitMessage": {
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Upgraden",
+  "upgradeToUnlimited": "Upgraden naar onbeperkt",
+  "basicPlanDesc": "Je abonnement bevat {limit} gratis minuten per maand. Upgrade naar onbeperkt.",
+  "@basicPlanDesc": {
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Ik deel mijn Omi-statistieken! (omi.me - je altijd-aan AI-assistent)",
+  "sharePeriodToday": "Vandaag heeft Omi:",
+  "sharePeriodMonth": "Deze maand heeft Omi:",
+  "sharePeriodYear": "Dit jaar heeft Omi:",
+  "sharePeriodAllTime": "Tot nu toe heeft Omi:",
+  "shareStatsListened": "🎧 {minutes} minuten geluisterd",
+  "@shareStatsListened": {
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 {words} woorden begrepen",
+  "@shareStatsWords": {
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ {count} inzichten gegeven",
+  "@shareStatsInsights": {
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 {count} herinneringen onthouden",
+  "@shareStatsMemories": {
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Debug-logboeken",
+  "debugLogsAutoDelete": "Automatisch verwijderd na 3 dagen.",
+  "debugLogsDesc": "Helpt bij het diagnosticeren van problemen",
+  "noLogFilesFound": "Geen logbestanden gevonden.",
+  "omiDebugLog": "Omi debug-log",
+  "logShared": "Log gedeeld",
+  "selectLogFile": "Logbestand selecteren",
+  "shareLogs": "Logboeken delen",
+  "debugLogCleared": "Debug-log gewist",
+  "exportStarted": "Export gestart. Dit kan enkele seconden duren...",
+  "exportAllData": "Alle gegevens exporteren",
+  "exportDataDesc": "Gesprekken exporteren naar een JSON-bestand",
+  "exportedConversations": "Geëxporteerde gesprekken van Omi",
+  "exportShared": "Export gedeeld",
+  "deleteKnowledgeGraphTitle": "Kennisgraaf verwijderen?",
+  "deleteKnowledgeGraphMessage": "Dit verwijdert alle afgeleide kennisgraafgegevens (knooppunten en verbindingen). Je originele herinneringen blijven veilig. De graaf wordt na verloop van tijd of bij het volgende verzoek opnieuw opgebouwd.",
+  "knowledgeGraphDeleted": "Kennisgraaf succesvol verwijderd",
+  "deleteGraphFailed": "Verwijderen graaf mislukt: {error}",
+  "@deleteGraphFailed": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Kennisgraaf verwijderen",
+  "deleteKnowledgeGraphDesc": "Alle knooppunten en verbindingen wissen",
+  "mcp": "MCP",
+  "mcpServer": "MCP-server",
+  "mcpServerDesc": "AI-assistenten verbinden met je gegevens",
+  "serverUrl": "Server-URL",
+  "urlCopied": "URL gekopieerd",
+  "apiKeyAuth": "API-sleutel authenticatie",
+  "header": "Header",
+  "authorizationBearer": "Authorization: Bearer <sleutel>",
+  "oauth": "OAuth",
+  "clientId": "Client-ID",
+  "clientSecret": "Client-geheim",
+  "useMcpApiKey": "Gebruik je MCP API-sleutel",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Gespreksgebeurtenissen",
+  "newConversationCreated": "Nieuw gesprek aangemaakt",
+  "realtimeTranscript": "Realtime transcript",
+  "transcriptReceived": "Transcript ontvangen",
+  "audioBytes": "Audiobytes",
+  "audioDataReceived": "Audiogegevens ontvangen",
+  "intervalSeconds": "Interval (seconden)",
+  "daySummary": "Dagsamenvatting",
+  "summaryGenerated": "Samenvatting gegenereerd",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Toevoegen aan claude_desktop_config.json",
+  "copyConfig": "Configuratie kopiëren",
+  "configCopied": "Configuratie gekopieerd naar klembord",
+  "listeningMins": "Luisteren (min)",
+  "understandingWords": "Begrijpen (woorden)",
+  "insights": "Inzichten",
+  "memories": "Herinneringen",
+  "minsUsedThisMonth": "{used} van {limit} min gebruikt deze maand",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} van {limit} woorden gebruikt deze maand",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} van {limit} inzichten verkregen deze maand",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} van {limit} herinneringen aangemaakt deze maand",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Zichtbaarheid",
+  "visibilitySubtitle": "Bepaal welke gesprekken in je lijst verschijnen",
+  "showShortConversations": "Korte gesprekken tonen",
+  "showShortConversationsDesc": "Gesprekken korter dan de drempel weergeven",
+  "showDiscardedConversations": "Verwijderde gesprekken tonen",
+  "showDiscardedConversationsDesc": "Gesprekken gemarkeerd als verwijderd opnemen",
+  "shortConversationThreshold": "Drempel voor korte gesprekken",
+  "shortConversationThresholdSubtitle": "Gesprekken korter dan dit worden verborgen tenzij hierboven ingeschakeld",
+  "durationThreshold": "Duurdrempel",
+  "durationThresholdDesc": "Gesprekken korter dan dit verbergen",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Aangepaste woordenlijst",
+  "addWords": "Woorden toevoegen",
+  "addWordsDesc": "Namen, termen of ongewone woorden",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Verbinden",
+  "comingSoon": "Binnenkort beschikbaar",
+  "chatToolsFooter": "Verbind je apps om gegevens en statistieken in de chat te bekijken.",
+  "completeAuthInBrowser": "Voltooi de authenticatie in je browser. Keer daarna terug naar de app.",
+  "failedToStartAuth": "Kan {appName}-authenticatie niet starten",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "{appName} loskoppelen?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Weet je zeker dat je de verbinding met {appName} wilt verbreken? Je kunt altijd opnieuw verbinden.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Losgekoppeld van {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Loskoppelen mislukt",
+  "connectTo": "Verbinden met {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Je moet Omi autoriseren om toegang te krijgen tot je {appName}-gegevens. Dit opent je browser voor authenticatie.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Doorgaan",
+  "languageTitle": "Taal",
+  "primaryLanguage": "Primaire taal",
+  "automaticTranslation": "Automatische vertaling",
+  "detectLanguages": "Detecteer 10+ talen",
+  "authorizeSavingRecordings": "Opnames opslaan autoriseren",
+  "thanksForAuthorizing": "Bedankt voor het autoriseren!",
+  "needYourPermission": "We hebben je toestemming nodig",
+  "alreadyGavePermission": "Je hebt ons al toestemming gegeven om je opnames op te slaan. Hier is een herinnering waarom we het nodig hebben:",
+  "wouldLikePermission": "We willen graag je toestemming om je spraakopnames op te slaan. Dit is waarom:",
+  "improveSpeechProfile": "Verbeter je spraakprofiel",
+  "improveSpeechProfileDesc": "We gebruiken opnames om je persoonlijke spraakprofiel verder te trainen en te verbeteren.",
+  "trainFamilyProfiles": "Train profielen voor vrienden en familie",
+  "trainFamilyProfilesDesc": "Je opnames helpen ons om profielen voor je vrienden en familie te herkennen en aan te maken.",
+  "enhanceTranscriptAccuracy": "Verbeter transcriptnauwkeurigheid",
+  "enhanceTranscriptAccuracyDesc": "Naarmate ons model verbetert, kunnen we betere transcriptieresultaten voor je opnames bieden.",
+  "legalNotice": "Juridische kennisgeving: De legaliteit van het opnemen en opslaan van spraakgegevens kan variëren afhankelijk van je locatie en hoe je deze functie gebruikt. Het is jouw verantwoordelijkheid om naleving van lokale wet- en regelgeving te waarborgen.",
+  "alreadyAuthorized": "Al geautoriseerd",
+  "authorize": "Autoriseren",
+  "revokeAuthorization": "Autorisatie intrekken",
+  "authorizationSuccessful": "Autorisatie succesvol!",
+  "failedToAuthorize": "Autorisatie mislukt. Probeer het opnieuw.",
+  "authorizationRevoked": "Autorisatie ingetrokken.",
+  "recordingsDeleted": "Opnames verwijderd.",
+  "failedToRevoke": "Autorisatie intrekken mislukt. Probeer het opnieuw.",
+  "permissionRevokedTitle": "Toestemming ingetrokken",
+  "permissionRevokedMessage": "Wil je dat we ook al je bestaande opnames verwijderen?",
+  "yes": "Ja",
+  "editName": "Naam bewerken",
+  "howShouldOmiCallYou": "Hoe moet Omi je noemen?",
+  "enterYourName": "Voer je naam in",
+  "nameCannotBeEmpty": "Naam mag niet leeg zijn",
+  "nameUpdatedSuccessfully": "Naam succesvol bijgewerkt!",
+  "calendarSettings": "Agenda-instellingen",
+  "calendarProviders": "Agenda-providers",
+  "macOsCalendar": "macOS-agenda",
+  "connectMacOsCalendar": "Verbind je lokale macOS-agenda",
+  "googleCalendar": "Google Agenda",
+  "syncGoogleAccount": "Synchroniseer met je Google-account",
+  "showMeetingsMenuBar": "Toon aankomende vergaderingen in menubalk",
+  "showMeetingsMenuBarDesc": "Toon je volgende vergadering en tijd tot deze begint in de macOS-menubalk",
+  "showEventsNoParticipants": "Evenementen zonder deelnemers tonen",
+  "showEventsNoParticipantsDesc": "Wanneer ingeschakeld, toont Binnenkort evenementen zonder deelnemers of videolink.",
+  "yourMeetings": "Je vergaderingen",
+  "refresh": "Vernieuwen",
+  "noUpcomingMeetings": "Geen aankomende vergaderingen gevonden",
+  "checkingNextDays": "Volgende 30 dagen controleren",
+  "tomorrow": "Morgen",
+  "googleCalendarComingSoon": "Google Agenda-integratie komt binnenkort!",
+  "connectedAsUser": "Verbonden als gebruiker: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Standaard werkruimte",
+  "tasksCreatedInWorkspace": "Taken worden aangemaakt in deze werkruimte",
+  "defaultProjectOptional": "Standaardproject (optioneel)",
+  "leaveUnselectedTasks": "Laat niet geselecteerd om taken zonder project aan te maken",
+  "noProjectsInWorkspace": "Geen projecten gevonden in deze werkruimte",
+  "conversationTimeoutDesc": "Kies hoe lang te wachten in stilte voordat een gesprek automatisch wordt beëindigd:",
+  "timeout2Minutes": "2 minuten",
+  "timeout2MinutesDesc": "Gesprek beëindigen na 2 minuten stilte",
+  "timeout5Minutes": "5 minuten",
+  "timeout5MinutesDesc": "Gesprek beëindigen na 5 minuten stilte",
+  "timeout10Minutes": "10 minuten",
+  "timeout10MinutesDesc": "Gesprek beëindigen na 10 minuten stilte",
+  "timeout30Minutes": "30 minuten",
+  "timeout30MinutesDesc": "Gesprek beëindigen na 30 minuten stilte",
+  "timeout4Hours": "4 uur",
+  "timeout4HoursDesc": "Gesprek beëindigen na 4 uur stilte",
+  "conversationEndAfterHours": "Gesprekken eindigen nu na 4 uur stilte",
+  "conversationEndAfterMinutes": "Gesprekken eindigen nu na {minutes} minuut/minuten stilte",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Vertel ons je primaire taal",
+  "languageForTranscription": "Stel je taal in voor scherpere transcripties en een gepersonaliseerde ervaring.",
+  "singleLanguageModeInfo": "Enkeltaalmodus is ingeschakeld. Vertaling is uitgeschakeld voor hogere nauwkeurigheid.",
+  "searchLanguageHint": "Zoek taal op naam of code",
+  "noLanguagesFound": "Geen talen gevonden",
+  "skip": "Overslaan",
+  "languageSetTo": "Taal ingesteld op {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Kan taal niet instellen",
+  "appSettings": "{appName}-instellingen",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Loskoppelen van {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Dit verwijdert je {appName}-authenticatie. Je moet opnieuw verbinden om het weer te gebruiken.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Verbonden met {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Account",
+  "actionItemsSyncedTo": "Je actiepunten worden gesynchroniseerd met je {appName}-account",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Standaardruimte",
+  "selectSpaceInWorkspace": "Selecteer een ruimte in je werkruimte",
+  "noSpacesInWorkspace": "Geen ruimtes gevonden in deze werkruimte",
+  "defaultList": "Standaardlijst",
+  "tasksAddedToList": "Taken worden toegevoegd aan deze lijst",
+  "noListsInSpace": "Geen lijsten gevonden in deze ruimte",
+  "failedToLoadRepos": "Laden van repositories mislukt: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Standaard repository opgeslagen",
+  "failedToSaveDefaultRepo": "Opslaan van standaard repository mislukt",
+  "defaultRepository": "Standaard repository",
+  "selectDefaultRepoDesc": "Selecteer een standaard repository voor het aanmaken van issues. Je kunt nog steeds een andere repository opgeven bij het aanmaken van issues.",
+  "noReposFound": "Geen repositories gevonden",
+  "private": "Privé",
+  "updatedDate": "Bijgewerkt {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "gisteren",
+  "daysAgo": "{count} dagen geleden",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 week geleden",
+  "weeksAgo": "{count} weken geleden",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 maand geleden",
+  "monthsAgo": "{count} maanden geleden",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Issues worden aangemaakt in je standaard repository",
+  "taskIntegrations": "Taakintegraties",
+  "configureSettings": "Instellingen configureren",
+  "completeAuthBrowser": "Voltooi de authenticatie in je browser. Keer daarna terug naar de app.",
+  "failedToStartAppAuth": "Kan {appName}-authenticatie niet starten",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Verbinden met {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Je moet Omi autoriseren om taken aan te maken in je {appName}-account. Dit opent je browser voor authenticatie.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Doorgaan",
+  "appIntegration": "{appName}-integratie",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integratie met {appName} komt binnenkort! We werken hard om je meer taakbeheeropties te bieden.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Begrepen",
+  "tasksExportedOneApp": "Taken kunnen naar één app tegelijk worden geëxporteerd.",
+  "completeYourUpgrade": "Voltooi je upgrade",
+  "importConfiguration": "Configuratie importeren",
+  "exportConfiguration": "Configuratie exporteren",
+  "bringYourOwn": "Breng je eigen mee",
+  "payYourSttProvider": "Gebruik Omi vrij. Je betaalt alleen je STT-provider rechtstreeks.",
+  "freeMinutesMonth": "1.200 gratis minuten/maand inbegrepen. Onbeperkt met ",
+  "omiUnlimited": "Omi Onbeperkt",
+  "hostRequired": "Host is vereist",
+  "validPortRequired": "Geldige poort is vereist",
+  "validWebsocketUrlRequired": "Geldige WebSocket-URL is vereist (wss://)",
+  "apiUrlRequired": "API-URL is vereist",
+  "apiKeyRequired": "API-sleutel is vereist",
+  "invalidJsonConfig": "Ongeldige JSON-configuratie",
+  "errorSaving": "Fout bij opslaan: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Configuratie gekopieerd naar klembord",
+  "pasteJsonConfig": "Plak je JSON-configuratie hieronder:",
+  "addApiKeyAfterImport": "Je moet je eigen API-sleutel toevoegen na het importeren",
+  "paste": "Plakken",
+  "import": "Importeren",
+  "invalidProviderInConfig": "Ongeldige provider in configuratie",
+  "importedConfig": "{providerName}-configuratie geïmporteerd",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Ongeldige JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Provider",
+  "live": "Live",
+  "onDevice": "Op apparaat",
+  "apiUrl": "API-URL",
+  "enterSttHttpEndpoint": "Voer je STT HTTP-endpoint in",
+  "websocketUrl": "WebSocket-URL",
+  "enterLiveSttWebsocket": "Voer je live STT WebSocket-endpoint in",
+  "apiKey": "API-sleutel",
+  "enterApiKey": "Voer je API-sleutel in",
+  "storedLocallyNeverShared": "Lokaal opgeslagen, nooit gedeeld",
+  "host": "Host",
+  "port": "Poort",
+  "advanced": "Geavanceerd",
+  "configuration": "Configuratie",
+  "requestConfiguration": "Verzoek configuratie",
+  "responseSchema": "Response schema",
+  "modified": "Aangepast",
+  "resetRequestConfig": "Verzoekconfiguratie resetten naar standaard",
+  "logs": "Logboeken",
+  "logsCopied": "Logboeken gekopieerd",
+  "noLogsYet": "Nog geen logboeken. Start een opname om aangepaste STT-activiteit te zien.",
+  "deviceUsesCodec": "{deviceName} gebruikt {codecReason}. Omi wordt gebruikt.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi-transcriptie",
+  "bestInClassTranscription": "Beste transcriptie zonder configuratie",
+  "instantSpeakerLabels": "Directe sprekerslabels",
+  "languageTranslation": "100+ taalvertaling",
+  "optimizedForConversation": "Geoptimaliseerd voor gesprekken",
+  "autoLanguageDetection": "Automatische taaldetectie",
+  "highAccuracy": "Hoge nauwkeurigheid",
+  "privacyFirst": "Privacy eerst",
+  "saveChanges": "Wijzigingen opslaan",
+  "resetToDefault": "Resetten naar standaard",
+  "viewTemplate": "Template bekijken",
+  "trySomethingLike": "Probeer iets als...",
+  "tryIt": "Probeer het",
+  "creatingPlan": "Plan maken",
+  "developingLogic": "Logica ontwikkelen",
+  "designingApp": "App ontwerpen",
+  "generatingIconStep": "Icoon genereren",
+  "finalTouches": "Laatste aanpassingen",
+  "processing": "Verwerken...",
+  "features": "Functies",
+  "creatingYourApp": "Je app maken...",
+  "generatingIcon": "Icoon genereren...",
+  "whatShouldWeMake": "Wat zullen we maken?",
+  "appName": "App-naam",
+  "description": "Beschrijving",
+  "publicLabel": "Openbaar",
+  "privateLabel": "Privé",
+  "free": "Gratis",
+  "perMonth": "/ Maand",
+  "tailoredConversationSummaries": "Op maat gemaakte gesprekssamenvattingen",
+  "customChatbotPersonality": "Aangepaste chatbot-persoonlijkheid",
+  "makePublic": "Openbaar maken",
+  "anyoneCanDiscover": "Iedereen kan je app ontdekken",
+  "onlyYouCanUse": "Alleen jij kunt deze app gebruiken",
+  "paidApp": "Betaalde app",
+  "usersPayToUse": "Gebruikers betalen om je app te gebruiken",
+  "freeForEveryone": "Gratis voor iedereen",
+  "perMonthLabel": "/ maand",
+  "creating": "Maken...",
+  "createApp": "App maken",
+  "searchingForDevices": "Zoeken naar apparaten...",
+  "devicesFoundNearby": "{count} {count, plural, =1{APPARAAT} other{APPARATEN}} GEVONDEN IN DE BUURT",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "KOPPELEN SUCCESVOL",
+  "errorConnectingAppleWatch": "Fout bij verbinden met Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Niet meer tonen",
+  "iUnderstand": "Ik begrijp het",
+  "enableBluetooth": "Bluetooth inschakelen",
+  "bluetoothNeeded": "Omi heeft Bluetooth nodig om verbinding te maken met je wearable. Schakel Bluetooth in en probeer het opnieuw.",
+  "contactSupport": "Contact opnemen met support?",
+  "connectLater": "Later verbinden",
+  "grantPermissions": "Machtigingen verlenen",
+  "backgroundActivity": "Achtergrondactiviteit",
+  "backgroundActivityDesc": "Laat Omi op de achtergrond draaien voor betere stabiliteit",
+  "locationAccess": "Locatietoegang",
+  "locationAccessDesc": "Schakel achtergrondlocatie in voor de volledige ervaring",
+  "notifications": "Meldingen",
+  "notificationsDesc": "Schakel meldingen in om op de hoogte te blijven",
+  "locationServiceDisabled": "Locatieservice uitgeschakeld",
+  "locationServiceDisabledDesc": "Locatieservice is uitgeschakeld. Ga naar Instellingen > Privacy en beveiliging > Locatievoorzieningen en schakel deze in",
+  "backgroundLocationDenied": "Achtergrondlocatietoegang geweigerd",
+  "backgroundLocationDeniedDesc": "Ga naar apparaatinstellingen en stel locatiemachtiging in op \"Altijd toestaan\"",
+  "lovingOmi": "Ben je blij met Omi?",
+  "leaveReviewIos": "Help ons meer mensen te bereiken door een review achter te laten in de App Store. Je feedback betekent enorm veel voor ons!",
+  "leaveReviewAndroid": "Help ons meer mensen te bereiken door een review achter te laten in de Google Play Store. Je feedback betekent enorm veel voor ons!",
+  "rateOnAppStore": "Beoordelen in App Store",
+  "rateOnGooglePlay": "Beoordelen in Google Play",
+  "maybeLater": "Misschien later",
+  "speechProfileIntro": "Omi moet je doelen en je stem leren. Je kunt dit later aanpassen.",
+  "getStarted": "Aan de slag",
+  "allDone": "Helemaal klaar!",
+  "keepGoing": "Ga zo door, je doet het geweldig",
+  "skipThisQuestion": "Deze vraag overslaan",
+  "skipForNow": "Voorlopig overslaan",
+  "connectionError": "Verbindingsfout",
+  "connectionErrorDesc": "Kan geen verbinding maken met de server. Controleer je internetverbinding en probeer het opnieuw.",
+  "invalidRecordingMultipleSpeakers": "Ongeldige opname gedetecteerd",
+  "multipleSpeakersDesc": "Het lijkt erop dat er meerdere sprekers in de opname zijn. Zorg ervoor dat je op een rustige locatie bent en probeer het opnieuw.",
+  "tooShortDesc": "Er is niet genoeg spraak gedetecteerd. Spreek meer en probeer het opnieuw.",
+  "invalidRecordingDesc": "Zorg ervoor dat je minimaal 5 seconden en niet meer dan 90 seconden spreekt.",
+  "areYouThere": "Ben je er nog?",
+  "noSpeechDesc": "We konden geen spraak detecteren. Zorg ervoor dat je minimaal 10 seconden en niet meer dan 3 minuten spreekt.",
+  "connectionLost": "Verbinding verbroken",
+  "connectionLostDesc": "De verbinding is onderbroken. Controleer je internetverbinding en probeer het opnieuw.",
+  "tryAgain": "Opnieuw proberen",
+  "connectOmiOmiGlass": "Omi / OmiGlass verbinden",
+  "continueWithoutDevice": "Doorgaan zonder apparaat",
+  "permissionsRequired": "Machtigingen vereist",
+  "permissionsRequiredDesc": "Deze app heeft Bluetooth- en locatiemachtigingen nodig om correct te functioneren. Schakel deze in via de instellingen.",
+  "openSettings": "Instellingen openen",
+  "wantDifferentName": "Wil je een andere naam gebruiken?",
+  "whatsYourName": "Hoe heet je?",
+  "speakTranscribeSummarize": "Spreek. Transcribeer. Vat samen.",
+  "signInWithApple": "Inloggen met Apple",
+  "signInWithGoogle": "Inloggen met Google",
+  "byContinuingAgree": "Door verder te gaan, ga je akkoord met ons ",
+  "termsOfUse": "Gebruiksvoorwaarden",
+  "omiYourAiCompanion": "Omi – Je AI-metgezel",
+  "captureEveryMoment": "Leg elk moment vast. Krijg AI-aangedreven\nsamenvattingen. Nooit meer notities maken.",
+  "appleWatchSetup": "Apple Watch instellen",
+  "permissionRequestedExclaim": "Toestemming gevraagd!",
+  "microphonePermission": "Microfoontoestemming",
+  "permissionGrantedNow": "Toestemming verleend! Nu:\n\nOpen de Omi-app op je horloge en tik hieronder op \"Doorgaan\"",
+  "needMicrophonePermission": "We hebben microfoontoestemming nodig.\n\n1. Tik op \"Toestemming verlenen\"\n2. Sta toe op je iPhone\n3. Horloge-app sluit\n4. Heropen en tik op \"Doorgaan\"",
+  "grantPermissionButton": "Toestemming verlenen",
+  "needHelp": "Hulp nodig?",
+  "troubleshootingSteps": "Probleemoplossing:\n\n1. Zorg dat Omi op je horloge is geïnstalleerd\n2. Open de Omi-app op je horloge\n3. Zoek naar de toestemmingspopup\n4. Tik op \"Toestaan\" wanneer gevraagd\n5. App op je horloge sluit - heropen deze\n6. Kom terug en tik op \"Doorgaan\" op je iPhone",
+  "recordingStartedSuccessfully": "Opname succesvol gestart!",
+  "permissionNotGrantedYet": "Toestemming nog niet verleend. Zorg dat je microfoontoestemming hebt gegeven en de app op je horloge hebt heropend.",
+  "errorRequestingPermission": "Fout bij het vragen van toestemming: {error}",
+  "@errorRequestingPermission": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Fout bij het starten van opname: {error}",
+  "@errorStartingRecording": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Selecteer je primaire taal",
+  "languageBenefits": "Stel je taal in voor scherpere transcripties en een gepersonaliseerde ervaring",
+  "whatsYourPrimaryLanguage": "Wat is je primaire taal?",
+  "selectYourLanguage": "Selecteer je taal",
+  "personalGrowthJourney": "Je persoonlijke groeireis met AI die naar elk woord luistert.",
+  "actionItemsTitle": "Taken",
+  "actionItemsDescription": "Tik om te bewerken • Lang indrukken om te selecteren • Veeg voor acties",
+  "tabToDo": "Te doen",
+  "tabDone": "Klaar",
+  "tabOld": "Oud",
+  "emptyTodoMessage": "🎉 Alles bijgewerkt!\nGeen openstaande actiepunten",
+  "emptyDoneMessage": "Nog geen voltooide items",
+  "emptyOldMessage": "✅ Geen oude taken",
+  "noItems": "Geen items",
+  "actionItemMarkedIncomplete": "Actiepunt gemarkeerd als niet voltooid",
+  "actionItemCompleted": "Actiepunt voltooid",
+  "deleteActionItemTitle": "Actiepunt verwijderen",
+  "deleteActionItemMessage": "Weet je zeker dat je dit actiepunt wilt verwijderen?",
+  "deleteSelectedItemsTitle": "Geselecteerde items verwijderen",
+  "deleteSelectedItemsMessage": "Weet je zeker dat je {count} geselecteerde actiepunt(en) wilt verwijderen?",
+  "@deleteSelectedItemsMessage": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Actiepunt \"{description}\" verwijderd",
+  "@actionItemDeletedResult": {
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} actiepunt(en) verwijderd",
+  "@itemsDeletedResult": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Kan actiepunt niet verwijderen",
+  "failedToDeleteItems": "Kan items niet verwijderen",
+  "failedToDeleteSomeItems": "Kan sommige items niet verwijderen",
+  "welcomeActionItemsTitle": "Klaar voor actiepunten",
+  "welcomeActionItemsDescription": "Je AI haalt automatisch taken en to-do's uit je gesprekken. Ze verschijnen hier wanneer ze zijn aangemaakt.",
+  "autoExtractionFeature": "Automatisch geëxtraheerd uit gesprekken",
+  "editSwipeFeature": "Tik om te bewerken, veeg om te voltooien of te verwijderen",
+  "itemsSelected": "{count} geselecteerd",
+  "@itemsSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Alles selecteren",
+  "deleteSelected": "Geselecteerde verwijderen",
+  "searchMemories": "Zoek in {count} herinneringen",
+  "@searchMemories": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Herinnering verwijderd.",
+  "undo": "Ongedaan maken",
+  "noMemoriesYet": "Nog geen herinneringen",
+  "noAutoMemories": "Nog geen automatisch geëxtraheerde herinneringen",
+  "noManualMemories": "Nog geen handmatige herinneringen",
+  "noMemoriesInCategories": "Geen herinneringen in deze categorieën",
+  "noMemoriesFound": "Geen herinneringen gevonden",
+  "addFirstMemory": "Voeg je eerste herinnering toe",
+  "clearMemoryTitle": "Omi's geheugen wissen",
+  "clearMemoryMessage": "Weet je zeker dat je Omi's geheugen wilt wissen? Deze actie kan niet ongedaan worden gemaakt.",
+  "clearMemoryButton": "Geheugen wissen",
+  "memoryClearedSuccess": "Omi's geheugen over jou is gewist",
+  "noMemoriesToDelete": "Geen herinneringen om te verwijderen",
+  "createMemoryTooltip": "Nieuwe herinnering maken",
+  "createActionItemTooltip": "Nieuw actiepunt maken",
+  "memoryManagement": "Geheugenbeheer",
+  "filterMemories": "Herinneringen filteren",
+  "totalMemoriesCount": "Je hebt {count} herinneringen in totaal",
+  "@totalMemoriesCount": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Openbare herinneringen",
+  "privateMemories": "Privé herinneringen",
+  "makeAllPrivate": "Alle herinneringen privé maken",
+  "makeAllPublic": "Alle herinneringen openbaar maken",
+  "deleteAllMemories": "Alle herinneringen verwijderen",
+  "allMemoriesPrivateResult": "Alle herinneringen zijn nu privé",
+  "allMemoriesPublicResult": "Alle herinneringen zijn nu openbaar",
+  "newMemory": "Nieuwe herinnering",
+  "editMemory": "Herinnering bewerken",
+  "memoryContentHint": "Ik hou van ijs eten...",
+  "failedToSaveMemory": "Opslaan mislukt. Controleer je verbinding.",
+  "saveMemory": "Herinnering opslaan",
+  "retry": "Opnieuw proberen",
+  "createActionItem": "Actiepunt maken",
+  "editActionItem": "Actiepunt bewerken",
+  "actionItemDescriptionHint": "Wat moet er gedaan worden?",
+  "actionItemDescriptionEmpty": "Actiepuntbeschrijving mag niet leeg zijn.",
+  "actionItemUpdated": "Actiepunt bijgewerkt",
+  "failedToUpdateActionItem": "Kan actiepunt niet bijwerken",
+  "actionItemCreated": "Actiepunt aangemaakt",
+  "failedToCreateActionItem": "Kan actiepunt niet maken",
+  "dueDate": "Vervaldatum",
+  "time": "Tijd",
+  "addDueDate": "Vervaldatum toevoegen",
+  "pressDoneToSave": "Druk op Klaar om op te slaan",
+  "pressDoneToCreate": "Druk op Klaar om aan te maken",
+  "filterAll": "Alle",
+  "filterSystem": "Over jou",
+  "filterInteresting": "Inzichten",
+  "filterManual": "Handmatig",
+  "completed": "Voltooid",
+  "markComplete": "Markeer als voltooid",
+  "actionItemDeleted": "Actiepunt verwijderd",
+  "failedToDeleteActionItem": "Kan actiepunt niet verwijderen",
+  "deleteActionItemConfirmTitle": "Actiepunt verwijderen",
+  "deleteActionItemConfirmMessage": "Weet je zeker dat je dit actiepunt wilt verwijderen?",
+  "appLanguage": "App-taal",
+  "appInterfaceSectionTitle": "APP-INTERFACE",
+  "speechTranscriptionSectionTitle": "SPRAAK & TRANSCRIPTIE",
+  "languageSettingsHelperText": "App-taal verandert menu's en knoppen. Spraaktaal beïnvloedt hoe je opnames worden getranscribeerd."
+}

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "no",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Samtale",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkripsjon",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Handlingspunkter",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Slette samtale?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Er du sikker på at du vil slette denne samtalen? Dette kan ikke angres.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Bekreft",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Avbryt",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Slett",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Legg til",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Oppdater",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Lagre",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Rediger",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Lukk",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Tøm",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopier transkripsjon",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopier sammendrag",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Test prompt",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Behandle samtale på nytt",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Slett samtale",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Innhold kopiert til utklippstavlen",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Kunne ikke oppdatere favoritt-status.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Samtale-URL kunne ikke deles.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Feil under behandling av samtale. Prøv igjen senere.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Sjekk internettforbindelsen din og prøv igjen.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Kan ikke slette samtale",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Noe gikk galt! Prøv igjen senere.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopier feilmelding",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Feilmelding kopiert til utklippstavlen",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Gjenstående",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Laster...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Laster varighet...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekunder",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Personer",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Legg til ny person",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Rediger person",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Opprett en ny person og tren Omi til å gjenkjenne deres tale også!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Taleprofil",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Prøve {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Innstillinger",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Språk",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Velg språk",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Sletter...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Kunne ikke starte autentisering",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import startet! Du vil bli varslet når den er fullført.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Kunne ikke starte import. Prøv igjen.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Kunne ikke åpne den valgte filen",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Spør Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Ferdig",
+  "@done": {
+    "description": "Button to confirm selection"
+  },
+  "disconnected": "Frakoblet",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Søker",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Koble til enhet",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Du har nådd din månedlige grense.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Sjekk forbruk",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Synkroniserer opptak",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Opptak å synkronisere",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Alt er oppdatert",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Synkroniser",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Anheng er oppdatert",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Alle opptak er synkronisert",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Synkronisering pågår",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Klar til synkronisering",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Trykk Synkroniser for å starte",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Anheng ikke tilkoblet. Koble til for å synkronisere.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Alt er allerede synkronisert.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Du har opptak som ikke er synkronisert ennå.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Vi fortsetter å synkronisere opptakene dine i bakgrunnen.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Ingen samtaler ennå.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Ingen favorittsamtaler ennå.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "For å favorittmarkere en samtale, åpne den og trykk på stjerneikonet i overskriften.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Søk i samtaler",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} valgt",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Slå sammen",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Slå sammen samtaler",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Dette vil kombinere {count} samtaler til én. Alt innhold vil bli slått sammen og regenerert.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Slår sammen i bakgrunnen. Dette kan ta et øyeblikk.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Kunne ikke starte sammenslåing",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Spør om hva som helst",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Ingen meldinger ennå!\nHvorfor ikke starte en samtale?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Sletter meldingene dine fra Omis minne...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Melding kopiert til utklippstavlen.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Du kan ikke rapportere dine egne meldinger.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Rapporter melding",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Er du sikker på at du vil rapportere denne meldingen?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Melding rapportert.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Takk for tilbakemeldingen!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Tøm chat?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Er du sikker på at du vil tømme chatten? Dette kan ikke angres.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Du kan bare laste opp 4 filer om gangen",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Chat med Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Apper",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Ingen apper funnet",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Prøv å justere søket eller filtrene dine",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Lag din egen app",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Bygg og del din egendefinerte app",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Søk i 1500+ apper",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Mine apper",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Installerte apper",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Kan ikke hente apper :(\n\nSjekk internettforbindelsen din og prøv igjen.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Om Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Personvernserklæring",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Besøk nettside",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Hjelp eller henvendelser?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Bli med i fellesskapet!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ medlemmer og flere.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Slett konto",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Er du sikker på at du vil slette kontoen din?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Dette kan ikke angres.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Alle minnene og samtalene dine vil bli permanent slettet.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Appene og integrasjonene dine vil bli frakoblet umiddelbart.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Du kan eksportere dataene dine før du sletter kontoen, men når den er slettet, kan den ikke gjenopprettes.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Jeg forstår at sletting av kontoen min er permanent og at alle data, inkludert minner og samtaler, vil gå tapt og ikke kan gjenopprettes.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Er du sikker?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Denne handlingen kan ikke angres og vil permanent slette kontoen din og alle tilknyttede data. Er du sikker på at du vil fortsette?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Slett nå",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Gå tilbake",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Kryss av for å bekrefte at du forstår at sletting av kontoen din er permanent og irreversibel.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Navn",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-post",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Tilpasset ordforråd",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identifisere andre",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Betalingsmetoder",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Samtalevisning",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Data og personvern",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Bruker-ID",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Ikke angitt",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Bruker-ID kopiert til utklippstavlen",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Systemstandard",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Abonnement og forbruk",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Frakoblet synkronisering",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Enhetsinnstillinger",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Chatverktøy",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Tilbakemelding / Feil",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Hjelpesenter",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Utviklerinnstillinger",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Få Omi for Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Henvisningsprogram",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Logg ut",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "App- og enhetsdetaljer kopiert",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Oppsummert 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Ditt personvern, din kontroll",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Hos Omi er vi opptatt av å beskytte ditt personvern. Denne siden lar deg kontrollere hvordan dataene dine lagres og brukes.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Lær mer...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Databeskyttelsesnivå",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Dataene dine er sikret som standard med sterk kryptering. Se gjennom innstillingene dine og fremtidige personvernalternativer nedenfor.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Apptilgang",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Følgende apper har tilgang til dataene dine. Trykk på en app for å administrere tillatelsene.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Ingen installerte apper har ekstern tilgang til dataene dine.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Enhetsnavn",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Enhets-ID",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Fastvare",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD-kortsynkronisering",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Maskinvarerevisjon",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Modellnummer",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Produsent",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dobbelttrykk",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED-lysstyrke",
+  "@ledBrightness": {
+    "description": "LED brightness label"
+  },
+  "micGain": "Mikrofonforsterkning",
+  "@micGain": {
+    "description": "Microphone gain label"
+  },
+  "disconnect": "Koble fra",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Glem enhet",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Ladeproblemer",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Koble fra enhet",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Fjern paring av enhet",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Fjern paring og glem enhet",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Din Omi har blitt frakoblet 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Enhet fjernet fra paring. Gå til Innstillinger > Bluetooth og glem enheten for å fullføre fjerningen.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Fjern paring av enhet",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Dette vil fjerne paringen av enheten slik at den kan kobles til en annen telefon. Du må gå til Innstillinger > Bluetooth og glemme enheten for å fullføre prosessen.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Enhet ikke tilkoblet",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Koble til Omi-enheten din for å få tilgang til\nenhetsinnstillinger og tilpasning",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Enhetsinformasjon",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Tilpasning",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Maskinvare",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 ikke oppdaget",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Vi ser at du enten har en V1-enhet eller at enheten din ikke er tilkoblet. SD-kortfunksjonalitet er kun tilgjengelig for V2-enheter.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Avslutt samtale",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pause/Fortsett",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Favorittmerk samtale",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Dobbelttrykk-handling",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Avslutt og behandle samtale",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pause/Fortsett opptak",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Favorittmerk pågående samtale",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Av",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maks",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Demp",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Stille",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normal",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Høy",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon er dempet",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Veldig stille - for høylydte omgivelser",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Stille - for moderat støy",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Nøytral - balansert opptak",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Litt forsterket - normal bruk",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Forsterket - for stille omgivelser",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Høy - for fjerne eller myke stemmer",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Veldig høy - for veldig stille kilder",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimal - bruk med forsiktighet",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Utviklerinnstillinger",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Lagrer...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Konfigurer din AI-persona",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkripsjon",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Konfigurer STT-leverandør",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Samtale-timeout",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Angi når samtaler avsluttes automatisk",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importer data",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importer data fra andre kilder",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Feilsøking og diagnostikk",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Endepunkt-URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Ingen API-nøkler ennå",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Opprett en nøkkel for å komme i gang",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Opprett nøkkel",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentasjon",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Dine Omi-innsikter",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "I dag",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Denne måneden",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Dette året",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "All tid",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Ingen aktivitet ennå",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Start en samtale med Omi\nfor å se forbruksinnsiktene dine her.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Lytter",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Total tid Omi har lyttet aktivt.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Forstår",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Ord forstått fra samtalene dine.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Gir",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Handlingspunkter og notater automatisk registrert.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Husker",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakta og detaljer husket for deg.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Ubegrenset abonnement",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Administrer abonnement",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Abonnementet ditt vil kanselleres {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Abonnementet ditt fornyes {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Gratis abonnement",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} av {limit} min brukt",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Oppgrader",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Oppgrader til ubegrenset",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Abonnementet ditt inkluderer {limit} gratis minutter per måned. Oppgrader for ubegrenset bruk.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Deler mine Omi-statistikker! (omi.me - din alltid tilgjengelige AI-assistent)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "I dag har omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Denne måneden har omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Dette året har omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Så langt har omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Lyttet i {minutes} minutter",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Forstått {words} ord",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Gitt {count} innsikter",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Husket {count} minner",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Feilsøkingslogger",
+  "debugLogsAutoDelete": "Slettes automatisk etter 3 dager.",
+  "debugLogsDesc": "Hjelper med å diagnostisere problemer",
+  "noLogFilesFound": "Ingen loggfiler funnet.",
+  "omiDebugLog": "Omi feilsøkingslogg",
+  "logShared": "Logg delt",
+  "selectLogFile": "Velg loggfil",
+  "shareLogs": "Del logger",
+  "debugLogCleared": "Feilsøkingslogg tømt",
+  "exportStarted": "Eksport startet. Dette kan ta noen sekunder...",
+  "exportAllData": "Eksporter alle data",
+  "exportDataDesc": "Eksporter samtaler til en JSON-fil",
+  "exportedConversations": "Eksporterte samtaler fra Omi",
+  "exportShared": "Eksport delt",
+  "deleteKnowledgeGraphTitle": "Slette kunnskapsgraf?",
+  "deleteKnowledgeGraphMessage": "Dette vil slette alle utledede kunnskapsdata (noder og forbindelser). De originale minnene dine vil forbli trygge. Grafen vil bli gjenoppbygget over tid eller ved neste forespørsel.",
+  "knowledgeGraphDeleted": "Kunnskapsgraf slettet",
+  "deleteGraphFailed": "Kunne ikke slette graf: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Slett kunnskapsgraf",
+  "deleteKnowledgeGraphDesc": "Tøm alle noder og forbindelser",
+  "mcp": "MCP",
+  "mcpServer": "MCP-server",
+  "mcpServerDesc": "Koble AI-assistenter til dataene dine",
+  "serverUrl": "Server-URL",
+  "urlCopied": "URL kopiert",
+  "apiKeyAuth": "API-nøkkelautentisering",
+  "header": "Topptekst",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Klient-ID",
+  "clientSecret": "Klienthemmelighet",
+  "useMcpApiKey": "Bruk din MCP API-nøkkel",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Samtalehendelser",
+  "newConversationCreated": "Ny samtale opprettet",
+  "realtimeTranscript": "Sanntidstranskripsjon",
+  "transcriptReceived": "Transkripsjon mottatt",
+  "audioBytes": "Lydbytes",
+  "audioDataReceived": "Lyddata mottatt",
+  "intervalSeconds": "Intervall (sekunder)",
+  "daySummary": "Dagsammendrag",
+  "summaryGenerated": "Sammendrag generert",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Legg til i claude_desktop_config.json",
+  "copyConfig": "Kopier konfigurasjon",
+  "configCopied": "Konfigurasjon kopiert til utklippstavlen",
+  "listeningMins": "Lytting (min)",
+  "understandingWords": "Forståelse (ord)",
+  "insights": "Innsikter",
+  "memories": "Minner",
+  "minsUsedThisMonth": "{used} av {limit} min brukt denne måneden",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} av {limit} ord brukt denne måneden",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} av {limit} innsikter fått denne måneden",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} av {limit} minner opprettet denne måneden",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Synlighet",
+  "visibilitySubtitle": "Kontroller hvilke samtaler som vises i listen din",
+  "showShortConversations": "Vis korte samtaler",
+  "showShortConversationsDesc": "Vis samtaler kortere enn terskelen",
+  "showDiscardedConversations": "Vis forkastede samtaler",
+  "showDiscardedConversationsDesc": "Inkluder samtaler merket som forkastet",
+  "shortConversationThreshold": "Terskel for korte samtaler",
+  "shortConversationThresholdSubtitle": "Samtaler kortere enn dette vil være skjult med mindre aktivert ovenfor",
+  "durationThreshold": "Varighetsterskel",
+  "durationThresholdDesc": "Skjul samtaler kortere enn dette",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Tilpasset ordforråd",
+  "addWords": "Legg til ord",
+  "addWordsDesc": "Navn, termer eller uvanlige ord",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Koble til",
+  "comingSoon": "Kommer snart",
+  "chatToolsFooter": "Koble til appene dine for å se data og måledata i chat.",
+  "completeAuthInBrowser": "Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.",
+  "failedToStartAuth": "Kunne ikke starte {appName}-autentisering",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Koble fra {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Er du sikker på at du vil koble fra {appName}? Du kan koble til igjen når som helst.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Frakoblet fra {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Kunne ikke koble fra",
+  "connectTo": "Koble til {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Du må autorisere Omi til å få tilgang til {appName}-dataene dine. Dette vil åpne nettleseren din for autentisering.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Fortsett",
+  "languageTitle": "Språk",
+  "primaryLanguage": "Hovedspråk",
+  "automaticTranslation": "Automatisk oversettelse",
+  "detectLanguages": "Oppdage 10+ språk",
+  "authorizeSavingRecordings": "Autoriser lagring av opptak",
+  "thanksForAuthorizing": "Takk for at du autoriserte!",
+  "needYourPermission": "Vi trenger din tillatelse",
+  "alreadyGavePermission": "Du har allerede gitt oss tillatelse til å lagre opptakene dine. Her er en påminnelse om hvorfor vi trenger det:",
+  "wouldLikePermission": "Vi vil gjerne ha tillatelse til å lagre stemmeopptakene dine. Her er hvorfor:",
+  "improveSpeechProfile": "Forbedre taleprofilen din",
+  "improveSpeechProfileDesc": "Vi bruker opptak for å videreutvikle og forbedre din personlige taleprofil.",
+  "trainFamilyProfiles": "Tren profiler for venner og familie",
+  "trainFamilyProfilesDesc": "Opptakene dine hjelper oss med å gjenkjenne og opprette profiler for venner og familie.",
+  "enhanceTranscriptAccuracy": "Forbedre transkripsjonsnøyaktighet",
+  "enhanceTranscriptAccuracyDesc": "Etter hvert som modellen vår forbedres, kan vi gi bedre transkripsjon av opptakene dine.",
+  "legalNotice": "Juridisk merknad: Lovligheten av å ta opp og lagre taledata kan variere avhengig av hvor du befinner deg og hvordan du bruker denne funksjonen. Det er ditt ansvar å sikre overholdelse av lokale lover og forskrifter.",
+  "alreadyAuthorized": "Allerede autorisert",
+  "authorize": "Autoriser",
+  "revokeAuthorization": "Tilbakekall autorisasjon",
+  "authorizationSuccessful": "Autorisasjon vellykket!",
+  "failedToAuthorize": "Kunne ikke autorisere. Prøv igjen.",
+  "authorizationRevoked": "Autorisasjon tilbakekalt.",
+  "recordingsDeleted": "Opptak slettet.",
+  "failedToRevoke": "Kunne ikke tilbakekalle autorisasjon. Prøv igjen.",
+  "permissionRevokedTitle": "Tillatelse tilbakekalt",
+  "permissionRevokedMessage": "Vil du at vi skal fjerne alle eksisterende opptak også?",
+  "yes": "Ja",
+  "editName": "Rediger navn",
+  "howShouldOmiCallYou": "Hva skal Omi kalle deg?",
+  "enterYourName": "Skriv inn navnet ditt",
+  "nameCannotBeEmpty": "Navn kan ikke være tomt",
+  "nameUpdatedSuccessfully": "Navn oppdatert!",
+  "calendarSettings": "Kalenderinnstillinger",
+  "calendarProviders": "Kalenderleverandører",
+  "macOsCalendar": "macOS-kalender",
+  "connectMacOsCalendar": "Koble til din lokale macOS-kalender",
+  "googleCalendar": "Google-kalender",
+  "syncGoogleAccount": "Synkroniser med Google-kontoen din",
+  "showMeetingsMenuBar": "Vis kommende møter i menylinje",
+  "showMeetingsMenuBarDesc": "Vis neste møte og tid til det starter i macOS-menylinjen",
+  "showEventsNoParticipants": "Vis hendelser uten deltakere",
+  "showEventsNoParticipantsDesc": "Når aktivert, viser Kommende hendelser uten deltakere eller videolenke.",
+  "yourMeetings": "Dine møter",
+  "refresh": "Oppdater",
+  "noUpcomingMeetings": "Ingen kommende møter funnet",
+  "checkingNextDays": "Sjekker neste 30 dager",
+  "tomorrow": "I morgen",
+  "googleCalendarComingSoon": "Google-kalenderintegrasjon kommer snart!",
+  "connectedAsUser": "Tilkoblet som bruker: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Standard arbeidsområde",
+  "tasksCreatedInWorkspace": "Oppgaver vil bli opprettet i dette arbeidsområdet",
+  "defaultProjectOptional": "Standard prosjekt (valgfritt)",
+  "leaveUnselectedTasks": "La være uvalgt for å opprette oppgaver uten prosjekt",
+  "noProjectsInWorkspace": "Ingen prosjekter funnet i dette arbeidsområdet",
+  "conversationTimeoutDesc": "Velg hvor lenge du vil vente i stillhet før samtalen avsluttes automatisk:",
+  "timeout2Minutes": "2 minutter",
+  "timeout2MinutesDesc": "Avslutt samtale etter 2 minutters stillhet",
+  "timeout5Minutes": "5 minutter",
+  "timeout5MinutesDesc": "Avslutt samtale etter 5 minutters stillhet",
+  "timeout10Minutes": "10 minutter",
+  "timeout10MinutesDesc": "Avslutt samtale etter 10 minutters stillhet",
+  "timeout30Minutes": "30 minutter",
+  "timeout30MinutesDesc": "Avslutt samtale etter 30 minutters stillhet",
+  "timeout4Hours": "4 timer",
+  "timeout4HoursDesc": "Avslutt samtale etter 4 timers stillhet",
+  "conversationEndAfterHours": "Samtaler vil nå avsluttes etter 4 timers stillhet",
+  "conversationEndAfterMinutes": "Samtaler vil nå avsluttes etter {minutes} minutt(er) stillhet",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Fortell oss ditt hovedspråk",
+  "languageForTranscription": "Angi språket ditt for skarpere transkripsjoner og en personlig opplevelse.",
+  "singleLanguageModeInfo": "Enkeltspråkmodus er aktivert. Oversettelse er deaktivert for høyere nøyaktighet.",
+  "searchLanguageHint": "Søk etter språk med navn eller kode",
+  "noLanguagesFound": "Ingen språk funnet",
+  "skip": "Hopp over",
+  "languageSetTo": "Språk satt til {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Kunne ikke angi språk",
+  "appSettings": "{appName}-innstillinger",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Koble fra {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Dette vil fjerne {appName}-autentiseringen din. Du må koble til igjen for å bruke den.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Tilkoblet {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Konto",
+  "actionItemsSyncedTo": "Handlingspunktene dine vil bli synkronisert til {appName}-kontoen din",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Standard område",
+  "selectSpaceInWorkspace": "Velg et område i arbeidsområdet ditt",
+  "noSpacesInWorkspace": "Ingen områder funnet i dette arbeidsområdet",
+  "defaultList": "Standard liste",
+  "tasksAddedToList": "Oppgaver vil bli lagt til denne listen",
+  "noListsInSpace": "Ingen lister funnet i dette området",
+  "failedToLoadRepos": "Kunne ikke laste inn repositorier: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Standard repositorium lagret",
+  "failedToSaveDefaultRepo": "Kunne ikke lagre standard repositorium",
+  "defaultRepository": "Standard repositorium",
+  "selectDefaultRepoDesc": "Velg et standard repositorium for å opprette problemer. Du kan fortsatt spesifisere et annet repositorium når du oppretter problemer.",
+  "noReposFound": "Ingen repositorier funnet",
+  "private": "Privat",
+  "updatedDate": "Oppdatert {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "i går",
+  "daysAgo": "{count} dager siden",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 uke siden",
+  "weeksAgo": "{count} uker siden",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 måned siden",
+  "monthsAgo": "{count} måneder siden",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Problemer vil bli opprettet i ditt standard repositorium",
+  "taskIntegrations": "Oppgaveintegrasjoner",
+  "configureSettings": "Konfigurer innstillinger",
+  "completeAuthBrowser": "Fullfør autentisering i nettleseren din. Når du er ferdig, gå tilbake til appen.",
+  "failedToStartAppAuth": "Kunne ikke starte {appName}-autentisering",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Koble til {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Du må autorisere Omi til å opprette oppgaver i {appName}-kontoen din. Dette vil åpne nettleseren din for autentisering.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Fortsett",
+  "appIntegration": "{appName}-integrasjon",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integrasjon med {appName} kommer snart! Vi jobber hardt for å gi deg flere oppgavebehandlingsalternativer.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Skjønner",
+  "tasksExportedOneApp": "Oppgaver kan eksporteres til én app om gangen.",
+  "completeYourUpgrade": "Fullfør oppgraderingen din",
+  "importConfiguration": "Importer konfigurasjon",
+  "exportConfiguration": "Eksporter konfigurasjon",
+  "bringYourOwn": "Ta med din egen",
+  "payYourSttProvider": "Bruk omi fritt. Du betaler bare STT-leverandøren direkte.",
+  "freeMinutesMonth": "1 200 gratis minutter/måned inkludert. Ubegrenset med ",
+  "omiUnlimited": "Omi Ubegrenset",
+  "hostRequired": "Vert er påkrevd",
+  "validPortRequired": "Gyldig port er påkrevd",
+  "validWebsocketUrlRequired": "Gyldig WebSocket-URL er påkrevd (wss://)",
+  "apiUrlRequired": "API-URL er påkrevd",
+  "apiKeyRequired": "API-nøkkel er påkrevd",
+  "invalidJsonConfig": "Ugyldig JSON-konfigurasjon",
+  "errorSaving": "Feil ved lagring: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfigurasjon kopiert til utklippstavlen",
+  "pasteJsonConfig": "Lim inn JSON-konfigurasjonen din nedenfor:",
+  "addApiKeyAfterImport": "Du må legge til din egen API-nøkkel etter import",
+  "paste": "Lim inn",
+  "import": "Importer",
+  "invalidProviderInConfig": "Ugyldig leverandør i konfigurasjon",
+  "importedConfig": "Importert {providerName}-konfigurasjon",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Ugyldig JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Leverandør",
+  "live": "Live",
+  "onDevice": "På enhet",
+  "apiUrl": "API-URL",
+  "enterSttHttpEndpoint": "Skriv inn ditt STT HTTP-endepunkt",
+  "websocketUrl": "WebSocket-URL",
+  "enterLiveSttWebsocket": "Skriv inn ditt live STT WebSocket-endepunkt",
+  "apiKey": "API-nøkkel",
+  "enterApiKey": "Skriv inn API-nøkkelen din",
+  "storedLocallyNeverShared": "Lagret lokalt, aldri delt",
+  "host": "Vert",
+  "port": "Port",
+  "advanced": "Avansert",
+  "configuration": "Konfigurasjon",
+  "requestConfiguration": "Forespørselskonfigurasjon",
+  "responseSchema": "Responsskjema",
+  "modified": "Endret",
+  "resetRequestConfig": "Tilbakestill forespørselskonfigurasjon til standard",
+  "logs": "Logger",
+  "logsCopied": "Logger kopiert",
+  "noLogsYet": "Ingen logger ennå. Start opptak for å se tilpasset STT-aktivitet.",
+  "deviceUsesCodec": "{deviceName} bruker {codecReason}. Omi vil bli brukt.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi-transkripsjon",
+  "bestInClassTranscription": "Beste transkripsjon i sin klasse uten oppsett",
+  "instantSpeakerLabels": "Øyeblikkelige talermerkinger",
+  "languageTranslation": "100+ språkoversettelser",
+  "optimizedForConversation": "Optimalisert for samtaler",
+  "autoLanguageDetection": "Automatisk språkdeteksjon",
+  "highAccuracy": "Høy nøyaktighet",
+  "privacyFirst": "Personvern først",
+  "saveChanges": "Lagre endringer",
+  "resetToDefault": "Tilbakestill til standard",
+  "viewTemplate": "Vis mal",
+  "trySomethingLike": "Prøv noe som...",
+  "tryIt": "Prøv det",
+  "creatingPlan": "Oppretter plan",
+  "developingLogic": "Utvikler logikk",
+  "designingApp": "Designer app",
+  "generatingIconStep": "Genererer ikon",
+  "finalTouches": "Siste finpuss",
+  "processing": "Behandler...",
+  "features": "Funksjoner",
+  "creatingYourApp": "Oppretter appen din...",
+  "generatingIcon": "Genererer ikon...",
+  "whatShouldWeMake": "Hva skal vi lage?",
+  "appName": "Appnavn",
+  "description": "Beskrivelse",
+  "publicLabel": "Offentlig",
+  "privateLabel": "Privat",
+  "free": "Gratis",
+  "perMonth": "/ Måned",
+  "tailoredConversationSummaries": "Tilpassede samtalesammendrag",
+  "customChatbotPersonality": "Tilpasset chatbot-personlighet",
+  "makePublic": "Gjør offentlig",
+  "anyoneCanDiscover": "Alle kan oppdage appen din",
+  "onlyYouCanUse": "Bare du kan bruke denne appen",
+  "paidApp": "Betalt app",
+  "usersPayToUse": "Brukere betaler for å bruke appen din",
+  "freeForEveryone": "Gratis for alle",
+  "perMonthLabel": "/ måned",
+  "creating": "Oppretter...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Opprett app",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Søker etter enheter...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{ENHET} other{ENHETER}} FUNNET I NÆRHETEN",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PARING VELLYKKET",
+  "errorConnectingAppleWatch": "Feil ved tilkobling til Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Ikke vis igjen",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Jeg forstår",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Aktiver Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi trenger Bluetooth for å koble til den bærbare enheten din. Aktiver Bluetooth og prøv igjen.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Kontakte support?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Koble til senere",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Gi tillatelser",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Bakgrunnsaktivitet",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "La Omi kjøre i bakgrunnen for bedre stabilitet",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Posisjonstilgang",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Aktiver bakgrunnsposisjon for full opplevelse",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Varsler",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Aktiver varsler for å holde deg informert",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Posisjonstjeneste deaktivert",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Posisjonstjeneste er deaktivert. Gå til Innstillinger > Personvern og sikkerhet > Posisjonstjenester og aktiver den",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Bakgrunnsposisjonstilgang nektet",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Gå til enhetsinnstillinger og sett posisjonstillatelse til \"Alltid tillat\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Liker du Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Hjelp oss med å nå flere personer ved å legge igjen en anmeldelse i App Store. Tilbakemeldingen din betyr alt for oss!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Hjelp oss med å nå flere personer ved å legge igjen en anmeldelse i Google Play Store. Tilbakemeldingen din betyr alt for oss!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Vurder i App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Vurder i Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Kanskje senere",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi må lære målene og stemmen din. Du kan endre det senere.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Kom i gang",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Alt ferdig!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Fortsett, du gjør det bra",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Hopp over dette spørsmålet",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Hopp over foreløpig",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Tilkoblingsfeil",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Kunne ikke koble til serveren. Sjekk internettforbindelsen din og prøv igjen.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Ugyldig opptak oppdaget",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Det ser ut til å være flere talere i opptaket. Pass på at du er på et stille sted og prøv igjen.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Det er ikke nok tale oppdaget. Snakk mer og prøv igjen.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Pass på at du snakker i minst 5 sekunder og ikke mer enn 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Er du der?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Vi kunne ikke oppdage noen tale. Pass på å snakke i minst 10 sekunder og ikke mer enn 3 minutter.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Tilkobling tapt",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Tilkoblingen ble avbrutt. Sjekk internettforbindelsen din og prøv igjen.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Prøv igjen",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Koble til Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Fortsett uten enhet",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Tillatelser kreves",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Denne appen trenger Bluetooth- og posisjonstillatelser for å fungere ordentlig. Aktiver dem i innstillingene.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Åpne innstillinger",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Vil du bli kalt noe annet?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Hva heter du?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Snakk. Transkriber. Sammenfatt.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Logg inn med Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Logg inn med Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Ved å fortsette godtar du vår ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Bruksvilkår",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Din AI-følgesvenn",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Fang hvert øyeblikk. Få AI-drevne\nsammendrag. Aldri ta notater igjen.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch-oppsett",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Tillatelse forespurt!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Mikrofontillatelse",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Tillatelse gitt! Nå:\n\nÅpne Omi-appen på klokken din og trykk \"Fortsett\" nedenfor",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Vi trenger mikrofontillatelse.\n\n1. Trykk \"Gi tillatelse\"\n2. Tillat på iPhone\n3. Klokkeapp vil lukkes\n4. Åpne på nytt og trykk \"Fortsett\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Gi tillatelse",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Trenger du hjelp?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Feilsøking:\n\n1. Sørg for at Omi er installert på klokken din\n2. Åpne Omi-appen på klokken din\n3. Se etter tillatelsespopup\n4. Trykk \"Tillat\" når du blir bedt om det\n5. App på klokken vil lukkes - åpne den på nytt\n6. Kom tilbake og trykk \"Fortsett\" på iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Opptak startet!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Tillatelse ikke gitt ennå. Pass på at du tillot mikrofontilgang og åpnet appen på nytt på klokken din.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Feil ved forespørsel om tillatelse: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Feil ved oppstart av opptak: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Velg hovedspråket ditt",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Angi språket ditt for skarpere transkripsjoner og en personlig opplevelse",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Hva er ditt hovedspråk?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Velg språket ditt",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Din personlige vekstreise med AI som lytter til hvert ord.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Gjøremål",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Trykk for å redigere • Langt trykk for å velge • Sveip for handlinger",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Å gjøre",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Ferdig",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Gamle",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Alt ferdig!\nIngen ventende handlingspunkter",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Ingen fullførte elementer ennå",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Ingen gamle oppgaver",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Ingen elementer",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Handlingspunkt merket som ufullført",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Handlingspunkt fullført",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Slette handlingspunkt",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Er du sikker på at du vil slette dette handlingspunktet?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Slette valgte elementer",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Er du sikker på at du vil slette {count} valgte handlingspunkt{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Handlingspunkt \"{description}\" slettet",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} handlingspunkt{s} slettet",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Kunne ikke slette handlingspunkt",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Kunne ikke slette elementer",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Kunne ikke slette noen elementer",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Klar for handlingspunkter",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "AI-en din vil automatisk trekke ut oppgaver og gjøremål fra samtalene dine. De vil dukke opp her når de opprettes.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automatisk trukket ut fra samtaler",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Trykk for å redigere, sveip for å fullføre eller slette",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} valgt",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Velg alle",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Slett valgte",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Søk i {count} minner",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Minne slettet.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Angre",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Ingen minner ennå",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Ingen automatisk uttrukne minner ennå",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Ingen manuelle minner ennå",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Ingen minner i disse kategoriene",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Ingen minner funnet",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Legg til ditt første minne",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Tømme Omis minne",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Er du sikker på at du vil tømme Omis minne? Dette kan ikke angres.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Tøm minne",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omis minne om deg har blitt tømt",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Ingen minner å slette",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Opprett nytt minne",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Opprett nytt handlingspunkt",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Minneadministrasjon",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtrer minner",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Du har {count} totale minner",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Offentlige minner",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Private minner",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Gjør alle minner private",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Gjør alle minner offentlige",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Slett alle minner",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Alle minner er nå private",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Alle minner er nå offentlige",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Nytt minne",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Rediger minne",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Jeg liker å spise iskrem...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Kunne ikke lagre. Sjekk forbindelsen din.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Lagre minne",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Prøv igjen",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Opprett handlingspunkt",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Rediger handlingspunkt",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Hva må gjøres?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Beskrivelse av handlingspunkt kan ikke være tom.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Handlingspunkt oppdatert",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Kunne ikke oppdatere handlingspunkt",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Handlingspunkt opprettet",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Kunne ikke opprette handlingspunkt",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Forfallsdato",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Tid",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Legg til forfallsdato",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Trykk ferdig for å lagre",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Trykk ferdig for å opprette",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Alle",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Om deg",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Innsikter",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuell",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Fullført",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Merk som fullført",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Handlingspunkt slettet",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Kunne ikke slette handlingspunkt",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Slette handlingspunkt",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Er du sikker på at du vil slette dette handlingspunktet?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Appspråk",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "APP-GRENSESNITT",
+  "speechTranscriptionSectionTitle": "TALE OG TRANSKRIPSJON",
+  "languageSettingsHelperText": "App-språk endrer menyer og knapper. Talespråk påvirker hvordan opptakene dine transkriberes."
+}

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "pl",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Rozmowa",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkrypcja",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Zadania",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Usunąć rozmowę?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Czy na pewno chcesz usunąć tę rozmowę? Ta czynność nie może zostać cofnięta.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Potwierdź",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Anuluj",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "OK",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Usuń",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Dodaj",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Aktualizuj",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Zapisz",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Edytuj",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Zamknij",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Wyczyść",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopiuj transkrypcję",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopiuj podsumowanie",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Testuj prompt",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Przetwórz ponownie rozmowę",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Usuń rozmowę",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Zawartość skopiowana do schowka",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Nie udało się zaktualizować statusu ulubionego.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Nie można udostępnić adresu URL rozmowy.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Błąd podczas przetwarzania rozmowy. Spróbuj ponownie później.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Sprawdź połączenie internetowe i spróbuj ponownie.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Nie można usunąć rozmowy",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Coś poszło nie tak! Spróbuj ponownie później.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopiuj komunikat błędu",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Komunikat błędu skopiowany do schowka",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Pozostało",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Ładowanie...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Ładowanie czasu trwania...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekund",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Osoby",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Dodaj nową osobę",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Edytuj osobę",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Utwórz nową osobę i naucz Omi rozpoznawać jej głos!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Profil głosu",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Próbka {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Ustawienia",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Język",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Wybierz język",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Usuwanie...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Ukończ uwierzytelnianie w przeglądarce. Po zakończeniu wróć do aplikacji.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Nie udało się rozpocząć uwierzytelniania",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import rozpoczęty! Otrzymasz powiadomienie po zakończeniu.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Nie udało się rozpocząć importu. Spróbuj ponownie.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Nie można uzyskać dostępu do wybranego pliku",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Zapytaj Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Gotowe",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Rozłączono",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Wyszukiwanie",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Połącz urządzenie",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Osiągnięto miesięczny limit.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Sprawdź wykorzystanie",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Synchronizacja nagrań",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Nagrania do synchronizacji",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Wszystko na bieżąco",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Synchronizuj",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Pendant jest aktualny",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Wszystkie nagrania są zsynchronizowane",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Trwa synchronizacja",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Gotowe do synchronizacji",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Dotknij Synchronizuj, aby rozpocząć",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Pendant nie jest podłączony. Podłącz, aby zsynchronizować.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Wszystko jest już zsynchronizowane.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Masz nagrania, które nie zostały jeszcze zsynchronizowane.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Będziemy synchronizować Twoje nagrania w tle.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Brak rozmów.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Brak ulubionych rozmów.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Aby oznaczyć rozmowę gwiazdką, otwórz ją i dotknij ikony gwiazdki w nagłówku.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Szukaj rozmów",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "Wybrano: {count}",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Scal",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Scal rozmowy",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Spowoduje to połączenie {count} rozmów w jedną. Cała zawartość zostanie scalone i wygenerowana ponownie.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Scalanie w tle. To może chwilę potrwać.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Nie udało się rozpocząć scalania",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Zapytaj o cokolwiek",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Brak wiadomości!\nCzemu nie rozpoczniesz rozmowy?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Usuwanie Twoich wiadomości z pamięci Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Wiadomość skopiowana do schowka.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Nie możesz zgłosić własnych wiadomości.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Zgłoś wiadomość",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Czy na pewno chcesz zgłosić tę wiadomość?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Wiadomość zgłoszona pomyślnie.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Dziękujemy za opinię!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Wyczyścić czat?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Czy na pewno chcesz wyczyścić czat? Ta czynność nie może zostać cofnięta.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Możesz przesłać maksymalnie 4 pliki naraz",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Czat z Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Aplikacje",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Nie znaleziono aplikacji",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Spróbuj dostosować wyszukiwanie lub filtry",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Stwórz własną aplikację",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Zbuduj i udostępnij swoją własną aplikację",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Przeszukaj ponad 1500 aplikacji",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Moje aplikacje",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Zainstalowane aplikacje",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Nie można pobrać aplikacji :(\n\nSprawdź połączenie internetowe i spróbuj ponownie.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "O Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Polityką prywatności",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Odwiedź stronę",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Pomoc lub pytania?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Dołącz do społeczności!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "Ponad 8000 członków i wciąż przybywa.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Usuń konto",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Czy na pewno chcesz usunąć swoje konto?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Tej operacji nie można cofnąć.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Wszystkie Twoje wspomnienia i rozmowy zostaną trwale usunięte.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Twoje aplikacje i integracje zostaną natychmiast rozłączone.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Możesz wyeksportować swoje dane przed usunięciem konta, ale po usunięciu nie można ich odzyskać.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Rozumiem, że usunięcie mojego konta jest trwałe i wszystkie dane, w tym wspomnienia i rozmowy, zostaną utracone bez możliwości odzyskania.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Czy jesteś pewien?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Ta czynność jest nieodwracalna i trwale usunie Twoje konto oraz wszystkie powiązane dane. Czy na pewno chcesz kontynuować?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Usuń teraz",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Wróć",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Zaznacz pole, aby potwierdzić, że rozumiesz, iż usunięcie konta jest trwałe i nieodwracalne.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Imię",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Email",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Własny słownik",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identyfikacja innych osób",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Metody płatności",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Wyświetlanie rozmów",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Dane i prywatność",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID użytkownika",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Nie ustawiono",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID użytkownika skopiowane do schowka",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Domyślny systemowy",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plan i wykorzystanie",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Synchronizacja offline",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Ustawienia urządzenia",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Narzędzia czatu",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Opinia / Błąd",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Centrum pomocy",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Ustawienia programisty",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Pobierz Omi dla Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Program poleceń",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Wyloguj się",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Szczegóły aplikacji i urządzenia skopiowane",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Podsumowanie 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Twoja prywatność, Twoja kontrola",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "W Omi dbamy o Twoją prywatność. Ta strona pozwala kontrolować sposób przechowywania i wykorzystywania Twoich danych.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Dowiedz się więcej...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Poziom ochrony danych",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Twoje dane są domyślnie zabezpieczone silnym szyfrowaniem. Przejrzyj swoje ustawienia i przyszłe opcje prywatności poniżej.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Dostęp aplikacji",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Następujące aplikacje mogą uzyskać dostęp do Twoich danych. Dotknij aplikacji, aby zarządzać jej uprawnieniami.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Żadne zainstalowane aplikacje nie mają zewnętrznego dostępu do Twoich danych.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Nazwa urządzenia",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID urządzenia",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Oprogramowanie",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Synchronizacja karty SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Wersja sprzętu",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Numer modelu",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Producent",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Podwójne dotknięcie",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Jasność LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Wzmocnienie mikrofonu",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Rozłącz",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Zapomnij urządzenie",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Problemy z ładowaniem",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Rozłącz urządzenie",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Rozparuj urządzenie",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Rozparuj i zapomnij urządzenie",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Twoje Omi zostało rozłączone 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Urządzenie rozparowane. Przejdź do Ustawienia > Bluetooth i zapomnij urządzenie, aby zakończyć parowanie.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Rozparuj urządzenie",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Spowoduje to rozparowanie urządzenia, aby można je było podłączyć do innego telefonu. Musisz przejść do Ustawienia > Bluetooth i zapomnieć urządzenie, aby zakończyć proces.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Urządzenie nie jest podłączone",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Podłącz swoje urządzenie Omi, aby uzyskać dostęp\ndo ustawień urządzenia i personalizacji",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Informacje o urządzeniu",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Personalizacja",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Sprzęt",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "Nie wykryto V2",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Widzimy, że masz urządzenie V1 lub Twoje urządzenie nie jest podłączone. Funkcja karty SD jest dostępna tylko dla urządzeń V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Zakończ rozmowę",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Wstrzymaj/Wznów",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Oznacz rozmowę gwiazdką",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Akcja podwójnego dotknięcia",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Zakończ i przetwórz rozmowę",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Wstrzymaj/wznów nagrywanie",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Oznacz bieżącą rozmowę gwiazdką",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Wył.",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maks.",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Wycisz",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Cicho",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normalnie",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Wysoko",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon jest wyciszony",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Bardzo cicho - do głośnych środowisk",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Cicho - do umiarkowanego hałasu",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutralnie - zrównoważone nagrywanie",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Lekko wzmocnione - normalne użycie",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Wzmocnione - do cichych środowisk",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Wysokie - do odległych lub cichych głosów",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Bardzo wysokie - do bardzo cichych źródeł",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksymalne - używaj z ostrożnością",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Ustawienia programisty",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Zapisywanie...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Skonfiguruj swoją osobowość AI",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkrypcja",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Skonfiguruj dostawcę STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Limit czasu rozmowy",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Ustaw, kiedy rozmowy kończą się automatycznie",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importuj dane",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importuj dane z innych źródeł",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Debugowanie i diagnostyka",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Adres URL punktu końcowego",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Brak kluczy API",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Utwórz klucz, aby rozpocząć",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Utwórz klucz",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentacja",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Twoje statystyki Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Dzisiaj",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "W tym miesiącu",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "W tym roku",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Cały czas",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Brak aktywności",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Rozpocznij rozmowę z Omi,\naby zobaczyć tutaj statystyki wykorzystania.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Słuchanie",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Całkowity czas, przez który Omi aktywnie słuchało.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Rozumienie",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Słowa zrozumiane z Twoich rozmów.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Dostarczanie",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Zadania i notatki automatycznie zarejestrowane.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Zapamiętywanie",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakty i szczegóły zapamiętane dla Ciebie.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Plan nieograniczony",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Zarządzaj planem",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Twój plan zostanie anulowany {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Twój plan odnawia się {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Plan darmowy",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "Wykorzystano {used} z {limit} min",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Ulepsz",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Ulepsz do nieograniczonego",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Twój plan obejmuje {limit} darmowych minut miesięcznie. Ulepsz, aby uzyskać nielimitowany dostęp.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Udostępniam moje statystyki Omi! (omi.me - Twój asystent AI zawsze dostępny)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Dzisiaj Omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "W tym miesiącu Omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "W tym roku Omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Do tej pory Omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Słuchało przez {minutes} minut",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Zrozumiało {words} słów",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Dostarczyło {count} spostrzeżeń",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Zapamiętało {count} wspomnień",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Logi debugowania",
+  "debugLogsAutoDelete": "Automatyczne usuwanie po 3 dniach.",
+  "debugLogsDesc": "Pomaga diagnozować problemy",
+  "noLogFilesFound": "Nie znaleziono plików logów.",
+  "omiDebugLog": "Log debugowania Omi",
+  "logShared": "Log udostępniony",
+  "selectLogFile": "Wybierz plik logu",
+  "shareLogs": "Udostępnij logi",
+  "debugLogCleared": "Log debugowania wyczyszczony",
+  "exportStarted": "Eksport rozpoczęty. To może potrwać kilka sekund...",
+  "exportAllData": "Eksportuj wszystkie dane",
+  "exportDataDesc": "Eksportuj rozmowy do pliku JSON",
+  "exportedConversations": "Wyeksportowane rozmowy z Omi",
+  "exportShared": "Eksport udostępniony",
+  "deleteKnowledgeGraphTitle": "Usunąć graf wiedzy?",
+  "deleteKnowledgeGraphMessage": "Spowoduje to usunięcie wszystkich danych grafu wiedzy (węzłów i połączeń). Twoje oryginalne wspomnienia pozostaną bezpieczne. Graf zostanie odbudowany z czasem lub na następne żądanie.",
+  "knowledgeGraphDeleted": "Graf wiedzy usunięty pomyślnie",
+  "deleteGraphFailed": "Nie udało się usunąć grafu: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Usuń graf wiedzy",
+  "deleteKnowledgeGraphDesc": "Wyczyść wszystkie węzły i połączenia",
+  "mcp": "MCP",
+  "mcpServer": "Serwer MCP",
+  "mcpServerDesc": "Połącz asystentów AI z Twoimi danymi",
+  "serverUrl": "Adres URL serwera",
+  "urlCopied": "Adres URL skopiowany",
+  "apiKeyAuth": "Uwierzytelnianie kluczem API",
+  "header": "Nagłówek",
+  "authorizationBearer": "Authorization: Bearer <klucz>",
+  "oauth": "OAuth",
+  "clientId": "ID klienta",
+  "clientSecret": "Sekret klienta",
+  "useMcpApiKey": "Użyj swojego klucza API MCP",
+  "webhooks": "Webhooki",
+  "conversationEvents": "Zdarzenia rozmowy",
+  "newConversationCreated": "Utworzono nową rozmowę",
+  "realtimeTranscript": "Transkrypcja w czasie rzeczywistym",
+  "transcriptReceived": "Otrzymano transkrypcję",
+  "audioBytes": "Bajty audio",
+  "audioDataReceived": "Otrzymano dane audio",
+  "intervalSeconds": "Interwał (sekundy)",
+  "daySummary": "Podsumowanie dnia",
+  "summaryGenerated": "Wygenerowano podsumowanie",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Dodaj do claude_desktop_config.json",
+  "copyConfig": "Kopiuj konfigurację",
+  "configCopied": "Konfiguracja skopiowana do schowka",
+  "listeningMins": "Słuchanie (min)",
+  "understandingWords": "Rozumienie (słowa)",
+  "insights": "Spostrzeżenia",
+  "memories": "Wspomnienia",
+  "minsUsedThisMonth": "Wykorzystano {used} z {limit} min w tym miesiącu",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "Wykorzystano {used} z {limit} słów w tym miesiącu",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "Uzyskano {used} z {limit} spostrzeżeń w tym miesiącu",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "Utworzono {used} z {limit} wspomnień w tym miesiącu",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Widoczność",
+  "visibilitySubtitle": "Kontroluj, które rozmowy pojawiają się na Twojej liście",
+  "showShortConversations": "Pokaż krótkie rozmowy",
+  "showShortConversationsDesc": "Wyświetl rozmowy krótsze niż próg",
+  "showDiscardedConversations": "Pokaż odrzucone rozmowy",
+  "showDiscardedConversationsDesc": "Uwzględnij rozmowy oznaczone jako odrzucone",
+  "shortConversationThreshold": "Próg krótkiej rozmowy",
+  "shortConversationThresholdSubtitle": "Rozmowy krótsze niż ten próg będą ukryte, chyba że włączysz powyższą opcję",
+  "durationThreshold": "Próg czasu trwania",
+  "durationThresholdDesc": "Ukryj rozmowy krótsze niż ten próg",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Własny słownik",
+  "addWords": "Dodaj słowa",
+  "addWordsDesc": "Imiona, terminy lub rzadkie słowa",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Połącz",
+  "comingSoon": "Wkrótce",
+  "chatToolsFooter": "Połącz swoje aplikacje, aby wyświetlać dane i metryki w czacie.",
+  "completeAuthInBrowser": "Ukończ uwierzytelnianie w przeglądarce. Po zakończeniu wróć do aplikacji.",
+  "failedToStartAuth": "Nie udało się rozpocząć uwierzytelniania {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Rozłączyć {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Czy na pewno chcesz rozłączyć się z {appName}? Możesz ponownie połączyć w dowolnym momencie.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Rozłączono z {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Nie udało się rozłączyć",
+  "connectTo": "Połącz z {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Musisz upoważnić Omi do dostępu do Twoich danych {appName}. Otworzy to przeglądarkę w celu uwierzytelnienia.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Kontynuuj",
+  "languageTitle": "Język",
+  "primaryLanguage": "Język podstawowy",
+  "automaticTranslation": "Automatyczne tłumaczenie",
+  "detectLanguages": "Wykryj ponad 10 języków",
+  "authorizeSavingRecordings": "Autoryzuj zapisywanie nagrań",
+  "thanksForAuthorizing": "Dziękujemy za autoryzację!",
+  "needYourPermission": "Potrzebujemy Twojego pozwolenia",
+  "alreadyGavePermission": "Już udzieliłeś nam zgody na zapisywanie nagrań. Oto przypomnienie, dlaczego tego potrzebujemy:",
+  "wouldLikePermission": "Chcielibyśmy uzyskać Twoją zgodę na zapisywanie nagrań głosowych. Oto dlaczego:",
+  "improveSpeechProfile": "Popraw swój profil głosu",
+  "improveSpeechProfileDesc": "Używamy nagrań do dalszego szkolenia i ulepszania Twojego osobistego profilu głosu.",
+  "trainFamilyProfiles": "Trenuj profile dla przyjaciół i rodziny",
+  "trainFamilyProfilesDesc": "Twoje nagrania pomagają nam rozpoznawać i tworzyć profile dla Twoich przyjaciół i rodziny.",
+  "enhanceTranscriptAccuracy": "Zwiększ dokładność transkrypcji",
+  "enhanceTranscriptAccuracyDesc": "W miarę jak nasz model się poprawia, możemy zapewnić lepsze wyniki transkrypcji Twoich nagrań.",
+  "legalNotice": "Uwaga prawna: Legalność nagrywania i przechowywania danych głosowych może się różnić w zależności od lokalizacji i sposobu korzystania z tej funkcji. Twoim obowiązkiem jest zapewnienie zgodności z lokalnymi przepisami i regulacjami.",
+  "alreadyAuthorized": "Już autoryzowano",
+  "authorize": "Autoryzuj",
+  "revokeAuthorization": "Cofnij autoryzację",
+  "authorizationSuccessful": "Autoryzacja pomyślna!",
+  "failedToAuthorize": "Nie udało się autoryzować. Spróbuj ponownie.",
+  "authorizationRevoked": "Autoryzacja cofnięta.",
+  "recordingsDeleted": "Nagrania usunięte.",
+  "failedToRevoke": "Nie udało się cofnąć autoryzacji. Spróbuj ponownie.",
+  "permissionRevokedTitle": "Cofnięto pozwolenie",
+  "permissionRevokedMessage": "Czy chcesz, abyśmy usunęli również wszystkie Twoje istniejące nagrania?",
+  "yes": "Tak",
+  "editName": "Edytuj imię",
+  "howShouldOmiCallYou": "Jak Omi powinno Cię nazywać?",
+  "enterYourName": "Wprowadź swoje imię",
+  "nameCannotBeEmpty": "Imię nie może być puste",
+  "nameUpdatedSuccessfully": "Imię zaktualizowane pomyślnie!",
+  "calendarSettings": "Ustawienia kalendarza",
+  "calendarProviders": "Dostawcy kalendarza",
+  "macOsCalendar": "Kalendarz macOS",
+  "connectMacOsCalendar": "Połącz swój lokalny kalendarz macOS",
+  "googleCalendar": "Kalendarz Google",
+  "syncGoogleAccount": "Synchronizuj z kontem Google",
+  "showMeetingsMenuBar": "Pokaż nadchodzące spotkania w pasku menu",
+  "showMeetingsMenuBarDesc": "Wyświetl następne spotkanie i czas do jego rozpoczęcia w pasku menu macOS",
+  "showEventsNoParticipants": "Pokaż wydarzenia bez uczestników",
+  "showEventsNoParticipantsDesc": "Po włączeniu, Nadchodzące pokazuje wydarzenia bez uczestników lub linku wideo.",
+  "yourMeetings": "Twoje spotkania",
+  "refresh": "Odśwież",
+  "noUpcomingMeetings": "Nie znaleziono nadchodzących spotkań",
+  "checkingNextDays": "Sprawdzanie następnych 30 dni",
+  "tomorrow": "Jutro",
+  "googleCalendarComingSoon": "Integracja z Kalendarzem Google wkrótce!",
+  "connectedAsUser": "Połączono jako użytkownik: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Domyślny obszar roboczy",
+  "tasksCreatedInWorkspace": "Zadania będą tworzone w tym obszarze roboczym",
+  "defaultProjectOptional": "Domyślny projekt (opcjonalnie)",
+  "leaveUnselectedTasks": "Pozostaw niezaznaczone, aby tworzyć zadania bez projektu",
+  "noProjectsInWorkspace": "Nie znaleziono projektów w tym obszarze roboczym",
+  "conversationTimeoutDesc": "Wybierz, jak długo czekać w ciszy przed automatycznym zakończeniem rozmowy:",
+  "timeout2Minutes": "2 minuty",
+  "timeout2MinutesDesc": "Zakończ rozmowę po 2 minutach ciszy",
+  "timeout5Minutes": "5 minut",
+  "timeout5MinutesDesc": "Zakończ rozmowę po 5 minutach ciszy",
+  "timeout10Minutes": "10 minut",
+  "timeout10MinutesDesc": "Zakończ rozmowę po 10 minutach ciszy",
+  "timeout30Minutes": "30 minut",
+  "timeout30MinutesDesc": "Zakończ rozmowę po 30 minutach ciszy",
+  "timeout4Hours": "4 godziny",
+  "timeout4HoursDesc": "Zakończ rozmowę po 4 godzinach ciszy",
+  "conversationEndAfterHours": "Rozmowy będą teraz kończyć się po 4 godzinach ciszy",
+  "conversationEndAfterMinutes": "Rozmowy będą teraz kończyć się po {minutes} minutach ciszy",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Podaj nam swój język podstawowy",
+  "languageForTranscription": "Ustaw swój język dla ostrzejszych transkrypcji i spersonalizowanego doświadczenia.",
+  "singleLanguageModeInfo": "Tryb pojedynczego języka jest włączony. Tłumaczenie jest wyłączone dla większej dokładności.",
+  "searchLanguageHint": "Szukaj języka według nazwy lub kodu",
+  "noLanguagesFound": "Nie znaleziono języków",
+  "skip": "Pomiń",
+  "languageSetTo": "Język ustawiony na {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Nie udało się ustawić języka",
+  "appSettings": "Ustawienia {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Rozłączyć z {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Spowoduje to usunięcie uwierzytelnienia {appName}. Będziesz musiał ponownie połączyć, aby użyć go ponownie.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Połączono z {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Konto",
+  "actionItemsSyncedTo": "Twoje zadania będą synchronizowane z Twoim kontem {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Domyślna przestrzeń",
+  "selectSpaceInWorkspace": "Wybierz przestrzeń w swoim obszarze roboczym",
+  "noSpacesInWorkspace": "Nie znaleziono przestrzeni w tym obszarze roboczym",
+  "defaultList": "Domyślna lista",
+  "tasksAddedToList": "Zadania będą dodawane do tej listy",
+  "noListsInSpace": "Nie znaleziono list w tej przestrzeni",
+  "failedToLoadRepos": "Nie udało się załadować repozytoriów: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Domyślne repozytorium zapisane",
+  "failedToSaveDefaultRepo": "Nie udało się zapisać domyślnego repozytorium",
+  "defaultRepository": "Domyślne repozytorium",
+  "selectDefaultRepoDesc": "Wybierz domyślne repozytorium do tworzenia problemów. Nadal możesz określić inne repozytorium podczas tworzenia problemów.",
+  "noReposFound": "Nie znaleziono repozytoriów",
+  "private": "Prywatne",
+  "updatedDate": "Zaktualizowano {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "wczoraj",
+  "daysAgo": "{count} dni temu",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 tydzień temu",
+  "weeksAgo": "{count} tygodni temu",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 miesiąc temu",
+  "monthsAgo": "{count} miesięcy temu",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Problemy będą tworzone w Twoim domyślnym repozytorium",
+  "taskIntegrations": "Integracje zadań",
+  "configureSettings": "Konfiguruj ustawienia",
+  "completeAuthBrowser": "Ukończ uwierzytelnianie w przeglądarce. Po zakończeniu wróć do aplikacji.",
+  "failedToStartAppAuth": "Nie udało się rozpocząć uwierzytelniania {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Połącz z {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Musisz upoważnić Omi do tworzenia zadań w Twoim koncie {appName}. Otworzy to przeglądarkę w celu uwierzytelnienia.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Kontynuuj",
+  "appIntegration": "Integracja z {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integracja z {appName} wkrótce! Ciężko pracujemy, aby przynieść Ci więcej opcji zarządzania zadaniami.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Rozumiem",
+  "tasksExportedOneApp": "Zadania mogą być eksportowane do jednej aplikacji naraz.",
+  "completeYourUpgrade": "Ukończ aktualizację",
+  "importConfiguration": "Importuj konfigurację",
+  "exportConfiguration": "Eksportuj konfigurację",
+  "bringYourOwn": "Przynieś własny",
+  "payYourSttProvider": "Swobodnie korzystaj z Omi. Płacisz tylko swojemu dostawcy STT bezpośrednio.",
+  "freeMinutesMonth": "1200 darmowych minut/miesiąc w zestawie. Nieograniczone z ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Host jest wymagany",
+  "validPortRequired": "Wymagany jest prawidłowy port",
+  "validWebsocketUrlRequired": "Wymagany jest prawidłowy adres URL WebSocket (wss://)",
+  "apiUrlRequired": "Adres URL API jest wymagany",
+  "apiKeyRequired": "Klucz API jest wymagany",
+  "invalidJsonConfig": "Nieprawidłowa konfiguracja JSON",
+  "errorSaving": "Błąd zapisu: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfiguracja skopiowana do schowka",
+  "pasteJsonConfig": "Wklej swoją konfigurację JSON poniżej:",
+  "addApiKeyAfterImport": "Musisz dodać własny klucz API po zaimportowaniu",
+  "paste": "Wklej",
+  "import": "Importuj",
+  "invalidProviderInConfig": "Nieprawidłowy dostawca w konfiguracji",
+  "importedConfig": "Zaimportowano konfigurację {providerName}",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Nieprawidłowy JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Dostawca",
+  "live": "Na żywo",
+  "onDevice": "Na urządzeniu",
+  "apiUrl": "Adres URL API",
+  "enterSttHttpEndpoint": "Wprowadź swój punkt końcowy HTTP STT",
+  "websocketUrl": "Adres URL WebSocket",
+  "enterLiveSttWebsocket": "Wprowadź swój punkt końcowy WebSocket STT na żywo",
+  "apiKey": "Klucz API",
+  "enterApiKey": "Wprowadź swój klucz API",
+  "storedLocallyNeverShared": "Przechowywane lokalnie, nigdy nie udostępniane",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Zaawansowane",
+  "configuration": "Konfiguracja",
+  "requestConfiguration": "Konfiguracja żądania",
+  "responseSchema": "Schemat odpowiedzi",
+  "modified": "Zmodyfikowano",
+  "resetRequestConfig": "Zresetuj konfigurację żądania do domyślnej",
+  "logs": "Logi",
+  "logsCopied": "Logi skopiowane",
+  "noLogsYet": "Brak logów. Rozpocznij nagrywanie, aby zobaczyć aktywność niestandardowego STT.",
+  "deviceUsesCodec": "{deviceName} używa {codecReason}. Będzie używane Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Transkrypcja Omi",
+  "bestInClassTranscription": "Najlepsza w klasie transkrypcja bez konfiguracji",
+  "instantSpeakerLabels": "Natychmiastowe etykiety mówców",
+  "languageTranslation": "Tłumaczenie na ponad 100 języków",
+  "optimizedForConversation": "Zoptymalizowane pod kątem rozmów",
+  "autoLanguageDetection": "Automatyczne wykrywanie języka",
+  "highAccuracy": "Wysoka dokładność",
+  "privacyFirst": "Prywatność na pierwszym miejscu",
+  "saveChanges": "Zapisz zmiany",
+  "resetToDefault": "Zresetuj do domyślnego",
+  "viewTemplate": "Zobacz szablon",
+  "trySomethingLike": "Spróbuj czegoś takiego...",
+  "tryIt": "Wypróbuj",
+  "creatingPlan": "Tworzenie planu",
+  "developingLogic": "Rozwijanie logiki",
+  "designingApp": "Projektowanie aplikacji",
+  "generatingIconStep": "Generowanie ikony",
+  "finalTouches": "Końcowe poprawki",
+  "processing": "Przetwarzanie...",
+  "features": "Funkcje",
+  "creatingYourApp": "Tworzenie Twojej aplikacji...",
+  "generatingIcon": "Generowanie ikony...",
+  "whatShouldWeMake": "Co powinniśmy stworzyć?",
+  "appName": "Nazwa aplikacji",
+  "description": "Opis",
+  "publicLabel": "Publiczne",
+  "privateLabel": "Prywatne",
+  "free": "Darmowe",
+  "perMonth": "/ miesiąc",
+  "tailoredConversationSummaries": "Dostosowane podsumowania rozmów",
+  "customChatbotPersonality": "Niestandardowa osobowość chatbota",
+  "makePublic": "Upublicznij",
+  "anyoneCanDiscover": "Każdy może odkryć Twoją aplikację",
+  "onlyYouCanUse": "Tylko Ty możesz korzystać z tej aplikacji",
+  "paidApp": "Płatna aplikacja",
+  "usersPayToUse": "Użytkownicy płacą za korzystanie z Twojej aplikacji",
+  "freeForEveryone": "Darmowa dla wszystkich",
+  "perMonthLabel": "/ miesiąc",
+  "creating": "Tworzenie...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Utwórz aplikację",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Wyszukiwanie urządzeń...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "ZNALEZIONO {count} {count, plural, =1{URZĄDZENIE} few{URZĄDZENIA} other{URZĄDZEŃ}} W POBLIŻU",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PAROWANIE UDANE",
+  "errorConnectingAppleWatch": "Błąd połączenia z Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Nie pokazuj ponownie",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Rozumiem",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Włącz Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi potrzebuje Bluetooth, aby połączyć się z Twoim urządzeniem noszonym. Włącz Bluetooth i spróbuj ponownie.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Skontaktuj się z pomocą techniczną?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Połącz później",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Przyznaj uprawnienia",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Aktywność w tle",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Pozwól Omi działać w tle dla lepszej stabilności",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Dostęp do lokalizacji",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Włącz lokalizację w tle dla pełnego doświadczenia",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Powiadomienia",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Włącz powiadomienia, aby być na bieżąco",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Usługa lokalizacji wyłączona",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Usługa lokalizacji jest wyłączona. Przejdź do Ustawienia > Prywatność i bezpieczeństwo > Usługi lokalizacji i włącz ją",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Odmowa dostępu do lokalizacji w tle",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Przejdź do ustawień urządzenia i ustaw uprawnienie lokalizacji na \"Zawsze zezwalaj\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Podoba Ci się Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Pomóż nam dotrzeć do większej liczby osób, zostawiając recenzję w App Store. Twoja opinia wiele dla nas znaczy!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Pomóż nam dotrzeć do większej liczby osób, zostawiając recenzję w Google Play Store. Twoja opinia wiele dla nas znaczy!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Oceń w App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Oceń w Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Może później",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi musi poznać Twoje cele i Twój głos. Będziesz mógł to później zmodyfikować.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Rozpocznij",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Wszystko gotowe!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Dalej tak trzymaj, świetnie Ci idzie",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Pomiń to pytanie",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Pomiń na razie",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Błąd połączenia",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Nie udało się połączyć z serwerem. Sprawdź połączenie internetowe i spróbuj ponownie.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Wykryto nieprawidłowe nagranie",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Wygląda na to, że w nagraniu jest wielu mówców. Upewnij się, że jesteś w cichym miejscu i spróbuj ponownie.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Nie wykryto wystarczającej ilości mowy. Mów więcej i spróbuj ponownie.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Upewnij się, że mówisz przez co najmniej 5 sekund i nie więcej niż 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Jesteś tam?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Nie udało się wykryć żadnej mowy. Upewnij się, że mówisz przez co najmniej 10 sekund i nie więcej niż 3 minuty.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Utracono połączenie",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Połączenie zostało przerwane. Sprawdź połączenie internetowe i spróbuj ponownie.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Spróbuj ponownie",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Połącz Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Kontynuuj bez urządzenia",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Wymagane uprawnienia",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Ta aplikacja wymaga uprawnień Bluetooth i lokalizacji, aby działać prawidłowo. Włącz je w ustawieniach.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Otwórz ustawienia",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Chcesz być nazywany inaczej?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Jak masz na imię?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Mów. Transkrybuj. Podsumuj.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Zaloguj się przez Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Zaloguj się przez Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Kontynuując, zgadzasz się z naszą ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Warunkami korzystania",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Twój kompan AI",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Uchwycaj każdą chwilę. Otrzymuj podsumowania\nnapędzane przez AI. Nigdy więcej nie rób notatek.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Konfiguracja Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Zażądano uprawnień!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Uprawnienie mikrofonu",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Uprawnienie przyznane! Teraz:\n\nOtwórz aplikację Omi na zegarku i dotknij \"Kontynuuj\" poniżej",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Potrzebujemy uprawnienia do mikrofonu.\n\n1. Dotknij \"Przyznaj uprawnienie\"\n2. Zezwól na iPhone\n3. Aplikacja na zegarku zostanie zamknięta\n4. Otwórz ponownie i dotknij \"Kontynuuj\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Przyznaj uprawnienie",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Potrzebujesz pomocy?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Rozwiązywanie problemów:\n\n1. Upewnij się, że Omi jest zainstalowane na Twoim zegarku\n2. Otwórz aplikację Omi na zegarku\n3. Poszukaj okna z prośbą o uprawnienie\n4. Dotknij \"Zezwól\" po wyświetleniu monitu\n5. Aplikacja na zegarku zostanie zamknięta - otwórz ją ponownie\n6. Wróć i dotknij \"Kontynuuj\" na iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Nagrywanie rozpoczęte pomyślnie!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Uprawnienie nie zostało jeszcze przyznane. Upewnij się, że zezwoliłeś na dostęp do mikrofonu i ponownie otworzyłeś aplikację na zegarku.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Błąd żądania uprawnień: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Błąd rozpoczęcia nagrywania: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Wybierz swój język podstawowy",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Ustaw swój język dla ostrzejszych transkrypcji i spersonalizowanego doświadczenia",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Jaki jest Twój język podstawowy?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Wybierz swój język",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Twoja osobista podróż rozwoju z AI, który słucha każdego Twojego słowa.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Zadania",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Dotknij, aby edytować • Przytrzymaj, aby wybrać • Przesuń, aby wykonać akcje",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Do zrobienia",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Zrobione",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Stare",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Wszystko na bieżąco!\nBrak oczekujących zadań",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Brak ukończonych zadań",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Brak starych zadań",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Brak elementów",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Zadanie oznaczone jako nieukończone",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Zadanie ukończone",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Usuń zadanie",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Czy na pewno chcesz usunąć to zadanie?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Usuń wybrane elementy",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Czy na pewno chcesz usunąć {count} wybrane zadani{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Zadanie \"{description}\" usunięte",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "Usunięto {count} zadani{s}",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Nie udało się usunąć zadania",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Nie udało się usunąć zadań",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Nie udało się usunąć niektórych zadań",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Gotowe na zadania",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Twoje AI automatycznie wyodrębni zadania z Twoich rozmów. Pojawią się tutaj, gdy zostaną utworzone.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automatycznie wyodrębniane z rozmów",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Dotknij, aby edytować, przesuń, aby ukończyć lub usunąć",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "Wybrano: {count}",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Zaznacz wszystko",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Usuń zaznaczone",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Przeszukaj {count} wspomnień",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Wspomnienie usunięte.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Cofnij",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Brak wspomnień",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Brak automatycznie wyodrębnionych wspomnień",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Brak ręcznych wspomnień",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Brak wspomnień w tych kategoriach",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Nie znaleziono wspomnień",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Dodaj swoje pierwsze wspomnienie",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Wyczyść pamięć Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Czy na pewno chcesz wyczyścić pamięć Omi? Tej czynności nie można cofnąć.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Wyczyść pamięć",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Pamięć Omi o Tobie została wyczyszczona",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Brak wspomnień do usunięcia",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Utwórz nowe wspomnienie",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Utwórz nowe zadanie",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Zarządzanie wspomnieniami",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtruj wspomnienia",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Masz {count} wspomnień łącznie",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Publiczne wspomnienia",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Prywatne wspomnienia",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Ustaw wszystkie wspomnienia jako prywatne",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Ustaw wszystkie wspomnienia jako publiczne",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Usuń wszystkie wspomnienia",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Wszystkie wspomnienia są teraz prywatne",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Wszystkie wspomnienia są teraz publiczne",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Nowe wspomnienie",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Edytuj wspomnienie",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Lubię jeść lody...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Nie udało się zapisać. Sprawdź połączenie.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Zapisz wspomnienie",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Spróbuj ponownie",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Utwórz zadanie",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Edytuj zadanie",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Co trzeba zrobić?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Opis zadania nie może być pusty.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Zadanie zaktualizowane",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Nie udało się zaktualizować zadania",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Zadanie utworzone",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Nie udało się utworzyć zadania",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Termin",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Czas",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Dodaj termin",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Naciśnij Gotowe, aby zapisać",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Naciśnij Gotowe, aby utworzyć",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Wszystkie",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "O Tobie",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Spostrzeżenia",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Ręczne",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Ukończone",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Oznacz jako ukończone",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Zadanie usunięte",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Nie udało się usunąć zadania",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Usuń zadanie",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Czy na pewno chcesz usunąć to zadanie?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Język aplikacji",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "INTERFEJS APLIKACJI",
+  "speechTranscriptionSectionTitle": "MOWA I TRANSKRYPCJA",
+  "languageSettingsHelperText": "Język aplikacji zmienia menu i przyciski. Język mowy wpływa na sposób transkrypcji nagrań."
+}

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -90,7 +90,9 @@
   "selectedCount": "{count} selecionados",
   "@selectedCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "merge": "Mesclar",
@@ -98,7 +100,9 @@
   "mergeConversationsMessage": "Isso combinará {count} conversas em uma. Todo o conteúdo será mesclado e regenerado.",
   "@mergeConversationsMessage": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "mergingInBackground": "Mesclando em segundo plano. Isso pode levar um momento.",
@@ -408,7 +412,6 @@
   "defaultProjectOptional": "Projeto padrão (Opcional)",
   "leaveUnselectedTasks": "Deixe desmarcado para tarefas sem projeto",
   "noProjectsInWorkspace": "Nenhum projeto encontrado neste workspace",
-  "conversationTimeout": "Tempo limite de conversa",
   "conversationTimeoutDesc": "Escolha quanto tempo esperar em silêncio antes de terminar:",
   "timeout2Minutes": "2 minutos",
   "timeout2MinutesDesc": "Terminar após 2 minutos de silêncio",
@@ -696,6 +699,8 @@
   "pressDoneToCreate": "Pressione Concluído para criar",
   "filterAll": "Todos",
   "filterAuto": "Auto",
+  "filterInteresting": "Insights",
+  "filterSystem": "Sobre você",
   "filterManual": "Manual",
   "completed": "Concluído",
   "markComplete": "Marcar como concluído",
@@ -729,5 +734,8 @@
       }
     }
   },
-  "continueButton": "Continuar"
+  "continueButton": "Continuar",
+  "appInterfaceSectionTitle": "INTERFACE DO APLICATIVO",
+  "speechTranscriptionSectionTitle": "FALA E TRANSCRIÇÃO",
+  "languageSettingsHelperText": "O idioma do aplicativo altera menus e botões. O idioma de fala afeta como suas gravações são transcritas."
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "ro",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Conversație",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transcriere",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Sarcini",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Ștergi conversația?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Ești sigur că vrei să ștergi această conversație? Această acțiune nu poate fi anulată.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Confirmă",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Cancel",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Delete",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Adaugă",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Actualizează",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Salvează",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Editează",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Închide",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Șterge",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Copiază transcrierea",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Copiază rezumatul",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Testează promptul",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Reprocesează conversația",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Șterge conversația",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Conținut copiat în clipboard",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Nu s-a putut actualiza starea de favorit.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "URL-ul conversației nu a putut fi partajat.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Eroare la procesarea conversației. Te rugăm să încerci din nou mai târziu.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Te rugăm să verifici conexiunea la internet și să încerci din nou.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Nu se poate șterge conversația",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Ceva nu a mers bine! Te rugăm să încerci din nou mai târziu.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Copiază mesajul de eroare",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Mesaj de eroare copiat în clipboard",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Rămas",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Se încarcă...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Se încarcă durata...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} secunde",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Persoane",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Adaugă persoană nouă",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Editează persoana",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Creează o persoană nouă și antrenează Omi să recunoască și vorbirea ei!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Profil vocal",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Eșantion {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Setări",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Limbă",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Selectează limba",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Se șterge...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Nu s-a putut inițializa autentificarea",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import inițiat! Vei fi notificat când se finalizează.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Nu s-a putut inițializa importul. Te rugăm să încerci din nou.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Nu s-a putut accesa fișierul selectat",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Întreabă Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Done",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Deconectat",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Se caută",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Conectează dispozitivul",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Ai atins limita lunară.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Verifică utilizarea",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Se sincronizează înregistrările",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Înregistrări de sincronizat",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Totul este actualizat",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Sincronizează",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Pandantivul este actualizat",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Toate înregistrările sunt sincronizate",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Sincronizare în curs",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Pregătit pentru sincronizare",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Apasă Sincronizează pentru a începe",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Pandantivul nu este conectat. Conectează pentru a sincroniza.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Totul este deja sincronizat.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Ai înregistrări care nu sunt încă sincronizate.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Vom continua să sincronizăm înregistrările în fundal.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Încă nu există conversații.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Încă nu există conversații favorite.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Pentru a marca o conversație ca favorită, deschide-o și apasă iconița de stea din antet.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Caută conversații",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} selectate",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Combină",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Combină conversațiile",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Aceasta va combina {count} conversații într-una singură. Tot conținutul va fi combinat și regenerat.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Se combină în fundal. Acest lucru poate dura câteva momente.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Nu s-a putut inițializa combinarea",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Întreabă orice",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Încă nu există mesaje!\nDe ce nu începi o conversație?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Se șterg mesajele din memoria Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Mesaj copiat în clipboard.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Nu poți raporta propriile mesaje.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Raportează mesajul",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Ești sigur că vrei să raportezi acest mesaj?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Mesaj raportat cu succes.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Mulțumim pentru feedback!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Ștergi chat-ul?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Ești sigur că vrei să ștergi chat-ul? Această acțiune nu poate fi anulată.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Poți încărca doar 4 fișiere simultan",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Chat cu Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Aplicații",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Nu s-au găsit aplicații",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Încearcă să ajustezi căutarea sau filtrele",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Creează-ți propria aplicație",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Construiește și partajează aplicația ta personalizată",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Caută peste 1500 de aplicații",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Aplicațiile mele",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Aplicații instalate",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Nu s-au putut prelua aplicațiile :(\n\nTe rugăm să verifici conexiunea la internet și să încerci din nou.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Despre Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Privacy Policy",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Vizitează site-ul web",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Ajutor sau întrebări?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Alătură-te comunității!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "Peste 8000 de membri și numărul crește.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Șterge contul",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Ești sigur că vrei să îți ștergi contul?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Acest lucru nu poate fi anulat.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Toate amintirile și conversațiile tale vor fi șterse permanent.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Aplicațiile și integrările tale vor fi deconectate imediat.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Poți exporta datele înainte de a-ți șterge contul, dar odată șters, nu poate fi recuperat.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Înțeleg că ștergerea contului meu este permanentă și toate datele, inclusiv amintirile și conversațiile, vor fi pierdute și nu pot fi recuperate.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Ești sigur?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Această acțiune este ireversibilă și va șterge permanent contul tău și toate datele asociate. Ești sigur că vrei să continui?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Șterge acum",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Înapoi",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Bifează caseta pentru a confirma că înțelegi că ștergerea contului este permanentă și ireversibilă.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Nume",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Email",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Vocabular personalizat",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identificarea altora",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Metode de plată",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Afișare conversații",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Date și confidențialitate",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID utilizator",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Nesetat",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID utilizator copiat în clipboard",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Implicit sistem",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plan și utilizare",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Sincronizare offline",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Setări dispozitiv",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Instrumente chat",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Feedback / Bug",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Centru de asistență",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Setări dezvoltator",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Obține Omi pentru Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Program de recomandări",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Deconectare",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Detalii aplicație și dispozitiv copiate",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Confidențialitatea ta, sub controlul tău",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "La Omi, ne angajăm să îți protejăm confidențialitatea. Această pagină îți permite să controlezi modul în care datele tale sunt stocate și utilizate.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Află mai multe...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Nivel de protecție a datelor",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Datele tale sunt securizate implicit cu criptare puternică. Revizuiește setările și opțiunile viitoare de confidențialitate mai jos.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Acces aplicații",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Următoarele aplicații pot accesa datele tale. Apasă pe o aplicație pentru a-i gestiona permisiunile.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Nicio aplicație instalată nu are acces extern la datele tale.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Nume dispozitiv",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID dispozitiv",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmware",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Sincronizare card SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Revizie hardware",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Număr model",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Producător",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dublă apăsare",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Luminozitate LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Câștig microfon",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Deconectează",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Uită dispozitivul",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Probleme la încărcare",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Deconectează dispozitivul",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Deperechează dispozitivul",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Deperechează și uită dispozitivul",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Omi-ul tău a fost deconectat 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Dispozitiv depereche. Mergi la Setări > Bluetooth și uită dispozitivul pentru a finaliza deperecherea.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Deperechează dispozitivul",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Acest lucru va deperechia dispozitivul astfel încât să poată fi conectat la alt telefon. Va trebui să mergi la Setări > Bluetooth și să uiți dispozitivul pentru a finaliza procesul.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Dispozitiv neconectat",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Conectează dispozitivul Omi pentru a accesa\nsetările și personalizarea dispozitivului",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Informații dispozitiv",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Personalizare",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Hardware",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 nedetectat",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Vedem că ai fie un dispozitiv V1, fie dispozitivul tău nu este conectat. Funcționalitatea card SD este disponibilă doar pentru dispozitivele V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Încheie conversația",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pauză/Reia",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Marchează conversația ca favorită",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Acțiune dublă apăsare",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Încheie și procesează conversația",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pauză/Reia înregistrarea",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Marchează conversația în curs ca favorită",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Oprit",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maxim",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Mut",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Silențios",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normal",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Ridicat",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Microfonul este mut",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Foarte silențios - pentru medii zgomotoase",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Silențios - pentru zgomot moderat",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutru - înregistrare echilibrată",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Ușor amplificat - utilizare normală",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Amplificat - pentru medii liniștite",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Ridicat - pentru voci distante sau line",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Foarte ridicat - pentru surse foarte liniștite",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maxim - folosește cu atenție",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Setări dezvoltator",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Se salvează...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Configurează personalitatea AI",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transcriere",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Configurează furnizorul STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Timeout conversație",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Setează când se încheie automat conversațiile",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importă date",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importă date din alte surse",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Depanare și diagnosticare",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL endpoint",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Încă nu există chei API",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Creează o cheie pentru a începe",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Creează cheie",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Documente",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Statisticile tale Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Astăzi",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Luna aceasta",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Anul acesta",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Toate timpurile",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Încă nu există activitate",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Începe o conversație cu Omi\npentru a vedea statisticile de utilizare aici.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Ascultare",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Timpul total în care Omi a ascultat activ.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Înțelegere",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Cuvinte înțelese din conversațiile tale.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Furnizare",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Sarcini și notițe capturate automat.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Memorare",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fapte și detalii memorate pentru tine.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Plan nelimitat",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Gestionează planul",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Planul tău se va anula pe {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Planul tău se reînnoiește pe {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Plan gratuit",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} din {limit} minute utilizate",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Upgrade",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Upgrade la Nelimitat",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Planul tău include {limit} minute gratuite pe lună. Fă upgrade pentru a deveni nelimitat.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Împărtășesc statisticile mele Omi! (omi.me - asistentul tău AI mereu activ)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Astăzi, Omi a:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Luna aceasta, Omi a:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Anul acesta, Omi a:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Până acum, Omi a:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Ascultat timp de {minutes} minute",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Înțeles {words} cuvinte",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Furnizat {count} perspective",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Memorat {count} amintiri",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Jurnale de depanare",
+  "debugLogsAutoDelete": "Se șterg automat după 3 zile.",
+  "debugLogsDesc": "Ajută la diagnosticarea problemelor",
+  "noLogFilesFound": "Nu s-au găsit fișiere jurnal.",
+  "omiDebugLog": "Jurnal de depanare Omi",
+  "logShared": "Jurnal partajat",
+  "selectLogFile": "Selectează fișier jurnal",
+  "shareLogs": "Partajează jurnalele",
+  "debugLogCleared": "Jurnal de depanare șters",
+  "exportStarted": "Export inițiat. Acest lucru poate dura câteva secunde...",
+  "exportAllData": "Exportă toate datele",
+  "exportDataDesc": "Exportă conversațiile într-un fișier JSON",
+  "exportedConversations": "Conversații exportate din Omi",
+  "exportShared": "Export partajat",
+  "deleteKnowledgeGraphTitle": "Ștergi graficul de cunoștințe?",
+  "deleteKnowledgeGraphMessage": "Acest lucru va șterge toate datele derivate din graficul de cunoștințe (noduri și conexiuni). Amintirile tale originale vor rămâne în siguranță. Graficul va fi reconstruit în timp sau la următoarea solicitare.",
+  "knowledgeGraphDeleted": "Grafic de cunoștințe șters cu succes",
+  "deleteGraphFailed": "Nu s-a putut șterge graficul: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Șterge graficul de cunoștințe",
+  "deleteKnowledgeGraphDesc": "Șterge toate nodurile și conexiunile",
+  "mcp": "MCP",
+  "mcpServer": "Server MCP",
+  "mcpServerDesc": "Conectează asistenți AI la datele tale",
+  "serverUrl": "URL server",
+  "urlCopied": "URL copiat",
+  "apiKeyAuth": "Autentificare cheie API",
+  "header": "Antet",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "ID client",
+  "clientSecret": "Secret client",
+  "useMcpApiKey": "Folosește cheia ta API MCP",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Evenimente conversație",
+  "newConversationCreated": "Conversație nouă creată",
+  "realtimeTranscript": "Transcriere în timp real",
+  "transcriptReceived": "Transcriere primită",
+  "audioBytes": "Bytes audio",
+  "audioDataReceived": "Date audio primite",
+  "intervalSeconds": "Interval (secunde)",
+  "daySummary": "Rezumat zilnic",
+  "summaryGenerated": "Rezumat generat",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Adaugă la claude_desktop_config.json",
+  "copyConfig": "Copiază configurația",
+  "configCopied": "Configurație copiată în clipboard",
+  "listeningMins": "Ascultare (minute)",
+  "understandingWords": "Înțelegere (cuvinte)",
+  "insights": "Perspective",
+  "memories": "Amintiri",
+  "minsUsedThisMonth": "{used} din {limit} minute utilizate luna aceasta",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} din {limit} cuvinte utilizate luna aceasta",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} din {limit} perspective obținute luna aceasta",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} din {limit} amintiri create luna aceasta",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Vizibilitate",
+  "visibilitySubtitle": "Controlează care conversații apar în lista ta",
+  "showShortConversations": "Afișează conversații scurte",
+  "showShortConversationsDesc": "Afișează conversații mai scurte decât pragul",
+  "showDiscardedConversations": "Afișează conversații eliminate",
+  "showDiscardedConversationsDesc": "Include conversații marcate ca eliminate",
+  "shortConversationThreshold": "Prag conversații scurte",
+  "shortConversationThresholdSubtitle": "Conversațiile mai scurte decât aceasta vor fi ascunse dacă nu este activată opțiunea de mai sus",
+  "durationThreshold": "Prag durată",
+  "durationThresholdDesc": "Ascunde conversații mai scurte decât aceasta",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Vocabular personalizat",
+  "addWords": "Adaugă cuvinte",
+  "addWordsDesc": "Nume, termeni sau cuvinte neobișnuite",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Connect",
+  "comingSoon": "În curând",
+  "chatToolsFooter": "Conectează aplicațiile tale pentru a vizualiza date și statistici în chat.",
+  "completeAuthInBrowser": "Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.",
+  "failedToStartAuth": "Nu s-a putut inițializa autentificarea {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Deconectezi {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Ești sigur că vrei să te deconectezi de la {appName}? Te poți reconecta oricând.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Deconectat de la {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Nu s-a putut deconecta",
+  "connectTo": "Conectează-te la {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Va trebui să autorizezi Omi să acceseze datele tale {appName}. Aceasta va deschide browser-ul pentru autentificare.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Continuă",
+  "languageTitle": "Limbă",
+  "primaryLanguage": "Limbă principală",
+  "automaticTranslation": "Traducere automată",
+  "detectLanguages": "Detectează peste 10 limbi",
+  "authorizeSavingRecordings": "Autorizează salvarea înregistrărilor",
+  "thanksForAuthorizing": "Mulțumim pentru autorizare!",
+  "needYourPermission": "Avem nevoie de permisiunea ta",
+  "alreadyGavePermission": "Ne-ai dat deja permisiunea de a salva înregistrările tale. Iată un memento despre motivul pentru care avem nevoie:",
+  "wouldLikePermission": "Am dori permisiunea ta de a salva înregistrările vocale. Iată de ce:",
+  "improveSpeechProfile": "Îmbunătățește profilul tău vocal",
+  "improveSpeechProfileDesc": "Folosim înregistrările pentru a antrena și îmbunătăți în continuare profilul tău vocal personal.",
+  "trainFamilyProfiles": "Antrenează profiluri pentru prieteni și familie",
+  "trainFamilyProfilesDesc": "Înregistrările tale ne ajută să recunoaștem și să creăm profiluri pentru prietenii și familia ta.",
+  "enhanceTranscriptAccuracy": "Îmbunătățește acuratețea transcrierii",
+  "enhanceTranscriptAccuracyDesc": "Pe măsură ce modelul nostru se îmbunătățește, putem oferi rezultate de transcriere mai bune pentru înregistrările tale.",
+  "legalNotice": "Notificare legală: Legalitatea înregistrării și stocării datelor vocale poate varia în funcție de locația ta și modul în care folosești această funcție. Este responsabilitatea ta să te asiguri că respecți legile și reglementările locale.",
+  "alreadyAuthorized": "Deja autorizat",
+  "authorize": "Autorizează",
+  "revokeAuthorization": "Revocă autorizarea",
+  "authorizationSuccessful": "Autorizare reușită!",
+  "failedToAuthorize": "Nu s-a putut autoriza. Te rugăm să încerci din nou.",
+  "authorizationRevoked": "Autorizare revocată.",
+  "recordingsDeleted": "Înregistrări șterse.",
+  "failedToRevoke": "Nu s-a putut revoca autorizarea. Te rugăm să încerci din nou.",
+  "permissionRevokedTitle": "Permisiune revocată",
+  "permissionRevokedMessage": "Vrei să ștergem toate înregistrările tale existente?",
+  "yes": "Da",
+  "editName": "Editează numele",
+  "howShouldOmiCallYou": "Cum ar trebui Omi să te numească?",
+  "enterYourName": "Enter your name",
+  "nameCannotBeEmpty": "Numele nu poate fi gol",
+  "nameUpdatedSuccessfully": "Nume actualizat cu succes!",
+  "calendarSettings": "Setări calendar",
+  "calendarProviders": "Furnizori calendar",
+  "macOsCalendar": "Calendar macOS",
+  "connectMacOsCalendar": "Conectează calendarul tău local macOS",
+  "googleCalendar": "Google Calendar",
+  "syncGoogleAccount": "Sincronizează cu contul tău Google",
+  "showMeetingsMenuBar": "Afișează întâlnirile viitoare în bara de meniu",
+  "showMeetingsMenuBarDesc": "Afișează următoarea întâlnire și timpul rămas până începe în bara de meniu macOS",
+  "showEventsNoParticipants": "Afișează evenimente fără participanți",
+  "showEventsNoParticipantsDesc": "Când este activat, Coming Up afișează evenimente fără participanți sau link video.",
+  "yourMeetings": "Întâlnirile tale",
+  "refresh": "Reîmprospătează",
+  "noUpcomingMeetings": "Nu s-au găsit întâlniri viitoare",
+  "checkingNextDays": "Se verifică următoarele 30 de zile",
+  "tomorrow": "Mâine",
+  "googleCalendarComingSoon": "Integrarea Google Calendar va fi disponibilă în curând!",
+  "connectedAsUser": "Conectat ca utilizator: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Spațiu de lucru implicit",
+  "tasksCreatedInWorkspace": "Sarcinile vor fi create în acest spațiu de lucru",
+  "defaultProjectOptional": "Proiect implicit (opțional)",
+  "leaveUnselectedTasks": "Lasă neselectat pentru a crea sarcini fără proiect",
+  "noProjectsInWorkspace": "Nu s-au găsit proiecte în acest spațiu de lucru",
+  "conversationTimeoutDesc": "Alege cât timp să aștepți în tăcere înainte de a încheia automat o conversație:",
+  "timeout2Minutes": "2 minute",
+  "timeout2MinutesDesc": "Încheie conversația după 2 minute de tăcere",
+  "timeout5Minutes": "5 minute",
+  "timeout5MinutesDesc": "Încheie conversația după 5 minute de tăcere",
+  "timeout10Minutes": "10 minute",
+  "timeout10MinutesDesc": "Încheie conversația după 10 minute de tăcere",
+  "timeout30Minutes": "30 de minute",
+  "timeout30MinutesDesc": "Încheie conversația după 30 de minute de tăcere",
+  "timeout4Hours": "4 ore",
+  "timeout4HoursDesc": "Încheie conversația după 4 ore de tăcere",
+  "conversationEndAfterHours": "Conversațiile se vor încheia acum după 4 ore de tăcere",
+  "conversationEndAfterMinutes": "Conversațiile se vor încheia acum după {minutes} minut(e) de tăcere",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Spune-ne limba ta principală",
+  "languageForTranscription": "Setează limba pentru transcrieri mai precise și o experiență personalizată.",
+  "singleLanguageModeInfo": "Modul limbă unică este activat. Traducerea este dezactivată pentru o acuratețe mai mare.",
+  "searchLanguageHint": "Search language by name or code",
+  "noLanguagesFound": "No languages found",
+  "skip": "Omite",
+  "languageSetTo": "Limba setată la {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Nu s-a putut seta limba",
+  "appSettings": "Setări {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Deconectezi de la {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Aceasta va elimina autentificarea ta {appName}. Va trebui să te reconectezi pentru a o folosi din nou.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Conectat la {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Cont",
+  "actionItemsSyncedTo": "Sarcinile tale vor fi sincronizate cu contul tău {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Spațiu implicit",
+  "selectSpaceInWorkspace": "Selectează un spațiu în spațiul tău de lucru",
+  "noSpacesInWorkspace": "Nu s-au găsit spații în acest spațiu de lucru",
+  "defaultList": "Listă implicită",
+  "tasksAddedToList": "Sarcinile vor fi adăugate la această listă",
+  "noListsInSpace": "Nu s-au găsit liste în acest spațiu",
+  "failedToLoadRepos": "Nu s-au putut încărca repository-urile: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Repository implicit salvat",
+  "failedToSaveDefaultRepo": "Nu s-a putut salva repository-ul implicit",
+  "defaultRepository": "Repository implicit",
+  "selectDefaultRepoDesc": "Selectează un repository implicit pentru crearea de issue-uri. Poți specifica totuși un repository diferit când creezi issue-uri.",
+  "noReposFound": "Nu s-au găsit repository-uri",
+  "private": "Privat",
+  "updatedDate": "Actualizat {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "ieri",
+  "daysAgo": "acum {count} zile",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "acum 1 săptămână",
+  "weeksAgo": "acum {count} săptămâni",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "acum 1 lună",
+  "monthsAgo": "acum {count} luni",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Issue-urile vor fi create în repository-ul tău implicit",
+  "taskIntegrations": "Integrări sarcini",
+  "configureSettings": "Configurează setările",
+  "completeAuthBrowser": "Te rugăm să finalizezi autentificarea în browser. După ce ai terminat, revino la aplicație.",
+  "failedToStartAppAuth": "Nu s-a putut inițializa autentificarea {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Conectează-te la {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Va trebui să autorizezi Omi să creeze sarcini în contul tău {appName}. Aceasta va deschide browser-ul pentru autentificare.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Continue",
+  "appIntegration": "Integrare {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integrarea cu {appName} va fi disponibilă în curând! Lucrăm din greu pentru a-ți aduce mai multe opțiuni de gestionare a sarcinilor.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Got it",
+  "tasksExportedOneApp": "Sarcinile pot fi exportate către o singură aplicație odată.",
+  "completeYourUpgrade": "Finalizează upgrade-ul",
+  "importConfiguration": "Importă configurația",
+  "exportConfiguration": "Exportă configurația",
+  "bringYourOwn": "Folosește propriul tău",
+  "payYourSttProvider": "Folosește Omi liber. Plătești doar furnizorul STT direct.",
+  "freeMinutesMonth": "1.200 de minute gratuite/lună incluse. Nelimitat cu ",
+  "omiUnlimited": "Omi Nelimitat",
+  "hostRequired": "Host-ul este necesar",
+  "validPortRequired": "Port valid este necesar",
+  "validWebsocketUrlRequired": "URL WebSocket valid este necesar (wss://)",
+  "apiUrlRequired": "URL API este necesar",
+  "apiKeyRequired": "Cheia API este necesară",
+  "invalidJsonConfig": "Configurație JSON invalidă",
+  "errorSaving": "Eroare la salvare: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Configurație copiată în clipboard",
+  "pasteJsonConfig": "Lipește configurația JSON mai jos:",
+  "addApiKeyAfterImport": "Va trebui să adaugi propria cheie API după import",
+  "paste": "Lipește",
+  "import": "Importă",
+  "invalidProviderInConfig": "Furnizor invalid în configurație",
+  "importedConfig": "Configurație {providerName} importată",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON invalid: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Furnizor",
+  "live": "Live",
+  "onDevice": "Pe dispozitiv",
+  "apiUrl": "URL API",
+  "enterSttHttpEndpoint": "Introdu endpoint-ul HTTP STT",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Introdu endpoint-ul WebSocket STT live",
+  "apiKey": "Cheie API",
+  "enterApiKey": "Introdu cheia API",
+  "storedLocallyNeverShared": "Stocat local, niciodată partajat",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Avansat",
+  "configuration": "Configurație",
+  "requestConfiguration": "Configurație cerere",
+  "responseSchema": "Schemă răspuns",
+  "modified": "Modificat",
+  "resetRequestConfig": "Resetează configurația cererii la implicit",
+  "logs": "Jurnale",
+  "logsCopied": "Jurnale copiate",
+  "noLogsYet": "Încă nu există jurnale. Începe să înregistrezi pentru a vedea activitatea STT personalizată.",
+  "deviceUsesCodec": "{deviceName} folosește {codecReason}. Omi va fi folosit.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Transcriere Omi",
+  "bestInClassTranscription": "Cea mai bună transcriere din clasă fără configurare",
+  "instantSpeakerLabels": "Etichete vorbitor instant",
+  "languageTranslation": "Traducere în peste 100 de limbi",
+  "optimizedForConversation": "Optimizat pentru conversație",
+  "autoLanguageDetection": "Detectare automată a limbii",
+  "highAccuracy": "Acuratețe ridicată",
+  "privacyFirst": "Confidențialitate pe primul loc",
+  "saveChanges": "Salvează modificările",
+  "resetToDefault": "Resetează la implicit",
+  "viewTemplate": "Vezi șablonul",
+  "trySomethingLike": "Încearcă ceva precum...",
+  "tryIt": "Încearcă",
+  "creatingPlan": "Se creează planul",
+  "developingLogic": "Se dezvoltă logica",
+  "designingApp": "Se proiectează aplicația",
+  "generatingIconStep": "Se generează iconița",
+  "finalTouches": "Retușuri finale",
+  "processing": "Se procesează...",
+  "features": "Funcționalități",
+  "creatingYourApp": "Se creează aplicația ta...",
+  "generatingIcon": "Se generează iconița...",
+  "whatShouldWeMake": "Ce ar trebui să facem?",
+  "appName": "Nume aplicație",
+  "description": "Descriere",
+  "publicLabel": "Public",
+  "privateLabel": "Privat",
+  "free": "Gratuit",
+  "perMonth": "/ Lună",
+  "tailoredConversationSummaries": "Rezumate de conversație personalizate",
+  "customChatbotPersonality": "Personalitate chatbot personalizată",
+  "makePublic": "Fă publică",
+  "anyoneCanDiscover": "Oricine poate descoperi aplicația ta",
+  "onlyYouCanUse": "Doar tu poți folosi această aplicație",
+  "paidApp": "Aplicație plătită",
+  "usersPayToUse": "Utilizatorii plătesc pentru a folosi aplicația ta",
+  "freeForEveryone": "Gratuit pentru toată lumea",
+  "perMonthLabel": "/ lună",
+  "creating": "Se creează...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Creează aplicație",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Searching for devices...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{DEVICE} other{DEVICES}} FOUND NEARBY",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PAIRING SUCCESSFUL",
+  "errorConnectingAppleWatch": "Error connecting to Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Don't show it again",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "I Understand",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Enable Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi needs Bluetooth to connect to your wearable. Please enable Bluetooth and try again.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Contact Support?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Connect Later",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Grant permissions",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Background activity",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Let Omi run in the background for better stability",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Location access",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Enable background location for the full experience",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Notifications",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Enable notifications to stay informed",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Location Service Disabled",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Location Service is Disabled. Please go to Settings > Privacy & Security > Location Services and enable it",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Background Location Access Denied",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Please go to device settings and set location permission to \"Always Allow\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Loving Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Help us reach more people by leaving a review in the App Store. Your feedback means the world to us!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Help us reach more people by leaving a review in the Google Play Store. Your feedback means the world to us!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Rate on App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Rate on Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Maybe later",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi needs to learn your goals and your voice. You'll be able to modify it later.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Get Started",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "All done!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Keep going, you are doing great",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Skip this question",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Skip for now",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Connection Error",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Failed to connect to the server. Please check your internet connection and try again.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Invalid recording detected",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "It seems like there are multiple speakers in the recording. Please make sure you are in a quiet location and try again.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "There is not enough speech detected. Please speak more and try again.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Please make sure you speak for at least 5 seconds and not more than 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Are you there?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "We could not detect any speech. Please make sure to speak for at least 10 seconds and not more than 3 minutes.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Connection Lost",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "The connection was interrupted. Please check your internet connection and try again.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Try Again",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Connect Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Continue Without Device",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Permissions Required",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "This app needs Bluetooth and Location permissions to function properly. Please enable them in the settings.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Open Settings",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Want to go by something else?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "What's your name?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Speak. Transcribe. Summarize.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Sign in with Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Sign in with Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "By continuing, you agree to our ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Terms of Use",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Your AI Companion",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Capture every moment. Get AI-powered\nsummaries. Never take notes again.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch Setup",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Permission Requested!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Microphone Permission",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Permission granted! Now:\n\nOpen the Omi app on your watch and tap \"Continue\" below",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "We need microphone permission.\n\n1. Tap \"Grant Permission\"\n2. Allow on your iPhone\n3. Watch app will close\n4. Reopen and tap \"Continue\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Grant Permission",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Need Help?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Troubleshooting:\n\n1. Ensure Omi is installed on your watch\n2. Open the Omi app on your watch\n3. Look for the permission popup\n4. Tap \"Allow\" when prompted\n5. App on your watch will close - reopen it\n6. Come back and tap \"Continue\" on your iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Recording started successfully!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Permission not granted yet. Please make sure you allowed microphone access and reopened the app on your watch.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Error requesting permission: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Error starting recording: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Select your primary language",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Set your language for sharper transcriptions and a personalized experience",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "What's your primary language?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Select your language",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Your personal growth journey with AI that listens to your every word.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "To-Do's",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Tap to edit • Long press to select • Swipe for actions",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "To Do",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Done",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Old",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 All caught up!\nNo pending action items",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "No completed items yet",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ No old tasks",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "No items",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Action item marked as incomplete",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Action item completed",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Delete Action Item",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Are you sure you want to delete this action item?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Delete Selected Items",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Are you sure you want to delete {count} selected action item{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Action item \"{description}\" deleted",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} action item{s} deleted",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Failed to delete action item",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Failed to delete items",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Failed to delete some items",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Ready for Action Items",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Your AI will automatically extract tasks and to-dos from your conversations. They'll appear here when created.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automatically extracted from conversations",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Tap to edit, swipe to complete or delete",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} selected",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Select all",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Delete selected",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Search {count} Memories",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Memory Deleted.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Undo",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "No memories yet",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "No auto-extracted memories yet",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "No manual memories yet",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "No memories in these categories",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "No memories found",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Add your first memory",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Clear Omi's Memory",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Are you sure you want to clear Omi's memory? This action cannot be undone.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Clear Memory",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omi's memory about you has been cleared",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "No memories to delete",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Create new memory",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Create new action item",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Memory Management",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filter Memories",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "You have {count} total memories",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Public memories",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Private memories",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Make All Memories Private",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Make All Memories Public",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Delete All Memories",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "All memories are now private",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "All memories are now public",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "New Memory",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Edit Memory",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "I like to eat ice cream...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Failed to save. Please check your connection.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Save Memory",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Retry",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Create Action Item",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Edit Action Item",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "What needs to be done?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Action item description cannot be empty.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Action item updated",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Failed to update action item",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Action item created",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Failed to create action item",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Due Date",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Time",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Add due date",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Press done to save",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Press done to create",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "All",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "About You",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Insights",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manual",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Completed",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Mark complete",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Action item deleted",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Failed to delete action item",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Delete Action Item",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Are you sure you want to delete this action item?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "App Language",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "INTERFAȚĂ APLICAȚIE",
+  "speechTranscriptionSectionTitle": "VORBIRE ȘI TRANSCRIERE",
+  "languageSettingsHelperText": "Limba aplicației schimbă meniurile și butoanele. Limba vorbirii afectează modul în care sunt transcrise înregistrările."
+}

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "ru",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Разговор",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Расшифровка",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Задачи",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Удалить разговор?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Вы уверены, что хотите удалить этот разговор? Это действие нельзя будет отменить.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Подтвердить",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Отмена",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ок",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Удалить",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Добавить",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Обновить",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Сохранить",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Редактировать",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Закрыть",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Очистить",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Копировать расшифровку",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Копировать резюме",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Тестовый запрос",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Переобработать разговор",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Удалить разговор",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Содержимое скопировано в буфер обмена",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Не удалось обновить статус избранного.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Не удалось поделиться ссылкой на разговор.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Ошибка при обработке разговора. Пожалуйста, попробуйте позже.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Пожалуйста, проверьте подключение к интернету и попробуйте снова.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Не удалось удалить разговор",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Что-то пошло не так! Пожалуйста, попробуйте позже.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Копировать сообщение об ошибке",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Сообщение об ошибке скопировано в буфер обмена",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Осталось",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Загрузка...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Загрузка длительности...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} секунд",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Люди",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Добавить нового человека",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Редактировать человека",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Создайте нового человека и обучите Omi распознавать его голос тоже!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Голосовой профиль",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Образец {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Настройки",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Язык",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Выберите язык",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Удаление...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Не удалось начать аутентификацию",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Импорт начат! Вы получите уведомление, когда он завершится.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Не удалось начать импорт. Пожалуйста, попробуйте снова.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Не удалось получить доступ к выбранному файлу",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Спросить Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Готово",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Отключено",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Поиск",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Подключить устройство",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Вы достигли месячного лимита.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Проверить использование",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Синхронизация записей",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Записи для синхронизации",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Всё синхронизировано",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Синхронизация",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Кулон обновлён",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Все записи синхронизированы",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Идёт синхронизация",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Готово к синхронизации",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Нажмите Синхронизация для начала",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Кулон не подключён. Подключите для синхронизации.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Всё уже синхронизировано.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "У вас есть записи, которые ещё не синхронизированы.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Мы продолжим синхронизировать ваши записи в фоновом режиме.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Разговоров пока нет.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Избранных разговоров пока нет.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Чтобы добавить разговор в избранное, откройте его и нажмите на значок звезды в заголовке.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Поиск разговоров",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "Выбрано {count}",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Объединить",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Объединить разговоры",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Это объединит {count} разговоров в один. Всё содержимое будет объединено и перегенерировано.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Объединение в фоновом режиме. Это может занять некоторое время.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Не удалось начать объединение",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Спросите что угодно",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Сообщений пока нет!\nПочему бы не начать разговор?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Удаление ваших сообщений из памяти Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Сообщение скопировано в буфер обмена.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Вы не можете пожаловаться на свои собственные сообщения.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Пожаловаться на сообщение",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Вы уверены, что хотите пожаловаться на это сообщение?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Жалоба на сообщение успешно отправлена.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Спасибо за ваш отзыв!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Очистить чат?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Вы уверены, что хотите очистить чат? Это действие нельзя будет отменить.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Вы можете загрузить только 4 файла одновременно",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Чат с Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Приложения",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Приложения не найдены",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Попробуйте изменить параметры поиска или фильтры",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Создайте своё приложение",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Создавайте и делитесь своим пользовательским приложением",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Поиск среди 1500+ приложений",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Мои приложения",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Установленные приложения",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Не удалось загрузить приложения :(\n\nПожалуйста, проверьте подключение к интернету и попробуйте снова.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "О Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Политикой конфиденциальности",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Посетить сайт",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Помощь или вопросы?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Присоединяйтесь к сообществу!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "Более 8000 участников.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Удалить аккаунт",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Вы уверены, что хотите удалить свой аккаунт?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Это действие нельзя отменить.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Все ваши воспоминания и разговоры будут безвозвратно удалены.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Ваши приложения и интеграции будут немедленно отключены.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Вы можете экспортировать свои данные перед удалением аккаунта, но после удаления восстановить их будет невозможно.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Я понимаю, что удаление аккаунта необратимо, и все данные, включая воспоминания и разговоры, будут потеряны без возможности восстановления.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Вы уверены?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Это действие необратимо и навсегда удалит ваш аккаунт и все связанные с ним данные. Вы уверены, что хотите продолжить?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Удалить сейчас",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Вернуться назад",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Поставьте галочку, чтобы подтвердить, что вы понимаете: удаление аккаунта необратимо.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Профиль",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Имя",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Электронная почта",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Пользовательский словарь",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Идентификация других",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Способы оплаты",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Отображение разговоров",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Данные и конфиденциальность",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID пользователя",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Не задано",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID пользователя скопирован в буфер обмена",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "По умолчанию системы",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Тариф и использование",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Оффлайн-синхронизация",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Настройки устройства",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Инструменты чата",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Отзыв / Ошибка",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Центр помощи",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Настройки разработчика",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Получить Omi для Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Реферальная программа",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Выйти",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Информация о приложении и устройстве скопирована",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Итоги 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Ваша конфиденциальность, ваш контроль",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "В Omi мы стремимся защитить вашу конфиденциальность. Эта страница позволяет вам контролировать, как хранятся и используются ваши данные.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Узнать больше...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Уровень защиты данных",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Ваши данные по умолчанию защищены надёжным шифрованием. Просмотрите ваши настройки и будущие опции конфиденциальности ниже.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Доступ приложений",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Следующие приложения могут получить доступ к вашим данным. Нажмите на приложение, чтобы управлять его разрешениями.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Ни одно установленное приложение не имеет внешнего доступа к вашим данным.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Название устройства",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID устройства",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Прошивка",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Синхронизация SD-карты",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Ревизия оборудования",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Номер модели",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Производитель",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Двойное нажатие",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Яркость LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Усиление микрофона",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Отключить",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Забыть устройство",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Проблемы с зарядкой",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Отключить устройство",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Разорвать пару с устройством",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Разорвать пару и забыть устройство",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Ваш Omi был отключён 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Пара с устройством разорвана. Перейдите в Настройки > Bluetooth и забудьте устройство для завершения разрыва пары.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Разорвать пару с устройством",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Это разорвёт пару с устройством, чтобы оно могло быть подключено к другому телефону. Вам нужно будет перейти в Настройки > Bluetooth и забыть устройство для завершения процесса.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Устройство не подключено",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Подключите устройство Omi для доступа\nк настройкам устройства и настройке",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Информация об устройстве",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Настройка",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Оборудование",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 не обнаружено",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Мы видим, что у вас либо устройство V1, либо ваше устройство не подключено. Функция SD-карты доступна только для устройств V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Завершить разговор",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Пауза/Возобновить",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Добавить разговор в избранное",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Действие при двойном нажатии",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Завершить и обработать разговор",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Пауза/Возобновить запись",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Добавить текущий разговор в избранное",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Выкл",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Макс",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Без звука",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Тихий",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Обычный",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Высокий",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Микрофон выключен",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Очень тихий - для шумной обстановки",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Тихий - для умеренного шума",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Нейтральный - сбалансированная запись",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Слегка усиленный - обычное использование",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Усиленный - для тихой обстановки",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Высокий - для отдалённых или тихих голосов",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Очень высокий - для очень тихих источников",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Максимальный - используйте с осторожностью",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Настройки разработчика",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Сохранение...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Настройте вашу AI-персону",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "БЕТА",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Расшифровка",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Настройте провайдера STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Тайм-аут разговора",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Установите, когда разговоры автоматически завершаются",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Импорт данных",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Импортируйте данные из других источников",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Отладка и диагностика",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL конечной точки",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "API-ключей пока нет",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Создайте ключ для начала",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Создать ключ",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Документация",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Ваша статистика Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Сегодня",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Этот месяц",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Этот год",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Всё время",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Активности пока нет",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Начните разговор с Omi,\nчтобы увидеть здесь вашу статистику использования.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Прослушивание",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Общее время активного прослушивания Omi.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Понимание",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Слов понято из ваших разговоров.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Предоставление",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Задач и заметок, автоматически зафиксированных.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Запоминание",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Фактов и деталей, запомненных для вас.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Безлимитный тариф",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Управление тарифом",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Ваш тариф будет отменён {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Ваш тариф продлится {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Бесплатный тариф",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "Использовано {used} из {limit} минут",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Повысить тариф",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Перейти на безлимитный",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Ваш тариф включает {limit} бесплатных минут в месяц. Перейдите на безлимитный тариф.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Делюсь статистикой Omi! (omi.me - ваш постоянный AI-помощник)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Сегодня omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "В этом месяце omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "В этом году omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "За всё время omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Слушал {minutes} минут",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Понял {words} слов",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Предоставил {count} инсайтов",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Запомнил {count} воспоминаний",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Журналы отладки",
+  "debugLogsAutoDelete": "Автоматически удаляются через 3 дня.",
+  "debugLogsDesc": "Помогает диагностировать проблемы",
+  "noLogFilesFound": "Файлы журналов не найдены.",
+  "omiDebugLog": "Журнал отладки Omi",
+  "logShared": "Журнал отправлен",
+  "selectLogFile": "Выберите файл журнала",
+  "shareLogs": "Поделиться журналами",
+  "debugLogCleared": "Журнал отладки очищен",
+  "exportStarted": "Экспорт начат. Это может занять несколько секунд...",
+  "exportAllData": "Экспортировать все данные",
+  "exportDataDesc": "Экспортировать разговоры в JSON-файл",
+  "exportedConversations": "Экспортированные разговоры из Omi",
+  "exportShared": "Экспорт отправлен",
+  "deleteKnowledgeGraphTitle": "Удалить граф знаний?",
+  "deleteKnowledgeGraphMessage": "Это удалит все производные данные графа знаний (узлы и связи). Ваши исходные воспоминания останутся в безопасности. Граф будет восстановлен со временем или при следующем запросе.",
+  "knowledgeGraphDeleted": "Граф знаний успешно удалён",
+  "deleteGraphFailed": "Не удалось удалить граф: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Удалить граф знаний",
+  "deleteKnowledgeGraphDesc": "Очистить все узлы и связи",
+  "mcp": "MCP",
+  "mcpServer": "Сервер MCP",
+  "mcpServerDesc": "Подключите AI-помощников к вашим данным",
+  "serverUrl": "URL сервера",
+  "urlCopied": "URL скопирован",
+  "apiKeyAuth": "Аутентификация по API-ключу",
+  "header": "Заголовок",
+  "authorizationBearer": "Authorization: Bearer <ключ>",
+  "oauth": "OAuth",
+  "clientId": "ID клиента",
+  "clientSecret": "Секрет клиента",
+  "useMcpApiKey": "Используйте ваш MCP API-ключ",
+  "webhooks": "Вебхуки",
+  "conversationEvents": "События разговоров",
+  "newConversationCreated": "Создан новый разговор",
+  "realtimeTranscript": "Расшифровка в реальном времени",
+  "transcriptReceived": "Расшифровка получена",
+  "audioBytes": "Байты аудио",
+  "audioDataReceived": "Данные аудио получены",
+  "intervalSeconds": "Интервал (секунды)",
+  "daySummary": "Сводка дня",
+  "summaryGenerated": "Сводка создана",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Добавить в claude_desktop_config.json",
+  "copyConfig": "Копировать конфигурацию",
+  "configCopied": "Конфигурация скопирована в буфер обмена",
+  "listeningMins": "Прослушивание (мин)",
+  "understandingWords": "Понимание (слов)",
+  "insights": "Инсайты",
+  "memories": "Воспоминания",
+  "minsUsedThisMonth": "Использовано {used} из {limit} минут в этом месяце",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "Использовано {used} из {limit} слов в этом месяце",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "Получено {used} из {limit} инсайтов в этом месяце",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "Создано {used} из {limit} воспоминаний в этом месяце",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Видимость",
+  "visibilitySubtitle": "Контролируйте, какие разговоры появляются в вашем списке",
+  "showShortConversations": "Показывать короткие разговоры",
+  "showShortConversationsDesc": "Показывать разговоры короче порогового значения",
+  "showDiscardedConversations": "Показывать отброшенные разговоры",
+  "showDiscardedConversationsDesc": "Включать разговоры, отмеченные как отброшенные",
+  "shortConversationThreshold": "Порог коротких разговоров",
+  "shortConversationThresholdSubtitle": "Разговоры короче этого значения будут скрыты, если не включено выше",
+  "durationThreshold": "Порог длительности",
+  "durationThresholdDesc": "Скрыть разговоры короче этого значения",
+  "minLabel": "{count} мин",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Пользовательский словарь",
+  "addWords": "Добавить слова",
+  "addWordsDesc": "Имена, термины или редкие слова",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Подключить",
+  "comingSoon": "Скоро",
+  "chatToolsFooter": "Подключите ваши приложения для просмотра данных и метрик в чате.",
+  "completeAuthInBrowser": "Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.",
+  "failedToStartAuth": "Не удалось начать аутентификацию {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Отключить {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Вы уверены, что хотите отключиться от {appName}? Вы можете переподключиться в любое время.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Отключено от {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Не удалось отключить",
+  "connectTo": "Подключиться к {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Вам нужно авторизовать Omi для доступа к вашим данным {appName}. Это откроет браузер для аутентификации.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Продолжить",
+  "languageTitle": "Язык",
+  "primaryLanguage": "Основной язык",
+  "automaticTranslation": "Автоматический перевод",
+  "detectLanguages": "Определение 10+ языков",
+  "authorizeSavingRecordings": "Разрешить сохранение записей",
+  "thanksForAuthorizing": "Спасибо за разрешение!",
+  "needYourPermission": "Нам нужно ваше разрешение",
+  "alreadyGavePermission": "Вы уже дали нам разрешение на сохранение ваших записей. Напоминаем, зачем нам это нужно:",
+  "wouldLikePermission": "Мы хотели бы получить ваше разрешение на сохранение ваших голосовых записей. Вот почему:",
+  "improveSpeechProfile": "Улучшение вашего голосового профиля",
+  "improveSpeechProfileDesc": "Мы используем записи для дальнейшего обучения и улучшения вашего персонального голосового профиля.",
+  "trainFamilyProfiles": "Обучение профилей друзей и семьи",
+  "trainFamilyProfilesDesc": "Ваши записи помогают нам распознавать и создавать профили для ваших друзей и семьи.",
+  "enhanceTranscriptAccuracy": "Повышение точности расшифровки",
+  "enhanceTranscriptAccuracyDesc": "По мере улучшения нашей модели мы сможем предоставлять лучшие результаты расшифровки для ваших записей.",
+  "legalNotice": "Юридическое уведомление: Законность записи и хранения голосовых данных может различаться в зависимости от вашего местоположения и того, как вы используете эту функцию. Вы несёте ответственность за соблюдение местных законов и нормативных актов.",
+  "alreadyAuthorized": "Уже разрешено",
+  "authorize": "Разрешить",
+  "revokeAuthorization": "Отозвать разрешение",
+  "authorizationSuccessful": "Разрешение успешно получено!",
+  "failedToAuthorize": "Не удалось получить разрешение. Пожалуйста, попробуйте снова.",
+  "authorizationRevoked": "Разрешение отозвано.",
+  "recordingsDeleted": "Записи удалены.",
+  "failedToRevoke": "Не удалось отозвать разрешение. Пожалуйста, попробуйте снова.",
+  "permissionRevokedTitle": "Разрешение отозвано",
+  "permissionRevokedMessage": "Хотите, чтобы мы удалили все ваши существующие записи тоже?",
+  "yes": "Да",
+  "editName": "Изменить имя",
+  "howShouldOmiCallYou": "Как Omi должен вас называть?",
+  "enterYourName": "Введите ваше имя",
+  "nameCannotBeEmpty": "Имя не может быть пустым",
+  "nameUpdatedSuccessfully": "Имя успешно обновлено!",
+  "calendarSettings": "Настройки календаря",
+  "calendarProviders": "Провайдеры календаря",
+  "macOsCalendar": "Календарь macOS",
+  "connectMacOsCalendar": "Подключите ваш локальный календарь macOS",
+  "googleCalendar": "Google Календарь",
+  "syncGoogleAccount": "Синхронизация с вашим аккаунтом Google",
+  "showMeetingsMenuBar": "Показывать предстоящие встречи в строке меню",
+  "showMeetingsMenuBarDesc": "Отображать вашу следующую встречу и время до её начала в строке меню macOS",
+  "showEventsNoParticipants": "Показывать события без участников",
+  "showEventsNoParticipantsDesc": "Когда включено, Coming Up показывает события без участников или видеосвязи.",
+  "yourMeetings": "Ваши встречи",
+  "refresh": "Обновить",
+  "noUpcomingMeetings": "Предстоящих встреч не найдено",
+  "checkingNextDays": "Проверка следующих 30 дней",
+  "tomorrow": "Завтра",
+  "googleCalendarComingSoon": "Интеграция с Google Календарём скоро!",
+  "connectedAsUser": "Подключено как пользователь: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Рабочее пространство по умолчанию",
+  "tasksCreatedInWorkspace": "Задачи будут созданы в этом рабочем пространстве",
+  "defaultProjectOptional": "Проект по умолчанию (опционально)",
+  "leaveUnselectedTasks": "Оставьте не выбранным для создания задач без проекта",
+  "noProjectsInWorkspace": "Проекты в этом рабочем пространстве не найдены",
+  "conversationTimeoutDesc": "Выберите, сколько времени ждать в тишине перед автоматическим завершением разговора:",
+  "timeout2Minutes": "2 минуты",
+  "timeout2MinutesDesc": "Завершить разговор после 2 минут тишины",
+  "timeout5Minutes": "5 минут",
+  "timeout5MinutesDesc": "Завершить разговор после 5 минут тишины",
+  "timeout10Minutes": "10 минут",
+  "timeout10MinutesDesc": "Завершить разговор после 10 минут тишины",
+  "timeout30Minutes": "30 минут",
+  "timeout30MinutesDesc": "Завершить разговор после 30 минут тишины",
+  "timeout4Hours": "4 часа",
+  "timeout4HoursDesc": "Завершить разговор после 4 часов тишины",
+  "conversationEndAfterHours": "Разговоры теперь будут завершаться после 4 часов тишины",
+  "conversationEndAfterMinutes": "Разговоры теперь будут завершаться после {minutes} минут тишины",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Укажите ваш основной язык",
+  "languageForTranscription": "Установите ваш язык для более точной расшифровки и персонализированного опыта.",
+  "singleLanguageModeInfo": "Режим одного языка включён. Перевод отключён для повышения точности.",
+  "searchLanguageHint": "Поиск языка по названию или коду",
+  "noLanguagesFound": "Языки не найдены",
+  "skip": "Пропустить",
+  "languageSetTo": "Язык установлен на {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Не удалось установить язык",
+  "appSettings": "Настройки {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Отключиться от {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Это удалит вашу аутентификацию {appName}. Вам нужно будет переподключиться для повторного использования.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Подключено к {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Аккаунт",
+  "actionItemsSyncedTo": "Ваши задачи будут синхронизированы с вашим аккаунтом {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Пространство по умолчанию",
+  "selectSpaceInWorkspace": "Выберите пространство в вашем рабочем пространстве",
+  "noSpacesInWorkspace": "Пространства в этом рабочем пространстве не найдены",
+  "defaultList": "Список по умолчанию",
+  "tasksAddedToList": "Задачи будут добавлены в этот список",
+  "noListsInSpace": "Списки в этом пространстве не найдены",
+  "failedToLoadRepos": "Не удалось загрузить репозитории: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Репозиторий по умолчанию сохранён",
+  "failedToSaveDefaultRepo": "Не удалось сохранить репозиторий по умолчанию",
+  "defaultRepository": "Репозиторий по умолчанию",
+  "selectDefaultRepoDesc": "Выберите репозиторий по умолчанию для создания задач. Вы все еще можете указать другой репозиторий при создании задач.",
+  "noReposFound": "Репозитории не найдены",
+  "private": "Приватный",
+  "updatedDate": "Обновлено {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "вчера",
+  "daysAgo": "{count} дней назад",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 неделю назад",
+  "weeksAgo": "{count} недель назад",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 месяц назад",
+  "monthsAgo": "{count} месяцев назад",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Задачи будут создаваться в вашем репозитории по умолчанию",
+  "taskIntegrations": "Интеграции задач",
+  "configureSettings": "Настроить параметры",
+  "completeAuthBrowser": "Пожалуйста, завершите аутентификацию в браузере. После этого вернитесь в приложение.",
+  "failedToStartAppAuth": "Не удалось начать аутентификацию {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Подключиться к {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Вам нужно авторизовать Omi для создания задач в вашем аккаунте {appName}. Это откроет браузер для аутентификации.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Продолжить",
+  "appIntegration": "Интеграция {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Интеграция с {appName} скоро! Мы упорно работаем, чтобы предоставить вам больше вариантов управления задачами.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Понятно",
+  "tasksExportedOneApp": "Задачи могут быть экспортированы только в одно приложение за раз.",
+  "completeYourUpgrade": "Завершите обновление",
+  "importConfiguration": "Импорт конфигурации",
+  "exportConfiguration": "Экспорт конфигурации",
+  "bringYourOwn": "Используйте свой",
+  "payYourSttProvider": "Свободно используйте omi. Вы платите только своему провайдеру STT напрямую.",
+  "freeMinutesMonth": "1200 бесплатных минут в месяц включено. Безлимитно с ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Требуется хост",
+  "validPortRequired": "Требуется действительный порт",
+  "validWebsocketUrlRequired": "Требуется действительный URL WebSocket (wss://)",
+  "apiUrlRequired": "Требуется URL API",
+  "apiKeyRequired": "Требуется API-ключ",
+  "invalidJsonConfig": "Недействительная конфигурация JSON",
+  "errorSaving": "Ошибка сохранения: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Конфигурация скопирована в буфер обмена",
+  "pasteJsonConfig": "Вставьте вашу конфигурацию JSON ниже:",
+  "addApiKeyAfterImport": "Вам нужно будет добавить свой API-ключ после импорта",
+  "paste": "Вставить",
+  "import": "Импорт",
+  "invalidProviderInConfig": "Недействительный провайдер в конфигурации",
+  "importedConfig": "Импортирована конфигурация {providerName}",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Недействительный JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Провайдер",
+  "live": "В реальном времени",
+  "onDevice": "На устройстве",
+  "apiUrl": "URL API",
+  "enterSttHttpEndpoint": "Введите вашу конечную точку STT HTTP",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Введите вашу конечную точку WebSocket для STT в реальном времени",
+  "apiKey": "API-ключ",
+  "enterApiKey": "Введите ваш API-ключ",
+  "storedLocallyNeverShared": "Хранится локально, никогда не передаётся",
+  "host": "Хост",
+  "port": "Порт",
+  "advanced": "Расширенные",
+  "configuration": "Конфигурация",
+  "requestConfiguration": "Конфигурация запроса",
+  "responseSchema": "Схема ответа",
+  "modified": "Изменено",
+  "resetRequestConfig": "Сбросить конфигурацию запроса по умолчанию",
+  "logs": "Журналы",
+  "logsCopied": "Журналы скопированы",
+  "noLogsYet": "Журналов пока нет. Начните запись, чтобы увидеть активность пользовательского STT.",
+  "deviceUsesCodec": "{deviceName} использует {codecReason}. Будет использован Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Расшифровка Omi",
+  "bestInClassTranscription": "Лучшая расшифровка без настройки",
+  "instantSpeakerLabels": "Мгновенные метки спикеров",
+  "languageTranslation": "Перевод на 100+ языков",
+  "optimizedForConversation": "Оптимизировано для разговоров",
+  "autoLanguageDetection": "Автоматическое определение языка",
+  "highAccuracy": "Высокая точность",
+  "privacyFirst": "Конфиденциальность прежде всего",
+  "saveChanges": "Сохранить изменения",
+  "resetToDefault": "Сбросить по умолчанию",
+  "viewTemplate": "Просмотреть шаблон",
+  "trySomethingLike": "Попробуйте что-то вроде...",
+  "tryIt": "Попробовать",
+  "creatingPlan": "Создание плана",
+  "developingLogic": "Разработка логики",
+  "designingApp": "Проектирование приложения",
+  "generatingIconStep": "Генерация иконки",
+  "finalTouches": "Завершающие штрихи",
+  "processing": "Обработка...",
+  "features": "Возможности",
+  "creatingYourApp": "Создание вашего приложения...",
+  "generatingIcon": "Генерация иконки...",
+  "whatShouldWeMake": "Что мы должны создать?",
+  "appName": "Название приложения",
+  "description": "Описание",
+  "publicLabel": "Публичное",
+  "privateLabel": "Приватное",
+  "free": "Бесплатно",
+  "perMonth": "/ Месяц",
+  "tailoredConversationSummaries": "Персонализированные резюме разговоров",
+  "customChatbotPersonality": "Пользовательская личность чат-бота",
+  "makePublic": "Сделать публичным",
+  "anyoneCanDiscover": "Любой может найти ваше приложение",
+  "onlyYouCanUse": "Только вы можете использовать это приложение",
+  "paidApp": "Платное приложение",
+  "usersPayToUse": "Пользователи платят за использование вашего приложения",
+  "freeForEveryone": "Бесплатно для всех",
+  "perMonthLabel": "/ месяц",
+  "creating": "Создание...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Создать приложение",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Поиск устройств...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count, plural, =1{УСТРОЙСТВО} few{УСТРОЙСТВА} other{УСТРОЙСТВ}} НАЙДЕНО РЯДОМ: {count}",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "СОПРЯЖЕНИЕ УСПЕШНО",
+  "errorConnectingAppleWatch": "Ошибка подключения к Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Больше не показывать",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Я понимаю",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Включите Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi требуется Bluetooth для подключения к вашему устройству. Пожалуйста, включите Bluetooth и попробуйте снова.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Связаться с поддержкой?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Подключить позже",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Предоставить разрешения",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Фоновая активность",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Позвольте Omi работать в фоновом режиме для лучшей стабильности",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Доступ к местоположению",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Включите фоновое определение местоположения для полного опыта",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Уведомления",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Включите уведомления, чтобы быть в курсе",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Служба определения местоположения отключена",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Служба определения местоположения отключена. Пожалуйста, перейдите в Настройки > Конфиденциальность и безопасность > Службы геолокации и включите её",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Доступ к местоположению в фоновом режиме отклонён",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Пожалуйста, перейдите в настройки устройства и установите разрешение на местоположение как \"Всегда разрешать\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Нравится Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Помогите нам достичь большего количества людей, оставив отзыв в App Store. Ваш отзыв очень важен для нас!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Помогите нам достичь большего количества людей, оставив отзыв в Google Play Store. Ваш отзыв очень важен для нас!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Оценить в App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Оценить в Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Может быть, позже",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi нужно узнать ваши цели и ваш голос. Вы сможете изменить это позже.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Начать",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Всё готово!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Продолжайте, вы отлично справляетесь",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Пропустить этот вопрос",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Пропустить пока",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Ошибка подключения",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Не удалось подключиться к серверу. Пожалуйста, проверьте подключение к интернету и попробуйте снова.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Обнаружена недействительная запись",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Похоже, в записи несколько говорящих. Пожалуйста, убедитесь, что вы находитесь в тихом месте, и попробуйте снова.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Обнаружено недостаточно речи. Пожалуйста, говорите больше и попробуйте снова.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Пожалуйста, убедитесь, что вы говорите не менее 5 секунд и не более 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Вы здесь?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Мы не смогли обнаружить речь. Пожалуйста, убедитесь, что говорите не менее 10 секунд и не более 3 минут.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Соединение потеряно",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Соединение было прервано. Пожалуйста, проверьте подключение к интернету и попробуйте снова.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Попробовать снова",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Подключить Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Продолжить без устройства",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Требуются разрешения",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Этому приложению нужны разрешения Bluetooth и Местоположение для правильной работы. Пожалуйста, включите их в настройках.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Открыть настройки",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Хотите использовать другое имя?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Как вас зовут?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Говорите. Расшифровывайте. Резюмируйте.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Войти с Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Войти с Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Продолжая, вы соглашаетесь с нашей ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Условиями использования",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – ваш AI-компаньон",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Фиксируйте каждый момент. Получайте резюме на основе AI.\nБольше никаких заметок.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Настройка Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Разрешение запрошено!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Разрешение на микрофон",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Разрешение предоставлено! Теперь:\n\nОткройте приложение Omi на ваших часах и нажмите \"Продолжить\" ниже",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Нам нужно разрешение на микрофон.\n\n1. Нажмите \"Предоставить разрешение\"\n2. Разрешите на вашем iPhone\n3. Приложение на часах закроется\n4. Откройте снова и нажмите \"Продолжить\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Предоставить разрешение",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Нужна помощь?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Устранение неполадок:\n\n1. Убедитесь, что Omi установлен на ваших часах\n2. Откройте приложение Omi на ваших часах\n3. Найдите всплывающее окно с разрешением\n4. Нажмите \"Разрешить\" при запросе\n5. Приложение на часах закроется - откройте его снова\n6. Вернитесь и нажмите \"Продолжить\" на вашем iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Запись успешно начата!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Разрешение ещё не предоставлено. Пожалуйста, убедитесь, что вы разрешили доступ к микрофону и открыли приложение на часах заново.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Ошибка при запросе разрешения: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Ошибка при начале записи: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Выберите ваш основной язык",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Установите ваш язык для более точной расшифровки и персонализированного опыта",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Какой ваш основной язык?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Выберите ваш язык",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Ваше личностное развитие с AI, который слушает каждое ваше слово.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Задачи",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Нажмите для редактирования • Удерживайте для выбора • Свайп для действий",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "К выполнению",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Выполнено",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Старые",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Всё выполнено!\nНет ожидающих задач",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Выполненных задач пока нет",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Нет старых задач",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Нет элементов",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Задача отмечена как невыполненная",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Задача выполнена",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Удалить задачу",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Вы уверены, что хотите удалить эту задачу?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Удалить выбранные элементы",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Вы уверены, что хотите удалить {count} выбранных задач{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Задача \"{description}\" удалена",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "Удалено {count} задач{s}",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Не удалось удалить задачу",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Не удалось удалить элементы",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Не удалось удалить некоторые элементы",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Готово к задачам",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Ваш AI автоматически извлечёт задачи и дела из ваших разговоров. Они появятся здесь при создании.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Автоматически извлекается из разговоров",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Нажмите для редактирования, свайп для завершения или удаления",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "Выбрано {count}",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Выбрать всё",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Удалить выбранное",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Поиск среди {count} воспоминаний",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Воспоминание удалено.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Отменить",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Воспоминаний пока нет",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Автоматически извлечённых воспоминаний пока нет",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Ручных воспоминаний пока нет",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Нет воспоминаний в этих категориях",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Воспоминания не найдены",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Добавьте ваше первое воспоминание",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Очистить память Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Вы уверены, что хотите очистить память Omi? Это действие нельзя отменить.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Очистить память",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Память Omi о вас была очищена",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Нет воспоминаний для удаления",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Создать новое воспоминание",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Создать новую задачу",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Управление памятью",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Фильтр воспоминаний",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "У вас всего {count} воспоминаний",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Публичные воспоминания",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Приватные воспоминания",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Сделать все воспоминания приватными",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Сделать все воспоминания публичными",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Удалить все воспоминания",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Все воспоминания теперь приватные",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Все воспоминания теперь публичные",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Новое воспоминание",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Редактировать воспоминание",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Я люблю есть мороженое...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Не удалось сохранить. Пожалуйста, проверьте подключение.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Сохранить воспоминание",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Повторить",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Создать задачу",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Редактировать задачу",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Что нужно сделать?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Описание задачи не может быть пустым.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Задача обновлена",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Не удалось обновить задачу",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Задача создана",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Не удалось создать задачу",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Срок выполнения",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Время",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Добавить срок выполнения",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Нажмите готово для сохранения",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Нажмите готово для создания",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Все",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "О вас",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Инсайты",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Ручные",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Выполнено",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Отметить как выполненное",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Задача удалена",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Не удалось удалить задачу",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Удалить задачу",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Вы уверены, что хотите удалить эту задачу?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Язык приложения",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ИНТЕРФЕЙС ПРИЛОЖЕНИЯ",
+  "speechTranscriptionSectionTitle": "РЕЧЬ И ТРАНСКРИПЦИЯ",
+  "languageSettingsHelperText": "Язык приложения изменяет меню и кнопки. Язык речи влияет на то, как транскрибируются ваши записи."
+}

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "sk",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Konverzácia",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Prepis",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Úlohy",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Odstrániť konverzáciu?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Naozaj chcete odstrániť túto konverzáciu? Túto akciu nie je možné vrátiť späť.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Potvrdiť",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Zrušiť",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Odstrániť",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Pridať",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Aktualizovať",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Uložiť",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Upraviť",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Zavrieť",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Vymazať",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Skopírovať prepis",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Skopírovať zhrnutie",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Otestovať výzvu",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Znovu spracovať konverzáciu",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Odstrániť konverzáciu",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Obsah bol skopírovaný do schránky",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Nepodarilo sa aktualizovať stav obľúbenej.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "URL konverzácie sa nepodarilo zdieľať.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Chyba pri spracovaní konverzácie. Skúste to prosím neskôr.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Skontrolujte prosím svoje internetové pripojenie a skúste to znova.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Nepodarilo sa odstrániť konverzáciu",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Niečo sa pokazilo! Skúste to prosím neskôr.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Skopírovať chybovú správu",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Chybová správa bola skopírovaná do schránky",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Zostáva",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Načítava sa...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Načítava sa trvanie...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekúnd",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Ľudia",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Pridať novú osobu",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Upraviť osobu",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Vytvorte novú osobu a naučte Omi rozpoznávať aj jej hlas!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Hlasový profil",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Vzorka {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Nastavenia",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Jazyk",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Vyberte jazyk",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Odstraňuje sa...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Nepodarilo sa spustiť autentifikáciu",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import bol spustený! Budete upozornení, keď bude dokončený.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Nepodarilo sa spustiť import. Skúste to prosím znova.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Nepodarilo sa pristúpiť k vybranému súboru",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Spýtať sa Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Hotovo",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Odpojené",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Vyhľadáva sa",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Pripojiť zariadenie",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Dosiahli ste váš mesačný limit.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Skontrolovať využitie",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Synchronizujú sa nahrávky",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Nahrávky na synchronizáciu",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Všetko je aktuálne",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Synchronizovať",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Prívesok je aktuálny",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Všetky nahrávky sú synchronizované",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Prebieha synchronizácia",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Pripravené na synchronizáciu",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Ťuknite na Synchronizovať pre spustenie",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Prívesok nie je pripojený. Pripojte ho pre synchronizáciu.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Všetko je už synchronizované.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Máte nahrávky, ktoré ešte nie sú synchronizované.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Budeme naďalej synchronizovať vaše nahrávky na pozadí.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Zatiaľ žiadne konverzácie.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Zatiaľ žiadne obľúbené konverzácie.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Ak chcete označiť konverzáciu hviezdičkou, otvorte ju a ťuknite na ikonu hviezdy v hlavičke.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Hľadať konverzácie",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} vybraných",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Zlúčiť",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Zlúčiť konverzácie",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Toto zlúči {count} konverzácií do jednej. Celý obsah bude zlúčený a znovu vygenerovaný.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Zlučovanie prebieha na pozadí. Môže to chvíľu trvať.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Nepodarilo sa spustiť zlučovanie",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Spýtajte sa na čokoľvek",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Zatiaľ žiadne správy!\nPrečo nespustíte konverzáciu?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Odstraňujú sa vaše správy z pamäte Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Správa bola skopírovaná do schránky.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Nemôžete nahlásiť vlastné správy.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Nahlásiť správu",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Naozaj chcete nahlásiť túto správu?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Správa bola úspešne nahlásená.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Ďakujeme za vašu spätnú väzbu!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Vymazať chat?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Naozaj chcete vymazať chat? Túto akciu nie je možné vrátiť späť.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Môžete nahrať maximálne 4 súbory naraz",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Chat s Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Aplikácie",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Neboli nájdené žiadne aplikácie",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Skúste upraviť vyhľadávanie alebo filtre",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Vytvorte si vlastnú aplikáciu",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Vytvorte a zdieľajte vlastnú aplikáciu",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Hľadať v 1500+ aplikáciách",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Moje aplikácie",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Nainštalované aplikácie",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Nepodarilo sa načítať aplikácie :(\n\nSkontrolujte prosím svoje internetové pripojenie a skúste to znova.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "O aplikácii Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Zásady ochrany osobných údajov",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Navštíviť webovú stránku",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Pomoc alebo otázky?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Pridajte sa ku komunite!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "Viac ako 8000 členov a stále pribúdajú.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Odstrániť účet",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Naozaj chcete odstrániť svoj účet?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Túto akciu nie je možné vrátiť späť.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Všetky vaše spomienky a konverzácie budú natrvalo odstránené.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Vaše aplikácie a integrácie budú okamžite odpojené.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Pred odstránením účtu môžete exportovať svoje údaje, ale po odstránení ich nebude možné obnoviť.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Rozumiem, že odstránenie môjho účtu je trvalé a všetky údaje vrátane spomienok a konverzácií budú stratené a nebude ich možné obnoviť.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Ste si istí?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Táto akcia je nezvratná a natrvalo odstráni váš účet a všetky súvisiace údaje. Naozaj chcete pokračovať?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Odstrániť teraz",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Vrátiť sa",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Začiarknite políčko na potvrdenie, že rozumiete, že odstránenie vášho účtu je trvalé a nezvratné.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Meno",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-mail",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Vlastný slovník",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identifikácia ostatných",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Platobné metódy",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Zobrazenie konverzácií",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Údaje a súkromie",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID používateľa",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Nie je nastavené",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID používateľa bolo skopírované do schránky",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Predvolené nastavenie systému",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plán a využitie",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Offline synchronizácia",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Nastavenia zariadenia",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Nástroje chatu",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Spätná väzba / chyba",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Centrum pomoci",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Vývojárske nastavenia",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Získať Omi pre Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Odporúčací program",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Odhlásiť sa",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Podrobnosti o aplikácii a zariadení boli skopírované",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Wrapped 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Vaše súkromie, vaša kontrola",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "V Omi sa zaväzujeme chrániť vaše súkromie. Táto stránka vám umožňuje kontrolovať, ako sú vaše údaje ukladané a používané.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Dozvedieť sa viac...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Úroveň ochrany údajov",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Vaše údaje sú predvolene zabezpečené silným šifrovaním. Skontrolujte svoje nastavenia a budúce možnosti ochrany súkromia nižšie.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Prístup aplikácií",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Nasledujúce aplikácie majú prístup k vašim údajom. Ťuknutím na aplikáciu spravujte jej oprávnenia.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Žiadne nainštalované aplikácie nemajú externý prístup k vašim údajom.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Názov zariadenia",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID zariadenia",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmvér",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Synchronizácia SD karty",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Revízia hardvéru",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Číslo modelu",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Výrobca",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dvojité ťuknutie",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Jas LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Zosilnenie mikrofónu",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Odpojiť",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Zabudnúť zariadenie",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Problémy s nabíjaním",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Odpojiť zariadenie",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Zrušiť párovanie zariadenia",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Zrušiť párovanie a zabudnúť zariadenie",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Vaše Omi bolo odpojené 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Párovanie zariadenia bolo zrušené. Prejdite do Nastavenia > Bluetooth a zabudnite zariadenie pre dokončenie.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Zrušiť párovanie zariadenia",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Týmto sa zruší párovanie zariadenia, aby sa mohlo pripojiť k inému telefónu. Budete musieť prejsť do Nastavenia > Bluetooth a zabudnúť zariadenie pre dokončenie procesu.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Zariadenie nie je pripojené",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Pripojte svoje zariadenie Omi pre prístup\nk nastaveniam a prispôsobeniu zariadenia",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Informácie o zariadení",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Prispôsobenie",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Hardvér",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 nebolo zistené",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Zistili sme, že máte zariadenie V1 alebo vaše zariadenie nie je pripojené. Funkcia SD karty je dostupná len pre zariadenia V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Ukončiť konverzáciu",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pozastaviť/Pokračovať",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Označiť konverzáciu hviezdičkou",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Akcia dvojitého ťuknutia",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Ukončiť a spracovať konverzáciu",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pozastaviť/Pokračovať nahrávanie",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Označiť prebiehajúcu konverzáciu hviezdičkou",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Vypnuté",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maximum",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Stlmiť",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Tiché",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normálne",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Vysoké",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofón je stlmený",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Veľmi tiché - pre hlučné prostredia",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Tiché - pre mierne hlučné prostredie",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutrálne - vyvážené nahrávanie",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Mierne zosilnené - normálne použitie",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Zosilnené - pre tiché prostredia",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Vysoké - pre vzdialené alebo tiché hlasy",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Veľmi vysoké - pre veľmi tiché zdroje",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maximálne - používať opatrne",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Vývojárske nastavenia",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Ukladá sa...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Nakonfigurujte svoju AI persónu",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Prepis",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Nakonfigurovať poskytovateľa STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Časový limit konverzácie",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Nastaviť, kedy sa konverzácie automaticky ukončia",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importovať údaje",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importovať údaje z iných zdrojov",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Ladenie a diagnostika",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL koncového bodu",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Zatiaľ žiadne API kľúče",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Vytvorte kľúč pre začiatok",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Vytvoriť kľúč",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentácia",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Vaše štatistiky Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Dnes",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Tento mesiac",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Tento rok",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Celkovo",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Zatiaľ žiadna aktivita",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Začnite konverzáciu s Omi,\naby ste tu videli svoje štatistiky využitia.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Počúvanie",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Celkový čas, počas ktorého Omi aktívne počúvalo.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Porozumenie",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Slová pochopené z vašich konverzácií.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Poskytovanie",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Úlohy a poznámky automaticky zachytené.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Pamätanie",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakty a detaily zapamätané pre vás.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Neobmedzený plán",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Spravovať plán",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Váš plán bude zrušený {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Váš plán sa obnoví {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Bezplatný plán",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} z {limit} min použitých",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Upgradovať",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Upgradovať na neobmedzený",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Váš plán zahŕňa {limit} bezplatných minút mesačne. Upgradujte na neobmedzený.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Zdieľam svoje štatistiky Omi! (omi.me - váš AI asistent vždy po ruke)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Dnes Omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Tento mesiac Omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Tento rok Omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Doteraz Omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Počúvalo {minutes} minút",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Porozumelo {words} slovám",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Poskytlo {count} postrehov",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Zapamätalo si {count} spomienok",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Debug logy",
+  "debugLogsAutoDelete": "Automaticky sa odstránia po 3 dňoch.",
+  "debugLogsDesc": "Pomáha diagnostikovať problémy",
+  "noLogFilesFound": "Neboli nájdené žiadne súbory logov.",
+  "omiDebugLog": "Omi debug log",
+  "logShared": "Log bol zdieľaný",
+  "selectLogFile": "Vyberte súbor logu",
+  "shareLogs": "Zdieľať logy",
+  "debugLogCleared": "Debug log bol vymazaný",
+  "exportStarted": "Export bol spustený. Môže to trvať niekoľko sekúnd...",
+  "exportAllData": "Exportovať všetky údaje",
+  "exportDataDesc": "Exportovať konverzácie do JSON súboru",
+  "exportedConversations": "Exportované konverzácie z Omi",
+  "exportShared": "Export bol zdieľaný",
+  "deleteKnowledgeGraphTitle": "Odstrániť graf znalostí?",
+  "deleteKnowledgeGraphMessage": "Týmto odstránite všetky odvodené údaje grafu znalostí (uzly a prepojenia). Vaše pôvodné spomienky zostanú v bezpečí. Graf bude znovu vytvorený postupom času alebo na ďalšiu požiadavku.",
+  "knowledgeGraphDeleted": "Graf znalostí bol úspešne odstránený",
+  "deleteGraphFailed": "Nepodarilo sa odstrániť graf: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Odstrániť graf znalostí",
+  "deleteKnowledgeGraphDesc": "Vymazať všetky uzly a prepojenia",
+  "mcp": "MCP",
+  "mcpServer": "MCP server",
+  "mcpServerDesc": "Pripojte AI asistentov k vašim údajom",
+  "serverUrl": "URL servera",
+  "urlCopied": "URL bola skopírovaná",
+  "apiKeyAuth": "Autentifikácia API kľúčom",
+  "header": "Hlavička",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Client ID",
+  "clientSecret": "Client Secret",
+  "useMcpApiKey": "Použite svoj MCP API kľúč",
+  "webhooks": "Webhooky",
+  "conversationEvents": "Udalosti konverzácií",
+  "newConversationCreated": "Nová konverzácia bola vytvorená",
+  "realtimeTranscript": "Prepis v reálnom čase",
+  "transcriptReceived": "Prepis bol prijatý",
+  "audioBytes": "Audio bajty",
+  "audioDataReceived": "Audio dáta boli prijaté",
+  "intervalSeconds": "Interval (sekundy)",
+  "daySummary": "Denné zhrnutie",
+  "summaryGenerated": "Zhrnutie bolo vygenerované",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Pridať do claude_desktop_config.json",
+  "copyConfig": "Skopírovať konfiguráciu",
+  "configCopied": "Konfigurácia bola skopírovaná do schránky",
+  "listeningMins": "Počúvanie (min)",
+  "understandingWords": "Porozumenie (slová)",
+  "insights": "Postrehy",
+  "memories": "Spomienky",
+  "minsUsedThisMonth": "{used} z {limit} min použitých tento mesiac",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} z {limit} slov použitých tento mesiac",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} z {limit} postrehov získaných tento mesiac",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} z {limit} spomienok vytvorených tento mesiac",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Viditeľnosť",
+  "visibilitySubtitle": "Kontrolujte, ktoré konverzácie sa zobrazia vo vašom zozname",
+  "showShortConversations": "Zobraziť krátke konverzácie",
+  "showShortConversationsDesc": "Zobraziť konverzácie kratšie ako hranica",
+  "showDiscardedConversations": "Zobraziť zahodené konverzácie",
+  "showDiscardedConversationsDesc": "Zahrnúť konverzácie označené ako zahodené",
+  "shortConversationThreshold": "Hranica krátkej konverzácie",
+  "shortConversationThresholdSubtitle": "Konverzácie kratšie ako toto budú skryté, pokiaľ nie sú povolené vyššie",
+  "durationThreshold": "Hranica trvania",
+  "durationThresholdDesc": "Skryť konverzácie kratšie ako toto",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Vlastný slovník",
+  "addWords": "Pridať slová",
+  "addWordsDesc": "Mená, výrazy alebo neobvyklé slová",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Pripojiť",
+  "comingSoon": "Čoskoro",
+  "chatToolsFooter": "Pripojte svoje aplikácie na zobrazenie údajov a metrík v chate.",
+  "completeAuthInBrowser": "Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.",
+  "failedToStartAuth": "Nepodarilo sa spustiť autentifikáciu {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Odpojiť {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Naozaj chcete odpojiť {appName}? Môžete sa znovu pripojiť kedykoľvek.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Odpojené od {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Nepodarilo sa odpojiť",
+  "connectTo": "Pripojiť k {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Budete musieť autorizovať Omi na prístup k vašim údajom {appName}. Toto otvorí váš prehliadač pre autentifikáciu.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Pokračovať",
+  "languageTitle": "Jazyk",
+  "primaryLanguage": "Primárny jazyk",
+  "automaticTranslation": "Automatický preklad",
+  "detectLanguages": "Zistiť 10+ jazykov",
+  "authorizeSavingRecordings": "Autorizovať ukladanie nahrávok",
+  "thanksForAuthorizing": "Ďakujeme za autorizáciu!",
+  "needYourPermission": "Potrebujeme vaše povolenie",
+  "alreadyGavePermission": "Už ste nám dali povolenie uložiť vaše nahrávky. Tu je pripomenutie, prečo ho potrebujeme:",
+  "wouldLikePermission": "Chceli by sme vaše povolenie na uloženie vašich hlasových nahrávok. Tu je dôvod:",
+  "improveSpeechProfile": "Zlepšiť váš hlasový profil",
+  "improveSpeechProfileDesc": "Používame nahrávky na ďalšie trénovanie a vylepšenie vášho osobného hlasového profilu.",
+  "trainFamilyProfiles": "Trénovať profily pre priateľov a rodinu",
+  "trainFamilyProfilesDesc": "Vaše nahrávky nám pomáhajú rozpoznávať a vytvárať profily pre vašich priateľov a rodinu.",
+  "enhanceTranscriptAccuracy": "Zlepšiť presnosť prepisu",
+  "enhanceTranscriptAccuracyDesc": "Keď sa náš model zlepší, môžeme poskytovať lepšie výsledky prepisu pre vaše nahrávky.",
+  "legalNotice": "Právne upozornenie: Zákonnosť nahrávania a ukladania hlasových dát sa môže líšiť v závislosti od vašej lokality a spôsobu používania tejto funkcie. Je vašou zodpovednosťou zabezpečiť súlad s miestnymi zákonmi a predpismi.",
+  "alreadyAuthorized": "Už autorizované",
+  "authorize": "Autorizovať",
+  "revokeAuthorization": "Zrušiť autorizáciu",
+  "authorizationSuccessful": "Autorizácia bola úspešná!",
+  "failedToAuthorize": "Nepodarilo sa autorizovať. Skúste to prosím znova.",
+  "authorizationRevoked": "Autorizácia bola zrušená.",
+  "recordingsDeleted": "Nahrávky boli odstránené.",
+  "failedToRevoke": "Nepodarilo sa zrušiť autorizáciu. Skúste to prosím znova.",
+  "permissionRevokedTitle": "Povolenie bolo zrušené",
+  "permissionRevokedMessage": "Chcete, aby sme odstránili aj všetky vaše existujúce nahrávky?",
+  "yes": "Áno",
+  "editName": "Upraviť meno",
+  "howShouldOmiCallYou": "Ako by vás malo Omi oslovovať?",
+  "enterYourName": "Zadajte svoje meno",
+  "nameCannotBeEmpty": "Meno nemôže byť prázdne",
+  "nameUpdatedSuccessfully": "Meno bolo úspešne aktualizované!",
+  "calendarSettings": "Nastavenia kalendára",
+  "calendarProviders": "Poskytovatelia kalendára",
+  "macOsCalendar": "macOS kalendár",
+  "connectMacOsCalendar": "Pripojte svoj lokálny macOS kalendár",
+  "googleCalendar": "Google kalendár",
+  "syncGoogleAccount": "Synchronizovať s vaším Google účtom",
+  "showMeetingsMenuBar": "Zobraziť nadchádzajúce stretnutia v paneli ponúk",
+  "showMeetingsMenuBarDesc": "Zobraziť vaše ďalšie stretnutie a čas do jeho začiatku v paneli ponúk macOS",
+  "showEventsNoParticipants": "Zobraziť udalosti bez účastníkov",
+  "showEventsNoParticipantsDesc": "Keď je povolené, Nadchádzajúce zobrazí udalosti bez účastníkov alebo video odkazu.",
+  "yourMeetings": "Vaše stretnutia",
+  "refresh": "Obnoviť",
+  "noUpcomingMeetings": "Neboli nájdené žiadne nadchádzajúce stretnutia",
+  "checkingNextDays": "Kontrola nasledujúcich 30 dní",
+  "tomorrow": "Zajtra",
+  "googleCalendarComingSoon": "Integrácia Google kalendára čoskoro!",
+  "connectedAsUser": "Pripojený ako používateľ: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Predvolený pracovný priestor",
+  "tasksCreatedInWorkspace": "Úlohy budú vytvorené v tomto pracovnom priestore",
+  "defaultProjectOptional": "Predvolený projekt (voliteľné)",
+  "leaveUnselectedTasks": "Nechajte nevybrané pre vytvorenie úloh bez projektu",
+  "noProjectsInWorkspace": "V tomto pracovnom priestore neboli nájdené žiadne projekty",
+  "conversationTimeoutDesc": "Vyberte, ako dlho čakať v tichosti pred automatickým ukončením konverzácie:",
+  "timeout2Minutes": "2 minúty",
+  "timeout2MinutesDesc": "Ukončiť konverzáciu po 2 minútach ticha",
+  "timeout5Minutes": "5 minút",
+  "timeout5MinutesDesc": "Ukončiť konverzáciu po 5 minútach ticha",
+  "timeout10Minutes": "10 minút",
+  "timeout10MinutesDesc": "Ukončiť konverzáciu po 10 minútach ticha",
+  "timeout30Minutes": "30 minút",
+  "timeout30MinutesDesc": "Ukončiť konverzáciu po 30 minútach ticha",
+  "timeout4Hours": "4 hodiny",
+  "timeout4HoursDesc": "Ukončiť konverzáciu po 4 hodinách ticha",
+  "conversationEndAfterHours": "Konverzácie sa teraz ukončia po 4 hodinách ticha",
+  "conversationEndAfterMinutes": "Konverzácie sa teraz ukončia po {minutes} minúte/minútach ticha",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Povedzte nám váš primárny jazyk",
+  "languageForTranscription": "Nastavte svoj jazyk pre presnejšie prepisy a personalizovaný zážitok.",
+  "singleLanguageModeInfo": "Režim jedného jazyka je povolený. Preklad je vypnutý pre vyššiu presnosť.",
+  "searchLanguageHint": "Hľadať jazyk podľa názvu alebo kódu",
+  "noLanguagesFound": "Neboli nájdené žiadne jazyky",
+  "skip": "Preskočiť",
+  "languageSetTo": "Jazyk bol nastavený na {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Nepodarilo sa nastaviť jazyk",
+  "appSettings": "{appName} Nastavenia",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Odpojiť od {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Toto odstráni vašu autentifikáciu {appName}. Budete sa musieť znovu pripojiť, aby ste ho mohli použiť.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Pripojené k {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Účet",
+  "actionItemsSyncedTo": "Vaše úlohy budú synchronizované s vaším účtom {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Predvolený priestor",
+  "selectSpaceInWorkspace": "Vyberte priestor vo vašom pracovnom priestore",
+  "noSpacesInWorkspace": "V tomto pracovnom priestore neboli nájdené žiadne priestory",
+  "defaultList": "Predvolený zoznam",
+  "tasksAddedToList": "Úlohy budú pridané do tohto zoznamu",
+  "noListsInSpace": "V tomto priestore neboli nájdené žiadne zoznamy",
+  "failedToLoadRepos": "Nepodarilo sa načítať repozitáre: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Predvolený repozitár bol uložený",
+  "failedToSaveDefaultRepo": "Nepodarilo sa uložiť predvolený repozitár",
+  "defaultRepository": "Predvolený repozitár",
+  "selectDefaultRepoDesc": "Vyberte predvolený repozitár pre vytváranie problémov. Pri vytváraní problémov môžete stále zadať iný repozitár.",
+  "noReposFound": "Neboli nájdené žiadne repozitáre",
+  "private": "Súkromný",
+  "updatedDate": "Aktualizované {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "včera",
+  "daysAgo": "pred {count} dňami",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "pred 1 týždňom",
+  "weeksAgo": "pred {count} týždňami",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "pred 1 mesiacom",
+  "monthsAgo": "pred {count} mesiacmi",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Problémy budú vytvorené vo vašom predvolenom repozitári",
+  "taskIntegrations": "Integrácie úloh",
+  "configureSettings": "Konfigurovať nastavenia",
+  "completeAuthBrowser": "Dokončite prosím autentifikáciu vo vašom prehliadači. Po dokončení sa vráťte do aplikácie.",
+  "failedToStartAppAuth": "Nepodarilo sa spustiť autentifikáciu {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Pripojiť k {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Budete musieť autorizovať Omi na vytváranie úloh vo vašom účte {appName}. Toto otvorí váš prehliadač pre autentifikáciu.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Pokračovať",
+  "appIntegration": "{appName} Integrácia",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integrácia s {appName} čoskoro! Usilovne pracujeme na tom, aby sme vám priniesli viac možností správy úloh.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Rozumiem",
+  "tasksExportedOneApp": "Úlohy možno exportovať do jednej aplikácie naraz.",
+  "completeYourUpgrade": "Dokončite svoj upgrade",
+  "importConfiguration": "Importovať konfiguráciu",
+  "exportConfiguration": "Exportovať konfiguráciu",
+  "bringYourOwn": "Prineste si vlastný",
+  "payYourSttProvider": "Voľne používajte omi. Platíte len svojmu poskytovateľovi STT priamo.",
+  "freeMinutesMonth": "1 200 bezplatných minút/mesiac je zahrnutých. Neobmedzené s ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Hostiteľ je povinný",
+  "validPortRequired": "Platný port je povinný",
+  "validWebsocketUrlRequired": "Platná WebSocket URL je povinná (wss://)",
+  "apiUrlRequired": "API URL je povinná",
+  "apiKeyRequired": "API kľúč je povinný",
+  "invalidJsonConfig": "Neplatná JSON konfigurácia",
+  "errorSaving": "Chyba pri ukladaní: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfigurácia bola skopírovaná do schránky",
+  "pasteJsonConfig": "Vložte svoju JSON konfiguráciu nižšie:",
+  "addApiKeyAfterImport": "Po importe budete musieť pridať svoj vlastný API kľúč",
+  "paste": "Vložiť",
+  "import": "Importovať",
+  "invalidProviderInConfig": "Neplatný poskytovateľ v konfigurácii",
+  "importedConfig": "Importovaná konfigurácia {providerName}",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Neplatný JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Poskytovateľ",
+  "live": "Naživo",
+  "onDevice": "Na zariadení",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "Zadajte svoj STT HTTP koncový bod",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "Zadajte svoj live STT WebSocket koncový bod",
+  "apiKey": "API kľúč",
+  "enterApiKey": "Zadajte svoj API kľúč",
+  "storedLocallyNeverShared": "Uložené lokálne, nikdy nezdieľané",
+  "host": "Hostiteľ",
+  "port": "Port",
+  "advanced": "Pokročilé",
+  "configuration": "Konfigurácia",
+  "requestConfiguration": "Konfigurácia požiadavky",
+  "responseSchema": "Schéma odpovede",
+  "modified": "Zmenené",
+  "resetRequestConfig": "Obnoviť konfiguráciu požiadavky na predvolenú",
+  "logs": "Logy",
+  "logsCopied": "Logy boli skopírované",
+  "noLogsYet": "Zatiaľ žiadne logy. Začnite nahrávanie, aby ste videli vlastnú STT aktivitu.",
+  "deviceUsesCodec": "{deviceName} používa {codecReason}. Omi bude použité.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi Prepis",
+  "bestInClassTranscription": "Najlepší prepis v triede s nulovou konfiguráciou",
+  "instantSpeakerLabels": "Okamžité značky rečníkov",
+  "languageTranslation": "Preklad do 100+ jazykov",
+  "optimizedForConversation": "Optimalizované pre konverzáciu",
+  "autoLanguageDetection": "Automatická detekcia jazyka",
+  "highAccuracy": "Vysoká presnosť",
+  "privacyFirst": "Súkromie na prvom mieste",
+  "saveChanges": "Uložiť zmeny",
+  "resetToDefault": "Obnoviť na predvolené",
+  "viewTemplate": "Zobraziť šablónu",
+  "trySomethingLike": "Skúste niečo ako...",
+  "tryIt": "Vyskúšajte to",
+  "creatingPlan": "Vytváranie plánu",
+  "developingLogic": "Vyvíjanie logiky",
+  "designingApp": "Navrhovanie aplikácie",
+  "generatingIconStep": "Generovanie ikony",
+  "finalTouches": "Záverečné úpravy",
+  "processing": "Spracováva sa...",
+  "features": "Funkcie",
+  "creatingYourApp": "Vytváranie vašej aplikácie...",
+  "generatingIcon": "Generovanie ikony...",
+  "whatShouldWeMake": "Čo by sme mali vytvoriť?",
+  "appName": "Názov aplikácie",
+  "description": "Popis",
+  "publicLabel": "Verejná",
+  "privateLabel": "Súkromná",
+  "free": "Zadarmo",
+  "perMonth": "/ Mesiac",
+  "tailoredConversationSummaries": "Prispôsobené zhrnutia konverzácií",
+  "customChatbotPersonality": "Vlastná osobnosť chatbota",
+  "makePublic": "Zverejniť",
+  "anyoneCanDiscover": "Ktokoľvek môže objaviť vašu aplikáciu",
+  "onlyYouCanUse": "Túto aplikáciu môžete používať len vy",
+  "paidApp": "Platená aplikácia",
+  "usersPayToUse": "Používatelia platia za používanie vašej aplikácie",
+  "freeForEveryone": "Bezplatné pre všetkých",
+  "perMonthLabel": "/ mesiac",
+  "creating": "Vytvára sa...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Vytvoriť aplikáciu",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Vyhľadávajú sa zariadenia...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{ZARIADENIE} other{ZARIADENIA}} NÁJDENÉ V BLÍZKOSTI",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PÁROVANIE ÚSPEŠNÉ",
+  "errorConnectingAppleWatch": "Chyba pri pripájaní Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Znovu to neukazovať",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Rozumiem",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Povoliť Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi potrebuje Bluetooth na pripojenie k vášmu nositeľnému zariadeniu. Povoľte prosím Bluetooth a skúste to znova.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Kontaktovať podporu?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Pripojiť neskôr",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Udeliť povolenia",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Aktivita na pozadí",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Nechajte Omi bežať na pozadí pre lepšiu stabilitu",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Prístup k polohe",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Povoliť polohu na pozadí pre plný zážitok",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Upozornenia",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Povoliť upozornenia, aby ste zostali informovaní",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Služba polohy je vypnutá",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Služba polohy je vypnutá. Prejdite do Nastavenia > Súkromie a zabezpečenie > Služby polohy a povoľte ju",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Prístup k polohe na pozadí bol zamietnutý",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Prejdite do nastavení zariadenia a nastavte povolenie polohy na \"Vždy povoliť\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Páči sa vám Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Pomôžte nám osloviť viac ľudí tým, že zanecháte recenziu v App Store. Vaša spätná väzba pre nás znamená celý svet!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Pomôžte nám osloviť viac ľudí tým, že zanecháte recenziu v Google Play Store. Vaša spätná väzba pre nás znamená celý svet!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Ohodnotiť v App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Ohodnotiť v Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Možno neskôr",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi potrebuje naučiť sa vaše ciele a váš hlas. Neskôr to budete môcť upraviť.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Začať",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Všetko hotové!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Pokračujte, darí sa vám to skvele",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Preskočiť túto otázku",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Preskočiť zatiaľ",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Chyba pripojenia",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Nepodarilo sa pripojiť k serveru. Skontrolujte prosím svoje internetové pripojenie a skúste to znova.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Bola zistená neplatná nahrávka",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Zdá sa, že v nahrávke je viacero rečníkov. Uistite sa, že ste na tichom mieste, a skúste to znova.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Nezistilo sa dostatok reči. Hovorte viac a skúste to znova.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Uistite sa, že hovoríte minimálne 5 sekúnd a najviac 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Ste tam?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Nepodarilo sa zistiť žiadnu reč. Uistite sa, že hovoríte minimálne 10 sekúnd a najviac 3 minúty.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Pripojenie bolo stratené",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Pripojenie bolo prerušené. Skontrolujte prosím svoje internetové pripojenie a skúste to znova.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Skúsiť znova",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Pripojiť Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Pokračovať bez zariadenia",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Vyžadujú sa povolenia",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Táto aplikácia potrebuje povolenia Bluetooth a Poloha, aby mohla správne fungovať. Povoľte ich prosím v nastaveniach.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Otvoriť nastavenia",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Chcete sa volať inak?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Ako sa voláte?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Hovoriť. Prepisovať. Sumarizovať.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Prihlásiť sa cez Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Prihlásiť sa cez Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Pokračovaním súhlasíte s našimi ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Podmienky používania",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Váš AI spoločník",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Zachyťte každý moment. Získajte zhrnutia\npoháňané AI. Nikdy viac si nerobte poznámky.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Nastavenie Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Povolenie bolo vyžiadané!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Povolenie mikrofónu",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Povolenie bolo udelené! Teraz:\n\nOtvorte aplikáciu Omi na hodinkách a ťuknite na \"Pokračovať\" nižšie",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Potrebujeme povolenie mikrofónu.\n\n1. Ťuknite na \"Udeliť povolenie\"\n2. Povoľte na vašom iPhone\n3. Aplikácia na hodinkách sa zatvorí\n4. Znovu ju otvorte a ťuknite na \"Pokračovať\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Udeliť povolenie",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Potrebujete pomoc?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Riešenie problémov:\n\n1. Uistite sa, že Omi je nainštalované na vašich hodinkách\n2. Otvorte aplikáciu Omi na hodinkách\n3. Hľadajte vyskakovacie okno s povolením\n4. Ťuknite na \"Povoliť\", keď sa zobrazí\n5. Aplikácia na hodinkách sa zatvorí - znovu ju otvorte\n6. Vráťte sa a ťuknite na \"Pokračovať\" na vašom iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Nahrávanie bolo úspešne spustené!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Povolenie ešte nebolo udelené. Uistite sa, že ste povolili prístup k mikrofónu a znovu otvorili aplikáciu na hodinkách.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Chyba pri vyžiadaní povolenia: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Chyba pri spustení nahrávania: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Vyberte svoj primárny jazyk",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Nastavte svoj jazyk pre presnejšie prepisy a personalizovaný zážitok",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Aký je váš primárny jazyk?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Vyberte svoj jazyk",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Vaša cesta osobného rastu s AI, ktorá počúva každé vaše slovo.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Úlohy",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Ťuknite pre úpravu • Dlhé stlačenie pre výber • Potiahnutím pre akcie",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Urobiť",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Hotové",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Staré",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Všetko je aktuálne!\nŽiadne čakajúce úlohy",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Zatiaľ žiadne dokončené položky",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Žiadne staré úlohy",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Žiadne položky",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Úloha bola označená ako nedokončená",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Úloha bola dokončená",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Odstrániť úlohu",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Naozaj chcete odstrániť túto úlohu?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Odstrániť vybrané položky",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Naozaj chcete odstrániť {count} vybranú úlohu/úlohy{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Úloha \"{description}\" bola odstránená",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} úloha/úlohy{s} bola odstránená",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Nepodarilo sa odstrániť úlohu",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Nepodarilo sa odstrániť položky",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Nepodarilo sa odstrániť niektoré položky",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Pripravené na úlohy",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Vaša AI automaticky extrahuje úlohy z vašich konverzácií. Objavia sa tu, keď budú vytvorené.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automaticky extrahované z konverzácií",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Ťuknite pre úpravu, potiahnutím dokončíte alebo odstránite",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} vybraných",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Vybrať všetko",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Odstrániť vybrané",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Hľadať v {count} spomienkach",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Spomienka bola odstránená.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Vrátiť späť",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Zatiaľ žiadne spomienky",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Zatiaľ žiadne automaticky extrahované spomienky",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Zatiaľ žiadne manuálne spomienky",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Žiadne spomienky v týchto kategóriách",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Neboli nájdené žiadne spomienky",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Pridajte svoju prvú spomienku",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Vymazať pamäť Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Naozaj chcete vymazať pamäť Omi? Túto akciu nie je možné vrátiť späť.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Vymazať pamäť",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Pamäť Omi o vás bola vymazaná",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Žiadne spomienky na odstránenie",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Vytvoriť novú spomienku",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Vytvoriť novú úlohu",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Správa pamäte",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtrovať spomienky",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Máte {count} spomienok celkom",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Verejné spomienky",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Súkromné spomienky",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Urobiť všetky spomienky súkromnými",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Urobiť všetky spomienky verejnými",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Odstrániť všetky spomienky",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Všetky spomienky sú teraz súkromné",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Všetky spomienky sú teraz verejné",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Nová spomienka",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Upraviť spomienku",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Rád jem zmrzlinu...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Nepodarilo sa uložiť. Skontrolujte prosím svoje pripojenie.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Uložiť spomienku",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Skúsiť znova",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Vytvoriť úlohu",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Upraviť úlohu",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Čo je potrebné urobiť?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Popis úlohy nemôže byť prázdny.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Úloha bola aktualizovaná",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Nepodarilo sa aktualizovať úlohu",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Úloha bola vytvorená",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Nepodarilo sa vytvoriť úlohu",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Termín dokončenia",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Čas",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Pridať termín dokončenia",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Stlačte hotovo pre uloženie",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Stlačte hotovo pre vytvorenie",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Všetko",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "O vás",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Postrehy",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuálne",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Dokončené",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Označiť ako dokončené",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Úloha bola odstránená",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Nepodarilo sa odstrániť úlohu",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Odstrániť úlohu",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Naozaj chcete odstrániť túto úlohu?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Jazyk aplikácie",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ROZHRANIE APLIKÁCIE",
+  "speechTranscriptionSectionTitle": "REČ A PREPIS",
+  "languageSettingsHelperText": "Jazyk aplikácie mení ponuky a tlačidlá. Jazyk reči ovplyvňuje spôsob prepisu vašich nahrávok."
+}

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "sv",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Konversation",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkription",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Åtgärder",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Ta bort konversation?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Är du säker på att du vill ta bort denna konversation? Detta kan inte ångras.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Bekräfta",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Avbryt",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Ta bort",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Lägg till",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Uppdatera",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Spara",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Redigera",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Stäng",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Rensa",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Kopiera transkription",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Kopiera sammanfattning",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Testa prompt",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Bearbeta konversation igen",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Ta bort konversation",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Innehåll kopierat till urklipp",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Det gick inte att uppdatera stjärnstatus.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Konversationens URL kunde inte delas.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Fel vid bearbetning av konversation. Försök igen senare.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Kontrollera din internetanslutning och försök igen.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Kan inte ta bort konversation",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Något gick fel! Försök igen senare.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Kopiera felmeddelande",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Felmeddelande kopierat till urklipp",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Återstående",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Läser in...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Läser in längd...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} sekunder",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Personer",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Lägg till ny person",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Redigera person",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Skapa en ny person och träna Omi att känna igen deras röst också!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Röstprofil",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Exempel {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Inställningar",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Språk",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Välj språk",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Tar bort...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Slutför autentiseringen i din webbläsare. När du är klar, återvänd till appen.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Det gick inte att starta autentisering",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Import har startat! Du får ett meddelande när den är klar.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Det gick inte att starta import. Försök igen.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Kunde inte komma åt den valda filen",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Fråga Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Klar",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Frånkopplad",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Söker",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Anslut enhet",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Du har nått din månatliga gräns.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Kontrollera användning",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Synkroniserar inspelningar",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Inspelningar att synkronisera",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Allt är klart",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Synkronisera",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Hängsmycket är uppdaterat",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Alla inspelningar är synkroniserade",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Synkronisering pågår",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Redo att synkronisera",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Tryck på Synkronisera för att starta",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Hängsmycket är inte anslutet. Anslut för att synkronisera.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Allt är redan synkroniserat.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Du har inspelningar som inte är synkroniserade ännu.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Vi fortsätter synkronisera dina inspelningar i bakgrunden.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Inga konversationer ännu.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Inga stjärnmärkta konversationer ännu.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "För att stjärnmärka en konversation, öppna den och tryck på stjärnikonen i sidhuvudet.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Sök konversationer",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} valda",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Slå ihop",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Slå ihop konversationer",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Detta kommer att kombinera {count} konversationer till en. Allt innehåll kommer att slås ihop och genereras på nytt.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Slår ihop i bakgrunden. Detta kan ta en stund.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Det gick inte att starta ihopslagning",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Fråga vad som helst",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Inga meddelanden ännu!\nVarför inte starta en konversation?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Tar bort dina meddelanden från Omis minne...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Meddelande kopierat till urklipp.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Du kan inte rapportera dina egna meddelanden.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Rapportera meddelande",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Är du säker på att du vill rapportera detta meddelande?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Meddelande rapporterat.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Tack för din återkoppling!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Rensa chatt?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Är du säker på att du vill rensa chatten? Detta kan inte ångras.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Du kan bara ladda upp 4 filer åt gången",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Chatta med Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Appar",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Inga appar hittades",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Prova att justera din sökning eller filter",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Skapa din egen app",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Bygg och dela din anpassade app",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Sök bland 1500+ appar",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Mina appar",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Installerade appar",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Kunde inte hämta appar :(\n\nKontrollera din internetanslutning och försök igen.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Om Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Integritetspolicy",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Besök webbplatsen",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Hjälp eller frågor?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Gå med i communityn!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ medlemmar och fler tillkommer.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Ta bort konto",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Är du säker på att du vill ta bort ditt konto?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Detta kan inte ångras.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Alla dina minnen och konversationer kommer att raderas permanent.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Dina appar och integrationer kommer att kopplas från omedelbart.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Du kan exportera dina data innan du tar bort ditt konto, men när det väl är borttaget kan det inte återställas.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Jag förstår att borttagning av mitt konto är permanent och att all data, inklusive minnen och konversationer, kommer att förloras och inte kan återställas.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Är du säker?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Denna åtgärd är oåterkallelig och kommer permanent ta bort ditt konto och all associerad data. Är du säker på att du vill fortsätta?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Ta bort nu",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Gå tillbaka",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Markera kryssrutan för att bekräfta att du förstår att borttagning av ditt konto är permanent och oåterkalleligt.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Namn",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-post",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Anpassat ordförråd",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Identifiera andra",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Betalningsmetoder",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Konversationsvisning",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Data och integritet",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Användar-ID",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Inte inställt",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Användar-ID kopierat till urklipp",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Systemstandard",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plan och användning",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Offlinesynkronisering",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Enhetsinställningar",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Chattverktyg",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Återkoppling / Bugg",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Hjälpcenter",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Utvecklarinställningar",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Hämta Omi för Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Hänvisningsprogram",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Logga ut",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "App- och enhetsdetaljer kopierade",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Årssummering 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Din integritet, din kontroll",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "På Omi är vi engagerade i att skydda din integritet. Denna sida låter dig kontrollera hur din data lagras och används.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Läs mer...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Dataskyddsnivå",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Din data är säkrad som standard med stark kryptering. Granska dina inställningar och framtida integritetsalternativ nedan.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Appåtkomst",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Följande appar kan komma åt din data. Tryck på en app för att hantera dess behörigheter.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Inga installerade appar har extern åtkomst till din data.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Enhetsnamn",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Enhets-ID",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Firmware",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD-kortssynkronisering",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Hårdvarurevision",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Modellnummer",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Tillverkare",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Dubbeltryck",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED-ljusstyrka",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Mikrofonförstärkning",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Koppla från",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Glöm enhet",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Laddningsproblem",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Koppla från enhet",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Koppla bort enhet",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Koppla bort och glöm enhet",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Din Omi har kopplats från 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Enhet bortkopplad. Gå till Inställningar > Bluetooth och glöm enheten för att slutföra.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Koppla bort enhet",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Detta kommer att koppla bort enheten så att den kan anslutas till en annan telefon. Du behöver gå till Inställningar > Bluetooth och glömma enheten för att slutföra processen.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Enheten är inte ansluten",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Anslut din Omi-enhet för att få tillgång till\nenhetsinställningar och anpassning",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Enhetsinformation",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Anpassning",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Hårdvara",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 ej upptäckt",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Vi ser att du antingen har en V1-enhet eller att din enhet inte är ansluten. SD-kortsfunktionalitet är endast tillgänglig för V2-enheter.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Avsluta konversation",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Pausa/Återuppta",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Stjärnmärk konversation",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Dubbeltrycksåtgärd",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Avsluta och bearbeta konversation",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Pausa/Återuppta inspelning",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Stjärnmärk pågående konversation",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Av",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Max",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Tysta",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Tyst",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normal",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Hög",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon är tystad",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Mycket tyst - för högljudda miljöer",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Tyst - för måttligt buller",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Neutral - balanserad inspelning",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Lätt förstärkt - normal användning",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Förstärkt - för tysta miljöer",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Hög - för avlägsna eller svaga röster",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Mycket hög - för mycket tysta källor",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maximum - använd med försiktighet",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Utvecklarinställningar",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Sparar...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Konfigurera din AI-persona",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkription",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Konfigurera STT-leverantör",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Konversations timeout",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Ställ in när konversationer avslutas automatiskt",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Importera data",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Importera data från andra källor",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Felsökning och diagnostik",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Endpoint-URL",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Inga API-nycklar ännu",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Skapa en nyckel för att komma igång",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Skapa nyckel",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokumentation",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Dina Omi-insikter",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Idag",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Denna månad",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Detta år",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "All tid",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Ingen aktivitet ännu",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Starta en konversation med Omi\nför att se dina användningsinsikter här.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Lyssnar",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Total tid Omi har aktivt lyssnat.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Förstår",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Ord förstådda från dina konversationer.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Tillhandahåller",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Åtgärder och anteckningar automatiskt fångade.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Kommer ihåg",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Fakta och detaljer som kommer ihåg för dig.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Obegränsad plan",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Hantera plan",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Din plan kommer att avbrytas den {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Din plan förnyas den {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Gratisplan",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} av {limit} min använt",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Uppgradera",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Uppgradera till obegränsat",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Din plan inkluderar {limit} gratis minuter per månad. Uppgradera för att få obegränsat.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Delar mina Omi-statistik! (omi.me - din alltid påslagna AI-assistent)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Idag har Omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Denna månad har Omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Detta år har Omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Hittills har Omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Lyssnat i {minutes} minuter",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Förstått {words} ord",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Tillhandahållit {count} insikter",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Kommit ihåg {count} minnen",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Felsökningsloggar",
+  "debugLogsAutoDelete": "Raderas automatiskt efter 3 dagar.",
+  "debugLogsDesc": "Hjälper till att diagnostisera problem",
+  "noLogFilesFound": "Inga loggfiler hittades.",
+  "omiDebugLog": "Omi felsökningslogg",
+  "logShared": "Logg delad",
+  "selectLogFile": "Välj loggfil",
+  "shareLogs": "Dela loggar",
+  "debugLogCleared": "Felsökningslogg rensad",
+  "exportStarted": "Export har startat. Detta kan ta några sekunder...",
+  "exportAllData": "Exportera all data",
+  "exportDataDesc": "Exportera konversationer till en JSON-fil",
+  "exportedConversations": "Exporterade konversationer från Omi",
+  "exportShared": "Export delad",
+  "deleteKnowledgeGraphTitle": "Ta bort kunskapsgraf?",
+  "deleteKnowledgeGraphMessage": "Detta kommer att ta bort all härledd kunskapsgrafsdata (noder och kopplingar). Dina ursprungliga minnen förblir säkra. Grafen kommer att byggas om över tid eller vid nästa begäran.",
+  "knowledgeGraphDeleted": "Kunskapsgraf borttagen",
+  "deleteGraphFailed": "Det gick inte att ta bort graf: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Ta bort kunskapsgraf",
+  "deleteKnowledgeGraphDesc": "Rensa alla noder och kopplingar",
+  "mcp": "MCP",
+  "mcpServer": "MCP-server",
+  "mcpServerDesc": "Anslut AI-assistenter till din data",
+  "serverUrl": "Server-URL",
+  "urlCopied": "URL kopierad",
+  "apiKeyAuth": "API-nyckel autentisering",
+  "header": "Header",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Klient-ID",
+  "clientSecret": "Klienthemlighet",
+  "useMcpApiKey": "Använd din MCP API-nyckel",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Konversationshändelser",
+  "newConversationCreated": "Ny konversation skapad",
+  "realtimeTranscript": "Realtidstranskription",
+  "transcriptReceived": "Transkription mottagen",
+  "audioBytes": "Ljudbytes",
+  "audioDataReceived": "Ljuddata mottagen",
+  "intervalSeconds": "Intervall (sekunder)",
+  "daySummary": "Dagsammanfattning",
+  "summaryGenerated": "Sammanfattning genererad",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Lägg till i claude_desktop_config.json",
+  "copyConfig": "Kopiera konfiguration",
+  "configCopied": "Konfiguration kopierad till urklipp",
+  "listeningMins": "Lyssnar (min)",
+  "understandingWords": "Förstår (ord)",
+  "insights": "Insikter",
+  "memories": "Minnen",
+  "minsUsedThisMonth": "{used} av {limit} min använt denna månad",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} av {limit} ord använt denna månad",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} av {limit} insikter vunna denna månad",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} av {limit} minnen skapade denna månad",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Synlighet",
+  "visibilitySubtitle": "Kontrollera vilka konversationer som visas i din lista",
+  "showShortConversations": "Visa korta konversationer",
+  "showShortConversationsDesc": "Visa konversationer som är kortare än tröskelvärdet",
+  "showDiscardedConversations": "Visa kasserade konversationer",
+  "showDiscardedConversationsDesc": "Inkludera konversationer markerade som kasserade",
+  "shortConversationThreshold": "Kort konversationströskel",
+  "shortConversationThresholdSubtitle": "Konversationer kortare än detta döljs om de inte aktiveras ovan",
+  "durationThreshold": "Varaktighetströskel",
+  "durationThresholdDesc": "Dölj konversationer kortare än detta",
+  "minLabel": "{count} min",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Anpassat ordförråd",
+  "addWords": "Lägg till ord",
+  "addWordsDesc": "Namn, termer eller ovanliga ord",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Anslut",
+  "comingSoon": "Kommer snart",
+  "chatToolsFooter": "Anslut dina appar för att visa data och mått i chatten.",
+  "completeAuthInBrowser": "Slutför autentiseringen i din webbläsare. När du är klar, återvänd till appen.",
+  "failedToStartAuth": "Det gick inte att starta {appName}-autentisering",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Koppla från {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Är du säker på att du vill koppla från {appName}? Du kan ansluta igen när som helst.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Frånkopplad från {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Det gick inte att koppla från",
+  "connectTo": "Anslut till {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Du behöver auktorisera Omi för att komma åt din {appName}-data. Detta öppnar din webbläsare för autentisering.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Fortsätt",
+  "languageTitle": "Språk",
+  "primaryLanguage": "Primärt språk",
+  "automaticTranslation": "Automatisk översättning",
+  "detectLanguages": "Upptäck 10+ språk",
+  "authorizeSavingRecordings": "Auktorisera lagring av inspelningar",
+  "thanksForAuthorizing": "Tack för auktoriseringen!",
+  "needYourPermission": "Vi behöver ditt tillstånd",
+  "alreadyGavePermission": "Du har redan gett oss tillstånd att spara dina inspelningar. Här är en påminnelse om varför vi behöver det:",
+  "wouldLikePermission": "Vi skulle vilja ha ditt tillstånd att spara dina röstinspelningar. Här är varför:",
+  "improveSpeechProfile": "Förbättra din röstprofil",
+  "improveSpeechProfileDesc": "Vi använder inspelningar för att ytterligare träna och förbättra din personliga röstprofil.",
+  "trainFamilyProfiles": "Träna profiler för vänner och familj",
+  "trainFamilyProfilesDesc": "Dina inspelningar hjälper oss att känna igen och skapa profiler för dina vänner och familj.",
+  "enhanceTranscriptAccuracy": "Förbättra transkriptionsnoggrannhet",
+  "enhanceTranscriptAccuracyDesc": "När vår modell förbättras kan vi ge bättre transkriptionsresultat för dina inspelningar.",
+  "legalNotice": "Juridiskt meddelande: Lagligheten av att spela in och lagra röstdata kan variera beroende på var du befinner dig och hur du använder denna funktion. Det är ditt ansvar att säkerställa efterlevnad av lokala lagar och förordningar.",
+  "alreadyAuthorized": "Redan auktoriserad",
+  "authorize": "Auktorisera",
+  "revokeAuthorization": "Återkalla auktorisering",
+  "authorizationSuccessful": "Auktorisering lyckades!",
+  "failedToAuthorize": "Det gick inte att auktorisera. Försök igen.",
+  "authorizationRevoked": "Auktorisering återkallad.",
+  "recordingsDeleted": "Inspelningar raderade.",
+  "failedToRevoke": "Det gick inte att återkalla auktorisering. Försök igen.",
+  "permissionRevokedTitle": "Tillstånd återkallat",
+  "permissionRevokedMessage": "Vill du att vi tar bort alla dina befintliga inspelningar också?",
+  "yes": "Ja",
+  "editName": "Redigera namn",
+  "howShouldOmiCallYou": "Vad ska Omi kalla dig?",
+  "enterYourName": "Ange ditt namn",
+  "nameCannotBeEmpty": "Namnet kan inte vara tomt",
+  "nameUpdatedSuccessfully": "Namnet har uppdaterats!",
+  "calendarSettings": "Kalenderinställningar",
+  "calendarProviders": "Kalenderleverantörer",
+  "macOsCalendar": "macOS Kalender",
+  "connectMacOsCalendar": "Anslut din lokala macOS-kalender",
+  "googleCalendar": "Google Kalender",
+  "syncGoogleAccount": "Synkronisera med ditt Google-konto",
+  "showMeetingsMenuBar": "Visa kommande möten i menyraden",
+  "showMeetingsMenuBarDesc": "Visa ditt nästa möte och tid tills det börjar i macOS menyraden",
+  "showEventsNoParticipants": "Visa händelser utan deltagare",
+  "showEventsNoParticipantsDesc": "När det är aktiverat visar Kommande händelser utan deltagare eller en videolänk.",
+  "yourMeetings": "Dina möten",
+  "refresh": "Uppdatera",
+  "noUpcomingMeetings": "Inga kommande möten hittades",
+  "checkingNextDays": "Kontrollerar nästa 30 dagar",
+  "tomorrow": "Imorgon",
+  "googleCalendarComingSoon": "Google Kalender-integration kommer snart!",
+  "connectedAsUser": "Ansluten som användare: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Standardarbetsyta",
+  "tasksCreatedInWorkspace": "Uppgifter skapas i denna arbetsyta",
+  "defaultProjectOptional": "Standardprojekt (valfritt)",
+  "leaveUnselectedTasks": "Lämna omarkerad för att skapa uppgifter utan projekt",
+  "noProjectsInWorkspace": "Inga projekt hittades i denna arbetsyta",
+  "conversationTimeoutDesc": "Välj hur länge du vill vänta i tystnad innan en konversation avslutas automatiskt:",
+  "timeout2Minutes": "2 minuter",
+  "timeout2MinutesDesc": "Avsluta konversation efter 2 minuters tystnad",
+  "timeout5Minutes": "5 minuter",
+  "timeout5MinutesDesc": "Avsluta konversation efter 5 minuters tystnad",
+  "timeout10Minutes": "10 minuter",
+  "timeout10MinutesDesc": "Avsluta konversation efter 10 minuters tystnad",
+  "timeout30Minutes": "30 minuter",
+  "timeout30MinutesDesc": "Avsluta konversation efter 30 minuters tystnad",
+  "timeout4Hours": "4 timmar",
+  "timeout4HoursDesc": "Avsluta konversation efter 4 timmars tystnad",
+  "conversationEndAfterHours": "Konversationer avslutas nu efter 4 timmars tystnad",
+  "conversationEndAfterMinutes": "Konversationer avslutas nu efter {minutes} minuters tystnad",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Berätta ditt primära språk",
+  "languageForTranscription": "Ställ in ditt språk för skarpare transkriptioner och en personlig upplevelse.",
+  "singleLanguageModeInfo": "Enspråksläge är aktiverat. Översättning är inaktiverad för högre noggrannhet.",
+  "searchLanguageHint": "Sök språk efter namn eller kod",
+  "noLanguagesFound": "Inga språk hittades",
+  "skip": "Hoppa över",
+  "languageSetTo": "Språk inställt på {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Det gick inte att ställa in språk",
+  "appSettings": "{appName}-inställningar",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Koppla från {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Detta tar bort din {appName}-autentisering. Du måste ansluta igen för att använda den.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Ansluten till {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Konto",
+  "actionItemsSyncedTo": "Dina åtgärder kommer att synkroniseras till ditt {appName}-konto",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Standardutrymme",
+  "selectSpaceInWorkspace": "Välj ett utrymme i din arbetsyta",
+  "noSpacesInWorkspace": "Inga utrymmen hittades i denna arbetsyta",
+  "defaultList": "Standardlista",
+  "tasksAddedToList": "Uppgifter läggs till i denna lista",
+  "noListsInSpace": "Inga listor hittades i detta utrymme",
+  "failedToLoadRepos": "Det gick inte att ladda repositories: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Standardrepository sparad",
+  "failedToSaveDefaultRepo": "Det gick inte att spara standardrepository",
+  "defaultRepository": "Standardrepository",
+  "selectDefaultRepoDesc": "Välj en standardrepository för att skapa ärenden. Du kan fortfarande ange en annan repository när du skapar ärenden.",
+  "noReposFound": "Inga repositories hittades",
+  "private": "Privat",
+  "updatedDate": "Uppdaterad {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "igår",
+  "daysAgo": "{count} dagar sedan",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 vecka sedan",
+  "weeksAgo": "{count} veckor sedan",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 månad sedan",
+  "monthsAgo": "{count} månader sedan",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Ärenden skapas i din standardrepository",
+  "taskIntegrations": "Uppgiftsintegrationer",
+  "configureSettings": "Konfigurera inställningar",
+  "completeAuthBrowser": "Slutför autentiseringen i din webbläsare. När du är klar, återvänd till appen.",
+  "failedToStartAppAuth": "Det gick inte att starta {appName}-autentisering",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Anslut till {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Du behöver auktorisera Omi för att skapa uppgifter i ditt {appName}-konto. Detta öppnar din webbläsare för autentisering.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Fortsätt",
+  "appIntegration": "{appName}-integration",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Integration med {appName} kommer snart! Vi arbetar hårt för att ge dig fler alternativ för uppgiftshantering.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Förstår",
+  "tasksExportedOneApp": "Uppgifter kan exporteras till en app åt gången.",
+  "completeYourUpgrade": "Slutför din uppgradering",
+  "importConfiguration": "Importera konfiguration",
+  "exportConfiguration": "Exportera konfiguration",
+  "bringYourOwn": "Ta med din egen",
+  "payYourSttProvider": "Använd Omi fritt. Du betalar bara din STT-leverantör direkt.",
+  "freeMinutesMonth": "1 200 gratis minuter/månad ingår. Obegränsat med ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Värd krävs",
+  "validPortRequired": "Giltig port krävs",
+  "validWebsocketUrlRequired": "Giltig WebSocket-URL krävs (wss://)",
+  "apiUrlRequired": "API-URL krävs",
+  "apiKeyRequired": "API-nyckel krävs",
+  "invalidJsonConfig": "Ogiltig JSON-konfiguration",
+  "errorSaving": "Fel vid sparande: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Konfiguration kopierad till urklipp",
+  "pasteJsonConfig": "Klistra in din JSON-konfiguration nedan:",
+  "addApiKeyAfterImport": "Du behöver lägga till din egen API-nyckel efter import",
+  "paste": "Klistra in",
+  "import": "Importera",
+  "invalidProviderInConfig": "Ogiltig leverantör i konfiguration",
+  "importedConfig": "Importerad {providerName}-konfiguration",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Ogiltig JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Leverantör",
+  "live": "Live",
+  "onDevice": "På enhet",
+  "apiUrl": "API-URL",
+  "enterSttHttpEndpoint": "Ange din STT HTTP-endpoint",
+  "websocketUrl": "WebSocket-URL",
+  "enterLiveSttWebsocket": "Ange din live STT WebSocket-endpoint",
+  "apiKey": "API-nyckel",
+  "enterApiKey": "Ange din API-nyckel",
+  "storedLocallyNeverShared": "Lagras lokalt, delas aldrig",
+  "host": "Värd",
+  "port": "Port",
+  "advanced": "Avancerat",
+  "configuration": "Konfiguration",
+  "requestConfiguration": "Begäran konfiguration",
+  "responseSchema": "Svarsschema",
+  "modified": "Modifierad",
+  "resetRequestConfig": "Återställ begäran konfiguration till standard",
+  "logs": "Loggar",
+  "logsCopied": "Loggar kopierade",
+  "noLogsYet": "Inga loggar ännu. Börja spela in för att se anpassad STT-aktivitet.",
+  "deviceUsesCodec": "{deviceName} använder {codecReason}. Omi kommer att användas.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi-transkription",
+  "bestInClassTranscription": "Bästa i klassen transkription utan konfiguration",
+  "instantSpeakerLabels": "Omedelbara talaretiketter",
+  "languageTranslation": "100+ språköversättning",
+  "optimizedForConversation": "Optimerad för konversation",
+  "autoLanguageDetection": "Automatisk språkdetektering",
+  "highAccuracy": "Hög noggrannhet",
+  "privacyFirst": "Integritet först",
+  "saveChanges": "Spara ändringar",
+  "resetToDefault": "Återställ till standard",
+  "viewTemplate": "Visa mall",
+  "trySomethingLike": "Prova något som...",
+  "tryIt": "Prova det",
+  "creatingPlan": "Skapar plan",
+  "developingLogic": "Utvecklar logik",
+  "designingApp": "Designar app",
+  "generatingIconStep": "Genererar ikon",
+  "finalTouches": "Sista finishen",
+  "processing": "Bearbetar...",
+  "features": "Funktioner",
+  "creatingYourApp": "Skapar din app...",
+  "generatingIcon": "Genererar ikon...",
+  "whatShouldWeMake": "Vad ska vi skapa?",
+  "appName": "Appnamn",
+  "description": "Beskrivning",
+  "publicLabel": "Offentlig",
+  "privateLabel": "Privat",
+  "free": "Gratis",
+  "perMonth": "/ Månad",
+  "tailoredConversationSummaries": "Skräddarsydda konversationssammanfattningar",
+  "customChatbotPersonality": "Anpassad chatbot-personlighet",
+  "makePublic": "Gör offentlig",
+  "anyoneCanDiscover": "Vem som helst kan upptäcka din app",
+  "onlyYouCanUse": "Endast du kan använda denna app",
+  "paidApp": "Betald app",
+  "usersPayToUse": "Användare betalar för att använda din app",
+  "freeForEveryone": "Gratis för alla",
+  "perMonthLabel": "/ månad",
+  "creating": "Skapar...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Skapa app",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Söker efter enheter...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{ENHET} other{ENHETER}} HITTAD(E) I NÄRHETEN",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "PARKOPPLING LYCKADES",
+  "errorConnectingAppleWatch": "Fel vid anslutning till Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Visa inte igen",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Jag förstår",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Aktivera Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi behöver Bluetooth för att ansluta till din bärbara enhet. Aktivera Bluetooth och försök igen.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Kontakta support?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Anslut senare",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Bevilja behörigheter",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Bakgrundsaktivitet",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Låt Omi köra i bakgrunden för bättre stabilitet",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Platsåtkomst",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Aktivera bakgrundsplats för den fullständiga upplevelsen",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Notifieringar",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Aktivera notifieringar för att hålla dig informerad",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Platstjänst inaktiverad",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Platstjänsten är inaktiverad. Gå till Inställningar > Integritet och säkerhet > Platstjänster och aktivera den",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Bakgrundsplatsåtkomst nekad",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Gå till enhetsinställningar och ställ in platsbehörighet till \"Tillåt alltid\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Älskar du Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Hjälp oss att nå fler människor genom att lämna en recension i App Store. Din återkoppling betyder världen för oss!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Hjälp oss att nå fler människor genom att lämna en recension i Google Play Store. Din återkoppling betyder världen för oss!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Betygsätt i App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Betygsätt i Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Kanske senare",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi behöver lära sig dina mål och din röst. Du kan ändra det senare.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Kom igång",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Allt klart!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Fortsätt, du gör det bra",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Hoppa över denna fråga",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Hoppa över för tillfället",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Anslutningsfel",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Det gick inte att ansluta till servern. Kontrollera din internetanslutning och försök igen.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Ogiltig inspelning upptäckt",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Det verkar som det finns flera talare i inspelningen. Se till att du är på en tyst plats och försök igen.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Det finns inte tillräckligt med tal upptäckt. Tala mer och försök igen.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Se till att du talar i minst 5 sekunder och inte mer än 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Är du där?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Vi kunde inte upptäcka något tal. Se till att tala i minst 10 sekunder och inte mer än 3 minuter.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Anslutning förlorad",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Anslutningen avbröts. Kontrollera din internetanslutning och försök igen.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Försök igen",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Anslut Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Fortsätt utan enhet",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Behörigheter krävs",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Denna app behöver Bluetooth- och platsbehörigheter för att fungera korrekt. Aktivera dem i inställningarna.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Öppna inställningar",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Vill du kallas något annat?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Vad heter du?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Tala. Transkribera. Sammanfatta.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Logga in med Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Logga in med Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Genom att fortsätta godkänner du vår ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Användarvillkor",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Din AI-följeslagare",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Fånga varje ögonblick. Få AI-drivna\nsammanfattningar. Ta aldrig anteckningar igen.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch-konfiguration",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Behörighet begärd!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Mikrofonbehörighet",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Behörighet beviljad! Nu:\n\nÖppna Omi-appen på din klocka och tryck på \"Fortsätt\" nedan",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Vi behöver mikrofonbehörighet.\n\n1. Tryck på \"Bevilja behörighet\"\n2. Tillåt på din iPhone\n3. Klockappen stängs\n4. Öppna igen och tryck på \"Fortsätt\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Bevilja behörighet",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Behöver du hjälp?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Felsökning:\n\n1. Se till att Omi är installerat på din klocka\n2. Öppna Omi-appen på din klocka\n3. Leta efter behörighetspopupen\n4. Tryck på \"Tillåt\" när du uppmanas\n5. Appen på din klocka stängs - öppna den igen\n6. Kom tillbaka och tryck på \"Fortsätt\" på din iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Inspelning startade!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Behörighet har inte beviljats ännu. Se till att du tillät mikrofonåtkomst och öppnade appen igen på din klocka.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Fel vid begäran av behörighet: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Fel vid start av inspelning: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Välj ditt primära språk",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Ställ in ditt språk för skarpare transkriptioner och en personlig upplevelse",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Vilket är ditt primära språk?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Välj ditt språk",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Din personliga utvecklingsresa med AI som lyssnar på varje ord.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Att göra",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Tryck för att redigera • Långtryck för att välja • Svep för åtgärder",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Att göra",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Klar",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Gamla",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Allt klart!\nInga väntande åtgärder",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Inga avslutade objekt ännu",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Inga gamla uppgifter",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Inga objekt",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Åtgärd markerad som ofullständig",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Åtgärd slutförd",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Ta bort åtgärd",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Är du säker på att du vill ta bort denna åtgärd?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Ta bort valda objekt",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Är du säker på att du vill ta bort {count} vald{s} åtgärd{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Åtgärd \"{description}\" borttagen",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} åtgärd{s} borttagen{s}",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Det gick inte att ta bort åtgärd",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Det gick inte att ta bort objekt",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Det gick inte att ta bort vissa objekt",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Redo för åtgärder",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Din AI kommer automatiskt att extrahera uppgifter och att-göra-saker från dina konversationer. De kommer att visas här när de skapas.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Automatiskt extraherat från konversationer",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Tryck för att redigera, svep för att slutföra eller ta bort",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} valda",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Välj alla",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Ta bort valda",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Sök {count} minnen",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Minne borttaget.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Ångra",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Inga minnen ännu",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Inga automatiskt extraherade minnen ännu",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Inga manuella minnen ännu",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Inga minnen i dessa kategorier",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Inga minnen hittades",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Lägg till ditt första minne",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Rensa Omis minne",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Är du säker på att du vill rensa Omis minne? Detta kan inte ångras.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Rensa minne",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omis minne om dig har rensats",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Inga minnen att ta bort",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Skapa nytt minne",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Skapa ny åtgärd",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Minneshantering",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Filtrera minnen",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Du har {count} totala minnen",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Offentliga minnen",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Privata minnen",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Gör alla minnen privata",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Gör alla minnen offentliga",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Ta bort alla minnen",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Alla minnen är nu privata",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Alla minnen är nu offentliga",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Nytt minne",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Redigera minne",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Jag gillar att äta glass...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Det gick inte att spara. Kontrollera din anslutning.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Spara minne",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Försök igen",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Skapa åtgärd",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Redigera åtgärd",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Vad behöver göras?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Åtgärdsbeskrivning kan inte vara tom.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Åtgärd uppdaterad",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Det gick inte att uppdatera åtgärd",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Åtgärd skapad",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Det gick inte att skapa åtgärd",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Förfallodatum",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Tid",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Lägg till förfallodatum",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Tryck på klar för att spara",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Tryck på klar för att skapa",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Alla",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Om dig",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Insikter",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuell",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Slutförd",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Markera som slutförd",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Åtgärd borttagen",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Det gick inte att ta bort åtgärd",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Ta bort åtgärd",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Är du säker på att du vill ta bort denna åtgärd?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Appspråk",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "APPGRÄNSSNITT",
+  "speechTranscriptionSectionTitle": "TAL OCH TRANSKRIPTION",
+  "languageSettingsHelperText": "Appspråk ändrar menyer och knappar. Talspråk påverkar hur dina inspelningar transkriberas."
+}

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "th",
+  "@@last_modified": "2024-12-26",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "บทสนทนา",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "บันทึกเสียง",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "รายการสิ่งที่ต้องทำ",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "ลบบทสนทนา?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "คุณแน่ใจหรือไม่ว่าต้องการลบบทสนทนานี้? การดำเนินการนี้ไม่สามารถยกเลิกได้",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "ยืนยัน",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "ยกเลิก",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "ตกลง",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "ลบ",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "เพิ่ม",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "อัปเดต",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "บันทึก",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "แก้ไข",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "ปิด",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "ล้าง",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "คัดลอกบันทึกเสียง",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "คัดลอกสรุป",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "ทดสอบคำสั่ง",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "ประมวลผลบทสนทนาใหม่",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "ลบบทสนทนา",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "คัดลอกเนื้อหาไปยังคลิปบอร์ดแล้ว",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "ไม่สามารถอัปเดตสถานะการติดดาวได้",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "ไม่สามารถแชร์ URL บทสนทนาได้",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "เกิดข้อผิดพลาดขณะประมวลผลบทสนทนา กรุณาลองใหม่ภายหลัง",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองใหม่อีกครั้ง",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "ไม่สามารถลบบทสนทนาได้",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "เกิดข้อผิดพลาดบางอย่าง! กรุณาลองใหม่ภายหลัง",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "คัดลอกข้อความแสดงข้อผิดพลาด",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "คัดลอกข้อความแสดงข้อผิดพลาดไปยังคลิปบอร์ดแล้ว",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "เหลืออยู่",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "กำลังโหลด...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "กำลังโหลดระยะเวลา...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} วินาที",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "บุคคล",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "เพิ่มบุคคลใหม่",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "แก้ไขบุคคล",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "สร้างบุคคลใหม่และฝึก Omi ให้รู้จักเสียงพูดของพวกเขาด้วย!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "โปรไฟล์การพูด",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "ตัวอย่างที่ {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "การตั้งค่า",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "ภาษา",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "เลือกภาษา",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "กำลังลบ...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "กรุณายืนยันตัวตนในเบราว์เซอร์ของคุณ เมื่อเสร็จแล้วกลับมาที่แอป",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "ไม่สามารถเริ่มการยืนยันตัวตนได้",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "เริ่มการนำเข้าแล้ว! คุณจะได้รับการแจ้งเตือนเมื่อเสร็จสิ้น",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "ไม่สามารถเริ่มการนำเข้าได้ กรุณาลองใหม่อีกครั้ง",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "ไม่สามารถเข้าถึงไฟล์ที่เลือกได้",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "ถาม Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "เสร็จสิ้น",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "ตัดการเชื่อมต่อแล้ว",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "กำลังค้นหา",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "เชื่อมต่ออุปกรณ์",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "คุณถึงขีดจำกัดรายเดือนแล้ว",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "ตรวจสอบการใช้งาน",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "กำลังซิงค์การบันทึก",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "การบันทึกที่ต้องซิงค์",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "ทำทุกอย่างเรียบร้อยแล้ว",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "ซิงค์",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "จี้อัปเดตแล้ว",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "ซิงค์การบันทึกทั้งหมดแล้ว",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "กำลังดำเนินการซิงค์",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "พร้อมซิงค์",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "แตะซิงค์เพื่อเริ่มต้น",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "ไม่ได้เชื่อมต่อจี้ เชื่อมต่อเพื่อซิงค์",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "ซิงค์ทุกอย่างเรียบร้อยแล้ว",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "คุณมีการบันทึกที่ยังไม่ได้ซิงค์",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "เราจะซิงค์การบันทึกของคุณต่อในเบื้องหลัง",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "ยังไม่มีบทสนทนา",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "ยังไม่มีบทสนทนาที่ติดดาว",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "หากต้องการติดดาวบทสนทนา ให้เปิดและแตะไอคอนดาวในส่วนหัว",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "ค้นหาบทสนทนา",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "เลือก {count} รายการ",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "รวม",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "รวมบทสนทนา",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "นี่จะรวม {count} บทสนทนาเป็นหนึ่งเดียว เนื้อหาทั้งหมดจะถูกรวมและสร้างใหม่",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "กำลังรวมในเบื้องหลัง อาจใช้เวลาสักครู่",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "ไม่สามารถเริ่มการรวมได้",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "ถามอะไรก็ได้",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "ยังไม่มีข้อความ!\nลองเริ่มบทสนทนาสิ",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "กำลังลบข้อความของคุณจากความทรงจำของ Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "คัดลอกข้อความไปยังคลิปบอร์ดแล้ว",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "คุณไม่สามารถรายงานข้อความของตัวเองได้",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "รายงานข้อความ",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "คุณแน่ใจหรือไม่ว่าต้องการรายงานข้อความนี้?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "รายงานข้อความสำเร็จแล้ว",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "ขอบคุณสำหรับคำติชมของคุณ!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "ล้างแชท?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "คุณแน่ใจหรือไม่ว่าต้องการล้างแชท? การดำเนินการนี้ไม่สามารถยกเลิกได้",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "คุณสามารถอัปโหลดได้เพียง 4 ไฟล์ในคราวเดียว",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "แชทกับ Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "แอป",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "ไม่พบแอป",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "ลองปรับการค้นหาหรือตัวกรองของคุณ",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "สร้างแอปของคุณเอง",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "สร้างและแชร์แอปที่คุณกำหนดเอง",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "ค้นหา 1,500+ แอป",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "แอปของฉัน",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "แอปที่ติดตั้ง",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "ไม่สามารถดึงข้อมูลแอปได้ :(\n\nกรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองใหม่อีกครั้ง",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "เกี่ยวกับ Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "นโยบายความเป็นส่วนตัว",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "เยี่ยมชมเว็บไซต์",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "ต้องการความช่วยเหลือหรือสอบถามข้อมูล?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "เข้าร่วมชุมชน!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "สมาชิก 8,000+ คนและกำลังเพิ่มขึ้น",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "ลบบัญชี",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "คุณแน่ใจหรือไม่ว่าต้องการลบบัญชีของคุณ?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "การกระทำนี้ไม่สามารถยกเลิกได้",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "ความทรงจำและบทสนทนาทั้งหมดของคุณจะถูกลบอย่างถาวร",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "แอปและการเชื่อมต่อของคุณจะถูกตัดการเชื่อมต่อทันที",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "คุณสามารถส่งออกข้อมูลของคุณก่อนลบบัญชี แต่เมื่อลบแล้วจะไม่สามารถกู้คืนได้",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "ฉันเข้าใจว่าการลบบัญชีของฉันเป็นการถาวรและข้อมูลทั้งหมด รวมถึงความทรงจำและบทสนทนา จะสูญหายและไม่สามารถกู้คืนได้",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "คุณแน่ใจหรือไม่?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "การดำเนินการนี้ไม่สามารถย้อนกลับได้และจะลบบัญชีของคุณและข้อมูลที่เกี่ยวข้องทั้งหมดอย่างถาวร คุณแน่ใจหรือไม่ว่าต้องการดำเนินการต่อ?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "ลบเลย",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "กลับ",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "กาเครื่องหมายในช่องเพื่อยืนยันว่าคุณเข้าใจว่าการลบบัญชีของคุณเป็นการถาวรและไม่สามารถย้อนกลับได้",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "โปรไฟล์",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "ชื่อ",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "อีเมล",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "คำศัพท์ที่กำหนดเอง",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "การระบุบุคคลอื่น",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "วิธีการชำระเงิน",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "การแสดงผลบทสนทนา",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "ข้อมูลและความเป็นส่วนตัว",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "รหัสผู้ใช้",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "ยังไม่ได้ตั้งค่า",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "คัดลอกรหัสผู้ใช้ไปยังคลิปบอร์ดแล้ว",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "ค่าเริ่มต้นของระบบ",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "แผนและการใช้งาน",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "ซิงค์แบบออฟไลน์",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "การตั้งค่าอุปกรณ์",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "เครื่องมือแชท",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "คำติชม / รายงานข้อผิดพลาด",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "ศูนย์ช่วยเหลือ",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "การตั้งค่านักพัฒนา",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "ดาวน์โหลด Omi สำหรับ Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "โปรแกรมแนะนำเพื่อน",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "ออกจากระบบ",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "คัดลอกรายละเอียดแอปและอุปกรณ์แล้ว",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "สรุปปี 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "ความเป็นส่วนตัวของคุณ อยู่ในการควบคุมของคุณ",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "ที่ Omi เรามุ่งมั่นในการปกป้องความเป็นส่วนตัวของคุณ หน้านี้ช่วยให้คุณสามารถควบคุมวิธีการจัดเก็บและใช้ข้อมูลของคุณได้",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "เรียนรู้เพิ่มเติม...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "ระดับการปกป้องข้อมูล",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "ข้อมูลของคุณได้รับการรักษาความปลอดภัยโดยค่าเริ่มต้นด้วยการเข้ารหัสที่แข็งแกร่ง ตรวจสอบการตั้งค่าและตัวเลือกความเป็นส่วนตัวในอนาคตด้านล่าง",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "การเข้าถึงแอป",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "แอปต่อไปนี้สามารถเข้าถึงข้อมูลของคุณได้ แตะที่แอปเพื่อจัดการสิทธิ์",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "ไม่มีแอปที่ติดตั้งซึ่งมีการเข้าถึงข้อมูลของคุณจากภายนอก",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "ชื่ออุปกรณ์",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "รหัสอุปกรณ์",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "เฟิร์มแวร์",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "ซิงค์การ์ด SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "เวอร์ชันฮาร์ดแวร์",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "หมายเลขรุ่น",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "ผู้ผลิต",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "แตะสองครั้ง",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "ความสว่าง LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "ระดับไมโครโฟน",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "ตัดการเชื่อมต่อ",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "ลืมอุปกรณ์",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "ปัญหาการชาร์จ",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "ตัดการเชื่อมต่ออุปกรณ์",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "ยกเลิกการจับคู่อุปกรณ์",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "ยกเลิกการจับคู่และลืมอุปกรณ์",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Omi ของคุณถูกตัดการเชื่อมต่อแล้ว 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "ยกเลิกการจับคู่อุปกรณ์แล้ว ไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำการยกเลิกการจับคู่ให้เสร็จสมบูรณ์",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "ยกเลิกการจับคู่อุปกรณ์",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "นี่จะยกเลิกการจับคู่อุปกรณ์เพื่อให้สามารถเชื่อมต่อกับโทรศัพท์เครื่องอื่นได้ คุณจะต้องไปที่การตั้งค่า > Bluetooth และลืมอุปกรณ์เพื่อทำกระบวนการให้เสร็จสมบูรณ์",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "ไม่ได้เชื่อมต่ออุปกรณ์",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "เชื่อมต่ออุปกรณ์ Omi ของคุณเพื่อเข้าถึง\nการตั้งค่าและการปรับแต่งอุปกรณ์",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "ข้อมูลอุปกรณ์",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "การปรับแต่ง",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "ฮาร์ดแวร์",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "ไม่พบ V2",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "เราเห็นว่าคุณมีอุปกรณ์ V1 หรืออุปกรณ์ของคุณไม่ได้เชื่อมต่อ ฟังก์ชัน SD Card จะใช้ได้เฉพาะกับอุปกรณ์ V2 เท่านั้น",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "จบบทสนทนา",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "หยุดชั่วคราว/ดำเนินการต่อ",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "ติดดาวบทสนทนา",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "การดำเนินการแตะสองครั้ง",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "จบและประมวลผลบทสนทนา",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "หยุดชั่วคราว/ดำเนินการบันทึกต่อ",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "ติดดาวบทสนทนาที่กำลังดำเนินการ",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "ปิด",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "สูงสุด",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "ปิดเสียง",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "เงียบ",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "ปกติ",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "สูง",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "ไมโครโฟนถูกปิดเสียง",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "เงียบมาก - สำหรับสภาพแวดล้อมที่เสียงดัง",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "เงียบ - สำหรับเสียงรบกวนปานกลาง",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "กลางๆ - การบันทึกที่สมดุล",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "เพิ่มขึ้นเล็กน้อย - การใช้งานปกติ",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "เพิ่มขึ้น - สำหรับสภาพแวดล้อมที่เงียบ",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "สูง - สำหรับเสียงที่ไกลหรือเบา",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "สูงมาก - สำหรับแหล่งเสียงที่เงียบมาก",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "สูงสุด - ใช้ด้วยความระมัดระวัง",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "การตั้งค่านักพัฒนา",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "กำลังบันทึก...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "กำหนดค่าบุคลิก AI ของคุณ",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "เบต้า",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "การถอดเสียง",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "กำหนดค่าผู้ให้บริการ STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "หมดเวลาบทสนทนา",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "ตั้งค่าเมื่อบทสนทนาจะจบอัตโนมัติ",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "นำเข้าข้อมูล",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "นำเข้าข้อมูลจากแหล่งอื่น",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "การแก้ไขจุดบกพร่องและการวินิจฉัย",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL ปลายทาง",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "ยังไม่มีคีย์ API",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "สร้างคีย์เพื่อเริ่มต้น",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "สร้างคีย์",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "เอกสาร",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "ข้อมูลเชิงลึก Omi ของคุณ",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "วันนี้",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "เดือนนี้",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "ปีนี้",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "ตลอดเวลา",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "ยังไม่มีกิจกรรม",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "เริ่มบทสนทนากับ Omi\nเพื่อดูข้อมูลเชิงลึกการใช้งานของคุณที่นี่",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "การฟัง",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "เวลารวมที่ Omi ฟังอย่างกระตือรือร้น",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "การเข้าใจ",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "คำที่เข้าใจจากบทสนทนาของคุณ",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "การให้บริการ",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "รายการสิ่งที่ต้องทำและบันทึกที่จับได้โดยอัตโนมัติ",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "การจดจำ",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "ข้อเท็จจริงและรายละเอียดที่จำไว้ให้คุณ",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "แผนไม่จำกัด",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "จัดการแผน",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "แผนของคุณจะยกเลิกในวันที่ {date}",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "แผนของคุณจะต่ออายุในวันที่ {date}",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "แผนฟรี",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "ใช้ไป {used} จาก {limit} นาที",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "อัปเกรด",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "อัปเกรดเป็นแบบไม่จำกัด",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "แผนของคุณรวม {limit} นาทีฟรีต่อเดือน อัปเกรดเพื่อใช้งานแบบไม่จำกัด",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "แชร์สถิติ Omi ของฉัน! (omi.me - ผู้ช่วย AI ที่เปิดอยู่ตลอดเวลา)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "วันนี้ omi ได้:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "เดือนนี้ omi ได้:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "ปีนี้ omi ได้:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "จนถึงตอนนี้ omi ได้:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 ฟังเป็นเวลา {minutes} นาที",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 เข้าใจ {words} คำ",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ ให้ข้อมูลเชิงลึก {count} รายการ",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 จำความทรงจำ {count} รายการ",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "บันทึกการแก้ไขจุดบกพร่อง",
+  "debugLogsAutoDelete": "ลบอัตโนมัติหลังจาก 3 วัน",
+  "debugLogsDesc": "ช่วยวินิจฉัยปัญหา",
+  "noLogFilesFound": "ไม่พบไฟล์บันทึก",
+  "omiDebugLog": "บันทึกการแก้ไขจุดบกพร่อง Omi",
+  "logShared": "แชร์บันทึกแล้ว",
+  "selectLogFile": "เลือกไฟล์บันทึก",
+  "shareLogs": "แชร์บันทึก",
+  "debugLogCleared": "ล้างบันทึกการแก้ไขจุดบกพร่องแล้ว",
+  "exportStarted": "เริ่มการส่งออกแล้ว อาจใช้เวลาสักครู่...",
+  "exportAllData": "ส่งออกข้อมูลทั้งหมด",
+  "exportDataDesc": "ส่งออกบทสนทนาเป็นไฟล์ JSON",
+  "exportedConversations": "บทสนทนาที่ส่งออกจาก Omi",
+  "exportShared": "แชร์การส่งออกแล้ว",
+  "deleteKnowledgeGraphTitle": "ลบกราฟความรู้?",
+  "deleteKnowledgeGraphMessage": "นี่จะลบข้อมูลกราฟความรู้ที่สร้างขึ้นทั้งหมด (โหนดและการเชื่อมต่อ) ความทรงจำเดิมของคุณจะยังคงปลอดภัย กราฟจะถูกสร้างขึ้นใหม่เมื่อเวลาผ่านไปหรือเมื่อมีคำขอครั้งถัดไป",
+  "knowledgeGraphDeleted": "ลบกราฟความรู้สำเร็จแล้ว",
+  "deleteGraphFailed": "ไม่สามารถลบกราฟ: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "ลบกราฟความรู้",
+  "deleteKnowledgeGraphDesc": "ล้างโหนดและการเชื่อมต่อทั้งหมด",
+  "mcp": "MCP",
+  "mcpServer": "เซิร์ฟเวอร์ MCP",
+  "mcpServerDesc": "เชื่อมต่อผู้ช่วย AI กับข้อมูลของคุณ",
+  "serverUrl": "URL เซิร์ฟเวอร์",
+  "urlCopied": "คัดลอก URL แล้ว",
+  "apiKeyAuth": "การยืนยันตัวตนด้วยคีย์ API",
+  "header": "ส่วนหัว",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Client ID",
+  "clientSecret": "Client Secret",
+  "useMcpApiKey": "ใช้คีย์ API MCP ของคุณ",
+  "webhooks": "Webhooks",
+  "conversationEvents": "เหตุการณ์บทสนทนา",
+  "newConversationCreated": "สร้างบทสนทนาใหม่แล้ว",
+  "realtimeTranscript": "บันทึกเสียงแบบเรียลไทม์",
+  "transcriptReceived": "ได้รับบันทึกเสียงแล้ว",
+  "audioBytes": "ไบต์เสียง",
+  "audioDataReceived": "ได้รับข้อมูลเสียงแล้ว",
+  "intervalSeconds": "ช่วงเวลา (วินาที)",
+  "daySummary": "สรุปรายวัน",
+  "summaryGenerated": "สร้างสรุปแล้ว",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "เพิ่มไปยัง claude_desktop_config.json",
+  "copyConfig": "คัดลอกการกำหนดค่า",
+  "configCopied": "คัดลอกการกำหนดค่าไปยังคลิปบอร์ดแล้ว",
+  "listeningMins": "การฟัง (นาที)",
+  "understandingWords": "การเข้าใจ (คำ)",
+  "insights": "ข้อมูลเชิงลึก",
+  "memories": "ความทรงจำ",
+  "minsUsedThisMonth": "ใช้ไป {used} จาก {limit} นาทีในเดือนนี้",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "ใช้ไป {used} จาก {limit} คำในเดือนนี้",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "ได้รับข้อมูลเชิงลึก {used} จาก {limit} รายการในเดือนนี้",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "สร้างความทรงจำ {used} จาก {limit} รายการในเดือนนี้",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "การมองเห็น",
+  "visibilitySubtitle": "ควบคุมว่าบทสนทนาใดจะปรากฏในรายการของคุณ",
+  "showShortConversations": "แสดงบทสนทนาสั้น",
+  "showShortConversationsDesc": "แสดงบทสนทนาที่สั้นกว่าเกณฑ์",
+  "showDiscardedConversations": "แสดงบทสนทนาที่ถูกทิ้ง",
+  "showDiscardedConversationsDesc": "รวมบทสนทนาที่ถูกทำเครื่องหมายว่าทิ้ง",
+  "shortConversationThreshold": "เกณฑ์บทสนทนาสั้น",
+  "shortConversationThresholdSubtitle": "บทสนทนาที่สั้นกว่านี้จะถูกซ่อนเว้นแต่จะเปิดใช้งานด้านบน",
+  "durationThreshold": "เกณฑ์ระยะเวลา",
+  "durationThresholdDesc": "ซ่อนบทสนทนาที่สั้นกว่านี้",
+  "minLabel": "{count} นาที",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "คำศัพท์ที่กำหนดเอง",
+  "addWords": "เพิ่มคำ",
+  "addWordsDesc": "ชื่อ คำศัพท์ หรือคำที่ไม่ธรรมดา",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "เชื่อมต่อ",
+  "comingSoon": "เร็วๆ นี้",
+  "chatToolsFooter": "เชื่อมต่อแอปของคุณเพื่อดูข้อมูลและตัวชี้วัดในแชท",
+  "completeAuthInBrowser": "กรุณายืนยันตัวตนในเบราว์เซอร์ของคุณ เมื่อเสร็จแล้วกลับมาที่แอป",
+  "failedToStartAuth": "ไม่สามารถเริ่มการยืนยันตัวตน {appName} ได้",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "ตัดการเชื่อมต่อ {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "คุณแน่ใจหรือไม่ว่าต้องการตัดการเชื่อมต่อจาก {appName}? คุณสามารถเชื่อมต่อใหม่ได้ตลอดเวลา",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "ตัดการเชื่อมต่อจาก {appName} แล้ว",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "ตัดการเชื่อมต่อไม่สำเร็จ",
+  "connectTo": "เชื่อมต่อกับ {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "คุณต้องอนุญาตให้ Omi เข้าถึงข้อมูล {appName} ของคุณ ระบบจะเปิดเบราว์เซอร์เพื่อยืนยันตัวตน",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "ดำเนินการต่อ",
+  "languageTitle": "ภาษา",
+  "primaryLanguage": "ภาษาหลัก",
+  "automaticTranslation": "แปลภาษาอัตโนมัติ",
+  "detectLanguages": "ตรวจจับมากกว่า 10 ภาษา",
+  "authorizeSavingRecordings": "อนุญาตให้บันทึกการอัด",
+  "thanksForAuthorizing": "ขอบคุณสำหรับการอนุญาต!",
+  "needYourPermission": "เราต้องการความยินยอมจากคุณ",
+  "alreadyGavePermission": "คุณได้อนุญาตให้เราบันทึกการอัดของคุณแล้ว นี่คือเหตุผลที่เราต้องการ:",
+  "wouldLikePermission": "เราต้องการความยินยอมในการบันทึกเสียงของคุณ นี่คือเหตุผล:",
+  "improveSpeechProfile": "ปรับปรุงโปรไฟล์เสียงของคุณ",
+  "improveSpeechProfileDesc": "เราใช้การบันทึกเพื่อฝึกและปรับปรุงโปรไฟล์เสียงส่วนบุคคลของคุณ",
+  "trainFamilyProfiles": "ฝึกโปรไฟล์สำหรับเพื่อนและครอบครัว",
+  "trainFamilyProfilesDesc": "การบันทึกของคุณช่วยให้เราจดจำและสร้างโปรไฟล์สำหรับเพื่อนและครอบครัวของคุณ",
+  "enhanceTranscriptAccuracy": "เพิ่มความแม่นยำของการถอดเสียง",
+  "enhanceTranscriptAccuracyDesc": "เมื่อโมเดลของเราดีขึ้น เราสามารถให้ผลการถอดเสียงที่ดีขึ้นสำหรับการบันทึกของคุณ",
+  "legalNotice": "ประกาศทางกฎหมาย: ความถูกต้องตามกฎหมายในการบันทึกและจัดเก็บข้อมูลเสียงอาจแตกต่างกันไปตามสถานที่และวิธีที่คุณใช้ฟีเจอร์นี้ เป็นความรับผิดชอบของคุณที่จะต้องปฏิบัติตามกฎหมายและข้อบังคับในพื้นที่",
+  "alreadyAuthorized": "อนุญาตแล้ว",
+  "authorize": "อนุญาต",
+  "revokeAuthorization": "เพิกถอนการอนุญาต",
+  "authorizationSuccessful": "อนุญาตสำเร็จ!",
+  "failedToAuthorize": "อนุญาตไม่สำเร็จ กรุณาลองอีกครั้ง",
+  "authorizationRevoked": "เพิกถอนการอนุญาตแล้ว",
+  "recordingsDeleted": "ลบการบันทึกแล้ว",
+  "failedToRevoke": "เพิกถอนการอนุญาตไม่สำเร็จ กรุณาลองอีกครั้ง",
+  "permissionRevokedTitle": "เพิกถอนการอนุญาต",
+  "permissionRevokedMessage": "คุณต้องการให้เราลบการบันทึกที่มีอยู่ทั้งหมดของคุณด้วยหรือไม่?",
+  "yes": "ใช่",
+  "editName": "แก้ไขชื่อ",
+  "howShouldOmiCallYou": "Omi ควรเรียกคุณว่าอะไร?",
+  "enterYourName": "ใส่ชื่อของคุณ",
+  "nameCannotBeEmpty": "ชื่อต้องไม่ว่างเปล่า",
+  "nameUpdatedSuccessfully": "อัปเดตชื่อสำเร็จ!",
+  "calendarSettings": "การตั้งค่าปฏิทิน",
+  "calendarProviders": "ผู้ให้บริการปฏิทิน",
+  "macOsCalendar": "ปฏิทิน macOS",
+  "connectMacOsCalendar": "เชื่อมต่อปฏิทิน macOS ในเครื่องของคุณ",
+  "googleCalendar": "ปฏิทิน Google",
+  "syncGoogleAccount": "ซิงค์กับบัญชี Google ของคุณ",
+  "showMeetingsMenuBar": "แสดงการประชุมที่กำลังจะมาถึงในแถบเมนู",
+  "showMeetingsMenuBarDesc": "แสดงการประชุมถัดไปและเวลาที่เหลือก่อนเริ่มในแถบเมนู macOS",
+  "showEventsNoParticipants": "แสดงกิจกรรมที่ไม่มีผู้เข้าร่วม",
+  "showEventsNoParticipantsDesc": "เมื่อเปิดใช้งาน Coming Up จะแสดงกิจกรรมที่ไม่มีผู้เข้าร่วมหรือลิงก์วิดีโอ",
+  "yourMeetings": "การประชุมของคุณ",
+  "refresh": "รีเฟรช",
+  "noUpcomingMeetings": "ไม่พบการประชุมที่กำลังจะมาถึง",
+  "checkingNextDays": "ตรวจสอบ 30 วันถัดไป",
+  "tomorrow": "พรุ่งนี้",
+  "googleCalendarComingSoon": "การผสานรวมปฏิทิน Google เร็วๆ นี้!",
+  "connectedAsUser": "เชื่อมต่อในชื่อผู้ใช้: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "พื้นที่ทำงานเริ่มต้น",
+  "tasksCreatedInWorkspace": "งานจะถูกสร้างในพื้นที่ทำงานนี้",
+  "defaultProjectOptional": "โปรเจกต์เริ่มต้น (ไม่บังคับ)",
+  "leaveUnselectedTasks": "เว้นว่างไว้เพื่อสร้างงานโดยไม่มีโปรเจกต์",
+  "noProjectsInWorkspace": "ไม่พบโปรเจกต์ในพื้นที่ทำงานนี้",
+  "conversationTimeoutDesc": "เลือกระยะเวลาที่จะรอในความเงียบก่อนสิ้นสุดบทสนทนาอัตโนมัติ:",
+  "timeout2Minutes": "2 นาที",
+  "timeout2MinutesDesc": "สิ้นสุดบทสนทนาหลังจากเงียบ 2 นาที",
+  "timeout5Minutes": "5 นาที",
+  "timeout5MinutesDesc": "สิ้นสุดบทสนทนาหลังจากเงียบ 5 นาที",
+  "timeout10Minutes": "10 นาที",
+  "timeout10MinutesDesc": "สิ้นสุดบทสนทนาหลังจากเงียบ 10 นาที",
+  "timeout30Minutes": "30 นาที",
+  "timeout30MinutesDesc": "สิ้นสุดบทสนทนาหลังจากเงียบ 30 นาที",
+  "timeout4Hours": "4 ชั่วโมง",
+  "timeout4HoursDesc": "สิ้นสุดบทสนทนาหลังจากเงียบ 4 ชั่วโมง",
+  "conversationEndAfterHours": "บทสนทนาจะสิ้นสุดหลังจากเงียบ 4 ชั่วโมง",
+  "conversationEndAfterMinutes": "บทสนทนาจะสิ้นสุดหลังจากเงียบ {minutes} นาที",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "บอกเราถึงภาษาหลักของคุณ",
+  "languageForTranscription": "ตั้งค่าภาษาของคุณเพื่อการถอดเสียงที่แม่นยำขึ้นและประสบการณ์ที่เป็นส่วนตัว",
+  "singleLanguageModeInfo": "โหมดภาษาเดียวถูกเปิดใช้งาน การแปลภาษาถูกปิดเพื่อความแม่นยำที่สูงขึ้น",
+  "searchLanguageHint": "ค้นหาภาษาตามชื่อหรือรหัส",
+  "noLanguagesFound": "ไม่พบภาษา",
+  "skip": "ข้าม",
+  "languageSetTo": "ตั้งค่าภาษาเป็น {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "ตั้งค่าภาษาไม่สำเร็จ",
+  "appSettings": "การตั้งค่า {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "ตัดการเชื่อมต่อจาก {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "การดำเนินการนี้จะลบการยืนยันตัวตน {appName} ของคุณ คุณจะต้องเชื่อมต่อใหม่เพื่อใช้งานอีกครั้ง",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "เชื่อมต่อกับ {appName} แล้ว",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "บัญชี",
+  "actionItemsSyncedTo": "รายการสิ่งที่ต้องทำของคุณจะถูกซิงค์ไปยังบัญชี {appName} ของคุณ",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "พื้นที่เริ่มต้น",
+  "selectSpaceInWorkspace": "เลือกพื้นที่ในพื้นที่ทำงานของคุณ",
+  "noSpacesInWorkspace": "ไม่พบพื้นที่ในพื้นที่ทำงานนี้",
+  "defaultList": "รายการเริ่มต้น",
+  "tasksAddedToList": "งานจะถูกเพิ่มลงในรายการนี้",
+  "noListsInSpace": "ไม่พบรายการในพื้นที่นี้",
+  "failedToLoadRepos": "โหลดที่เก็บไม่สำเร็จ: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "บันทึกที่เก็บเริ่มต้นแล้ว",
+  "failedToSaveDefaultRepo": "บันทึกที่เก็บเริ่มต้นไม่สำเร็จ",
+  "defaultRepository": "ที่เก็บเริ่มต้น",
+  "selectDefaultRepoDesc": "เลือกที่เก็บเริ่มต้นสำหรับสร้าง issue คุณยังสามารถระบุที่เก็บอื่นได้เมื่อสร้าง issue",
+  "noReposFound": "ไม่พบที่เก็บ",
+  "private": "ส่วนตัว",
+  "updatedDate": "อัปเดต {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "เมื่อวาน",
+  "daysAgo": "{count} วันที่แล้ว",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 สัปดาห์ที่แล้ว",
+  "weeksAgo": "{count} สัปดาห์ที่แล้ว",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 เดือนที่แล้ว",
+  "monthsAgo": "{count} เดือนที่แล้ว",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Issue จะถูกสร้างในที่เก็บเริ่มต้นของคุณ",
+  "taskIntegrations": "การผสานรวมงาน",
+  "configureSettings": "กำหนดการตั้งค่า",
+  "completeAuthBrowser": "กรุณายืนยันตัวตนในเบราว์เซอร์ของคุณ เมื่อเสร็จแล้วกลับมาที่แอป",
+  "failedToStartAppAuth": "เริ่มการยืนยันตัวตน {appName} ไม่สำเร็จ",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "เชื่อมต่อกับ {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "คุณต้องอนุญาตให้ Omi สร้างงานในบัญชี {appName} ของคุณ ระบบจะเปิดเบราว์เซอร์เพื่อยืนยันตัวตน",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "ดำเนินการต่อ",
+  "appIntegration": "การผสานรวม {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "การผสานรวมกับ {appName} เร็วๆ นี้! เรากำลังพยายามนำตัวเลือกการจัดการงานเพิ่มเติมมาให้คุณ",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "เข้าใจแล้ว",
+  "tasksExportedOneApp": "สามารถส่งออกงานไปยังแอปหนึ่งแอปในแต่ละครั้ง",
+  "completeYourUpgrade": "ดำเนินการอัปเกรดของคุณให้เสร็จสมบูรณ์",
+  "importConfiguration": "นำเข้าการกำหนดค่า",
+  "exportConfiguration": "ส่งออกการกำหนดค่า",
+  "bringYourOwn": "นำของคุณเองมาใช้",
+  "payYourSttProvider": "ใช้ Omi ได้อย่างอิสระ คุณจ่ายเฉพาะผู้ให้บริการ STT ของคุณโดยตรง",
+  "freeMinutesMonth": "รวม 1,200 นาทีฟรี/เดือน ไม่จำกัดด้วย ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "ต้องระบุ Host",
+  "validPortRequired": "ต้องระบุพอร์ตที่ถูกต้อง",
+  "validWebsocketUrlRequired": "ต้องระบุ URL WebSocket ที่ถูกต้อง (wss://)",
+  "apiUrlRequired": "ต้องระบุ API URL",
+  "apiKeyRequired": "ต้องระบุ API key",
+  "invalidJsonConfig": "การกำหนดค่า JSON ไม่ถูกต้อง",
+  "errorSaving": "ข้อผิดพลาดในการบันทึก: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "คัดลอกการกำหนดค่าไปยังคลิปบอร์ดแล้ว",
+  "pasteJsonConfig": "วางการกำหนดค่า JSON ของคุณด้านล่าง:",
+  "addApiKeyAfterImport": "คุณจะต้องเพิ่ม API key ของคุณเองหลังจากนำเข้า",
+  "paste": "วาง",
+  "import": "นำเข้า",
+  "invalidProviderInConfig": "ผู้ให้บริการในการกำหนดค่าไม่ถูกต้อง",
+  "importedConfig": "นำเข้าการกำหนดค่า {providerName} แล้ว",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON ไม่ถูกต้อง: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "ผู้ให้บริการ",
+  "live": "สด",
+  "onDevice": "บนอุปกรณ์",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "ใส่ endpoint HTTP ของ STT ของคุณ",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "ใส่ endpoint WebSocket ของ STT แบบสดของคุณ",
+  "apiKey": "API Key",
+  "enterApiKey": "ใส่ API key ของคุณ",
+  "storedLocallyNeverShared": "จัดเก็บในเครื่อง ไม่แชร์เลย",
+  "host": "Host",
+  "port": "พอร์ต",
+  "advanced": "ขั้นสูง",
+  "configuration": "การกำหนดค่า",
+  "requestConfiguration": "การกำหนดค่าคำขอ",
+  "responseSchema": "โครงสร้างการตอบกลับ",
+  "modified": "แก้ไขแล้ว",
+  "resetRequestConfig": "รีเซ็ตการกำหนดค่าคำขอเป็นค่าเริ่มต้น",
+  "logs": "บันทึก",
+  "logsCopied": "คัดลอกบันทึกแล้ว",
+  "noLogsYet": "ยังไม่มีบันทึก เริ่มบันทึกเพื่อดูกิจกรรม STT แบบกำหนดเอง",
+  "deviceUsesCodec": "{deviceName} ใช้ {codecReason} จะใช้ Omi แทน",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "การถอดเสียง Omi",
+  "bestInClassTranscription": "การถอดเสียงชั้นนำโดยไม่ต้องตั้งค่า",
+  "instantSpeakerLabels": "ติดป้ายผู้พูดทันที",
+  "languageTranslation": "แปลมากกว่า 100 ภาษา",
+  "optimizedForConversation": "เหมาะสำหรับบทสนทนา",
+  "autoLanguageDetection": "ตรวจจับภาษาอัตโนมัติ",
+  "highAccuracy": "ความแม่นยำสูง",
+  "privacyFirst": "ความเป็นส่วนตัวเป็นอันดับแรก",
+  "saveChanges": "บันทึกการเปลี่ยนแปลง",
+  "resetToDefault": "รีเซ็ตเป็นค่าเริ่มต้น",
+  "viewTemplate": "ดูเทมเพลต",
+  "trySomethingLike": "ลองอะไรแบบนี้...",
+  "tryIt": "ลองดู",
+  "creatingPlan": "กำลังสร้างแผน",
+  "developingLogic": "กำลังพัฒนาตรรกะ",
+  "designingApp": "กำลังออกแบบแอป",
+  "generatingIconStep": "กำลังสร้างไอคอน",
+  "finalTouches": "ตกแต่งขั้นสุดท้าย",
+  "processing": "กำลังประมวลผล...",
+  "features": "ฟีเจอร์",
+  "creatingYourApp": "กำลังสร้างแอปของคุณ...",
+  "generatingIcon": "กำลังสร้างไอคอน...",
+  "whatShouldWeMake": "เราควรสร้างอะไร?",
+  "appName": "ชื่อแอป",
+  "description": "คำอธิบาย",
+  "publicLabel": "สาธารณะ",
+  "privateLabel": "ส่วนตัว",
+  "free": "ฟรี",
+  "perMonth": "/ เดือน",
+  "tailoredConversationSummaries": "สรุปบทสนทนาที่ปรับแต่งได้",
+  "customChatbotPersonality": "บุคลิกแชทบอทที่กำหนดเอง",
+  "makePublic": "ทำให้เป็นสาธารณะ",
+  "anyoneCanDiscover": "ทุกคนสามารถค้นพบแอปของคุณได้",
+  "onlyYouCanUse": "เฉพาะคุณเท่านั้นที่สามารถใช้แอปนี้ได้",
+  "paidApp": "แอปแบบชำระเงิน",
+  "usersPayToUse": "ผู้ใช้จ่ายเงินเพื่อใช้แอปของคุณ",
+  "freeForEveryone": "ฟรีสำหรับทุกคน",
+  "perMonthLabel": "/ เดือน",
+  "creating": "กำลังสร้าง...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "สร้างแอป",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "กำลังค้นหาอุปกรณ์...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "พบ {count} {count, plural, =1{อุปกรณ์} other{อุปกรณ์}} ในบริเวณใกล้เคียง",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "จับคู่สำเร็จ",
+  "errorConnectingAppleWatch": "เชื่อมต่อกับ Apple Watch ไม่สำเร็จ: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "อย่าแสดงอีก",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "ฉันเข้าใจ",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "เปิดใช้งาน Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi ต้องการ Bluetooth เพื่อเชื่อมต่อกับอุปกรณ์สวมใส่ของคุณ กรุณาเปิดใช้งาน Bluetooth แล้วลองอีกครั้ง",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "ติดต่อฝ่ายสนับสนุน?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "เชื่อมต่อภายหลัง",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "อนุญาตสิทธิ์",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "กิจกรรมพื้นหลัง",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "ให้ Omi ทำงานในพื้นหลังเพื่อความเสถียรที่ดีขึ้น",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "การเข้าถึงตำแหน่ง",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "เปิดใช้งานตำแหน่งพื้นหลังเพื่อประสบการณ์ที่สมบูรณ์",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "การแจ้งเตือน",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "เปิดใช้งานการแจ้งเตือนเพื่อรับข้อมูล",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "บริการตำแหน่งถูกปิด",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "บริการตำแหน่งถูกปิด กรุณาไปที่ การตั้งค่า > ความเป็นส่วนตัวและความปลอดภัย > บริการตำแหน่ง แล้วเปิดใช้งาน",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "การเข้าถึงตำแหน่งพื้นหลังถูกปฏิเสธ",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "กรุณาไปที่การตั้งค่าอุปกรณ์และตั้งค่าสิทธิ์ตำแหน่งเป็น \"อนุญาตเสมอ\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "ชอบ Omi ไหม?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "ช่วยเราเข้าถึงคนมากขึ้นด้วยการรีวิวใน App Store ความคิดเห็นของคุณมีความหมายมากสำหรับเรา!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "ช่วยเราเข้าถึงคนมากขึ้นด้วยการรีวิวใน Google Play Store ความคิดเห็นของคุณมีความหมายมากสำหรับเรา!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "ให้คะแนนบน App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "ให้คะแนนบน Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "ทีหลังก็ได้",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi ต้องเรียนรู้เป้าหมายและเสียงของคุณ คุณสามารถแก้ไขได้ในภายหลัง",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "เริ่มต้น",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "เสร็จแล้ว!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "ทำต่อไป คุณทำได้ดีมาก",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "ข้ามคำถามนี้",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "ข้ามไว้ก่อน",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "ข้อผิดพลาดในการเชื่อมต่อ",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "เชื่อมต่อกับเซิร์ฟเวอร์ไม่สำเร็จ กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "ตรวจพบการบันทึกที่ไม่ถูกต้อง",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "ดูเหมือนว่ามีผู้พูดหลายคนในการบันทึก กรุณาตรวจสอบให้แน่ใจว่าคุณอยู่ในสถานที่เงียบและลองอีกครั้ง",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "ตรวจพบคำพูดไม่เพียงพอ กรุณาพูดมากขึ้นและลองอีกครั้ง",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "กรุณาตรวจสอบให้แน่ใจว่าคุณพูดอย่างน้อย 5 วินาทีและไม่เกิน 90 วินาที",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "คุณยังอยู่ไหม?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "เราตรวจไม่พบคำพูดใดๆ กรุณาตรวจสอบให้แน่ใจว่าคุณพูดอย่างน้อย 10 วินาทีและไม่เกิน 3 นาที",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "การเชื่อมต่อขาดหาย",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "การเชื่อมต่อถูกขัดจังหวะ กรุณาตรวจสอบการเชื่อมต่ออินเทอร์เน็ตของคุณและลองอีกครั้ง",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "ลองอีกครั้ง",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "เชื่อมต่อ Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "ดำเนินการต่อโดยไม่มีอุปกรณ์",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "ต้องการสิทธิ์",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "แอปนี้ต้องการสิทธิ์ Bluetooth และตำแหน่งเพื่อทำงานอย่างถูกต้อง กรุณาเปิดใช้งานในการตั้งค่า",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "เปิดการตั้งค่า",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "ต้องการใช้ชื่ออื่นไหม?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "คุณชื่ออะไร?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "พูด ถอดเสียง สรุป",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "ลงชื่อเข้าใช้ด้วย Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "ลงชื่อเข้าใช้ด้วย Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "การดำเนินการต่อแสดงว่าคุณยอมรับ ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "เงื่อนไขการใช้งาน",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – เพื่อนคู่ใจ AI ของคุณ",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "บันทึกทุกช่วงเวลา รับสรุปโดย AI\nไม่ต้องจดบันทึกอีกต่อไป",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "ตั้งค่า Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "ขอสิทธิ์แล้ว!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "สิทธิ์ไมโครโฟน",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "อนุญาตสิทธิ์แล้ว! ตอนนี้:\n\nเปิดแอป Omi บนนาฬิกาของคุณและแตะ \"ดำเนินการต่อ\" ด้านล่าง",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "เราต้องการสิทธิ์ไมโครโฟน\n\n1. แตะ \"อนุญาตสิทธิ์\"\n2. อนุญาตบน iPhone ของคุณ\n3. แอปบนนาฬิกาจะปิด\n4. เปิดใหม่และแตะ \"ดำเนินการต่อ\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "อนุญาตสิทธิ์",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "ต้องการความช่วยเหลือ?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "วิธีแก้ปัญหา:\n\n1. ตรวจสอบว่าได้ติดตั้ง Omi บนนาฬิกาแล้ว\n2. เปิดแอป Omi บนนาฬิกาของคุณ\n3. มองหาป๊อปอัปสิทธิ์\n4. แตะ \"อนุญาต\" เมื่อได้รับแจ้ง\n5. แอปบนนาฬิกาจะปิด - เปิดใหม่\n6. กลับมาและแตะ \"ดำเนินการต่อ\" บน iPhone ของคุณ",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "เริ่มบันทึกสำเร็จ!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "ยังไม่ได้อนุญาตสิทธิ์ กรุณาตรวจสอบให้แน่ใจว่าคุณได้อนุญาตการเข้าถึงไมโครโฟนและเปิดแอปบนนาฬิกาใหม่แล้ว",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "ขอสิทธิ์ไม่สำเร็จ: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "เริ่มบันทึกไม่สำเร็จ: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "เลือกภาษาหลักของคุณ",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "ตั้งค่าภาษาของคุณเพื่อการถอดเสียงที่แม่นยำขึ้นและประสบการณ์ที่เป็นส่วนตัว",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "ภาษาหลักของคุณคืออะไร?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "เลือกภาษาของคุณ",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "เส้นทางการเติบโตส่วนบุคคลของคุณกับ AI ที่ฟังทุกคำพูดของคุณ",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "สิ่งที่ต้องทำ",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "แตะเพื่อแก้ไข • กดค้างเพื่อเลือก • ปัดเพื่อดำเนินการ",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "ต้องทำ",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "เสร็จแล้ว",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "เก่า",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 ทำทุกอย่างเสร็จแล้ว!\nไม่มีสิ่งที่ต้องทำที่รอดำเนินการ",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "ยังไม่มีรายการที่เสร็จสมบูรณ์",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ ไม่มีงานเก่า",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "ไม่มีรายการ",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "ทำเครื่องหมายสิ่งที่ต้องทำเป็นยังไม่เสร็จสมบูรณ์",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "ทำสิ่งที่ต้องทำเสร็จแล้ว",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "ลบสิ่งที่ต้องทำ",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "คุณแน่ใจหรือไม่ว่าต้องการลบสิ่งที่ต้องทำนี้?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "ลบรายการที่เลือก",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "คุณแน่ใจหรือไม่ว่าต้องการลบสิ่งที่ต้องทำที่เลือก {count} รายการ{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "ลบสิ่งที่ต้องทำ \"{description}\" แล้ว",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "ลบสิ่งที่ต้องทำ {count} รายการ{s}แล้ว",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "ลบสิ่งที่ต้องทำไม่สำเร็จ",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "ลบรายการไม่สำเร็จ",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "ลบบางรายการไม่สำเร็จ",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "พร้อมสำหรับสิ่งที่ต้องทำ",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "AI ของคุณจะดึงงานและสิ่งที่ต้องทำจากบทสนทนาโดยอัตโนมัติ รายการจะปรากฏที่นี่เมื่อสร้าง",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "ดึงจากบทสนทนาอัตโนมัติ",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "แตะเพื่อแก้ไข ปัดเพื่อทำให้เสร็จหรือลบ",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "เลือกแล้ว {count} รายการ",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "เลือกทั้งหมด",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "ลบที่เลือก",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "ค้นหา {count} ความทรงจำ",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "ลบความทรงจำแล้ว",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "เลิกทำ",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "ยังไม่มีความทรงจำ",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "ยังไม่มีความทรงจำที่ดึงอัตโนมัติ",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "ยังไม่มีความทรงจำที่สร้างด้วยตนเอง",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "ไม่มีความทรงจำในหมวดหมู่เหล่านี้",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "ไม่พบความทรงจำ",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "เพิ่มความทรงจำแรกของคุณ",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "ล้างความทรงจำของ Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "คุณแน่ใจหรือไม่ว่าต้องการล้างความทรงจำของ Omi? การกระทำนี้ไม่สามารถยกเลิกได้",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "ล้างความทรงจำ",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "ล้างความทรงจำของ Omi เกี่ยวกับคุณแล้ว",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "ไม่มีความทรงจำที่จะลบ",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "สร้างความทรงจำใหม่",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "สร้างสิ่งที่ต้องทำใหม่",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "การจัดการความทรงจำ",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "กรองความทรงจำ",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "คุณมีความทรงจำทั้งหมด {count} รายการ",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "ความทรงจำสาธารณะ",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "ความทรงจำส่วนตัว",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "ทำให้ความทรงจำทั้งหมดเป็นส่วนตัว",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "ทำให้ความทรงจำทั้งหมดเป็นสาธารณะ",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "ลบความทรงจำทั้งหมด",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "ความทรงจำทั้งหมดเป็นส่วนตัวแล้ว",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "ความทรงจำทั้งหมดเป็นสาธารณะแล้ว",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "ความทรงจำใหม่",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "แก้ไขความทรงจำ",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "ฉันชอบกินไอศกรีม...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "บันทึกไม่สำเร็จ กรุณาตรวจสอบการเชื่อมต่อของคุณ",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "บันทึกความทรงจำ",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "ลองใหม่",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "สร้างสิ่งที่ต้องทำ",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "แก้ไขสิ่งที่ต้องทำ",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "ต้องทำอะไร?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "คำอธิบายสิ่งที่ต้องทำต้องไม่ว่างเปล่า",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "อัปเดตสิ่งที่ต้องทำแล้ว",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "อัปเดตสิ่งที่ต้องทำไม่สำเร็จ",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "สร้างสิ่งที่ต้องทำแล้ว",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "สร้างสิ่งที่ต้องทำไม่สำเร็จ",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "วันครบกำหนด",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "เวลา",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "เพิ่มวันครบกำหนด",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "กดเสร็จสิ้นเพื่อบันทึก",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "กดเสร็จสิ้นเพื่อสร้าง",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "ทั้งหมด",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "เกี่ยวกับคุณ",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "ข้อมูลเชิงลึก",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "ด้วยตนเอง",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "เสร็จสมบูรณ์",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "ทำเครื่องหมายว่าเสร็จสมบูรณ์",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "ลบสิ่งที่ต้องทำแล้ว",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "ลบสิ่งที่ต้องทำไม่สำเร็จ",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "ลบสิ่งที่ต้องทำ",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "คุณแน่ใจหรือไม่ว่าต้องการลบสิ่งที่ต้องทำนี้?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "ภาษาแอป",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "อินเทอร์เฟซแอป",
+  "speechTranscriptionSectionTitle": "คำพูดและการถอดเสียง",
+  "languageSettingsHelperText": "ภาษาแอปเปลี่ยนเมนูและปุ่ม ภาษาคำพูดส่งผลต่อวิธีถอดเสียงการบันทึกของคุณ"
+}

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -1,0 +1,2299 @@
+{
+  "@@locale": "tr",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Konuşma",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Transkript",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Eylem Öğeleri",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Konuşma Silinsin mi?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Bu konuşmayı silmek istediğinizden emin misiniz? Bu işlem geri alınamaz.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Onayla",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "İptal",
+  "@cancel": {
+    "description": "Cancel button label"
+  },
+  "ok": "Tamam",
+  "@ok": {
+    "description": "OK button label"
+  },
+  "delete": "Sil",
+  "@delete": {
+    "description": "Delete button/action label"
+  },
+  "add": "Ekle",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Güncelle",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Kaydet",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Düzenle",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Kapat",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Temizle",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Transkripti Kopyala",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Özeti Kopyala",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "İstemi Test Et",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Konuşmayı Yeniden İşle",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Konuşmayı Sil",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "İçerik panoya kopyalandı",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Favorilere ekleme durumu güncellenemedi.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Konuşma URL'si paylaşılamadı.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Konuşma işlenirken hata oluştu. Lütfen daha sonra tekrar deneyin.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Konuşma Silinemiyor",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Bir şeyler ters gitti! Lütfen daha sonra tekrar deneyin.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Hata mesajını kopyala",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Hata mesajı panoya kopyalandı",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Kalan",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Yükleniyor...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Süre yükleniyor...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} saniye",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Kişiler",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Yeni Kişi Ekle",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Kişiyi Düzenle",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Yeni bir kişi oluşturun ve Omi'yi onların konuşmasını da tanımaya eğitin!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Konuşma Profili",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Örnek {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Ayarlar",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Dil",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Dil Seç",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Siliniyor...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Kimlik doğrulama başlatılamadı",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "İçe aktarma başladı! Tamamlandığında bildirim alacaksınız.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "İçe aktarma başlatılamadı. Lütfen tekrar deneyin.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Seçilen dosyaya erişilemedi",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Omi'ye Sor",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Bitti",
+  "@done": {
+    "description": "Done button label"
+  },
+  "disconnected": "Bağlantı Kesildi",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Aranıyor",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Cihazı Bağla",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Aylık limitinize ulaştınız.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Kullanımı Kontrol Et",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Kayıtlar senkronize ediliyor",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Senkronize edilecek kayıtlar",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Her şey güncel",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Senkronize Et",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Kolye güncel",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Tüm kayıtlar senkronize edildi",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Senkronizasyon devam ediyor",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Senkronize etmeye hazır",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Başlatmak için Senkronize Et'e dokunun",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Kolye bağlı değil. Senkronize etmek için bağlayın.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Her şey zaten senkronize edilmiş.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Henüz senkronize edilmemiş kayıtlarınız var.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Kayıtlarınızı arka planda senkronize etmeye devam edeceğiz.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Henüz konuşma yok.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Henüz favorilere eklenmiş konuşma yok.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Bir konuşmayı favorilere eklemek için açın ve üst kısımdaki yıldız simgesine dokunun.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Konuşmalarda Ara",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "{count} seçildi",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Birleştir",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Konuşmaları Birleştir",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Bu işlem {count} konuşmayı birleştirecek. Tüm içerik birleştirilecek ve yeniden oluşturulacak.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Arka planda birleştiriliyor. Bu biraz zaman alabilir.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Birleştirme başlatılamadı",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Her şeyi sor",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Henüz mesaj yok!\nNeden bir konuşma başlatmıyorsunuz?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Mesajlarınız Omi'nin hafızasından siliniyor...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Mesaj panoya kopyalandı.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Kendi mesajlarınızı bildiremezsiniz.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Mesajı Bildir",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Bu mesajı bildirmek istediğinizden emin misiniz?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Mesaj başarıyla bildirildi.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Geri bildiriminiz için teşekkürler!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Sohbet Temizlensin mi?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Sohbeti temizlemek istediğinizden emin misiniz? Bu işlem geri alınamaz.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Aynı anda en fazla 4 dosya yükleyebilirsiniz",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Omi ile Sohbet",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Uygulamalar",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Uygulama bulunamadı",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Arama veya filtreleri ayarlamayı deneyin",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Kendi Uygulamanızı Oluşturun",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Özel uygulamanızı oluşturun ve paylaşın",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "1500+ Uygulama Ara",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Uygulamalarım",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Yüklü Uygulamalar",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Uygulamalar alınamadı :(\n\nLütfen internet bağlantınızı kontrol edin ve tekrar deneyin.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Omi Hakkında",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Gizlilik Politikası",
+  "@privacyPolicy": {
+    "description": "Privacy policy link"
+  },
+  "visitWebsite": "Web Sitesini Ziyaret Et",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Yardım veya Sorular?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Topluluğa katılın!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "8000+ üye ve artıyor.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Hesabı Sil",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Hesabınızı silmek istediğinizden emin misiniz?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Bu işlem geri alınamaz.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Tüm anılarınız ve konuşmalarınız kalıcı olarak silinecek.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Uygulamalarınız ve Entegrasyonlarınızın bağlantısı derhal kesilecek.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Hesabınızı silmeden önce verilerinizi dışa aktarabilirsiniz, ancak silindikten sonra kurtarılamaz.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Hesabımı silmenin kalıcı olduğunu ve anılar ve konuşmalar dahil tüm verilerin kaybolacağını ve kurtarılamayacağını anlıyorum.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Emin misiniz?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Bu işlem geri alınamaz ve hesabınızı ve tüm ilgili verileri kalıcı olarak silecektir. Devam etmek istediğinizden emin misiniz?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Şimdi Sil",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Geri Dön",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Hesabınızı silmenin kalıcı ve geri alınamaz olduğunu anladığınızı onaylamak için kutucuğu işaretleyin.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Profil",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "İsim",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "E-posta",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Özel Kelime Hazinesi",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Diğerlerini Tanımlama",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Ödeme Yöntemleri",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Konuşma Görünümü",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Veri ve Gizlilik",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "Kullanıcı Kimliği",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Ayarlanmadı",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Kullanıcı kimliği panoya kopyalandı",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Sistem Varsayılanı",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Plan ve Kullanım",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Çevrimdışı Senkronizasyon",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Cihaz Ayarları",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Sohbet Araçları",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Geri Bildirim / Hata",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Yardım Merkezi",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Geliştirici Ayarları",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Mac için Omi'yi Edinin",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Yönlendirme Programı",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Çıkış Yap",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Uygulama ve cihaz detayları kopyalandı",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "2025 Özeti",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Gizliliğiniz, Kontrolünüz",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Omi'de gizliliğinizi korumaya kararlıyız. Bu sayfa verilerinizin nasıl saklandığını ve kullanıldığını kontrol etmenizi sağlar.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Daha fazla bilgi...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Veri Koruma Seviyesi",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Verileriniz varsayılan olarak güçlü şifreleme ile korunmaktadır. Ayarlarınızı ve gelecekteki gizlilik seçeneklerini aşağıda inceleyin.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Uygulama Erişimi",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Aşağıdaki uygulamalar verilerinize erişebilir. İzinlerini yönetmek için bir uygulamaya dokunun.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Yüklü hiçbir uygulama verilerinize harici erişime sahip değil.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Cihaz Adı",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "Cihaz Kimliği",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Ürün Yazılımı",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "SD Kart Senkronizasyonu",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Donanım Revizyonu",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Model Numarası",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Üretici",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Çift Dokunma",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "LED Parlaklığı",
+  "@ledBrightness": {
+    "description": "LED brightness label"
+  },
+  "micGain": "Mikrofon Kazancı",
+  "@micGain": {
+    "description": "Microphone gain label"
+  },
+  "disconnect": "Bağlantıyı Kes",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Cihazı Unut",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Şarj Sorunları",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Cihazın Bağlantısını Kes",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Cihazı Eşleştirmeyi Kaldır",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Eşleştirmeyi Kaldır ve Cihazı Unut",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Omi'nizin bağlantısı kesildi 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Cihazın eşleştirilmesi kaldırıldı. Eşleştirmeyi tamamlamak için Ayarlar > Bluetooth'a gidin ve cihazı unutun.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Cihazı Eşleştirmeyi Kaldır",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Bu, cihazın eşleştirilmesini kaldıracak ve başka bir telefona bağlanabilecek. İşlemi tamamlamak için Ayarlar > Bluetooth'a gidip cihazı unutmanız gerekecek.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Cihaz Bağlı Değil",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Cihaz ayarlarına ve özelleştirmeye erişmek için\nOmi cihazınızı bağlayın",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Cihaz Bilgileri",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Özelleştirme",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Donanım",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 algılanamadı",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "V1 cihazınız olduğunu veya cihazınızın bağlı olmadığını görüyoruz. SD Kart işlevi yalnızca V2 cihazlar için mevcuttur.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Konuşmayı Sonlandır",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Duraklat/Devam Et",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Konuşmayı Favorilere Ekle",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Çift Dokunma İşlemi",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Konuşmayı Sonlandır ve İşle",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Kaydı Duraklat/Devam Ettir",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Devam Eden Konuşmayı Favorilere Ekle",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Kapalı",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Maksimum",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Sessiz",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Sessiz",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Normal",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Yüksek",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Mikrofon sessize alındı",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Çok sessiz - gürültülü ortamlar için",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Sessiz - orta düzey gürültü için",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Nötr - dengeli kayıt",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Hafif artırılmış - normal kullanım",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Artırılmış - sessiz ortamlar için",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Yüksek - uzak veya yumuşak sesler için",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Çok yüksek - çok sessiz kaynaklar için",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Maksimum - dikkatli kullanın",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Geliştirici Ayarları",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Kaydediliyor...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Yapay zeka kişiliğinizi yapılandırın",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Transkripsiyon",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "STT sağlayıcısını yapılandırın",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Konuşma Zaman Aşımı",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Konuşmaların ne zaman otomatik sonlandırılacağını ayarlayın",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Veri İçe Aktar",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Diğer kaynaklardan veri içe aktarın",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Hata Ayıklama ve Teşhis",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "Uç Nokta URL'si",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Henüz API anahtarı yok",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Başlamak için bir anahtar oluşturun",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Anahtar Oluştur",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Dokümanlar",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Omi İçgörüleriniz",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Bugün",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Bu Ay",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Bu Yıl",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Tüm Zamanlar",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Henüz Aktivite Yok",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Kullanım içgörülerinizi burada görmek için\nOmi ile bir konuşma başlatın.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Dinleme",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Omi'nin aktif olarak dinlediği toplam süre.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Anlama",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Konuşmalarınızdan anlaşılan kelimeler.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Sağlama",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Otomatik olarak yakalanan eylem öğeleri ve notlar.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Hatırlama",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Sizin için hatırlanan gerçekler ve detaylar.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Sınırsız Plan",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Planı Yönet",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Planınız {date} tarihinde iptal edilecek.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Planınız {date} tarihinde yenilenecek.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Ücretsiz Plan",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{limit} dakikadan {used} kullanıldı",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Yükselt",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Sınırsız'a Yükselt",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Planınız ayda {limit} ücretsiz dakika içerir. Sınırsız kullanım için yükseltin.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Omi istatistiklerimi paylaşıyorum! (omi.me - her zaman açık yapay zeka asistanınız)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Bugün, omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Bu ay, omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Bu yıl, omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Şimdiye kadar, omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 {minutes} dakika dinledi",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 {words} kelime anladı",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ {count} içgörü sağladı",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 {count} anı hatırladı",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Hata Ayıklama Günlükleri",
+  "debugLogsAutoDelete": "3 gün sonra otomatik olarak silinir.",
+  "debugLogsDesc": "Sorunların teşhisine yardımcı olur",
+  "noLogFilesFound": "Günlük dosyası bulunamadı.",
+  "omiDebugLog": "Omi hata ayıklama günlüğü",
+  "logShared": "Günlük paylaşıldı",
+  "selectLogFile": "Günlük Dosyası Seç",
+  "shareLogs": "Günlükleri Paylaş",
+  "debugLogCleared": "Hata ayıklama günlüğü temizlendi",
+  "exportStarted": "Dışa aktarma başladı. Bu birkaç saniye sürebilir...",
+  "exportAllData": "Tüm Verileri Dışa Aktar",
+  "exportDataDesc": "Konuşmaları JSON dosyasına aktar",
+  "exportedConversations": "Omi'den Dışa Aktarılan Konuşmalar",
+  "exportShared": "Dışa aktarma paylaşıldı",
+  "deleteKnowledgeGraphTitle": "Bilgi Grafiği Silinsin mi?",
+  "deleteKnowledgeGraphMessage": "Bu, tüm türetilmiş bilgi grafiği verilerini (düğümler ve bağlantılar) silecektir. Orijinal anılarınız güvende kalacaktır. Grafik zamanla veya bir sonraki istekte yeniden oluşturulacaktır.",
+  "knowledgeGraphDeleted": "Bilgi Grafiği başarıyla silindi",
+  "deleteGraphFailed": "Grafik silinemedi: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Bilgi Grafiğini Sil",
+  "deleteKnowledgeGraphDesc": "Tüm düğümleri ve bağlantıları temizle",
+  "mcp": "MCP",
+  "mcpServer": "MCP Sunucusu",
+  "mcpServerDesc": "Yapay zeka asistanlarını verilerinize bağlayın",
+  "serverUrl": "Sunucu URL'si",
+  "urlCopied": "URL kopyalandı",
+  "apiKeyAuth": "API Anahtar Kimlik Doğrulaması",
+  "header": "Başlık",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "İstemci Kimliği",
+  "clientSecret": "İstemci Gizli Anahtarı",
+  "useMcpApiKey": "MCP API anahtarınızı kullanın",
+  "webhooks": "Web Hook'ları",
+  "conversationEvents": "Konuşma Olayları",
+  "newConversationCreated": "Yeni konuşma oluşturuldu",
+  "realtimeTranscript": "Gerçek Zamanlı Transkript",
+  "transcriptReceived": "Transkript alındı",
+  "audioBytes": "Ses Baytları",
+  "audioDataReceived": "Ses verisi alındı",
+  "intervalSeconds": "Aralık (saniye)",
+  "daySummary": "Gün Özeti",
+  "summaryGenerated": "Özet oluşturuldu",
+  "claudeDesktop": "Claude Masaüstü",
+  "addToClaudeConfig": "claude_desktop_config.json'a ekle",
+  "copyConfig": "Yapılandırmayı Kopyala",
+  "configCopied": "Yapılandırma panoya kopyalandı",
+  "listeningMins": "Dinleme (dk)",
+  "understandingWords": "Anlama (kelime)",
+  "insights": "İçgörüler",
+  "memories": "Anılar",
+  "minsUsedThisMonth": "Bu ay {limit} dakikadan {used} kullanıldı",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "Bu ay {limit} kelimeden {used} kullanıldı",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "Bu ay {limit} içgörüden {used} elde edildi",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "Bu ay {limit} anıdan {used} oluşturuldu",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Görünürlük",
+  "visibilitySubtitle": "Listenizde hangi konuşmaların görüneceğini kontrol edin",
+  "showShortConversations": "Kısa Konuşmaları Göster",
+  "showShortConversationsDesc": "Eşik değerinden kısa konuşmaları göster",
+  "showDiscardedConversations": "Atılan Konuşmaları Göster",
+  "showDiscardedConversationsDesc": "Atılanmış olarak işaretlenmiş konuşmaları dahil et",
+  "shortConversationThreshold": "Kısa Konuşma Eşiği",
+  "shortConversationThresholdSubtitle": "Bundan kısa konuşmalar yukarıda etkinleştirilmedikçe gizlenecek",
+  "durationThreshold": "Süre Eşiği",
+  "durationThresholdDesc": "Bundan kısa konuşmaları gizle",
+  "minLabel": "{count} dk",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Özel Kelime Hazinesi",
+  "addWords": "Kelime Ekle",
+  "addWordsDesc": "İsimler, terimler veya yaygın olmayan kelimeler",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Bağlan",
+  "comingSoon": "Yakında",
+  "chatToolsFooter": "Sohbette veri ve metrikleri görmek için uygulamalarınızı bağlayın.",
+  "completeAuthInBrowser": "Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.",
+  "failedToStartAuth": "{appName} kimlik doğrulaması başlatılamadı",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "{appName} Bağlantısı Kesilsin mi?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "{appName} bağlantısını kesmek istediğinizden emin misiniz? İstediğiniz zaman tekrar bağlanabilirsiniz.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "{appName} bağlantısı kesildi",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Bağlantı kesilemedi",
+  "connectTo": "{appName}'e Bağlan",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Omi'nin {appName} verilerinize erişmesine yetki vermeniz gerekecek. Bu, kimlik doğrulama için tarayıcınızı açacaktır.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Devam Et",
+  "languageTitle": "Dil",
+  "primaryLanguage": "Ana Dil",
+  "automaticTranslation": "Otomatik Çeviri",
+  "detectLanguages": "10+ dil algıla",
+  "authorizeSavingRecordings": "Kayıtların Kaydedilmesine İzin Ver",
+  "thanksForAuthorizing": "İzin verdiğiniz için teşekkürler!",
+  "needYourPermission": "İzninize ihtiyacımız var",
+  "alreadyGavePermission": "Kayıtlarınızı kaydetmemiz için bize zaten izin verdiniz. İşte neden buna ihtiyacımız olduğunun bir hatırlatması:",
+  "wouldLikePermission": "Ses kayıtlarınızı kaydetmek için izninizi istiyoruz. İşte nedeni:",
+  "improveSpeechProfile": "Konuşma Profilinizi Geliştirin",
+  "improveSpeechProfileDesc": "Kişisel konuşma profilinizi eğitmek ve geliştirmek için kayıtları kullanıyoruz.",
+  "trainFamilyProfiles": "Arkadaşlar ve Aile için Profil Eğitin",
+  "trainFamilyProfilesDesc": "Kayıtlarınız arkadaşlarınızı ve ailenizi tanımamıza ve profil oluşturmamıza yardımcı olur.",
+  "enhanceTranscriptAccuracy": "Transkript Doğruluğunu Artırın",
+  "enhanceTranscriptAccuracyDesc": "Modelimiz geliştikçe, kayıtlarınız için daha iyi transkripsiyon sonuçları sağlayabiliriz.",
+  "legalNotice": "Yasal Uyarı: Ses verilerini kaydetme ve saklama yasallığı bulunduğunuz yere ve bu özelliği nasıl kullandığınıza bağlı olarak değişebilir. Yerel yasalara ve düzenlemelere uyumu sağlamak sizin sorumluluğunuzdur.",
+  "alreadyAuthorized": "Zaten İzin Verildi",
+  "authorize": "İzin Ver",
+  "revokeAuthorization": "İzni Geri Al",
+  "authorizationSuccessful": "İzin verme başarılı!",
+  "failedToAuthorize": "İzin verilemedi. Lütfen tekrar deneyin.",
+  "authorizationRevoked": "İzin geri alındı.",
+  "recordingsDeleted": "Kayıtlar silindi.",
+  "failedToRevoke": "İzin geri alınamadı. Lütfen tekrar deneyin.",
+  "permissionRevokedTitle": "İzin Geri Alındı",
+  "permissionRevokedMessage": "Mevcut tüm kayıtlarınızı da kaldırmamızı ister misiniz?",
+  "yes": "Evet",
+  "editName": "İsmi Düzenle",
+  "howShouldOmiCallYou": "Omi size nasıl hitap etmeli?",
+  "enterYourName": "İsminizi girin",
+  "nameCannotBeEmpty": "İsim boş olamaz",
+  "nameUpdatedSuccessfully": "İsim başarıyla güncellendi!",
+  "calendarSettings": "Takvim ayarları",
+  "calendarProviders": "Takvim Sağlayıcıları",
+  "macOsCalendar": "macOS Takvimi",
+  "connectMacOsCalendar": "Yerel macOS takviminizi bağlayın",
+  "googleCalendar": "Google Takvim",
+  "syncGoogleAccount": "Google hesabınızla senkronize edin",
+  "showMeetingsMenuBar": "Yaklaşan toplantıları menü çubuğunda göster",
+  "showMeetingsMenuBarDesc": "Bir sonraki toplantınızı ve başlamasına kalan süreyi macOS menü çubuğunda gösterin",
+  "showEventsNoParticipants": "Katılımcısı olmayan etkinlikleri göster",
+  "showEventsNoParticipantsDesc": "Etkinleştirildiğinde, Yaklaşanlar katılımcısı veya video bağlantısı olmayan etkinlikleri gösterir.",
+  "yourMeetings": "Toplantılarınız",
+  "refresh": "Yenile",
+  "noUpcomingMeetings": "Yaklaşan toplantı bulunamadı",
+  "checkingNextDays": "Sonraki 30 gün kontrol ediliyor",
+  "tomorrow": "Yarın",
+  "googleCalendarComingSoon": "Google Takvim entegrasyonu yakında!",
+  "connectedAsUser": "Kullanıcı olarak bağlandı: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Varsayılan Çalışma Alanı",
+  "tasksCreatedInWorkspace": "Görevler bu çalışma alanında oluşturulacak",
+  "defaultProjectOptional": "Varsayılan Proje (İsteğe Bağlı)",
+  "leaveUnselectedTasks": "Görevleri proje olmadan oluşturmak için seçilmemiş bırakın",
+  "noProjectsInWorkspace": "Bu çalışma alanında proje bulunamadı",
+  "conversationTimeoutDesc": "Sessizlikte ne kadar bekledikten sonra konuşmanın otomatik olarak sonlandırılacağını seçin:",
+  "timeout2Minutes": "2 dakika",
+  "timeout2MinutesDesc": "2 dakika sessizlikten sonra konuşmayı sonlandır",
+  "timeout5Minutes": "5 dakika",
+  "timeout5MinutesDesc": "5 dakika sessizlikten sonra konuşmayı sonlandır",
+  "timeout10Minutes": "10 dakika",
+  "timeout10MinutesDesc": "10 dakika sessizlikten sonra konuşmayı sonlandır",
+  "timeout30Minutes": "30 dakika",
+  "timeout30MinutesDesc": "30 dakika sessizlikten sonra konuşmayı sonlandır",
+  "timeout4Hours": "4 saat",
+  "timeout4HoursDesc": "4 saat sessizlikten sonra konuşmayı sonlandır",
+  "conversationEndAfterHours": "Konuşmalar artık 4 saat sessizlikten sonra sonlanacak",
+  "conversationEndAfterMinutes": "Konuşmalar artık {minutes} dakika sessizlikten sonra sonlanacak",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Bize ana dilinizi söyleyin",
+  "languageForTranscription": "Daha keskin transkripsiyonlar ve kişiselleştirilmiş bir deneyim için dilinizi ayarlayın.",
+  "singleLanguageModeInfo": "Tek Dil Modu etkin. Daha yüksek doğruluk için çeviri devre dışı.",
+  "searchLanguageHint": "Dili isim veya koda göre arayın",
+  "noLanguagesFound": "Dil bulunamadı",
+  "skip": "Atla",
+  "languageSetTo": "Dil {language} olarak ayarlandı",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Dil ayarlanamadı",
+  "appSettings": "{appName} Ayarları",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "{appName} Bağlantısı Kesilsin mi?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Bu, {appName} kimlik doğrulamanızı kaldıracaktır. Tekrar kullanmak için yeniden bağlanmanız gerekecek.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "{appName}'e bağlandı",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Hesap",
+  "actionItemsSyncedTo": "Eylem öğeleriniz {appName} hesabınıza senkronize edilecek",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Varsayılan Alan",
+  "selectSpaceInWorkspace": "Çalışma alanınızda bir alan seçin",
+  "noSpacesInWorkspace": "Bu çalışma alanında alan bulunamadı",
+  "defaultList": "Varsayılan Liste",
+  "tasksAddedToList": "Görevler bu listeye eklenecek",
+  "noListsInSpace": "Bu alanda liste bulunamadı",
+  "failedToLoadRepos": "Depolar yüklenemedi: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Varsayılan depo kaydedildi",
+  "failedToSaveDefaultRepo": "Varsayılan depo kaydedilemedi",
+  "defaultRepository": "Varsayılan Depo",
+  "selectDefaultRepoDesc": "Sorun oluşturmak için varsayılan bir depo seçin. Sorun oluştururken farklı bir depo belirtebilirsiniz.",
+  "noReposFound": "Depo bulunamadı",
+  "private": "Özel",
+  "updatedDate": "{date} güncellendi",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "dün",
+  "daysAgo": "{count} gün önce",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 hafta önce",
+  "weeksAgo": "{count} hafta önce",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 ay önce",
+  "monthsAgo": "{count} ay önce",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Sorunlar varsayılan deponuzda oluşturulacak",
+  "taskIntegrations": "Görev Entegrasyonları",
+  "configureSettings": "Ayarları Yapılandır",
+  "completeAuthBrowser": "Lütfen tarayıcınızda kimlik doğrulamayı tamamlayın. Tamamlandığında uygulamaya geri dönün.",
+  "failedToStartAppAuth": "{appName} kimlik doğrulaması başlatılamadı",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "{appName}'e Bağlan",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Omi'nin {appName} hesabınızda görev oluşturmasına yetki vermeniz gerekecek. Bu, kimlik doğrulama için tarayıcınızı açacaktır.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Devam Et",
+  "appIntegration": "{appName} Entegrasyonu",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "{appName} ile entegrasyon yakında! Size daha fazla görev yönetimi seçeneği sunmak için çok çalışıyoruz.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Anladım",
+  "tasksExportedOneApp": "Görevler aynı anda bir uygulamaya aktarılabilir.",
+  "completeYourUpgrade": "Yükseltmenizi Tamamlayın",
+  "importConfiguration": "Yapılandırma İçe Aktar",
+  "exportConfiguration": "Yapılandırmayı dışa aktar",
+  "bringYourOwn": "Kendininkini getir",
+  "payYourSttProvider": "Omi'yi özgürce kullanın. Sadece STT sağlayıcınıza doğrudan ödeme yaparsınız.",
+  "freeMinutesMonth": "Ayda 1.200 ücretsiz dakika dahildir. ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Host gereklidir",
+  "validPortRequired": "Geçerli port gereklidir",
+  "validWebsocketUrlRequired": "Geçerli WebSocket URL'si gereklidir (wss://)",
+  "apiUrlRequired": "API URL'si gereklidir",
+  "apiKeyRequired": "API anahtarı gereklidir",
+  "invalidJsonConfig": "Geçersiz JSON yapılandırması",
+  "errorSaving": "Kaydetme hatası: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Yapılandırma panoya kopyalandı",
+  "pasteJsonConfig": "JSON yapılandırmanızı aşağıya yapıştırın:",
+  "addApiKeyAfterImport": "İçe aktardıktan sonra kendi API anahtarınızı eklemeniz gerekecek",
+  "paste": "Yapıştır",
+  "import": "İçe Aktar",
+  "invalidProviderInConfig": "Yapılandırmada geçersiz sağlayıcı",
+  "importedConfig": "{providerName} yapılandırması içe aktarıldı",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Geçersiz JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Sağlayıcı",
+  "live": "Canlı",
+  "onDevice": "Cihazda",
+  "apiUrl": "API URL'si",
+  "enterSttHttpEndpoint": "STT HTTP uç noktanızı girin",
+  "websocketUrl": "WebSocket URL'si",
+  "enterLiveSttWebsocket": "Canlı STT WebSocket uç noktanızı girin",
+  "apiKey": "API Anahtarı",
+  "enterApiKey": "API anahtarınızı girin",
+  "storedLocallyNeverShared": "Yerel olarak saklanır, asla paylaşılmaz",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Gelişmiş",
+  "configuration": "Yapılandırma",
+  "requestConfiguration": "İstek Yapılandırması",
+  "responseSchema": "Yanıt Şeması",
+  "modified": "Değiştirildi",
+  "resetRequestConfig": "İstek yapılandırmasını varsayılana sıfırla",
+  "logs": "Günlükler",
+  "logsCopied": "Günlükler kopyalandı",
+  "noLogsYet": "Henüz günlük yok. Özel STT etkinliğini görmek için kayda başlayın.",
+  "deviceUsesCodec": "{deviceName} {codecReason} kullanıyor. Omi kullanılacak.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Omi Transkripsiyonu",
+  "bestInClassTranscription": "Sıfır kurulum ile sınıfının en iyisi transkripsiyon",
+  "instantSpeakerLabels": "Anında konuşmacı etiketleri",
+  "languageTranslation": "100+ dil çevirisi",
+  "optimizedForConversation": "Konuşma için optimize edilmiş",
+  "autoLanguageDetection": "Otomatik dil algılama",
+  "highAccuracy": "Yüksek doğruluk",
+  "privacyFirst": "Önce gizlilik",
+  "saveChanges": "Değişiklikleri Kaydet",
+  "resetToDefault": "Varsayılana Sıfırla",
+  "viewTemplate": "Şablonu Görüntüle",
+  "trySomethingLike": "Şöyle bir şey deneyin...",
+  "tryIt": "Dene",
+  "creatingPlan": "Plan oluşturuluyor",
+  "developingLogic": "Mantık geliştiriliyor",
+  "designingApp": "Uygulama tasarlanıyor",
+  "generatingIconStep": "İkon oluşturuluyor",
+  "finalTouches": "Son dokunuşlar",
+  "processing": "İşleniyor...",
+  "features": "Özellikler",
+  "creatingYourApp": "Uygulamanız oluşturuluyor...",
+  "generatingIcon": "İkon oluşturuluyor...",
+  "whatShouldWeMake": "Ne yapalım?",
+  "appName": "Uygulama Adı",
+  "description": "Açıklama",
+  "publicLabel": "Genel",
+  "privateLabel": "Özel",
+  "free": "Ücretsiz",
+  "perMonth": "/ Ay",
+  "tailoredConversationSummaries": "Özelleştirilmiş Konuşma Özetleri",
+  "customChatbotPersonality": "Özel Chatbot Kişiliği",
+  "makePublic": "Herkese açık yap",
+  "anyoneCanDiscover": "Herkes uygulamanızı keşfedebilir",
+  "onlyYouCanUse": "Yalnızca siz bu uygulamayı kullanabilirsiniz",
+  "paidApp": "Ücretli uygulama",
+  "usersPayToUse": "Kullanıcılar uygulamanızı kullanmak için ödeme yapar",
+  "freeForEveryone": "Herkes için ücretsiz",
+  "perMonthLabel": "/ ay",
+  "creating": "Oluşturuluyor...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Uygulama Oluştur",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "searchingForDevices": "Cihazlar aranıyor...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{CİHAZ} other{CİHAZ}} YAKINLARDA BULUNDU",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "EŞLEŞTIRME BAŞARILI",
+  "errorConnectingAppleWatch": "Apple Watch'a bağlanırken hata: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Bir daha gösterme",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Anladım",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Bluetooth'u Etkinleştir",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi'nin giyilebilir cihazınıza bağlanması için Bluetooth gereklidir. Lütfen Bluetooth'u etkinleştirin ve tekrar deneyin.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Desteğe Başvur?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Sonra Bağlan",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "İzinleri ver",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Arka plan etkinliği",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Daha iyi stabilite için Omi'nin arka planda çalışmasına izin verin",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Konum erişimi",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Tam deneyim için arka plan konumunu etkinleştirin",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Bildirimler",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Bilgilendirilmek için bildirimleri etkinleştirin",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "locationServiceDisabled": "Konum Servisi Devre Dışı",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Konum Servisi Devre Dışı. Lütfen Ayarlar > Gizlilik ve Güvenlik > Konum Servisleri'ne gidin ve etkinleştirin",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Arka Plan Konum Erişimi Reddedildi",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Lütfen cihaz ayarlarına gidin ve konum iznini \"Her Zaman İzin Ver\" olarak ayarlayın",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Omi'yi Beğeniyor musunuz?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "App Store'da bir yorum bırakarak daha fazla insana ulaşmamıza yardımcı olun. Geri bildiriminiz bizim için çok değerli!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Google Play Store'da bir yorum bırakarak daha fazla insana ulaşmamıza yardımcı olun. Geri bildiriminiz bizim için çok değerli!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "App Store'da Değerlendir",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Google Play'de Değerlendir",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Belki sonra",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi'nin hedeflerinizi ve sesinizi öğrenmesi gerekiyor. Daha sonra değiştirebilirsiniz.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Başlayın",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Hepsi tamam!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Devam et, harika gidiyorsun",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Bu soruyu atla",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Şimdilik atla",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Bağlantı Hatası",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Sunucuya bağlanılamadı. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Geçersiz kayıt algılandı",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Kayıtta birden fazla konuşmacı var gibi görünüyor. Lütfen sessiz bir yerde olduğunuzdan emin olun ve tekrar deneyin.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Yeterli konuşma algılanamadı. Lütfen daha fazla konuşun ve tekrar deneyin.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Lütfen en az 5 saniye, en fazla 90 saniye konuştuğunuzdan emin olun.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Orada mısınız?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Herhangi bir konuşma algılayamadık. Lütfen en az 10 saniye, en fazla 3 dakika konuştuğunuzdan emin olun.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Bağlantı Kesildi",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Bağlantı kesildi. Lütfen internet bağlantınızı kontrol edin ve tekrar deneyin.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Tekrar Dene",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Omi / OmiGlass Bağla",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Cihaz Olmadan Devam Et",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "İzinler Gerekli",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Bu uygulamanın düzgün çalışması için Bluetooth ve Konum izinlerine ihtiyacı var. Lütfen ayarlardan bunları etkinleştirin.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Ayarları Aç",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Farklı bir isimle mi anılmak istiyorsunuz?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Adınız nedir?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "speakTranscribeSummarize": "Konuş. Transkripsiyonu Oluştur. Özetle.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Apple ile Giriş Yap",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Google ile Giriş Yap",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Devam ederek ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Kullanım Koşulları",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Yapay Zeka Yardımcınız",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Her anı yakalayın. Yapay zeka destekli\nözetler alın. Artık not almayın.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Apple Watch Kurulumu",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "İzin İstendi!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Mikrofon İzni",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "İzin verildi! Şimdi:\n\nSaatinizdeki Omi uygulamasını açın ve aşağıda \"Devam Et\"e dokunun",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Mikrofon iznine ihtiyacımız var.\n\n1. \"İzin Ver\"e dokunun\n2. iPhone'unuzda izin verin\n3. Saat uygulaması kapanacak\n4. Yeniden açın ve \"Devam Et\"e dokunun",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "İzin Ver",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Yardıma mı İhtiyacınız Var?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Sorun giderme:\n\n1. Omi'nin saatinizde yüklü olduğundan emin olun\n2. Saatinizdeki Omi uygulamasını açın\n3. İzin açılır penceresini arayın\n4. İstendiğinde \"İzin Ver\"e dokunun\n5. Saatinizdeki uygulama kapanacak - yeniden açın\n6. Geri gelin ve iPhone'unuzda \"Devam Et\"e dokunun",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "recordingStartedSuccessfully": "Kayıt başarıyla başladı!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Henüz izin verilmedi. Lütfen mikrofon erişimine izin verdiğinizden ve saatinizdeki uygulamayı yeniden açtığınızdan emin olun.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "İzin isteği hatası: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Kayıt başlatma hatası: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Ana dilinizi seçin",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Daha keskin transkripsiyonlar ve kişiselleştirilmiş bir deneyim için dilinizi ayarlayın",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "whatsYourPrimaryLanguage": "Ana diliniz nedir?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Dilinizi seçin",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Her kelimenizi dinleyen yapay zeka ile kişisel gelişim yolculuğunuz.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Yapılacaklar",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Düzenlemek için dokunun • Seçmek için uzun basın • Eylemler için kaydırın",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Yapılacak",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Bitti",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Eski",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Her şey güncel!\nBekleyen eylem öğesi yok",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Henüz tamamlanmış öğe yok",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Eski görev yok",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Öğe yok",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Eylem öğesi tamamlanmamış olarak işaretlendi",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Eylem öğesi tamamlandı",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Eylem Öğesini Sil",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Bu eylem öğesini silmek istediğinizden emin misiniz?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Seçili Öğeleri Sil",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "{count} seçili eylem öğesini silmek istediğinizden emin misiniz?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Eylem öğesi \"{description}\" silindi",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} eylem öğesi silindi",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Eylem öğesi silinemedi",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Öğeler silinemedi",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Bazı öğeler silinemedi",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Eylem Öğeleri için Hazır",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Yapay zekanız konuşmalarınızdan otomatik olarak görevleri ve yapılacakları çıkaracaktır. Oluşturulduklarında burada görünecekler.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Konuşmalardan otomatik olarak çıkarıldı",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Düzenlemek için dokunun, tamamlamak veya silmek için kaydırın",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "{count} seçildi",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Tümünü seç",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Seçilenleri sil",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "{count} Anıda Ara",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Anı Silindi.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Geri Al",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Henüz anı yok",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Henüz otomatik çıkarılan anı yok",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Henüz manuel anı yok",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Bu kategorilerde anı yok",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Anı bulunamadı",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "İlk anınızı ekleyin",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Omi'nin Hafızasını Temizle",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Omi'nin hafızasını temizlemek istediğinizden emin misiniz? Bu işlem geri alınamaz.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Hafızayı Temizle",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Omi'nin sizinle ilgili hafızası temizlendi",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Silinecek anı yok",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Yeni anı oluştur",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Yeni eylem öğesi oluştur",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Anı Yönetimi",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Anıları Filtrele",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Toplam {count} anınız var",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Genel anılar",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Özel anılar",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Tüm Anıları Özel Yap",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Tüm Anıları Genel Yap",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Tüm Anıları Sil",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Tüm anılar artık özel",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Tüm anılar artık genel",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Yeni Anı",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Anıyı Düzenle",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Dondurma yemeyi severim...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Kaydedilemedi. Lütfen bağlantınızı kontrol edin.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Anıyı Kaydet",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Tekrar Dene",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Eylem Öğesi Oluştur",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Eylem Öğesini Düzenle",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Ne yapılması gerekiyor?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Eylem öğesi açıklaması boş olamaz.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Eylem öğesi güncellendi",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Eylem öğesi güncellenemedi",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Eylem öğesi oluşturuldu",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Eylem öğesi oluşturulamadı",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Teslim Tarihi",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Saat",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Teslim tarihi ekle",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Kaydetmek için bitti'ye basın",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Oluşturmak için bitti'ye basın",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Tümü",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Hakkınızda",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "İçgörüler",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Manuel",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Tamamlandı",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Tamamlandı olarak işaretle",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Eylem öğesi silindi",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Eylem öğesi silinemedi",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Eylem Öğesini Sil",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Bu eylem öğesini silmek istediğinizden emin misiniz?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Uygulama Dili",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "UYGULAMA ARAYÜZÜ",
+  "speechTranscriptionSectionTitle": "KONUŞMA VE TRANSKRİPSİYON",
+  "languageSettingsHelperText": "Uygulama Dili menüleri ve düğmeleri değiştirir. Konuşma Dili, kayıtlarınızın nasıl transkribe edildiğini etkiler."
+}

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "uk",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Розмова",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Транскрипція",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Завдання",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Видалити розмову?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Ви впевнені, що хочете видалити цю розмову? Цю дію не можна скасувати.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Підтвердити",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Скасувати",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "OK",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Видалити",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Додати",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Оновити",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Зберегти",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Редагувати",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Закрити",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Очистити",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Копіювати транскрипцію",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Копіювати підсумок",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Тестовий запит",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Перепрацювати розмову",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Видалити розмову",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Вміст скопійовано до буфера обміну",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Не вдалося оновити статус обраного.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Не вдалося поділитися URL розмови.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Помилка під час обробки розмови. Будь ласка, спробуйте пізніше.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Не вдалося видалити розмову",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Щось пішло не так! Будь ласка, спробуйте пізніше.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Копіювати повідомлення про помилку",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Повідомлення про помилку скопійовано до буфера обміну",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Залишилось",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Завантаження...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Завантаження тривалості...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} секунд",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Люди",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Додати нову особу",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Редагувати особу",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Створіть нову особу та навчіть Omi розпізнавати її мовлення!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Мовний профіль",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Зразок {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Налаштування",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Мова",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Вибрати мову",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Видалення...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Не вдалося розпочати автентифікацію",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Імпорт розпочато! Ви отримаєте сповіщення після завершення.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Не вдалося розпочати імпорт. Будь ласка, спробуйте ще раз.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Не вдалося отримати доступ до вибраного файлу",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Запитати Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Готово",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Відключено",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Пошук",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Підключити пристрій",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Ви досягли свого місячного ліміту.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Перевірити використання",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Синхронізація записів",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Записи для синхронізації",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Все синхронізовано",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Синхронізувати",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Підвіска оновлена",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Всі записи синхронізовано",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Йде синхронізація",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Готово до синхронізації",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Натисніть Синхронізувати, щоб почати",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Підвіска не підключена. Підключіть для синхронізації.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Все вже синхронізовано.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "У вас є записи, які ще не синхронізовано.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Ми продовжимо синхронізацію ваших записів у фоновому режимі.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Розмов поки немає.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Обраних розмов поки немає.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Щоб позначити розмову зірочкою, відкрийте її та натисніть іконку зірки в заголовку.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Пошук розмов",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "Вибрано: {count}",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Об'єднати",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Об'єднати розмови",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Це об'єднає {count} розмов в одну. Весь вміст буде об'єднано та перегенеровано.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Об'єднання у фоновому режимі. Це може зайняти деякий час.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Не вдалося розпочати об'єднання",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Запитайте що завгодно",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Повідомлень поки немає!\nЧому б не почати розмову?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Видалення ваших повідомлень з пам'яті Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Повідомлення скопійовано до буфера обміну.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Ви не можете поскаржитись на власні повідомлення.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Поскаржитись на повідомлення",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Ви впевнені, що хочете поскаржитись на це повідомлення?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Повідомлення успішно відправлено.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Дякуємо за ваш відгук!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Очистити чат?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Ви впевнені, що хочете очистити чат? Цю дію не можна скасувати.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Ви можете завантажити лише 4 файли за раз",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Чат з Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Додатки",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Додатки не знайдено",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Спробуйте змінити пошуковий запит або фільтри",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Створіть власний додаток",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Створюйте та діліться своїм власним додатком",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Пошук серед 1500+ додатків",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Мої додатки",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Встановлені додатки",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Не вдалося завантажити додатки :(\n\nБудь ласка, перевірте підключення до інтернету та спробуйте ще раз.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Про Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Політикою конфіденційності",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Відвідати веб-сайт",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Допомога або запитання?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Приєднуйтесь до спільноти!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "Понад 8000 учасників.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Видалити обліковий запис",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Ви впевнені, що хочете видалити свій обліковий запис?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Це не можна скасувати.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Всі ваші спогади та розмови будуть остаточно видалені.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Ваші додатки та інтеграції будуть негайно відключені.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Ви можете експортувати свої дані перед видаленням облікового запису, але після видалення їх неможливо буде відновити.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Я розумію, що видалення мого облікового запису є остаточним, і всі дані, включно зі спогадами та розмовами, будуть втрачені і не можуть бути відновлені.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Ви впевнені?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Ця дія є незворотною та назавжди видалить ваш обліковий запис і всі пов'язані дані. Ви впевнені, що хочете продовжити?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Видалити зараз",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Повернутися",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Встановіть прапорець, щоб підтвердити, що ви розумієте, що видалення облікового запису є остаточним і незворотним.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Профіль",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Ім'я",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Електронна пошта",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Власний словник",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Ідентифікація інших",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Способи оплати",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Відображення розмов",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Дані та конфіденційність",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID користувача",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Не встановлено",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "ID користувача скопійовано до буфера обміну",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "За замовчуванням системи",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "План та використання",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Офлайн-синхронізація",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Налаштування пристрою",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Інструменти чату",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Відгук / Помилка",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Центр допомоги",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Налаштування розробника",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Отримати Omi для Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Реферальна програма",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Вийти",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Деталі додатка та пристрою скопійовано",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Підсумки 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Ваша конфіденційність, ваш контроль",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "В Omi ми прагнемо захистити вашу конфіденційність. Ця сторінка дозволяє контролювати, як зберігаються та використовуються ваші дані.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Дізнатися більше...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Рівень захисту даних",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Ваші дані за замовчуванням захищені надійним шифруванням. Перегляньте свої налаштування та майбутні параметри конфіденційності нижче.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Доступ додатків",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Наступні додатки можуть отримувати доступ до ваших даних. Натисніть на додаток, щоб керувати його дозволами.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Жоден встановлений додаток не має зовнішнього доступу до ваших даних.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Назва пристрою",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID пристрою",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Прошивка",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Синхронізація SD-карти",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Ревізія апаратного забезпечення",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Номер моделі",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Виробник",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Подвійне натискання",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Яскравість світлодіода",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Підсилення мікрофона",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Відключити",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Забути пристрій",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Проблеми із зарядкою",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Відключити пристрій",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Роз'єднати пристрій",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Роз'єднати та забути пристрій",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Ваш Omi було відключено 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Пристрій роз'єднано. Перейдіть до Налаштування > Bluetooth і забудьте пристрій, щоб завершити роз'єднання.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Роз'єднати пристрій",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Це роз'єднає пристрій, щоб його можна було підключити до іншого телефону. Вам потрібно буде перейти до Налаштування > Bluetooth і забути пристрій, щоб завершити процес.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Пристрій не підключено",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Підключіть свій пристрій Omi для доступу до\nналаштувань пристрою та налаштування",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Інформація про пристрій",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Налаштування",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Апаратне забезпечення",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "V2 не виявлено",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Ми бачимо, що у вас або пристрій V1, або ваш пристрій не підключений. Функціонал SD-карти доступний лише для пристроїв V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Завершити розмову",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Призупинити/Відновити",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Позначити розмову",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Дія подвійного натискання",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Завершити та обробити розмову",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Призупинити/Відновити запис",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Позначити поточну розмову",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Вимкнено",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Максимум",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Без звуку",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Тихо",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Нормально",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Високо",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Мікрофон вимкнено",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Дуже тихо - для гучного середовища",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Тихо - для помірного шуму",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Нейтрально - збалансований запис",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Трохи посилено - нормальне використання",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Посилено - для тихого середовища",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Високо - для далеких або тихих голосів",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Дуже високо - для дуже тихих джерел",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Максимум - використовувати обережно",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Налаштування розробника",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Збереження...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Налаштуйте свою AI-персону",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "БЕТА",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Транскрипція",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Налаштувати STT-провайдер",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Час очікування розмови",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Встановіть, коли розмови завершуються автоматично",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Імпортувати дані",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Імпортуйте дані з інших джерел",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Налагодження та діагностика",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL кінцевої точки",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "API-ключів поки немає",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Створіть ключ, щоб почати",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Створити ключ",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Документація",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Ваша статистика Omi",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Сьогодні",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Цей місяць",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Цей рік",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "За весь час",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Активності поки немає",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Почніть розмову з Omi,\nщоб побачити статистику використання тут.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Прослуховування",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Загальний час активного прослуховування Omi.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Розуміння",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Слів зрозуміно з ваших розмов.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Надання",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Завдання та нотатки, автоматично зафіксовані.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Запам'ятовування",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Факти та деталі, запам'ятовані для вас.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Необмежений план",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Керувати планом",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Ваш план буде скасовано {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Ваш план поновиться {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Безкоштовний план",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "{used} з {limit} хв використано",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Оновити",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Оновити до Необмеженого",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Ваш план включає {limit} безкоштовних хвилин на місяць. Оновіть, щоб отримати необмежений доступ.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Ділюся своєю статистикою Omi! (omi.me - ваш завжди активний AI-асистент)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Сьогодні omi:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Цього місяця omi:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Цього року omi:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Загалом omi:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Прослухав {minutes} хвилин",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Зрозумів {words} слів",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Надав {count} insights",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Запам'ятав {count} спогадів",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Журнали налагодження",
+  "debugLogsAutoDelete": "Автоматичне видалення через 3 дні.",
+  "debugLogsDesc": "Допомагає діагностувати проблеми",
+  "noLogFilesFound": "Файли журналів не знайдено.",
+  "omiDebugLog": "Журнал налагодження Omi",
+  "logShared": "Журнал надіслано",
+  "selectLogFile": "Вибрати файл журналу",
+  "shareLogs": "Поділитися журналами",
+  "debugLogCleared": "Журнал налагодження очищено",
+  "exportStarted": "Експорт розпочато. Це може зайняти кілька секунд...",
+  "exportAllData": "Експортувати всі дані",
+  "exportDataDesc": "Експортувати розмови у файл JSON",
+  "exportedConversations": "Експортовані розмови з Omi",
+  "exportShared": "Експорт надіслано",
+  "deleteKnowledgeGraphTitle": "Видалити граф знань?",
+  "deleteKnowledgeGraphMessage": "Це видалить всі похідні дані графа знань (вузли та з'єднання). Ваші оригінальні спогади залишаться в безпеці. Граф буде перебудовано з часом або за наступним запитом.",
+  "knowledgeGraphDeleted": "Граф знань успішно видалено",
+  "deleteGraphFailed": "Не вдалося видалити граф: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Видалити граф знань",
+  "deleteKnowledgeGraphDesc": "Очистити всі вузли та з'єднання",
+  "mcp": "MCP",
+  "mcpServer": "MCP-сервер",
+  "mcpServerDesc": "Підключіть AI-асистентів до ваших даних",
+  "serverUrl": "URL сервера",
+  "urlCopied": "URL скопійовано",
+  "apiKeyAuth": "Автентифікація API-ключем",
+  "header": "Заголовок",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "ID клієнта",
+  "clientSecret": "Секрет клієнта",
+  "useMcpApiKey": "Використовуйте свій MCP API-ключ",
+  "webhooks": "Вебхуки",
+  "conversationEvents": "Події розмови",
+  "newConversationCreated": "Створено нову розмову",
+  "realtimeTranscript": "Транскрипція в реальному часі",
+  "transcriptReceived": "Транскрипцію отримано",
+  "audioBytes": "Аудіо байти",
+  "audioDataReceived": "Аудіо дані отримано",
+  "intervalSeconds": "Інтервал (секунди)",
+  "daySummary": "Підсумок дня",
+  "summaryGenerated": "Підсумок згенеровано",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Додати до claude_desktop_config.json",
+  "copyConfig": "Копіювати конфігурацію",
+  "configCopied": "Конфігурацію скопійовано до буфера обміну",
+  "listeningMins": "Прослуховування (хв)",
+  "understandingWords": "Розуміння (слів)",
+  "insights": "Insights",
+  "memories": "Спогади",
+  "minsUsedThisMonth": "{used} з {limit} хв використано цього місяця",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "{used} з {limit} слів використано цього місяця",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "{used} з {limit} insights отримано цього місяця",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "{used} з {limit} спогадів створено цього місяця",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Видимість",
+  "visibilitySubtitle": "Керуйте тим, які розмови відображаються у вашому списку",
+  "showShortConversations": "Показувати короткі розмови",
+  "showShortConversationsDesc": "Відображати розмови коротші за поріг",
+  "showDiscardedConversations": "Показувати відхилені розмови",
+  "showDiscardedConversationsDesc": "Включати розмови, позначені як відхилені",
+  "shortConversationThreshold": "Поріг коротких розмов",
+  "shortConversationThresholdSubtitle": "Розмови коротші за це значення будуть приховані, якщо не увімкнено вище",
+  "durationThreshold": "Поріг тривалості",
+  "durationThresholdDesc": "Приховувати розмови коротші за це",
+  "minLabel": "{count} хв",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Власний словник",
+  "addWords": "Додати слова",
+  "addWordsDesc": "Імена, терміни або незвичні слова",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Підключити",
+  "comingSoon": "Незабаром",
+  "chatToolsFooter": "Підключіть свої додатки для перегляду даних та метрик у чаті.",
+  "completeAuthInBrowser": "Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.",
+  "failedToStartAuth": "Не вдалося розпочати автентифікацію {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Відключити {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Ви впевнені, що хочете відключитись від {appName}? Ви можете підключитись знову в будь-який час.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Відключено від {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Не вдалося відключитись",
+  "connectTo": "Підключитись до {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Вам потрібно авторизувати Omi для доступу до ваших даних {appName}. Це відкриє ваш браузер для автентифікації.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Продовжити",
+  "languageTitle": "Мова",
+  "primaryLanguage": "Основна мова",
+  "automaticTranslation": "Автоматичний переклад",
+  "detectLanguages": "Виявлення 10+ мов",
+  "authorizeSavingRecordings": "Авторизувати збереження записів",
+  "thanksForAuthorizing": "Дякуємо за авторизацію!",
+  "needYourPermission": "Нам потрібен ваш дозвіл",
+  "alreadyGavePermission": "Ви вже надали нам дозвіл на збереження ваших записів. Нагадуємо, навіщо це потрібно:",
+  "wouldLikePermission": "Ми хотіли б отримати ваш дозвіл на збереження ваших голосових записів. Ось чому:",
+  "improveSpeechProfile": "Покращити ваш мовний профіль",
+  "improveSpeechProfileDesc": "Ми використовуємо записи для подальшого навчання та покращення вашого особистого мовного профілю.",
+  "trainFamilyProfiles": "Навчити профілі для друзів та родини",
+  "trainFamilyProfilesDesc": "Ваші записи допомагають нам розпізнавати та створювати профілі для ваших друзів та родини.",
+  "enhanceTranscriptAccuracy": "Покращити точність транскрипції",
+  "enhanceTranscriptAccuracyDesc": "У міру вдосконалення нашої моделі ми можемо надавати кращі результати транскрипції ваших записів.",
+  "legalNotice": "Юридичне повідомлення: Законність запису та зберігання голосових даних може відрізнятися залежно від вашого місцезнаходження та того, як ви використовуєте цю функцію. Ви несете відповідальність за дотримання місцевих законів та правил.",
+  "alreadyAuthorized": "Вже авторизовано",
+  "authorize": "Авторизувати",
+  "revokeAuthorization": "Відкликати авторизацію",
+  "authorizationSuccessful": "Авторизація успішна!",
+  "failedToAuthorize": "Не вдалося авторизувати. Будь ласка, спробуйте ще раз.",
+  "authorizationRevoked": "Авторизацію відкликано.",
+  "recordingsDeleted": "Записи видалено.",
+  "failedToRevoke": "Не вдалося відкликати авторизацію. Будь ласка, спробуйте ще раз.",
+  "permissionRevokedTitle": "Дозвіл відкликано",
+  "permissionRevokedMessage": "Чи хочете ви також видалити всі ваші існуючі записи?",
+  "yes": "Так",
+  "editName": "Редагувати ім'я",
+  "howShouldOmiCallYou": "Як Omi має до вас звертатися?",
+  "enterYourName": "Введіть своє ім'я",
+  "nameCannotBeEmpty": "Ім'я не може бути порожнім",
+  "nameUpdatedSuccessfully": "Ім'я успішно оновлено!",
+  "calendarSettings": "Налаштування календаря",
+  "calendarProviders": "Провайдери календаря",
+  "macOsCalendar": "Календар macOS",
+  "connectMacOsCalendar": "Підключіть свій локальний календар macOS",
+  "googleCalendar": "Google Календар",
+  "syncGoogleAccount": "Синхронізація з вашим обліковим записом Google",
+  "showMeetingsMenuBar": "Показувати майбутні зустрічі у меню",
+  "showMeetingsMenuBarDesc": "Відображати вашу наступну зустріч та час до її початку у меню macOS",
+  "showEventsNoParticipants": "Показувати події без учасників",
+  "showEventsNoParticipantsDesc": "Коли увімкнено, показує події без учасників або відео-посилання.",
+  "yourMeetings": "Ваші зустрічі",
+  "refresh": "Оновити",
+  "noUpcomingMeetings": "Майбутніх зустрічей не знайдено",
+  "checkingNextDays": "Перевірка наступних 30 днів",
+  "tomorrow": "Завтра",
+  "googleCalendarComingSoon": "Інтеграція з Google Календарем незабаром!",
+  "connectedAsUser": "Підключено як користувач: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Робочий простір за замовчуванням",
+  "tasksCreatedInWorkspace": "Завдання будуть створені у цьому робочому просторі",
+  "defaultProjectOptional": "Проект за замовчуванням (необов'язково)",
+  "leaveUnselectedTasks": "Залиште невибраним для створення завдань без проекту",
+  "noProjectsInWorkspace": "У цьому робочому просторі не знайдено проектів",
+  "conversationTimeoutDesc": "Виберіть, скільки часу чекати в тиші перед автоматичним завершенням розмови:",
+  "timeout2Minutes": "2 хвилини",
+  "timeout2MinutesDesc": "Завершити розмову після 2 хвилин тиші",
+  "timeout5Minutes": "5 хвилин",
+  "timeout5MinutesDesc": "Завершити розмову після 5 хвилин тиші",
+  "timeout10Minutes": "10 хвилин",
+  "timeout10MinutesDesc": "Завершити розмову після 10 хвилин тиші",
+  "timeout30Minutes": "30 хвилин",
+  "timeout30MinutesDesc": "Завершити розмову після 30 хвилин тиші",
+  "timeout4Hours": "4 години",
+  "timeout4HoursDesc": "Завершити розмову після 4 годин тиші",
+  "conversationEndAfterHours": "Розмови тепер завершуватимуться після 4 годин тиші",
+  "conversationEndAfterMinutes": "Розмови тепер завершуватимуться після {minutes} хвилин тиші",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Вкажіть свою основну мову",
+  "languageForTranscription": "Встановіть свою мову для точнішої транскрипції та персоналізованого досвіду.",
+  "singleLanguageModeInfo": "Режим однієї мови увімкнено. Переклад вимкнено для вищої точності.",
+  "searchLanguageHint": "Шукайте мову за назвою або кодом",
+  "noLanguagesFound": "Мов не знайдено",
+  "skip": "Пропустити",
+  "languageSetTo": "Мову встановлено на {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Не вдалося встановити мову",
+  "appSettings": "Налаштування {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Відключитись від {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Це видалить вашу автентифікацію {appName}. Вам потрібно буде підключитися знову, щоб використовувати це.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Підключено до {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Обліковий запис",
+  "actionItemsSyncedTo": "Ваші завдання будуть синхронізовані з вашим обліковим записом {appName}",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Простір за замовчуванням",
+  "selectSpaceInWorkspace": "Виберіть простір у вашому робочому просторі",
+  "noSpacesInWorkspace": "У цьому робочому просторі не знайдено просторів",
+  "defaultList": "Список за замовчуванням",
+  "tasksAddedToList": "Завдання будуть додані до цього списку",
+  "noListsInSpace": "У цьому просторі не знайдено списків",
+  "failedToLoadRepos": "Не вдалося завантажити репозиторії: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Репозиторій за замовчуванням збережено",
+  "failedToSaveDefaultRepo": "Не вдалося зберегти репозиторій за замовчуванням",
+  "defaultRepository": "Репозиторій за замовчуванням",
+  "selectDefaultRepoDesc": "Виберіть репозиторій за замовчуванням для створення issues. Ви все ще можете вказати інший репозиторій під час створення issues.",
+  "noReposFound": "Репозиторіїв не знайдено",
+  "private": "Приватний",
+  "updatedDate": "Оновлено {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "вчора",
+  "daysAgo": "{count} днів тому",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 тиждень тому",
+  "weeksAgo": "{count} тижнів тому",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 місяць тому",
+  "monthsAgo": "{count} місяців тому",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Issues будуть створені у вашому репозиторії за замовчуванням",
+  "taskIntegrations": "Інтеграції завдань",
+  "configureSettings": "Налаштувати параметри",
+  "completeAuthBrowser": "Будь ласка, завершіть автентифікацію у браузері. Після завершення поверніться до додатка.",
+  "failedToStartAppAuth": "Не вдалося розпочати автентифікацію {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Підключитися до {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Вам потрібно авторизувати Omi для створення завдань у вашому обліковому записі {appName}. Це відкриє ваш браузер для автентифікації.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Продовжити",
+  "appIntegration": "Інтеграція {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Інтеграція з {appName} незабаром! Ми наполегливо працюємо, щоб надати вам більше опцій управління завданнями.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Зрозуміло",
+  "tasksExportedOneApp": "Завдання можна експортувати в один додаток за раз.",
+  "completeYourUpgrade": "Завершіть оновлення",
+  "importConfiguration": "Імпортувати конфігурацію",
+  "exportConfiguration": "Експортувати конфігурацію",
+  "bringYourOwn": "Використовуйте власний",
+  "payYourSttProvider": "Вільно користуйтесь omi. Ви платите лише своєму STT-провайдеру безпосередньо.",
+  "freeMinutesMonth": "1,200 безкоштовних хвилин/місяць включено. Необмежено з ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Хост обов'язковий",
+  "validPortRequired": "Потрібен дійсний порт",
+  "validWebsocketUrlRequired": "Потрібен дійсний URL WebSocket (wss://)",
+  "apiUrlRequired": "API URL обов'язковий",
+  "apiKeyRequired": "API-ключ обов'язковий",
+  "invalidJsonConfig": "Недійсна конфігурація JSON",
+  "errorSaving": "Помилка збереження: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Конфігурацію скопійовано до буфера обміну",
+  "pasteJsonConfig": "Вставте свою конфігурацію JSON нижче:",
+  "addApiKeyAfterImport": "Вам потрібно буде додати власний API-ключ після імпорту",
+  "paste": "Вставити",
+  "import": "Імпортувати",
+  "invalidProviderInConfig": "Недійсний провайдер у конфігурації",
+  "importedConfig": "Імпортовано конфігурацію {providerName}",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "Недійсний JSON: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Провайдер",
+  "live": "В реальному часі",
+  "onDevice": "На пристрої",
+  "apiUrl": "API URL",
+  "enterSttHttpEndpoint": "Введіть свою HTTP кінцеву точку STT",
+  "websocketUrl": "WebSocket URL",
+  "enterLiveSttWebsocket": "Введіть свою WebSocket кінцеву точку STT в реальному часі",
+  "apiKey": "API-ключ",
+  "enterApiKey": "Введіть свій API-ключ",
+  "storedLocallyNeverShared": "Зберігається локально, ніколи не передається",
+  "host": "Хост",
+  "port": "Порт",
+  "advanced": "Розширені",
+  "configuration": "Конфігурація",
+  "requestConfiguration": "Конфігурація запиту",
+  "responseSchema": "Схема відповіді",
+  "modified": "Змінено",
+  "resetRequestConfig": "Скинути конфігурацію запиту до значень за замовчуванням",
+  "logs": "Журнали",
+  "logsCopied": "Журнали скопійовано",
+  "noLogsYet": "Журналів поки немає. Почніть запис, щоб побачити активність власного STT.",
+  "deviceUsesCodec": "{deviceName} використовує {codecReason}. Буде використано Omi.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Транскрипція Omi",
+  "bestInClassTranscription": "Найкраща транскрипція без налаштування",
+  "instantSpeakerLabels": "Миттєві мітки спікерів",
+  "languageTranslation": "Переклад 100+ мов",
+  "optimizedForConversation": "Оптимізовано для розмов",
+  "autoLanguageDetection": "Автоматичне визначення мови",
+  "highAccuracy": "Висока точність",
+  "privacyFirst": "Конфіденційність на першому місці",
+  "saveChanges": "Зберегти зміни",
+  "resetToDefault": "Скинути до значень за замовчуванням",
+  "viewTemplate": "Переглянути шаблон",
+  "trySomethingLike": "Спробуйте щось подібне...",
+  "tryIt": "Спробувати",
+  "creatingPlan": "Створення плану",
+  "developingLogic": "Розробка логіки",
+  "designingApp": "Проектування додатка",
+  "generatingIconStep": "Генерація іконки",
+  "finalTouches": "Фінальні штрихи",
+  "processing": "Обробка...",
+  "features": "Можливості",
+  "creatingYourApp": "Створення вашого додатка...",
+  "generatingIcon": "Генерація іконки...",
+  "whatShouldWeMake": "Що ми повинні створити?",
+  "appName": "Назва додатка",
+  "description": "Опис",
+  "publicLabel": "Публічний",
+  "privateLabel": "Приватний",
+  "free": "Безкоштовно",
+  "perMonth": "/ Місяць",
+  "tailoredConversationSummaries": "Персоналізовані підсумки розмов",
+  "customChatbotPersonality": "Налаштована особистість чат-бота",
+  "makePublic": "Зробити публічним",
+  "anyoneCanDiscover": "Будь-хто може знайти ваш додаток",
+  "onlyYouCanUse": "Лише ви можете використовувати цей додаток",
+  "paidApp": "Платний додаток",
+  "usersPayToUse": "Користувачі платять за використання вашого додатка",
+  "freeForEveryone": "Безкоштовно для всіх",
+  "perMonthLabel": "/ місяць",
+  "creating": "Створення...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Створити додаток",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Пошук пристроїв...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "{count} {count, plural, =1{ПРИСТРІЙ} other{ПРИСТРОЇВ}} ЗНАЙДЕНО ПОБЛИЗУ",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "З'ЄДНАННЯ УСПІШНЕ",
+  "errorConnectingAppleWatch": "Помилка підключення до Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Не показувати знову",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Я розумію",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Увімкнути Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi потребує Bluetooth для підключення до вашого носимого пристрою. Будь ласка, увімкніть Bluetooth та спробуйте ще раз.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Зв'язатися з підтримкою?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Підключити пізніше",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Надати дозволи",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Фонова активність",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Дозвольте Omi працювати у фоновому режимі для кращої стабільності",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Доступ до місцезнаходження",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Увімкніть фонове місцезнаходження для повного досвіду",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Сповіщення",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Увімкніть сповіщення, щоб бути в курсі",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Служба визначення місцезнаходження вимкнена",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Служба визначення місцезнаходження вимкнена. Будь ласка, перейдіть до Налаштування > Конфіденційність і безпека > Служби визначення місцезнаходження та увімкніть її",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Відмовлено в доступі до фонового місцезнаходження",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Будь ласка, перейдіть до налаштувань пристрою та встановіть дозвіл на місцезнаходження на \"Завжди дозволяти\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Подобається Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Допоможіть нам охопити більше людей, залишивши відгук в App Store. Ваші відгуки дуже важливі для нас!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Допоможіть нам охопити більше людей, залишивши відгук в Google Play Store. Ваші відгуки дуже важливі для нас!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Оцінити в App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Оцінити в Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Можливо пізніше",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi потрібно дізнатися про ваші цілі та ваш голос. Ви зможете змінити це пізніше.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Почати",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Все готово!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Продовжуйте, у вас чудово виходить",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Пропустити це питання",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Пропустити зараз",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Помилка підключення",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Не вдалося підключитися до сервера. Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Виявлено недійсний запис",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Схоже, що в записі кілька спікерів. Будь ласка, переконайтеся, що ви знаходитесь у тихому місці, та спробуйте ще раз.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Недостатньо мовлення виявлено. Будь ласка, говоріть більше та спробуйте ще раз.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Будь ласка, переконайтеся, що ви говорите щонайменше 5 секунд і не більше 90.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Ви тут?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Ми не змогли виявити жодного мовлення. Будь ласка, переконайтеся, що ви говорите щонайменше 10 секунд і не більше 3 хвилин.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "З'єднання втрачено",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "З'єднання було перервано. Будь ласка, перевірте підключення до інтернету та спробуйте ще раз.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Спробувати ще раз",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Підключити Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Продовжити без пристрою",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Потрібні дозволи",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Цей додаток потребує дозволів Bluetooth та Місцезнаходження для правильної роботи. Будь ласка, увімкніть їх у налаштуваннях.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Відкрити налаштування",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Хочете, щоб до вас звертались інакше?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Як вас звати?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Говоріть. Транскрибуйте. Підсумовуйте.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Увійти через Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Увійти через Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Продовжуючи, ви погоджуєтесь з нашою ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Умовами використання",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – ваш AI-компаньйон",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Захопіть кожну мить. Отримуйте підсумки на основі AI.\nНіколи більше не робіть нотатки.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Налаштування Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Запит дозволу!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Дозвіл на мікрофон",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Дозвіл надано! Тепер:\n\nВідкрийте додаток Omi на вашому годиннику та натисніть \"Продовжити\" нижче",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Нам потрібен дозвіл на мікрофон.\n\n1. Натисніть \"Надати дозвіл\"\n2. Дозвольте на вашому iPhone\n3. Додаток на годиннику закриється\n4. Відкрийте знову та натисніть \"Продовжити\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Надати дозвіл",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Потрібна допомога?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Усунення несправностей:\n\n1. Переконайтеся, що Omi встановлено на вашому годиннику\n2. Відкрийте додаток Omi на вашому годиннику\n3. Шукайте спливаюче вікно дозволу\n4. Натисніть \"Дозволити\" при запиті\n5. Додаток на вашому годиннику закриється - відкрийте його знову\n6. Поверніться та натисніть \"Продовжити\" на вашому iPhone",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Запис успішно розпочато!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Дозвіл ще не надано. Будь ласка, переконайтеся, що ви дозволили доступ до мікрофона та відкрили додаток на вашому годиннику знову.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Помилка запиту дозволу: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Помилка початку запису: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Виберіть свою основну мову",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Встановіть свою мову для точнішої транскрипції та персоналізованого досвіду",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Яка ваша основна мова?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Виберіть свою мову",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Ваша подорож особистого зростання з AI, який слухає кожне ваше слово.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Завдання",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Торкніться для редагування • Довге натискання для вибору • Проведіть для дій",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "До виконання",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Виконано",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Старі",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Все виконано!\nНемає завдань у черзі",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Виконаних завдань поки немає",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Немає старих завдань",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Немає елементів",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Завдання позначено як невиконане",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Завдання виконано",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Видалити завдання",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Ви впевнені, що хочете видалити це завдання?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Видалити вибрані елементи",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Ви впевнені, що хочете видалити {count} вибраних завдань{s}?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Завдання \"{description}\" видалено",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "{count} завдань{s} видалено",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Не вдалося видалити завдання",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Не вдалося видалити елементи",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Не вдалося видалити деякі елементи",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Готовий до завдань",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "Ваш AI автоматично витягатиме завдання з ваших розмов. Вони з'являться тут після створення.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Автоматично витягуються з розмов",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Торкніться для редагування, проведіть для завершення або видалення",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "Вибрано: {count}",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Вибрати все",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Видалити вибрані",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Пошук серед {count} спогадів",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Спогад видалено.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Скасувати",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Спогадів поки немає",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Автоматично витягнутих спогадів поки немає",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Власних спогадів поки немає",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Немає спогадів у цих категоріях",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Спогадів не знайдено",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Додати перший спогад",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Очистити пам'ять Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Ви впевнені, що хочете очистити пам'ять Omi? Цю дію не можна скасувати.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Очистити пам'ять",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Пам'ять Omi про вас очищено",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Немає спогадів для видалення",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Створити новий спогад",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Створити нове завдання",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Управління спогадами",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Фільтрувати спогади",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "У вас є {count} спогадів загалом",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Публічні спогади",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Приватні спогади",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Зробити всі спогади приватними",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Зробити всі спогади публічними",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Видалити всі спогади",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Всі спогади тепер приватні",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Всі спогади тепер публічні",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Новий спогад",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Редагувати спогад",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Мені подобається їсти морозиво...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Не вдалося зберегти. Будь ласка, перевірте підключення.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Зберегти спогад",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Спробувати ще раз",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Створити завдання",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Редагувати завдання",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Що потрібно зробити?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Опис завдання не може бути порожнім.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Завдання оновлено",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Не вдалося оновити завдання",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Завдання створено",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Не вдалося створити завдання",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Термін виконання",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Час",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Додати термін виконання",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Натисніть готово для збереження",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Натисніть готово для створення",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Всі",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Про вас",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Insights",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Власні",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Виконано",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Позначити виконаним",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Завдання видалено",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Не вдалося видалити завдання",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Видалити завдання",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Ви впевнені, що хочете видалити це завдання?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Мова додатка",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "ІНТЕРФЕЙС ДОДАТКУ",
+  "speechTranscriptionSectionTitle": "МОВЛЕННЯ ТА ТРАНСКРИПЦІЯ",
+  "languageSettingsHelperText": "Мова додатку змінює меню та кнопки. Мова мовлення впливає на те, як транскрибуються ваші записи."
+}

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -1,0 +1,2317 @@
+{
+  "@@locale": "vi",
+  "@@last_modified": "2026-01-13",
+  "appTitle": "Omi",
+  "@appTitle": {
+    "description": "The app title displayed in various places"
+  },
+  "conversationTab": "Cuộc trò chuyện",
+  "@conversationTab": {
+    "description": "Tab label for conversation summary"
+  },
+  "transcriptTab": "Bản ghi",
+  "@transcriptTab": {
+    "description": "Tab label for transcript view"
+  },
+  "actionItemsTab": "Việc cần làm",
+  "@actionItemsTab": {
+    "description": "Tab label for action items"
+  },
+  "deleteConversationTitle": "Xóa cuộc trò chuyện?",
+  "@deleteConversationTitle": {
+    "description": "Title for delete confirmation dialog"
+  },
+  "deleteConversationMessage": "Bạn có chắc chắn muốn xóa cuộc trò chuyện này? Hành động này không thể hoàn tác.",
+  "@deleteConversationMessage": {
+    "description": "Message for delete confirmation dialog"
+  },
+  "confirm": "Xác nhận",
+  "@confirm": {
+    "description": "Confirm button label"
+  },
+  "cancel": "Hủy",
+  "@cancel": {
+    "description": "Button label"
+  },
+  "ok": "Ok",
+  "@ok": {
+    "description": "Generic OK button text"
+  },
+  "delete": "Xóa",
+  "@delete": {
+    "description": "Button label"
+  },
+  "add": "Thêm",
+  "@add": {
+    "description": "Add button label"
+  },
+  "update": "Cập nhật",
+  "@update": {
+    "description": "Update button label"
+  },
+  "save": "Lưu",
+  "@save": {
+    "description": "Save button label"
+  },
+  "edit": "Sửa",
+  "@edit": {
+    "description": "Edit button/action label"
+  },
+  "close": "Đóng",
+  "@close": {
+    "description": "Close button label"
+  },
+  "clear": "Xóa",
+  "@clear": {
+    "description": "Clear button label"
+  },
+  "copyTranscript": "Sao chép bản ghi",
+  "@copyTranscript": {
+    "description": "Menu item to copy transcript"
+  },
+  "copySummary": "Sao chép tóm tắt",
+  "@copySummary": {
+    "description": "Menu item to copy summary"
+  },
+  "testPrompt": "Thử nghiệm",
+  "@testPrompt": {
+    "description": "Menu item for testing prompts"
+  },
+  "reprocessConversation": "Xử lý lại cuộc trò chuyện",
+  "@reprocessConversation": {
+    "description": "Menu item to reprocess a conversation"
+  },
+  "deleteConversation": "Xóa cuộc trò chuyện",
+  "@deleteConversation": {
+    "description": "Menu item to delete a conversation"
+  },
+  "contentCopied": "Đã sao chép nội dung vào clipboard",
+  "@contentCopied": {
+    "description": "Snackbar message when content is copied"
+  },
+  "failedToUpdateStarred": "Không thể cập nhật trạng thái gắn sao.",
+  "@failedToUpdateStarred": {
+    "description": "Error message when starring fails"
+  },
+  "conversationUrlNotShared": "Không thể chia sẻ URL cuộc trò chuyện.",
+  "@conversationUrlNotShared": {
+    "description": "Error message when sharing fails"
+  },
+  "errorProcessingConversation": "Lỗi khi xử lý cuộc trò chuyện. Vui lòng thử lại sau.",
+  "@errorProcessingConversation": {
+    "description": "Error message for conversation processing failure"
+  },
+  "noInternetConnection": "Vui lòng kiểm tra kết nối internet và thử lại.",
+  "@noInternetConnection": {
+    "description": "Message shown when there's no internet"
+  },
+  "unableToDeleteConversation": "Không thể xóa cuộc trò chuyện",
+  "@unableToDeleteConversation": {
+    "description": "Title for delete error dialog"
+  },
+  "somethingWentWrong": "Đã có lỗi xảy ra! Vui lòng thử lại sau.",
+  "@somethingWentWrong": {
+    "description": "Generic error message"
+  },
+  "copyErrorMessage": "Sao chép thông báo lỗi",
+  "@copyErrorMessage": {
+    "description": "Button to copy error details"
+  },
+  "errorCopied": "Đã sao chép thông báo lỗi vào clipboard",
+  "@errorCopied": {
+    "description": "Snackbar message after copying error"
+  },
+  "remaining": "Còn lại",
+  "@remaining": {
+    "description": "Label for remaining time/items"
+  },
+  "loading": "Đang tải...",
+  "@loading": {
+    "description": "Loading indicator text"
+  },
+  "loadingDuration": "Đang tải thời lượng...",
+  "@loadingDuration": {
+    "description": "Loading duration indicator"
+  },
+  "secondsCount": "{count} giây",
+  "@secondsCount": {
+    "description": "Duration in seconds",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "example": "30"
+      }
+    }
+  },
+  "people": "Mọi người",
+  "@people": {
+    "description": "People section title"
+  },
+  "addNewPerson": "Thêm người mới",
+  "@addNewPerson": {
+    "description": "Title for add person dialog"
+  },
+  "editPerson": "Chỉnh sửa người",
+  "@editPerson": {
+    "description": "Title for edit person dialog"
+  },
+  "createPersonHint": "Tạo một người mới và huấn luyện Omi để nhận biết giọng nói của họ!",
+  "@createPersonHint": {
+    "description": "Hint text for creating a person"
+  },
+  "speechProfile": "Hồ sơ giọng nói",
+  "@speechProfile": {
+    "description": "Speech profile label"
+  },
+  "sampleNumber": "Mẫu {number}",
+  "@sampleNumber": {
+    "description": "Label for speech sample",
+    "placeholders": {
+      "number": {
+        "type": "int",
+        "example": "1"
+      }
+    }
+  },
+  "settings": "Cài đặt",
+  "@settings": {
+    "description": "Settings page title"
+  },
+  "language": "Ngôn ngữ",
+  "@language": {
+    "description": "Language setting label"
+  },
+  "selectLanguage": "Chọn ngôn ngữ",
+  "@selectLanguage": {
+    "description": "Title for language selection"
+  },
+  "deleting": "Đang xóa...",
+  "@deleting": {
+    "description": "Deleting in progress indicator"
+  },
+  "pleaseCompleteAuthentication": "Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.",
+  "@pleaseCompleteAuthentication": {
+    "description": "Message shown during OAuth flow"
+  },
+  "failedToStartAuthentication": "Không thể bắt đầu xác thực",
+  "@failedToStartAuthentication": {
+    "description": "Error when OAuth fails to start"
+  },
+  "importStarted": "Đã bắt đầu nhập dữ liệu! Bạn sẽ được thông báo khi hoàn tất.",
+  "@importStarted": {
+    "description": "Success message when import begins"
+  },
+  "failedToStartImport": "Không thể bắt đầu nhập dữ liệu. Vui lòng thử lại.",
+  "@failedToStartImport": {
+    "description": "Error when import fails to start"
+  },
+  "couldNotAccessFile": "Không thể truy cập tệp đã chọn",
+  "@couldNotAccessFile": {
+    "description": "Error when file access fails"
+  },
+  "askOmi": "Hỏi Omi",
+  "@askOmi": {
+    "description": "Chat button label"
+  },
+  "done": "Xong",
+  "@done": {
+    "description": "Button label"
+  },
+  "disconnected": "Đã ngắt kết nối",
+  "@disconnected": {
+    "description": "Device disconnected status"
+  },
+  "searching": "Đang tìm kiếm",
+  "@searching": {
+    "description": "Searching for device status"
+  },
+  "connectDevice": "Kết nối thiết bị",
+  "@connectDevice": {
+    "description": "Button to connect a device"
+  },
+  "monthlyLimitReached": "Bạn đã đạt đến giới hạn hàng tháng.",
+  "@monthlyLimitReached": {
+    "description": "Message when usage limit is reached"
+  },
+  "checkUsage": "Kiểm tra mức sử dụng",
+  "@checkUsage": {
+    "description": "Button to check usage details"
+  },
+  "syncingRecordings": "Đang đồng bộ bản ghi âm",
+  "@syncingRecordings": {
+    "description": "Title when sync is in progress"
+  },
+  "recordingsToSync": "Bản ghi âm cần đồng bộ",
+  "@recordingsToSync": {
+    "description": "Title when there are recordings to sync"
+  },
+  "allCaughtUp": "Đã đồng bộ tất cả",
+  "@allCaughtUp": {
+    "description": "Title when everything is synced"
+  },
+  "sync": "Đồng bộ",
+  "@sync": {
+    "description": "Sync button label"
+  },
+  "pendantUpToDate": "Pendant đã được cập nhật",
+  "@pendantUpToDate": {
+    "description": "Status when pendant is synced"
+  },
+  "allRecordingsSynced": "Tất cả bản ghi âm đã được đồng bộ",
+  "@allRecordingsSynced": {
+    "description": "Status text when sync is complete"
+  },
+  "syncingInProgress": "Đang đồng bộ",
+  "@syncingInProgress": {
+    "description": "Status when sync is happening"
+  },
+  "readyToSync": "Sẵn sàng đồng bộ",
+  "@readyToSync": {
+    "description": "Status when ready to sync"
+  },
+  "tapSyncToStart": "Nhấn Đồng bộ để bắt đầu",
+  "@tapSyncToStart": {
+    "description": "Hint to start sync"
+  },
+  "pendantNotConnected": "Pendant chưa kết nối. Kết nối để đồng bộ.",
+  "@pendantNotConnected": {
+    "description": "Warning when pendant is not connected"
+  },
+  "everythingSynced": "Mọi thứ đã được đồng bộ.",
+  "@everythingSynced": {
+    "description": "Message when all is synced"
+  },
+  "recordingsNotSynced": "Bạn có những bản ghi âm chưa được đồng bộ.",
+  "@recordingsNotSynced": {
+    "description": "Message when there are unsynced recordings"
+  },
+  "syncingBackground": "Chúng tôi sẽ tiếp tục đồng bộ bản ghi âm của bạn trong nền.",
+  "@syncingBackground": {
+    "description": "Message during background sync"
+  },
+  "noConversationsYet": "Chưa có cuộc trò chuyện nào.",
+  "@noConversationsYet": {
+    "description": "Empty state when no conversations exist"
+  },
+  "noStarredConversations": "Chưa có cuộc trò chuyện được gắn sao.",
+  "@noStarredConversations": {
+    "description": "Empty state for starred filter"
+  },
+  "starConversationHint": "Để gắn sao cuộc trò chuyện, hãy mở nó và nhấn vào biểu tượng ngôi sao ở phần đầu.",
+  "@starConversationHint": {
+    "description": "Hint explaining how to star conversations"
+  },
+  "searchConversations": "Tìm kiếm cuộc trò chuyện",
+  "@searchConversations": {
+    "description": "Search field placeholder"
+  },
+  "selectedCount": "Đã chọn {count}",
+  "@selectedCount": {
+    "description": "Selection count label",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "merge": "Gộp",
+  "@merge": {
+    "description": "Merge button label"
+  },
+  "mergeConversations": "Gộp cuộc trò chuyện",
+  "@mergeConversations": {
+    "description": "Merge dialog title"
+  },
+  "mergeConversationsMessage": "Thao tác này sẽ kết hợp {count} cuộc trò chuyện thành một. Tất cả nội dung sẽ được gộp và tạo lại.",
+  "@mergeConversationsMessage": {
+    "description": "Merge confirmation message",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "mergingInBackground": "Đang gộp trong nền. Có thể mất một chút thời gian.",
+  "@mergingInBackground": {
+    "description": "Snackbar message during merge"
+  },
+  "failedToStartMerge": "Không thể bắt đầu gộp",
+  "@failedToStartMerge": {
+    "description": "Error message when merge fails"
+  },
+  "askAnything": "Hỏi bất cứ điều gì",
+  "@askAnything": {
+    "description": "Chat input placeholder"
+  },
+  "noMessagesYet": "Chưa có tin nhắn nào!\nHãy bắt đầu cuộc trò chuyện nhé?",
+  "@noMessagesYet": {
+    "description": "Empty chat state message"
+  },
+  "deletingMessages": "Đang xóa tin nhắn của bạn khỏi bộ nhớ của Omi...",
+  "@deletingMessages": {
+    "description": "Loading text while clearing chat"
+  },
+  "messageCopied": "Đã sao chép tin nhắn vào clipboard.",
+  "@messageCopied": {
+    "description": "Snackbar after copying message"
+  },
+  "cannotReportOwnMessage": "Bạn không thể báo cáo tin nhắn của chính mình.",
+  "@cannotReportOwnMessage": {
+    "description": "Error when trying to report own message"
+  },
+  "reportMessage": "Báo cáo tin nhắn",
+  "@reportMessage": {
+    "description": "Report message dialog title"
+  },
+  "reportMessageConfirm": "Bạn có chắc chắn muốn báo cáo tin nhắn này?",
+  "@reportMessageConfirm": {
+    "description": "Report message confirmation"
+  },
+  "messageReported": "Đã báo cáo tin nhắn thành công.",
+  "@messageReported": {
+    "description": "Confirmation after reporting message"
+  },
+  "thankYouFeedback": "Cảm ơn phản hồi của bạn!",
+  "@thankYouFeedback": {
+    "description": "After thumbs up/down feedback"
+  },
+  "clearChat": "Xóa trò chuyện?",
+  "@clearChat": {
+    "description": "Clear chat dialog title"
+  },
+  "clearChatConfirm": "Bạn có chắc chắn muốn xóa trò chuyện? Hành động này không thể hoàn tác.",
+  "@clearChatConfirm": {
+    "description": "Clear chat confirmation message"
+  },
+  "maxFilesLimit": "Bạn chỉ có thể tải lên tối đa 4 tệp cùng lúc",
+  "@maxFilesLimit": {
+    "description": "Max files upload warning"
+  },
+  "chatWithOmi": "Trò chuyện với Omi",
+  "@chatWithOmi": {
+    "description": "Chat share subject"
+  },
+  "apps": "Ứng dụng",
+  "@apps": {
+    "description": "Apps page title"
+  },
+  "noAppsFound": "Không tìm thấy ứng dụng",
+  "@noAppsFound": {
+    "description": "Empty state when no apps match"
+  },
+  "tryAdjustingSearch": "Thử điều chỉnh tìm kiếm hoặc bộ lọc của bạn",
+  "@tryAdjustingSearch": {
+    "description": "Hint when no apps found"
+  },
+  "createYourOwnApp": "Tạo ứng dụng của riêng bạn",
+  "@createYourOwnApp": {
+    "description": "Create app button title"
+  },
+  "buildAndShareApp": "Xây dựng và chia sẻ ứng dụng tùy chỉnh của bạn",
+  "@buildAndShareApp": {
+    "description": "Create app button subtitle"
+  },
+  "searchApps": "Tìm kiếm hơn 1500 ứng dụng",
+  "@searchApps": {
+    "description": "Apps search placeholder"
+  },
+  "myApps": "Ứng dụng của tôi",
+  "@myApps": {
+    "description": "My Apps filter button"
+  },
+  "installedApps": "Ứng dụng đã cài đặt",
+  "@installedApps": {
+    "description": "Installed Apps filter button"
+  },
+  "unableToFetchApps": "Không thể tải ứng dụng :(\n\nVui lòng kiểm tra kết nối internet và thử lại.",
+  "@unableToFetchApps": {
+    "description": "Error when apps fail to load"
+  },
+  "aboutOmi": "Về Omi",
+  "@aboutOmi": {
+    "description": "About page title"
+  },
+  "privacyPolicy": "Chính sách bảo mật",
+  "@privacyPolicy": {
+    "description": "Link text for Privacy Policy"
+  },
+  "visitWebsite": "Truy cập website",
+  "@visitWebsite": {
+    "description": "Visit website link"
+  },
+  "helpOrInquiries": "Trợ giúp hoặc thắc mắc?",
+  "@helpOrInquiries": {
+    "description": "Help link title"
+  },
+  "joinCommunity": "Tham gia cộng đồng!",
+  "@joinCommunity": {
+    "description": "Discord community link"
+  },
+  "membersAndCounting": "Hơn 8000 thành viên và đang tăng.",
+  "@membersAndCounting": {
+    "description": "Discord member count"
+  },
+  "deleteAccountTitle": "Xóa tài khoản",
+  "@deleteAccountTitle": {
+    "description": "Delete account page title"
+  },
+  "deleteAccountConfirm": "Bạn có chắc chắn muốn xóa tài khoản của mình?",
+  "@deleteAccountConfirm": {
+    "description": "Delete account confirmation"
+  },
+  "cannotBeUndone": "Hành động này không thể hoàn tác.",
+  "@cannotBeUndone": {
+    "description": "Warning that action is permanent"
+  },
+  "allDataErased": "Tất cả ký ức và cuộc trò chuyện của bạn sẽ bị xóa vĩnh viễn.",
+  "@allDataErased": {
+    "description": "Delete account warning 1"
+  },
+  "appsDisconnected": "Các ứng dụng và tích hợp của bạn sẽ bị ngắt kết nối ngay lập tức.",
+  "@appsDisconnected": {
+    "description": "Delete account warning 2"
+  },
+  "exportBeforeDelete": "Bạn có thể xuất dữ liệu trước khi xóa tài khoản, nhưng một khi đã xóa, dữ liệu không thể khôi phục.",
+  "@exportBeforeDelete": {
+    "description": "Delete account warning 3"
+  },
+  "deleteAccountCheckbox": "Tôi hiểu rằng việc xóa tài khoản là vĩnh viễn và tất cả dữ liệu, bao gồm ký ức và cuộc trò chuyện, sẽ bị mất và không thể khôi phục.",
+  "@deleteAccountCheckbox": {
+    "description": "Delete account checkbox confirmation"
+  },
+  "areYouSure": "Bạn có chắc chắn?",
+  "@areYouSure": {
+    "description": "Final confirmation title"
+  },
+  "deleteAccountFinal": "Hành động này không thể hoàn tác và sẽ xóa vĩnh viễn tài khoản cùng tất cả dữ liệu liên quan. Bạn có chắc chắn muốn tiếp tục?",
+  "@deleteAccountFinal": {
+    "description": "Final delete confirmation message"
+  },
+  "deleteNow": "Xóa ngay",
+  "@deleteNow": {
+    "description": "Delete now button"
+  },
+  "goBack": "Quay lại",
+  "@goBack": {
+    "description": "Go back button"
+  },
+  "checkBoxToConfirm": "Đánh dấu vào ô để xác nhận bạn hiểu rằng việc xóa tài khoản là vĩnh viễn và không thể hoàn tác.",
+  "@checkBoxToConfirm": {
+    "description": "Checkbox validation error"
+  },
+  "profile": "Hồ sơ",
+  "@profile": {
+    "description": "Profile page title"
+  },
+  "name": "Tên",
+  "@name": {
+    "description": "Name field label"
+  },
+  "email": "Email",
+  "@email": {
+    "description": "Email field label"
+  },
+  "customVocabulary": "Từ vựng tùy chỉnh",
+  "@customVocabulary": {
+    "description": "Custom vocabulary setting"
+  },
+  "identifyingOthers": "Nhận diện người khác",
+  "@identifyingOthers": {
+    "description": "People identification setting"
+  },
+  "paymentMethods": "Phương thức thanh toán",
+  "@paymentMethods": {
+    "description": "Payment methods setting"
+  },
+  "conversationDisplay": "Hiển thị cuộc trò chuyện",
+  "@conversationDisplay": {
+    "description": "Conversation display setting"
+  },
+  "dataPrivacy": "Dữ liệu & Bảo mật",
+  "@dataPrivacy": {
+    "description": "Data and privacy setting"
+  },
+  "userId": "ID người dùng",
+  "@userId": {
+    "description": "User ID label"
+  },
+  "notSet": "Chưa đặt",
+  "@notSet": {
+    "description": "Default value when not set"
+  },
+  "userIdCopied": "Đã sao chép ID người dùng vào clipboard",
+  "@userIdCopied": {
+    "description": "Confirmation when user ID is copied"
+  },
+  "systemDefault": "Mặc định hệ thống",
+  "@systemDefault": {
+    "description": "System language option"
+  },
+  "planAndUsage": "Gói & Mức sử dụng",
+  "@planAndUsage": {
+    "description": "Plan and usage menu item"
+  },
+  "offlineSync": "Đồng bộ ngoại tuyến",
+  "@offlineSync": {
+    "description": "Offline sync menu item"
+  },
+  "deviceSettings": "Cài đặt thiết bị",
+  "@deviceSettings": {
+    "description": "Device settings menu item"
+  },
+  "chatTools": "Công cụ trò chuyện",
+  "@chatTools": {
+    "description": "Chat tools menu item"
+  },
+  "feedbackBug": "Phản hồi / Báo lỗi",
+  "@feedbackBug": {
+    "description": "Feedback menu item"
+  },
+  "helpCenter": "Trung tâm trợ giúp",
+  "@helpCenter": {
+    "description": "Help center menu item"
+  },
+  "developerSettings": "Cài đặt nhà phát triển",
+  "@developerSettings": {
+    "description": "Developer settings menu item"
+  },
+  "getOmiForMac": "Tải Omi cho Mac",
+  "@getOmiForMac": {
+    "description": "Mac app download link"
+  },
+  "referralProgram": "Chương trình giới thiệu",
+  "@referralProgram": {
+    "description": "Referral program menu item"
+  },
+  "signOut": "Đăng xuất",
+  "@signOut": {
+    "description": "Sign out button"
+  },
+  "appAndDeviceCopied": "Đã sao chép thông tin ứng dụng và thiết bị",
+  "@appAndDeviceCopied": {
+    "description": "Confirmation when version info is copied"
+  },
+  "wrapped2025": "Tổng kết 2025",
+  "@wrapped2025": {
+    "description": "Wrapped 2025 menu item"
+  },
+  "yourPrivacyYourControl": "Quyền riêng tư của bạn, Quyền kiểm soát của bạn",
+  "@yourPrivacyYourControl": {
+    "description": "Data privacy page heading"
+  },
+  "privacyIntro": "Tại Omi, chúng tôi cam kết bảo vệ quyền riêng tư của bạn. Trang này cho phép bạn kiểm soát cách dữ liệu của bạn được lưu trữ và sử dụng.",
+  "@privacyIntro": {
+    "description": "Data privacy page introduction"
+  },
+  "learnMore": "Tìm hiểu thêm...",
+  "@learnMore": {
+    "description": "Learn more link"
+  },
+  "dataProtectionLevel": "Mức độ bảo vệ dữ liệu",
+  "@dataProtectionLevel": {
+    "description": "Data protection section title"
+  },
+  "dataProtectionDesc": "Dữ liệu của bạn được bảo mật mặc định với mã hóa mạnh. Xem lại cài đặt và các tùy chọn bảo mật trong tương lai bên dưới.",
+  "@dataProtectionDesc": {
+    "description": "Data protection section description"
+  },
+  "appAccess": "Quyền truy cập ứng dụng",
+  "@appAccess": {
+    "description": "App access section title"
+  },
+  "appAccessDesc": "Các ứng dụng sau có thể truy cập dữ liệu của bạn. Nhấn vào ứng dụng để quản lý quyền của nó.",
+  "@appAccessDesc": {
+    "description": "App access section description"
+  },
+  "noAppsExternalAccess": "Không có ứng dụng đã cài đặt nào có quyền truy cập bên ngoài vào dữ liệu của bạn.",
+  "@noAppsExternalAccess": {
+    "description": "Empty state for app access"
+  },
+  "deviceName": "Tên thiết bị",
+  "@deviceName": {
+    "description": "Device name label"
+  },
+  "deviceId": "ID thiết bị",
+  "@deviceId": {
+    "description": "Device ID label"
+  },
+  "firmware": "Phần mềm",
+  "@firmware": {
+    "description": "Firmware label"
+  },
+  "sdCardSync": "Đồng bộ thẻ SD",
+  "@sdCardSync": {
+    "description": "SD Card sync label"
+  },
+  "hardwareRevision": "Phiên bản phần cứng",
+  "@hardwareRevision": {
+    "description": "Hardware revision label"
+  },
+  "modelNumber": "Số model",
+  "@modelNumber": {
+    "description": "Model number label"
+  },
+  "manufacturer": "Nhà sản xuất",
+  "@manufacturer": {
+    "description": "Manufacturer label"
+  },
+  "doubleTap": "Nhấn đúp",
+  "@doubleTap": {
+    "description": "Double tap action label"
+  },
+  "ledBrightness": "Độ sáng đèn LED",
+  "@ledBrightness": {
+    "description": "LED brightness setting"
+  },
+  "micGain": "Độ tăng micro",
+  "@micGain": {
+    "description": "Microphone gain setting"
+  },
+  "disconnect": "Ngắt kết nối",
+  "@disconnect": {
+    "description": "Disconnect device button"
+  },
+  "forgetDevice": "Xóa thiết bị",
+  "@forgetDevice": {
+    "description": "Forget device button"
+  },
+  "chargingIssues": "Vấn đề sạc pin",
+  "@chargingIssues": {
+    "description": "Charging issues help item"
+  },
+  "disconnectDevice": "Ngắt kết nối thiết bị",
+  "@disconnectDevice": {
+    "description": "Disconnect device button"
+  },
+  "unpairDevice": "Hủy ghép nối thiết bị",
+  "@unpairDevice": {
+    "description": "Unpair device button"
+  },
+  "unpairAndForget": "Hủy ghép nối và xóa thiết bị",
+  "@unpairAndForget": {
+    "description": "Unpair and forget device button"
+  },
+  "deviceDisconnectedMessage": "Omi của bạn đã bị ngắt kết nối 😔",
+  "@deviceDisconnectedMessage": {
+    "description": "Message shown when device is disconnected"
+  },
+  "deviceUnpairedMessage": "Đã hủy ghép nối thiết bị. Vào Cài đặt > Bluetooth và xóa thiết bị để hoàn tất việc hủy ghép nối.",
+  "@deviceUnpairedMessage": {
+    "description": "Message shown when device is unpaired"
+  },
+  "unpairDialogTitle": "Hủy ghép nối thiết bị",
+  "@unpairDialogTitle": {
+    "description": "Unpair dialog title"
+  },
+  "unpairDialogMessage": "Thao tác này sẽ hủy ghép nối thiết bị để có thể kết nối với điện thoại khác. Bạn cần vào Cài đặt > Bluetooth và xóa thiết bị để hoàn tất quá trình.",
+  "@unpairDialogMessage": {
+    "description": "Unpair dialog message"
+  },
+  "deviceNotConnected": "Thiết bị chưa kết nối",
+  "@deviceNotConnected": {
+    "description": "Device not connected header"
+  },
+  "connectDeviceMessage": "Kết nối thiết bị Omi của bạn để truy cập\ncài đặt thiết bị và tùy chỉnh",
+  "@connectDeviceMessage": {
+    "description": "Message encouraging user to connect device"
+  },
+  "deviceInfoSection": "Thông tin thiết bị",
+  "@deviceInfoSection": {
+    "description": "Device information section header"
+  },
+  "customizationSection": "Tùy chỉnh",
+  "@customizationSection": {
+    "description": "Customization section header"
+  },
+  "hardwareSection": "Phần cứng",
+  "@hardwareSection": {
+    "description": "Hardware section header"
+  },
+  "v2Undetected": "Không phát hiện V2",
+  "@v2Undetected": {
+    "description": "V2 device undeteced dialog title"
+  },
+  "v2UndetectedMessage": "Chúng tôi thấy rằng bạn có thiết bị V1 hoặc thiết bị của bạn chưa được kết nối. Chức năng thẻ SD chỉ khả dụng cho thiết bị V2.",
+  "@v2UndetectedMessage": {
+    "description": "V2 device undeteced dialog message"
+  },
+  "endConversation": "Kết thúc cuộc trò chuyện",
+  "@endConversation": {
+    "description": "End conversation action"
+  },
+  "pauseResume": "Tạm dừng/Tiếp tục",
+  "@pauseResume": {
+    "description": "Pause/Resume action"
+  },
+  "starConversation": "Gắn sao cuộc trò chuyện",
+  "@starConversation": {
+    "description": "Star conversation action"
+  },
+  "doubleTapAction": "Hành động nhấn đúp",
+  "@doubleTapAction": {
+    "description": "Double tap action setting"
+  },
+  "endAndProcess": "Kết thúc & Xử lý cuộc trò chuyện",
+  "@endAndProcess": {
+    "description": "End and process action"
+  },
+  "pauseResumeRecording": "Tạm dừng/Tiếp tục ghi âm",
+  "@pauseResumeRecording": {
+    "description": "Pause/Resume recording action"
+  },
+  "starOngoing": "Gắn sao cuộc trò chuyện đang diễn ra",
+  "@starOngoing": {
+    "description": "Star ongoing conversation action"
+  },
+  "off": "Tắt",
+  "@off": {
+    "description": "Off state"
+  },
+  "max": "Tối đa",
+  "@max": {
+    "description": "Max state"
+  },
+  "mute": "Tắt tiếng",
+  "@mute": {
+    "description": "Mute state"
+  },
+  "quiet": "Yên tĩnh",
+  "@quiet": {
+    "description": "Quiet preset"
+  },
+  "normal": "Bình thường",
+  "@normal": {
+    "description": "Normal preset"
+  },
+  "high": "Cao",
+  "@high": {
+    "description": "High preset"
+  },
+  "micGainDescMuted": "Microphone đã tắt tiếng",
+  "@micGainDescMuted": {
+    "description": "Mic gain description: Muted"
+  },
+  "micGainDescLow": "Rất yên tĩnh - cho môi trường ồn ào",
+  "@micGainDescLow": {
+    "description": "Mic gain description: Low"
+  },
+  "micGainDescModerate": "Yên tĩnh - cho tiếng ồn vừa phải",
+  "@micGainDescModerate": {
+    "description": "Mic gain description: Moderate"
+  },
+  "micGainDescNeutral": "Trung tính - ghi âm cân bằng",
+  "@micGainDescNeutral": {
+    "description": "Mic gain description: Neutral"
+  },
+  "micGainDescSlightlyBoosted": "Tăng nhẹ - sử dụng thông thường",
+  "@micGainDescSlightlyBoosted": {
+    "description": "Mic gain description: Slightly Boosted"
+  },
+  "micGainDescBoosted": "Tăng cao - cho môi trường yên tĩnh",
+  "@micGainDescBoosted": {
+    "description": "Mic gain description: Boosted"
+  },
+  "micGainDescHigh": "Cao - cho giọng nói xa hoặc nhỏ",
+  "@micGainDescHigh": {
+    "description": "Mic gain description: High"
+  },
+  "micGainDescVeryHigh": "Rất cao - cho nguồn rất yên tĩnh",
+  "@micGainDescVeryHigh": {
+    "description": "Mic gain description: Very High"
+  },
+  "micGainDescMax": "Tối đa - sử dụng cẩn thận",
+  "@micGainDescMax": {
+    "description": "Mic gain description: Max"
+  },
+  "developerSettingsTitle": "Cài đặt nhà phát triển",
+  "@developerSettingsTitle": {
+    "description": "Developer settings page title"
+  },
+  "saving": "Đang lưu...",
+  "@saving": {
+    "description": "Saving state text"
+  },
+  "personaConfig": "Cấu hình nhân cách AI của bạn",
+  "@personaConfig": {
+    "description": "Persona configuration subtitle"
+  },
+  "beta": "BETA",
+  "@beta": {
+    "description": "Beta tag"
+  },
+  "transcription": "Phiên âm",
+  "@transcription": {
+    "description": "Transcription settings title"
+  },
+  "transcriptionConfig": "Cấu hình nhà cung cấp STT",
+  "@transcriptionConfig": {
+    "description": "Transcription configuration subtitle"
+  },
+  "conversationTimeout": "Thời gian chờ cuộc trò chuyện",
+  "@conversationTimeout": {
+    "description": "Conversation timeout settings title"
+  },
+  "conversationTimeoutConfig": "Đặt thời gian tự động kết thúc cuộc trò chuyện",
+  "@conversationTimeoutConfig": {
+    "description": "Conversation timeout configuration subtitle"
+  },
+  "importData": "Nhập dữ liệu",
+  "@importData": {
+    "description": "Import data details title"
+  },
+  "importDataConfig": "Nhập dữ liệu từ các nguồn khác",
+  "@importDataConfig": {
+    "description": "Import data details subtitle"
+  },
+  "debugDiagnostics": "Gỡ lỗi & Chẩn đoán",
+  "@debugDiagnostics": {
+    "description": "Debug & Diagnostics section header"
+  },
+  "endpointUrl": "URL điểm cuối",
+  "@endpointUrl": {
+    "description": "Endpoint URL label"
+  },
+  "noApiKeys": "Chưa có API key",
+  "@noApiKeys": {
+    "description": "No API keys message"
+  },
+  "createKeyToStart": "Tạo key để bắt đầu",
+  "@createKeyToStart": {
+    "description": "Create key instruction"
+  },
+  "createKey": "Tạo Key",
+  "@createKey": {
+    "description": "Create Key button"
+  },
+  "docs": "Tài liệu",
+  "@docs": {
+    "description": "Documentation link"
+  },
+  "yourOmiInsights": "Thông tin chi tiết Omi của bạn",
+  "@yourOmiInsights": {
+    "description": "Usage page title"
+  },
+  "today": "Hôm nay",
+  "@today": {
+    "description": "Time period: Today"
+  },
+  "thisMonth": "Tháng này",
+  "@thisMonth": {
+    "description": "Time period: This Month"
+  },
+  "thisYear": "Năm nay",
+  "@thisYear": {
+    "description": "Time period: This Year"
+  },
+  "allTime": "Tất cả thời gian",
+  "@allTime": {
+    "description": "Time period: All Time"
+  },
+  "noActivityYet": "Chưa có hoạt động",
+  "@noActivityYet": {
+    "description": "Empty state title"
+  },
+  "startConversationToSeeInsights": "Bắt đầu cuộc trò chuyện với Omi\nđể xem thông tin chi tiết về mức sử dụng của bạn tại đây.",
+  "@startConversationToSeeInsights": {
+    "description": "Empty state description"
+  },
+  "listening": "Lắng nghe",
+  "@listening": {
+    "description": "Listening stat title"
+  },
+  "listeningSubtitle": "Tổng thời gian Omi đã lắng nghe tích cực.",
+  "@listeningSubtitle": {
+    "description": "Listening stat subtitle"
+  },
+  "understanding": "Hiểu biết",
+  "@understanding": {
+    "description": "Understanding stat title"
+  },
+  "understandingSubtitle": "Số từ đã hiểu từ cuộc trò chuyện của bạn.",
+  "@understandingSubtitle": {
+    "description": "Understanding stat subtitle"
+  },
+  "providing": "Cung cấp",
+  "@providing": {
+    "description": "Providing stat title"
+  },
+  "providingSubtitle": "Việc cần làm và ghi chú được ghi lại tự động.",
+  "@providingSubtitle": {
+    "description": "Providing stat subtitle"
+  },
+  "remembering": "Ghi nhớ",
+  "@remembering": {
+    "description": "Remembering stat title"
+  },
+  "rememberingSubtitle": "Sự kiện và chi tiết được ghi nhớ cho bạn.",
+  "@rememberingSubtitle": {
+    "description": "Remembering stat subtitle"
+  },
+  "unlimitedPlan": "Gói không giới hạn",
+  "@unlimitedPlan": {
+    "description": "Unlimited plan name"
+  },
+  "managePlan": "Quản lý gói",
+  "@managePlan": {
+    "description": "Manage plan button"
+  },
+  "cancelAtPeriodEnd": "Gói của bạn sẽ bị hủy vào {date}.",
+  "@cancelAtPeriodEnd": {
+    "description": "Cancellation message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "renewsOn": "Gói của bạn sẽ gia hạn vào {date}.",
+  "@renewsOn": {
+    "description": "Renewal message",
+    "placeholders": {
+      "date": {
+        "type": "String",
+        "example": "Jan 1, 2026"
+      }
+    }
+  },
+  "basicPlan": "Gói miễn phí",
+  "@basicPlan": {
+    "description": "Basic plan name"
+  },
+  "usageLimitMessage": "Đã sử dụng {used} trong số {limit} phút",
+  "@usageLimitMessage": {
+    "description": "Usage limit message",
+    "placeholders": {
+      "used": {
+        "type": "String",
+        "example": "100"
+      },
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "upgrade": "Nâng cấp",
+  "@upgrade": {
+    "description": "Upgrade button"
+  },
+  "upgradeToUnlimited": "Nâng cấp lên không giới hạn",
+  "@upgradeToUnlimited": {
+    "description": "Upgrade to unlimited button"
+  },
+  "basicPlanDesc": "Gói của bạn bao gồm {limit} phút miễn phí mỗi tháng. Nâng cấp để sử dụng không giới hạn.",
+  "@basicPlanDesc": {
+    "description": "Basic plan description",
+    "placeholders": {
+      "limit": {
+        "type": "int",
+        "example": "60"
+      }
+    }
+  },
+  "shareStatsMessage": "Chia sẻ thống kê Omi của tôi! (omi.me - trợ lý AI luôn bên bạn)",
+  "@shareStatsMessage": {
+    "description": "Share stats base message"
+  },
+  "sharePeriodToday": "Hôm nay, omi đã:",
+  "@sharePeriodToday": {
+    "description": "Share stats period: Today"
+  },
+  "sharePeriodMonth": "Tháng này, omi đã:",
+  "@sharePeriodMonth": {
+    "description": "Share stats period: Month"
+  },
+  "sharePeriodYear": "Năm nay, omi đã:",
+  "@sharePeriodYear": {
+    "description": "Share stats period: Year"
+  },
+  "sharePeriodAllTime": "Cho đến nay, omi đã:",
+  "@sharePeriodAllTime": {
+    "description": "Share stats period: All Time"
+  },
+  "shareStatsListened": "🎧 Đã lắng nghe trong {minutes} phút",
+  "@shareStatsListened": {
+    "description": "Share stats: listened",
+    "placeholders": {
+      "minutes": {
+        "type": "String",
+        "example": "120"
+      }
+    }
+  },
+  "shareStatsWords": "🧠 Đã hiểu {words} từ",
+  "@shareStatsWords": {
+    "description": "Share stats: words",
+    "placeholders": {
+      "words": {
+        "type": "String",
+        "example": "5000"
+      }
+    }
+  },
+  "shareStatsInsights": "✨ Đã cung cấp {count} thông tin chi tiết",
+  "@shareStatsInsights": {
+    "description": "Share stats: insights",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "10"
+      }
+    }
+  },
+  "shareStatsMemories": "📚 Đã ghi nhớ {count} ký ức",
+  "@shareStatsMemories": {
+    "description": "Share stats: memories",
+    "placeholders": {
+      "count": {
+        "type": "String",
+        "example": "5"
+      }
+    }
+  },
+  "debugLogs": "Nhật ký gỡ lỗi",
+  "debugLogsAutoDelete": "Tự động xóa sau 3 ngày.",
+  "debugLogsDesc": "Giúp chẩn đoán các vấn đề",
+  "noLogFilesFound": "Không tìm thấy tệp nhật ký.",
+  "omiDebugLog": "Nhật ký gỡ lỗi Omi",
+  "logShared": "Đã chia sẻ nhật ký",
+  "selectLogFile": "Chọn tệp nhật ký",
+  "shareLogs": "Chia sẻ nhật ký",
+  "debugLogCleared": "Đã xóa nhật ký gỡ lỗi",
+  "exportStarted": "Đã bắt đầu xuất dữ liệu. Có thể mất vài giây...",
+  "exportAllData": "Xuất tất cả dữ liệu",
+  "exportDataDesc": "Xuất cuộc trò chuyện sang tệp JSON",
+  "exportedConversations": "Cuộc trò chuyện đã xuất từ Omi",
+  "exportShared": "Đã chia sẻ bản xuất",
+  "deleteKnowledgeGraphTitle": "Xóa biểu đồ tri thức?",
+  "deleteKnowledgeGraphMessage": "Thao tác này sẽ xóa tất cả dữ liệu biểu đồ tri thức được tạo ra (nút và kết nối). Ký ức gốc của bạn sẽ vẫn an toàn. Biểu đồ sẽ được xây dựng lại theo thời gian hoặc khi có yêu cầu tiếp theo.",
+  "knowledgeGraphDeleted": "Đã xóa biểu đồ tri thức thành công",
+  "deleteGraphFailed": "Không thể xóa biểu đồ: {error}",
+  "@deleteGraphFailed": {
+    "description": "Error message when deleting graph fails",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "deleteKnowledgeGraph": "Xóa biểu đồ tri thức",
+  "deleteKnowledgeGraphDesc": "Xóa tất cả nút và kết nối",
+  "mcp": "MCP",
+  "mcpServer": "Máy chủ MCP",
+  "mcpServerDesc": "Kết nối trợ lý AI với dữ liệu của bạn",
+  "serverUrl": "URL máy chủ",
+  "urlCopied": "Đã sao chép URL",
+  "apiKeyAuth": "Xác thực API Key",
+  "header": "Header",
+  "authorizationBearer": "Authorization: Bearer <key>",
+  "oauth": "OAuth",
+  "clientId": "Client ID",
+  "clientSecret": "Client Secret",
+  "useMcpApiKey": "Sử dụng API key MCP của bạn",
+  "webhooks": "Webhooks",
+  "conversationEvents": "Sự kiện cuộc trò chuyện",
+  "newConversationCreated": "Đã tạo cuộc trò chuyện mới",
+  "realtimeTranscript": "Bản ghi thời gian thực",
+  "transcriptReceived": "Đã nhận bản ghi",
+  "audioBytes": "Dữ liệu âm thanh",
+  "audioDataReceived": "Đã nhận dữ liệu âm thanh",
+  "intervalSeconds": "Khoảng thời gian (giây)",
+  "daySummary": "Tóm tắt ngày",
+  "summaryGenerated": "Đã tạo tóm tắt",
+  "claudeDesktop": "Claude Desktop",
+  "addToClaudeConfig": "Thêm vào claude_desktop_config.json",
+  "copyConfig": "Sao chép cấu hình",
+  "configCopied": "Đã sao chép cấu hình vào clipboard",
+  "listeningMins": "Lắng nghe (phút)",
+  "understandingWords": "Hiểu biết (từ)",
+  "insights": "Thông tin chi tiết",
+  "memories": "Ký ức",
+  "minsUsedThisMonth": "Đã sử dụng {used} trong số {limit} phút trong tháng này",
+  "@minsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "int"
+      }
+    }
+  },
+  "wordsUsedThisMonth": "Đã sử dụng {used} trong số {limit} từ trong tháng này",
+  "@wordsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "insightsUsedThisMonth": "Đã thu được {used} trong số {limit} thông tin chi tiết trong tháng này",
+  "@insightsUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "memoriesUsedThisMonth": "Đã tạo {used} trong số {limit} ký ức trong tháng này",
+  "@memoriesUsedThisMonth": {
+    "placeholders": {
+      "used": {
+        "type": "String"
+      },
+      "limit": {
+        "type": "String"
+      }
+    }
+  },
+  "visibility": "Hiển thị",
+  "visibilitySubtitle": "Kiểm soát cuộc trò chuyện nào xuất hiện trong danh sách của bạn",
+  "showShortConversations": "Hiển thị cuộc trò chuyện ngắn",
+  "showShortConversationsDesc": "Hiển thị cuộc trò chuyện ngắn hơn ngưỡng",
+  "showDiscardedConversations": "Hiển thị cuộc trò chuyện đã hủy",
+  "showDiscardedConversationsDesc": "Bao gồm cuộc trò chuyện được đánh dấu là đã hủy",
+  "shortConversationThreshold": "Ngưỡng cuộc trò chuyện ngắn",
+  "shortConversationThresholdSubtitle": "Cuộc trò chuyện ngắn hơn sẽ bị ẩn trừ khi được bật ở trên",
+  "durationThreshold": "Ngưỡng thời lượng",
+  "durationThresholdDesc": "Ẩn cuộc trò chuyện ngắn hơn",
+  "minLabel": "{count} phút",
+  "@minLabel": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "customVocabularyTitle": "Từ vựng tùy chỉnh",
+  "addWords": "Thêm từ",
+  "addWordsDesc": "Tên, thuật ngữ hoặc từ không phổ biến",
+  "vocabularyHint": "Omi, Callie, OpenAI",
+  "connect": "Kết nối",
+  "comingSoon": "Sắp ra mắt",
+  "chatToolsFooter": "Kết nối ứng dụng của bạn để xem dữ liệu và số liệu trong trò chuyện.",
+  "completeAuthInBrowser": "Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.",
+  "failedToStartAuth": "Không thể bắt đầu xác thực {appName}",
+  "@failedToStartAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppTitle": "Ngắt kết nối {appName}?",
+  "@disconnectAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectAppMessage": "Bạn có chắc chắn muốn ngắt kết nối khỏi {appName}? Bạn có thể kết nối lại bất kỳ lúc nào.",
+  "@disconnectAppMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectedFrom": "Đã ngắt kết nối khỏi {appName}",
+  "@disconnectedFrom": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDisconnect": "Không thể ngắt kết nối",
+  "connectTo": "Kết nối với {appName}",
+  "@connectTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authAccessMessage": "Bạn cần cho phép Omi truy cập dữ liệu {appName} của bạn. Thao tác này sẽ mở trình duyệt để xác thực.",
+  "@authAccessMessage": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueAction": "Tiếp tục",
+  "languageTitle": "Ngôn ngữ",
+  "primaryLanguage": "Ngôn ngữ chính",
+  "automaticTranslation": "Dịch tự động",
+  "detectLanguages": "Phát hiện hơn 10 ngôn ngữ",
+  "authorizeSavingRecordings": "Cho phép lưu bản ghi âm",
+  "thanksForAuthorizing": "Cảm ơn bạn đã cho phép!",
+  "needYourPermission": "Chúng tôi cần sự cho phép của bạn",
+  "alreadyGavePermission": "Bạn đã cho phép chúng tôi lưu bản ghi âm của bạn. Đây là lời nhắc nhở về lý do chúng tôi cần:",
+  "wouldLikePermission": "Chúng tôi muốn được phép lưu bản ghi âm giọng nói của bạn. Đây là lý do:",
+  "improveSpeechProfile": "Cải thiện hồ sơ giọng nói của bạn",
+  "improveSpeechProfileDesc": "Chúng tôi sử dụng bản ghi âm để huấn luyện và nâng cao hồ sơ giọng nói cá nhân của bạn.",
+  "trainFamilyProfiles": "Huấn luyện hồ sơ cho bạn bè và gia đình",
+  "trainFamilyProfilesDesc": "Bản ghi âm của bạn giúp chúng tôi nhận dạng và tạo hồ sơ cho bạn bè và gia đình của bạn.",
+  "enhanceTranscriptAccuracy": "Tăng độ chính xác bản ghi",
+  "enhanceTranscriptAccuracyDesc": "Khi mô hình của chúng tôi được cải thiện, chúng tôi có thể cung cấp kết quả phiên âm tốt hơn cho bản ghi âm của bạn.",
+  "legalNotice": "Thông báo pháp lý: Tính hợp pháp của việc ghi âm và lưu trữ dữ liệu giọng nói có thể khác nhau tùy thuộc vào vị trí của bạn và cách bạn sử dụng tính năng này. Bạn có trách nhiệm đảm bảo tuân thủ luật pháp và quy định địa phương.",
+  "alreadyAuthorized": "Đã cho phép",
+  "authorize": "Cho phép",
+  "revokeAuthorization": "Thu hồi quyền",
+  "authorizationSuccessful": "Cho phép thành công!",
+  "failedToAuthorize": "Không thể cho phép. Vui lòng thử lại.",
+  "authorizationRevoked": "Đã thu hồi quyền.",
+  "recordingsDeleted": "Đã xóa bản ghi âm.",
+  "failedToRevoke": "Không thể thu hồi quyền. Vui lòng thử lại.",
+  "permissionRevokedTitle": "Đã thu hồi quyền",
+  "permissionRevokedMessage": "Bạn có muốn chúng tôi xóa tất cả bản ghi âm hiện có của bạn không?",
+  "yes": "Có",
+  "editName": "Chỉnh sửa tên",
+  "howShouldOmiCallYou": "Omi nên gọi bạn như thế nào?",
+  "enterYourName": "Nhập tên của bạn",
+  "nameCannotBeEmpty": "Tên không được để trống",
+  "nameUpdatedSuccessfully": "Đã cập nhật tên thành công!",
+  "calendarSettings": "Cài đặt lịch",
+  "calendarProviders": "Nhà cung cấp lịch",
+  "macOsCalendar": "Lịch macOS",
+  "connectMacOsCalendar": "Kết nối lịch macOS cục bộ của bạn",
+  "googleCalendar": "Google Calendar",
+  "syncGoogleAccount": "Đồng bộ với tài khoản Google của bạn",
+  "showMeetingsMenuBar": "Hiển thị cuộc họp sắp tới trên thanh menu",
+  "showMeetingsMenuBarDesc": "Hiển thị cuộc họp tiếp theo và thời gian cho đến khi nó bắt đầu trên thanh menu macOS",
+  "showEventsNoParticipants": "Hiển thị sự kiện không có người tham gia",
+  "showEventsNoParticipantsDesc": "Khi được bật, Coming Up hiển thị các sự kiện không có người tham gia hoặc liên kết video.",
+  "yourMeetings": "Cuộc họp của bạn",
+  "refresh": "Làm mới",
+  "noUpcomingMeetings": "Không tìm thấy cuộc họp sắp tới",
+  "checkingNextDays": "Kiểm tra 30 ngày tiếp theo",
+  "tomorrow": "Ngày mai",
+  "googleCalendarComingSoon": "Tích hợp Google Calendar sắp ra mắt!",
+  "connectedAsUser": "Đã kết nối với tư cách người dùng: {userId}",
+  "@connectedAsUser": {
+    "placeholders": {
+      "userId": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultWorkspace": "Workspace mặc định",
+  "tasksCreatedInWorkspace": "Nhiệm vụ sẽ được tạo trong workspace này",
+  "defaultProjectOptional": "Dự án mặc định (Tùy chọn)",
+  "leaveUnselectedTasks": "Bỏ trống để tạo nhiệm vụ không có dự án",
+  "noProjectsInWorkspace": "Không tìm thấy dự án trong workspace này",
+  "conversationTimeoutDesc": "Chọn thời gian chờ im lặng trước khi tự động kết thúc cuộc trò chuyện:",
+  "timeout2Minutes": "2 phút",
+  "timeout2MinutesDesc": "Kết thúc cuộc trò chuyện sau 2 phút im lặng",
+  "timeout5Minutes": "5 phút",
+  "timeout5MinutesDesc": "Kết thúc cuộc trò chuyện sau 5 phút im lặng",
+  "timeout10Minutes": "10 phút",
+  "timeout10MinutesDesc": "Kết thúc cuộc trò chuyện sau 10 phút im lặng",
+  "timeout30Minutes": "30 phút",
+  "timeout30MinutesDesc": "Kết thúc cuộc trò chuyện sau 30 phút im lặng",
+  "timeout4Hours": "4 giờ",
+  "timeout4HoursDesc": "Kết thúc cuộc trò chuyện sau 4 giờ im lặng",
+  "conversationEndAfterHours": "Cuộc trò chuyện bây giờ sẽ kết thúc sau 4 giờ im lặng",
+  "conversationEndAfterMinutes": "Cuộc trò chuyện bây giờ sẽ kết thúc sau {minutes} phút im lặng",
+  "@conversationEndAfterMinutes": {
+    "placeholders": {
+      "minutes": {
+        "type": "int"
+      }
+    }
+  },
+  "tellUsPrimaryLanguage": "Cho chúng tôi biết ngôn ngữ chính của bạn",
+  "languageForTranscription": "Đặt ngôn ngữ của bạn để có phiên âm chính xác hơn và trải nghiệm được cá nhân hóa.",
+  "singleLanguageModeInfo": "Chế độ đơn ngôn ngữ đã được bật. Dịch bị vô hiệu hóa để có độ chính xác cao hơn.",
+  "searchLanguageHint": "Tìm kiếm ngôn ngữ theo tên hoặc mã",
+  "noLanguagesFound": "Không tìm thấy ngôn ngữ",
+  "skip": "Bỏ qua",
+  "languageSetTo": "Đã đặt ngôn ngữ thành {language}",
+  "@languageSetTo": {
+    "placeholders": {
+      "language": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToSetLanguage": "Không thể đặt ngôn ngữ",
+  "appSettings": "Cài đặt {appName}",
+  "@appSettings": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromApp": "Ngắt kết nối khỏi {appName}?",
+  "@disconnectFromApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "disconnectFromAppDesc": "Thao tác này sẽ xóa xác thực {appName} của bạn. Bạn sẽ cần kết nối lại để sử dụng.",
+  "@disconnectFromAppDesc": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectedToApp": "Đã kết nối với {appName}",
+  "@connectedToApp": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "account": "Tài khoản",
+  "actionItemsSyncedTo": "Việc cần làm của bạn sẽ được đồng bộ với tài khoản {appName} của bạn",
+  "@actionItemsSyncedTo": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultSpace": "Space mặc định",
+  "selectSpaceInWorkspace": "Chọn một space trong workspace của bạn",
+  "noSpacesInWorkspace": "Không tìm thấy space trong workspace này",
+  "defaultList": "Danh sách mặc định",
+  "tasksAddedToList": "Nhiệm vụ sẽ được thêm vào danh sách này",
+  "noListsInSpace": "Không tìm thấy danh sách trong space này",
+  "failedToLoadRepos": "Không thể tải kho lưu trữ: {error}",
+  "@failedToLoadRepos": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "defaultRepoSaved": "Đã lưu kho lưu trữ mặc định",
+  "failedToSaveDefaultRepo": "Không thể lưu kho lưu trữ mặc định",
+  "defaultRepository": "Kho lưu trữ mặc định",
+  "selectDefaultRepoDesc": "Chọn một kho lưu trữ mặc định để tạo issue. Bạn vẫn có thể chỉ định kho lưu trữ khác khi tạo issue.",
+  "noReposFound": "Không tìm thấy kho lưu trữ",
+  "private": "Riêng tư",
+  "updatedDate": "Đã cập nhật {date}",
+  "@updatedDate": {
+    "placeholders": {
+      "date": {
+        "type": "String"
+      }
+    }
+  },
+  "yesterday": "hôm qua",
+  "daysAgo": "{count} ngày trước",
+  "@daysAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneWeekAgo": "1 tuần trước",
+  "weeksAgo": "{count} tuần trước",
+  "@weeksAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "oneMonthAgo": "1 tháng trước",
+  "monthsAgo": "{count} tháng trước",
+  "@monthsAgo": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "issuesCreatedInRepo": "Issue sẽ được tạo trong kho lưu trữ mặc định của bạn",
+  "taskIntegrations": "Tích hợp nhiệm vụ",
+  "configureSettings": "Cấu hình cài đặt",
+  "completeAuthBrowser": "Vui lòng hoàn tất xác thực trong trình duyệt của bạn. Sau khi hoàn tất, hãy quay lại ứng dụng.",
+  "failedToStartAppAuth": "Không thể bắt đầu xác thực {appName}",
+  "@failedToStartAppAuth": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "connectToAppTitle": "Kết nối với {appName}",
+  "@connectToAppTitle": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "authorizeOmiForTasks": "Bạn cần cho phép Omi tạo nhiệm vụ trong tài khoản {appName} của bạn. Thao tác này sẽ mở trình duyệt để xác thực.",
+  "@authorizeOmiForTasks": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "continueButton": "Tiếp tục",
+  "appIntegration": "Tích hợp {appName}",
+  "@appIntegration": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "integrationComingSoon": "Tích hợp với {appName} sắp ra mắt! Chúng tôi đang nỗ lực để mang đến cho bạn nhiều tùy chọn quản lý nhiệm vụ hơn.",
+  "@integrationComingSoon": {
+    "placeholders": {
+      "appName": {
+        "type": "String"
+      }
+    }
+  },
+  "gotIt": "Đã hiểu",
+  "tasksExportedOneApp": "Nhiệm vụ có thể được xuất sang một ứng dụng tại một thời điểm.",
+  "completeYourUpgrade": "Hoàn tất nâng cấp của bạn",
+  "importConfiguration": "Nhập cấu hình",
+  "exportConfiguration": "Xuất cấu hình",
+  "bringYourOwn": "Mang của riêng bạn",
+  "payYourSttProvider": "Sử dụng omi tự do. Bạn chỉ trả tiền cho nhà cung cấp STT trực tiếp.",
+  "freeMinutesMonth": "1.200 phút miễn phí/tháng được bao gồm. Không giới hạn với ",
+  "omiUnlimited": "Omi Unlimited",
+  "hostRequired": "Bắt buộc có host",
+  "validPortRequired": "Bắt buộc có port hợp lệ",
+  "validWebsocketUrlRequired": "Bắt buộc có URL WebSocket hợp lệ (wss://)",
+  "apiUrlRequired": "Bắt buộc có URL API",
+  "apiKeyRequired": "Bắt buộc có API key",
+  "invalidJsonConfig": "Cấu hình JSON không hợp lệ",
+  "errorSaving": "Lỗi khi lưu: {error}",
+  "@errorSaving": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "configCopiedToClipboard": "Đã sao chép cấu hình vào clipboard",
+  "pasteJsonConfig": "Dán cấu hình JSON của bạn bên dưới:",
+  "addApiKeyAfterImport": "Bạn cần thêm API key của riêng mình sau khi nhập",
+  "paste": "Dán",
+  "import": "Nhập",
+  "invalidProviderInConfig": "Nhà cung cấp không hợp lệ trong cấu hình",
+  "importedConfig": "Đã nhập cấu hình {providerName}",
+  "@importedConfig": {
+    "placeholders": {
+      "providerName": {
+        "type": "String"
+      }
+    }
+  },
+  "invalidJson": "JSON không hợp lệ: {error}",
+  "@invalidJson": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "provider": "Nhà cung cấp",
+  "live": "Trực tiếp",
+  "onDevice": "Trên thiết bị",
+  "apiUrl": "URL API",
+  "enterSttHttpEndpoint": "Nhập điểm cuối HTTP STT của bạn",
+  "websocketUrl": "URL WebSocket",
+  "enterLiveSttWebsocket": "Nhập điểm cuối WebSocket STT trực tiếp của bạn",
+  "apiKey": "API Key",
+  "enterApiKey": "Nhập API key của bạn",
+  "storedLocallyNeverShared": "Lưu trữ cục bộ, không bao giờ chia sẻ",
+  "host": "Host",
+  "port": "Port",
+  "advanced": "Nâng cao",
+  "configuration": "Cấu hình",
+  "requestConfiguration": "Cấu hình yêu cầu",
+  "responseSchema": "Schema phản hồi",
+  "modified": "Đã sửa đổi",
+  "resetRequestConfig": "Đặt lại cấu hình yêu cầu về mặc định",
+  "logs": "Nhật ký",
+  "logsCopied": "Đã sao chép nhật ký",
+  "noLogsYet": "Chưa có nhật ký. Bắt đầu ghi âm để xem hoạt động STT tùy chỉnh.",
+  "deviceUsesCodec": "{deviceName} sử dụng {codecReason}. Omi sẽ được sử dụng.",
+  "@deviceUsesCodec": {
+    "placeholders": {
+      "deviceName": {
+        "type": "String"
+      },
+      "codecReason": {
+        "type": "String"
+      }
+    }
+  },
+  "omiTranscription": "Phiên âm Omi",
+  "bestInClassTranscription": "Phiên âm tốt nhất với cài đặt bằng không",
+  "instantSpeakerLabels": "Nhãn người nói tức thì",
+  "languageTranslation": "Dịch hơn 100 ngôn ngữ",
+  "optimizedForConversation": "Được tối ưu hóa cho cuộc trò chuyện",
+  "autoLanguageDetection": "Tự động phát hiện ngôn ngữ",
+  "highAccuracy": "Độ chính xác cao",
+  "privacyFirst": "Ưu tiên bảo mật",
+  "saveChanges": "Lưu thay đổi",
+  "resetToDefault": "Đặt lại về mặc định",
+  "viewTemplate": "Xem mẫu",
+  "trySomethingLike": "Thử một cái gì đó như...",
+  "tryIt": "Thử ngay",
+  "creatingPlan": "Đang tạo kế hoạch",
+  "developingLogic": "Đang phát triển logic",
+  "designingApp": "Đang thiết kế ứng dụng",
+  "generatingIconStep": "Đang tạo biểu tượng",
+  "finalTouches": "Hoàn thiện cuối cùng",
+  "processing": "Đang xử lý...",
+  "features": "Tính năng",
+  "creatingYourApp": "Đang tạo ứng dụng của bạn...",
+  "generatingIcon": "Đang tạo biểu tượng...",
+  "whatShouldWeMake": "Chúng ta nên tạo gì?",
+  "appName": "Tên ứng dụng",
+  "description": "Mô tả",
+  "publicLabel": "Công khai",
+  "privateLabel": "Riêng tư",
+  "free": "Miễn phí",
+  "perMonth": "/ Tháng",
+  "tailoredConversationSummaries": "Tóm tắt cuộc trò chuyện được tùy chỉnh",
+  "customChatbotPersonality": "Tính cách chatbot tùy chỉnh",
+  "makePublic": "Công khai",
+  "anyoneCanDiscover": "Bất kỳ ai cũng có thể khám phá ứng dụng của bạn",
+  "onlyYouCanUse": "Chỉ bạn mới có thể sử dụng ứng dụng này",
+  "paidApp": "Ứng dụng trả phí",
+  "usersPayToUse": "Người dùng trả tiền để sử dụng ứng dụng của bạn",
+  "freeForEveryone": "Miễn phí cho tất cả mọi người",
+  "perMonthLabel": "/ tháng",
+  "creating": "Đang tạo...",
+  "@creating": {
+    "description": "Loading state text when app generation is in progress"
+  },
+  "createApp": "Tạo ứng dụng",
+  "@createApp": {
+    "description": "Button text to initiate app creation"
+  },
+  "@connect": {
+    "description": "Title for device connection page"
+  },
+  "searchingForDevices": "Đang tìm kiếm thiết bị...",
+  "@searchingForDevices": {
+    "description": "Status text while scanning for Bluetooth devices"
+  },
+  "devicesFoundNearby": "ĐÃ TÌM THẤY {count} {count, plural, =1{THIẾT BỊ} other{THIẾT BỊ}} GẦN ĐÂY",
+  "@devicesFoundNearby": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "pairingSuccessful": "GHÉP NỐI THÀNH CÔNG",
+  "errorConnectingAppleWatch": "Lỗi khi kết nối với Apple Watch: {error}",
+  "@errorConnectingAppleWatch": {
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "dontShowAgain": "Không hiển thị lại",
+  "@dontShowAgain": {
+    "description": "Checkbox text to suppress future connection confirmations"
+  },
+  "iUnderstand": "Tôi hiểu",
+  "@iUnderstand": {
+    "description": "Button text to acknowledge connection warnings"
+  },
+  "enableBluetooth": "Bật Bluetooth",
+  "@enableBluetooth": {
+    "description": "Title for dialog prompting user to enable Bluetooth"
+  },
+  "bluetoothNeeded": "Omi cần Bluetooth để kết nối với thiết bị đeo của bạn. Vui lòng bật Bluetooth và thử lại.",
+  "@bluetoothNeeded": {
+    "description": "Explanation text for why Bluetooth is required"
+  },
+  "contactSupport": "Liên hệ hỗ trợ?",
+  "@contactSupport": {
+    "description": "Link text to contact support"
+  },
+  "connectLater": "Kết nối sau",
+  "@connectLater": {
+    "description": "Button text to skip immediate device connection"
+  },
+  "grantPermissions": "Cấp quyền",
+  "@grantPermissions": {
+    "description": "Title for the permissions request page"
+  },
+  "backgroundActivity": "Hoạt động nền",
+  "@backgroundActivity": {
+    "description": "Title for background activity permission"
+  },
+  "backgroundActivityDesc": "Cho phép Omi chạy trong nền để ổn định hơn",
+  "@backgroundActivityDesc": {
+    "description": "Description for background activity permission"
+  },
+  "locationAccess": "Truy cập vị trí",
+  "@locationAccess": {
+    "description": "Title for location access permission"
+  },
+  "locationAccessDesc": "Bật vị trí nền để có trải nghiệm đầy đủ",
+  "@locationAccessDesc": {
+    "description": "Description for location access permission"
+  },
+  "notifications": "Thông báo",
+  "@notifications": {
+    "description": "Title for notifications permission"
+  },
+  "notificationsDesc": "Bật thông báo để luôn được thông tin",
+  "@notificationsDesc": {
+    "description": "Description for notifications permission"
+  },
+  "@continueButton": {
+    "description": "Generic continue button text"
+  },
+  "locationServiceDisabled": "Dịch vụ vị trí đã bị tắt",
+  "@locationServiceDisabled": {
+    "description": "Title for dialog when location services are off"
+  },
+  "locationServiceDisabledDesc": "Dịch vụ vị trí đã bị tắt. Vui lòng vào Cài đặt > Quyền riêng tư & Bảo mật > Dịch vụ vị trí và bật nó",
+  "@locationServiceDisabledDesc": {
+    "description": "Instructions to enable location services"
+  },
+  "backgroundLocationDenied": "Quyền truy cập vị trí nền bị từ chối",
+  "@backgroundLocationDenied": {
+    "description": "Title for dialog when background location is denied"
+  },
+  "backgroundLocationDeniedDesc": "Vui lòng vào cài đặt thiết bị và đặt quyền vị trí thành \"Luôn cho phép\"",
+  "@backgroundLocationDeniedDesc": {
+    "description": "Instructions to grant background location permission"
+  },
+  "lovingOmi": "Bạn thích Omi?",
+  "@lovingOmi": {
+    "description": "Title for the app review prompt"
+  },
+  "leaveReviewIos": "Giúp chúng tôi tiếp cận nhiều người hơn bằng cách để lại đánh giá trên App Store. Phản hồi của bạn có ý nghĩa rất lớn với chúng tôi!",
+  "@leaveReviewIos": {
+    "description": "App review prompt text for iOS users"
+  },
+  "leaveReviewAndroid": "Giúp chúng tôi tiếp cận nhiều người hơn bằng cách để lại đánh giá trên Google Play Store. Phản hồi của bạn có ý nghĩa rất lớn với chúng tôi!",
+  "@leaveReviewAndroid": {
+    "description": "App review prompt text for Android users"
+  },
+  "rateOnAppStore": "Đánh giá trên App Store",
+  "@rateOnAppStore": {
+    "description": "Button text to rate on Apple App Store"
+  },
+  "rateOnGooglePlay": "Đánh giá trên Google Play",
+  "@rateOnGooglePlay": {
+    "description": "Button text to rate on Google Play Store"
+  },
+  "maybeLater": "Có thể sau",
+  "@maybeLater": {
+    "description": "Button text to dismiss the review prompt"
+  },
+  "speechProfileIntro": "Omi cần học hỏi mục tiêu và giọng nói của bạn. Bạn có thể sửa đổi nó sau.",
+  "@speechProfileIntro": {
+    "description": "Introduction text for speech profile creation"
+  },
+  "getStarted": "Bắt đầu",
+  "@getStarted": {
+    "description": "Button text to begin a process"
+  },
+  "allDone": "Hoàn tất!",
+  "@allDone": {
+    "description": "Success message after completing a task"
+  },
+  "keepGoing": "Tiếp tục, bạn đang làm rất tốt",
+  "@keepGoing": {
+    "description": "Encouragement text during a multi-step process"
+  },
+  "skipThisQuestion": "Bỏ qua câu hỏi này",
+  "@skipThisQuestion": {
+    "description": "Button text to skip the current question"
+  },
+  "skipForNow": "Bỏ qua bây giờ",
+  "@skipForNow": {
+    "description": "Button text to skip the entire process temporarily"
+  },
+  "connectionError": "Lỗi kết nối",
+  "@connectionError": {
+    "description": "Title for connection error dialog"
+  },
+  "connectionErrorDesc": "Không thể kết nối với máy chủ. Vui lòng kiểm tra kết nối internet và thử lại.",
+  "@connectionErrorDesc": {
+    "description": "Description of connection error"
+  },
+  "invalidRecordingMultipleSpeakers": "Phát hiện bản ghi âm không hợp lệ",
+  "@invalidRecordingMultipleSpeakers": {
+    "description": "Error title when multiple speakers are detected"
+  },
+  "multipleSpeakersDesc": "Có vẻ như có nhiều người nói trong bản ghi âm. Vui lòng đảm bảo bạn ở nơi yên tĩnh và thử lại.",
+  "@multipleSpeakersDesc": {
+    "description": "Error description for multiple speakers"
+  },
+  "tooShortDesc": "Không phát hiện đủ giọng nói. Vui lòng nói nhiều hơn và thử lại.",
+  "@tooShortDesc": {
+    "description": "Error description for recording being too short"
+  },
+  "invalidRecordingDesc": "Vui lòng đảm bảo bạn nói ít nhất 5 giây và không quá 90 giây.",
+  "@invalidRecordingDesc": {
+    "description": "Error description for invalid recording duration"
+  },
+  "areYouThere": "Bạn có ở đó không?",
+  "@areYouThere": {
+    "description": "Timeout warning title"
+  },
+  "noSpeechDesc": "Chúng tôi không thể phát hiện giọng nói nào. Vui lòng đảm bảo nói ít nhất 10 giây và không quá 3 phút.",
+  "@noSpeechDesc": {
+    "description": "Error description when no speech is detected"
+  },
+  "connectionLost": "Mất kết nối",
+  "@connectionLost": {
+    "description": "Title for lost connection dialog"
+  },
+  "connectionLostDesc": "Kết nối đã bị gián đoạn. Vui lòng kiểm tra kết nối internet và thử lại.",
+  "@connectionLostDesc": {
+    "description": "Description for lost connection"
+  },
+  "tryAgain": "Thử lại",
+  "@tryAgain": {
+    "description": "Button text to retry an action"
+  },
+  "connectOmiOmiGlass": "Kết nối Omi / OmiGlass",
+  "@connectOmiOmiGlass": {
+    "description": "Button text to connect specific device models"
+  },
+  "continueWithoutDevice": "Tiếp tục không có thiết bị",
+  "@continueWithoutDevice": {
+    "description": "Button text to proceed without connecting a hardware device"
+  },
+  "permissionsRequired": "Yêu cầu quyền",
+  "@permissionsRequired": {
+    "description": "Title for permissions required dialog"
+  },
+  "permissionsRequiredDesc": "Ứng dụng này cần quyền Bluetooth và Vị trí để hoạt động đúng cách. Vui lòng bật chúng trong cài đặt.",
+  "@permissionsRequiredDesc": {
+    "description": "Explanation of why permissions are needed"
+  },
+  "openSettings": "Mở cài đặt",
+  "@openSettings": {
+    "description": "Button text to open app settings"
+  },
+  "wantDifferentName": "Muốn được gọi bằng tên khác?",
+  "@wantDifferentName": {
+    "description": "Question asking if user wants to change their display name"
+  },
+  "whatsYourName": "Bạn tên gì?",
+  "@whatsYourName": {
+    "description": "Question asking for user's name"
+  },
+  "@enterYourName": {
+    "description": "Hint text for name input field"
+  },
+  "speakTranscribeSummarize": "Nói. Phiên âm. Tóm tắt.",
+  "@speakTranscribeSummarize": {
+    "description": "Tagline or slogan on the welcome/auth screen"
+  },
+  "signInWithApple": "Đăng nhập bằng Apple",
+  "@signInWithApple": {
+    "description": "Button text for Apple Sign In"
+  },
+  "signInWithGoogle": "Đăng nhập bằng Google",
+  "@signInWithGoogle": {
+    "description": "Button text for Google Sign In"
+  },
+  "byContinuingAgree": "Bằng cách tiếp tục, bạn đồng ý với ",
+  "@byContinuingAgree": {
+    "description": "Legal disclaimer prefix text"
+  },
+  "termsOfUse": "Điều khoản sử dụng",
+  "@termsOfUse": {
+    "description": "Link text for Terms of Use"
+  },
+  "omiYourAiCompanion": "Omi – Trợ lý AI của bạn",
+  "@omiYourAiCompanion": {
+    "description": "App title or branding on onboarding screen"
+  },
+  "captureEveryMoment": "Ghi lại mọi khoảnh khắc. Nhận tóm tắt\nbằng AI. Không bao giờ phải ghi chú lại.",
+  "@captureEveryMoment": {
+    "description": "App value proposition or description"
+  },
+  "appleWatchSetup": "Thiết lập Apple Watch",
+  "@appleWatchSetup": {
+    "description": "Title for Apple Watch setup page"
+  },
+  "permissionRequestedExclaim": "Đã yêu cầu quyền!",
+  "@permissionRequestedExclaim": {
+    "description": "Title when permission has been requested"
+  },
+  "microphonePermission": "Quyền microphone",
+  "@microphonePermission": {
+    "description": "Title for microphone permission section"
+  },
+  "permissionGrantedNow": "Đã cấp quyền! Bây giờ:\n\nMở ứng dụng Omi trên đồng hồ của bạn và nhấn \"Tiếp tục\" bên dưới",
+  "@permissionGrantedNow": {
+    "description": "Instructions after permission is granted"
+  },
+  "needMicrophonePermission": "Chúng tôi cần quyền microphone.\n\n1. Nhấn \"Cấp quyền\"\n2. Cho phép trên iPhone của bạn\n3. Ứng dụng đồng hồ sẽ đóng\n4. Mở lại và nhấn \"Tiếp tục\"",
+  "@needMicrophonePermission": {
+    "description": "Instructions for granting microphone permission"
+  },
+  "grantPermissionButton": "Cấp quyền",
+  "@grantPermissionButton": {
+    "description": "Button to request permission"
+  },
+  "needHelp": "Cần trợ giúp?",
+  "@needHelp": {
+    "description": "Link to help dialog"
+  },
+  "troubleshootingSteps": "Khắc phục sự cố:\n\n1. Đảm bảo Omi được cài đặt trên đồng hồ của bạn\n2. Mở ứng dụng Omi trên đồng hồ của bạn\n3. Tìm cửa sổ bật lên yêu cầu quyền\n4. Nhấn \"Cho phép\" khi được nhắc\n5. Ứng dụng trên đồng hồ của bạn sẽ đóng - mở lại\n6. Quay lại và nhấn \"Tiếp tục\" trên iPhone của bạn",
+  "@troubleshootingSteps": {
+    "description": "Troubleshooting instructions for watch setup"
+  },
+  "@gotIt": {
+    "description": "Button to dismiss dialog"
+  },
+  "recordingStartedSuccessfully": "Đã bắt đầu ghi âm thành công!",
+  "@recordingStartedSuccessfully": {
+    "description": "Success message"
+  },
+  "permissionNotGrantedYet": "Quyền chưa được cấp. Vui lòng đảm bảo bạn đã cho phép quyền microphone và mở lại ứng dụng trên đồng hồ của bạn.",
+  "@permissionNotGrantedYet": {
+    "description": "Error message when permission is missing"
+  },
+  "errorRequestingPermission": "Lỗi khi yêu cầu quyền: {error}",
+  "@errorRequestingPermission": {
+    "description": "Error message for permission request failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "errorStartingRecording": "Lỗi khi bắt đầu ghi âm: {error}",
+  "@errorStartingRecording": {
+    "description": "Error message for recording start failure",
+    "placeholders": {
+      "error": {
+        "type": "String"
+      }
+    }
+  },
+  "selectPrimaryLanguage": "Chọn ngôn ngữ chính của bạn",
+  "@selectPrimaryLanguage": {
+    "description": "Title for language selection dialog"
+  },
+  "languageBenefits": "Đặt ngôn ngữ của bạn để có phiên âm chính xác hơn và trải nghiệm được cá nhân hóa",
+  "@languageBenefits": {
+    "description": "Explanation of why language selection matters"
+  },
+  "@searchLanguageHint": {
+    "description": "Hint text for language search"
+  },
+  "@noLanguagesFound": {
+    "description": "Text when search returns no results"
+  },
+  "whatsYourPrimaryLanguage": "Ngôn ngữ chính của bạn là gì?",
+  "@whatsYourPrimaryLanguage": {
+    "description": "Question asking for primary language"
+  },
+  "selectYourLanguage": "Chọn ngôn ngữ của bạn",
+  "@selectYourLanguage": {
+    "description": "Placeholder for selected language name"
+  },
+  "personalGrowthJourney": "Hành trình phát triển cá nhân của bạn với AI lắng nghe mọi lời nói của bạn.",
+  "@personalGrowthJourney": {
+    "description": "Tagline on onboarding wrapper"
+  },
+  "actionItemsTitle": "Việc cần làm",
+  "@actionItemsTitle": {
+    "description": "Title for the Action Items page"
+  },
+  "actionItemsDescription": "Nhấn để sửa • Nhấn giữ để chọn • Vuốt để thực hiện hành động",
+  "@actionItemsDescription": {
+    "description": "Instruction text for Action Items interactions"
+  },
+  "tabToDo": "Cần làm",
+  "@tabToDo": {
+    "description": "Label for To Do tab"
+  },
+  "tabDone": "Đã xong",
+  "@tabDone": {
+    "description": "Label for Done tab"
+  },
+  "tabOld": "Cũ",
+  "@tabOld": {
+    "description": "Label for Old tab"
+  },
+  "emptyTodoMessage": "🎉 Đã hoàn tất tất cả!\nKhông còn việc cần làm",
+  "@emptyTodoMessage": {
+    "description": "Message when To Do list is empty"
+  },
+  "emptyDoneMessage": "Chưa có mục nào hoàn thành",
+  "@emptyDoneMessage": {
+    "description": "Message when Done list is empty"
+  },
+  "emptyOldMessage": "✅ Không có nhiệm vụ cũ",
+  "@emptyOldMessage": {
+    "description": "Message when Old list is empty"
+  },
+  "noItems": "Không có mục nào",
+  "@noItems": {
+    "description": "Generic no items message"
+  },
+  "actionItemMarkedIncomplete": "Đã đánh dấu việc cần làm là chưa hoàn thành",
+  "@actionItemMarkedIncomplete": {
+    "description": "Snackbar message when item marked incomplete"
+  },
+  "actionItemCompleted": "Đã hoàn thành việc cần làm",
+  "@actionItemCompleted": {
+    "description": "Snackbar message when item completed"
+  },
+  "deleteActionItemTitle": "Xóa việc cần làm",
+  "@deleteActionItemTitle": {
+    "description": "Title for delete item dialog"
+  },
+  "deleteActionItemMessage": "Bạn có chắc chắn muốn xóa việc cần làm này?",
+  "@deleteActionItemMessage": {
+    "description": "Confirmation message for deleting single item"
+  },
+  "deleteSelectedItemsTitle": "Xóa các mục đã chọn",
+  "@deleteSelectedItemsTitle": {
+    "description": "Title for bulk delete dialog"
+  },
+  "deleteSelectedItemsMessage": "Bạn có chắc chắn muốn xóa {count} việc cần làm{s} đã chọn?",
+  "@deleteSelectedItemsMessage": {
+    "description": "Confirmation message for bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String",
+        "description": "Plural suffix (s) if needed, handled by logic or just append 's' for simplicity if count > 1"
+      }
+    }
+  },
+  "actionItemDeletedResult": "Đã xóa việc cần làm \"{description}\"",
+  "@actionItemDeletedResult": {
+    "description": "Snackbar message after deleting single item",
+    "placeholders": {
+      "description": {
+        "type": "String"
+      }
+    }
+  },
+  "itemsDeletedResult": "Đã xóa {count} việc cần làm{s}",
+  "@itemsDeletedResult": {
+    "description": "Snackbar message after bulk delete",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      },
+      "s": {
+        "type": "String"
+      }
+    }
+  },
+  "failedToDeleteItem": "Không thể xóa việc cần làm",
+  "@failedToDeleteItem": {
+    "description": "Error message when deletion fails"
+  },
+  "failedToDeleteItems": "Không thể xóa các mục",
+  "@failedToDeleteItems": {
+    "description": "Error message when bulk deletion fails"
+  },
+  "failedToDeleteSomeItems": "Không thể xóa một số mục",
+  "@failedToDeleteSomeItems": {
+    "description": "Error message when partial deletion failure"
+  },
+  "welcomeActionItemsTitle": "Sẵn sàng cho việc cần làm",
+  "@welcomeActionItemsTitle": {
+    "description": "Heading for empty state welcome"
+  },
+  "welcomeActionItemsDescription": "AI của bạn sẽ tự động trích xuất nhiệm vụ và việc cần làm từ cuộc trò chuyện của bạn. Chúng sẽ xuất hiện ở đây khi được tạo.",
+  "@welcomeActionItemsDescription": {
+    "description": "Description for empty state welcome"
+  },
+  "autoExtractionFeature": "Tự động trích xuất từ cuộc trò chuyện",
+  "@autoExtractionFeature": {
+    "description": "Feature point description"
+  },
+  "editSwipeFeature": "Nhấn để sửa, vuốt để hoàn thành hoặc xóa",
+  "@editSwipeFeature": {
+    "description": "Feature point description"
+  },
+  "itemsSelected": "Đã chọn {count}",
+  "@itemsSelected": {
+    "description": "Selection count in app bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Chọn tất cả",
+  "@selectAll": {
+    "description": "Tooltip for select all"
+  },
+  "deleteSelected": "Xóa đã chọn",
+  "@deleteSelected": {
+    "description": "Tooltip for delete selected"
+  },
+  "searchMemories": "Tìm kiếm {count} ký ức",
+  "@searchMemories": {
+    "description": "Hint text for memories search bar",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "memoryDeleted": "Đã xóa ký ức.",
+  "@memoryDeleted": {
+    "description": "Notification when memory deleted"
+  },
+  "undo": "Hoàn tác",
+  "@undo": {
+    "description": "Undo button text"
+  },
+  "noMemoriesYet": "Chưa có ký ức",
+  "@noMemoriesYet": {
+    "description": "Empty state text"
+  },
+  "noAutoMemories": "Chưa có ký ức tự động trích xuất",
+  "@noAutoMemories": {
+    "description": "Empty state text for auto category"
+  },
+  "noManualMemories": "Chưa có ký ức thủ công",
+  "@noManualMemories": {
+    "description": "Empty state text for manual category"
+  },
+  "noMemoriesInCategories": "Không có ký ức trong các danh mục này",
+  "@noMemoriesInCategories": {
+    "description": "Empty state text for filtered categories"
+  },
+  "noMemoriesFound": "Không tìm thấy ký ức",
+  "@noMemoriesFound": {
+    "description": "Empty state text for search results"
+  },
+  "addFirstMemory": "Thêm ký ức đầu tiên của bạn",
+  "@addFirstMemory": {
+    "description": "Button to add first memory"
+  },
+  "clearMemoryTitle": "Xóa bộ nhớ của Omi",
+  "@clearMemoryTitle": {
+    "description": "Dialog title for clearing memory"
+  },
+  "clearMemoryMessage": "Bạn có chắc chắn muốn xóa bộ nhớ của Omi? Hành động này không thể hoàn tác.",
+  "@clearMemoryMessage": {
+    "description": "Dialog content for clearing memory"
+  },
+  "clearMemoryButton": "Xóa bộ nhớ",
+  "@clearMemoryButton": {
+    "description": "Button text to confirm clear"
+  },
+  "memoryClearedSuccess": "Đã xóa bộ nhớ của Omi về bạn",
+  "@memoryClearedSuccess": {
+    "description": "Snackbar success message"
+  },
+  "noMemoriesToDelete": "Không có ký ức để xóa",
+  "@noMemoriesToDelete": {
+    "description": "Snackbar message"
+  },
+  "createMemoryTooltip": "Tạo ký ức mới",
+  "@createMemoryTooltip": {
+    "description": "Tooltip for create memory FAB"
+  },
+  "createActionItemTooltip": "Tạo việc cần làm mới",
+  "@createActionItemTooltip": {
+    "description": "Tooltip for create action item FAB"
+  },
+  "memoryManagement": "Quản lý ký ức",
+  "@memoryManagement": {
+    "description": "Title for memory management sheet"
+  },
+  "filterMemories": "Lọc ký ức",
+  "@filterMemories": {
+    "description": "Section header"
+  },
+  "totalMemoriesCount": "Bạn có tổng cộng {count} ký ức",
+  "@totalMemoriesCount": {
+    "description": "Count display",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "publicMemories": "Ký ức công khai",
+  "@publicMemories": {
+    "description": "Label"
+  },
+  "privateMemories": "Ký ức riêng tư",
+  "@privateMemories": {
+    "description": "Label"
+  },
+  "makeAllPrivate": "Đặt tất cả ký ức thành riêng tư",
+  "@makeAllPrivate": {
+    "description": "Button label"
+  },
+  "makeAllPublic": "Đặt tất cả ký ức thành công khai",
+  "@makeAllPublic": {
+    "description": "Button label"
+  },
+  "deleteAllMemories": "Xóa tất cả ký ức",
+  "@deleteAllMemories": {
+    "description": "Button label"
+  },
+  "allMemoriesPrivateResult": "Tất cả ký ức hiện là riêng tư",
+  "@allMemoriesPrivateResult": {
+    "description": "Snackbar"
+  },
+  "allMemoriesPublicResult": "Tất cả ký ức hiện là công khai",
+  "@allMemoriesPublicResult": {
+    "description": "Snackbar"
+  },
+  "newMemory": "Ký ức mới",
+  "@newMemory": {
+    "description": "Dialog title"
+  },
+  "editMemory": "Chỉnh sửa ký ức",
+  "@editMemory": {
+    "description": "Dialog title"
+  },
+  "memoryContentHint": "Tôi thích ăn kem...",
+  "@memoryContentHint": {
+    "description": "Input hint"
+  },
+  "failedToSaveMemory": "Không thể lưu. Vui lòng kiểm tra kết nối của bạn.",
+  "@failedToSaveMemory": {
+    "description": "Error message"
+  },
+  "saveMemory": "Lưu ký ức",
+  "@saveMemory": {
+    "description": "Button label"
+  },
+  "retry": "Thử lại",
+  "@retry": {
+    "description": "Button label"
+  },
+  "createActionItem": "Tạo việc cần làm",
+  "@createActionItem": {
+    "description": "Sheet title"
+  },
+  "editActionItem": "Chỉnh sửa việc cần làm",
+  "@editActionItem": {
+    "description": "Sheet title"
+  },
+  "actionItemDescriptionHint": "Cần làm gì?",
+  "@actionItemDescriptionHint": {
+    "description": "Input hint"
+  },
+  "actionItemDescriptionEmpty": "Mô tả việc cần làm không được để trống.",
+  "@actionItemDescriptionEmpty": {
+    "description": "Error message"
+  },
+  "actionItemUpdated": "Đã cập nhật việc cần làm",
+  "@actionItemUpdated": {
+    "description": "Snackbar"
+  },
+  "failedToUpdateActionItem": "Không thể cập nhật việc cần làm",
+  "@failedToUpdateActionItem": {
+    "description": "Snackbar"
+  },
+  "actionItemCreated": "Đã tạo việc cần làm",
+  "@actionItemCreated": {
+    "description": "Snackbar"
+  },
+  "failedToCreateActionItem": "Không thể tạo việc cần làm",
+  "@failedToCreateActionItem": {
+    "description": "Snackbar"
+  },
+  "dueDate": "Ngày đến hạn",
+  "@dueDate": {
+    "description": "Label"
+  },
+  "time": "Thời gian",
+  "@time": {
+    "description": "Label"
+  },
+  "addDueDate": "Thêm ngày đến hạn",
+  "@addDueDate": {
+    "description": "Placeholder"
+  },
+  "pressDoneToSave": "Nhấn xong để lưu",
+  "@pressDoneToSave": {
+    "description": "Instruction"
+  },
+  "pressDoneToCreate": "Nhấn xong để tạo",
+  "@pressDoneToCreate": {
+    "description": "Instruction"
+  },
+  "filterAll": "Tất cả",
+  "@filterAll": {
+    "description": "Filter option"
+  },
+  "filterSystem": "Về bạn",
+  "@filterSystem": {
+    "description": "Filter option for facts about the user"
+  },
+  "filterInteresting": "Thông tin chi tiết",
+  "@filterInteresting": {
+    "description": "Filter option for external wisdom/advice"
+  },
+  "filterManual": "Thủ công",
+  "@filterManual": {
+    "description": "Filter option"
+  },
+  "completed": "Đã hoàn thành",
+  "@completed": {
+    "description": "Status label"
+  },
+  "markComplete": "Đánh dấu hoàn thành",
+  "@markComplete": {
+    "description": "Action label"
+  },
+  "actionItemDeleted": "Đã xóa việc cần làm",
+  "@actionItemDeleted": {
+    "description": "Snackbar"
+  },
+  "failedToDeleteActionItem": "Không thể xóa việc cần làm",
+  "@failedToDeleteActionItem": {
+    "description": "Snackbar"
+  },
+  "deleteActionItemConfirmTitle": "Xóa việc cần làm",
+  "@deleteActionItemConfirmTitle": {
+    "description": "Dialog title"
+  },
+  "deleteActionItemConfirmMessage": "Bạn có chắc chắn muốn xóa việc cần làm này?",
+  "@deleteActionItemConfirmMessage": {
+    "description": "Dialog message"
+  },
+  "appLanguage": "Ngôn ngữ ứng dụng",
+  "@appLanguage": {
+    "description": "Label for app language selector"
+  },
+  "appInterfaceSectionTitle": "GIAO DIỆN ỨNG DỤNG",
+  "speechTranscriptionSectionTitle": "GIỌNG NÓI & PHIÊN ÂM",
+  "languageSettingsHelperText": "Ngôn ngữ Ứng dụng thay đổi menu và nút. Ngôn ngữ Giọng nói ảnh hưởng đến cách bản ghi âm của bạn được phiên âm."
+}

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -90,7 +90,9 @@
   "selectedCount": "已选择 {count} 项",
   "@selectedCount": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "merge": "合并",
@@ -98,7 +100,9 @@
   "mergeConversationsMessage": "这将把 {count} 个对话合并为一个。所有内容将被合并并重新生成。",
   "@mergeConversationsMessage": {
     "placeholders": {
-      "count": {"type": "int"}
+      "count": {
+        "type": "int"
+      }
     }
   },
   "mergingInBackground": "后台合并中。这可能需要一点时间。",
@@ -408,7 +412,6 @@
   "defaultProjectOptional": "默认项目（可选）",
   "leaveUnselectedTasks": "如果不选择，任务将没有项目",
   "noProjectsInWorkspace": "在此工作区未找到项目",
-  "conversationTimeout": "对话超时",
   "conversationTimeoutDesc": "选择静音多久后自动结束对话：",
   "timeout2Minutes": "2 分钟",
   "timeout2MinutesDesc": "静音 2 分钟后结束",
@@ -696,6 +699,8 @@
   "pressDoneToCreate": "按完成创建",
   "filterAll": "全部",
   "filterAuto": "自动",
+  "filterInteresting": "见解",
+  "filterSystem": "关于你",
   "filterManual": "手动",
   "completed": "已完成",
   "markComplete": "标记为完成",
@@ -729,5 +734,8 @@
       }
     }
   },
-  "continueButton": "继续"
+  "continueButton": "继续",
+  "appInterfaceSectionTitle": "应用界面",
+  "speechTranscriptionSectionTitle": "语音与转录",
+  "languageSettingsHelperText": "应用语言更改菜单和按钮。语音语言影响录音的转录方式。"
 }

--- a/app/lib/models/subscription.g.dart
+++ b/app/lib/models/subscription.g.dart
@@ -12,11 +12,15 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
       currentPeriodEnd: (json['current_period_end'] as num?)?.toInt(),
       stripeSubscriptionId: json['stripe_subscription_id'] as String?,
       currentPriceId: json['current_price_id'] as String?,
-      features: (json['features'] as List<dynamic>?)?.map((e) => e as String).toList() ?? [],
+      features: (json['features'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
       cancelAtPeriodEnd: json['cancel_at_period_end'] as bool? ?? false,
     );
 
-Map<String, dynamic> _$SubscriptionToJson(Subscription instance) => <String, dynamic>{
+Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
+    <String, dynamic>{
       'plan': _$PlanTypeEnumMap[instance.plan]!,
       'status': _$SubscriptionStatusEnumMap[instance.status]!,
       'current_period_end': instance.currentPeriodEnd,
@@ -36,40 +40,53 @@ const _$SubscriptionStatusEnumMap = {
   SubscriptionStatus.inactive: 'inactive',
 };
 
-PricingOption _$PricingOptionFromJson(Map<String, dynamic> json) => PricingOption(
+PricingOption _$PricingOptionFromJson(Map<String, dynamic> json) =>
+    PricingOption(
       id: json['id'] as String,
       title: json['title'] as String,
       description: json['description'] as String?,
       priceString: json['price_string'] as String,
     );
 
-Map<String, dynamic> _$PricingOptionToJson(PricingOption instance) => <String, dynamic>{
+Map<String, dynamic> _$PricingOptionToJson(PricingOption instance) =>
+    <String, dynamic>{
       'id': instance.id,
       'title': instance.title,
       'description': instance.description,
       'price_string': instance.priceString,
     };
 
-SubscriptionPlan _$SubscriptionPlanFromJson(Map<String, dynamic> json) => SubscriptionPlan(
+SubscriptionPlan _$SubscriptionPlanFromJson(Map<String, dynamic> json) =>
+    SubscriptionPlan(
       id: json['id'] as String,
       title: json['title'] as String,
-      features: (json['features'] as List<dynamic>?)?.map((e) => e as String).toList() ?? [],
-      prices:
-          (json['prices'] as List<dynamic>?)?.map((e) => PricingOption.fromJson(e as Map<String, dynamic>)).toList() ??
-              [],
+      features: (json['features'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+      prices: (json['prices'] as List<dynamic>?)
+              ?.map((e) => PricingOption.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          [],
     );
 
-Map<String, dynamic> _$SubscriptionPlanToJson(SubscriptionPlan instance) => <String, dynamic>{
+Map<String, dynamic> _$SubscriptionPlanToJson(SubscriptionPlan instance) =>
+    <String, dynamic>{
       'id': instance.id,
       'title': instance.title,
       'features': instance.features,
       'prices': instance.prices,
     };
 
-UserSubscriptionResponse _$UserSubscriptionResponseFromJson(Map<String, dynamic> json) => UserSubscriptionResponse(
-      subscription: Subscription.fromJson(json['subscription'] as Map<String, dynamic>),
-      transcriptionSecondsUsed: (json['transcription_seconds_used'] as num).toInt(),
-      transcriptionSecondsLimit: (json['transcription_seconds_limit'] as num).toInt(),
+UserSubscriptionResponse _$UserSubscriptionResponseFromJson(
+        Map<String, dynamic> json) =>
+    UserSubscriptionResponse(
+      subscription:
+          Subscription.fromJson(json['subscription'] as Map<String, dynamic>),
+      transcriptionSecondsUsed:
+          (json['transcription_seconds_used'] as num).toInt(),
+      transcriptionSecondsLimit:
+          (json['transcription_seconds_limit'] as num).toInt(),
       wordsTranscribedUsed: (json['words_transcribed_used'] as num).toInt(),
       wordsTranscribedLimit: (json['words_transcribed_limit'] as num).toInt(),
       insightsGainedUsed: (json['insights_gained_used'] as num).toInt(),
@@ -83,7 +100,9 @@ UserSubscriptionResponse _$UserSubscriptionResponseFromJson(Map<String, dynamic>
       showSubscriptionUi: json['show_subscription_ui'] as bool? ?? false,
     );
 
-Map<String, dynamic> _$UserSubscriptionResponseToJson(UserSubscriptionResponse instance) => <String, dynamic>{
+Map<String, dynamic> _$UserSubscriptionResponseToJson(
+        UserSubscriptionResponse instance) =>
+    <String, dynamic>{
       'subscription': instance.subscription,
       'transcription_seconds_used': instance.transcriptionSecondsUsed,
       'transcription_seconds_limit': instance.transcriptionSecondsLimit,

--- a/app/lib/models/user_usage.g.dart
+++ b/app/lib/models/user_usage.g.dart
@@ -13,14 +13,16 @@ UsageStats _$UsageStatsFromJson(Map<String, dynamic> json) => UsageStats(
       memoriesCreated: (json['memories_created'] as num).toInt(),
     );
 
-Map<String, dynamic> _$UsageStatsToJson(UsageStats instance) => <String, dynamic>{
+Map<String, dynamic> _$UsageStatsToJson(UsageStats instance) =>
+    <String, dynamic>{
       'transcription_seconds': instance.transcriptionSeconds,
       'words_transcribed': instance.wordsTranscribed,
       'insights_gained': instance.insightsGained,
       'memories_created': instance.memoriesCreated,
     };
 
-UsageHistoryPoint _$UsageHistoryPointFromJson(Map<String, dynamic> json) => UsageHistoryPoint(
+UsageHistoryPoint _$UsageHistoryPointFromJson(Map<String, dynamic> json) =>
+    UsageHistoryPoint(
       date: json['date'] as String,
       transcriptionSeconds: (json['transcription_seconds'] as num).toInt(),
       wordsTranscribed: (json['words_transcribed'] as num).toInt(),
@@ -28,7 +30,8 @@ UsageHistoryPoint _$UsageHistoryPointFromJson(Map<String, dynamic> json) => Usag
       memoriesCreated: (json['memories_created'] as num).toInt(),
     );
 
-Map<String, dynamic> _$UsageHistoryPointToJson(UsageHistoryPoint instance) => <String, dynamic>{
+Map<String, dynamic> _$UsageHistoryPointToJson(UsageHistoryPoint instance) =>
+    <String, dynamic>{
       'date': instance.date,
       'transcription_seconds': instance.transcriptionSeconds,
       'words_transcribed': instance.wordsTranscribed,
@@ -36,17 +39,27 @@ Map<String, dynamic> _$UsageHistoryPointToJson(UsageHistoryPoint instance) => <S
       'memories_created': instance.memoriesCreated,
     };
 
-UserUsageResponse _$UserUsageResponseFromJson(Map<String, dynamic> json) => UserUsageResponse(
-      today: json['today'] == null ? null : UsageStats.fromJson(json['today'] as Map<String, dynamic>),
-      monthly: json['monthly'] == null ? null : UsageStats.fromJson(json['monthly'] as Map<String, dynamic>),
-      yearly: json['yearly'] == null ? null : UsageStats.fromJson(json['yearly'] as Map<String, dynamic>),
-      allTime: json['all_time'] == null ? null : UsageStats.fromJson(json['all_time'] as Map<String, dynamic>),
+UserUsageResponse _$UserUsageResponseFromJson(Map<String, dynamic> json) =>
+    UserUsageResponse(
+      today: json['today'] == null
+          ? null
+          : UsageStats.fromJson(json['today'] as Map<String, dynamic>),
+      monthly: json['monthly'] == null
+          ? null
+          : UsageStats.fromJson(json['monthly'] as Map<String, dynamic>),
+      yearly: json['yearly'] == null
+          ? null
+          : UsageStats.fromJson(json['yearly'] as Map<String, dynamic>),
+      allTime: json['all_time'] == null
+          ? null
+          : UsageStats.fromJson(json['all_time'] as Map<String, dynamic>),
       history: (json['history'] as List<dynamic>?)
           ?.map((e) => UsageHistoryPoint.fromJson(e as Map<String, dynamic>))
           .toList(),
     );
 
-Map<String, dynamic> _$UserUsageResponseToJson(UserUsageResponse instance) => <String, dynamic>{
+Map<String, dynamic> _$UserUsageResponseToJson(UserUsageResponse instance) =>
+    <String, dynamic>{
       'today': instance.today,
       'monthly': instance.monthly,
       'yearly': instance.yearly,

--- a/app/lib/pages/conversations/widgets/merge_action_bar.dart
+++ b/app/lib/pages/conversations/widgets/merge_action_bar.dart
@@ -101,7 +101,7 @@ class _MergeActionBarState extends State<MergeActionBar> with SingleTickerProvid
                       AnimatedSwitcher(
                         duration: const Duration(milliseconds: 150),
                         child: Text(
-                          context.l10n.selectedCount(count),
+                          context.l10n.selectedCount(count, ''),
                           key: ValueKey(count),
                           style: const TextStyle(
                             color: Colors.white,

--- a/app/lib/pages/settings/language_settings_page.dart
+++ b/app/lib/pages/settings/language_settings_page.dart
@@ -20,11 +20,89 @@ class LanguageSettingsPage extends StatefulWidget {
 class _LanguageSettingsPageState extends State<LanguageSettingsPage> {
   bool _isUpdatingLanguage = false;
 
-  Widget _buildLanguageCard(
+  Widget _buildSectionHeader(String title) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 4, bottom: 8),
+      child: Text(
+        title,
+        style: TextStyle(
+          color: Colors.grey.shade500,
+          fontSize: 13,
+          fontWeight: FontWeight.w600,
+          letterSpacing: 0.5,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAppInterfaceCard(LocaleProvider localeProvider) {
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1C1C1E),
+        borderRadius: BorderRadius.circular(14),
+      ),
+      child: GestureDetector(
+        behavior: HitTestBehavior.opaque,
+        onTap: () => _showAppLanguageSelectionSheet(localeProvider),
+        child: Row(
+          children: [
+            Container(
+              width: 40,
+              height: 40,
+              decoration: BoxDecoration(
+                color: const Color(0xFF2A2A2E),
+                borderRadius: BorderRadius.circular(10),
+              ),
+              child: Center(
+                child: FaIcon(
+                  FontAwesomeIcons.textHeight,
+                  color: Colors.grey.shade400,
+                  size: 16,
+                ),
+              ),
+            ),
+            const SizedBox(width: 14),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    context.l10n.appLanguage,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 2),
+                  Text(
+                    localeProvider.locale != null
+                        ? LocaleProvider.getDisplayName(localeProvider.locale!)
+                        : context.l10n.systemDefault,
+                    style: TextStyle(
+                      color: Colors.grey.shade500,
+                      fontSize: 13,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            FaIcon(
+              FontAwesomeIcons.chevronRight,
+              color: Colors.grey.shade600,
+              size: 14,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSpeechTranscriptionCard(
     HomeProvider homeProvider,
     UserProvider userProvider,
     CaptureProvider captureProvider,
-    LocaleProvider localeProvider,
   ) {
     final languageName = homeProvider.userPrimaryLanguage.isNotEmpty
         ? homeProvider.availableLanguages.entries
@@ -46,66 +124,7 @@ class _LanguageSettingsPageState extends State<LanguageSettingsPage> {
       ),
       child: Column(
         children: [
-          // App Language Row
-          GestureDetector(
-            behavior: HitTestBehavior.opaque,
-            onTap: () => _showAppLanguageSelectionSheet(localeProvider),
-            child: Row(
-              children: [
-                Container(
-                  width: 40,
-                  height: 40,
-                  decoration: BoxDecoration(
-                    color: const Color(0xFF2A2A2E),
-                    borderRadius: BorderRadius.circular(10),
-                  ),
-                  child: Center(
-                    child: FaIcon(
-                      FontAwesomeIcons.mobileScreen,
-                      color: Colors.grey.shade400,
-                      size: 16,
-                    ),
-                  ),
-                ),
-                const SizedBox(width: 14),
-                Expanded(
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(
-                        context.l10n.appLanguage,
-                        style: const TextStyle(
-                          color: Colors.white,
-                          fontSize: 16,
-                          fontWeight: FontWeight.w500,
-                        ),
-                      ),
-                      const SizedBox(height: 2),
-                      Text(
-                        localeProvider.locale != null
-                            ? LocaleProvider.getDisplayName(localeProvider.locale!)
-                            : context.l10n.systemDefault,
-                        style: TextStyle(
-                          color: Colors.grey.shade500,
-                          fontSize: 13,
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                FaIcon(
-                  FontAwesomeIcons.chevronRight,
-                  color: Colors.grey.shade600,
-                  size: 14,
-                ),
-              ],
-            ),
-          ),
-          Padding(
-            padding: const EdgeInsets.symmetric(vertical: 16),
-            child: Divider(height: 1, color: Colors.grey.shade800),
-          ),
-          // Primary Language Row
+          // Speech Language Row
           GestureDetector(
             behavior: HitTestBehavior.opaque,
             onTap: _isUpdatingLanguage ? null : () => _showLanguageSelectionSheet(homeProvider, captureProvider),
@@ -120,7 +139,7 @@ class _LanguageSettingsPageState extends State<LanguageSettingsPage> {
                   ),
                   child: Center(
                     child: FaIcon(
-                      FontAwesomeIcons.globe,
+                      FontAwesomeIcons.microphone,
                       color: Colors.grey.shade400,
                       size: 16,
                     ),
@@ -174,7 +193,7 @@ class _LanguageSettingsPageState extends State<LanguageSettingsPage> {
             child: Divider(height: 1, color: Colors.grey.shade800),
           ),
 
-          // Automatic Translation Row
+          // Multi-language Detection Row
           Row(
             children: [
               Container(
@@ -240,6 +259,20 @@ class _LanguageSettingsPageState extends State<LanguageSettingsPage> {
             ],
           ),
         ],
+      ),
+    );
+  }
+
+  Widget _buildHelperText() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 8),
+      child: Text(
+        context.l10n.languageSettingsHelperText,
+        style: TextStyle(
+          color: Colors.grey.shade600,
+          fontSize: 12,
+          height: 1.4,
+        ),
       ),
     );
   }
@@ -435,7 +468,15 @@ class _LanguageSettingsPageState extends State<LanguageSettingsPage> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 const SizedBox(height: 16),
-                _buildLanguageCard(homeProvider, userProvider, captureProvider, localeProvider),
+                // App Interface Section
+                _buildSectionHeader(context.l10n.appInterfaceSectionTitle),
+                _buildAppInterfaceCard(localeProvider),
+                const SizedBox(height: 24),
+                // Speech & Transcription Section
+                _buildSectionHeader(context.l10n.speechTranscriptionSectionTitle),
+                _buildSpeechTranscriptionCard(homeProvider, userProvider, captureProvider),
+                const SizedBox(height: 12),
+                _buildHelperText(),
                 const SizedBox(height: 32),
               ],
             ),

--- a/app/lib/providers/locale_provider.dart
+++ b/app/lib/providers/locale_provider.dart
@@ -71,6 +71,54 @@ class LocaleProvider extends ChangeNotifier {
         return 'العربية (Arabic)';
       case 'hi':
         return 'हिंदी (Hindi)';
+      case 'ru':
+        return 'Русский (Russian)';
+      case 'it':
+        return 'Italiano (Italian)';
+      case 'nl':
+        return 'Nederlands (Dutch)';
+      case 'tr':
+        return 'Türkçe (Turkish)';
+      case 'vi':
+        return 'Tiếng Việt (Vietnamese)';
+      case 'th':
+        return 'ไทย (Thai)';
+      case 'id':
+        return 'Bahasa Indonesia (Indonesian)';
+      case 'pl':
+        return 'Polski (Polish)';
+      case 'uk':
+        return 'Українська (Ukrainian)';
+      case 'sv':
+        return 'Svenska (Swedish)';
+      case 'da':
+        return 'Dansk (Danish)';
+      case 'fi':
+        return 'Suomi (Finnish)';
+      case 'no':
+        return 'Norsk (Norwegian)';
+      case 'cs':
+        return 'Čeština (Czech)';
+      case 'el':
+        return 'Ελληνικά (Greek)';
+      case 'hu':
+        return 'Magyar (Hungarian)';
+      case 'ro':
+        return 'Română (Romanian)';
+      case 'sk':
+        return 'Slovenčina (Slovak)';
+      case 'bg':
+        return 'Български (Bulgarian)';
+      case 'ca':
+        return 'Català (Catalan)';
+      case 'et':
+        return 'Eesti (Estonian)';
+      case 'lt':
+        return 'Lietuvių (Lithuanian)';
+      case 'lv':
+        return 'Latviešu (Latvian)';
+      case 'ms':
+        return 'Bahasa Melayu (Malay)';
       default:
         return locale.languageCode;
     }

--- a/app/lib/utils/manifest/manifest.g.dart
+++ b/app/lib/utils/manifest/manifest.g.dart
@@ -9,7 +9,9 @@ part of 'manifest.dart';
 Manifest _$ManifestFromJson(Map<String, dynamic> json) => Manifest(
       formatVersion: (json['format-version'] as num).toInt(),
       time: (json['time'] as num).toInt(),
-      files: (json['files'] as List<dynamic>).map((e) => ManifestFile.fromJson(e as Map<String, dynamic>)).toList(),
+      files: (json['files'] as List<dynamic>)
+          .map((e) => ManifestFile.fromJson(e as Map<String, dynamic>))
+          .toList(),
     );
 
 Map<String, dynamic> _$ManifestToJson(Manifest instance) => <String, dynamic>{
@@ -32,7 +34,8 @@ ManifestFile _$ManifestFileFromJson(Map<String, dynamic> json) => ManifestFile(
       imageIndex: json['image_index'] as String?,
     );
 
-Map<String, dynamic> _$ManifestFileToJson(ManifestFile instance) => <String, dynamic>{
+Map<String, dynamic> _$ManifestFileToJson(ManifestFile instance) =>
+    <String, dynamic>{
       'type': instance.type,
       'board': instance.board,
       'soc': instance.soc,


### PR DESCRIPTION
because it's weird when the supported transcription languages are more than the app languages

to maximize the UX for users in other countries

omi now supports 33 languages

<img width="591" height="1304" alt="Screenshot 2026-01-13 at 15 53 52" src="https://github.com/user-attachments/assets/5041ad13-c2ce-4c23-b751-a0a58fe2759f" />

<img width="579" height="1307" alt="Screenshot 2026-01-13 at 15 53 41" src="https://github.com/user-attachments/assets/cb82b6be-46f9-445b-8177-5148a28a5d05" />
