### PR TITLE
fix(macos): prevent retain cycle in AudioManager device listener

### DIFF
--- a/app/macos/Runner/AudioManager.swift
+++ b/app/macos/Runner/AudioManager.swift
@@ -866,7 +866,9 @@ class AudioManager: NSObject, SCStreamDelegate, SCStreamOutput {
             mElement: kAudioObjectPropertyElementMain
         )
 
-        deviceListChangedListener = { (inNumberAddresses, inAddresses) in
+        deviceListChangedListener = { [weak self] (inNumberAddresses, inAddresses) in
+            guard let self = self else { return }
+
             // Invalidate any existing work item to reset the debounce period
             self.deviceChangeWorkItem?.cancel()
 


### PR DESCRIPTION
## Summary
- Add `[weak self]` capture to `deviceListChangedListener` closure to prevent potential memory leak from strong reference cycle

## Changes
```swift
-        deviceListChangedListener = { (inNumberAddresses, inAddresses) in
+        deviceListChangedListener = { [weak self] (inNumberAddresses, inAddresses) in
+            guard let self = self else { return }
```

## Test plan
- [x] macOS app builds successfully
- [x] Audio device switching still works

🤖 Generated with [Claude Code](https://claude.ai/code)