### PR TITLE
fix: chart_data not propagating in chat responses

### DIFF
--- a/backend/utils/retrieval/tools/chart_tools.py
+++ b/backend/utils/retrieval/tools/chart_tools.py
@@ -5,7 +5,6 @@ Tool for creating inline chart visualizations in chat responses.
 import contextvars
 from typing import List, Optional
 
-from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import tool
 
 try:
@@ -24,7 +23,6 @@ def create_chart_tool(
     color: Optional[str] = None,
     x_label: Optional[str] = None,
     y_label: Optional[str] = None,
-    config: RunnableConfig = None,
 ) -> str:
     """
     Create an inline chart visualization in the chat response.
@@ -73,11 +71,10 @@ def create_chart_tool(
         ],
     }
 
-    if config is None:
-        try:
-            config = agent_config_context.get()
-        except LookupError:
-            config = None
+    try:
+        config = agent_config_context.get()
+    except LookupError:
+        config = None
 
     if config:
         configurable = config.get('configurable', {})


### PR DESCRIPTION
## Summary
- LangChain's `@tool` decorator injects a **copied** `RunnableConfig` when the parameter is declared, so `create_chart_tool` was writing `chart_data` to a disposable copy instead of the original config dict
- Removed the `config: RunnableConfig` parameter so the tool always reads from `agent_config_context` (which holds a reference to the original config)
- This fixes charts showing a shimmer loading state then vanishing — the `done:` message was arriving with `chart_data: null`

## Test plan
- [ ] Send a chat message asking to visualize data (e.g. "chart my sleep this week")
- [ ] Verify the chart renders inline instead of showing shimmer then disappearing
- [ ] Verify non-chart messages still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)