### PR TITLE
fix: only count usage minutes when words are actually transcribed

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -317,7 +317,7 @@ async def _stream_handler(
                 words_to_record = words_transcribed_since_last_record
                 words_transcribed_since_last_record = 0  # reset
 
-                if transcription_seconds > 0 or words_to_record > 0:
+                if words_to_record > 0:
                     record_usage(uid, transcription_seconds=transcription_seconds, words_transcribed=words_to_record)
                 last_usage_record_timestamp = current_time
 
@@ -2033,7 +2033,7 @@ async def _stream_handler(
         if not use_custom_stt and last_usage_record_timestamp:
             transcription_seconds = int(time.time() - last_usage_record_timestamp)
             words_to_record = words_transcribed_since_last_record
-            if transcription_seconds > 0 or words_to_record > 0:
+            if words_to_record > 0:
                 record_usage(uid, transcription_seconds=transcription_seconds, words_transcribed=words_to_record)
         websocket_active = False
 


### PR DESCRIPTION
## Summary

- Usage tracking was recording wall-clock elapsed time (every 60s) as `transcription_seconds` regardless of whether any speech was actually transcribed
- This caused free-tier/basic plan users to burn through their monthly minute quota while the device was idle or picking up only silence
- Example: a user showing 25 minutes of actual transcription but 246 minutes of "used" quota

## Root Cause

In `_record_usage_periodically()` and the `finally` cleanup block, the condition was:

```python
if transcription_seconds > 0 or words_to_record > 0:
    record_usage(...)
```

Since `transcription_seconds` is wall-clock elapsed time (always > 0), usage was **always** recorded even when `words_to_record == 0` (no speech in that interval).

## Fix

Changed the condition to only record usage when words were actually transcribed:

```python
if words_to_record > 0:
    record_usage(...)
```

The `transcription_seconds` still reflects the time window those words arrived in, which is a reasonable measure of active listening time — it just no longer records seconds for periods of pure silence.

## Test plan

- [x] Backend tests pass
- [ ] Verify free-tier user's monthly usage only increments when speech is detected
- [ ] Confirm usage page shows accurate minutes after idle periods

🤖 Generated with [Claude Code](https://claude.com/claude-code)