### PR TITLE
fix: use .get() for user_review to prevent KeyError

### DIFF
--- a/backend/database/memories.py
+++ b/backend/database/memories.py
@@ -91,7 +91,7 @@ def get_memories(
     # TODO: put user review to firestore query
     memories = [doc.to_dict() for doc in memories_ref.stream()]
     print("get_memories", len(memories))
-    result = [memory for memory in memories if memory['user_review'] is not False]
+    result = [memory for memory in memories if memory.get('user_review') is not False]
     return result
 
 


### PR DESCRIPTION
## Summary
- Use `.get('user_review')` instead of direct dict access `['user_review']` in `get_memories()`
- Prevents KeyError when memory documents are missing the `user_review` field
- Missing field now correctly returns `None`, which passes the `is not False` check

Fixes #4498

## Test plan
- [ ] Deploy to staging and verify `/v3/memories` returns 200 for users with legacy memory documents
- [ ] Confirm no regression for users with `user_review` field present

🤖 Generated with [Claude Code](https://claude.ai/code)