### PR TITLE
fix provider access during widget disposal

### DIFF
--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -62,8 +62,6 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
 
   @override
   void dispose() {
-    _speechProvider?.forceCompletionTimer?.cancel();
-    _speechProvider?.forceCompletionTimer = null;
     _speechProvider?.close();
 
     _scrollController.dispose();

--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -29,6 +29,13 @@ class SpeechProfileWidget extends StatefulWidget {
 class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerProviderStateMixin {
   late AnimationController _questionAnimationController;
   late Animation<double> _questionFadeAnimation;
+  SpeechProfileProvider? _speechProvider;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _speechProvider = context.read<SpeechProfileProvider>();
+  }
 
   @override
   void initState() {
@@ -53,11 +60,9 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
 
   @override
   void dispose() {
-    final speechProvider = context.read<SpeechProfileProvider>();
-
-    speechProvider.forceCompletionTimer?.cancel();
-    speechProvider.forceCompletionTimer = null;
-    speechProvider.close();
+    _speechProvider?.forceCompletionTimer?.cancel();
+    _speechProvider?.forceCompletionTimer = null;
+    _speechProvider?.close();
 
     _scrollController.dispose();
     _questionAnimationController.dispose();

--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -51,9 +51,11 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       if (!mounted) return;
       // Check if user has set primary language
-      if (!context.read<HomeProvider>().hasSetPrimaryLanguage) {
-        await LanguageSelectionDialog.show(context);
-      }
+      final homeProvider = context.read<HomeProvider>();
+      final needsLanguage = !homeProvider.hasSetPrimaryLanguage;
+
+      if (!needsLanguage || !mounted) return;
+      await LanguageSelectionDialog.show(context);
     });
     SharedPreferencesUtil().onboardingCompleted = true;
   }


### PR DESCRIPTION
https://github.com/BasedHardware/omi/blob/8804f2ef8dbb1d10222ab2ed9b2eebda2a0518ef/app/lib/pages/onboarding/speech_profile_widget.dart#L56

here the widget tried to use context to get a provider after it was disposed, fixed it by reading provider earlier in didChangeDependencies() and also moved `context.read<HomeProvider>()` provider reads before calling