### PR TITLE
CaptureProvider._processVoiceCommandBytes - Null check crash

### DIFF
--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -469,6 +469,11 @@ class CaptureProvider extends ChangeNotifier
       return;
     }
 
+    if (_recordingDevice == null) {
+      Logger.debug("_processVoiceCommandBytes: recording device is null, skipping");
+      return;
+    }
+
     BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
     if (messageProvider != null) {
       await messageProvider?.sendVoiceMessageStreamToServer(

--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -469,12 +469,13 @@ class CaptureProvider extends ChangeNotifier
       return;
     }
 
-    if (_recordingDevice == null) {
+    final recordingDevice = _recordingDevice;
+    if (recordingDevice == null) {
       Logger.debug("_processVoiceCommandBytes: recording device is null, skipping");
       return;
     }
 
-    BleAudioCodec codec = await _getAudioCodec(_recordingDevice!.id);
+    BleAudioCodec codec = await _getAudioCodec(recordingDevice.id);
     if (messageProvider != null) {
       await messageProvider?.sendVoiceMessageStreamToServer(
         data,


### PR DESCRIPTION
## Summary
- Add null check for `_recordingDevice` before accessing `.id` in `_processVoiceCommandBytes`
- Prevents crash when device disconnects during voice command processing

## Crash Stats
- **Events**: 111 (iOS) + 56 (Android)
- **Users affected**: 84 (iOS) + 33 (Android)
- **Crashlytics (iOS)**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/c0f728388b4475647c4c246fb72ca2e5)
- **Crashlytics (Android)**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues)

## Test plan
- [ ] Verify voice commands still work when device is connected
- [ ] Test disconnecting device during voice command (should log warning, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)