### PR TITLE
Adjust HPA config of backend-listen to prevent flappy issue

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -308,7 +308,7 @@ startupProbe:
 autoscaling:
   enabled: true
   minReplicas: 26
-  maxReplicas: 60
+  maxReplicas: 50
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 600
@@ -317,7 +317,7 @@ autoscaling:
         value: 20
         periodSeconds: 300
     scaleUp:
-      stabilizationWindowSeconds: 0
+      stabilizationWindowSeconds: 30
       policies:
       - type: Percent
         value: 100
@@ -328,8 +328,8 @@ autoscaling:
       selectPolicy: Max
   # targetCPUUtilizationPercentage: 70
   # targetMemoryUtilizationPercentage: 70
-  requestsPerPod: 8
-  failedResponseCode: 10
+  requestsPerPod: 10
+  # failedResponseCode: 10
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -309,7 +309,7 @@ startupProbe:
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: true
-  minReplicas: 24
+  minReplicas: 30
   maxReplicas: 60
   behavior:
     scaleDown:


### PR DESCRIPTION
Changes:
- Adjust HPA config of backend-listen to prevent flappy issue
- Rollback min replica of pusher to 30