### PR TITLE
SocketException: Reading from a closed socket crash

### DIFF
--- a/app/lib/backend/http/http_pool_manager.dart
+++ b/app/lib/backend/http/http_pool_manager.dart
@@ -90,8 +90,17 @@ class HttpPoolManager {
   Future<http.StreamedResponse> sendStreaming(
     http.BaseRequest request, {
     Duration timeout = const Duration(minutes: 5),
-  }) {
-    return _client.send(request).timeout(timeout);
+  }) async {
+    try {
+      return await _client.send(request).timeout(timeout);
+    } on SocketException {
+      // Return an empty streamed response instead of crashing on closed socket
+      return http.StreamedResponse(
+        Stream.empty(),
+        503,
+        reasonPhrase: 'Socket closed',
+      );
+    }
   }
 
   void dispose() {


### PR DESCRIPTION
## Summary
- Fix crash in `sendStreaming` when a `SocketException` ("Reading from a closed socket") is thrown
- Return a synthetic 503 `StreamedResponse` instead of letting the exception propagate as a fatal crash
- This handles the case where the socket is closed mid-request (e.g., server drops connection, network switch)

## Crash Stats
- **Events**: 3,021
- **Users affected**: 533
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/cb152d812ae0db140a8fee14bd1a44d2)

## Test plan
- [ ] Verify streaming requests still work normally
- [ ] Test with intermittent network (should gracefully return 503 instead of crashing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)