### PR TITLE
chore: bump app version to 1.0.524+690

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.523+690
+version: 1.0.524+690
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bump app version from 1.0.523+690 to 1.0.524+690

🤖 Generated with [Claude Code](https://claude.com/claude-code)