### PR TITLE
fix: remove tick mark dots from goal sliders

### DIFF
--- a/app/lib/pages/conversations/widgets/goals_widget.dart
+++ b/app/lib/pages/conversations/widgets/goals_widget.dart
@@ -663,6 +663,7 @@ class GoalsWidgetState extends State<GoalsWidget> with WidgetsBindingObserver {
                                 thumbShape: const RoundSliderThumbShape(enabledThumbRadius: 0),
                                 overlayShape: const RoundSliderOverlayShape(overlayRadius: 12),
                                 trackShape: const RoundedRectSliderTrackShape(),
+                                tickMarkShape: SliderTickMarkShape.noTickMark,
                               ),
                               child: Slider(
                                 value: goal.currentValue.clamp(0.0, goal.targetValue),


### PR DESCRIPTION
## Summary
- Hides the visual tick mark dots on goal sliders on the homepage by setting `tickMarkShape: SliderTickMarkShape.noTickMark` in the SliderThemeData
- Slider still snaps to integer values via `divisions`, only the visual dots are removed

## Test plan
- [ ] Open the app and navigate to the homepage with goals
- [ ] Verify goal sliders no longer show dots at integer positions
- [ ] Verify sliders still snap to integer values when dragged

🤖 Generated with [Claude Code](https://claude.com/claude-code)