### PR TITLE
fix dialog navigator context crash

### DIFF
--- a/app/lib/pages/apps/list_item.dart
+++ b/app/lib/pages/apps/list_item.dart
@@ -183,10 +183,10 @@ class AppListItem extends StatelessWidget {
                             showDialog(
                               context: context,
                               builder: (c) => getDialog(
-                                context,
-                                () => Navigator.pop(context),
+                                c,
+                                () => Navigator.pop(c),
                                 () async {
-                                  Navigator.pop(context);
+                                  Navigator.pop(c);
                                   appProvider.toggleApp(app.id.toString(), true, index);
                                 },
                                 'Authorize External App',


### PR DESCRIPTION
https://github.com/BasedHardware/omi/blob/40754f7fff76a8071404db25aa5919f1fb41bae6/app/lib/pages/apps/list_item.dart#L189
here Navigator.pop used outdated context, so no navigator existed above it

closes #4308