### PR TITLE
Add speaker metadata handling for transcript segments

### DIFF
--- a/app/lib/desktop/pages/conversations/widgets/desktop_name_speaker_dialog.dart
+++ b/app/lib/desktop/pages/conversations/widgets/desktop_name_speaker_dialog.dart
@@ -196,7 +196,7 @@ class _DesktopNameSpeakerDialogState extends State<DesktopNameSpeakerDialog> {
           children: [
             Expanded(
               child: Text(
-                context.l10n.tagSpeaker(widget.speakerId),
+                context.l10n.tagSpeaker(TranscriptSegment.displaySpeakerId(widget.speakerId)),
                 style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
               ),
             ),

--- a/app/lib/desktop/pages/conversations/widgets/desktop_recording_widget.dart
+++ b/app/lib/desktop/pages/conversations/widgets/desktop_recording_widget.dart
@@ -574,7 +574,8 @@ class _DesktopRecordingWidgetState extends State<DesktopRecordingWidget> {
         final segment = entry.value;
         final isLatest = index == displaySegments.length - 1;
 
-        String speakerName = segment.isUser ? context.l10n.you : context.l10n.speakerWithId(segment.speakerId.toString());
+        final speakerDisplayId = TranscriptSegment.displaySpeakerId(segment.speakerId).toString();
+        String speakerName = segment.isUser ? context.l10n.you : context.l10n.speakerWithId(speakerDisplayId);
         if (segment.personId != null && !segment.isUser) {
           final person = people.firstWhereOrNull((p) => p.id == segment.personId);
           if (person != null) {

--- a/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
+++ b/app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart
@@ -191,7 +191,7 @@ class _NameSpeakerBottomSheetState extends State<NameSpeakerBottomSheet> {
           children: [
             Expanded(
               child: Text(
-                context.l10n.tagSpeaker(widget.speakerId),
+                context.l10n.tagSpeaker(TranscriptSegment.displaySpeakerId(widget.speakerId)),
                 style: const TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
               ),
             ),

--- a/app/lib/providers/speech_profile_provider.dart
+++ b/app/lib/providers/speech_profile_provider.dart
@@ -362,7 +362,7 @@ class SpeechProfileProvider extends ChangeNotifier
     // Filter out Omi question segments for speaker validation
     final userSegments = segments.where((e) => e.speakerId != omiSpeakerId).toList();
 
-    int speakersCount = userSegments.map((e) => e.speaker).toSet().length;
+    int speakersCount = userSegments.map((e) => e.speakerId).toSet().length;
     Logger.debug('_validateSingleSpeaker speakers count: $speakersCount');
     if (speakersCount > 1) {
       var speakerToWords = userSegments.fold<Map<int, int>>(

--- a/app/lib/widgets/transcript.dart
+++ b/app/lib/widgets/transcript.dart
@@ -528,7 +528,11 @@ class _TranscriptWidgetState extends State<TranscriptWidget> {
                                     ? 'omi'
                                     : (suggestion != null && person == null
                                         ? '${suggestion.personName}?'
-                                        : (person != null ? person.name : 'Speaker ${data.speakerId}')),
+                                        : (person != null
+                                            ? person.name
+                                            : context.l10n.speakerWithId(
+                                                TranscriptSegment.displaySpeakerId(data.speakerId).toString(),
+                                              ))),
                                 style: TextStyle(
                                   color: data.speakerId == omiSpeakerId || person != null
                                       ? Colors.grey.shade300

--- a/app/test/providers/capture_provider_test.dart
+++ b/app/test/providers/capture_provider_test.dart
@@ -65,4 +65,29 @@ void main() {
     expect(provider.taggingSegmentIds.contains('a'), false);
     expect(provider.hasTranscripts, true);
   });
+
+  test('TranscriptSegment parses speaker metadata with fallbacks', () {
+    final segmentWithSpeakerId = TranscriptSegment.fromJson({
+      'id': 'segment-1',
+      'text': 'Hello',
+      'speaker_id': '2',
+      'speaker_confidence': 0.82,
+      'start': 0,
+      'end': 1,
+    });
+
+    expect(segmentWithSpeakerId.speakerId, 2);
+    expect(segmentWithSpeakerId.speakerConfidence, 0.82);
+
+    final segmentWithSpeakerString = TranscriptSegment.fromJson({
+      'id': 'segment-2',
+      'text': 'Hi',
+      'speaker': 'SPEAKER_03',
+      'start': 0,
+      'end': 1,
+    });
+
+    expect(segmentWithSpeakerString.speakerId, 3);
+    expect(segmentWithSpeakerString.speakerConfidence, isNull);
+  });
 }


### PR DESCRIPTION
Fixes #3040 

### Motivation

- Flow speaker diarization metadata from backend into the app model and show per-speaker labels in transcript views so different speakers are visually distinguishable.

### Description

- Added `speakerId` (int) and `speakerConfidence` (double?) to `TranscriptSegment`, with robust parsing of `speaker`, `speaker_id` and `speaker_confidence` JSON fields and safe fallbacks to `0`/`null` when absent.
- Normalized speaker IDs and introduced `displaySpeakerId` helper to present human-friendly 1-based speaker numbers, and switched segment merging/logic to use `speakerId` instead of legacy `speaker` string.
- Updated UI rendering to use localized speaker labels (`context.l10n.speakerWithId(...)`) and `displaySpeakerId(...)` in transcript widgets and speaker-tagging dialogs so the UI shows "Speaker 1", "Speaker 2", etc., consistently during a session.
- Aligned speech-profile speaker counting to use `speakerId` and added a simple unit test to verify parsing fallbacks for `speaker_id` and `speaker_confidence`.

Files changed (key):
- `app/lib/backend/schema/transcript_segment.dart` (new fields, parsing, toJson, helpers)
- `app/lib/widgets/transcript.dart` (use localized speaker label/display helper)
- `app/lib/desktop/pages/conversations/widgets/desktop_recording_widget.dart` (live transcript label)
- `app/lib/desktop/pages/conversations/widgets/desktop_name_speaker_dialog.dart` and `app/lib/pages/conversation_detail/widgets/name_speaker_sheet.dart` (tag dialogs)
- `app/lib/providers/speech_profile_provider.dart` (counting fix)
- `app/test/providers/capture_provider_test.dart` (added parsing unit test)

### Testing

- Added unit test `app/test/providers/capture_provider_test.dart` to assert parsing of `speaker_id` and `speaker_confidence` and fallback from `speaker` string; the test was added but not executed in this environment.
- Attempted to run project tests via `app/test.sh` but it failed in this environment due to missing generated files and `flutter` not being available (environment lacks Flutter toolchain), so automated test execution did not complete.
- Attempted to run `dart format` but it failed because `dart` was not available in this environment; formatting should be run locally or in CI before merging.

Notes: The changes are backward-compatible: when `speaker_id`/`speaker_confidence` are absent the code falls back to previous behavior (`speakerId = 0`, `speakerConfidence = null`) so existing transcript flows remain functional.
