### PR TITLE
fix: validate audio duration before speaker embedding

### DIFF
--- a/backend/diarizer/embedding.py
+++ b/backend/diarizer/embedding.py
@@ -3,22 +3,23 @@ import shutil
 import uuid
 
 import torch
-from fastapi import UploadFile
+import torchaudio
+from fastapi import HTTPException, UploadFile
 from pyannote.audio import Model, Inference
+
+# Minimum audio duration in seconds for speaker embedding
+# wespeaker requires sufficient samples for fbank window computation
+MIN_AUDIO_DURATION_SECONDS = 0.1  # 100ms
 
 # Instantiate pretrained speaker embedding model
 device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-embedding_model = Model.from_pretrained(
-    "pyannote/embedding",
-    token=os.getenv('HUGGINGFACE_TOKEN')
-)
+embedding_model = Model.from_pretrained("pyannote/embedding", token=os.getenv('HUGGINGFACE_TOKEN'))
 embedding_inference = Inference(embedding_model, window="whole")
 embedding_inference.to(device)
 
 # Instantiate wespeaker-voxceleb-resnet34-LM model for v2
 embedding_model_v2 = Model.from_pretrained(
-    "pyannote/wespeaker-voxceleb-resnet34-LM",
-    token=os.getenv('HUGGINGFACE_TOKEN')
+    "pyannote/wespeaker-voxceleb-resnet34-LM", token=os.getenv('HUGGINGFACE_TOKEN')
 )
 embedding_inference_v2 = Inference(embedding_model_v2, window="whole")
 embedding_inference_v2.to(device)
@@ -26,13 +27,41 @@ embedding_inference_v2.to(device)
 os.makedirs('_temp', exist_ok=True)
 
 
+def _validate_audio_duration(file_path: str) -> float:
+    """
+    Validate that audio file meets minimum duration requirement.
+
+    Args:
+        file_path: Path to audio file
+
+    Returns:
+        Audio duration in seconds
+
+    Raises:
+        HTTPException: If audio is too short for speaker embedding
+    """
+    try:
+        info = torchaudio.info(file_path)
+        duration = info.num_frames / info.sample_rate
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Failed to read audio file: {str(e)}")
+
+    if duration < MIN_AUDIO_DURATION_SECONDS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Audio too short for speaker embedding. Duration: {duration:.3f}s, minimum: {MIN_AUDIO_DURATION_SECONDS}s",
+        )
+
+    return duration
+
+
 def embedding_endpoint(file: UploadFile):
     """
     Extract speaker embedding from an audio file.
-    
+
     Args:
         file: Audio file (wav, mp3, etc.)
-    
+
     Returns:
         Dictionary containing the embedding vector and metadata
     """
@@ -40,18 +69,21 @@ def embedding_endpoint(file: UploadFile):
     # Sanitize filename to prevent path traversal
     filename = os.path.basename(file.filename)
     file_path = f"_temp/{upload_id}_{filename}"
-    
+
     try:
         # Save uploaded file in chunks to avoid high memory usage
         with open(file_path, 'wb') as f:
             shutil.copyfileobj(file.file, f)
-        
+
+        # Validate audio duration before processing
+        _validate_audio_duration(file_path)
+
         # Extract embedding
         embedding = embedding_inference(file_path)
-        
+
         # Convert numpy array to list for JSON serialization
         return embedding.tolist()
-    
+
     finally:
         # Clean up temporary file
         if os.path.exists(file_path):
@@ -61,10 +93,10 @@ def embedding_endpoint(file: UploadFile):
 def embedding_endpoint_v2(file: UploadFile):
     """
     Extract speaker embedding from an audio file using wespeaker-voxceleb-resnet34-LM model.
-    
+
     Args:
         file: Audio file (wav, mp3, etc.)
-    
+
     Returns:
         Dictionary containing the embedding vector and metadata
     """
@@ -72,18 +104,21 @@ def embedding_endpoint_v2(file: UploadFile):
     # Sanitize filename to prevent path traversal
     filename = os.path.basename(file.filename)
     file_path = f"_temp/{upload_id}_{filename}"
-    
+
     try:
         # Save uploaded file in chunks to avoid high memory usage
         with open(file_path, 'wb') as f:
             shutil.copyfileobj(file.file, f)
