### PR TITLE
AudioPlayerUtils._startPlayback - Unable to create playable audio file crash

### DIFF
--- a/app/lib/utils/audio_player_utils.dart
+++ b/app/lib/utils/audio_player_utils.dart
@@ -100,7 +100,8 @@ class AudioPlayerUtils extends ChangeNotifier {
     final audioFilePath = await _getOrCreateAudioFile(wal);
     if (audioFilePath == null) {
       _resetPlaybackState();
-      throw Exception('Unable to create playable audio file');
+      Logger.debug('AudioPlayerUtils: Unable to create playable audio file for WAL ${wal.id}');
+      return;
     }
 
     _currentPlayingId = wal.id;


### PR DESCRIPTION
## Summary
- Return gracefully instead of throwing `Exception` when audio file creation fails
- Log a debug message with the WAL ID for diagnostics
- Prevents crash when WAL audio data can't be converted to a playable format

## Crash Stats
- **Events**: 10
- **Users affected**: 2
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/bfc65dd285b5fae4d57254f27923eabc)

## Test plan
- [ ] Verify audio playback still works for valid WALs
- [ ] Test with corrupted WAL data (should fail silently, not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)