### PR TITLE
feat(app): show goals on tasks and unify bottom nav

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -204,6 +204,24 @@ class SharedPreferencesUtil {
     }
   }
 
+  // Task -> goal mapping (local UI state)
+  // Format: { "taskId": "goalId" }
+  set taskGoalLinks(Map<String, String> value) {
+    final encoded = jsonEncode(value);
+    saveString('taskGoalLinks', encoded);
+  }
+
+  Map<String, String> get taskGoalLinks {
+    final encoded = getString('taskGoalLinks');
+    if (encoded.isEmpty) return {};
+    try {
+      final decoded = jsonDecode(encoded) as Map<String, dynamic>;
+      return decoded.map((key, value) => MapEntry(key, value.toString()));
+    } catch (e) {
+      return {};
+    }
+  }
+
   // Wrapped 2025 - track if user has viewed their wrapped
   set hasViewedWrapped2025(bool value) => saveBool('hasViewedWrapped2025', value);
 

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -1,11 +1,16 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:omi/backend/http/api/goals.dart';
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/schema.dart';
 import 'package:omi/providers/action_items_provider.dart';
+import 'package:omi/providers/home_provider.dart';
 import 'package:omi/services/app_review_service.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/l10n_extensions.dart';
@@ -26,6 +31,13 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
 
   // Track indent levels for each task (task id -> indent level 0-3)
   final Map<String, int> _indentLevels = {};
+
+  // Task -> goal mapping and goals list
+  final Map<String, String> _taskGoalLinks = {};
+  List<Goal> _goals = [];
+  bool _isLoadingGoals = true;
+  static const String _goalsStorageKey = 'goals_tracker_local_goals';
+  Function(int)? _previousHomeIndexHandler;
 
   // Track custom order for each category (category -> list of item ids)
   final Map<TaskCategory, List<String>> _categoryOrder = {};
@@ -50,8 +62,13 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
   @override
   void initState() {
     super.initState();
+    final homeProvider = Provider.of<HomeProvider>(context, listen: false);
+    _previousHomeIndexHandler = homeProvider.onSelectedIndexChanged;
+    homeProvider.onSelectedIndexChanged = _handleHomeIndexChanged;
     _scrollController.addListener(_onScroll);
     _loadCategoryOrder();
+    _loadTaskGoalLinks();
+    _loadGoals();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       MixpanelManager().actionItemsPageOpened();
@@ -77,6 +94,81 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     });
   }
 
