### PR TITLE
fix: persist speaker diarization across conversations

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -67,6 +67,25 @@ def get_people(uid: str):
     return [person.to_dict() for person in people]
 
 
+def get_people_with_embeddings(uid: str) -> list:
+    """Get all people who have stored speaker embeddings.
+
+    Returns list of dicts with 'id', 'name', and 'speaker_embedding' fields.
+    """
+    people_ref = db.collection('users').document(uid).collection('people')
+    people = people_ref.stream()
+    result = []
+    for person in people:
+        data = person.to_dict()
+        if data.get('speaker_embedding'):
+            result.append({
+                'id': data['id'],
+                'name': data.get('name', ''),
+                'speaker_embedding': data['speaker_embedding'],
+            })
+    return result
+
+
 def get_person_by_name(uid: str, name: str):
     people_ref = db.collection('users').document(uid).collection('people')
     query = people_ref.where(filter=FieldFilter('name', '==', name)).limit(1)

--- a/backend/tests/unit/test_embedding_preload.py
+++ b/backend/tests/unit/test_embedding_preload.py
@@ -1,0 +1,121 @@
+"""Tests for cross-conversation speaker embedding persistence."""
+
+import numpy as np
+import pytest
+from unittest.mock import patch, MagicMock
+
+from utils.speaker_assignment import load_person_embeddings_cache
+
+
+class TestLoadPersonEmbeddingsCache:
+    """Tests for load_person_embeddings_cache."""
+
+    @patch('utils.speaker_assignment.user_db')
+    def test_loads_embeddings_for_people_with_data(self, mock_user_db):
+        mock_user_db.get_people_with_embeddings.return_value = [
+            {
+                'id': 'person-1',
+                'name': 'Alice',
+                'speaker_embedding': [0.1] * 512,
+            },
+            {
+                'id': 'person-2',
+                'name': 'Bob',
+                'speaker_embedding': [0.2] * 512,
+            },
+        ]
+
+        cache = load_person_embeddings_cache('test-uid')
+
+        assert len(cache) == 2
+        assert 'person-1' in cache
+        assert 'person-2' in cache
+        assert cache['person-1']['name'] == 'Alice'
+        assert cache['person-2']['name'] == 'Bob'
+        assert cache['person-1']['embedding'].shape == (1, 512)
+        assert cache['person-2']['embedding'].shape == (1, 512)
+
+    @patch('utils.speaker_assignment.user_db')
+    def test_returns_empty_cache_when_no_people(self, mock_user_db):
+        mock_user_db.get_people_with_embeddings.return_value = []
+
+        cache = load_person_embeddings_cache('test-uid')
+
+        assert len(cache) == 0
+
+    @patch('utils.speaker_assignment.user_db')
+    def test_skips_people_with_invalid_embeddings(self, mock_user_db):
+        mock_user_db.get_people_with_embeddings.return_value = [
+            {
+                'id': 'person-1',
+                'name': 'Alice',
+                'speaker_embedding': [0.1] * 512,
+            },
+            {
+                'id': 'person-2',
+                'name': 'Bob',
+                'speaker_embedding': 'not-a-valid-embedding',
+            },
+        ]
+
+        cache = load_person_embeddings_cache('test-uid')
+
+        assert len(cache) == 1
+        assert 'person-1' in cache
+
+    @patch('utils.speaker_assignment.user_db')
+    def test_reshapes_1d_embeddings(self, mock_user_db):
+        mock_user_db.get_people_with_embeddings.return_value = [
+            {
+                'id': 'person-1',
+                'name': 'Alice',
+                'speaker_embedding': [0.5] * 256,
+            },
+        ]
+
+        cache = load_person_embeddings_cache('test-uid')
+
+        assert cache['person-1']['embedding'].shape == (1, 256)
+
+    @patch('utils.speaker_assignment.user_db')
+    def test_embedding_values_are_correct(self, mock_user_db):
+        embedding_data = [float(i) / 10.0 for i in range(128)]
+        mock_user_db.get_people_with_embeddings.return_value = [
+            {
+                'id': 'person-1',
+                'name': 'Alice',
+                'speaker_embedding': embedding_data,
+            },
+        ]
+
+        cache = load_person_embeddings_cache('test-uid')
+
+        expected = np.array(embedding_data, dtype=np.float32).reshape(1, -1)
+        np.testing.assert_array_almost_equal(cache['person-1']['embedding'], expected)
+
+    @patch('utils.speaker_assignment.user_db')
+    def test_continues_after_single_failure(self, mock_user_db):
+        """Ensure one bad embedding doesn't prevent loading others."""
+        mock_user_db.get_people_with_embeddings.return_value = [
+            {
+                'id': 'person-1',
+                'name': 'Alice',
+                'speaker_embedding': [0.1] * 512,
+            },
+            {
+                'id': 'person-2',
+                'name': 'Bob',
+                'speaker_embedding': None,  # Will cause np.array to fail meaningfully
+            },
+            {
+                'id': 'person-3',
+                'name': 'Charlie',
+                'speaker_embedding': [0.3] * 512,
+            },
+        ]
+
+        cache = load_person_embeddings_cache('test-uid')
+
+        assert len(cache) == 2
+        assert 'person-1' in cache
+        assert 'person-3' in cache


### PR DESCRIPTION
# Fix: Persist speaker diarization across conversations

Fixes #4455

## Summary

Speaker diarization (identifying who is speaking) doesn't persist across WebSocket sessions. Each time a new conversation starts, the `speaker_to_person_map` and `person_embeddings_cache` are initialized empty, even though the database already stores `speaker_embedding` for known people. This means the system has to re-learn every speaker from scratch each session.

This PR preloads stored speaker embeddings from the database when a new streaming session begins, so previously identified speakers are recognized immediately in subsequent conversations.

## Changes

| File | Change |
|------|--------|
| `backend/database/users.py` | Add `get_people_with_embeddings(uid)` to fetch all people with stored speaker embeddings |
| `backend/utils/speaker_assignment.py` | Add `load_person_embeddings_cache(uid)` to convert stored embeddings into the in-memory cache format |
| `backend/routers/transcribe.py` | Import `load_person_embeddings_cache` and preload embeddings at session start when speaker ID is enabled |
| `backend/tests/unit/test_embedding_preload.py` | Unit tests for the new `load_person_embeddings_cache` function |

## How It Works

1. When a new WebSocket session starts with speaker identification enabled, `load_person_embeddings_cache(uid)` is called
2. This queries Firestore for all people under the user who have a `speaker_embedding` field
3. Embeddings are converted to numpy arrays and loaded into `person_embeddings_cache`
4. The existing speaker ID worker can now match incoming audio against known speakers immediately

## Backward Compatibility

- No breaking changes
- No schema changes — reads existing `speaker_embedding` fields already written by the speaker ID worker
- If no stored embeddings exist, behavior is identical to before (empty cache)
- The preload is wrapped in try/except so any failure falls back to the existing empty-cache behavior

## Testing

- Unit tests added for `load_person_embeddings_cache` covering:
  - Loading embeddings for multiple people
  - Empty result when no people have embeddings
  - Graceful handling of invalid/corrupt embeddings
  - Correct reshaping of 1D embedding arrays to 2D

## Deploy

- Backend only
- No migration needed
- No new environment variables
