### PR TITLE
Indented tasks persistence

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -222,6 +222,24 @@ class SharedPreferencesUtil {
     }
   }
 
+  // Task indent levels (local UI state)
+  // Format: { "taskId": indentLevel }
+  set taskIndentLevels(Map<String, int> value) {
+    final encoded = jsonEncode(value);
+    saveString('taskIndentLevels', encoded);
+  }
+
+  Map<String, int> get taskIndentLevels {
+    final encoded = getString('taskIndentLevels');
+    if (encoded.isEmpty) return {};
+    try {
+      final decoded = jsonDecode(encoded) as Map<String, dynamic>;
+      return decoded.map((key, value) => MapEntry(key, (value as num).toInt()));
+    } catch (e) {
+      return {};
+    }
+  }
+
   // Wrapped 2025 - track if user has viewed their wrapped
   set hasViewedWrapped2025(bool value) => saveBool('hasViewedWrapped2025', value);
 

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -63,6 +63,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     _scrollController.addListener(_onScroll);
     _loadCategoryOrder();
     _loadTaskGoalLinks();
+    _loadTaskIndentLevels();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
       MixpanelManager().actionItemsPageOpened();
@@ -98,6 +99,15 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     // Prune orphaned links after loading
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (mounted) _pruneTaskGoalLinks();
+    });
+  }
+
+  void _loadTaskIndentLevels() {
+    final savedIndents = SharedPreferencesUtil().taskIndentLevels;
+    setState(() {
+      _indentLevels
+        ..clear()
+        ..addAll(savedIndents);
     });
   }
 
@@ -138,6 +148,10 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
       toSave[entry.key.name] = entry.value;
     }
     SharedPreferencesUtil().taskCategoryOrder = toSave;
+  }
+
+  void _saveTaskIndentLevels() {
+    SharedPreferencesUtil().taskIndentLevels = Map<String, int>.from(_indentLevels);
   }
 
   @override
@@ -313,6 +327,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
         _indentLevels[itemId] = current + 1;
       }
     });
+    _saveTaskIndentLevels();
     HapticFeedback.lightImpact();
   }
 
@@ -323,6 +338,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
         _indentLevels[itemId] = current - 1;
       }
     });
+    _saveTaskIndentLevels();
     HapticFeedback.lightImpact();
   }
 


### PR DESCRIPTION
Persist task indent levels across app restarts to ensure indentation state is restored.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-810379db-c6fc-4335-9a5a-11704afd6001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-810379db-c6fc-4335-9a5a-11704afd6001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

