### PR TITLE
fix(ios): add missing Google Sign In configuration for dev environment

### DIFF
--- a/app/ios/Flutter/Custom.xcconfig
+++ b/app/ios/Flutter/Custom.xcconfig
@@ -1,3 +1,4 @@
 // This is a generated file; do not edit or check into version control.
-GOOGLE_REVERSE_CLIENT_ID=com.googleusercontent.apps.1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde
+GOOGLE_CLIENT_ID=208440318997-ukinsq3sijhcetkhr26ssqp1terbq7as.apps.googleusercontent.com
+GOOGLE_REVERSE_CLIENT_ID=com.googleusercontent.apps.208440318997-ukinsq3sijhcetkhr26ssqp1terbq7as
 //APP_BUNDLE_IDENTIFIER=<run `setup.sh ios` to generate the bundle id automatically, or uncomment this line and put your own here.>

--- a/app/ios/Podfile.lock
+++ b/app/ios/Podfile.lock
@@ -239,6 +239,8 @@ PODS:
     - Flutter
   - package_info_plus (0.4.5):
     - Flutter
+  - pasteboard (0.0.1):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -312,6 +314,7 @@ DEPENDENCIES:
   - nordic_dfu (from `.symlinks/plugins/nordic_dfu/ios`)
   - opus_flutter_ios (from `.symlinks/plugins/opus_flutter_ios/ios`)
   - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
+  - pasteboard (from `.symlinks/plugins/pasteboard/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
   - permission_handler_apple (from `.symlinks/plugins/permission_handler_apple/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
@@ -432,6 +435,8 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/opus_flutter_ios/ios"
   package_info_plus:
     :path: ".symlinks/plugins/package_info_plus/ios"
+  pasteboard:
+    :path: ".symlinks/plugins/pasteboard/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
   permission_handler_apple:
@@ -516,6 +521,7 @@ SPEC CHECKSUMS:
   nordic_dfu: e4fb6f461f4a290b28ea4b1dfb69071665cdfa3e
   opus_flutter_ios: f16ed3599997ced564ad44509e87003159a86def
   package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
+  pasteboard: 49088aeb6119d51f976a421db60d8e1ab079b63c
   path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
   permission_handler_apple: 4ed2196e43d0651e8ff7ca3483a069d469701f2d
   PromisesObjC: f5707f49cb48b9636751c5b2e7d227e43fba9f47

--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -154,5 +154,7 @@
 	<false/>
 	<key>com.posthog.posthog.AUTO_INIT</key>
 	<false/>
+	<key>GIDClientID</key>
+	<string>$(GOOGLE_CLIENT_ID)</string>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Fixes Google Sign In crashes on iOS by adding missing OAuth configuration. **This saved me significant debugging time.**

## Problem
- App crashed immediately when tapping "Sign in with Google"
- Crash occurred at `GIDSignIn.m:517` due to missing `GIDClientID`
- After fixing that, API calls failed due to missing `.dev.env` file

## Solution
1. **Add `GIDClientID` to Info.plist** - Required by Google Sign In SDK
2. **Update Custom.xcconfig** - Add `GOOGLE_CLIENT_ID` matching Firebase config
3. **Update Podfile.lock** - Include pasteboard plugin dependency

## Testing
✅ Successfully tested Google Sign In flow on iOS simulator  
✅ Backend API calls working correctly after sign-in  
✅ Language selection and onboarding flow complete

## Impact
Without these changes, **any developer running in dev flavor mode would experience immediate crashes** when trying to sign in with Google. This PR ensures the configuration works out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)