### PR TITLE
PlatformService.executeIfSupportedAsync - HandshakeException crash

### DIFF
--- a/app/lib/utils/platform/platform_service.dart
+++ b/app/lib/utils/platform/platform_service.dart
@@ -29,7 +29,11 @@ class PlatformService {
   /// Execute a future function only if the platform supports it
   static Future<T?> executeIfSupportedAsync<T>(bool isSupported, Future<T> Function() function, {T? fallback}) async {
     if (isSupported) {
-      return await function();
+      try {
+        return await function();
+      } on HandshakeException {
+        return fallback;
+      }
     }
     return fallback;
   }


### PR DESCRIPTION
## Summary
- Catch `HandshakeException` in `PlatformService.executeIfSupportedAsync` to prevent crash
- Returns fallback value instead of crashing when TLS handshake fails during platform-specific async operations (analytics, Intercom, etc.)

## Crash Stats
- **Events**: 120
- **Users affected**: 105
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/20ce3a411652a4319af29267a4b2fdb7)

## Test plan
- [ ] Verify platform-specific async operations still work normally
- [ ] Test with network issues (should return fallback, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)