### PR TITLE
CERTIFICATE_VERIFY_FAILED crash in _RawSecureSocket._tryFilter

### DIFF
--- a/app/lib/backend/http/http_pool_manager.dart
+++ b/app/lib/backend/http/http_pool_manager.dart
@@ -73,6 +73,10 @@ class HttpPoolManager {
         lastError = e;
       } on http.ClientException catch (e) {
         lastError = e;
+      } on HandshakeException catch (e) {
+        lastError = e;
+      } on TlsException catch (e) {
+        lastError = e;
       } catch (e) {
         lastError = e;
         rethrow;
@@ -84,6 +88,12 @@ class HttpPoolManager {
     }
 
     if (lastResponse != null) return lastResponse;
+
+    // Return synthetic 503 for TLS/certificate errors instead of crashing
+    if (lastError is HandshakeException || lastError is TlsException) {
+      return http.Response('', 503, reasonPhrase: 'TLS error: $lastError');
+    }
+
     throw lastError ?? Exception('Request failed with unknown error');
   }
 


### PR DESCRIPTION
## Summary
- Catch `HandshakeException` and `TlsException` in the HTTP retry loop
- Return synthetic 503 response for TLS/certificate errors instead of letting them crash the app
- Handles CERTIFICATE_VERIFY_FAILED errors that occur when device clock is wrong, CA issues, or network middleboxes

## Crash Stats
- **Events**: 333 (iOS) + 456 (Android)
- **Users affected**: 72 (iOS) + 36 (Android)
- **Crashlytics (iOS)**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/f8539d5ac2450ab5a5df6663916f782e)
- **Crashlytics (Android)**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues)

## Test plan
- [ ] Verify normal HTTPS requests still work
- [ ] Test with expired certificate scenario (should return 503, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)