### PR TITLE
chore: add Codemagic notification email and build status script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,8 @@ web/app/next-env.d.ts
 .claude/settings.local.json
 LOCAL_DEV_SETUP.md
 app/macos/Config/Prod/GoogleService-Info.plist
+app/.metadata
+app/macos/DerivedData/
+app/macos/Runner/LocalDev.entitlements
+.env.local
+.backups/

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -166,6 +166,7 @@ workflows:
           - joan@basedhardware.com
           - nik@basedhardware.com
           - mohsin.lp710@gmail.com
+          - i@m13v.com
         notify:
           success: true
           failure: true
@@ -328,6 +329,7 @@ workflows:
           - joan@basedhardware.com
           - nik@basedhardware.com
           - mohsin.lp710@gmail.com
+          - i@m13v.com
         notify:
           success: true
           failure: true
@@ -519,6 +521,7 @@ workflows:
           - joan@basedhardware.com
           - nik@basedhardware.com
           - mohsin.lp710@gmail.com
+          - i@m13v.com
         notify:
           success: true
           failure: false
@@ -708,6 +711,7 @@ workflows:
           - joan@basedhardware.com
           - nik@basedhardware.com
           - mohsin.lp710@gmail.com
+          - i@m13v.com
         notify:
           success: true
           failure: false
@@ -875,6 +879,7 @@ workflows:
           - joan@basedhardware.com
           - nik@basedhardware.com
           - mohsin.lp710@gmail.com
+          - i@m13v.com
         notify:
           success: true
           failure: false
@@ -1019,6 +1024,7 @@ workflows:
           - joan@basedhardware.com
           - nik@basedhardware.com
           - mohsin.lp710@gmail.com
+          - i@m13v.com
         notify:
           success: true
           failure: false
@@ -1589,8 +1595,10 @@ workflows:
       email:
         recipients:
           - ngocthinhdp@gmail.com
+          - joan@basedhardware.com
           - nik@basedhardware.com
           - mohsin.lp710@gmail.com
+          - i@m13v.com
         notify:
           success: true
           failure: false
@@ -1750,6 +1758,7 @@ workflows:
           - joan@basedhardware.com
           - nik@basedhardware.com
           - mohsin.lp710@gmail.com
+          - i@m13v.com
         notify:
           success: true
           failure: false

--- a/scripts/cm-builds
+++ b/scripts/cm-builds
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Codemagic build status checker
+# Usage: cm-builds [limit]
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+# Load token from .env.local
+if [ -f "$ROOT_DIR/.env.local" ]; then
+  export $(grep CODEMAGIC_API_TOKEN "$ROOT_DIR/.env.local" | xargs)
+fi
+
+if [ -z "$CODEMAGIC_API_TOKEN" ]; then
+  echo "Error: CODEMAGIC_API_TOKEN not set"
+  echo "Add it to .env.local or export it"
+  exit 1
+fi
+
+LIMIT=${1:-10}
+
+curl -s -H "x-auth-token: $CODEMAGIC_API_TOKEN" \
+  "https://api.codemagic.io/builds?limit=$LIMIT" | jq -r '
+  .builds | .[] |
+  "\(
+    .status |
+    if . == "building" then "🔨 BUILDING"
+    elif . == "finished" then "✅ DONE    "
+    elif . == "queued" then "⏳ QUEUED  "
+    elif . == "canceled" then "❌ CANCELED"
+    elif . == "failed" then "💥 FAILED  "
+    elif . == "skipped" then "⏭️  SKIPPED "
+    else .
+    end
+  )  \((.config.name // "unknown workflow")[0:45])  (\(.branch))"'


### PR DESCRIPTION
## Summary
- Add i@m13v.com to all Codemagic build notification email lists
- Add `scripts/cm-builds` helper script for checking Codemagic build status from CLI
- Add `.env.local` and other local dev files to `.gitignore`

## Changes
- **codemagic.yaml**: Added email to 8 notification recipient lists
- **scripts/cm-builds**: New script to check build status using Codemagic API
- **.gitignore**: Added `.env.local`, `.backups/`, `app/.metadata`, `app/macos/DerivedData/`, `app/macos/Runner/LocalDev.entitlements`

## Test plan
- [x] `cm-builds` script works with valid API token
- [x] Gitignore entries don't affect tracked files

🤖 Generated with [Claude Code](https://claude.ai/code)