### PR TITLE
fix: iOS deep link + Android prod package for task sharing

### DIFF
--- a/web/frontend/src/app/tasks/[token]/page.tsx
+++ b/web/frontend/src/app/tasks/[token]/page.tsx
@@ -63,15 +63,15 @@ function getPlatformLink(userAgent: string, token: string) {
   const isAndroid = /android/i.test(userAgent);
   const isIOS = /iphone|ipad|ipod/i.test(userAgent);
 
-  // Deep link into the app if installed; App Links / Universal Links handle interception
-  const deepLink = `https://h.omi.me/tasks/${token}`;
-
+  // iOS: Use custom URL scheme because Universal Links don't trigger for same-domain navigation
+  // (user is already on h.omi.me, so tapping https://h.omi.me/... just reloads the page)
+  // Android: Use intent:// with fallback to Google Play if app not installed
   return isAndroid
-    ? `intent://h.omi.me/tasks/${token}#Intent;scheme=https;package=com.friend.ios.dev;S.browser_fallback_url=${encodeURIComponent(
+    ? `intent://h.omi.me/tasks/${token}#Intent;scheme=https;package=com.friend.ios;S.browser_fallback_url=${encodeURIComponent(
         'https://play.google.com/store/apps/details?id=com.friend.ios',
       )};end`
     : isIOS
-    ? deepLink
+    ? `omi://tasks/${token}`
     : 'https://omi.me';
 }
 


### PR DESCRIPTION
## Summary
Two bugs preventing "Open in Omi" from working on the task share page:

1. **iOS (web)**: Universal Links don't trigger for same-domain navigation — user is already on `h.omi.me` so tapping `https://h.omi.me/tasks/{token}` just reloads the page. Fixed by using `omi://` custom URL scheme.

2. **Android (web)**: Intent URL had `package=com.friend.ios.dev` (dev flavor) instead of `com.friend.ios` (production).

3. **App (Flutter)**: `omi://tasks/{token}` parses "tasks" as `uri.host` (not `uri.pathSegments`), so the existing routing check `pathSegments.first == 'tasks'` never matches. Added `uri.host == 'tasks'` handler matching the pattern used by other `omi://` callbacks (todoist, asana, etc).

## Files changed
| File | Fix |
|------|-----|
| `web/frontend/src/app/tasks/[token]/page.tsx` | iOS: `https://` → `omi://`, Android: fix prod package name |
| `app/lib/core/app_shell.dart` | Add `uri.host == 'tasks'` handler for `omi://` scheme |

## Test plan
- [ ] iOS: open share page in Safari → tap "Open in Omi" → app opens → AcceptSharedTasksSheet appears
- [ ] Android: same flow in Chrome
- [ ] Verify existing deep links still work (apps, wrapped, unlimited, OAuth callbacks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)