### PR TITLE
launchUrl - Invalid argument: url not http(s) crash

### DIFF
--- a/app/lib/pages/apps/markdown_viewer.dart
+++ b/app/lib/pages/apps/markdown_viewer.dart
@@ -67,7 +67,10 @@ class _MarkdownViewerState extends State<MarkdownViewer> {
                   } else {
                     href += '?uid=${SharedPreferencesUtil().uid}';
                   }
-                  launchUrl(Uri.parse(href));
+                  final uri = Uri.tryParse(href);
+                  if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+                    launchUrl(uri);
+                  }
                 }
               },
             ),

--- a/app/lib/pages/chat/widgets/markdown_message_widget.dart
+++ b/app/lib/pages/chat/widgets/markdown_message_widget.dart
@@ -33,7 +33,10 @@ Widget getMarkdownWidget(BuildContext context, String message, {Function(String)
     ),
     onTapLink: (text, href, title) {
       if (href != null) {
-        launchUrl(Uri.parse(href));
+        final uri = Uri.tryParse(href);
+        if (uri != null && (uri.scheme == 'http' || uri.scheme == 'https')) {
+          launchUrl(uri);
+        }
       }
     },
   );


### PR DESCRIPTION
## Summary
- Validate URL scheme (http/https only) before calling `launchUrl` in markdown renderers
- Prevents crash when user-provided markdown content contains non-HTTP URLs (e.g. javascript:, data:, tel:, or malformed URLs)
- Fixed in both chat markdown widget and app markdown viewer

## Crash Stats
- **Events**: 131 (iOS) + 75 (Android)
- **Users affected**: 24 (iOS) + 19 (Android)
- **Crashlytics (iOS)**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/3702160d9af280ef1be30d8dd5d92966)
- **Crashlytics (Android)**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues)

## Test plan
- [ ] Verify markdown links with http/https still work
- [ ] Test markdown with non-standard URL schemes (should be ignored, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)