### PR TITLE
Downgrade conv_action_items from gpt-5.1 to gpt-4.1-mini (#4637)

### DIFF
--- a/backend/tests/unit/test_process_conversation_usage_context.py
+++ b/backend/tests/unit/test_process_conversation_usage_context.py
@@ -445,16 +445,14 @@ def test_models_unchanged_for_llm_calls():
         app_match.group(1) == "llm_medium_experiment"
     ), f"Expected llm_medium_experiment for app result, got {app_match.group(1)}"
 
-    # extract_action_items should use llm_medium_experiment
+    # extract_action_items should use llm_mini (downgraded from llm_medium_experiment for cost savings)
     action_match = re.search(
         r'def extract_action_items.*?chain = prompt \| (\w+) \| action_items_parser',
         conv_proc_source,
         re.DOTALL,
     )
     assert action_match is not None
-    assert (
-        action_match.group(1) == "llm_medium_experiment"
-    ), f"Expected llm_medium_experiment for action items, got {action_match.group(1)}"
+    assert action_match.group(1) == "llm_mini", f"Expected llm_mini for action items, got {action_match.group(1)}"
 
 
 def test_threaded_tracking_context_isolation():

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -548,7 +548,7 @@ def extract_action_items(
     # Second system message: conversation context + existing items (dynamic, per-conversation)
     context_message = 'The content language is {language_code}. Use the same language {language_code} for your response.\n\nContent:\n{conversation_context}{existing_items_context}'
     prompt = ChatPromptTemplate.from_messages([('system', instructions_text), ('system', context_message)])
-    chain = prompt | llm_medium_experiment | action_items_parser
+    chain = prompt | llm_mini | action_items_parser
 
     try:
         response = chain.invoke(


### PR DESCRIPTION
## Summary

Switches `extract_action_items()` from `llm_medium_experiment` (gpt-5.1) to `llm_mini` (gpt-4.1-mini).

Action item extraction is a well-constrained task — pattern matching explicit requests ("remind me to X", "don't forget to Y") and outputting structured Pydantic objects. gpt-4.1-mini handles this class of task well.

**Impact:** `conv_action_items` is 19.8% of total LLM spend. gpt-4.1-mini is ~80% cheaper → estimated **10-15% reduction in total LLM costs**.

**Changes:**
- `conversation_processing.py:551` — swap `llm_medium_experiment` → `llm_mini`
- Updated model assertion test

## Test plan

- [x] All backend tests pass (25 tests)
- [ ] Monitor action item quality post-deploy via sampling
- [ ] Compare token costs in BQ `llm_usage.raw` before/after

Closes #4637

🤖 Generated with [Claude Code](https://claude.com/claude-code)