### PR TITLE
feat: add dedicated Notifications settings page with frequency slider

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -185,6 +185,11 @@ class SharedPreferencesUtil {
 
   bool get dailyReflectionEnabled => getBool('dailyReflectionEnabled', defaultValue: true);
 
+  // Notification frequency (0-5): 0 = off, 5 = most frequent. Default is 3 (balanced)
+  set notificationFrequency(int value) => saveInt('notificationFrequency', value);
+
+  int get notificationFrequency => getInt('notificationFrequency', defaultValue: 3);
+
   // Wrapped 2025 - track if user has viewed their wrapped
   set hasViewedWrapped2025(bool value) => saveBool('hasViewedWrapped2025', value);
 

--- a/app/lib/desktop/pages/settings/desktop_settings_modal.dart
+++ b/app/lib/desktop/pages/settings/desktop_settings_modal.dart
@@ -4,20 +4,22 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:intl/intl.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:provider/provider.dart';
-import 'package:share_plus/share_plus.dart';
-import 'package:url_launcher/url_launcher.dart';
-
 import 'package:omi/backend/http/api/conversations.dart';
-import 'package:omi/backend/http/api/knowledge_graph_api.dart';
 import 'package:omi/backend/http/api/users.dart';
 import 'package:omi/backend/preferences.dart';
+import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/providers/user_provider.dart';
 import 'package:omi/backend/schema/conversation.dart';
 import 'package:omi/desktop/pages/onboarding/desktop_onboarding_wrapper.dart';
+import 'package:omi/pages/settings/widgets/create_mcp_api_key_dialog.dart';
+import 'package:omi/pages/settings/widgets/mcp_api_key_list_item.dart';
+import 'package:omi/providers/developer_mode_provider.dart';
+import 'package:omi/providers/mcp_provider.dart';
+import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:share_plus/share_plus.dart';
+import 'package:omi/backend/http/api/knowledge_graph_api.dart';
 import 'package:omi/env/env.dart';
 import 'package:omi/pages/payments/payments_page.dart';
 import 'package:omi/pages/persona/persona_profile.dart';
@@ -30,34 +32,31 @@ import 'package:omi/pages/settings/import_history_page.dart';
 import 'package:omi/pages/settings/language_selection_dialog.dart';
 import 'package:omi/pages/settings/people.dart';
 import 'package:omi/pages/settings/transcription_settings_page.dart';
-import 'package:omi/pages/settings/usage_page.dart';
-import 'package:omi/pages/settings/widgets/create_mcp_api_key_dialog.dart';
-import 'package:omi/pages/settings/widgets/developer_api_keys_section.dart';
-import 'package:omi/pages/settings/widgets/mcp_api_key_list_item.dart';
-import 'package:omi/pages/speech_profile/page.dart';
 import 'package:omi/providers/calendar_provider.dart';
-import 'package:omi/providers/capture_provider.dart';
-import 'package:omi/providers/developer_mode_provider.dart';
-import 'package:omi/providers/home_provider.dart';
-import 'package:omi/providers/mcp_provider.dart';
-import 'package:omi/providers/user_provider.dart';
-import 'package:omi/services/auth_service.dart';
 import 'package:omi/services/calendar_service.dart';
+import 'package:intl/intl.dart';
+import 'package:omi/pages/settings/usage_page.dart';
+import 'package:omi/pages/settings/widgets/developer_api_keys_section.dart';
+import 'package:omi/pages/speech_profile/page.dart';
+import 'package:omi/utils/debug_log_manager.dart';
+import 'package:omi/providers/home_provider.dart';
+import 'package:omi/services/auth_service.dart';
 import 'package:omi/services/shortcut_service.dart';
 import 'package:omi/ui/atoms/omi_checkbox.dart';
 import 'package:omi/ui/atoms/omi_icon_button.dart';
-import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
-import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
+import 'package:omi/services/notifications/daily_reflection_notification.dart';
+import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 enum SettingsSection {
   account,
   plansAndBilling,
   calendarIntegration,
   customVocabulary,
-  dailySummary,
+  notifications,
   shortcuts,
   developer,
   about,
@@ -101,7 +100,7 @@ class DesktopSettingsModal extends StatefulWidget {
 
 class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
   late SettingsSection _selectedSection;
-
+  
   // Shortcuts state
   ShortcutInfo? _askAIShortcut;
   ShortcutInfo? _toggleControlBarShortcut;
@@ -118,10 +117,12 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
   Timer? _deletionDebounceTimer;
   bool _isDeletingBatch = false;
 
-  // Daily summary state
+  // Notifications state
   bool _dailySummaryLoading = true;
   bool _dailySummaryEnabled = true;
   int _dailySummaryHour = 22;
+  bool _dailyReflectionEnabled = true;
+  int _notificationFrequency = 3;
 
   @override
   void initState() {
@@ -130,7 +131,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
     _loadShortcuts();
     _loadCalendarSettings();
     _loadDailySummarySettings();
-
+    
     // Initialize developer mode provider
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) {
@@ -162,14 +163,22 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
 
   Future<void> _loadDailySummarySettings() async {
     final settings = await getDailySummarySettings();
+    final reflectionEnabled = SharedPreferencesUtil().dailyReflectionEnabled;
+    final frequency = SharedPreferencesUtil().notificationFrequency;
     if (settings != null && mounted) {
       setState(() {
         _dailySummaryEnabled = settings.enabled;
         _dailySummaryHour = settings.hour;
+        _dailyReflectionEnabled = reflectionEnabled;
+        _notificationFrequency = frequency;
         _dailySummaryLoading = false;
       });
     } else if (mounted) {
-      setState(() => _dailySummaryLoading = false);
+      setState(() {
+        _dailyReflectionEnabled = reflectionEnabled;
+        _notificationFrequency = frequency;
+        _dailySummaryLoading = false;
+      });
     }
   }
 
@@ -189,6 +198,61 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
     setState(() => _dailySummaryHour = hour);
     await setDailySummarySettings(hour: hour);
     MixpanelManager().dailySummaryTimeChanged(hour: hour);
+  }
+
+  void _updateDailyReflectionEnabled(bool value) {
+    setState(() => _dailyReflectionEnabled = value);
+    SharedPreferencesUtil().dailyReflectionEnabled = value;
+    
+    // Schedule or cancel the notification based on the setting
+    if (value) {
+      DailyReflectionNotification.scheduleDailyNotification(channelKey: 'channel');
+    } else {
+      DailyReflectionNotification.cancelNotification();
+    }
+  }
+
+  void _updateNotificationFrequency(int value) {
+    setState(() => _notificationFrequency = value);
+    SharedPreferencesUtil().notificationFrequency = value;
+  }
+
+  String _getFrequencyLabel(int value) {
+    switch (value) {
+      case 0:
+        return 'Off';
+      case 1:
+        return 'Minimal';
+      case 2:
+        return 'Low';
+      case 3:
+        return 'Balanced';
+      case 4:
+        return 'High';
+      case 5:
+        return 'Maximum';
+      default:
+        return 'Balanced';
+    }
+  }
+
+  String _getFrequencyDescription(int value) {
+    switch (value) {
+      case 0:
+        return 'No proactive notifications';
+      case 1:
+        return 'Only critical reminders';
+      case 2:
+        return 'Important updates only';
+      case 3:
+        return 'Regular helpful nudges';
+      case 4:
+        return 'Frequent check-ins';
+      case 5:
+        return 'Stay constantly engaged';
+      default:
+        return 'Regular helpful nudges';
+    }
   }
 
   Future<void> _showHourPicker() async {
@@ -245,8 +309,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                     _updateDailySummaryHour(tempHour);
                     Navigator.pop(context);
                   },
-                  child: const Text('Done',
-                      style: TextStyle(color: ResponsiveHelper.purplePrimary, fontWeight: FontWeight.w600)),
+                  child: const Text('Done', style: TextStyle(color: ResponsiveHelper.purplePrimary, fontWeight: FontWeight.w600)),
                 ),
               ],
             );
