### PR TITLE
UrlLauncherIOS Safari view controller load crash

### DIFF
--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -180,10 +180,20 @@ class AuthenticationProvider extends BaseProvider {
       return;
     }
 
-    await launchUrl(
-      uri,
-      mode: LaunchMode.inAppBrowserView,
-    );
+    try {
+      await launchUrl(
+        uri,
+        mode: LaunchMode.inAppBrowserView,
+      );
+    } catch (e) {
+      Logger.debug('Failed to launch URL: $e');
+      // Fallback to external browser if in-app browser fails
+      try {
+        await launchUrl(uri, mode: LaunchMode.externalApplication);
+      } catch (e) {
+        Logger.debug('Failed to launch URL externally: $e');
+      }
+    }
   }
 
   Future<void> linkWithGoogle() async {


### PR DESCRIPTION
## Summary
- Add try-catch around `launchUrl` with `inAppBrowserView` mode
- Fallback to external browser when Safari view controller fails to load
- Prevents crash when iOS Safari view controller encounters an error loading the URL

## Crash Stats
- **Events**: 76
- **Users affected**: 40
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/191da13681395b983b0abb58423586e7)

## Test plan
- [ ] Verify in-app browser still opens URLs correctly
- [ ] Test fallback to external browser by simulating Safari view controller failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)