### PR TITLE
Reduce redundant fields in apps list API responses

### DIFF
--- a/backend/models/app.py
+++ b/backend/models/app.py
@@ -4,6 +4,22 @@ from typing import List, Optional, Set
 
 from pydantic import BaseModel
 
+# Fields to exclude when reducing App data for list views and cache
+APP_REDUCE_EXCLUDE_FIELDS = {
+    'reviews',
+    'user_review',
+    'persona_prompt',
+    'chat_prompt',
+    'memory_prompt',
+    'payment_product_id',
+    'payment_price_id',
+    'payment_link_id',
+    'twitter',
+    'email',
+    'money_made',
+    'usage_count',
+}
+
 
 class AppReview(BaseModel):
     uid: str
@@ -81,7 +97,9 @@ class ApiKey(BaseModel):
     created_at: Optional[datetime] = None
 
 
-class App(BaseModel):
+class AppBaseModel(BaseModel):
+    """Base App model for list views - contains common fields only."""
+
     id: str
     name: str
     uid: Optional[str] = None
@@ -89,43 +107,49 @@ class App(BaseModel):
     approved: bool = False
     status: str = 'approved'
     category: str
-    email: Optional[str] = None
     author: str
     description: str
     image: str
     capabilities: Set[str]
-    memory_prompt: Optional[str] = None
-    chat_prompt: Optional[str] = None
-    persona_prompt: Optional[str] = None
     username: Optional[str] = None
     connected_accounts: List[str] = []
-    twitter: Optional[dict] = None
     external_integration: Optional[ExternalIntegration] = None
-    reviews: List[AppReview] = []
-    user_review: Optional[AppReview] = None
     rating_avg: Optional[float] = 0
     rating_count: int = 0
     enabled: bool = False
-    trigger_workflow_memories: bool = True  # default true
+    trigger_workflow_memories: bool = True
     installs: int = 0
-    score: Optional[float] = None  # Computed ranking score for sorting
+    score: Optional[float] = None
     proactive_notification: Optional[ProactiveNotification] = None
     created_at: Optional[datetime] = None
+    is_paid: Optional[bool] = False
+    price: Optional[float] = 0.0
+    payment_plan: Optional[str] = None
+    payment_link: Optional[str] = None
+    is_user_paid: Optional[bool] = False
+    thumbnails: Optional[List[str]] = []
+    thumbnail_urls: Optional[List[str]] = []
+    is_influencer: Optional[bool] = False
+    is_popular: Optional[bool] = False
+    chat_tools: Optional[List[ChatTool]] = []
+
+
+class App(AppBaseModel):
+    """Full App model - includes large/internal fields for detail views."""
+
+    # Additional fields for detail views only
+    email: Optional[str] = None
+    memory_prompt: Optional[str] = None
+    chat_prompt: Optional[str] = None
+    persona_prompt: Optional[str] = None
+    twitter: Optional[dict] = None
+    reviews: List[AppReview] = []
+    user_review: Optional[AppReview] = None
     money_made: Optional[float] = None
     usage_count: Optional[int] = None
-    is_paid: Optional[bool] = False
-    price: Optional[float] = 0.0  # cents/100
-    payment_plan: Optional[str] = None
     payment_product_id: Optional[str] = None
     payment_price_id: Optional[str] = None
     payment_link_id: Optional[str] = None
-    payment_link: Optional[str] = None
-    is_user_paid: Optional[bool] = False
-    thumbnails: Optional[List[str]] = []  # List of thumbnail IDs
-    thumbnail_urls: Optional[List[str]] = []  # List of thumbnail URLs
-    is_influencer: Optional[bool] = False
-    is_popular: Optional[bool] = False
-    chat_tools: Optional[List[ChatTool]] = []  # Tools this app provides for chat
 
     def get_rating_avg(self) -> Optional[str]:
         return f'{self.rating_avg:.1f}' if self.rating_avg is not None else None
@@ -169,25 +193,18 @@ class App(BaseModel):
     def to_reduced_dict(self) -> dict:
         """Serialize for list views with reduced fields.
 
-        Excludes large/redundant fields that are not needed in app list displays:
-        - Prompts (persona_prompt, chat_prompt, memory_prompt)
-        - Full reviews array (rating_avg/rating_count are sufficient)
-        - Internal payment and social data
+        Excludes large/redundant fields that are not needed in app list displays.
+        Uses APP_REDUCE_EXCLUDE_FIELDS constant for consistency with cache reduction.
         """
-        return self.model_dump(
-            mode='json',
-            exclude={
-                'reviews',
-                'user_review',
-                'persona_prompt',
-                'chat_prompt',
-                'memory_prompt',
-                'payment_product_id',
-                'payment_price_id',
-                'payment_link_id',
-                'twitter',
-            },
-        )
+        return self.model_dump(mode='json', exclude=APP_REDUCE_EXCLUDE_FIELDS)
+
+    @staticmethod
+    def reduce_dict(app_dict: dict) -> dict:
+        """Reduce a raw app dict by excluding large/redundant fields.
+
+        Use this for reducing dicts before caching. For App instances, use to_reduced_dict().
+        """
+        return {k: v for k, v in app_dict.items() if k not in APP_REDUCE_EXCLUDE_FIELDS}
 
 
 class AppCreate(BaseModel):

