### PR TITLE
fix(chat): auto-scroll to bottom on keyboard open and add bottom padding

### DIFF
--- a/app/lib/pages/chat/page.dart
+++ b/app/lib/pages/chat/page.dart
@@ -81,6 +81,10 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
     });
     textFieldFocusNode.addListener(() {
       setState(() {});
+      if (textFieldFocusNode.hasFocus) {
+        // Scroll to bottom when keyboard opens, with delay to allow keyboard animation
+        _ensureAtBottom(delayMs: 300);
+      }
     });
 
     SchedulerBinding.instance.addPostFrameCallback((_) async {
@@ -657,7 +661,7 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
                     ]);
                   }),
                 ),
-                const SizedBox(height: 0),
+                SizedBox(height: textFieldFocusNode.hasFocus ? 12 : 0),
                 if (!textFieldFocusNode.hasFocus)
                   BottomNavBar(
                     showCenterButton: false,
@@ -1145,7 +1149,6 @@ class ChatPageState extends State<ChatPage> with AutomaticKeepAliveClientMixin {
       ),
     );
   }
-
 
   Widget _buildDrawerAppItem({
     required Widget avatar,


### PR DESCRIPTION
## Summary
- Auto-scrolls chat to the bottom when the keyboard opens, so users no longer need to manually scroll down
- Adds 12px bottom padding below the text input when the keyboard is active for better spacing

## Test plan
- [ ] Open chat page and tap the text input to open keyboard — chat should auto-scroll to bottom
- [ ] Verify bottom padding appears below the input when keyboard is open
- [ ] Verify no extra padding when keyboard is closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)