### PR TITLE
refactor: rename tools → triggers in proactive notification code

### DIFF
--- a/backend/utils/mentor_notifications.py
+++ b/backend/utils/mentor_notifications.py
@@ -82,8 +82,8 @@ MIN_SEGMENTS_FOR_ANALYSIS = 3
 # Minimum confidence to trigger a proactive notification
 PROACTIVE_CONFIDENCE_THRESHOLD = 0.7
 
-# Proactive tool definitions (OpenAI function-calling format)
-PROACTIVE_TOOLS = [
+# Proactive trigger definitions (OpenAI function-calling format)
+PROACTIVE_TRIGGERS = [
     {
         "type": "function",
         "function": {
@@ -314,7 +314,7 @@ Remember: First evaluate silently, then either respond with empty string OR give
         "prompt": adjusted_prompt,
         "params": ["user_name", "user_facts", "user_context", "user_chat"],
         "context": {"filters": {"people": [], "entities": [], "topics": topics}},
-        "tools": PROACTIVE_TOOLS,
+        "triggers": PROACTIVE_TRIGGERS,
         "messages": messages,
     }
 


### PR DESCRIPTION
## Summary

Rename "tools" → "triggers" throughout the proactive mentor notification code. "Tools" is OpenAI API jargon that leaked into the domain layer. "Triggers" matches the actual function names (`trigger_emotional_support`, `trigger_goal_misalignment`, `trigger_argument_perspective`) and better describes what these are: conditions that trigger notifications.

Depends on #4739 (print logging fix — first commit in this branch).

### Renames

| Before | After |
|--------|-------|
| `PROACTIVE_TOOLS` | `PROACTIVE_TRIGGERS` |
| `_process_tools()` | `_process_triggers()` |
| `_build_tool_context()` | `_build_trigger_context()` |
| `tool_uses=True` | `has_triggers=True` |
| `tool_results` | `trigger_results` |
| `tool_name` / `tool_args` | `trigger_name` / `trigger_args` |
| `data["tools"]` | `data["triggers"]` |
| `proactive_tool_*` logs | `proactive_trigger_*` logs |

### Files changed

| File | Change |
|------|--------|
| `backend/utils/mentor_notifications.py` | `PROACTIVE_TOOLS` → `PROACTIVE_TRIGGERS`, `"tools"` → `"triggers"` in data dict |
| `backend/utils/app_integrations.py` | All function/variable/log renames |
| `backend/tests/unit/test_mentor_notifications.py` | All references updated (30 tests) |

## Test plan

- [x] 30/30 unit tests pass
- [x] Live dev test on real user `OAEZL1gRvOQmLLg6E3BzjNpEmtf1` — 4 scenarios:
  - Emotional distress → `trigger_emotional_support` confidence=0.95 — PASS
  - Goal misalignment → no trigger (LLM non-determinism, fired at 0.92 in previous session) — model flake
  - Argument with partner → `trigger_emotional_support` confidence=0.90 — PASS
  - Neutral conversation → no trigger fired (correct, no false positive) — PASS
- [x] Verified `data["triggers"]` key in `create_notification_data()` output
- [x] Verified result dicts contain `trigger_name` and `trigger_args` keys
- [x] Verified log prefix is `proactive_trigger_*`:
  ```
  proactive_trigger triggered=true trigger=trigger_emotional_support confidence=0.95 OAEZL1gRvOQmLLg6E3BzjNpEmtf1
  proactive_trigger_results total_calls=1 accepted=1 OAEZL1gRvOQmLLg6E3BzjNpEmtf1
  proactive_trigger triggered=false OAEZL1gRvOQmLLg6E3BzjNpEmtf1
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)