@@ -301,7 +364,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
       }
     }
   }
-
+  
   Future<void> _loadShortcuts() async {
     if (!ShortcutService.isSupported) return;
     setState(() => _shortcutsLoading = true);
@@ -319,7 +382,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
       if (mounted) setState(() => _shortcutsLoading = false);
     }
   }
-
+  
   void _startRecording(String id) {
     setState(() => _recordingFor = id);
   }
@@ -443,8 +506,8 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
           ),
           _buildNavItem(
             icon: FontAwesomeIcons.bell,
-            label: 'Daily Summary',
-            section: SettingsSection.dailySummary,
+            label: 'Notifications',
+            section: SettingsSection.notifications,
           ),
           if (ShortcutService.isSupported)
             _buildNavItem(
@@ -544,7 +607,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
         return _buildCalendarIntegrationContent();
       case SettingsSection.customVocabulary:
         return _buildCustomVocabularyContent();
-      case SettingsSection.dailySummary:
+      case SettingsSection.notifications:
         return _buildDailySummaryContent();
       case SettingsSection.shortcuts:
         return _buildShortcutsContent();
@@ -670,8 +733,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
             Builder(
               builder: (context) {
                 final uid = SharedPreferencesUtil().uid;
-                final truncatedUid =
-                    uid.length > 6 ? '${uid.substring(0, 3)}•••••${uid.substring(uid.length - 3)}' : uid;
+                final truncatedUid = uid.length > 6 ? '${uid.substring(0, 3)}•••••${uid.substring(uid.length - 3)}' : uid;
                 return _buildSettingsRow(
                   title: 'User ID',
                   subtitle: truncatedUid,
@@ -784,8 +846,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                             style: const TextStyle(color: ResponsiveHelper.textPrimary, fontSize: 14),
                             decoration: InputDecoration(
                               hintText: 'Enter words (comma separated)',
-                              hintStyle:
-                                  TextStyle(color: ResponsiveHelper.textTertiary.withValues(alpha: 0.6), fontSize: 14),
+                              hintStyle: TextStyle(color: ResponsiveHelper.textTertiary.withValues(alpha: 0.6), fontSize: 14),
                               contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
                               border: InputBorder.none,
                             ),
@@ -813,8 +874,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                                 ? const SizedBox(
                                     width: 16,
                                     height: 16,
-                                    child:
-                                        CircularProgressIndicator(strokeWidth: 2, color: ResponsiveHelper.textTertiary),
+                                    child: CircularProgressIndicator(strokeWidth: 2, color: ResponsiveHelper.textTertiary),
                                   )
                                 : const Icon(FontAwesomeIcons.plus, color: Colors.white, size: 14),
                           ),
@@ -860,8 +920,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                                 const SizedBox(
                                   width: 16,
                                   height: 16,
-                                  child:
-                                      CircularProgressIndicator(strokeWidth: 2, color: ResponsiveHelper.textTertiary),
+                                  child: CircularProgressIndicator(strokeWidth: 2, color: ResponsiveHelper.textTertiary),
                                 )
                               else
                                 GestureDetector(
@@ -874,8 +933,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                                     ),
                                     child: Icon(
                                       Icons.close,
-                                      color:
-                                          isDisabled ? ResponsiveHelper.textTertiary : ResponsiveHelper.textSecondary,
+                                      color: isDisabled ? ResponsiveHelper.textTertiary : ResponsiveHelper.textSecondary,
                                       size: 10,
                                     ),
                                   ),
@@ -901,7 +959,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           const Text(
-            'DAILY SUMMARY',
+            'NOTIFICATIONS',
             style: TextStyle(
               fontSize: 11,
               fontWeight: FontWeight.w600,
@@ -931,6 +989,134 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // Notification Frequency Section
+        const Text(
+          'NOTIFICATION FREQUENCY',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: ResponsiveHelper.textTertiary,
+            letterSpacing: 0.5,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Control how often Omi sends you proactive notifications.',
+          style: TextStyle(
+            fontSize: 12,
+            color: ResponsiveHelper.textTertiary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          decoration: BoxDecoration(
+            color: ResponsiveHelper.backgroundTertiary.withValues(alpha: 0.4),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: ResponsiveHelper.backgroundTertiary.withValues(alpha: 0.5),
+              width: 1,
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              children: [
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _getFrequencyLabel(_notificationFrequency),
+                          style: const TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.w600,
+                            color: ResponsiveHelper.textPrimary,
+                          ),
+                        ),
+                        const SizedBox(height: 2),
+                        Text(
+                          _getFrequencyDescription(_notificationFrequency),
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: ResponsiveHelper.textTertiary,
+                          ),
+                        ),
+                      ],
+                    ),
+                    Container(
+                      width: 40,
+                      height: 40,
+                      decoration: BoxDecoration(
+                        color: _notificationFrequency == 0 
+                            ? ResponsiveHelper.backgroundTertiary 
+                            : ResponsiveHelper.purplePrimary.withOpacity(0.2),
+                        borderRadius: BorderRadius.circular(10),
+                      ),
+                      child: Center(
+                        child: Text(
+                          '$_notificationFrequency',
+                          style: TextStyle(
+                            color: _notificationFrequency == 0 
+                                ? ResponsiveHelper.textTertiary 
+                                : ResponsiveHelper.purplePrimary,
+                            fontSize: 18,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                SliderTheme(
+                  data: SliderTheme.of(context).copyWith(
+                    activeTrackColor: ResponsiveHelper.purplePrimary,
+                    inactiveTrackColor: ResponsiveHelper.backgroundTertiary,
+                    thumbColor: Colors.white,
+                    overlayColor: ResponsiveHelper.purplePrimary.withOpacity(0.2),
+                    trackHeight: 4,
+                    thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 8),
+                  ),
+                  child: Slider(
+                    value: _notificationFrequency.toDouble(),
+                    min: 0,
+                    max: 5,
+                    divisions: 5,
+                    onChanged: (value) => _updateNotificationFrequency(value.round()),
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 4),
+                  child: Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text(
+                        'Off',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: ResponsiveHelper.textTertiary,
+                        ),
+                      ),
+                      Text(
+                        'Max',
+                        style: TextStyle(
+                          fontSize: 11,
+                          color: ResponsiveHelper.textTertiary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+        
+        const SizedBox(height: 24),
+        
+        // Daily Summary Section
         const Text(
           'DAILY SUMMARY',
           style: TextStyle(
@@ -940,7 +1126,15 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
             letterSpacing: 0.5,
           ),
         ),
-        const SizedBox(height: 8),
+        const SizedBox(height: 4),
+        Text(
+          'Get a personalized summary of your day\'s conversations delivered as a notification.',
+          style: TextStyle(
+            fontSize: 12,
+            color: ResponsiveHelper.textTertiary,
+          ),
+        ),
+        const SizedBox(height: 12),
         Container(
           decoration: BoxDecoration(
             color: ResponsiveHelper.backgroundTertiary.withValues(alpha: 0.4),
@@ -958,26 +1152,13 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                 child: Row(
                   children: [
                     Expanded(
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          const Text(
-                            'Daily Summary',
-                            style: TextStyle(
-                              fontSize: 14,
-                              fontWeight: FontWeight.w500,
-                              color: ResponsiveHelper.textPrimary,
-                            ),
-                          ),
-                          const SizedBox(height: 2),
-                          Text(
-                            'Get a personalized summary of your conversations',
-                            style: TextStyle(
-                              fontSize: 12,
-                              color: ResponsiveHelper.textTertiary,
-                            ),
-                          ),
-                        ],
+                      child: const Text(
+                        'Enable',
+                        style: TextStyle(
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                          color: ResponsiveHelper.textPrimary,
+                        ),
                       ),
                     ),
                     OmiCheckbox(
@@ -1008,26 +1189,13 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                       child: Row(
                         children: [
                           Expanded(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                const Text(
-                                  'Delivery Time',
-                                  style: TextStyle(
-                                    fontSize: 14,
-                                    fontWeight: FontWeight.w500,
-                                    color: ResponsiveHelper.textPrimary,
-                                  ),
-                                ),
-                                const SizedBox(height: 2),
-                                Text(
-                                  'When to receive your daily summary',
-                                  style: TextStyle(
-                                    fontSize: 12,
-                                    color: ResponsiveHelper.textTertiary,
-                                  ),
-                                ),
-                              ],
+                            child: const Text(
+                              'Delivery Time',
+                              style: TextStyle(
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500,
+                                color: ResponsiveHelper.textPrimary,
+                              ),
                             ),
                           ),
                           Text(
@@ -1050,6 +1218,60 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                 ),
               ),
             ],
+          ),
+        ),
+        
+        const SizedBox(height: 24),
+        
+        // Daily Reflection Section
+        const Text(
+          'DAILY REFLECTION',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w600,
+            color: ResponsiveHelper.textTertiary,
+            letterSpacing: 0.5,
+          ),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          'Get a reminder at 9 PM to reflect on your day and capture your thoughts.',
+          style: TextStyle(
+            fontSize: 12,
+            color: ResponsiveHelper.textTertiary,
+          ),
+        ),
+        const SizedBox(height: 12),
+        Container(
+          decoration: BoxDecoration(
+            color: ResponsiveHelper.backgroundTertiary.withValues(alpha: 0.4),
+            borderRadius: BorderRadius.circular(14),
+            border: Border.all(
+              color: ResponsiveHelper.backgroundTertiary.withValues(alpha: 0.5),
+              width: 1,
+            ),
+          ),
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+            child: Row(
+              children: [
+                Expanded(
+                  child: const Text(
+                    'Enable',
+                    style: TextStyle(
+                      fontSize: 14,
+                      fontWeight: FontWeight.w500,
+                      color: ResponsiveHelper.textPrimary,
+                    ),
+                  ),
+                ),
+                OmiCheckbox(
+                  value: _dailyReflectionEnabled,
+                  onChanged: _updateDailyReflectionEnabled,
+                  size: 18,
+                ),
+              ],
+            ),
           ),
         ),
       ],
@@ -1534,7 +1756,9 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
             ),
           ],
         ),
+        
         const SizedBox(height: 16),
+        
         const Text(
           'Click on a shortcut to change it. Press Escape to cancel.',
           style: TextStyle(
@@ -1780,8 +2004,7 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                           borderRadius: BorderRadius.circular(12),
                           side: BorderSide(color: ResponsiveHelper.backgroundTertiary.withValues(alpha: 0.5)),
                         ),
-                        title: const Text('Delete Knowledge Graph?',
-                            style: TextStyle(color: ResponsiveHelper.textPrimary)),
+                        title: const Text('Delete Knowledge Graph?', style: TextStyle(color: ResponsiveHelper.textPrimary)),
                         content: const Text(
                           'This will delete all derived knowledge graph data. Your original memories remain safe.',
                           style: TextStyle(color: ResponsiveHelper.textSecondary),
@@ -1936,7 +2159,8 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                   value: devProvider.transcriptsToggled,
                   onChanged: devProvider.onTranscriptsToggled,
                 ),
-                if (devProvider.transcriptsToggled) _buildWebhookUrlField(devProvider.webhookOnTranscriptReceived),
+                if (devProvider.transcriptsToggled)
+                  _buildWebhookUrlField(devProvider.webhookOnTranscriptReceived),
                 _buildToggleRow(
                   title: 'Audio Bytes',
                   subtitle: 'Audio data received',
@@ -1953,7 +2177,8 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                   value: devProvider.daySummaryToggled,
                   onChanged: devProvider.onDaySummaryToggled,
                 ),
-                if (devProvider.daySummaryToggled) _buildWebhookUrlField(devProvider.webhookDaySummary),
+                if (devProvider.daySummaryToggled)
+                  _buildWebhookUrlField(devProvider.webhookDaySummary),
               ],
             ),
 
@@ -1986,12 +2211,6 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
                   subtitle: 'Track personal goals on homepage',
                   value: devProvider.showGoalTrackerEnabled,
                   onChanged: (v) => devProvider.onShowGoalTrackerChanged(v),
-                ),
-                _buildToggleRow(
-                  title: 'Daily Reflection',
-                  subtitle: '9 PM reminder to reflect on your day',
-                  value: devProvider.dailyReflectionEnabled,
-                  onChanged: (v) => devProvider.onDailyReflectionChanged(v),
                 ),
               ],
             ),
