### PR TITLE
Add combine_segments test coverage

### DIFF
--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -172,7 +172,7 @@ class TranscriptSegment(BaseModel):
         removed_ids = []
 
         # Join
-        joined_similar_segments = [segments[-1].copy(deep=True)] if segments else []
+        joined_similar_segments = [segments[-1].model_copy(deep=True)] if segments else []
         dropped_existing_tail = False
         for new_segment in new_segments:
             if delta_seconds > 0:

--- a/backend/tests/unit/test_transcript_segment.py
+++ b/backend/tests/unit/test_transcript_segment.py
@@ -7,43 +7,68 @@ def _segment(text, speaker="SPEAKER_00", is_user=False, start=0.0, end=1.0):
     return TranscriptSegment(text=text, speaker=speaker, is_user=is_user, start=start, end=end)
 
 
+def _concat_texts(texts):
+    return " ".join(text.strip() for text in texts if text).strip()
+
+
+def _concat_segments(segments):
+    return _concat_texts([segment.text for segment in segments])
+
+
+def _normalize_punctuation(text):
+    return text.strip().replace("  ", " ").replace(" ,", ",").replace(" .", ".").replace(" ?", "?")
+
+
 def test_forward_merge_on_short_incomplete_last_sentence():
     a = _segment("Hello there. and then", speaker="SPEAKER_00", start=0.0, end=4.0)
     b = _segment("we continue speaking.", speaker="SPEAKER_01", start=4.0, end=7.0)
+    input_concat = _concat_texts([a.text, b.text])
 
-    segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+    segments, _, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
     assert len(segments) == 2
     assert segments[0].text == "Hello there."
     assert segments[0].end == pytest.approx(4.0)
     assert segments[1].speaker == "SPEAKER_01"
     assert segments[1].text == "and then we continue speaking."
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_no_forward_merge_when_incomplete_is_longer_than_next_segment():
     a = _segment("and then we continue speaking", speaker="SPEAKER_00", start=0.0, end=3.0)
     b = _segment("Ok.", speaker="SPEAKER_01", start=3.0, end=4.0)
+    input_concat = _concat_texts([a.text, b.text])
 
-    segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+    segments, _, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
     assert len(segments) == 2
     assert segments[0].text == "and then we continue speaking"
     assert segments[1].text == "Ok."
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_merge_same_speaker_with_small_gap():
     a = _segment("Hello", speaker="SPEAKER_00", start=0.0, end=1.0)
     b = _segment("world.", speaker="SPEAKER_00", start=1.1, end=2.0)
+    input_concat = _concat_texts([a.text, b.text])
 
-    segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+    segments, _, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
     assert len(segments) == 1
     assert segments[0].text == "Hello world."
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_updated_segments_returned_for_existing_merge():
     existing = _segment("Hello", speaker="SPEAKER_00", start=0.0, end=1.0)
     new = _segment("world.", speaker="SPEAKER_00", start=1.1, end=2.0)
