### PR TITLE
SpeechProfilePage.build - Null check crash on device

### DIFF
--- a/app/lib/pages/speech_profile/page.dart
+++ b/app/lib/pages/speech_profile/page.dart
@@ -379,9 +379,10 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> with TickerProvid
                                         bool usePhoneMic = false;
 
                                         // Check if device is connected and supports opus
-                                        if (provider.device != null) {
+                                        final currentDevice = provider.device;
+                                        if (currentDevice != null) {
                                           try {
-                                            BleAudioCodec codec = await _getAudioCodec(provider.device!.id);
+                                            BleAudioCodec codec = await _getAudioCodec(currentDevice.id);
                                             if (!codec.isOpusSupported()) {
                                               // Device doesn't support opus, use phone mic
                                               usePhoneMic = true;
@@ -420,7 +421,9 @@ class _SpeechProfilePageState extends State<SpeechProfilePage> with TickerProvid
                                       padding: const EdgeInsets.symmetric(horizontal: 32, vertical: 14),
                                       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(28)),
                                       child: Text(
-                                        SharedPreferencesUtil().hasSpeakerProfile ? context.l10n.doItAgain : context.l10n.getStarted,
+                                        SharedPreferencesUtil().hasSpeakerProfile
+                                            ? context.l10n.doItAgain
+                                            : context.l10n.getStarted,
                                         style: const TextStyle(color: Colors.black),
                                       ),
                                     ),


### PR DESCRIPTION
## Summary
- Capture `provider.device` in a local variable before async operations
- Prevents race condition where device becomes null between the null check and access across an async gap
- Uses `currentDevice` local variable that remains non-null throughout the async operation

## Crash Stats
- **Events**: 36
- **Users affected**: 15
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/b75b93c3f19d841e59fd71af6449a1c4)

## Test plan
- [ ] Verify speech profile recording still works with device connected
- [ ] Test disconnecting device while on speech profile page (should not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)