### PR TITLE
Track LLM usage for high priority untracked call sites

### DIFF
--- a/backend/tests/unit/test_high_priority_usage_tracking.py
+++ b/backend/tests/unit/test_high_priority_usage_tracking.py
@@ -1,0 +1,389 @@
+"""
+Tests for HIGH priority LLM usage tracking (issue #4619).
+
+Verifies that track_usage context managers are properly placed around LLM calls in:
+- goals.py (suggest_goal, get_goal_advice, extract_and_update_goal_progress)
+- knowledge_graph.py (extract_knowledge_from_memory, rebuild_knowledge_graph.process_memory)
+- external_integrations.py (get_conversation_summary, generate_comprehensive_daily_summary)
+- notifications.py (generate_notification_message, generate_credit_limit_notification)
+"""
+
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, AsyncMock
+import asyncio
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _stub_module(name: str) -> types.ModuleType:
+    if name not in sys.modules:
+        mod = types.ModuleType(name)
+        sys.modules[name] = mod
+    return sys.modules[name]
+
+
+# --- Stub database package and submodules ---
+# Use _stub_module which only creates if not already loaded
+database_mod = _stub_module("database")
+if not hasattr(database_mod, '__path__'):
+    database_mod.__path__ = []
+for submodule in [
+    "redis_db",
+    "memories",
+    "conversations",
+    "users",
+    "tasks",
+    "trends",
+    "action_items",
+    "folders",
+    "calendar_meetings",
+    "vector_db",
+    "apps",
+    "llm_usage",
+    "_client",
+    "chat",
+    "goals",
+    "knowledge_graph",
+    "daily_summaries",
+    "mem_db",
+    "notifications",
+]:
+    mod = _stub_module(f"database.{submodule}")
+    setattr(database_mod, submodule, mod)
+
+# Set needed attributes on db stubs
+sys.modules["database.llm_usage"].record_llm_usage = MagicMock()
+sys.modules["database.goals"].get_user_goal = MagicMock(return_value=None)
+sys.modules["database.goals"].update_goal_progress = MagicMock()
+sys.modules["database.memories"].get_memories = MagicMock(return_value=[])
+sys.modules["database.conversations"].get_conversations = MagicMock(return_value=[])
+sys.modules["database.conversations"].get_conversations_by_id = MagicMock(return_value=[])
+sys.modules["database.chat"].get_messages = MagicMock(return_value=[])
+sys.modules["database.vector_db"].query_vectors = MagicMock(return_value=[])
+sys.modules["database.knowledge_graph"].get_knowledge_nodes = MagicMock(return_value=[])
+sys.modules["database.knowledge_graph"].get_knowledge_graph = MagicMock(return_value={'nodes': [], 'edges': []})
+sys.modules["database.knowledge_graph"].upsert_knowledge_node = MagicMock(return_value={'id': 'n1', 'label': 'test'})
+sys.modules["database.knowledge_graph"].upsert_knowledge_edge = MagicMock(return_value={'id': 'e1'})
+sys.modules["database.knowledge_graph"].delete_knowledge_graph = MagicMock()
+sys.modules["database.users"].get_user_profile = MagicMock(return_value={'time_zone': 'UTC'})
+sys.modules["database.users"].get_people_by_ids = MagicMock(return_value=[])
+sys.modules["database.action_items"].get_action_items = MagicMock(return_value=[])
+sys.modules["database.daily_summaries"].create_daily_summary = MagicMock(return_value="summary-1")
+sys.modules["database.notifications"].get_user_time_zone = MagicMock(return_value="UTC")
+sys.modules["database.notifications"].get_token_only = MagicMock(return_value=None)
+
+# --- Don't stub models — it's a real package on disk ---
+# Only add missing attributes if the real modules can't be loaded
+
+# --- Stub utils.llms.memory ---
+llms_mod = _stub_module("utils.llms")
+if not hasattr(llms_mod, '__path__'):
+    llms_mod.__path__ = []
+_stub_module("utils.llms.memory")
+sys.modules["utils.llms.memory"].get_prompt_memories = MagicMock(return_value=("TestUser", "some memories"))
+
+# --- Import real usage_tracker ---
+from utils.llm.usage_tracker import _usage_context, Features
+
+# --- Stub LLM clients (AFTER importing usage_tracker so it's already loaded) ---
+mock_llm_mini = MagicMock()
+mock_llm_mini.invoke = MagicMock(
+    return_value=MagicMock(
+        content='{"suggested_title": "test", "suggested_type": "scale", "suggested_target": 10, "suggested_min": 0, "suggested_max": 10, "reasoning": "test"}'
+    )
+)
+mock_llm_mini.ainvoke = AsyncMock(return_value=MagicMock(content="test response"))
+mock_llm_mini.with_structured_output = MagicMock(return_value=mock_llm_mini)
+
+mock_llm_medium = MagicMock()
+mock_llm_medium.invoke = MagicMock(return_value=MagicMock(content="test advice"))
+mock_llm_medium.ainvoke = AsyncMock(return_value=MagicMock(content="test notification body"))
+
+mock_llm_medium_experiment = MagicMock()
+mock_llm_medium_experiment.invoke = MagicMock(
+    return_value=MagicMock(
+        content='{"headline": "Test Day", "overview": "test", "day_emoji": "📅", "highlights": [], "unresolved_questions": [], "decisions_made": [], "knowledge_nuggets": []}'
+    )
+)
+
+mock_parser = MagicMock()
+
+# Replace clients module with stubs
+clients_mod = _stub_module("utils.llm.clients")
+clients_mod.llm_mini = mock_llm_mini
+clients_mod.llm_medium = mock_llm_medium
+clients_mod.llm_medium_experiment = mock_llm_medium_experiment
+clients_mod.parser = mock_parser
+
+
+# ── Source-level tests: verify track_usage wraps every LLM call ──
+
+
+def _read_source(relative_path: str) -> str:
+    """Read a source file relative to the backend directory."""
+    backend_dir = Path(__file__).resolve().parent.parent.parent
+    return (backend_dir / relative_path).read_text()
+
+
+class TestGoalsTracking:
+    """Verify track_usage(uid, Features.GOALS) wraps LLM calls in goals.py."""
+
+    def test_suggest_goal_has_tracking(self):
+        source = _read_source("utils/llm/goals.py")
+        assert "track_usage(uid, Features.GOALS)" in source
+
+    def test_all_three_goal_functions_tracked(self):
+        source = _read_source("utils/llm/goals.py")
+        count = source.count("with track_usage(uid, Features.GOALS):")
+        assert count == 3, f"Expected 3 track_usage(GOALS) wrappers, found {count}"
+
+    def test_suggest_goal_sets_context(self):
+        """Verify suggest_goal actually sets the usage context during LLM call."""
+        captured_ctx = {}
+        original_invoke = mock_llm_mini.invoke
+
+        def capturing_invoke(prompt):
+            ctx = _usage_context.get()
+            if ctx:
+                captured_ctx['uid'] = ctx.uid
+                captured_ctx['feature'] = ctx.feature
+            return MagicMock(
+                content='{"suggested_title": "test", "suggested_type": "scale", "suggested_target": 10, "suggested_min": 0, "suggested_max": 10, "reasoning": "test"}'
+            )
+
+        mock_llm_mini.invoke = capturing_invoke
+        # Provide memories so suggest_goal doesn't return early with default
+        sys.modules["database.memories"].get_memories = MagicMock(return_value=[{'content': 'User is learning Python'}])
+        try:
+            from utils.llm.goals import suggest_goal
+
+            suggest_goal("test-uid-123")
+            assert captured_ctx.get('feature') == Features.GOALS
+            assert captured_ctx.get('uid') == "test-uid-123"
+        finally:
+            mock_llm_mini.invoke = original_invoke
+
+    def test_get_goal_advice_sets_context(self):
+        """Verify get_goal_advice sets the usage context during LLM call."""
+        captured_ctx = {}
+        original_invoke = mock_llm_medium.invoke
+
+        def capturing_invoke(prompt):
+            ctx = _usage_context.get()
+            if ctx:
+                captured_ctx['uid'] = ctx.uid
+                captured_ctx['feature'] = ctx.feature
+            return MagicMock(content="Focus on one thing at a time.")
+
+        mock_llm_medium.invoke = capturing_invoke
+        sys.modules["database.goals"].get_user_goal = MagicMock(
+            return_value={
+                'id': 'goal-1',
+                'title': 'Read 20 books',
+                'current_value': 5,
+                'target_value': 20,
+                'goal_type': 'numeric',
+            }
+        )
+        try:
+            from utils.llm.goals import get_goal_advice
+
+            get_goal_advice("test-uid-456", "goal-1")
+            assert captured_ctx.get('feature') == Features.GOALS
+            assert captured_ctx.get('uid') == "test-uid-456"
+        finally:
+            mock_llm_medium.invoke = original_invoke
+
+    def test_extract_and_update_goal_progress_sets_context(self):
+        """Verify extract_and_update_goal_progress sets context during LLM call."""
+        captured_ctx = {}
+        original_invoke = mock_llm_mini.invoke
+
+        def capturing_invoke(prompt):
+            ctx = _usage_context.get()
+            if ctx:
+                captured_ctx['uid'] = ctx.uid
+                captured_ctx['feature'] = ctx.feature
+            return MagicMock(content='{"found": false, "value": null, "reasoning": "no progress"}')
+
+        mock_llm_mini.invoke = capturing_invoke
+        sys.modules["database.goals"].get_user_goal = MagicMock(
+            return_value={
+                'id': 'goal-1',
+                'title': 'Save $10000',
+                'current_value': 2000,
+                'target_value': 10000,
+                'goal_type': 'numeric',
+            }
+        )
+        try:
+            from utils.llm.goals import extract_and_update_goal_progress
+
+            extract_and_update_goal_progress("test-uid-789", "I saved another $500 today")
+            assert captured_ctx.get('feature') == Features.GOALS
+            assert captured_ctx.get('uid') == "test-uid-789"
+        finally:
+            mock_llm_mini.invoke = original_invoke
+
+
+class TestKnowledgeGraphTracking:
+    """Verify track_usage(uid, Features.KNOWLEDGE_GRAPH) wraps LLM calls."""
+
+    def test_extract_knowledge_has_tracking(self):
+        source = _read_source("utils/llm/knowledge_graph.py")
+        assert "with track_usage(uid, Features.KNOWLEDGE_GRAPH):" in source
+
+    def test_both_llm_calls_tracked(self):
+        source = _read_source("utils/llm/knowledge_graph.py")
+        count = source.count("with track_usage(uid, Features.KNOWLEDGE_GRAPH):")
+        assert count == 2, f"Expected 2 track_usage(KNOWLEDGE_GRAPH) wrappers, found {count}"
+
+    def test_extract_knowledge_sets_context(self):
+        """Verify extract_knowledge_from_memory sets context during LLM call."""
+        captured_ctx = {}
+        original_invoke = mock_llm_mini.invoke
+
+        def capturing_invoke(prompt):
+            ctx = _usage_context.get()
+            if ctx:
+                captured_ctx['uid'] = ctx.uid
+                captured_ctx['feature'] = ctx.feature
+            return MagicMock(content='{"nodes": [], "edges": []}')
+
+        mock_llm_mini.invoke = capturing_invoke
+        try:
+            from utils.llm.knowledge_graph import extract_knowledge_from_memory
+
+            extract_knowledge_from_memory("test-uid-kg", "User likes pizza", "mem-1", "TestUser")
+            assert captured_ctx.get('feature') == Features.KNOWLEDGE_GRAPH
+            assert captured_ctx.get('uid') == "test-uid-kg"
+        finally:
+            mock_llm_mini.invoke = original_invoke
+
+
+class TestExternalIntegrationsTracking:
+    """Verify track_usage wraps LLM calls in external_integrations.py."""
+
+    def test_get_conversation_summary_has_tracking(self):
+        source = _read_source("utils/llm/external_integrations.py")
+        assert "with track_usage(uid, Features.DAILY_SUMMARY):" in source
+
+    def test_both_daily_summary_calls_tracked(self):
+        source = _read_source("utils/llm/external_integrations.py")
+        count = source.count("with track_usage(uid, Features.DAILY_SUMMARY):")
+        assert count == 2, f"Expected 2 track_usage(DAILY_SUMMARY) wrappers, found {count}"
+
+    def test_get_conversation_summary_sets_context(self):
+        """Verify get_conversation_summary sets context during LLM call."""
+        captured_ctx = {}
+        original_invoke = mock_llm_mini.invoke
+
+        def capturing_invoke(prompt):
+            ctx = _usage_context.get()
+            if ctx:
+                captured_ctx['uid'] = ctx.uid
+                captured_ctx['feature'] = ctx.feature
+            return MagicMock(content="Summary: Do X, Y, Z")
+
+        mock_llm_mini.invoke = capturing_invoke
+        try:
+            from utils.llm.external_integrations import get_conversation_summary
+
+            get_conversation_summary("test-uid-summary", [])
+            assert captured_ctx.get('feature') == Features.DAILY_SUMMARY
+            assert captured_ctx.get('uid') == "test-uid-summary"
+        finally:
+            mock_llm_mini.invoke = original_invoke
+
+
+class TestNotificationsTracking:
+    """Verify track_usage wraps LLM calls in notifications.py."""
+
+    def test_both_notification_calls_tracked(self):
+        source = _read_source("utils/llm/notifications.py")
+        count = source.count("with track_usage(uid, Features.SUBSCRIPTION_NOTIFICATION):")
+        assert count == 2, f"Expected 2 track_usage(SUBSCRIPTION_NOTIFICATION) wrappers, found {count}"
+
+    def test_generate_notification_message_sets_context(self):
+        """Verify generate_notification_message sets context during async LLM call."""
+        captured_ctx = {}
+
+        async def capturing_ainvoke(prompt):
+            ctx = _usage_context.get()
+            if ctx:
+                captured_ctx['uid'] = ctx.uid
+                captured_ctx['feature'] = ctx.feature
+            return MagicMock(content="Hey there! Welcome!")
+
+        original_ainvoke = mock_llm_medium.ainvoke
+        mock_llm_medium.ainvoke = capturing_ainvoke
+        try:
+            from utils.llm.notifications import generate_notification_message
+
+            loop = asyncio.new_event_loop()
+            result = loop.run_until_complete(generate_notification_message("test-uid-notif", "Alice", "unlimited"))
+            loop.close()
+            assert captured_ctx.get('feature') == Features.SUBSCRIPTION_NOTIFICATION
+            assert captured_ctx.get('uid') == "test-uid-notif"
+            assert result[0] == "omi"
+        finally:
+            mock_llm_medium.ainvoke = original_ainvoke
+
+    def test_generate_credit_limit_notification_sets_context(self):
+        """Verify generate_credit_limit_notification sets context during async LLM call."""
+        captured_ctx = {}
+
+        async def capturing_ainvoke(prompt):
+            ctx = _usage_context.get()
+            if ctx:
+                captured_ctx['uid'] = ctx.uid
+                captured_ctx['feature'] = ctx.feature
+            return MagicMock(content="You've been using transcription a lot!")
+
+        original_ainvoke = mock_llm_medium.ainvoke
+        mock_llm_medium.ainvoke = capturing_ainvoke
+        try:
+            from utils.llm.notifications import generate_credit_limit_notification
+
+            loop = asyncio.new_event_loop()
+            result = loop.run_until_complete(generate_credit_limit_notification("test-uid-credit", "Bob"))
+            loop.close()
+            assert captured_ctx.get('feature') == Features.SUBSCRIPTION_NOTIFICATION
+            assert captured_ctx.get('uid') == "test-uid-credit"
+            assert result[0] == "omi"
+        finally:
+            mock_llm_medium.ainvoke = original_ainvoke
+
+
+class TestFeatureConstants:
+    """Verify all new feature constants exist."""
+
+    def test_daily_summary_constant(self):
+        assert Features.DAILY_SUMMARY == "daily_summary"
+
+    def test_subscription_notification_constant(self):
+        assert Features.SUBSCRIPTION_NOTIFICATION == "subscription_notification"
+
+    def test_knowledge_graph_constant(self):
+        assert Features.KNOWLEDGE_GRAPH == "knowledge_graph"
+
+    def test_goals_constant_exists(self):
+        assert Features.GOALS == "goals"
+
+
+class TestNoDoubleWrapping:
+    """Verify there's no double-wrapping of track_usage at caller + callee."""
+
+    def test_other_notifications_no_track_usage(self):
+        """utils/other/notifications.py should NOT wrap generate_comprehensive_daily_summary
+        since tracking is now inside the function itself."""
+        source = _read_source("utils/other/notifications.py")
+        assert (
+            "track_usage" not in source
+        ), "utils/other/notifications.py should not import or use track_usage (tracking is in the LLM function)"

