### PR TITLE
fix: resolve memory leak in /listen websocket endpoint

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -64,7 +64,6 @@ from utils.conversations.process_conversation import process_conversation, retri
 from utils.notifications import send_credit_limit_notification, send_silent_user_notification
 from utils.other import endpoints as auth
 from utils.other.storage import get_profile_audio_if_exists, get_user_has_speech_profile
-from utils.other.task import safe_create_task
 from utils.pusher import connect_to_trigger_pusher
 from utils.speaker_identification import detect_speaker_from_text
 from utils.stt.streaming import (
@@ -223,6 +222,16 @@ async def _stream_handler(
     person_embeddings_cache: Dict[str, dict] = {}  # person_id -> {embedding, name}
     speaker_id_enabled = False  # Will be set after private_cloud_sync_enabled is known
 
+    # Track background tasks to cancel on cleanup (prevents memory leaks)
+    bg_tasks: Set[asyncio.Task] = set()
+
+    def spawn(coro) -> asyncio.Task:
+        """Create a tracked background task that will be cancelled on cleanup."""
+        task = asyncio.create_task(coro)
+        bg_tasks.add(task)
+        task.add_done_callback(bg_tasks.discard)
+        return task
+
     # Onboarding handler
     onboarding_handler: Optional[OnboardingHandler] = None
     if onboarding_mode:
@@ -240,7 +249,7 @@ async def _stream_handler(
             realtime_segment_buffers.extend(segments)
 
         onboarding_handler = OnboardingHandler(uid, send_onboarding_event, onboarding_stream_transcript)
-        asyncio.create_task(onboarding_handler.send_current_question())
+        spawn(onboarding_handler.send_current_question())
 
     locked_conversation_ids: Set[str] = set()
     speaker_to_person_map: Dict[int, Tuple[str, str]] = {}
@@ -348,7 +357,7 @@ async def _stream_handler(
         nonlocal websocket_active
         if not websocket_active:
             return
-        return asyncio.create_task(_asend_message_event(msg))
+        return spawn(_asend_message_event(msg))
 
     # Heart beat
     started_at = time.time()
@@ -1286,7 +1295,7 @@ async def _stream_handler(
 
             duration = seg['duration']
             if duration >= SPEAKER_ID_MIN_AUDIO:
-                asyncio.create_task(_match_speaker_embedding(speaker_id, seg))
+                spawn(_match_speaker_embedding(speaker_id, seg))
 
         print("Speaker ID task ended", uid, session_id)
 
@@ -1612,7 +1621,7 @@ async def _stream_handler(
         if all(chunk is not None for chunk in image_chunks_cache[temp_id]):
             b64_image_data = "".join(image_chunks_cache[temp_id])
             del image_chunks_cache[temp_id]
-            safe_create_task(process_photo(uid, b64_image_data, temp_id, send_event_func, photo_buffer))
+            spawn(process_photo(uid, b64_image_data, temp_id, send_event_func, photo_buffer))
 
     # Initialize decoders based on codec
     opus_decoder = None
@@ -1666,7 +1675,7 @@ async def _stream_handler(
                             socket_to_close.finish()
                             print('Closed deepgram_profile_socket after 5s delay', uid, session_id)
 
-                        asyncio.create_task(close_dg_profile())
+                        spawn(close_dg_profile())
                 else:
                     deepgram_profile_socket.send(chunk)
 
@@ -1683,7 +1692,7 @@ async def _stream_handler(
                             await socket_to_close.close()
                             print('Closed soniox_profile_socket after 5s delay', uid, session_id)
 
-                        asyncio.create_task(close_soniox_profile())
+                        spawn(close_soniox_profile())
                 else:
                     await soniox_profile_socket.send(chunk)
 
@@ -1816,7 +1825,7 @@ async def _stream_handler(
                                         and send_speaker_sample_request is not None
                                         and current_conversation_id
                                     ):
-                                        asyncio.create_task(
+                                        spawn(
                                             send_speaker_sample_request(
                                                 person_id=person_id,
                                                 conv_id=current_conversation_id,
@@ -1953,6 +1962,22 @@ async def _stream_handler(
         # Clean up onboarding handler
         if onboarding_handler:
             onboarding_handler.cleanup()
+
+        # Cancel all background tasks to prevent memory leaks
+        for task in bg_tasks:
+            task.cancel()
+        if bg_tasks:
+            await asyncio.gather(*bg_tasks, return_exceptions=True)
+        bg_tasks.clear()
+
+        # Clean up decoders to release native resources
+        try:
+            if aac_decoder and hasattr(aac_decoder, 'codec_context'):
+                aac_decoder.codec_context.close()
+            # opus_decoder and lc3_decoder don't have explicit close methods,
+            # but setting to None helps GC release native resources
+        except Exception as e:
+            print(f"Error closing decoders: {e}", uid, session_id)
 
         # Clean up collections to aid garbage collection
         try:


### PR DESCRIPTION
## Summary
- Fix memory leak on backend-listen instances where memory keeps growing over time
- Root cause: Fire-and-forget asyncio tasks holding references to session state, preventing garbage collection

## Changes
- Add tracked background task set with `spawn()` helper function
- Replace all untracked `asyncio.create_task()` calls with `spawn()`
- Cancel and await all background tasks during cleanup
- Add explicit cleanup for AAC decoder codec context

## Task types affected
| Task | Frequency |
|------|-----------|
| `_send_message_event` | Every message event |
| `_match_speaker_embedding` | Per eligible segment |
| `process_photo` | Per photo |
| `close_dg_profile` / `close_soniox_profile` | Once per session |
| `send_speaker_sample_request` | Per speaker assignment |

## Test plan
- [ ] Deploy to staging and monitor memory usage over extended sessions
- [ ] Verify websocket connections still work normally
- [ ] Check that tasks are properly cancelled on disconnect (look for cleanup logs)

Fixes #2905

🤖 Generated with [Claude Code](https://claude.com/claude-code)