### PR TITLE
track firmware version on disconnect

### DIFF
--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -280,6 +280,11 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
 
   void onDeviceDisconnected() async {
     Logger.debug('onDisconnected inside: $connectedDevice');
+
+    final String trackFirmware = connectedDevice?.firmwareRevision ??
+        pairedDevice?.firmwareRevision ??
+        SharedPreferencesUtil().btDevice.firmwareRevision;
+
     _havingNewFirmware = false;
     setConnectedDevice(null);
     setisDeviceStorageSupport();
@@ -300,7 +305,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
         body: 'Please reconnect to continue using your Omi.',
       );
     });
-    MixpanelManager().deviceDisconnected();
+    MixpanelManager().deviceDisconnected(firmwareRevision: trackFirmware);
 
     // Retired 1s to prevent the race condition made by standby power of ble device
     Future.delayed(const Duration(seconds: 1), () {

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -281,9 +281,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
   void onDeviceDisconnected() async {
     Logger.debug('onDisconnected inside: $connectedDevice');
 
-    final String trackFirmware = connectedDevice?.firmwareRevision ??
-        pairedDevice?.firmwareRevision ??
-        SharedPreferencesUtil().btDevice.firmwareRevision;
+    final String trackFirmware = [connectedDevice?.firmwareRevision, pairedDevice?.firmwareRevision, SharedPreferencesUtil().btDevice.firmwareRevision].firstWhere((v) => v != null && v.isNotEmpty && v != 'Unknown', orElse: () => 'Unknown');
 
     _havingNewFirmware = false;
     setConnectedDevice(null);

--- a/app/lib/utils/analytics/mixpanel.dart
+++ b/app/lib/utils/analytics/mixpanel.dart
@@ -252,7 +252,9 @@ class MixpanelManager {
         ..._preferences.btDevice.toJson(),
       });
 
-  void deviceDisconnected() => track('Device Disconnected');
+  void deviceDisconnected({String? firmwareRevision}) => track('Device Disconnected', properties: {
+        if (firmwareRevision != null) 'firmware_revision': firmwareRevision,
+      });
 
   void memoriesPageCategoryOpened(MemoryCategory category) =>
       track('Fact Page Category Opened', properties: {'category': category.toString().split('.').last});


### PR DESCRIPTION
>When connecting device to app we already track that in Mixpanel—add a parameter for firmware version on that event so >we can see if connection issues correlate with people not updating firmware vs other problems.

we can't track firmware version at connect time because that time firmware version is not guaranteed to be available