### PR TITLE
Upgrade backend-listen CPU

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -279,10 +279,10 @@ resources:
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
   requests:
-    cpu: 0.7
+    cpu: 1.5
     memory: 2Gi
   limits:
-    cpu: 1
+    cpu: 2
     memory: 3.5Gi
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
@@ -361,3 +361,7 @@ affinity:
               operator: In
               values:
                 - prod
+            - key: type
+              operator: In
+              values:
+                - high-cpu


### PR DESCRIPTION
1. Created new node pool with latest CPU family n4 - with stronger CPU - n4-highcpu-4 (4vCPUs, 8GB RAM) ✅
2. Increased CPU for backend listen pod: ✅
- Request: 0.7 -> 1.5
- Limit:  1 -> 2