-        
+
+        # Validate audio duration before processing
+        _validate_audio_duration(file_path)
+
         # Extract embedding using v2 model
         embedding = embedding_inference_v2(file_path)
-        
+
         # Convert numpy array to list for JSON serialization
         return embedding.tolist()
-    
+
     finally:
         # Clean up temporary file
         if os.path.exists(file_path):

--- a/backend/diarizer/test_embedding.py
+++ b/backend/diarizer/test_embedding.py
@@ -1,0 +1,103 @@
+"""
+Unit tests for audio duration validation in embedding module.
+
+These tests focus on the validation logic and don't require model loading.
+To run: cd backend/diarizer && python -m pytest test_embedding.py -v
+"""
+
+import io
+import os
+import tempfile
+import wave
+
+import numpy as np
+import pytest
+from fastapi import HTTPException
+
+# Import only the validation function and constant to avoid model loading
+from embedding import _validate_audio_duration, MIN_AUDIO_DURATION_SECONDS
+
+
+def create_wav_file(duration_seconds: float, sample_rate: int = 16000) -> str:
+    """Create a temporary WAV file with the specified duration."""
+    num_samples = int(duration_seconds * sample_rate)
+    samples = np.zeros(num_samples, dtype=np.int16)
+
+    fd, path = tempfile.mkstemp(suffix='.wav')
+    try:
+        with wave.open(path, 'wb') as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(sample_rate)
+            wav_file.writeframes(samples.tobytes())
+    finally:
+        os.close(fd)
+
+    return path
+
+
+class TestValidateAudioDuration:
+    """Tests for _validate_audio_duration function."""
+
+    def test_rejects_audio_shorter_than_minimum(self):
+        """Audio shorter than MIN_AUDIO_DURATION_SECONDS should raise HTTPException."""
+        path = create_wav_file(0.025)  # 25ms
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_audio_duration(path)
+            assert exc_info.value.status_code == 400
+            assert "Audio too short" in exc_info.value.detail
+        finally:
+            os.unlink(path)
+
+    def test_accepts_audio_at_minimum_duration(self):
+        """Audio at exactly minimum duration should pass."""
+        path = create_wav_file(MIN_AUDIO_DURATION_SECONDS)
+        try:
+            duration = _validate_audio_duration(path)
+            assert duration >= MIN_AUDIO_DURATION_SECONDS
+        finally:
+            os.unlink(path)
+
+    def test_accepts_audio_longer_than_minimum(self):
+        """Audio longer than minimum duration should pass."""
+        path = create_wav_file(0.5)  # 500ms
+        try:
+            duration = _validate_audio_duration(path)
+            assert duration >= 0.5
+        finally:
+            os.unlink(path)
+
+    def test_error_includes_actual_duration(self):
+        """Error message should include actual audio duration."""
+        path = create_wav_file(0.030)  # 30ms
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_audio_duration(path)
+            # Duration should be in the error message
+            assert "0.03" in exc_info.value.detail
+        finally:
+            os.unlink(path)
+
+    def test_error_includes_minimum_duration(self):
+        """Error message should include minimum required duration."""
+        path = create_wav_file(0.025)
+        try:
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_audio_duration(path)
+            assert str(MIN_AUDIO_DURATION_SECONDS) in exc_info.value.detail
+        finally:
+            os.unlink(path)
+
+    def test_invalid_file_raises_error(self):
+        """Invalid audio file should raise HTTPException with file read error."""
+        fd, path = tempfile.mkstemp(suffix='.wav')
+        try:
+            os.write(fd, b"not a valid wav file")
+            os.close(fd)
+            with pytest.raises(HTTPException) as exc_info:
+                _validate_audio_duration(path)
+            assert exc_info.value.status_code == 400
+            assert "Failed to read audio file" in exc_info.value.detail
+        finally:
+            os.unlink(path)


### PR DESCRIPTION
## Summary
- Add minimum audio duration validation (100ms) to diarizer embedding endpoints
- Prevent AssertionError from wespeaker fbank when processing short audio clips (~25ms)
- Return clear 400 error with duration info instead of 500 internal error

Fixes #4572

## Test plan
- [ ] Deploy diarizer service to staging
- [ ] Test with short audio (<100ms) - should return 400 with clear error message
- [ ] Test with valid audio (>100ms) - should work as before
- [ ] Monitor production error rate after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)