### PR TITLE
feat: improve task sorting with drag-drop and persistence

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -190,6 +190,24 @@ class SharedPreferencesUtil {
 
   int get notificationFrequency => getInt('notificationFrequency', defaultValue: 3);
 
+  // Task category order for drag-and-drop sorting persistence
+  // Format: { "today": ["id1", "id2"], "tomorrow": ["id3"] }
+  set taskCategoryOrder(Map<String, List<String>> value) {
+    final encoded = jsonEncode(value);
+    saveString('taskCategoryOrder', encoded);
+  }
+
+  Map<String, List<String>> get taskCategoryOrder {
+    final encoded = getString('taskCategoryOrder');
+    if (encoded.isEmpty) return {};
+    try {
+      final decoded = jsonDecode(encoded) as Map<String, dynamic>;
+      return decoded.map((key, value) => MapEntry(key, (value as List).cast<String>()));
+    } catch (e) {
+      return {};
+    }
+  }
+
   // Wrapped 2025 - track if user has viewed their wrapped
   set hasViewedWrapped2025(bool value) => saveBool('hasViewedWrapped2025', value);
 

--- a/app/lib/desktop/pages/desktop_home_page.dart
+++ b/app/lib/desktop/pages/desktop_home_page.dart
@@ -498,7 +498,7 @@ class _DesktopHomePageState extends State<DesktopHomePage> with WidgetsBindingOb
                           ),
                           _buildNavItem(
                             icon: FontAwesomeIcons.squareCheck,
-                            label: 'Actions',
+                            label: 'Tasks',
                             index: 3,
                             isSelected: homeProvider.selectedIndex == 3,
                             onTap: () => _navigateToIndex(3, homeProvider),
@@ -791,7 +791,7 @@ class _DesktopHomePageState extends State<DesktopHomePage> with WidgetsBindingOb
         child: InkWell(
           onTap: () {
             MixpanelManager()
-                .bottomNavigationTabClicked(['Conversations', 'Chat', 'Memories', 'Actions', 'Apps'][index]);
+                .bottomNavigationTabClicked(['Conversations', 'Chat', 'Memories', 'Tasks', 'Apps'][index]);
             onTap();
           },
           borderRadius: BorderRadius.circular(10),


### PR DESCRIPTION
## Changes
- Rename 'Actions' to 'Tasks' in macOS menu
- Add drag-and-drop sorting for tasks on macOS desktop
- Add first position drop zone for reordering tasks to top
- Add persistence for task sorting order using SharedPreferences
- Sorting order persists across app restarts and when tasks move between categories

## Testing
- Tested on macOS and iOS simulators
- Task reordering works via long-press drag
- Order persists after app restart