### PR TITLE
direct device - backend sync via wifi

### DIFF
--- a/app/lib/backend/http/api/device.dart
+++ b/app/lib/backend/http/api/device.dart
@@ -22,3 +22,31 @@ Future<Map> getLatestFirmwareVersion({
 
   return jsonDecode(res.body);
 }
+
+Future<String?> generateDeviceSyncToken(String deviceId) async {
+  var res = await makeApiCall(
+    url: "${Env.apiBaseUrl}v1/device/generate-sync-token?device_id=$deviceId",
+    headers: {},
+    body: '',
+    method: 'POST',
+  );
+
+  if (res == null || res.statusCode != 200) {
+    return null;
+  }
+
+  final data = jsonDecode(res.body);
+  return data['token'] as String?;
+}
+
+Future<bool> revokeDeviceSyncToken(String deviceId) async {
+  var res = await makeApiCall(
+    url: "${Env.apiBaseUrl}v1/device/revoke-sync-token?device_id=$deviceId",
+    headers: {},
+    body: '',
+    method: 'POST',
+  );
+
+  return res != null && res.statusCode == 200;
+}
+

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -297,6 +297,32 @@ class SharedPreferencesUtil {
 
   set hasSeenFastTransferIntro(bool value) => saveBool('hasSeenFastTransferIntro', value);
 
+  // Direct WiFi Sync settings (device uploads directly to backend when charging)
+  bool get directWifiSyncEnabled => getBool('directWifiSyncEnabled');
+
+  set directWifiSyncEnabled(bool value) => saveBool('directWifiSyncEnabled', value);
+
+  String get directWifiSyncSSID => getString('directWifiSyncSSID');
+
+  set directWifiSyncSSID(String value) => saveString('directWifiSyncSSID', value);
+
+  String get directWifiSyncPassword => getString('directWifiSyncPassword');
+
+  set directWifiSyncPassword(String value) => saveString('directWifiSyncPassword', value);
+
+  String get directWifiSyncToken => getString('directWifiSyncToken');
+
+  set directWifiSyncToken(String value) => saveString('directWifiSyncToken', value);
+
+  bool get directWifiSyncConfigured => directWifiSyncSSID.isNotEmpty && directWifiSyncToken.isNotEmpty;
+
+  void clearDirectWifiSyncConfig() {
+    directWifiSyncEnabled = false;
+    directWifiSyncSSID = '';
+    directWifiSyncPassword = '';
+    directWifiSyncToken = '';
+  }
+
   bool get hasSpeakerProfile => getBool('hasSpeakerProfile');
 
   set hasSpeakerProfile(bool value) => saveBool('hasSpeakerProfile', value);

--- a/app/lib/services/devices/device_connection.dart
+++ b/app/lib/services/devices/device_connection.dart
@@ -532,6 +532,57 @@ abstract class DeviceConnection {
     return null;
   }
 
+  // Direct WiFi Sync - device uploads directly to backend when charging
+  Future<bool> setupDirectWifiSync({
+    required String ssid,
+    required String password,
+    required String backendUrl,
+    required String authToken,
+  }) async {
+    if (await isConnected()) {
+      return await performSetupDirectWifiSync(
+        ssid: ssid,
+        password: password,
+        backendUrl: backendUrl,
+        authToken: authToken,
+      );
+    }
+    _showDeviceDisconnectedNotification();
+    return false;
+  }
+
+  Future<bool> performSetupDirectWifiSync({
+    required String ssid,
+    required String password,
+    required String backendUrl,
+    required String authToken,
+  }) async {
+    return false;
+  }
+
+  Future<bool> clearDirectWifiSync() async {
+    if (await isConnected()) {
+      return await performClearDirectWifiSync();
+    }
+    _showDeviceDisconnectedNotification();
+    return false;
+  }
+
+  Future<bool> performClearDirectWifiSync() async {
+    return false;
+  }
+
+  Future<DirectSyncStatus> getDirectSyncStatus() async {
+    if (await isConnected()) {
+      return await performGetDirectSyncStatus();
+    }
+    return DirectSyncStatus.unknown();
+  }
+
+  Future<DirectSyncStatus> performGetDirectSyncStatus() async {
+    return DirectSyncStatus.unknown();
+  }
+
   void _showDeviceDisconnectedNotification() {
     final ctx = MyApp.navigatorKey.currentContext;
     final deviceName = device.name;

--- a/app/lib/services/devices/models.dart
+++ b/app/lib/services/devices/models.dart
@@ -30,6 +30,40 @@ const String storageDataStreamServiceUuid = '30295780-4301-eabd-2904-2849adfeae4
 const String storageDataStreamCharacteristicUuid = '30295781-4301-eabd-2904-2849adfeae43';
 const String storageReadControlCharacteristicUuid = '30295782-4301-eabd-2904-2849adfeae43';
 const String storageWifiCharacteristicUuid = '30295783-4301-eabd-2904-2849adfeae43';
+const String storageDirectSyncCharacteristicUuid = '30295784-4301-eabd-2904-2849adfeae43';
+
+class DirectSyncStatus {
+  final bool hasConfig;
+  final bool isEnabled;
+  final bool isConnected;
+  final int lastSyncResult;
+
+  DirectSyncStatus({
+    required this.hasConfig,
+    required this.isEnabled,
+    required this.isConnected,
+    required this.lastSyncResult,
+  });
+
+  factory DirectSyncStatus.unknown() => DirectSyncStatus(
+        hasConfig: false,
+        isEnabled: false,
+        isConnected: false,
+        lastSyncResult: -1,
+      );
+
+  factory DirectSyncStatus.fromBytes(List<int> bytes) {
+    if (bytes.length < 4) return DirectSyncStatus.unknown();
+    return DirectSyncStatus(
+      hasConfig: bytes[0] == 1,
+      isEnabled: bytes[1] == 1,
+      isConnected: bytes[2] == 1,
+      lastSyncResult: bytes[3],
+    );
+  }
+
+  bool get isConfigured => hasConfig && isEnabled;
+}
 
 const String accelDataStreamServiceUuid = '32403790-0000-1000-7450-bf445e5829a2';
 const String accelDataStreamCharacteristicUuid = '32403791-0000-1000-7450-bf445e5829a2';

--- a/backend/database/device_tokens.py
+++ b/backend/database/device_tokens.py
@@ -1,0 +1,67 @@
+import secrets
+from datetime import datetime, timedelta
+from typing import Optional
+from google.cloud import firestore
+
+db = firestore.Client()
+
+TOKEN_EXPIRY_DAYS = 30
+
+
+def create_device_sync_token(uid: str, device_id: str) -> str:
+    token = secrets.token_urlsafe(32)
+    doc_ref = db.collection("device_sync_tokens").document(token)
+    doc_ref.set({
+        "uid": uid,
+        "device_id": device_id,
+        "created_at": datetime.utcnow(),
+        "expires_at": datetime.utcnow() + timedelta(days=TOKEN_EXPIRY_DAYS),
+    })
+    return token
+
+
+def validate_device_sync_token(token: str, device_id: str) -> Optional[dict]:
+    doc = db.collection("device_sync_tokens").document(token).get()
+    if not doc.exists:
+        return None
+    
+    data = doc.to_dict()
+    if data.get("device_id") != device_id:
+        return None
+    
+    expires_at = data.get("expires_at")
+    if expires_at and expires_at.replace(tzinfo=None) < datetime.utcnow():
+        return None
+    
+    return data
+
+
+def revoke_device_sync_token(uid: str, device_id: str) -> int:
+    query = db.collection("device_sync_tokens").where("uid", "==", uid).where("device_id", "==", device_id)
+    docs = query.stream()
+    count = 0
+    for doc in docs:
+        doc.reference.delete()
+        count += 1
+    return count
+
+
+def revoke_all_user_device_tokens(uid: str) -> int:
+    query = db.collection("device_sync_tokens").where("uid", "==", uid)
+    docs = query.stream()
+    count = 0
+    for doc in docs:
+        doc.reference.delete()
+        count += 1
+    return count
+
+
+def get_user_device_tokens(uid: str) -> list[dict]:
+    query = db.collection("device_sync_tokens").where("uid", "==", uid)
+    docs = query.stream()
+    tokens = []
+    for doc in docs:
+        data = doc.to_dict()
+        data["token_id"] = doc.id[:8] + "..."
+        tokens.append(data)
+    return tokens

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,7 @@ from routers import (
     users,
     trends,
     sync,
+    device_sync,
     apps,
     custom_auth,
     payment,
@@ -79,6 +80,7 @@ app.include_router(other.router)
 app.include_router(firmware.router)
 app.include_router(updates.router)
 app.include_router(sync.router)
+app.include_router(device_sync.router)
 
 app.include_router(apps.router)
 app.include_router(custom_auth.router)

--- a/backend/routers/device_sync.py
+++ b/backend/routers/device_sync.py
@@ -1,0 +1,210 @@
+"""
+Device Direct Sync API
+
+Endpoints for device-initiated audio uploads over WiFi.
+Uses device-specific tokens for authentication instead of Firebase user tokens.
+"""
+
+import os
+import re
+import shutil
+import threading
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Header, HTTPException, UploadFile, File
+
+from database import device_tokens
+from models.conversation import ConversationSource
+from routers.sync import (
+    decode_opus_file_to_wav,
+    get_wav_duration,
+    retrieve_vad_segments,
+    process_segment,
+    get_timestamp_from_path,
+)
+from utils.other import endpoints as auth
+
+router = APIRouter(prefix="/v1/device", tags=["device"])
+
+
+@router.post("/generate-sync-token")
+def generate_device_sync_token(
+    device_id: str,
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """
+    Generate a device-specific token for direct WiFi sync.
+    
+    This token is tied to the user and device, allowing the device to upload
+    audio directly to the backend without phone involvement.
+    
+    Called by the mobile app when configuring direct sync on a device.
+    """
+    device_tokens.revoke_device_sync_token(uid, device_id)
+    
+    token = device_tokens.create_device_sync_token(uid, device_id)
+    
+    return {
+        "token": token,
+        "expires_in_days": device_tokens.TOKEN_EXPIRY_DAYS,
+    }
+
+
+@router.post("/revoke-sync-token")
+def revoke_device_sync_token(
+    device_id: str,
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """
+    Revoke device sync token.
+    
+    Called when user disables direct sync for a device.
+    """
+    count = device_tokens.revoke_device_sync_token(uid, device_id)
+    return {"status": "revoked", "tokens_revoked": count}
+
+
+@router.get("/sync-tokens")
+def list_device_sync_tokens(
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """
+    List all device sync tokens for the current user.
+    
+    Returns masked tokens for security.
+    """
+    tokens = device_tokens.get_user_device_tokens(uid)
+    return {"tokens": tokens}
+
+
+def _validate_device_auth(token: str, device_id: str) -> str:
+    """Validate device token and return user ID."""
+    token_data = device_tokens.validate_device_sync_token(token, device_id)
+    if not token_data:
+        raise HTTPException(status_code=401, detail="Invalid or expired device token")
+    return token_data["uid"]
+
+
+@router.post("/sync-audio")
+def device_sync_audio(
+    file: UploadFile = File(...),
+    x_device_token: str = Header(..., alias="X-Device-Token"),
+    x_device_id: str = Header(..., alias="X-Device-Id"),
+    x_file_timestamp: Optional[str] = Header(None, alias="X-File-Timestamp"),
+):
+    """
+    Receive audio upload directly from device.
+    
+    Uses device token for authentication instead of Firebase token.
+    Processes audio similar to sync-local-files endpoint.
+    
+    Headers:
+        X-Device-Token: Device-specific auth token
+        X-Device-Id: Device ID (must match token)
+        X-File-Timestamp: Unix timestamp of recording (optional, extracted from filename if not provided)
+    
+    Body:
+        file: Opus-encoded audio file (.bin format)
+    """
+    uid = _validate_device_auth(x_device_token, x_device_id)
+    
+    filename = file.filename or "audio.bin"
+    if not filename.endswith('.bin'):
+        raise HTTPException(status_code=400, detail="Invalid file format, expected .bin")
+    
+    if x_file_timestamp:
+        try:
+            timestamp = int(x_file_timestamp)
+        except ValueError:
+            raise HTTPException(status_code=400, detail="Invalid X-File-Timestamp header")
+    else:
+        try:
+            timestamp = get_timestamp_from_path(filename)
+        except (ValueError, IndexError):
+            timestamp = int(datetime.now().timestamp())
+    
+    ts_datetime = datetime.fromtimestamp(timestamp)
+    if ts_datetime > datetime.now() or ts_datetime < datetime(2024, 1, 1):
+        raise HTTPException(status_code=400, detail="Invalid timestamp")
+    
+    directory = f'syncing/{uid}/'
+    os.makedirs(directory, exist_ok=True)
+    
+    safe_filename = f"device_{x_device_id[-4:]}_{timestamp}.bin"
+    bin_path = f"{directory}{safe_filename}"
+    wav_path = bin_path.replace('.bin', '.wav')
+    
+    try:
+        with open(bin_path, "wb") as buffer:
+            shutil.copyfileobj(file.file, buffer)
+    except Exception as e:
+        if os.path.exists(bin_path):
+            os.remove(bin_path)
+        raise HTTPException(status_code=500, detail=f"Failed to write file: {str(e)}")
+    
+    try:
+        frame_size = 160
+        match = re.search(r'_fs(\d+)', filename)
+        if match:
+            frame_size = int(match.group(1))
+        
+        success = decode_opus_file_to_wav(bin_path, wav_path, frame_size=frame_size)
+        if not success:
+            raise HTTPException(status_code=400, detail="Failed to decode audio file")
+        
+        duration = get_wav_duration(wav_path)
+        if duration < 1:
+            return {"status": "skipped", "reason": "audio_too_short", "duration": duration}
+        
+        segmented_paths = set()
+        errors = []
+        retrieve_vad_segments(wav_path, segmented_paths, errors)
+        
+        if errors:
+            print(f"VAD errors for device sync: {errors}")
+        
+        if not segmented_paths:
+            return {"status": "skipped", "reason": "no_voice_detected"}
+        
+        response = {'updated_memories': set(), 'new_memories': set()}
+        
+        def chunk_threads(threads):
+            chunk_size = 3
+            for i in range(0, len(threads), chunk_size):
+                [t.start() for t in threads[i:i + chunk_size]]
+                [t.join() for t in threads[i:i + chunk_size]]
+        
+        threads = [
+            threading.Thread(
+                target=process_segment,
+                args=(path, uid, response, ConversationSource.omi),
+            )
+            for path in segmented_paths
+        ]
+        chunk_threads(threads)
+        
+        return {
+            "status": "success",
+            "new_conversations": list(response['new_memories']),
+            "updated_conversations": list(response['updated_memories']),
+            "segments_processed": len(segmented_paths),
+        }
+        
+    finally:
+        if os.path.exists(bin_path):
+            os.remove(bin_path)
+        if os.path.exists(wav_path):
+            os.remove(wav_path)
+
+
+@router.get("/sync-status")
+def get_device_sync_status(
+    x_device_token: str = Header(..., alias="X-Device-Token"),
+    x_device_id: str = Header(..., alias="X-Device-Id"),
+):
+    """
+    Check if device token is valid. Used by device to verify configuration.
+    """
+    uid = _validate_device_auth(x_device_token, x_device_id)
+    return {"status": "ok", "uid_prefix": uid[:8] + "..."}

--- a/omi/firmware/omi/src/wifi.h
+++ b/omi/firmware/omi/src/wifi.h
@@ -9,17 +9,23 @@
 #define WIFI_MAX_SSID_LEN        32
 #define WIFI_MAX_PASSWORD_LEN    64
 #define WIFI_MIN_PASSWORD_LEN    8
+#define WIFI_MAX_URL_LEN         256
+#define WIFI_MAX_TOKEN_LEN       64
 
 /* WiFi state machine states */
 typedef enum {
-	WIFI_STATE_OFF,        /* WiFi module is off */
-	WIFI_STATE_SHUTDOWN,   /* Try to shut down WiFi */
-	WIFI_STATE_ON,         /* WiFi is on in AP mode */
-	WIFI_STATE_CONNECTING, /* Trying to connect to TCP server */
-	WIFI_STATE_CONNECT     /* Connected to TCP server */
+	WIFI_STATE_OFF,            /* WiFi module is off */
+	WIFI_STATE_SHUTDOWN,       /* Try to shut down WiFi */
+	WIFI_STATE_ON,             /* WiFi is on in AP mode */
+	WIFI_STATE_CONNECTING,     /* Trying to connect to TCP server */
+	WIFI_STATE_CONNECT,        /* Connected to TCP server */
+	WIFI_STATE_STA_INIT,       /* Station mode initializing */
+	WIFI_STATE_STA_CONNECTING, /* Connecting to router in STA mode */
+	WIFI_STATE_STA_CONNECTED,  /* Connected to router in STA mode */
+	WIFI_STATE_UPLOADING,      /* HTTP upload in progress */
 } wifi_state_t;
 
-/* API functions */
+/* AP mode API functions */
 int wifi_init(void);
 void wifi_turn_off(void);
 int wifi_turn_on(void);
@@ -28,5 +34,13 @@ int setup_wifi_credentials(const char *ssid, const char *password);
 int wifi_send_data(const uint8_t *data, size_t len);
 bool is_wifi_transport_ready(void);
 bool is_wifi_on(void);
-bool wifi_is_hw_available(void);
+
+/* Direct sync (Station mode) API functions */
+int wifi_direct_sync_set_config(const char *ssid, const char *password,
+                                const char *backend_url, const char *auth_token);
+int wifi_direct_sync_clear_config(void);
+bool wifi_direct_sync_has_config(void);
+int wifi_direct_sync_trigger(void);
+void wifi_on_charging_changed(bool is_charging);
+
 #endif


### PR DESCRIPTION
This pull request introduces a new "Direct Sync" feature, allowing devices to automatically upload audio to the backend when charging and connected to WiFi. The implementation covers backend API integration, device connection logic, user interface for configuration, and persistent storage of sync settings.

The most important changes are:

**Direct Sync Feature Implementation**

- Added backend API calls for generating and revoking device sync tokens in `api/device.dart` to support secure direct sync setup.
- Implemented new methods in `DeviceConnection` and `OmiDeviceConnection` to handle direct WiFi sync setup, clearing, and status retrieval, including communication over a new BLE characteristic. [[1]](diffhunk://#diff-970cbe80947e8203e020d671c475cfde615d91c7bd75579979d500e6e8875bbbR535-R585) [[2]](diffhunk://#diff-22757b7a7a6abfabc86af56ca554126fd5b5183b96dcbe802cedd3a72f4118b6R741-R884)
- Introduced the `DirectSyncStatus` class and defined a new BLE characteristic UUID to track and manage the direct sync state and results.

**User Interface Enhancements**

- Added a modal bottom sheet in `device_settings.dart` for configuring direct sync, including fields for WiFi SSID, password, and toggling enable/disable, as well as handling save and clear operations.
- Updated the device settings UI to display the current state of direct sync and provide access to the configuration sheet. [[1]](diffhunk://#diff-cb08f219ea682ff0b4e7722723b9b2d70f5ae9ede2d4a3169919f520820db60eR46-R49) [[2]](diffhunk://#diff-cb08f219ea682ff0b4e7722723b9b2d70f5ae9ede2d4a3169919f520820db60eR143-R144) [[3]](diffhunk://#diff-cb08f219ea682ff0b4e7722723b9b2d70f5ae9ede2d4a3169919f520820db60eR975-R986)

**Persistent Storage**

- Extended `SharedPreferencesUtil` with getters, setters, and a clear method for direct sync configuration, ensuring sync settings persist across app sessions.

**Supporting Changes**

- Added necessary imports for backend API and environment access in `device_settings.dart`.