### PR TITLE
fix: AttributeError in KG extraction - wrong return type (#4626)

### DIFF
--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -456,10 +456,9 @@ def _extract_memories_inner(uid: str, conversation: Conversation):
 
         try:
             from utils.llm.knowledge_graph import extract_knowledge_from_memory
-            from database import users as users_db
+            from database.auth import get_user_name
 
-            user = users_db.get_user_profile(uid)
-            user_name = user.get('name', 'User') if user else 'User'
+            user_name = get_user_name(uid)
 
             from database.memories import set_memory_kg_extracted
 


### PR DESCRIPTION
## Summary
- **Bug:** `get_user_store_recording_permission(uid)` returns a `bool`, but KG extraction code on line 462 of `process_conversation.py` called `.get('name', 'User')` on it, raising `AttributeError` for users with `store_recording_permission=True`
- **Root cause:** Firestore `users` collection has no `name` field — so even `get_user_profile()` would always default to `'User'`
- **Fix:** Use `get_user_name()` from `database/auth.py` which reads `display_name` from Firebase Auth — the canonical way to get user names in this codebase (matching `chat.py`, `apps.py`, `memories.py` callers)
- **Also fixed:** `routers/knowledge_graph.py` had the same issue
- **Tests:** 6 tests covering source inspection, regression, missing name fallback, None name, and multi-memory batch extraction

## Changes
| File | Change |
|------|--------|
| `utils/conversations/process_conversation.py` | Replace `get_user_store_recording_permission()` with `get_user_name()` from `database.auth` |
| `routers/knowledge_graph.py` | Replace `get_user_profile()` with `get_user_name()` from `database.auth`, remove unused `users_db` import |
| `tests/unit/test_kg_user_type_mismatch.py` | 6 regression tests validating the fix |

## Test plan
- [x] Source inspection: no `get_user_store_recording_permission` or `get_user_profile` in KG path
- [x] Source inspection: `routers/knowledge_graph.py` uses `get_user_name`
- [x] Behavioral: `get_user_name` called with uid, result passed to `extract_knowledge_from_memory`
- [x] Default name: returns `The User` — passed through correctly
- [x] None name: returns `None` — no crash
- [x] Multi-memory: batch of 3, only 2 non-extracted get KG processing
- [x] All 6 tests pass, mutation tests confirm regressions are caught

CP7 re-run: 6/6 pass.

Closes #4626

_by AI for @beastoin_