### PR TITLE
fix: match memories FAB color and position to tasks page

### DIFF
--- a/app/lib/pages/memories/page.dart
+++ b/app/lib/pages/memories/page.dart
@@ -155,14 +155,14 @@ class MemoriesPageState extends State<MemoriesPage> with AutomaticKeepAliveClien
           child: Scaffold(
             backgroundColor: Theme.of(context).colorScheme.primary,
             floatingActionButton: Padding(
-              padding: const EdgeInsets.only(bottom: 100.0),
+              padding: const EdgeInsets.only(bottom: 48.0),
               child: FloatingActionButton(
                 heroTag: 'memories_fab',
                 onPressed: () {
                   showMemoryDialog(context, provider);
                   MixpanelManager().memoriesPageCreateMemoryBtn();
                 },
-                backgroundColor: Colors.deepPurpleAccent,
+                backgroundColor: Colors.deepPurple,
                 tooltip: context.l10n.createMemoryTooltip,
                 child: const Icon(
                   Icons.add,


### PR DESCRIPTION
## Summary
- Changed memories page FAB background color from `deepPurpleAccent` to `deepPurple` to match tasks page
- Changed memories page FAB bottom padding from `100.0` to `48.0` to match tasks page positioning

## Test plan
- [x] App tests pass
- [ ] Verify memories page FAB visually matches tasks page FAB

🤖 Generated with [Claude Code](https://claude.com/claude-code)