### PR TITLE
Fix daily score to use 0.1 increments instead of 0.5

### DIFF
--- a/app/lib/pages/conversations/widgets/daily_score_widget.dart
+++ b/app/lib/pages/conversations/widgets/daily_score_widget.dart
@@ -76,8 +76,8 @@ class DailyScoreWidgetState extends State<DailyScoreWidget> {
           score = (ratio * 5).clamp(0.0, 5.0);
         }
 
-        // Round to nearest 0.5
-        score = (score * 2).roundToDouble() / 2;
+        // Round to nearest 0.1
+        score = (score * 10).roundToDouble() / 10;
 
         final statusColor = _getStatusColor(score);
 


### PR DESCRIPTION
## Summary
- Changed daily score rounding from 0.5 increments to 0.1 increments for finer granularity
- Score now shows values like 0.3, 1.7, 2.4 instead of only 0.0, 0.5, 1.0, 1.5

## Test plan
- [x] All existing tests pass
- [ ] Verify daily score gauge shows 0.1 granularity values on device

🤖 Generated with [Claude Code](https://claude.com/claude-code)