### PR TITLE
hotfix: DFU needs external flash to store the image

### DIFF
--- a/omi/firmware/omi/src/lib/core/button.c
+++ b/omi/firmware/omi/src/lib/core/button.c
@@ -18,6 +18,7 @@
 #include "speaker.h"
 #include "transport.h"
 #include "wdog_facade.h"
+#include "spi_flash.h"
 #ifdef CONFIG_OMI_ENABLE_WIFI
 #include "wifi.h"
 #endif
@@ -384,6 +385,11 @@ void turnoff_all()
     accel_off();
     k_msleep(100);
 #endif
+
+    rc = flash_off();
+    if (rc) {
+        LOG_ERR("Can not suspend the spi flash module: %d", rc);
+    }
 
     if (is_sd_on()) {
         app_sd_off();

--- a/omi/firmware/omi/src/main.c
+++ b/omi/firmware/omi/src/main.c
@@ -20,7 +20,6 @@
 #include "lib/core/storage.h"
 #endif
 #include "lib/core/sd_card.h"
-#include "spi_flash.h"
 #include "wdog_facade.h"
 #include <hal/nrf_reset.h>
 
@@ -159,16 +158,6 @@ void set_led_state()
     set_led_red(red);
 }
 
-static int suspend_unused_modules(void)
-{
-    int err = flash_off();
-    if (err) {
-        LOG_ERR("Can not suspend the spi flash module: %d", err);
-    }
-
-    return 0;
-}
-
 int main(void)
 {
     int ret;
@@ -205,15 +194,6 @@ int main(void)
         LOG_ERR("Failed to initialize LEDs (err %d)", ret);
         error_led_driver();
         return ret;
-    }
-
-    // Suspend unused modules
-    LOG_PRINTK("\n");
-    LOG_INF("Suspending unused modules...\n");
-    ret = suspend_unused_modules();
-    if (ret) {
-        LOG_ERR("Failed to suspend unused modules (err %d)", ret);
-        ret = 0;
     }
 
     // Initialize settings


### PR DESCRIPTION
- Don't suspend the external flash when device is running, this flash is needed for DFU progress.
- Only suspend the external flash when the device is totally off to save power