+  void _loadTaskGoalLinks() {
+    final savedLinks = SharedPreferencesUtil().taskGoalLinks;
+    setState(() {
+      _taskGoalLinks
+        ..clear()
+        ..addAll(savedLinks);
+    });
+  }
+
+  Future<void> _loadGoals() async {
+    try {
+      final goals = await getAllGoals();
+      if (!mounted) return;
+      if (goals.isNotEmpty) {
+        setState(() {
+          _goals = goals;
+          _isLoadingGoals = false;
+        });
+        _pruneTaskGoalLinks();
+        return;
+      }
+    } catch (_) {}
+
+    // Fallback to locally cached goals from the goals widget
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final goalsJson = prefs.getString(_goalsStorageKey);
+      if (goalsJson != null) {
+        final List<dynamic> decoded = jsonDecode(goalsJson);
+        final localGoals = decoded.map((e) => Goal.fromJson(e)).toList();
+        if (mounted) {
+          setState(() {
+            _goals = localGoals;
+            _isLoadingGoals = false;
+          });
+          _pruneTaskGoalLinks();
+          return;
+        }
+      }
+    } catch (_) {}
+
+    if (!mounted) return;
+    setState(() {
+      _isLoadingGoals = false;
+    });
+  }
+
+  void _pruneTaskGoalLinks() {
+    if (_goals.isEmpty) return;
+    final goalIds = _goals.map((goal) => goal.id).toSet();
+    final removed = _taskGoalLinks.keys.where((taskId) => !goalIds.contains(_taskGoalLinks[taskId])).toList();
+    if (removed.isEmpty) return;
+    for (final taskId in removed) {
+      _taskGoalLinks.remove(taskId);
+    }
+    SharedPreferencesUtil().taskGoalLinks = Map<String, String>.from(_taskGoalLinks);
+  }
+
+  void _attachTaskToGoal(String taskId, String goalId) {
+    setState(() {
+      _taskGoalLinks[taskId] = goalId;
+    });
+    SharedPreferencesUtil().taskGoalLinks = Map<String, String>.from(_taskGoalLinks);
+    HapticFeedback.lightImpact();
+  }
+
+  String? _getGoalTitleForTask(ActionItemWithMetadata item) {
+    final goalId = _taskGoalLinks[item.id];
+    if (goalId == null) return null;
+    for (final goal in _goals) {
+      if (goal.id == goalId) return goal.title;
+    }
+    return null;
+  }
+
   void _saveCategoryOrder() {
     final Map<String, List<String>> toSave = {};
     for (final entry in _categoryOrder.entries) {
@@ -87,9 +179,20 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
 
   @override
   void dispose() {
+    final homeProvider = Provider.of<HomeProvider>(context, listen: false);
+    if (homeProvider.onSelectedIndexChanged == _handleHomeIndexChanged) {
+      homeProvider.onSelectedIndexChanged = _previousHomeIndexHandler;
+    }
     _scrollController.removeListener(_onScroll);
     _scrollController.dispose();
     super.dispose();
+  }
+
+  void _handleHomeIndexChanged(int index) {
+    _previousHomeIndexHandler?.call(index);
+    if (index == 1) {
+      _loadGoals();
+    }
   }
 
   void _onScroll() {
@@ -332,7 +435,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
             child: provider.isLoading && provider.actionItems.isEmpty
                 ? _buildLoadingState()
                 : categorizedItems.values.every((l) => l.isEmpty)
-                    ? _buildEmptyState()
+                    ? _buildEmptyTasksList()
                     : _buildTasksList(categorizedItems, provider),
           ),
         );
@@ -346,48 +449,62 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     );
   }
 