+    input_concat = _concat_texts([existing.text, new.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([existing], [new])
 
@@ -53,11 +78,15 @@ def test_updated_segments_returned_for_existing_merge():
     assert updated_segments[0].id == existing.id
     assert updated_segments[0].text == "Hello world."
     assert removed_ids == []
+    assert existing.id not in removed_ids
+    assert new.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_forward_merge_trims_completed_prefix():
     a = _segment("First sentence. trailing", speaker="SPEAKER_00", start=0.0, end=4.0)
     b = _segment("continue here.", speaker="SPEAKER_01", start=4.0, end=6.0)
+    input_concat = _concat_texts([a.text, b.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
@@ -68,11 +97,34 @@ def test_forward_merge_trims_completed_prefix():
     assert updated_segments[0].text == "First sentence."
     assert updated_segments[1].text == "trailing continue here."
     assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
+
+
+def test_forward_merge_preserves_prefix_when_tail_incomplete_multi_sentence():
+    a = _segment("First sentence. trailing", speaker="SPEAKER_00", start=0.0, end=4.0)
+    b = _segment("continues here with more.", speaker="SPEAKER_01", start=4.0, end=6.0)
+    input_concat = _concat_texts([a.text, b.text])
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
+
+    assert len(segments) == 2
+    assert segments[0].speaker == "SPEAKER_00"
+    assert segments[0].text == "First sentence."
+    assert segments[1].speaker == "SPEAKER_01"
+    assert segments[1].text == "trailing continues here with more."
+    assert len(updated_segments) == 2
+    assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_forward_merge_drops_segment_when_only_incomplete():
     a = _segment("unfinished", speaker="SPEAKER_00", start=0.0, end=2.0)
     b = _segment("continues now.", speaker="SPEAKER_01", start=2.0, end=4.0)
+    input_concat = _concat_texts([a.text, b.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
@@ -82,11 +134,15 @@ def test_forward_merge_drops_segment_when_only_incomplete():
     assert len(updated_segments) == 1
     assert updated_segments[0].speaker == "SPEAKER_01"
     assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_forward_merge_drops_existing_tail_segment():
     existing = _segment("we're", speaker="SPEAKER_02", start=0.0, end=1.0)
     new = _segment("we're struggling to connect.", speaker="SPEAKER_01", start=1.2, end=3.0)
+    input_concat = _concat_texts([existing.text, new.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([existing], [new])
 
@@ -96,15 +152,38 @@ def test_forward_merge_drops_existing_tail_segment():
     assert len(updated_segments) == 1
     assert updated_segments[0].speaker == "SPEAKER_01"
     assert removed_ids == [existing.id]
+    assert new.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
+
+
+def test_forward_merge_deletes_segment_when_only_incomplete_and_longer_next():
+    existing = _segment("unfinished", speaker="SPEAKER_00", start=0.0, end=1.0)
+    new = _segment("unfinished but continues here.", speaker="SPEAKER_01", start=1.1, end=3.0)
+    input_concat = _concat_texts([existing.text, new.text])
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([existing], [new])
+
+    assert len(segments) == 1
+    assert segments[0].speaker == "SPEAKER_01"
+    assert segments[0].text == "unfinished unfinished but continues here."
+    assert len(updated_segments) == 1
+    assert updated_segments[0].speaker == "SPEAKER_01"
+    assert removed_ids == [existing.id]
+    assert new.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_lowercase_continuation_only_merges_same_speaker():
     a = _segment("hello", speaker="SPEAKER_00", start=0.0, end=1.0)
     b = _segment("world", speaker="SPEAKER_01", start=1.2, end=2.0)
+    input_concat = _concat_texts([a.text, b.text])
 
-    segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+    segments, _, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
     assert len(segments) == 2
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_backward_merge_first_sentence_from_next_segment():
@@ -115,6 +194,7 @@ def test_backward_merge_first_sentence_from_next_segment():
         end=2.0,
     )
     b = _segment("move. Mhmm.", speaker="SPEAKER_01", start=2.0, end=2.5)
+    input_concat = _concat_texts([a.text, b.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
@@ -127,6 +207,28 @@ def test_backward_merge_first_sentence_from_next_segment():
     assert updated_segments[0].speaker == "SPEAKER_02"
     assert updated_segments[1].speaker == "SPEAKER_01"
     assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
+
+
+def test_backward_merge_preserves_next_segment_when_more_sentences_remain():
+    a = _segment("This is an incomplete thought", speaker="SPEAKER_00", start=0.0, end=2.0)
+    b = _segment("continued here. Another sentence stays.", speaker="SPEAKER_01", start=2.0, end=4.0)
+    input_concat = _concat_texts([a.text, b.text])
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
+
+    assert len(segments) == 2
+    assert segments[0].speaker == "SPEAKER_00"
+    assert segments[0].text.endswith("continued here.")
+    assert segments[1].speaker == "SPEAKER_01"
+    assert segments[1].text == "Another sentence stays."
+    assert len(updated_segments) == 2
+    assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_backward_merge_single_lowercase_sentence_from_next_segment():
@@ -137,6 +239,7 @@ def test_backward_merge_single_lowercase_sentence_from_next_segment():
         end=2.0,
     )
     b = _segment("listen.", speaker="SPEAKER_02", start=2.0, end=2.2)
+    input_concat = _concat_texts([a.text, b.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
@@ -145,6 +248,25 @@ def test_backward_merge_single_lowercase_sentence_from_next_segment():
     assert segments[0].text.endswith("listen.")
     assert len(updated_segments) == 1
     assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
+
+
+def test_merge_lowercase_continuation_same_speaker():
+    a = _segment("Hello", speaker="SPEAKER_00", start=0.0, end=1.0)
+    b = _segment("world", speaker="SPEAKER_00", start=1.1, end=2.0)
+    input_concat = _concat_texts([a.text, b.text])
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
+
+    assert len(segments) == 1
+    assert segments[0].text == "Hello world"
+    assert len(updated_segments) == 1
+    assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_backward_merge_lowercase_phrase_between_same_speaker_segments():
@@ -163,6 +285,7 @@ def test_backward_merge_lowercase_phrase_between_same_speaker_segments():
         start=2.5,
         end=3.5,
     )
+    input_concat = _concat_texts([a.text, b.text, c.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b, c])
 
@@ -171,6 +294,10 @@ def test_backward_merge_lowercase_phrase_between_same_speaker_segments():
     assert "able to just, like, go to different countries" in segments[0].text
     assert len(updated_segments) == 1
     assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert c.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_backward_merge_lowercase_phrase_at_end_of_speaker_segment():
@@ -182,6 +309,7 @@ def test_backward_merge_lowercase_phrase_at_end_of_speaker_segment():
         end=2.0,
     )
     b = _segment("pretty much", speaker="SPEAKER_1", start=2.0, end=2.5)
+    input_concat = _concat_texts([a.text, b.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
@@ -190,11 +318,15 @@ def test_backward_merge_lowercase_phrase_at_end_of_speaker_segment():
     assert segments[0].text.endswith("pretty much")
     assert len(updated_segments) == 1
     assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
 
 
 def test_updated_segments_returned_for_new_non_merge():
     a = _segment("Hello.", speaker="SPEAKER_00", start=0.0, end=1.0)
     b = _segment("Hi.", speaker="SPEAKER_01", start=1.1, end=2.0)
+    input_concat = _concat_texts([a.text, b.text])
 
     segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
 
@@ -203,3 +335,87 @@ def test_updated_segments_returned_for_new_non_merge():
     assert updated_segments[0].text == "Hello."
     assert updated_segments[1].text == "Hi."
     assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
+
+
+def test_delta_seconds_shifts_timestamps():
+    a = _segment("Hello.", speaker="SPEAKER_00", start=1.0, end=2.0)
+    input_concat = _concat_texts([a.text])
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a], delta_seconds=5)
+
+    assert len(segments) == 1
+    assert segments[0].start == pytest.approx(6.0)
+    assert segments[0].end == pytest.approx(7.0)
+    assert len(updated_segments) == 1
+    assert removed_ids == []
+    assert a.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
+
+
+def test_no_merge_when_stt_provider_differs():
+    a = _segment("Hello", speaker="SPEAKER_00", start=0.0, end=1.0)
+    b = _segment("world.", speaker="SPEAKER_00", start=1.1, end=2.0)
+    a.stt_provider = "provider_a"
+    b.stt_provider = "provider_b"
+    input_concat = _concat_texts([a.text, b.text])
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
+
+    assert len(segments) == 2
+    assert segments[0].text == "Hello"
+    assert segments[1].text == "world."
+    assert len(updated_segments) == 2
+    assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
+
+
+def test_punctuation_cleanup_normalizes_spacing():
+    a = _segment("Hello , world .", speaker="SPEAKER_00", start=0.0, end=1.0)
+    input_concat = _concat_texts([a.text])
+    expected_concat = _normalize_punctuation(input_concat)
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a])
+
+    assert len(segments) == 1
+    assert segments[0].text == "Hello, world."
+    assert len(updated_segments) == 1
+    assert removed_ids == []
+    assert a.id not in removed_ids
+    assert _concat_segments(segments) == expected_concat
+
+
+def test_empty_text_segment_does_not_break_concat():
+    a = _segment("Hello", speaker="SPEAKER_00", start=0.0, end=1.0)
+    b = _segment("   ", speaker="SPEAKER_00", start=1.1, end=2.0)
+    input_concat = _concat_texts([a.text, b.text])
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
+
+    assert len(segments) == 1
+    assert segments[0].text == "Hello"
+    assert len(updated_segments) == 1
+    assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat
+
+
+def test_non_latin_text_merges_same_speaker():
+    a = _segment("こんにちは", speaker="SPEAKER_00", start=0.0, end=1.0)
+    b = _segment("世界。", speaker="SPEAKER_00", start=1.1, end=2.0)
+    input_concat = _concat_texts([a.text, b.text])
+
+    segments, updated_segments, removed_ids = TranscriptSegment.combine_segments([], [a, b])
+
+    assert len(segments) == 1
+    assert segments[0].text == "こんにちは 世界。"
+    assert len(updated_segments) == 1
+    assert removed_ids == []
+    assert a.id not in removed_ids
+    assert b.id not in removed_ids
+    assert _concat_segments(segments) == input_concat


### PR DESCRIPTION
Add comprehensive combine_segments tests covering concat preservation, removed_ids expectations, edge cases (delta shift, provider mismatch, punctuation cleanup, empty text), non-Latin merging, and switch to model_copy to clear pydantic warning.

---
_This pr was drafted by AI on behalf of @beastoin_