### PR TITLE
PlaudDeviceConnection._parseAudioChunk - RangeError crash

### DIFF
--- a/app/lib/services/devices/plaud_connection.dart
+++ b/app/lib/services/devices/plaud_connection.dart
@@ -74,6 +74,7 @@ class PlaudDeviceConnection extends DeviceConnection {
     if (position == 0xFFFFFFFF) return null; // End marker
 
     final length = payload[8];
+    if (9 + length > payload.length) return null;
     return payload.sublist(9, 9 + length);
   }
 


### PR DESCRIPTION
## Summary
- Add bounds check before `payload.sublist(9, 9 + length)` to prevent RangeError
- Return null when payload is truncated or corrupted instead of crashing

## Crash Stats
- **Events**: 14
- **Users affected**: 1
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/e41b30a7d00bfab0ec63f691d271be55)

## Test plan
- [ ] Verify Plaud audio streaming still works correctly
- [ ] Test with corrupted BLE payload (should return null, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)