### PR TITLE
feat: add real-time AI mentor notifications

### DIFF
--- a/app/lib/backend/http/api/users.dart
+++ b/app/lib/backend/http/api/users.dart
@@ -589,3 +589,45 @@ Future<String?> generateDailySummary({String? date}) async {
     return null;
   }
 }
+
+// Mentor Notification Settings
+
+class MentorNotificationSettings {
+  final int frequency; // 0-5 where 0=disabled, 1=most selective, 5=most proactive
+
+  MentorNotificationSettings({required this.frequency});
+
+  factory MentorNotificationSettings.fromJson(Map<String, dynamic> json) {
+    return MentorNotificationSettings(
+      frequency: json['frequency'] ?? 0, // Default to 0 (disabled)
+    );
+  }
+}
+
+Future<MentorNotificationSettings?> getMentorNotificationSettings() async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/users/mentor-notification-settings',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+
+  Logger.debug('getMentorNotificationSettings response: ${response?.body}');
+  if (response != null && response.statusCode == 200) {
+    return MentorNotificationSettings.fromJson(jsonDecode(response.body));
+  }
+  return null;
+}
+
+Future<bool> setMentorNotificationSettings(int frequency) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/users/mentor-notification-settings',
+    headers: {},
+    method: 'PATCH',
+    body: jsonEncode({'frequency': frequency}),
+  );
+  if (response == null) return false;
+
+  Logger.debug('setMentorNotificationSettings response: ${response.body}');
+  return response.statusCode == 200;
+}

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -181,10 +181,10 @@ class SharedPreferencesUtil {
 
   bool get dailyReflectionEnabled => getBool('dailyReflectionEnabled', defaultValue: true);
 
-  // Notification frequency (0-5): 0 = off, 5 = most frequent. Default is 3 (balanced)
+  // Notification frequency (0-5): 0 = off, 5 = most frequent. Default is 0 (disabled)
   set notificationFrequency(int value) => saveInt('notificationFrequency', value);
 
-  int get notificationFrequency => getInt('notificationFrequency', defaultValue: 3);
+  int get notificationFrequency => getInt('notificationFrequency', defaultValue: 0);
 
   // Task category order for drag-and-drop sorting persistence
   // Format: { "today": ["id1", "id2"], "tomorrow": ["id3"] }

--- a/app/lib/pages/settings/notifications_settings_page.dart
+++ b/app/lib/pages/settings/notifications_settings_page.dart
@@ -18,14 +18,14 @@ class NotificationsSettingsPage extends StatefulWidget {
 
 class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
   bool _isLoading = true;
-  
-  // Notification frequency (0-5)
-  int _notificationFrequency = 3;
-  
+
+  // Notification frequency (0-5), default 0 (disabled)
+  int _notificationFrequency = 0;
+
   // Daily Summary settings
   bool _dailySummaryEnabled = true;
   int _dailySummaryHour = 22; // Default to 10 PM
-  
+
   // Daily Reflection settings
   bool _dailyReflectionEnabled = true;
 
@@ -39,27 +39,36 @@ class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
   Future<void> _loadSettings() async {
     // Load Daily Summary settings from API
     final settings = await getDailySummarySettings();
-    
+
+    // Load Mentor Notification settings from API
+    final mentorSettings = await getMentorNotificationSettings();
+
     // Load settings from local prefs
     final reflectionEnabled = SharedPreferencesUtil().dailyReflectionEnabled;
-    final frequency = SharedPreferencesUtil().notificationFrequency;
-    
+    final localFrequency = SharedPreferencesUtil().notificationFrequency;
+
     if (mounted) {
       setState(() {
         if (settings != null) {
           _dailySummaryEnabled = settings.enabled;
           _dailySummaryHour = settings.hour;
         }
+        // Use backend value if available, otherwise use local
+        _notificationFrequency = mentorSettings?.frequency ?? localFrequency;
+        // Sync local with backend
+        if (mentorSettings != null) {
+          SharedPreferencesUtil().notificationFrequency = mentorSettings.frequency;
+        }
         _dailyReflectionEnabled = reflectionEnabled;
-        _notificationFrequency = frequency;
         _isLoading = false;
       });
     }
   }
 
-  void _updateNotificationFrequency(int value) {
+  Future<void> _updateNotificationFrequency(int value) async {
     setState(() => _notificationFrequency = value);
     SharedPreferencesUtil().notificationFrequency = value;
+    await setMentorNotificationSettings(value);
   }
 
   String _getFrequencyLabel(BuildContext context, int value) {
@@ -121,7 +130,7 @@ class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
   void _updateDailyReflectionEnabled(bool value) {
     setState(() => _dailyReflectionEnabled = value);
     SharedPreferencesUtil().dailyReflectionEnabled = value;
-    
+
     // Schedule or cancel the notification based on the setting
     if (value) {
       DailyReflectionNotification.scheduleDailyNotification(channelKey: 'channel');
@@ -335,9 +344,9 @@ class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
                     ),
                   ),
                   _buildFrequencyCard(),
-                  
+
                   const SizedBox(height: 32),
-                  
+
                   // Daily Summary Section
                   _buildSectionHeader(context.l10n.dailySummary),
                   const SizedBox(height: 8),
@@ -353,9 +362,9 @@ class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
                     ),
                   ),
                   _buildDailySummaryCard(),
-                  
+
                   const SizedBox(height: 32),
-                  
+
                   // Daily Reflection Section
                   _buildSectionHeader(context.l10n.dailyReflection),
                   const SizedBox(height: 8),
@@ -426,18 +435,14 @@ class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
                 width: 48,
                 height: 48,
                 decoration: BoxDecoration(
-                  color: _notificationFrequency == 0 
-                      ? Colors.grey.shade800 
-                      : const Color(0xFF6366F1).withOpacity(0.2),
+                  color: _notificationFrequency == 0 ? Colors.grey.shade800 : const Color(0xFF6366F1).withOpacity(0.2),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Center(
                   child: Text(
                     '$_notificationFrequency',
                     style: TextStyle(
-                      color: _notificationFrequency == 0 
-                          ? Colors.grey.shade500 
-                          : const Color(0xFF6366F1),
+                      color: _notificationFrequency == 0 ? Colors.grey.shade500 : const Color(0xFF6366F1),
                       fontSize: 20,
                       fontWeight: FontWeight.w700,
                     ),
@@ -446,9 +451,9 @@ class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
               ),
             ],
           ),
-          
+
           const SizedBox(height: 20),
-          
+
           // Slider
           SliderTheme(
             data: SliderTheme.of(context).copyWith(
@@ -467,7 +472,7 @@ class _NotificationsSettingsPageState extends State<NotificationsSettingsPage> {
               onChanged: (value) => _updateNotificationFrequency(value.round()),
             ),
           ),
-          
+
           // Labels
           Padding(
             padding: const EdgeInsets.symmetric(horizontal: 8),

--- a/backend/database/notifications.py
+++ b/backend/database/notifications.py
@@ -135,6 +135,53 @@ def set_daily_summary_enabled(uid: str, enabled: bool) -> bool:
     return True
 
 
+# **************************************
+# *** Mentor Notification Frequency ***
+# **************************************
+
+# Default: 0 (disabled by default, user must explicitly enable)
+# Range: 0-5 where 0=disabled, 1=most selective, 5=most proactive
+DEFAULT_MENTOR_NOTIFICATION_FREQUENCY = 0
+
+
+def get_mentor_notification_frequency(uid: str) -> int:
+    """
+    Get user's mentor notification frequency preference.
+    Returns 0-5 where:
+    - 0 = disabled
+    - 1 = ultra selective (least frequent)
+    - 3 = balanced (default)
+    - 5 = very proactive (most frequent)
+    """
+    user_ref = db.collection('users').document(uid).get()
+    if user_ref.exists:
+        user_data = user_ref.to_dict()
+        return user_data.get('mentor_notification_frequency', DEFAULT_MENTOR_NOTIFICATION_FREQUENCY)
+    return DEFAULT_MENTOR_NOTIFICATION_FREQUENCY
+
+
+def set_mentor_notification_frequency(uid: str, frequency: int) -> bool:
+    """
+    Set user's mentor notification frequency preference.
+
+    Args:
+        uid: User ID
+        frequency: Notification frequency (0-5)
+
+    Returns:
+        True if successful
+
+    Raises:
+        ValueError if frequency is not in valid range
+    """
+    if not (0 <= frequency <= 5):
+        raise ValueError(f"Invalid frequency: {frequency}. Must be 0-5.")
+
+    user_ref = db.collection('users').document(uid)
+    user_ref.set({'mentor_notification_frequency': frequency}, merge=True)
+    return True
+
+
 def get_all_tokens(uid: str) -> list[str]:
     """Get all device tokens for a user from subcollection and legacy field"""
     tokens = []

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -323,7 +323,9 @@ async def _websocket_util_trigger(
                         current_conversation_id = memory_id
                     if len(transcript_queue) >= TRANSCRIPT_QUEUE_WARN_SIZE:
                         print(f"Warning: transcript_queue size {len(transcript_queue)}", uid)
-                    transcript_queue.append({'segments': segments, 'memory_id': memory_id})
+                    # Use memory_id if available, otherwise use current_conversation_id for conversations
+                    conversation_or_memory_id = memory_id or current_conversation_id
+                    transcript_queue.append({'segments': segments, 'memory_id': conversation_or_memory_id})
                     continue
 
                 # Process conversation request

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1493,6 +1493,13 @@ async def _stream_handler(
                 if transcript_send is not None and user_has_credits:
                     transcript_send([segment.dict() for segment in transcript_segments])
 
+                # Trigger realtime integrations (including mentor notifications)
+                from utils.app_integrations import trigger_realtime_integrations
+                try:
+                    await trigger_realtime_integrations(uid, [s.dict() for s in transcript_segments], current_conversation_id)
+                except Exception as e:
+                    print(f"Error triggering realtime integrations: {e}", uid, session_id)
+
                 # Onboarding: pass segments to handler for answer detection
                 if onboarding_handler and not onboarding_handler.completed:
                     onboarding_handler.on_segments_received([s.dict() for s in transcript_segments])

--- a/backend/utils/mentor_notifications.py
+++ b/backend/utils/mentor_notifications.py
@@ -1,0 +1,325 @@
+"""
+Mentor notification system for providing real-time mentorship during conversations.
+
+This module processes conversation segments and determines when to send mentor notifications
+based on the user's notification frequency preference (0-5 scale).
+"""
+
+import time
+import threading
+import logging
+from typing import List, Dict, Any
+from collections import defaultdict
+from openai import OpenAI
+import json
+import os
+
+from database.notifications import get_mentor_notification_frequency
+
+logger = logging.getLogger(__name__)
+
+# Initialize OpenAI client
+client = None
+if os.getenv('OPENAI_API_KEY'):
+    client = OpenAI(api_key=os.getenv('OPENAI_API_KEY'))
+else:
+    logger.warning("OPENAI_API_KEY not found - mentor notifications will be disabled")
+
+
+class MessageBuffer:
+    """Manages conversation buffers for mentor notification analysis."""
+
+    def __init__(self):
+        self.buffers: Dict[str, Dict[str, Any]] = {}
+        self.lock = threading.Lock()
+        self.cleanup_interval = 600  # 10 minutes
+        self.last_cleanup = time.time()
+        self.silence_threshold = 120  # 2 minutes silence threshold
+        self.min_words_after_silence = 5  # minimum words needed after silence
+
+    def get_buffer(self, session_id: str) -> Dict[str, Any]:
+        """Get or create buffer for a session."""
+        current_time = time.time()
+
+        # Cleanup old sessions periodically
+        if current_time - self.last_cleanup > self.cleanup_interval:
+            self.cleanup_old_sessions()
+
+        with self.lock:
+            if session_id not in self.buffers:
+                self.buffers[session_id] = {
+                    'messages': [],
+                    'last_analysis_time': time.time(),
+                    'last_activity': current_time,
+                    'words_after_silence': 0,
+                    'silence_detected': False
+                }
+            else:
+                # Check for silence period
+                time_since_activity = current_time - self.buffers[session_id]['last_activity']
+                if time_since_activity > self.silence_threshold:
+                    self.buffers[session_id]['silence_detected'] = True
+                    self.buffers[session_id]['words_after_silence'] = 0
+                    self.buffers[session_id]['messages'] = []  # Clear old messages after silence
+
+                self.buffers[session_id]['last_activity'] = current_time
+
+        return self.buffers[session_id]
+
+    def cleanup_old_sessions(self):
+        """Remove sessions older than 1 hour."""
+        current_time = time.time()
+        with self.lock:
+            expired_sessions = [
+                session_id for session_id, data in self.buffers.items()
+                if current_time - data['last_activity'] > 3600  # Remove sessions older than 1 hour
+            ]
+            for session_id in expired_sessions:
+                del self.buffers[session_id]
+            self.last_cleanup = current_time
+            if expired_sessions:
+                logger.info(f"Cleaned up {len(expired_sessions)} expired mentor notification sessions")
+
+
+# Global message buffer
+message_buffer = MessageBuffer()
+
+# Minimum segments needed before analysis (real-time processing)
+MIN_SEGMENTS_FOR_ANALYSIS = 3
+
+
+def extract_topics(discussion_text: str) -> List[str]:
+    """Extract topics from the discussion using OpenAI."""
+    if not client:
+        return []
+
+    try:
+        response = client.chat.completions.create(
+            model="gpt-4",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "You are a topic extraction specialist. Extract all relevant topics from the conversation. Return ONLY a JSON array of topic strings, nothing else. Example format: [\"topic1\", \"topic2\"]"
+                },
+                {
+                    "role": "user",
+                    "content": f"Extract all topics from this conversation:\n{discussion_text}"
+                }
+            ],
+            temperature=0.3,
+            max_tokens=150
+        )
+
+        # Parse the response text as JSON
+        response_text = response.choices[0].message.content.strip()
+        topics = json.loads(response_text)
+        logger.info(f"Extracted topics: {topics}")
+        return topics
+    except Exception as e:
+        logger.error(f"Error extracting topics: {str(e)}")
+        return []
+
+
+def adjust_prompt_for_frequency(base_prompt: str, frequency: int) -> str:
+    """
+    Adjust the evaluation criteria based on frequency level.
+
+    Args:
+        base_prompt: The base mentor prompt
+        frequency: 0-5 where 1=most selective, 5=most proactive
+
+    Returns:
+        Modified prompt with adjusted evaluation criteria
+    """
+    if frequency == 1:
+        # Ultra selective - only intervene for critical situations
+        adjustment = """
+CRITICAL: Be EXTREMELY selective. Only interrupt if:
+- The situation is urgent and time-sensitive
+- Your advice could prevent a significant mistake or missed opportunity
+- The insight is truly exceptional and game-changing
+"""
+    elif frequency == 2:
+        # Very selective
+        adjustment = """
+NOTE: Be very selective. Only interrupt if:
+- You have strong, actionable advice that significantly impacts the situation
+- The timing is critical
+"""
+    elif frequency == 3:
+        # Balanced (default)
+        adjustment = """
+NOTE: Be balanced in your interventions. Interrupt when:
+- You have clear, valuable insights that impact the situation
+- The advice is timely and actionable
+"""
+    elif frequency == 4:
+        # Proactive
+        adjustment = """
+NOTE: Be proactive. Consider interrupting when:
+- You have relevant experience or insights to share
+- You can add clarity or perspective to the discussion
+"""
+    else:  # frequency == 5
+        # Very proactive
+        adjustment = """
+NOTE: Be highly proactive. Look for opportunities to:
+- Share relevant insights and experiences
+- Offer guidance and perspective
+- Help clarify thinking and decision-making
+"""
+
+    # Insert adjustment after the first paragraph
+    lines = base_prompt.split('\n')
+    insert_index = next((i for i, line in enumerate(lines) if line.startswith('STEP 1')), 1)
+    lines.insert(insert_index, adjustment)
+
+    return '\n'.join(lines)
+
+
+def create_notification_data(messages: List[Dict[str, Any]], frequency: int) -> Dict[str, Any]:
+    """
+    Create notification data with prompt template adjusted for frequency level.
+
+    Args:
+        messages: List of message dicts with 'text', 'timestamp', 'is_user'
+        frequency: User's notification frequency preference (1-5)
+
+    Returns:
+        Notification data dict with prompt, params, and context filters
+    """
+    # Format the discussion with speaker labels
+    formatted_discussion = []
+    for msg in messages:
+        speaker = "{{user_name}}" if msg.get('is_user') else "other"
+        formatted_discussion.append(f"{msg['text']} ({speaker})")
+
+    discussion_text = "\n".join(formatted_discussion)
+
+    # Extract topics from the discussion
+    topics = extract_topics(discussion_text)
+
+    base_system_prompt = """You are {{user_name}}'s personal AI mentor. Your FIRST task is to determine if this conversation warrants interruption.
+
+STEP 1 - Evaluate SILENTLY if ALL these conditions are met:
+1. {{user_name}} is participating in the conversation (messages marked with '({{user_name}})' must be present)
+2. {{user_name}} has expressed a specific problem, challenge, goal, or question
+3. You have a STRONG, CLEAR opinion that would significantly impact {{user_name}}'s situation
+4. The insight is time-sensitive and worth interrupting for
+
+If ANY condition is not met, respond with an empty string and nothing else.
+
+STEP 2 - Only if ALL conditions are met, provide feedback following these guidelines:
+- NEVER use markdown formatting (no code blocks, no backticks, no asterisks)
+- Speak DIRECTLY to {{user_name}} - no analysis or third-person commentary
+- Take a clear stance - no "however" or "on the other hand"
+- Keep it under 300 chars
+- Use simple, everyday words like you're talking to a friend
+- Reference specific details from what {{user_name}} said
+- Be bold and direct - {{user_name}} needs clarity, not options
+- End with a specific question about implementing your advice
+
+What we know about {{user_name}}: {{user_facts}}
+
+Current discussion:
+{text}
+
+Previous discussions and context: {{user_context}}
+
+Chat history: {{user_chat}}
+
+Remember: First evaluate silently, then either respond with empty string OR give experience-backed advice.""".format(text=discussion_text)
+
+    # Adjust prompt based on frequency level
+    adjusted_prompt = adjust_prompt_for_frequency(base_system_prompt, frequency)
+
+    return {
+        "prompt": adjusted_prompt,
+        "params": ["user_name", "user_facts", "user_context", "user_chat"],
+        "context": {
+            "filters": {
+                "people": [],
+                "entities": [],
+                "topics": topics
+            }
+        }
+    }
+
+
+def process_mentor_notification(uid: str, segments: List[Dict[str, Any]]) -> Dict[str, Any] | None:
+    """
+    Process segments for mentor notification.
+
+    Args:
+        uid: User ID
+        segments: List of conversation segments
+
+    Returns:
+        Notification data dict if notification should be sent, None otherwise
+    """
+    # Check if mentor notifications are enabled for this user
+    frequency = get_mentor_notification_frequency(uid)
+    if frequency == 0:
+        return None
+
+    if not client:
+        logger.warning("OpenAI client not initialized - cannot process mentor notification")
+        return None
+
+    current_time = time.time()
+    buffer_data = message_buffer.get_buffer(uid)
+
+    # Process new messages
+    for segment in segments:
+        if not segment.get('text'):
+            continue
+
+        text = segment['text'].strip()
+        if text:
+            timestamp = segment.get('start', 0) or current_time
+            is_user = segment.get('is_user', False)
+
+            # Count words after silence
+            if buffer_data['silence_detected']:
+                words_in_segment = len(text.split())
+                buffer_data['words_after_silence'] += words_in_segment
+
+                # If we have enough words, start fresh conversation
+                if buffer_data['words_after_silence'] >= message_buffer.min_words_after_silence:
+                    buffer_data['silence_detected'] = False
+                    buffer_data['last_analysis_time'] = current_time  # Reset analysis timer
+                    logger.info(f"Silence period ended for user {uid}, starting fresh conversation")
+
+            can_append = (
+                buffer_data['messages'] and
+                abs(buffer_data['messages'][-1]['timestamp'] - timestamp) < 2.0 and
+                buffer_data['messages'][-1].get('is_user') == is_user
+            )
+
+            if can_append:
+                buffer_data['messages'][-1]['text'] += ' ' + text
+            else:
+                buffer_data['messages'].append({
+                    'text': text,
+                    'timestamp': timestamp,
+                    'is_user': is_user
+                })
+
+    # Real-time analysis: Process immediately when we have enough segments
+    # Rate limiting is handled by app_integrations.py (1 notification per 300s)
+    if (len(buffer_data['messages']) >= MIN_SEGMENTS_FOR_ANALYSIS and
+        not buffer_data['silence_detected']):  # Only analyze if not in silence period
+
+        # Sort messages by timestamp
+        sorted_messages = sorted(buffer_data['messages'], key=lambda x: x['timestamp'])
+
+        # Create notification with formatted discussion
+        notification_data = create_notification_data(sorted_messages, frequency)
+
+        buffer_data['last_analysis_time'] = current_time
+        buffer_data['messages'] = []  # Clear buffer after analysis
+
+        logger.info(f"Mentor notification ready for user {uid} (frequency: {frequency})")
+        return notification_data
+
+    return None


### PR DESCRIPTION
## Summary
Adds built-in AI mentor that provides real-time guidance during conversations with configurable notification frequency.

## Changes

### Backend
- ✅ **New file**: `utils/mentor_notifications.py` - Core mentor logic with real-time analysis
- ✅ **Modified**: `routers/transcribe.py` - Integrated mentor into `/v4/listen` endpoint
- ✅ **Modified**: `routers/users.py` - Added GET/PATCH endpoints for mentor settings
- ✅ **Modified**: `database/notifications.py` - Store user frequency preference (0-5)
- ✅ **Modified**: `utils/app_integrations.py` - Process mentor as virtual "Omi" app
- ✅ **Modified**: `routers/pusher.py` - Fix to queue conversation segments

### Frontend (Mobile + Desktop)
- ✅ **Modified**: `app/lib/backend/http/api/users.dart` - API client for mentor settings
- ✅ **Modified**: `app/lib/backend/preferences.dart` - Local storage (default: 0)
- ✅ **Modified**: `app/lib/pages/settings/notifications_settings_page.dart` - Mobile UI
- ✅ **Modified**: `app/lib/desktop/pages/settings/desktop_settings_modal.dart` - Desktop UI

## Features
- **Real-time evaluation** - Analyzes conversation segments as they stream in
- **Configurable frequency** - Slider from 0 (disabled) to 5 (very proactive)
- **Smart filtering** - Only interrupts for significant insights
- **Rate limiting** - Max 1 notification per 5 minutes
- **Silence detection** - Resets context after 2 minutes of silence
- **Notifications as "Omi"** - Shows as system messages

## Default Behavior
- **Disabled by default** - Users must explicitly enable (slider at 0)
- **Backend and frontend synced** - Settings stored in Firestore
- **Works on all platforms** - iOS, macOS tested

## Test Plan
- [x] Tested on iOS simulator
- [x] Tested on physical iPhone (WiFi)
- [x] Tested on macOS
- [x] Verified default is 0 (disabled)
- [x] Verified notifications show as "Omi"
- [x] Verified frequency slider works

🤖 Generated with [Claude Code](https://claude.com/claude-code)