### PR TITLE
Pool deadlock: all resources allocated crash

### DIFF
--- a/app/lib/backend/http/http_pool_manager.dart
+++ b/app/lib/backend/http/http_pool_manager.dart
@@ -20,7 +20,7 @@ class HttpPoolManager {
       ..idleTimeout = const Duration(seconds: 15);
 
     _client = IOClient(httpClient);
-    _pool = Pool(10, timeout: const Duration(seconds: 60));
+    _pool = Pool(20, timeout: const Duration(seconds: 120));
   }
 
   Future<http.Response> send(

--- a/app/lib/backend/http/http_pool_manager.dart
+++ b/app/lib/backend/http/http_pool_manager.dart
@@ -16,7 +16,7 @@ class HttpPoolManager {
 
   HttpPoolManager._() {
     final httpClient = HttpClient()
-      ..maxConnectionsPerHost = 15
+      ..maxConnectionsPerHost = 20
       ..idleTimeout = const Duration(seconds: 15);
 
     _client = IOClient(httpClient);


### PR DESCRIPTION
## Summary
- Increase HTTP connection pool size from 10 to 20 resources
- Increase pool timeout from 60s to 120s
- Prevents "TimeoutException: Pool deadlock: all 10 resources have been allocated for 60s" crash under heavy concurrent request load

## Crash Stats
- **Events**: 494
- **Users affected**: 212
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/0110095f49ac8f9b1018122b3becb661)

## Test plan
- [ ] Verify normal HTTP operations still work
- [ ] Stress test with many concurrent API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)