### PR TITLE
AwesomeNotifications INSUFFICIENT_PERMISSIONS crash

### DIFF
--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -108,12 +108,17 @@ class _FCMNotificationService implements NotificationInterface {
 
   @override
   Future<bool> requestNotificationPermissions() async {
-    bool isAllowed = await _awesomeNotifications.isNotificationAllowed();
-    if (!isAllowed) {
-      isAllowed = await _awesomeNotifications.requestPermissionToSendNotifications();
-      register();
+    try {
+      bool isAllowed = await _awesomeNotifications.isNotificationAllowed();
+      if (!isAllowed) {
+        isAllowed = await _awesomeNotifications.requestPermissionToSendNotifications();
+        register();
+      }
+      return isAllowed;
+    } catch (e) {
+      Logger.debug('Failed to request notification permissions: $e');
+      return false;
     }
-    return isAllowed;
   }
 
   @override


### PR DESCRIPTION
## Summary
- Wrap `requestNotificationPermissions` in try-catch
- Prevents crash when AwesomeNotifications throws `INSUFFICIENT_PERMISSIONS` on Android
- Returns false instead of crashing when permissions can't be requested

## Crash Stats
- **Events**: 203
- **Users affected**: 8
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/aea3265a1294cd0e06ce5cf23f1c24ef)

## Test plan
- [ ] Verify notification permissions still work on Android
- [ ] Test denying notification permissions (should return false, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)