@@ -2368,45 +2587,11 @@ class _ShortcutRecorderBadgeState extends State<_ShortcutRecorderBadge> {
   static const int controlKey = 0x1000;
 
   static final Map<int, int> _physicalKeyToCarbonKeyCode = {
-    0x04: 0,
-    0x05: 11,
-    0x06: 8,
-    0x07: 2,
-    0x08: 14,
-    0x09: 3,
-    0x0A: 5,
-    0x0B: 4,
-    0x0C: 34,
-    0x0D: 38,
-    0x0E: 40,
-    0x0F: 37,
-    0x10: 46,
-    0x11: 45,
-    0x12: 31,
-    0x13: 35,
-    0x14: 12,
-    0x15: 15,
-    0x16: 1,
-    0x17: 17,
-    0x18: 32,
-    0x19: 9,
-    0x1A: 13,
-    0x1B: 7,
-    0x1C: 16,
-    0x1D: 6,
-    0x1E: 18,
-    0x1F: 19,
-    0x20: 20,
-    0x21: 21,
-    0x22: 23,
-    0x23: 22,
-    0x24: 26,
-    0x25: 28,
-    0x26: 25,
-    0x27: 29,
-    0x28: 36,
-    0x2C: 49,
-    0x31: 42,
+    0x04: 0, 0x05: 11, 0x06: 8, 0x07: 2, 0x08: 14, 0x09: 3, 0x0A: 5, 0x0B: 4,
+    0x0C: 34, 0x0D: 38, 0x0E: 40, 0x0F: 37, 0x10: 46, 0x11: 45, 0x12: 31, 0x13: 35,
+    0x14: 12, 0x15: 15, 0x16: 1, 0x17: 17, 0x18: 32, 0x19: 9, 0x1A: 13, 0x1B: 7,
+    0x1C: 16, 0x1D: 6, 0x1E: 18, 0x1F: 19, 0x20: 20, 0x21: 21, 0x22: 23, 0x23: 22,
+    0x24: 26, 0x25: 28, 0x26: 25, 0x27: 29, 0x28: 36, 0x2C: 49, 0x31: 42,
   };
 
   @override
@@ -2530,3 +2715,4 @@ class _ShortcutRecorderBadgeState extends State<_ShortcutRecorderBadge> {
     );
   }
 }
