### PR TITLE
All apps install state

### DIFF
--- a/app/lib/providers/app_provider.dart
+++ b/app/lib/providers/app_provider.dart
@@ -430,6 +430,10 @@ class AppProvider extends BaseProvider {
         flat.addAll(data);
       }
       apps = flat;
+      
+      // Sync enabled state from local cache to fix install state mismatch bug
+      _syncEnabledStateFromCache();
+      
       appLoading = List.filled(apps.length, false, growable: true);
 
       // Delay filtering to prevent UI freezing with large datasets
@@ -588,6 +592,10 @@ class AppProvider extends BaseProvider {
         flat.addAll(data);
       }
       apps = flat;
+      
+      // Sync enabled state from local cache to fix install state mismatch bug
+      _syncEnabledStateFromCache();
+      
       appLoading = List.filled(apps.length, false, growable: true);
 
       // Refresh popular apps too
@@ -615,6 +623,26 @@ class AppProvider extends BaseProvider {
       apps = SharedPreferencesUtil().appsList;
       filterApps();
       notifyListeners();
+    }
+  }
+
+  /// Syncs the enabled state from the cached apps list to the current apps list.
+  /// This fixes the bug where the install state is incorrect after restarting the app.
+  void _syncEnabledStateFromCache() {
+    final cachedApps = SharedPreferencesUtil().appsList;
+    if (cachedApps.isEmpty) return;
+
+    // Create a map of app ID to enabled state from cache
+    final Map<String, bool> cachedEnabledStates = {};
+    for (final cachedApp in cachedApps) {
+      cachedEnabledStates[cachedApp.id] = cachedApp.enabled;
+    }
+
+    // Update enabled state for each app based on cache
+    for (int i = 0; i < apps.length; i++) {
+      if (cachedEnabledStates.containsKey(apps[i].id)) {
+        apps[i].enabled = cachedEnabledStates[apps[i].id]!;
+      }
     }
   }
 


### PR DESCRIPTION
Fixes incorrect app install states in the "all apps" list by syncing local cache after fetching server data.

---
<a href="https://cursor.com/background-agent?bcId=bc-6c2a7cd4-4329-43f5-9f25-fd5c239f8041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6c2a7cd4-4329-43f5-9f25-fd5c239f8041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>

