### PR TITLE
Intercom not initialized crash

### DIFF
--- a/app/lib/utils/analytics/intercom.dart
+++ b/app/lib/utils/analytics/intercom.dart
@@ -26,16 +26,24 @@ class IntercomManager {
   }
 
   Future<void> initIntercom() async {
-    if (Env.intercomAppId == null) return;
-    await PlatformService.executeIfSupportedAsync(
-      PlatformService.isIntercomSupported && (Env.intercomAppId != null && Env.intercomAppId!.isNotEmpty),
-      () => intercom.initialize(
+    if (Env.intercomAppId == null || Env.intercomAppId!.isEmpty) {
+      _initialized = true; // Mark as initialized (no-op) so methods degrade gracefully
+      return;
+    }
+    if (!PlatformService.isIntercomSupported) {
+      _initialized = true; // Mark as initialized on unsupported platforms
+      return;
+    }
+    try {
+      await intercom.initialize(
         Env.intercomAppId!,
         iosApiKey: Env.intercomIOSApiKey,
         androidApiKey: Env.intercomAndroidApiKey,
-      ),
-    );
-    _initialized = true;
+      );
+      _initialized = true;
+    } catch (e) {
+      // Initialization failed - _initialized stays false, all methods will no-op
+    }
   }
 
   Future displayChargingArticle(String device) async {

--- a/app/lib/utils/analytics/intercom.dart
+++ b/app/lib/utils/analytics/intercom.dart
@@ -11,11 +11,15 @@ class IntercomManager {
   static IntercomManager get instance => _instance;
   static final SharedPreferencesUtil _preferences = SharedPreferencesUtil();
 
+  bool _initialized = false;
+
   IntercomManager._internal();
 
   Intercom get intercom => Intercom.instance;
   bool get _isIntercomEnabled =>
-      PlatformService.isIntercomSupported && (Env.intercomAppId != null && Env.intercomAppId!.isNotEmpty);
+      _initialized &&
+      PlatformService.isIntercomSupported &&
+      (Env.intercomAppId != null && Env.intercomAppId!.isNotEmpty);
 
   factory IntercomManager() {
     return _instance;
@@ -23,14 +27,15 @@ class IntercomManager {
 
   Future<void> initIntercom() async {
     if (Env.intercomAppId == null) return;
-    return PlatformService.executeIfSupportedAsync(
-      _isIntercomEnabled,
+    await PlatformService.executeIfSupportedAsync(
+      PlatformService.isIntercomSupported && (Env.intercomAppId != null && Env.intercomAppId!.isNotEmpty),
       () => intercom.initialize(
         Env.intercomAppId!,
         iosApiKey: Env.intercomIOSApiKey,
         androidApiKey: Env.intercomAndroidApiKey,
       ),
     );
+    _initialized = true;
   }
 
   Future displayChargingArticle(String device) async {


### PR DESCRIPTION
## Summary
- Add `_initialized` flag to `IntercomManager` to guard all Intercom calls
- Prevents "Intercom not initialized" crash when Intercom methods are called before `initIntercom()` completes
- The `_isIntercomEnabled` check now includes the initialization flag, so all operations silently skip if not yet initialized

## Crash Stats
- **Events**: 373
- **Users affected**: 373
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/b9e2469f8f052156c4da33777429b657)

## Test plan
- [ ] Verify Intercom still works after app initialization
- [ ] Test rapid app startup where Intercom calls may happen before init completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)