### PR TITLE
fix: track Recap Tab Opened event on homepage recap button

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -848,6 +848,9 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           ),
                           onPressed: () {
                             HapticFeedback.mediumImpact();
+                            if (!convoProvider.showDailySummaries) {
+                              MixpanelManager().recapTabOpened();
+                            }
                             convoProvider.toggleDailySummaries();
                           },
                         ),


### PR DESCRIPTION
## Summary
- Re-maps the "Recap Tab Opened" Mixpanel event to the recap toggle button on the homepage top right
- Only fires when toggling recaps on, not off

## Test plan
- [ ] Tap the recap button on homepage top right to enable recaps
- [ ] Verify "Recap Tab Opened" event fires in Mixpanel
- [ ] Tap again to disable recaps and verify the event does not fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)