--- a/backend/utils/llm/goals.py
+++ b/backend/utils/llm/goals.py
@@ -2,6 +2,7 @@
 LLM utilities for goal tracking.
 Handles AI-powered goal suggestions, advice generation, and progress extraction.
 """
+
 import json
 import re
 import traceback
@@ -14,6 +15,7 @@ import database.conversations as conversations_db
 import database.chat as chat_db
 from database.vector_db import query_vectors as vector_search
 from utils.llm.clients import llm_mini, llm_medium
+from utils.llm.usage_tracker import track_usage, Features
 
 
 def _get_goal_context(uid: str, goal_title: str) -> Dict[str, str]:
@@ -23,12 +25,12 @@ def _get_goal_context(uid: str, goal_title: str) -> Dict[str, str]:
     2. Recent conversations (last 7 days)
     3. Recent chat messages
     4. User memories/facts
-    
+
     Returns dict with conversation_context, chat_context, memory_context
     """
     conv_summaries = []
     seen_ids = set()
-    
+
     # 1. Vector search: Find conversations semantically related to the goal
     try:
         relevant_ids = vector_search(query=goal_title, uid=uid, k=10)
@@ -43,15 +45,12 @@ def _get_goal_context(uid: str, goal_title: str) -> Dict[str, str]:
                         conv_summaries.append(f"[Relevant] {overview[:300]}")
     except Exception as e:
         print(f"[GOAL-ADVICE] Vector search error: {e}")
