### PR TITLE
fix(app): stop infinite goals API polling and fix Apple Reminders export

### DIFF
--- a/app/lib/pages/conversations/conversations_page.dart
+++ b/app/lib/pages/conversations/conversations_page.dart
@@ -42,7 +42,6 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
   final GlobalKey<DailyScoreWidgetState> _dailyScoreWidgetKey = GlobalKey<DailyScoreWidgetState>();
 
   void _refreshGoals() {
-    _goalsWidgetKey.currentState?.refresh();
     _dailyScoreWidgetKey.currentState?.reloadGoals();
   }
 
@@ -177,6 +176,7 @@ class _ConversationsPageState extends State<ConversationsPage> with AutomaticKee
           HapticFeedback.mediumImpact();
           Provider.of<CaptureProvider>(context, listen: false).refreshInProgressConversations();
           // Refresh goals widget
+          _goalsWidgetKey.currentState?.refresh();
           _refreshGoals();
           await Future.wait([
             convoProvider.getInitialConversations(),

--- a/app/lib/pages/settings/task_integrations_page.dart
+++ b/app/lib/pages/settings/task_integrations_page.dart
@@ -235,6 +235,8 @@ class _TaskIntegrationsPageState extends State<TaskIntegrationsPage> with Widget
         if (granted) {
           // Update the provider's cached permission status with the granted result
           await provider.updateAppleRemindersPermission(granted: true);
+          // Save connected status to backend so auto-sync works
+          await provider.saveConnectionDetails(app.key, {'connected': true});
           await provider.setSelectedApp(app);
           Logger.debug('✓ Task integration enabled: ${app.displayName} (${app.key})');
         } else {
@@ -250,6 +252,8 @@ class _TaskIntegrationsPageState extends State<TaskIntegrationsPage> with Widget
         }
         return;
       }
+      // Permission already granted - ensure backend knows it's connected
+      await provider.saveConnectionDetails(app.key, {'connected': true});
       await provider.setSelectedApp(app);
       return;
     }

--- a/app/lib/providers/task_integration_provider.dart
+++ b/app/lib/providers/task_integration_provider.dart
@@ -52,6 +52,10 @@ class TaskIntegrationProvider extends ChangeNotifier {
 
         if (PlatformService.isApple && !_appleRemindersPermissionManuallySet) {
           _appleRemindersPermission = await AppleRemindersService().hasPermission();
+          // Ensure backend has connected status for Apple Reminders if permission is granted
+          if (_appleRemindersPermission && _connectionDetails['apple_reminders']?['connected'] != true) {
+            await saveConnectionDetails('apple_reminders', {'connected': true});
+          }
         }
         _appleRemindersPermissionManuallySet = false;
 


### PR DESCRIPTION
## Summary
- **Fix infinite goals API polling**: `GoalsWidget._saveGoalsLocally()` called `onRefresh` which triggered `_refreshGoals()` → `GoalsWidget.refresh()` → `_loadGoals()` in an infinite loop, causing nonstop `GET /v1/goals/all` requests. Broke the cycle by removing the self-referential refresh from `_refreshGoals` callback.
- **Fix Apple Reminders export**: When Apple Reminders was selected as the default integration, no `connected: true` document was saved to the backend's `task_integrations` subcollection. The backend's `auto_sync_action_item` silently failed with `"integration_not_found"` and never sent the FCM push notification to create the reminder on device. Now saves `connected: true` when permission is granted.

## Test plan
- [ ] Open Tasks page, verify `GET /v1/goals/all` is not called in a loop in backend logs
- [ ] Pull-to-refresh on Conversations page still refreshes goals
- [ ] Select Apple Reminders as task integration, create a task, verify it appears in Apple Reminders app
- [ ] Verify Google Tasks export still works when selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)