### PR TITLE
feat: add Mixpanel tracking to export tasks icon button

### DIFF
--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -999,6 +999,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           ),
                           onPressed: () {
                             HapticFeedback.mediumImpact();
+                            MixpanelManager().exportTasksBannerClicked();
                             Navigator.of(context).push(
                               MaterialPageRoute(
                                 builder: (context) => const TaskIntegrationsPage(),


### PR DESCRIPTION
## Summary
- Added `MixpanelManager().exportTasksBannerClicked()` to the export tasks icon button in the home page app bar, reusing the existing event since the banner was replaced by this button

## Test plan
- [x] App tests pass
- [ ] Verify `Export Tasks Banner Clicked` event fires when tapping the export icon on the tasks tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)