### PR TITLE
webui: fix beta badge

### DIFF
--- a/web/app/src/components/layout/Sidebar.tsx
+++ b/web/app/src/components/layout/Sidebar.tsx
@@ -240,9 +240,11 @@ export function Sidebar({
                 height={showText ? 24 : 13}
                 className="object-contain"
               />
-              <span className="text-[10px] bg-purple-primary/20 text-purple-primary px-1.5 py-0.5 rounded-full font-medium">
-                Beta
-              </span>
+              {showText && (
+                <span className="text-[10px] bg-purple-primary/20 text-purple-primary px-1.5 py-0.5 rounded-full font-medium">
+                  Beta
+                </span>
+              )}
             </Link>
 
             {/* Mobile close button */}


### PR DESCRIPTION
<img width="93" height="121" alt="Bildschirmfoto 2026-01-21 um 23 32 34" src="https://github.com/user-attachments/assets/1307b4af-eb08-4589-97ed-1dc30e6cbed7" />

Gets hidden while the bar is closed and on small devices - not enough space.