### PR TITLE
feat(macos): add 'Check for Updates...' menu item

### DIFF
--- a/app/lib/desktop/pages/settings/desktop_settings_modal.dart
+++ b/app/lib/desktop/pages/settings/desktop_settings_modal.dart
@@ -50,7 +50,10 @@ import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/responsive/responsive_helper.dart';
 import 'package:omi/services/notifications/daily_reflection_notification.dart';
 import 'package:provider/provider.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:url_launcher/url_launcher.dart';
+
+import 'package:omi/services/desktop_update_service.dart';
 
 enum SettingsSection {
   account,
@@ -2290,6 +2293,38 @@ class _DesktopSettingsModalState extends State<DesktopSettingsModal> {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
+        // Software Update section
+        _buildSettingsGroup(
+          title: 'SOFTWARE UPDATE',
+          children: [
+            FutureBuilder<PackageInfo>(
+              future: PackageInfo.fromPlatform(),
+              builder: (context, snapshot) {
+                final version = snapshot.hasData
+                    ? 'v${snapshot.data!.version} (${snapshot.data!.buildNumber})'
+                    : '...';
+                return _buildSettingsRow(
+                  title: 'Current Version',
+                  subtitle: version,
+                  showChevron: false,
+                  onTap: () {},
+                );
+              },
+            ),
+            _buildSettingsRow(
+              title: 'Check for Updates...',
+              subtitle: DesktopUpdateService().isAvailable
+                  ? 'Checks every 3 hours automatically'
+                  : 'Update service not initialized',
+              onTap: () {
+                DesktopUpdateService().checkForUpdates();
+              },
+            ),
+          ],
+        ),
+
+        const SizedBox(height: 24),
+
         _buildSettingsGroup(
           title: context.l10n.links,
           children: [

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -121,9 +121,25 @@ class AppDelegate: FlutterAppDelegate {
     }
     
     // MARK: - Check for Updates
-    
+
     @IBAction func checkForUpdates(_ sender: Any) {
-        updateChannel?.invokeMethod("checkForUpdates", arguments: nil)
-        NSLog("DEBUG: Triggered check for updates via menu")
+        // Lazily initialize channel if needed (in case it wasn't ready at app launch)
+        if updateChannel == nil {
+            if let mainWindow = NSApp.windows.first(where: { $0 is MainFlutterWindow }) as? MainFlutterWindow,
+               let flutterViewController = mainWindow.contentViewController as? FlutterViewController {
+                updateChannel = FlutterMethodChannel(
+                    name: "com.omi/updates",
+                    binaryMessenger: flutterViewController.engine.binaryMessenger
+                )
+                NSLog("DEBUG: Lazily initialized updates method channel")
+            }
+        }
+
+        if let channel = updateChannel {
+            channel.invokeMethod("checkForUpdates", arguments: nil)
+            NSLog("DEBUG: Triggered check for updates via menu")
+        } else {
+            NSLog("ERROR: Could not initialize updates method channel - Flutter not ready")
+        }
     }
 }

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -9,6 +9,9 @@ import app_links
 class AppDelegate: FlutterAppDelegate {
     // Method channel for direct URL delivery to Flutter
     private var urlChannel: FlutterMethodChannel?
+    
+    // Method channel for update checking
+    private var updateChannel: FlutterMethodChannel?
 
     // Required for app_links plugin to register Apple Event handler for URL schemes
     override func applicationWillFinishLaunching(_ notification: Notification) {
@@ -104,6 +107,27 @@ class AppDelegate: FlutterAppDelegate {
         for url in urls {
             print("DEBUG: Received URL scheme callback: \(url.absoluteString)")
             AppLinks.shared.handleLink(link: url.absoluteString)
+        }
+    }
+    
+    // MARK: - Check for Updates
+    
+    @IBAction func checkForUpdates(_ sender: Any) {
+        setupUpdateChannel()
+        updateChannel?.invokeMethod("checkForUpdates", arguments: nil)
+        NSLog("DEBUG: Triggered check for updates via menu")
+    }
+    
+    private func setupUpdateChannel() {
+        guard updateChannel == nil else { return }
+        
+        if let mainWindow = NSApp.windows.first(where: { $0 is MainFlutterWindow }) as? MainFlutterWindow,
+           let flutterViewController = mainWindow.contentViewController as? FlutterViewController {
+            updateChannel = FlutterMethodChannel(
+                name: "com.omi/updates",
+                binaryMessenger: flutterViewController.engine.binaryMessenger
+            )
+            NSLog("DEBUG: Created updates method channel")
         }
     }
 }

--- a/app/macos/Runner/AppDelegate.swift
+++ b/app/macos/Runner/AppDelegate.swift
@@ -69,6 +69,16 @@ class AppDelegate: FlutterAppDelegate {
 
         super.applicationDidFinishLaunching(aNotification)
 
+        // Initialize method channels now that Flutter engine is ready
+        if let mainWindow = NSApp.windows.first(where: { $0 is MainFlutterWindow }) as? MainFlutterWindow,
+           let flutterViewController = mainWindow.contentViewController as? FlutterViewController {
+            updateChannel = FlutterMethodChannel(
+                name: "com.omi/updates",
+                binaryMessenger: flutterViewController.engine.binaryMessenger
+            )
+            NSLog("DEBUG: Initialized updates method channel")
+        }
+
         // Delay to check if app was launched hidden (e.g., as a login item)
         DispatchQueue.main.async {
             if !NSApp.isHidden {
@@ -113,21 +123,7 @@ class AppDelegate: FlutterAppDelegate {
     // MARK: - Check for Updates
     
     @IBAction func checkForUpdates(_ sender: Any) {
-        setupUpdateChannel()
         updateChannel?.invokeMethod("checkForUpdates", arguments: nil)
         NSLog("DEBUG: Triggered check for updates via menu")
-    }
-    
-    private func setupUpdateChannel() {
-        guard updateChannel == nil else { return }
-        
-        if let mainWindow = NSApp.windows.first(where: { $0 is MainFlutterWindow }) as? MainFlutterWindow,
-           let flutterViewController = mainWindow.contentViewController as? FlutterViewController {
-            updateChannel = FlutterMethodChannel(
-                name: "com.omi/updates",
-                binaryMessenger: flutterViewController.engine.binaryMessenger
-            )
-            NSLog("DEBUG: Created updates method channel")
-        }
     }
 }

--- a/app/macos/Runner/Base.lproj/MainMenu.xib
+++ b/app/macos/Runner/Base.lproj/MainMenu.xib
@@ -33,6 +33,13 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="VOq-y0-SEH"/>
+                            <menuItem title="Check for Updates…" id="9fK-3T-uXw">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="checkForUpdates:" target="Voe-Tx-rLC" id="kRq-8H-2mN"/>
+                                </connections>
+                            </menuItem>
+                            <menuItem isSeparatorItem="YES" id="aWz-Qf-7bP"/>
                             <menuItem title="Preferences…" keyEquivalent="," id="BOF-NM-1cW"/>
                             <menuItem isSeparatorItem="YES" id="wFC-TO-SCJ"/>
                             <menuItem title="Services" id="NMo-om-nkz">


### PR DESCRIPTION
## Summary
Adds a manual "Check for Updates..." menu item to the macOS app, allowing users to trigger update checks on demand.

Fixes #4550

## Changes

### Swift (AppDelegate.swift)
- Added `updateChannel` for Flutter communication
- Added `checkForUpdates:` IBAction triggered by menu
- Added `setupUpdateChannel()` to lazily initialize the method channel

### XIB (MainMenu.xib)
- Added "Check for Updates..." menu item after "About" separator
- Wired to `checkForUpdates:` selector on AppDelegate

### Dart (desktop_update_service.dart)
- Added `MethodChannel('com.omi/updates')` 
- Added `_handleMethodCall` to receive native calls and trigger `checkForUpdates()`

## Testing
- [ ] Menu item appears under Omi menu after "About Omi"
- [ ] Clicking triggers Sparkle update check dialog
- [ ] Works when app is up to date (shows "up to date" message)
- [ ] Works when update is available (shows update dialog)

## Screenshots
_(Menu item location: Omi > Check for Updates...)_