### PR TITLE
SDCardWalSyncImpl._getMissingWals - Null check crash

### DIFF
--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -175,6 +175,10 @@ class SDCardWalSyncImpl implements SDCardWalSync {
       var timerStart = DateTime.now().millisecondsSinceEpoch ~/ 1000 - seconds;
 
       var connection = await ServiceManager.instance().device.ensureConnection(deviceId);
+      if (connection == null) {
+        Logger.debug("SDCard: Failed to establish connection for device info");
+        return wals;
+      }
       var pd = await _device!.getDeviceInfo(connection);
       String deviceModel = pd.modelNumber.isNotEmpty ? pd.modelNumber : "Omi";
 


### PR DESCRIPTION
## Summary
- Add null check for BLE connection result before calling getDeviceInfo
- ensureConnection can return null when device is disconnected or unreachable
- Return early with existing WALs instead of crashing

## Crash Stats
- **Events**: 23
- **Users affected**: 16
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/ios:com.friend-app-with-wearable.ios12/issues/118f856bd13310b3c2d26c80ba8360ca)

## Test plan
- [ ] Verify SD card WAL sync still works when device is connected
- [ ] Test with device going offline during sync (should not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)