### PR TITLE
ForegroundServiceDidNotStopInTimeException crash

### DIFF
--- a/app/lib/services/services.dart
+++ b/app/lib/services/services.dart
@@ -126,8 +126,12 @@ Future onStart(ServiceInstance service) async {
   });
 
   service.on('stop').listen((event) async {
-    if (recorder?.status != RecorderServiceStatus.stop) {
-      recorder?.stop();
+    try {
+      if (recorder?.status != RecorderServiceStatus.stop) {
+        recorder?.stop();
+      }
+    } catch (e) {
+      Logger.debug('Error stopping recorder during service stop: $e');
     }
     service.invoke("recorder.ui.stateUpdate", {"state": 'stopped'});
     service.stopSelf();
@@ -141,8 +145,12 @@ Future onStart(ServiceInstance service) async {
   Timer.periodic(const Duration(seconds: 5), (timer) async {
     if (pongAt.isBefore(DateTime.now().subtract(const Duration(seconds: 15)))) {
       // retire
-      if (recorder?.status != RecorderServiceStatus.stop) {
-        recorder?.stop();
+      try {
+        if (recorder?.status != RecorderServiceStatus.stop) {
+          recorder?.stop();
+        }
+      } catch (e) {
+        Logger.debug('Error stopping recorder during watchdog retire: $e');
       }
       service.invoke("recorder.ui.stateUpdate", {"state": 'stopped'});
       service.stopSelf();


### PR DESCRIPTION
## Summary
- Wrap recorder `stop()` in try-catch during both service stop and watchdog retire
- Prevents errors during recorder cleanup from blocking `stopSelf()`, which causes `ForegroundServiceDidNotStopInTimeException` on Android
- Ensures `stopSelf()` is always called even if recorder stop fails

## Crash Stats
- **Events**: 9
- **Users affected**: 9
- **Crashlytics**: [View in Console](https://console.firebase.google.com/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/b9baeaede585fc3bc9b515c27cde532c)

## Test plan
- [ ] Verify background service still stops correctly
- [ ] Test force-stopping the app while recording (should not crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)