-    
+
     # 2. Recent conversations (last 7 days) - for current context
     try:
         week_ago = datetime.now(timezone.utc) - timedelta(days=7)
         recent_convs = conversations_db.get_conversations(
-            uid=uid, 
-            limit=20, 
-            statuses=['completed'],
-            include_discarded=False
+            uid=uid, limit=20, statuses=['completed'], include_discarded=False
         )
         for conv in recent_convs:
             conv_id = conv.get('id')
@@ -67,7 +66,7 @@ def _get_goal_context(uid: str, goal_title: str) -> Dict[str, str]:
                             break
     except Exception as e:
         print(f"[GOAL-ADVICE] Recent conversations error: {e}")
-    
+
     # 3. Recent chat messages
     chat_context = ""
     try:
@@ -82,7 +81,7 @@ def _get_goal_context(uid: str, goal_title: str) -> Dict[str, str]:
             chat_context = '\n'.join(chat_lines[-10:])  # Last 10 messages
     except Exception as e:
         print(f"[GOAL-ADVICE] Chat messages error: {e}")
-    
+
     # 4. User memories/facts
     memory_context = ""
     try:
@@ -91,11 +90,11 @@ def _get_goal_context(uid: str, goal_title: str) -> Dict[str, str]:
         memory_context = '\n'.join(memory_texts)
     except Exception as e:
         print(f"[GOAL-ADVICE] Memories error: {e}")
