### PR TITLE
_showForegroundNotification - Null check on title/body crash

### DIFF
--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -271,6 +271,7 @@ class _FCMNotificationService implements NotificationInterface {
       {required RemoteNotification noti,
       NotificationLayout layout = NotificationLayout.Default,
       Map<String, String?>? payload}) async {
+    if (noti.title == null || noti.body == null) return;
     final id = Random().nextInt(10000);
     showNotification(id: id, title: noti.title!, body: noti.body!, layout: layout, payload: payload);
   }


### PR DESCRIPTION
## Summary
- Add null check for `noti.title` and `noti.body` before using `!` operator
- Prevents null check crash when FCM sends a data-only notification without title or body
- Skip showing the notification instead of crashing

## Crash Stats
- **Events**: 11
- **Users affected**: 8
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/f753c637495d7b8ec4865400e40ac657)

## Test plan
- [ ] Verify foreground notifications still show correctly
- [ ] Test with data-only FCM messages (no title/body) - should not crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)