### PR TITLE
BleTransport.writeCharacteristic - device not connected crash

### DIFF
--- a/app/lib/services/devices/transports/ble_transport.dart
+++ b/app/lib/services/devices/transports/ble_transport.dart
@@ -184,9 +184,15 @@ class BleTransport extends DeviceTransport {
 
   @override
   Future<void> writeCharacteristic(String serviceUuid, String characteristicUuid, List<int> data) async {
+    if (!_bleDevice.isConnected) {
+      Logger.debug('BLE Transport: Cannot write characteristic - device not connected');
+      return;
+    }
+
     final characteristic = await _getCharacteristic(serviceUuid, characteristicUuid);
     if (characteristic == null) {
-      throw Exception('Characteristic not found: $serviceUuid:$characteristicUuid');
+      Logger.debug('BLE Transport: Characteristic not found: $serviceUuid:$characteristicUuid');
+      return;
     }
 
     try {
@@ -195,7 +201,8 @@ class BleTransport extends DeviceTransport {
       await characteristic.write(data, allowLongWrite: needsLongWrite);
     } catch (e) {
       Logger.debug('BLE Transport: Failed to write characteristic: $e');
-      rethrow;
+      // Don't rethrow - BLE write failures (e.g. GATT_WRITE_REQUEST_BUSY, device disconnected)
+      // should not crash the app
     }
   }
 


### PR DESCRIPTION
## Summary
- Add connection check before BLE writes to prevent crash when device is disconnected
- Log warning instead of throwing exception on write failures (device not connected, GATT_WRITE_REQUEST_BUSY)
- Return gracefully instead of crashing when characteristic not found

## Crash Stats
- **Events**: 900 (iOS) + 2,406 (Android GATT_WRITE_REQUEST_BUSY)
- **Users affected**: 192 (iOS) + 27 (Android)
- **Crashlytics (iOS)**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/6570980dfb92b5f8c61da8629b55ac14)
- **Crashlytics (Android)**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/8615e8ac419bd601ce2460ada92d482c)

## Test plan
- [ ] Verify BLE write still works when device is connected
- [ ] Test disconnecting device mid-write (should log warning, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)