-    
+
     return {
         'conversation_context': '\n'.join(conv_summaries),
         'chat_context': chat_context,
-        'memory_context': memory_context
+        'memory_context': memory_context,
     }
 
 
@@ -104,7 +103,7 @@ def suggest_goal(uid: str) -> Dict:
     try:
         # Get user's memories for context
         memories = memories_db.get_memories(uid, limit=100, offset=0)
-        
+
         if not memories:
             # Default suggestion when no memories
             return {
@@ -113,13 +112,13 @@ def suggest_goal(uid: str) -> Dict:
                 'suggested_target': 10,
                 'suggested_min': 0,
                 'suggested_max': 10,
-                'reasoning': 'Start tracking your daily learning progress!'
+                'reasoning': 'Start tracking your daily learning progress!',
             }
-        
+
         # Prepare memory context for AI
         memory_texts = [m.get('content', '') for m in memories[:50] if m.get('content')]
         memory_context = '\n'.join(memory_texts[:20])  # Limit context size
-        
+
         prompt = f"""Based on the user's memories and interests, suggest ONE meaningful personal goal they could track.
 
 User's recent memories/learnings:
@@ -142,8 +141,9 @@ Choose a goal type:
 
 Make the goal specific, measurable, and relevant to their interests."""
 
-        response = llm_mini.invoke(prompt).content
-        
+        with track_usage(uid, Features.GOALS):
+            response = llm_mini.invoke(prompt).content
+
         # Find JSON in response
         json_match = re.search(r'\{[^{}]*\}', response, re.DOTALL)
         if json_match:
