### PR TITLE
fix handle disposal and mounted check

### DIFF
--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -41,7 +41,8 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
       CurvedAnimation(parent: _questionAnimationController, curve: Curves.easeInOut),
     );
 
-    WidgetsBinding.instance.addPostFrameCallback((timeStamp) async {
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      if (!mounted) return;
       // Check if user has set primary language
       if (!context.read<HomeProvider>().hasSetPrimaryLanguage) {
         await LanguageSelectionDialog.show(context);


### PR DESCRIPTION
https://github.com/BasedHardware/omi/blob/4ba57c4ceb19b96dc5d505a83ebb2d009634aa49/app/lib/pages/onboarding/speech_profile_widget.dart#L334-L340

_questionAnimationController.forward() here animation controller trigger by provider event after the widget was disposed. fixed it by closing the provider in dispose() and guard with mounted check