### PR TITLE
feat(macos): add URL scheme for recording control

### DIFF
--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -307,12 +307,12 @@ class _AppShellState extends State<AppShell> {
       return;
     }
 
-    if (uri.pathSegments.length < 2) {
-      Logger.debug('Invalid recording URL: $uri');
+    if (uri.pathSegments.isEmpty) {
+      Logger.debug('Invalid recording URL: missing action: $uri');
       return;
     }
 
-    final action = uri.pathSegments[1];
+    final action = uri.pathSegments.first;
     final captureProvider = context.read<CaptureProvider>();
     final currentState = captureProvider.recordingState;
 
@@ -344,7 +344,7 @@ class _AppShellState extends State<AppShell> {
           Logger.debug('Toggling recording OFF via URL scheme');
           await captureProvider.stopSystemAudioRecording();
           PlatformManager.instance.mixpanel.track('Recording Toggled Off From URL Scheme');
-        } else {
+        } else if (currentState == RecordingState.stop || currentState == RecordingState.pause) {
           Logger.debug('Toggling recording ON via URL scheme');
           await captureProvider.streamSystemAudioRecording();
           PlatformManager.instance.mixpanel.track('Recording Toggled On From URL Scheme');


### PR DESCRIPTION
## Summary
Adds support for controlling recording via URL schemes on macOS desktop app.

## Supported URLs
- `omi://record/start` - Start recording
- `omi://record/stop` - Stop recording  
- `omi://record/toggle` - Toggle recording state
- `omi://record/status` - Log current recording status

## Use Case
This enables automation tools, scripts, and AI assistants to control Omi recording without requiring UI interaction. For example:

```bash
# Start recording
open 'omi://record/start'

# Stop recording
open 'omi://record/stop'
```

## Integration Examples
- **Oversight (macOS camera/mic monitor)**: Auto-start Omi when camera/mic activates
- **Calendar automation**: Start recording when meetings begin
- **Shortcuts.app**: Voice-triggered recording control via Siri

## Changes
- Added `_handleRecordingUrlScheme` method in `app_shell.dart`
- Imports `CaptureProvider` and `PlatformService` for recording control
- Desktop-only (gracefully ignores on mobile)
- Includes Mixpanel tracking for URL scheme usage

## Testing
Tested on macOS with:
- `open omi://record/start` ✓
- `open omi://record/stop` ✓
- `open omi://record/toggle` ✓

---
*This PR enables the community to build powerful automations around Omi recording.*