@@ -152,7 +152,7 @@ Make the goal specific, measurable, and relevant to their interests."""
             suggestion['suggested_min'] = suggestion.get('suggested_min', 0)
             suggestion['suggested_max'] = suggestion.get('suggested_max', suggestion.get('suggested_target', 10))
             return suggestion
-        
+
         # Fallback if parsing fails
         return {
             'suggested_title': 'Track your daily progress',
@@ -160,18 +160,18 @@ Make the goal specific, measurable, and relevant to their interests."""
             'suggested_target': 10,
             'suggested_min': 0,
             'suggested_max': 10,
-            'reasoning': 'A simple goal to get you started!'
+            'reasoning': 'A simple goal to get you started!',
         }
-        
+
     except Exception as e:
         print(f"Error generating goal suggestion: {e}")
         return {
             'suggested_title': 'Make progress every day',
-            'suggested_type': 'scale', 
+            'suggested_type': 'scale',
             'suggested_target': 10,
             'suggested_min': 0,
             'suggested_max': 10,
-            'reasoning': 'Start with a simple daily progress goal!'
+            'reasoning': 'Start with a simple daily progress goal!',
         }
 
 
@@ -185,19 +185,19 @@ def get_goal_advice(uid: str, goal_id: str) -> str:
         goal = goals_db.get_user_goal(uid)
         if not goal or goal.get('id') != goal_id:
             raise ValueError("Goal not found")