--- a/backend/routers/apps.py
+++ b/backend/routers/apps.py
@@ -91,7 +91,7 @@ from utils.llm.persona import generate_persona_intro_message
 from utils.llm.app_generator import generate_description
 from utils.notifications import send_notification, send_app_review_reply_notification, send_new_app_review_notification
 from utils.other import endpoints as auth
-from models.app import App, ActionType, AppCreate, AppUpdate
+from models.app import App, ActionType, AppCreate, AppUpdate, AppBaseModel
 from utils.other.storage import upload_app_logo, delete_app_logo, upload_app_thumbnail, get_app_thumbnail_url
 from utils.social import (
     get_twitter_profile,
@@ -130,7 +130,7 @@ def _get_categories():
 # ******************************************************
 
 
-@router.get('/v1/apps', tags=['v1'])
+@router.get('/v1/apps', tags=['v1'], response_model=List[AppBaseModel])
 def get_apps(uid: str = Depends(auth.get_current_user_uid), include_reviews: bool = True):
     apps = get_available_apps(uid, include_reviews=include_reviews)
     return [normalize_app_numeric_fields(app.to_reduced_dict()) for app in apps]
@@ -360,7 +360,7 @@ def search_apps(
     }
 
 
-@router.get('/v1/approved-apps', tags=['v1'])
+@router.get('/v1/approved-apps', tags=['v1'], response_model=List[AppBaseModel])
 def get_approved_apps(include_reviews: bool = False):
     apps = get_approved_available_apps(include_reviews=include_reviews)
     # Always exclude persona type apps
@@ -368,7 +368,7 @@ def get_approved_apps(include_reviews: bool = False):
     return [normalize_app_numeric_fields(app.to_reduced_dict()) for app in filtered_apps]
 
 
-@router.get('/v1/apps/popular', tags=['v1'])
+@router.get('/v1/apps/popular', tags=['v1'], response_model=List[AppBaseModel])
 def get_popular_apps_endpoint(uid: str = Depends(auth.get_current_user_uid)):
     apps = get_popular_apps()
     # Always exclude persona type apps

--- a/backend/utils/apps.py
+++ b/backend/utils/apps.py
@@ -169,7 +169,10 @@ def get_popular_apps() -> List[App]:
             # Database query
             print('get_popular_apps from db')
             popular_apps = get_popular_apps_db()
-            set_generic_cache(cache_key, popular_apps, 60 * 30)  # 30 minutes cached
+            # Reduce cache size by excluding large fields
+            reduced_apps = [App.reduce_dict(app) for app in popular_apps]
+            set_generic_cache(cache_key, reduced_apps, 60 * 30)  # 30 minutes cached
+            popular_apps = reduced_apps
 
         # Process apps (add installs, reviews, ratings)
         app_ids = [app['id'] for app in popular_apps]
@@ -206,8 +209,10 @@ def get_available_apps(uid: str, include_reviews: bool = False) -> List[App]:
             return data
         print('get_public_approved_apps_data from db')
         data = get_public_approved_apps_db()
-        set_generic_cache(cache_key, data, 60 * 10)  # 10 minutes cached
-        return data
+        # Reduce cache size by excluding large fields
+        reduced_data = [App.reduce_dict(app) for app in data]
+        set_generic_cache(cache_key, reduced_data, 60 * 10)  # 10 minutes cached
+        return reduced_data
 
     # Singleflight: only ONE request fetches, others wait
     public_approved_data = memory_cache.get_or_fetch(cache_key, fetch_public_approved, ttl=30) or []
@@ -340,7 +345,10 @@ def get_approved_available_apps(include_reviews: bool = False) -> list[App]:
             # Database query
             print('get_public_approved_apps_data from db')
             all_apps = get_public_approved_apps_db()
-            set_generic_cache(redis_cache_key, all_apps, 60 * 10)  # 10 minutes cached
+            # Reduce cache size by excluding large fields
+            reduced_apps = [App.reduce_dict(app) for app in all_apps]
+            set_generic_cache(redis_cache_key, reduced_apps, 60 * 10)  # 10 minutes cached
+            all_apps = reduced_apps
 
         # Process apps (add installs, reviews, etc.)
         app_ids = [app['id'] for app in all_apps]


### PR DESCRIPTION
 #4231 
 
Reduces Redis cache size by filtering large fields (prompts, reviews, payment IDs, twitter) BEFORE caching. This fixes the root cause of #4215 where `get_public_approved_apps_data` cache consumed 25MB per entry, causing Redis bandwidth spikes to 400 MB/s during WebSocket connections.

**deploy steps**
- [x] merge pr
- [x] deploy backend(s) https://github.com/BasedHardware/omi/actions/runs/21025316539
- [x] deploy pusher https://github.com/BasedHardware/omi/actions/runs/21025318504

---
_This PR was drafted by AI on behalf of @beastoin_