### PR TITLE
fix: gate realtime integrations fallback with user_has_credits

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1491,7 +1491,7 @@ async def _stream_handler(
 
                 if transcript_send is not None and user_has_credits:
                     transcript_send([segment.dict() for segment in transcript_segments])
-                elif not PUSHER_ENABLED:
+                elif not PUSHER_ENABLED and user_has_credits:
                     # Fallback: trigger realtime integrations directly when pusher is disabled
                     try:
                         await trigger_realtime_integrations(


### PR DESCRIPTION
## Summary
- Add `user_has_credits` check to non-pusher fallback for realtime integrations

## Problem
PR #4571 added a fallback to trigger realtime integrations when `PUSHER_ENABLED` is false, but it didn't check `user_has_credits`. This means integrations would fire for over-limit sessions in non-pusher setups.

## Fix
```python
# Before
elif not PUSHER_ENABLED:

# After  
elif not PUSHER_ENABLED and user_has_credits:
```

Now both paths (pusher and fallback) respect the same credit gating.

## Test plan
- [x] Backend tests pass

Follow-up to #4571

🤖 Generated with [Claude Code](https://claude.com/claude-code)