-        
+
         goal_title = goal.get('title', 'Unknown')
         current_value = goal.get('current_value', 0)
         target_value = goal.get('target_value', 10)
-        
+
         # Calculate progress
         progress_pct = 0
         if target_value > 0:
             progress_pct = (current_value / target_value) * 100
-        
+
         # Get rich context using hybrid retrieval
         context = _get_goal_context(uid, goal_title)
-        
+
         # Build the prompt with full context
         prompt = f"""You are a strategic advisor. Based on the user's goal and their context, give ONE specific actionable step they should take THIS WEEK.
 
@@ -215,16 +215,19 @@ USER FACTS:
 
 Give ONE specific action in 1-2 sentences. Be concise but complete. No generic advice."""
 
-        print(f"[GOAL-ADVICE] Generating advice for '{goal_title}' with {len(context['conversation_context'])} chars conv, {len(context['chat_context'])} chars chat")
-        
+        print(
+            f"[GOAL-ADVICE] Generating advice for '{goal_title}' with {len(context['conversation_context'])} chars conv, {len(context['chat_context'])} chars chat"
+        )
+
         # Use the better model for high-quality advice
-        advice = llm_medium.invoke(prompt).content
-        
+        with track_usage(uid, Features.GOALS):
+            advice = llm_medium.invoke(prompt).content
+
         # Clean up quotes but keep full text
         advice = advice.strip().strip('"').strip("'")
-        
+
         return advice
-        
+
     except Exception as e:
         print(f"[GOAL-ADVICE] Error: {e}")
         traceback.print_exc()
@@ -240,12 +243,12 @@ def extract_and_update_goal_progress(uid: str, text: str) -> Optional[Dict]:
         goal = goals_db.get_user_goal(uid)
         if not goal or not text or len(text) < 5:
             return None
-        
+
         goal_title = goal.get('title', '')
         current_value = goal.get('current_value', 0)
         target_value = goal.get('target_value', 10)
         goal_type = goal.get('goal_type', 'numeric')
-        
+
         prompt = f"""Analyze this message to see if it mentions progress toward this goal:
 
 Goal: "{goal_title}"
@@ -265,8 +268,9 @@ Handle formats like:
 Return JSON only: {{"found": true/false, "value": number_or_null, "reasoning": "brief explanation"}}
 Only return found=true if you're confident this is about the SPECIFIC goal mentioned above."""
 
-        response = llm_mini.invoke(prompt).content
-        
+        with track_usage(uid, Features.GOALS):
+            response = llm_mini.invoke(prompt).content
+
         # Extract JSON from response
         match = re.search(r'\{[^{}]*(?:\{[^{}]*\}[^{}]*)*\}', response, re.DOTALL)
         if match:
@@ -276,15 +280,16 @@ Only return found=true if you're confident this is about the SPECIFIC goal menti
                 old_value = current_value
                 if new_value != old_value:
                     goals_db.update_goal_progress(uid, goal['id'], new_value)