-  Widget _buildEmptyState() {
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Container(
-              width: 80,
-              height: 80,
-              decoration: BoxDecoration(
-                color: Colors.deepPurpleAccent.withOpacity(0.1),
-                borderRadius: BorderRadius.circular(24),
-              ),
-              child: Icon(
-                Icons.check_circle_outline,
-                size: 40,
-                color: Colors.deepPurpleAccent.withOpacity(0.6),
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              context.l10n.noTasksYet,
-              style: const TextStyle(
-                color: Colors.white,
-                fontSize: 24,
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 12),
-            Text(
-              context.l10n.tasksEmptyStateMessage,
-              textAlign: TextAlign.center,
-              style: TextStyle(
-                color: Colors.grey[400],
-                fontSize: 16,
-                height: 1.5,
-              ),
-            ),
-          ],
+  Widget _buildEmptyTasksList() {
+    return CustomScrollView(
+      controller: _scrollController,
+      physics: const AlwaysScrollableScrollPhysics(),
+      slivers: [
+        const SliverPadding(padding: EdgeInsets.only(top: 12)),
+        SliverToBoxAdapter(
+          child: _buildGoalsRow(),
         ),
-      ),
+        const SliverPadding(padding: EdgeInsets.only(top: 24)),
+        SliverToBoxAdapter(
+          child: Center(
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Container(
+                    width: 80,
+                    height: 80,
+                    decoration: BoxDecoration(
+                      color: Colors.deepPurpleAccent.withOpacity(0.1),
+                      borderRadius: BorderRadius.circular(24),
+                    ),
+                    child: Icon(
+                      Icons.check_circle_outline,
+                      size: 40,
+                      color: Colors.deepPurpleAccent.withOpacity(0.6),
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  Text(
+                    context.l10n.noTasksYet,
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 24,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Text(
+                    context.l10n.tasksEmptyStateMessage,
+                    textAlign: TextAlign.center,
+                    style: TextStyle(
+                      color: Colors.grey[400],
+                      fontSize: 16,
+                      height: 1.5,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        const SliverPadding(padding: EdgeInsets.only(bottom: 100)),
+      ],
     );
   }
 
@@ -400,6 +517,10 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
       physics: const AlwaysScrollableScrollPhysics(),
       slivers: [
         const SliverPadding(padding: EdgeInsets.only(top: 12)),
+        SliverToBoxAdapter(
+          child: _buildGoalsRow(),
+        ),
+        const SliverPadding(padding: EdgeInsets.only(top: 6)),
 
         // Build each category section (skip empty ones)
         for (final category in TaskCategory.values)
@@ -415,6 +536,83 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
         // Bottom padding
         const SliverPadding(padding: EdgeInsets.only(bottom: 100)),
       ],
+    );
+  }
+
+  Widget _buildGoalsRow() {
+    if (_isLoadingGoals) {
+      return const SizedBox.shrink();
+    }
+
+    final goalSlots = List<Goal?>.generate(
+      3,
+      (index) => index < _goals.length ? _goals[index] : null,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            context.l10n.goals,
+            style: const TextStyle(
+              color: Colors.white,
+              fontSize: 16,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 10),
+          Row(
+            children: [
+              for (final goal in goalSlots) ...[
+                Expanded(child: _buildGoalDropTile(goal)),
+                if (goal != goalSlots.last) const SizedBox(width: 8),
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildGoalDropTile(Goal? goal) {
+    return DragTarget<ActionItemWithMetadata>(
+      onWillAcceptWithDetails: (details) => goal != null,
+      onAcceptWithDetails: (details) {
+        if (goal == null) return;
+        _attachTaskToGoal(details.data.id, goal.id);
+      },
+      builder: (context, candidateData, rejectedData) {
+        final isHovering = candidateData.isNotEmpty && goal != null;
+        return AnimatedContainer(
+          duration: const Duration(milliseconds: 150),
+          height: 64,
+          padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 8),
+          decoration: BoxDecoration(
+            color: Colors.white.withOpacity(goal == null ? 0.04 : 0.08),
+            borderRadius: BorderRadius.circular(12),
+            border: Border.all(
+              color: isHovering ? Colors.white.withOpacity(0.5) : Colors.white.withOpacity(0.08),
+              width: 1,
+            ),
+          ),
+          child: Center(
+            child: Text(
+              goal?.title ?? '',
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: TextStyle(
+                color: goal == null ? Colors.white.withOpacity(0.2) : Colors.white.withOpacity(0.9),
+                fontSize: 12,
+                fontWeight: FontWeight.w500,
+                height: 1.2,
+              ),
+            ),
+          ),
+        );
+      },
     );
   }
 
@@ -684,15 +882,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
           }
           return true;
         },
-        background: Container(
-          alignment: Alignment.centerLeft,
-          padding: const EdgeInsets.only(left: 20.0),
-          decoration: BoxDecoration(
-            color: Colors.deepPurpleAccent,
-            borderRadius: BorderRadius.circular(8),
-          ),
-          child: const Icon(Icons.format_indent_increase, color: Colors.white),
-        ),
+        background: Container(color: Colors.transparent),
         secondaryBackground: Container(
           alignment: Alignment.centerRight,
           padding: const EdgeInsets.only(right: 20.0),
@@ -848,6 +1038,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     double indentWidth,
   ) {
     final indentLevel = _getIndentLevel(item.id);
+    final goalTitle = _getGoalTitleForTask(item);
 
     return GestureDetector(
       onTap: () => _showEditSheet(item),
@@ -886,13 +1077,28 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
                 const SizedBox(width: 12),
                 // Task text
                 Expanded(
-                  child: Text(
-                    item.description,
-                    style: TextStyle(
-                      color: item.completed ? Colors.grey[600] : Colors.white,
-                      fontSize: 15,
-                      decoration: item.completed ? TextDecoration.lineThrough : null,
-                    ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        item.description,
+                        style: TextStyle(
+                          color: item.completed ? Colors.grey[600] : Colors.white,
+                          fontSize: 15,
+                          decoration: item.completed ? TextDecoration.lineThrough : null,
+                        ),
+                      ),
+                      if (goalTitle != null) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          goalTitle,
+                          style: TextStyle(
+                            color: Colors.grey[600],
+                            fontSize: 12,
+                          ),
+                        ),
+                      ],
+                    ],
                   ),
                 ),
               ],

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -57,6 +57,7 @@ import 'package:omi/utils/responsive/responsive_helper.dart';
 import 'package:omi/widgets/calendar_date_picker_sheet.dart';
 import 'package:omi/widgets/freemium_switch_dialog.dart';
 import 'package:omi/widgets/upgrade_alert.dart';
+import 'package:omi/widgets/bottom_nav_bar.dart';
 import 'widgets/battery_info_widget.dart';
 
 class HomePageWrapper extends StatefulWidget {
@@ -604,236 +605,70 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           ),
                         ],
                       ),
-                      Consumer2<HomeProvider, DeviceProvider>(
-                        builder: (context, home, deviceProvider, child) {
+                      Consumer<HomeProvider>(
+                        builder: (context, home, child) {
                           if (home.isChatFieldFocused ||
                               home.isAppsSearchFieldFocused ||
                               home.isMemoriesSearchFieldFocused) {
                             return const SizedBox.shrink();
-                          } else {
-                            // Check if OMI device is connected
-                            bool isOmiDeviceConnected =
-                                deviceProvider.isConnected && deviceProvider.connectedDevice != null;
+                          }
 
-                            return Stack(
-                              children: [
-                                // Bottom Navigation Bar
-                                Align(
-                                  alignment: Alignment.bottomCenter,
-                                  child: Container(
-                                    width: double.infinity,
-                                    height: 100,
-                                    padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
-                                    decoration: const BoxDecoration(
-                                      gradient: LinearGradient(
-                                        begin: Alignment.topCenter,
-                                        end: Alignment.bottomCenter,
-                                        stops: [0.0, 0.30, 1.0],
-                                        colors: [
-                                          Colors.transparent,
-                                          Color.fromARGB(255, 15, 15, 15),
-                                          Color.fromARGB(255, 15, 15, 15),
+                          return Stack(
+                            children: [
+                              BottomNavBar(
+                                onTabTap: (index, isRepeat) {
+                                  if (isRepeat) {
+                                    _scrollToTop(index);
+                                  } else {
+                                    home.setIndex(index);
+                                  }
+                                },
+                              ),
+                              if (home.selectedIndex == 0)
+                                Positioned(
+                                  right: 20,
+                                  bottom: 100,
+                                  child: GestureDetector(
+                                    onTap: () {
+                                      HapticFeedback.mediumImpact();
+                                      MixpanelManager().bottomNavigationTabClicked('Chat');
+                                      Navigator.push(
+                                        context,
+                                        MaterialPageRoute(
+                                          builder: (context) => const ChatPage(isPivotBottom: false),
+                                        ),
+                                      );
+                                    },
+                                    child: Container(
+                                      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
+                                      decoration: BoxDecoration(
+                                        borderRadius: BorderRadius.circular(32),
+                                        color: Colors.deepPurple,
+                                      ),
+                                      child: Row(
+                                        mainAxisSize: MainAxisSize.min,
+                                        children: [
+                                          const Icon(
+                                            FontAwesomeIcons.solidComment,
+                                            size: 22,
+                                            color: Colors.white,
+                                          ),
+                                          const SizedBox(width: 10),
+                                          Text(
+                                            context.l10n.askOmi,
+                                            style: const TextStyle(
+                                              color: Colors.white,
+                                              fontSize: 17,
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                          ),
                                         ],
                                       ),
                                     ),
-                                    child: Row(
-                                      children: [
-                                        // Home tab
-                                        Expanded(
-                                          child: InkWell(
-                                            onTap: () {
-                                              HapticFeedback.mediumImpact();
-                                              MixpanelManager().bottomNavigationTabClicked('Home');
-                                              primaryFocus?.unfocus();
-                                              if (home.selectedIndex == 0) {
-                                                _scrollToTop(0);
-                                                return;
-                                              }
-                                              home.setIndex(0);
-                                            },
-                                            child: SizedBox(
-                                              height: 90,
-                                              child: Center(
-                                                child: Icon(
-                                                  FontAwesomeIcons.house,
-                                                  color: home.selectedIndex == 0 ? Colors.white : Colors.grey,
-                                                  size: 26,
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                        ),
-                                        // Action Items tab
-                                        Expanded(
-                                          child: InkWell(
-                                            onTap: () {
-                                              HapticFeedback.mediumImpact();
-                                              MixpanelManager().bottomNavigationTabClicked('Action Items');
-                                              primaryFocus?.unfocus();
-                                              if (home.selectedIndex == 1) {
-                                                _scrollToTop(1);
-                                                return;
-                                              }
-                                              home.setIndex(1);
-                                            },
-                                            child: SizedBox(
-                                              height: 90,
-                                              child: Center(
-                                                child: Icon(
-                                                  FontAwesomeIcons.listCheck,
-                                                  color: home.selectedIndex == 1 ? Colors.white : Colors.grey,
-                                                  size: 26,
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                        ),
-                                        // Center space for record button - only when no OMI device is connected
-                                        if (!isOmiDeviceConnected) const SizedBox(width: 80),
-                                        // Memories tab
-                                        Expanded(
-                                          child: InkWell(
-                                            onTap: () {
-                                              HapticFeedback.mediumImpact();
-                                              MixpanelManager().bottomNavigationTabClicked('Memories');
-                                              primaryFocus?.unfocus();
-                                              if (home.selectedIndex == 2) {
-                                                _scrollToTop(2);
-                                                return;
-                                              }
-                                              home.setIndex(2);
-                                            },
-                                            child: SizedBox(
-                                              height: 90,
-                                              child: Center(
-                                                child: Icon(
-                                                  FontAwesomeIcons.brain,
-                                                  color: home.selectedIndex == 2 ? Colors.white : Colors.grey,
-                                                  size: 26,
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                        ),
-                                        // Apps tab
-                                        Expanded(
-                                          child: InkWell(
-                                            onTap: () {
-                                              HapticFeedback.mediumImpact();
-                                              MixpanelManager().bottomNavigationTabClicked('Apps');
-                                              primaryFocus?.unfocus();
-                                              if (home.selectedIndex == 3) {
-                                                _scrollToTop(3);
-                                                return;
-                                              }
-                                              home.setIndex(3);
-                                            },
-                                            child: SizedBox(
-                                              height: 90,
-                                              child: Center(
-                                                child: Icon(
-                                                  FontAwesomeIcons.puzzlePiece,
-                                                  color: home.selectedIndex == 3 ? Colors.white : Colors.grey,
-                                                  size: 26,
-                                                ),
-                                              ),
-                                            ),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
                                   ),
                                 ),
-                                // Central Record Button - Only show when no OMI device is connected
-                                if (!isOmiDeviceConnected)
-                                  Positioned(
-                                    left: MediaQuery.of(context).size.width / 2 - 40,
-                                    bottom: 40, // Position it to protrude above the taller navbar (90px height)
-                                    child: Consumer<CaptureProvider>(
-                                      builder: (context, captureProvider, child) {
-                                        bool isRecording = captureProvider.recordingState == RecordingState.record;
-                                        bool isInitializing =
-                                            captureProvider.recordingState == RecordingState.initialising;
-                                        return GestureDetector(
-                                          onTap: () async {
-                                            HapticFeedback.heavyImpact();
-                                            if (isInitializing) return;
-                                            await _handleRecordButtonPress(context, captureProvider);
-                                          },
-                                          child: Container(
-                                            width: 80,
-                                            height: 80,
-                                            decoration: BoxDecoration(
-                                              shape: BoxShape.circle,
-                                              color: isRecording ? Colors.red : Colors.deepPurple,
-                                              border: Border.all(
-                                                color: Colors.black,
-                                                width: 5,
-                                              ),
-                                            ),
-                                            child: isInitializing
-                                                ? const CircularProgressIndicator(
-                                                    color: Colors.white,
-                                                    strokeWidth: 2,
-                                                  )
-                                                : Icon(
-                                                    isRecording ? FontAwesomeIcons.stop : FontAwesomeIcons.microphone,
-                                                    color: Colors.white,
-                                                    size: 24,
-                                                  ),
-                                          ),
-                                        );
-                                      },
-                                    ),
-                                  ),
-                                // Floating Chat Button - Bottom Right (only on homepage)
-                                if (home.selectedIndex == 0)
-                                  Positioned(
-                                    right: 20,
-                                    bottom: 100, // Position above the bottom navigation bar
-                                    child: GestureDetector(
-                                      onTap: () {
-                                        HapticFeedback.mediumImpact();
-                                        MixpanelManager().bottomNavigationTabClicked('Chat');
-                                        // Navigate to chat page
-                                        Navigator.push(
-                                          context,
-                                          MaterialPageRoute(
-                                            builder: (context) => const ChatPage(isPivotBottom: false),
-                                          ),
-                                        );
-                                      },
-                                      child: Container(
-                                        padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 14),
-                                        decoration: BoxDecoration(
-                                          borderRadius: BorderRadius.circular(32),
-                                          color: Colors.deepPurple,
-                                        ),
-                                        child: Row(
-                                          mainAxisSize: MainAxisSize.min,
-                                          children: [
-                                            const Icon(
-                                              FontAwesomeIcons.solidComment,
-                                              size: 22,
-                                              color: Colors.white,
-                                            ),
-                                            const SizedBox(width: 10),
-                                            Text(
-                                              context.l10n.askOmi,
-                                              style: const TextStyle(
-                                                color: Colors.white,
-                                                fontSize: 17,
-                                                fontWeight: FontWeight.w600,
-                                              ),
-                                            ),
-                                          ],
-                                        ),
-                                      ),
-                                    ),
-                                  ),
-                              ],
-                            );
-                          }
+                            ],
+                          );
                         },
                       ),
                       // Merge action bar - floats above bottom nav when in selection mode

--- a/app/lib/widgets/bottom_nav_bar.dart
+++ b/app/lib/widgets/bottom_nav_bar.dart
@@ -1,0 +1,218 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:provider/provider.dart';
+
+import 'package:omi/pages/conversation_capturing/page.dart';
+import 'package:omi/providers/capture_provider.dart';
+import 'package:omi/providers/device_provider.dart';
+import 'package:omi/providers/home_provider.dart';
+import 'package:omi/utils/analytics/mixpanel.dart';
+import 'package:omi/utils/enums.dart';
+import 'package:omi/utils/logger.dart';
+
+class BottomNavBar extends StatelessWidget {
+  const BottomNavBar({
+    super.key,
+    required this.onTabTap,
+    this.showCenterButton = true,
+  });
+
+  final void Function(int index, bool isRepeat) onTabTap;
+  final bool showCenterButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return Consumer2<HomeProvider, DeviceProvider>(
+      builder: (context, home, deviceProvider, child) {
+        final isOmiDeviceConnected =
+            deviceProvider.isConnected && deviceProvider.connectedDevice != null;
+
+        return Stack(
+          children: [
+            Align(
+              alignment: Alignment.bottomCenter,
+              child: Container(
+                width: double.infinity,
+                height: 100,
+                padding: const EdgeInsets.fromLTRB(20, 20, 20, 0),
+                decoration: const BoxDecoration(
+                  gradient: LinearGradient(
+                    begin: Alignment.topCenter,
+                    end: Alignment.bottomCenter,
+                    stops: [0.0, 0.30, 1.0],
+                    colors: [
+                      Colors.transparent,
+                      Color.fromARGB(255, 15, 15, 15),
+                      Color.fromARGB(255, 15, 15, 15),
+                    ],
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    // Home tab
+                    Expanded(
+                      child: InkWell(
+                        onTap: () {
+                          HapticFeedback.mediumImpact();
+                          MixpanelManager().bottomNavigationTabClicked('Home');
+                          primaryFocus?.unfocus();
+                          onTabTap(0, home.selectedIndex == 0);
+                        },
+                        child: SizedBox(
+                          height: 90,
+                          child: Center(
+                            child: Icon(
+                              FontAwesomeIcons.house,
+                              color: home.selectedIndex == 0 ? Colors.white : Colors.grey,
+                              size: 26,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    // Action Items tab
+                    Expanded(
+                      child: InkWell(
+                        onTap: () {
+                          HapticFeedback.mediumImpact();
+                          MixpanelManager().bottomNavigationTabClicked('Action Items');
+                          primaryFocus?.unfocus();
+                          onTabTap(1, home.selectedIndex == 1);
+                        },
+                        child: SizedBox(
+                          height: 90,
+                          child: Center(
+                            child: Icon(
+                              FontAwesomeIcons.listCheck,
+                              color: home.selectedIndex == 1 ? Colors.white : Colors.grey,
+                              size: 26,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    // Center space for record button - only when no OMI device is connected
+                    if (showCenterButton && !isOmiDeviceConnected) const SizedBox(width: 80),
+                    // Memories tab
+                    Expanded(
+                      child: InkWell(
+                        onTap: () {
+                          HapticFeedback.mediumImpact();
+                          MixpanelManager().bottomNavigationTabClicked('Memories');
+                          primaryFocus?.unfocus();
+                          onTabTap(2, home.selectedIndex == 2);
+                        },
+                        child: SizedBox(
+                          height: 90,
+                          child: Center(
+                            child: Icon(
+                              FontAwesomeIcons.brain,
+                              color: home.selectedIndex == 2 ? Colors.white : Colors.grey,
+                              size: 26,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                    // Apps tab
+                    Expanded(
+                      child: InkWell(
+                        onTap: () {
+                          HapticFeedback.mediumImpact();
+                          MixpanelManager().bottomNavigationTabClicked('Apps');
+                          primaryFocus?.unfocus();
+                          onTabTap(3, home.selectedIndex == 3);
+                        },
+                        child: SizedBox(
+                          height: 90,
+                          child: Center(
+                            child: Icon(
+                              FontAwesomeIcons.puzzlePiece,
+                              color: home.selectedIndex == 3 ? Colors.white : Colors.grey,
+                              size: 26,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            // Central Record Button - Only show when no OMI device is connected
+            if (!isOmiDeviceConnected)
+              Positioned(
+                left: MediaQuery.of(context).size.width / 2 - 40,
+                bottom: 40,
+                child: Consumer<CaptureProvider>(
+                  builder: (context, captureProvider, child) {
+                    final isRecording = captureProvider.recordingState == RecordingState.record;
+                    final isInitializing = captureProvider.recordingState == RecordingState.initialising;
+                    if (!showCenterButton) {
+                      return const SizedBox.shrink();
+                    }
+
+                    return GestureDetector(
+                      onTap: () async {
+                        HapticFeedback.heavyImpact();
+                        if (isInitializing) return;
+                        await _handleRecordButtonPress(context, captureProvider);
+                      },
+                      child: Container(
+                        width: 80,
+                        height: 80,
+                        decoration: BoxDecoration(
+                          shape: BoxShape.circle,
+                          color: isRecording ? Colors.red : Colors.deepPurple,
+                          border: Border.all(
+                            color: Colors.white.withOpacity(0.2),
+                            width: 4,
+                          ),
+                        ),
+                        child: Center(
+                          child: Icon(
+                            isRecording ? FontAwesomeIcons.stop : FontAwesomeIcons.microphone,
+                            color: Colors.white,
+                            size: 26,
+                          ),
+                        ),
+                      ),
+                    );
+                  },
+                ),
+              ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _handleRecordButtonPress(BuildContext context, CaptureProvider captureProvider) async {
+    final recordingState = captureProvider.recordingState;
+
+    if (recordingState == RecordingState.record) {
+      await captureProvider.stopStreamRecording();
+      captureProvider.forceProcessingCurrentConversation();
+      MixpanelManager().phoneMicRecordingStopped();
+    } else if (recordingState == RecordingState.initialising) {
+      Logger.debug('initialising, have to wait');
+    } else {
+      await captureProvider.streamRecording();
+      MixpanelManager().phoneMicRecordingStarted();
+
+      if (context.mounted) {
+        final topConvoId = (captureProvider.conversationProvider?.conversations ?? []).isNotEmpty
+            ? captureProvider.conversationProvider!.conversations.first.id
+            : null;
+        Navigator.push(
+          context,
+          MaterialPageRoute(
+            builder: (context) => ConversationCapturingPage(topConversationId: topConvoId),
+          ),
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- show goals row on tasks page (including empty state) and allow task→goal linking with local cache fallback
- add shared `BottomNavBar` widget and reuse it on home + chat
- tighten chat input spacing and hide center mic button on chat nav

## Test plan
- [x] ./test.sh (app)
- [ ] Manual: verify chat input spacing and bottom nav appearance