### PR TITLE
Add formatting and l10n documentation to CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,19 @@ Module hierarchy (lowest to highest):
 
 - Memory management: free large objects immediately after use. E.g., `del` for byte arrays after processing, `.clear()` for dicts/lists holding data.
 
+### App (Flutter)
+
+- After modifying ARB files in `app/lib/l10n/`, regenerate localizations: `cd app && flutter gen-l10n`
+
+## Formatting
+
+Always format code after making changes. The pre-commit hook handles this automatically, but you can also run manually:
+
+- **Dart (app/)**: `dart format --line-length 120 <files>`
+  - Files ending in `.gen.dart` or `.g.dart` are auto-generated and should not be formatted manually.
+- **Python (backend/)**: `black --line-length 120 --skip-string-normalization <files>`
+- **C/C++ (firmware: omi/, omiGlass/)**: `clang-format -i <files>`
+
 ## Testing
 
 - Always run tests before committing:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,34 @@ from database.redis_db import r
 ### Memory Management
 Free large objects immediately after use. E.g., `del` for byte arrays after processing, `.clear()` for dicts/lists holding data.
 
+## App (Flutter)
+
+### Localization (l10n)
+After modifying ARB files in `app/lib/l10n/`, regenerate the localization files:
+```bash
+cd app && flutter gen-l10n
+```
+
+## Formatting
+
+Always format code after making changes. The pre-commit hook handles this automatically, but you can also run manually:
+
+### Dart (app/)
+```bash
+dart format --line-length 120 <files>
+```
+Note: Files ending in `.gen.dart` or `.g.dart` are auto-generated and should not be formatted manually.
+
+### Python (backend/)
+```bash
+black --line-length 120 --skip-string-normalization <files>
+```
+
+### C/C++ (firmware: omi/, omiGlass/)
+```bash
+clang-format -i <files>
+```
+
 ## Testing
 
 ### Always Run Tests Before Committing


### PR DESCRIPTION
Documents the formatting commands from the pre-commit hook and adds l10n regeneration instructions for Flutter ARB file changes. This ensures AI agents and contributors know how to properly format code and regenerate localizations.

---
_This pr was drafted by AI on behalf of @beastoin_