+

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -1665,18 +1665,6 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                           value: provider.showGoalTrackerEnabled,
                           onChanged: provider.onShowGoalTrackerChanged,
                         ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(vertical: 16),
-                          child: Divider(color: Colors.grey.shade800, height: 1),
-                        ),
-                        // Daily Reflection
-                        _buildExperimentalItem(
-                          title: 'Daily Reflection',
-                          description: 'Get a 9 PM reminder to reflect on your day',
-                          icon: FontAwesomeIcons.moon,
-                          value: provider.dailyReflectionEnabled,
-                          onChanged: provider.onDailyReflectionChanged,
-                        ),
                       ],
                     ),
                   ),

--- a/app/lib/pages/settings/notifications_settings_page.dart
+++ b/app/lib/pages/settings/notifications_settings_page.dart
@@ -1,0 +1,609 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:omi/backend/http/api/users.dart';
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/providers/conversation_provider.dart';
+import 'package:omi/services/notifications/daily_reflection_notification.dart';
+import 'package:omi/utils/analytics/mixpanel.dart';
+import 'package:provider/provider.dart';
+
+class NotificationsSettingsPage extends StatefulWidget {
+  const NotificationsSettingsPage({super.key});
+
+  @override
+  State<NotificationsSettingsPage> createState() => _NotificationsSettingsPageState();
+}
+
+class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
+  bool _isLoading = true;
+  
+  // Notification frequency (0-5)
+  int _notificationFrequency = 3;
+  
+  // Daily Summary settings
+  bool _dailySummaryEnabled = true;
+  int _dailySummaryHour = 22; // Default to 10 PM
+  
+  // Daily Reflection settings
+  bool _dailyReflectionEnabled = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+    MixpanelManager().dailySummarySettingsOpened();
+  }
+
+  Future<void> _loadSettings() async {
+    // Load Daily Summary settings from API
+    final settings = await getDailySummarySettings();
+    
+    // Load settings from local prefs
+    final reflectionEnabled = SharedPreferencesUtil().dailyReflectionEnabled;
+    final frequency = SharedPreferencesUtil().notificationFrequency;
+    
+    if (mounted) {
+      setState(() {
+        if (settings != null) {
+          _dailySummaryEnabled = settings.enabled;
+          _dailySummaryHour = settings.hour;
+        }
+        _dailyReflectionEnabled = reflectionEnabled;
+        _notificationFrequency = frequency;
+        _isLoading = false;
+      });
+    }
+  }
+
+  void _updateNotificationFrequency(int value) {
+    setState(() => _notificationFrequency = value);
+    SharedPreferencesUtil().notificationFrequency = value;
+  }
+
+  String _getFrequencyLabel(int value) {
+    switch (value) {
+      case 0:
+        return 'Off';
+      case 1:
+        return 'Minimal';
+      case 2:
+        return 'Low';
+      case 3:
+        return 'Balanced';
+      case 4:
+        return 'High';
+      case 5:
+        return 'Maximum';
+      default:
+        return 'Balanced';
+    }
+  }
+
+  String _getFrequencyDescription(int value) {
+    switch (value) {
+      case 0:
+        return 'No proactive notifications';
+      case 1:
+        return 'Only critical reminders';
+      case 2:
+        return 'Important updates only';
+      case 3:
+        return 'Regular helpful nudges';
+      case 4:
+        return 'Frequent check-ins';
+      case 5:
+        return 'Stay constantly engaged';
+      default:
+        return 'Regular helpful nudges';
+    }
+  }
+
+  String _formatHourDisplay(int hour) {
+    final hour12 = hour == 0 ? 12 : (hour > 12 ? hour - 12 : hour);
+    final period = hour >= 12 ? 'PM' : 'AM';
+    return '$hour12:00 $period';
+  }
+
+  Future<void> _updateDailySummaryEnabled(bool value) async {
+    setState(() => _dailySummaryEnabled = value);
+    await setDailySummarySettings(enabled: value);
+    MixpanelManager().dailySummaryToggled(enabled: value);
+  }
+
+  Future<void> _updateDailySummaryHour(int hour) async {
+    setState(() => _dailySummaryHour = hour);
+    await setDailySummarySettings(hour: hour);
+    MixpanelManager().dailySummaryTimeChanged(hour: hour);
+  }
+
+  void _updateDailyReflectionEnabled(bool value) {
+    setState(() => _dailyReflectionEnabled = value);
+    SharedPreferencesUtil().dailyReflectionEnabled = value;
+    
+    // Schedule or cancel the notification based on the setting
+    if (value) {
+      DailyReflectionNotification.scheduleDailyNotification(channelKey: 'channel');
+    } else {
+      DailyReflectionNotification.cancelNotification();
+    }
+  }
+
+  Future<void> _showHourPicker() async {
+    if (!_dailySummaryEnabled) return;
+
+    await showModalBottomSheet(
+      context: context,
+      backgroundColor: const Color(0xFF1C1C1E),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(20)),
+      ),
+      builder: (context) {
+        int tempHour = _dailySummaryHour;
+        return StatefulBuilder(
+          builder: (context, setModalState) {
+            return Container(
+              height: 350,
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      TextButton(
+                        onPressed: () => Navigator.pop(context),
+                        child: Text(
+                          'Cancel',
+                          style: TextStyle(color: Colors.grey.shade400, fontSize: 16),
+                        ),
+                      ),
+                      const Text(
+                        'Select Time',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 17,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                      TextButton(
+                        onPressed: () {
+                          _updateDailySummaryHour(tempHour);
+                          Navigator.pop(context);
+                        },
+                        child: const Text(
+                          'Done',
+                          style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 8),
+                  Expanded(
+                    child: CupertinoTheme(
+                      data: const CupertinoThemeData(
+                        brightness: Brightness.dark,
+                      ),
+                      child: CupertinoPicker(
+                        scrollController: FixedExtentScrollController(initialItem: tempHour),
+                        itemExtent: 44,
+                        onSelectedItemChanged: (index) {
+                          setModalState(() => tempHour = index);
+                        },
+                        children: List.generate(24, (index) {
+                          final hour12 = index == 0 ? 12 : (index > 12 ? index - 12 : index);
+                          final period = index >= 12 ? 'PM' : 'AM';
+                          return Center(
+                            child: Text(
+                              '$hour12:00 $period',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 20,
+                              ),
+                            ),
+                          );
+                        }),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Future<void> _showGenerateSummaryPicker() async {
+    final now = DateTime.now();
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: now,
+      firstDate: now.subtract(const Duration(days: 365)),
+      lastDate: now,
+      builder: (context, child) {
+        return Theme(
+          data: Theme.of(context).copyWith(
+            colorScheme: const ColorScheme.dark(
+              primary: Color(0xFF6366F1),
+              onPrimary: Colors.white,
+              surface: Color(0xFF1C1C1E),
+              onSurface: Colors.white,
+            ),
+            dialogBackgroundColor: const Color(0xFF1C1C1E),
+          ),
+          child: child!,
+        );
+      },
+    );
+
+    if (picked != null && mounted) {
+      final dateStr =
+          '${picked.year}-${picked.month.toString().padLeft(2, '0')}-${picked.day.toString().padLeft(2, '0')}';
+
+      // Show loading
+      showDialog(
+        context: context,
+        barrierDismissible: false,
+        builder: (context) => const Center(
+          child: CircularProgressIndicator(color: Colors.white),
+        ),
+      );
+
+      final summaryId = await generateDailySummary(date: dateStr);
+
+      if (!mounted) return;
+      Navigator.pop(context); // Dismiss loading
+
+      if (summaryId != null) {
+        MixpanelManager().dailySummaryTestGenerated(date: dateStr);
+
+        // Refresh the hasDailySummaries flag so the Recap tab shows
+        Provider.of<ConversationProvider>(context, listen: false).checkHasDailySummaries();
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Summary generated for ${picked.month}/${picked.day}/${picked.year}'),
+            backgroundColor: Colors.green.shade700,
+          ),
+        );
+      } else {
+        MixpanelManager().dailySummaryTestGenerationFailed(date: dateStr);
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: const Text('Failed to generate summary. Make sure you have conversations for that day.'),
+            backgroundColor: Colors.red.shade700,
+          ),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: Theme.of(context).colorScheme.primary,
+      appBar: AppBar(
+        title: const Text('Notifications'),
+        backgroundColor: Theme.of(context).colorScheme.primary,
+        elevation: 0,
+        actions: [
+          PopupMenuButton<String>(
+            icon: const Icon(Icons.more_vert, color: Colors.white),
+            color: const Color(0xFF1C1C1E),
+            onSelected: (value) {
+              if (value == 'generate') {
+                _showGenerateSummaryPicker();
+              }
+            },
+            itemBuilder: (context) => [
+              const PopupMenuItem(
+                value: 'generate',
+                child: Row(
+                  children: [
+                    Icon(Icons.auto_awesome, color: Colors.white, size: 20),
+                    SizedBox(width: 12),
+                    Text('Generate Summary', style: TextStyle(color: Colors.white)),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+      body: _isLoading
+          ? const Center(child: CircularProgressIndicator(color: Colors.white))
+          : SingleChildScrollView(
+              padding: const EdgeInsets.all(20),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // Notification Frequency Section
+                  _buildSectionHeader('Notification Frequency'),
+                  const SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    child: Text(
+                      'Control how often Omi sends you proactive notifications and reminders.',
+                      style: TextStyle(
+                        color: Colors.grey.shade400,
+                        fontSize: 14,
+                        height: 1.5,
+                      ),
+                    ),
+                  ),
+                  _buildFrequencyCard(),
+                  
+                  const SizedBox(height: 32),
+                  
+                  // Daily Summary Section
+                  _buildSectionHeader('Daily Summary'),
+                  const SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    child: Text(
+                      'Get a personalized summary of your day\'s conversations delivered as a notification.',
+                      style: TextStyle(
+                        color: Colors.grey.shade400,
+                        fontSize: 14,
+                        height: 1.5,
+                      ),
+                    ),
+                  ),
+                  _buildDailySummaryCard(),
+                  
+                  const SizedBox(height: 32),
+                  
+                  // Daily Reflection Section
+                  _buildSectionHeader('Daily Reflection'),
+                  const SizedBox(height: 8),
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 16),
+                    child: Text(
+                      'Get a reminder at 9 PM to reflect on your day and capture your thoughts.',
+                      style: TextStyle(
+                        color: Colors.grey.shade400,
+                        fontSize: 14,
+                        height: 1.5,
+                      ),
+                    ),
+                  ),
+                  _buildDailyReflectionCard(),
+                ],
+              ),
+            ),
+    );
+  }
+
+  Widget _buildSectionHeader(String title) {
+    return Text(
+      title,
+      style: const TextStyle(
+        color: Colors.white,
+        fontSize: 20,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  Widget _buildFrequencyCard() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1C1C1E),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        children: [
+          // Current value display
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _getFrequencyLabel(_notificationFrequency),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 18,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    _getFrequencyDescription(_notificationFrequency),
+                    style: TextStyle(
+                      color: Colors.grey.shade400,
+                      fontSize: 14,
+                    ),
+                  ),
+                ],
+              ),
+              Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  color: _notificationFrequency == 0 
+                      ? Colors.grey.shade800 
+                      : const Color(0xFF6366F1).withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Center(
+                  child: Text(
+                    '$_notificationFrequency',
+                    style: TextStyle(
+                      color: _notificationFrequency == 0 
+                          ? Colors.grey.shade500 
+                          : const Color(0xFF6366F1),
+                      fontSize: 20,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+              ),
+            ],
+          ),
+          
+          const SizedBox(height: 20),
+          
+          // Slider
+          SliderTheme(
+            data: SliderTheme.of(context).copyWith(
+              activeTrackColor: const Color(0xFF6366F1),
+              inactiveTrackColor: Colors.grey.shade800,
+              thumbColor: Colors.white,
+              overlayColor: const Color(0xFF6366F1).withOpacity(0.2),
+              trackHeight: 6,
+              thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 10),
+            ),
+            child: Slider(
+              value: _notificationFrequency.toDouble(),
+              min: 0,
+              max: 5,
+              divisions: 5,
+              onChanged: (value) => _updateNotificationFrequency(value.round()),
+            ),
+          ),
+          
+          // Labels
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 8),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(
+                  'Off',
+                  style: TextStyle(
+                    color: Colors.grey.shade500,
+                    fontSize: 12,
+                  ),
+                ),
+                Text(
+                  'Max',
+                  style: TextStyle(
+                    color: Colors.grey.shade500,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDailySummaryCard() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1C1C1E),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Column(
+        children: [
+          // Enable toggle row
+          _buildSettingRow(
+            icon: FontAwesomeIcons.bell,
+            title: 'Enable',
+            trailing: Switch(
+              value: _dailySummaryEnabled,
+              onChanged: _updateDailySummaryEnabled,
+              activeColor: const Color(0xFF6366F1),
+            ),
+          ),
+
+          Padding(
+            padding: const EdgeInsets.symmetric(vertical: 12),
+            child: Divider(color: Colors.grey.shade800, height: 1),
+          ),
+
+          // Time selector row
+          AnimatedOpacity(
+            opacity: _dailySummaryEnabled ? 1.0 : 0.4,
+            duration: const Duration(milliseconds: 200),
+            child: GestureDetector(
+              onTap: _showHourPicker,
+              behavior: HitTestBehavior.opaque,
+              child: _buildSettingRow(
+                icon: FontAwesomeIcons.clock,
+                title: 'Delivery Time',
+                trailing: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      _formatHourDisplay(_dailySummaryHour),
+                      style: TextStyle(
+                        color: Colors.grey.shade400,
+                        fontSize: 16,
+                      ),
+                    ),
+                    const SizedBox(width: 6),
+                    Icon(
+                      Icons.chevron_right,
+                      color: Colors.grey.shade600,
+                      size: 20,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDailyReflectionCard() {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1C1C1E),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: _buildSettingRow(
+        icon: FontAwesomeIcons.moon,
+        title: 'Enable',
+        trailing: Switch(
+          value: _dailyReflectionEnabled,
+          onChanged: _updateDailyReflectionEnabled,
+          activeColor: const Color(0xFF6366F1),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingRow({
+    required IconData icon,
+    required String title,
+    required Widget trailing,
+  }) {
+    return Row(
+      children: [
+        Container(
+          width: 40,
+          height: 40,
+          decoration: BoxDecoration(
+            color: const Color(0xFF2A2A2E),
+            borderRadius: BorderRadius.circular(10),
+          ),
+          child: Center(child: FaIcon(icon, color: Colors.grey.shade400, size: 16)),
+        ),
+        const SizedBox(width: 14),
+        Expanded(
+          child: Text(
+            title,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+        trailing,
+      ],
+    );
+  }
+}

--- a/app/lib/pages/settings/profile.dart
+++ b/app/lib/pages/settings/profile.dart
@@ -1,21 +1,22 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/pages/payments/payments_page.dart';
 import 'package:omi/pages/settings/change_name_widget.dart';
-import 'package:omi/pages/settings/conversation_display_settings.dart';
-import 'package:omi/pages/settings/custom_vocabulary_page.dart';
-import 'package:omi/pages/settings/daily_summary_settings_page.dart';
-import 'package:omi/pages/settings/data_privacy_page.dart';
 import 'package:omi/pages/settings/language_settings_page.dart';
+import 'package:omi/pages/settings/custom_vocabulary_page.dart';
 import 'package:omi/pages/settings/people.dart';
+import 'package:omi/pages/settings/data_privacy_page.dart';
 import 'package:omi/pages/speech_profile/page.dart';
+
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/other/temp.dart';
+
+
+import 'package:omi/pages/settings/conversation_display_settings.dart';
+
 import 'delete_account.dart';
 
 class ProfilePage extends StatefulWidget {
@@ -239,21 +240,6 @@ class _ProfilePageState extends State<ProfilePage> {
                   icon: const FaIcon(FontAwesomeIcons.users, color: Color(0xFF8E8E93), size: 20),
                   onTap: () {
                     routeToPage(context, const UserPeoplePage());
-                  },
-                ),
-              ],
-            ),
-            const SizedBox(height: 32),
-
-            // NOTIFICATIONS SECTION
-            _buildSectionContainer(
-              children: [
-                _buildProfileItem(
-                  title: 'Daily Summary',
-                  subtitle: 'Configure your daily action items digest',
-                  icon: const FaIcon(FontAwesomeIcons.solidBell, color: Color(0xFF8E8E93), size: 20),
-                  onTap: () {
-                    routeToPage(context, const DailySummarySettingsPage());
                   },
                 ),
               ],

--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -1,35 +1,33 @@
 import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-
-import 'package:device_info_plus/device_info_plus.dart';
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
-import 'package:intercom_flutter/intercom_flutter.dart';
-import 'package:package_info_plus/package_info_plus.dart';
-import 'package:provider/provider.dart';
-import 'package:url_launcher/url_launcher.dart';
-
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/core/app_shell.dart';
-import 'package:omi/models/subscription.dart';
 import 'package:omi/pages/persona/persona_provider.dart';
-import 'package:omi/pages/referral/referral_page.dart';
-import 'package:omi/pages/settings/developer.dart';
-import 'package:omi/pages/settings/integrations_page.dart';
-import 'package:omi/pages/settings/profile.dart';
-import 'package:omi/pages/settings/usage_page.dart';
-import 'package:omi/providers/device_provider.dart';
-import 'package:omi/providers/locale_provider.dart';
-import 'package:omi/providers/usage_provider.dart';
 import 'package:omi/services/auth_service.dart';
-import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/pages/settings/developer.dart';
+import 'package:omi/pages/settings/notifications_settings_page.dart';
+import 'package:omi/pages/settings/profile.dart';
+import 'package:omi/pages/settings/integrations_page.dart';
+import 'package:omi/pages/settings/usage_page.dart';
+import 'package:omi/pages/referral/referral_page.dart';
+import 'package:omi/providers/device_provider.dart';
+import 'package:omi/providers/usage_provider.dart';
+import 'package:omi/models/subscription.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/widgets/dialog.dart';
-import '../conversations/sync_page.dart';
+import 'package:intercom_flutter/intercom_flutter.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+import 'package:provider/provider.dart';
+import 'package:omi/providers/locale_provider.dart';
+import 'package:omi/utils/l10n_extensions.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:device_info_plus/device_info_plus.dart';
 import 'device_settings.dart';
 import 'wrapped_2025_page.dart';
+import '../conversations/sync_page.dart';
 
 enum SettingsMode {
   no_device,
@@ -303,6 +301,8 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
     });
   }
 
+
+
   Widget _buildOmiModeContent(BuildContext context) {
     return Consumer<UsageProvider>(builder: (context, usageProvider, child) {
       return Column(
@@ -310,24 +310,33 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
           // Profile & Notifications Section
           _buildSectionContainer(
             children: [
-              _buildSettingsItem(
-                title: context.l10n.wrapped2025,
-                icon: const FaIcon(FontAwesomeIcons.gift, color: Color(0xFF8E8E93), size: 20),
-                showNewTag: true,
-                onTap: () {
-                  Navigator.of(context).push(
-                    MaterialPageRoute(
-                      builder: (context) => const Wrapped2025Page(),
-                    ),
-                  );
-                },
-              ),
-              const Divider(height: 1, color: Color(0xFF3C3C43)),
+              // Wrapped 2025 - temporarily disabled
+              // _buildSettingsItem(
+              //   title: context.l10n.wrapped2025,
+              //   icon: const FaIcon(FontAwesomeIcons.gift, color: Color(0xFF8E8E93), size: 20),
+              //   showNewTag: true,
+              //   onTap: () {
+              //     Navigator.of(context).push(
+              //       MaterialPageRoute(
+              //         builder: (context) => const Wrapped2025Page(),
+              //       ),
+              //     );
+              //   },
+              // ),
+              // const Divider(height: 1, color: Color(0xFF3C3C43)),
               _buildSettingsItem(
                 title: context.l10n.profile,
                 icon: const FaIcon(FontAwesomeIcons.solidUser, color: Color(0xFF8E8E93), size: 20),
                 onTap: () {
                   routeToPage(context, const ProfilePage());
+                },
+              ),
+              const Divider(height: 1, color: Color(0xFF3C3C43)),
+              _buildSettingsItem(
+                title: 'Notifications',
+                icon: const FaIcon(FontAwesomeIcons.solidBell, color: Color(0xFF8E8E93), size: 20),
+                onTap: () {
+                  routeToPage(context, const NotificationsSettingsPage());
                 },
               ),
               const Divider(height: 1, color: Color(0xFF3C3C43)),
@@ -462,6 +471,7 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                   await routeToPage(context, const DeveloperSettingsPage());
                 },
               ),
+
             ],
           ),
           const SizedBox(height: 32),


### PR DESCRIPTION
## Changes
- Add `NotificationsSettingsPage` combining Daily Summary, Daily Reflection, and Notification Frequency settings
- Move Notifications to main Settings drawer (after Profile)
- Remove Daily Summary from Profile page (now consolidated in Notifications page)
- Add 0-5 Notification Frequency slider to control proactive notification frequency
- Add notifications section to desktop settings modal with same functionality
- Comment out 'Wrapped 2025' option from settings drawer

## ⚠️ WARNING
**This PR is NOT fully tested and can be reverted if issues are found.**

The notification frequency slider currently only saves the preference locally. Backend integration for using this frequency value in notification scheduling is pending.