### PR TITLE
fix: crash when transcription segment speaker dont met expectation

### DIFF
--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -32,10 +32,11 @@ class TranscriptSegment(BaseModel):
 
         if self.speaker:
             try:
-                _prefix, self.speaker_id = self.speaker.split("_", 1)
-                self.speaker_id = int(self.speaker_id)
-            except (ValueError, AttributeError):
+                self.speaker_id = int(self.speaker.split('_', 1)[1])
+            except (ValueError, IndexError):
                 self.speaker_id = 0
+        else:
+            self.speaker_id = 0
 
     def get_timestamp_string(self):
         start_duration = timedelta(seconds=int(self.start))


### PR DESCRIPTION
Just provide a guard clause to prevent crash when a transcript_segment dont follow the expectation of have `speaker = "SPEAKER_x"`

Sending `speaker = "niceguy0"` crash he pipeline and transcription segment are permanently loose. 

`speaker = "Joe"` -> raises IndexError
`speaker = "Joe_Smith"` -> raises ValueError
