### PR TITLE
revert: speaker auto-assignment PRs #4555 and #4561

### DIFF
--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1559,46 +1559,24 @@ class CaptureProvider extends ChangeNotifier
   }
 
   void _handleSpeakerLabelSuggestionEvent(SpeakerLabelSuggestionEvent event) {
-    // Skip if currently tagging this segment
+    // Tagging
     if (taggingSegmentIds.contains(event.segmentId)) {
       return;
     }
-
-    // Skip if segment already has an assignment
+    // If segment already exists, check if it's assigned. If so, ignore suggestion.
     var segment = segments.firstWhereOrNull((s) => s.id == event.segmentId);
     if (segment != null && segment.id.isNotEmpty && (segment.personId != null || segment.isUser)) {
-      suggestionsBySegmentId.removeWhere((key, value) => value.speakerId == event.speakerId);
       return;
     }
 
-    // Backend owns all assignments - apply locally if person_id provided
-    if (event.personId.isNotEmpty) {
-      final isUser = event.personId == 'user';
-      if (!isUser && SharedPreferencesUtil().getPersonById(event.personId) == null) {
-        SharedPreferencesUtil().addCachedPerson(
-          Person(
-            id: event.personId,
-            name: event.personName,
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
-          ),
-        );
-      }
-      for (var seg in segments) {
-        if (seg.speakerId == event.speakerId && seg.personId == null && !seg.isUser) {
-          seg.isUser = isUser;
-          seg.personId = isUser ? null : event.personId;
-        }
-      }
-      // Clear any pending suggestions for this speaker
-      suggestionsBySegmentId.removeWhere((key, value) => value.speakerId == event.speakerId);
-      _segmentsPhotosVersion++;
+    // Auto-accept if enabled for new person suggestions
+    if (SharedPreferencesUtil().autoCreateSpeakersEnabled) {
+      assignSpeakerToConversation(event.speakerId, event.personId, event.personName, [event.segmentId]);
+    } else {
+      // Otherwise, store suggestion to be displayed.
+      suggestionsBySegmentId[event.segmentId] = event;
       notifyListeners();
-      return;
     }
-
-    // Empty person_id shouldn't happen with backend fix - log and ignore
-    Logger.debug('SpeakerLabelSuggestionEvent with empty person_id: ${event.segmentId}');
   }
 
   Future<void> assignSpeakerToConversation(
@@ -1617,18 +1595,6 @@ class CaptureProvider extends ChangeNotifier
         if (newPerson != null) {
           finalPersonId = newPerson.id;
         }
-      }
-      if (finalPersonId.isNotEmpty &&
-          finalPersonId != 'user' &&
-          SharedPreferencesUtil().getPersonById(finalPersonId) == null) {
-        SharedPreferencesUtil().addCachedPerson(
-          Person(
-            id: finalPersonId,
-            name: personName,
-            createdAt: DateTime.now(),
-            updatedAt: DateTime.now(),
-          ),
-        );
       }
 
       // Find conversation id

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -107,9 +107,6 @@ class TranscriptSegmentSocketService implements IPureSocketListener {
       params += '&onboarding=enabled';
     }
 
-    // Enable server-side person creation for speaker auto-assignment
-    params += '&server_person_id=enabled';
-
     String url =
         Env.apiBaseUrl!.replaceFirst('https://', 'wss://').replaceFirst('http://', 'ws://') + 'v4/listen$params';
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -93,6 +93,7 @@ from utils.stt.speaker_embedding import (
 )
 from utils.speaker_sample_migration import maybe_migrate_person_samples
 
+
 router = APIRouter()
 
 
@@ -120,7 +121,6 @@ async def _stream_handler(
     source: Optional[str] = None,
     custom_stt_mode: CustomSttMode = CustomSttMode.disabled,
     onboarding_mode: bool = False,
-    server_person_id_enabled: bool = False,
 ):
     """
     Core WebSocket streaming handler. Assumes websocket is already accepted and uid is validated.
@@ -139,7 +139,6 @@ async def _stream_handler(
         conversation_timeout,
         f'custom_stt={custom_stt_mode}',
         f'onboarding={onboarding_mode}',
-        f'server_person_id={server_person_id_enabled}',
     )
 
     use_custom_stt = custom_stt_mode == CustomSttMode.enabled
@@ -350,11 +349,6 @@ async def _stream_handler(
         if not websocket_active:
             return
         return asyncio.create_task(_asend_message_event(msg))
-
-    def _person_id_for_client(person_id: str) -> str:
-        if server_person_id_enabled:
-            return person_id
-        return ""
 
     # Heart beat
     started_at = time.time()
@@ -1401,7 +1395,7 @@ async def _stream_handler(
                 _send_message_event(
                     SpeakerLabelSuggestionEvent(
                         speaker_id=speaker_id,
-                        person_id=_person_id_for_client(person_id),
+                        person_id=person_id,
                         person_name=person_name,
                         segment_id=segment['id'],
                     )
@@ -1501,11 +1495,8 @@ async def _stream_handler(
 
                 # Trigger realtime integrations (including mentor notifications)
                 from utils.app_integrations import trigger_realtime_integrations
-
                 try:
-                    await trigger_realtime_integrations(
-                        uid, [s.dict() for s in transcript_segments], current_conversation_id
-                    )
+                    await trigger_realtime_integrations(uid, [s.dict() for s in transcript_segments], current_conversation_id)
                 except Exception as e:
                     print(f"Error triggering realtime integrations: {e}", uid, session_id)
 
@@ -1528,7 +1519,7 @@ async def _stream_handler(
                             _send_message_event(
                                 SpeakerLabelSuggestionEvent(
                                     speaker_id=segment.speaker_id,
-                                    person_id=_person_id_for_client(person_id),
+                                    person_id=person_id,
                                     person_name=person_name,
                                     segment_id=segment.id,
                                 )
@@ -1566,26 +1557,10 @@ async def _stream_handler(
                     if detected_name:
                         person = user_db.get_person_by_name(uid, detected_name)
                         person_id = person['id'] if person else ''
-
-                        # Backend owns person creation - create if missing
-                        if not person_id:
-                            now = datetime.now(timezone.utc)
-                            new_person = {
-                                'id': str(uuid.uuid4()),
-                                'name': detected_name,
-                                'created_at': now,
-                                'updated_at': now,
-                                'speech_samples': [],
-                                'speech_samples_version': 3,
-                            }
-                            user_db.create_person(uid, new_person)
-                            person_id = new_person['id']
-                            print(f"Speaker ID: created person '{detected_name}' ({person_id})", uid, session_id)
-
                         _send_message_event(
                             SpeakerLabelSuggestionEvent(
                                 speaker_id=segment.speaker_id,
-                                person_id=_person_id_for_client(person_id),
+                                person_id=person_id,
                                 person_name=detected_name,
                                 segment_id=segment.id,
                             )
@@ -2010,7 +1985,6 @@ async def _listen(
     source: Optional[str] = None,
     custom_stt_mode: CustomSttMode = CustomSttMode.disabled,
     onboarding_mode: bool = False,
-    server_person_id_enabled: bool = False,
 ):
     """
     WebSocket handler for app clients. Accepts the websocket connection and delegates to _stream_handler.
@@ -2035,7 +2009,6 @@ async def _listen(
         source=source,
         custom_stt_mode=custom_stt_mode,
         onboarding_mode=onboarding_mode,
-        server_person_id_enabled=server_person_id_enabled,
     )
     print("_listen ended", uid)
 
@@ -2054,11 +2027,9 @@ async def listen_handler(
     source: Optional[str] = None,
     custom_stt: str = 'disabled',
     onboarding: str = 'disabled',
-    server_person_id: str = 'disabled',
 ):
     custom_stt_mode = CustomSttMode.enabled if custom_stt == 'enabled' else CustomSttMode.disabled
     onboarding_mode = onboarding == 'enabled'
-    server_person_id_enabled = server_person_id == 'enabled'
     await _listen(
         websocket,
         uid,
@@ -2072,7 +2043,6 @@ async def listen_handler(
         source=source,
         custom_stt_mode=custom_stt_mode,
         onboarding_mode=onboarding_mode,
-        server_person_id_enabled=server_person_id_enabled,
     )
 
 
@@ -2088,7 +2058,6 @@ async def web_listen_handler(
     source: Optional[str] = None,
     custom_stt: str = 'disabled',
     onboarding: str = 'disabled',
-    server_person_id: str = 'disabled',
 ):
     """
     WebSocket endpoint for web browser clients using first-message authentication.
@@ -2135,7 +2104,6 @@ async def web_listen_handler(
     # Proceed with streaming (websocket already accepted, uid already validated)
     custom_stt_mode = CustomSttMode.enabled if custom_stt == 'enabled' else CustomSttMode.disabled
     onboarding_mode = onboarding == 'enabled'
-    server_person_id_enabled = server_person_id == 'enabled'
 
     await _stream_handler(
         websocket,
@@ -2150,6 +2118,5 @@ async def web_listen_handler(
         source=source,
         custom_stt_mode=custom_stt_mode,
         onboarding_mode=onboarding_mode,
-        server_person_id_enabled=server_person_id_enabled,
     )
     print("web_listen_handler ended", uid)

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -255,10 +255,7 @@ def get_private_cloud_sync(uid: str = Depends(auth.get_current_user_uid)):
 
 # TODO: consider adding person photo.
 @router.post('/v1/users/people', tags=['v1'], response_model=Person)
-def get_or_create_person(data: CreatePerson, uid: str = Depends(auth.get_current_user_uid)):
-    existing_person = get_person_by_name(uid, data.name)
-    if existing_person:
-        return existing_person
+def create_new_person(data: CreatePerson, uid: str = Depends(auth.get_current_user_uid)):
     data = {
         'id': str(uuid.uuid4()),
         'name': data.name,


### PR DESCRIPTION
## Summary

Reverts PRs #4555 and #4561 due to production issues with speaker assignment.

## Issues Found in Production

1. Previous segments' speaker not being updated when assignment changes
2. Latest segments (same speaker) not updated to the assigned person

## Reverted PRs

- #4555: fix: move speaker auto-assignment fully to backend
- #4561: fix: apply pending speaker assignments before conversation processing

## Next Steps

Need deeper investigation into the speaker assignment flow to ensure:
- All segments for a speaker are updated when assignment is made
- Assignments persist correctly to database
- Real-time updates propagate to all affected segments

## Test Results

- Backend tests: pass

---
_by AI for @beastoin_