-                    print(f"[GOAL-AUTO] Updated '{goal_title}': {old_value} -> {new_value} (reasoning: {result.get('reasoning', 'N/A')})")
+                    print(
+                        f"[GOAL-AUTO] Updated '{goal_title}': {old_value} -> {new_value} (reasoning: {result.get('reasoning', 'N/A')})"
+                    )
                     return {
                         "status": "updated",
                         "old_value": old_value,
                         "new_value": new_value,
-                        "reasoning": result.get('reasoning')
+                        "reasoning": result.get('reasoning'),
                     }
         return {"status": "no_update", "message": "No relevant progress mentioned or extracted."}
     except Exception as e:
         print(f"Error in extract_and_update_goal_progress: {e}")
         return {"status": "error", "message": str(e)}
-

--- a/backend/utils/llm/notifications.py
+++ b/backend/utils/llm/notifications.py
@@ -1,6 +1,7 @@
 import random
 from typing import Tuple, List
 from .clients import llm_medium
+from .usage_tracker import track_usage, Features
 from database.memories import get_memories
 
 
@@ -61,7 +62,8 @@ async def generate_notification_message(uid: str, name: str, plan_type: str = "b
     Return only the notification body text - make it personal, warm and engaging."""
 
     try:
-        response = await llm_medium.ainvoke(system_prompt + "\n" + user_prompt)
+        with track_usage(uid, Features.SUBSCRIPTION_NOTIFICATION):
+            response = await llm_medium.ainvoke(system_prompt + "\n" + user_prompt)
         body = response.content
         # Return placeholder title and generated body
         return "omi", body.strip()
@@ -118,7 +120,8 @@ async def generate_credit_limit_notification(uid: str, name: str) -> Tuple[str, 
     Return only the notification body text."""
 
     try:
-        response = await llm_medium.ainvoke(system_prompt + "\n" + user_prompt)
+        with track_usage(uid, Features.SUBSCRIPTION_NOTIFICATION):
+            response = await llm_medium.ainvoke(system_prompt + "\n" + user_prompt)
         body = response.content
         return "omi", body.strip()
 

--- a/backend/utils/llm/usage_tracker.py
+++ b/backend/utils/llm/usage_tracker.py
@@ -178,6 +178,9 @@ class Features:
     MEMORIES = "memories"
     TRANSCRIBE = "transcribe"
     REALTIME_INTEGRATIONS = "realtime_integrations"
+    DAILY_SUMMARY = "daily_summary"
+    SUBSCRIPTION_NOTIFICATION = "subscription_notification"
+    KNOWLEDGE_GRAPH = "knowledge_graph"
     OTHER = "other"
 
     # Conversation processing sub-features (granular cost tracking)


### PR DESCRIPTION
Partial fix for #4619 (HIGH priority subset)

Adds `track_usage` context managers to 10 previously untracked LLM call sites across 4 modules, enabling per-feature cost attribution for goals, knowledge graph, daily summaries, and subscription notifications.

### Changes
- **goals.py**: Wrap `suggest_goal` (llm_mini), `get_goal_advice` (llm_medium), `extract_and_update_goal_progress` (llm_mini) with `track_usage(uid, Features.GOALS)`
- **knowledge_graph.py**: Wrap `extract_knowledge_from_memory` and `rebuild_knowledge_graph.process_memory` with `track_usage(uid, Features.KNOWLEDGE_GRAPH)`
- **external_integrations.py**: Wrap `get_conversation_summary` (llm_mini) and `generate_comprehensive_daily_summary` (llm_medium_experiment) with `track_usage(uid, Features.DAILY_SUMMARY)`
- **notifications.py**: Wrap `generate_notification_message` and `generate_credit_limit_notification` (both llm_medium async) with `track_usage(uid, Features.SUBSCRIPTION_NOTIFICATION)`
- **usage_tracker.py**: Add 3 new feature constants: `DAILY_SUMMARY`, `SUBSCRIPTION_NOTIFICATION`, `KNOWLEDGE_GRAPH`
- Remove redundant outer `track_usage` wrapper in `utils/other/notifications.py` (tracking now lives inside the LLM function)

### Tests
19 unit tests covering:
- Source-level verification that all LLM calls are wrapped
- Runtime context capture confirming correct uid and feature during LLM invocation
- Feature constant existence
- No double-wrapping verification

---
_by AI for @beastoin_