### PR TITLE
feat: persist action item sort order and indentation

### DIFF
--- a/app/lib/backend/http/api/action_items.dart
+++ b/app/lib/backend/http/api/action_items.dart
@@ -102,6 +102,8 @@ Future<ActionItemWithMetadata?> updateActionItem(
   bool? exported,
   DateTime? exportDate,
   String? exportPlatform,
+  int? sortOrder,
+  int? indentLevel,
 }) async {
   var requestBody = <String, dynamic>{};
 
@@ -125,6 +127,12 @@ Future<ActionItemWithMetadata?> updateActionItem(
   }
   if (exportPlatform != null) {
     requestBody['export_platform'] = exportPlatform;
+  }
+  if (sortOrder != null) {
+    requestBody['sort_order'] = sortOrder;
+  }
+  if (indentLevel != null) {
+    requestBody['indent_level'] = indentLevel;
   }
 
   var response = await makeApiCall(
@@ -271,6 +279,25 @@ Future<Map<String, dynamic>?> acceptSharedActionItems(String token) async {
   } else {
     Logger.debug('acceptSharedActionItems error ${response.statusCode}');
     return null;
+  }
+}
+
+// Batch update sort_order/indent_level
+Future<bool> batchUpdateActionItems(List<Map<String, dynamic>> items) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/action-items/batch',
+    headers: {},
+    method: 'PATCH',
+    body: jsonEncode({'items': items}),
+  );
+
+  if (response == null) return false;
+
+  if (response.statusCode == 200) {
+    return true;
+  } else {
+    Logger.debug('batchUpdateActionItems error ${response.statusCode}');
+    return false;
   }
 }
 

--- a/app/lib/backend/schema/action_item.dart
+++ b/app/lib/backend/schema/action_item.dart
@@ -11,6 +11,8 @@ class ActionItemWithMetadata {
   final bool exported;
   final DateTime? exportDate;
   final String? exportPlatform;
+  final int sortOrder;
+  final int indentLevel;
 
   ActionItemWithMetadata({
     required this.id,
@@ -25,6 +27,8 @@ class ActionItemWithMetadata {
     this.exported = false,
     this.exportDate,
     this.exportPlatform,
+    this.sortOrder = 0,
+    this.indentLevel = 0,
   });
 
   factory ActionItemWithMetadata.fromJson(Map<String, dynamic> json) {
@@ -41,6 +45,8 @@ class ActionItemWithMetadata {
       exported: json['exported'] ?? false,
       exportDate: json['export_date'] != null ? DateTime.parse(json['export_date']).toLocal() : null,
       exportPlatform: json['export_platform'],
+      sortOrder: json['sort_order'] as int? ?? 0,
+      indentLevel: json['indent_level'] as int? ?? 0,
     );
   }
 
@@ -58,6 +64,8 @@ class ActionItemWithMetadata {
       'exported': exported,
       'export_date': exportDate?.toUtc().toIso8601String(),
       'export_platform': exportPlatform,
+      'sort_order': sortOrder,
+      'indent_level': indentLevel,
     };
   }
 
@@ -74,6 +82,8 @@ class ActionItemWithMetadata {
     bool? exported,
     DateTime? exportDate,
     String? exportPlatform,
+    int? sortOrder,
+    int? indentLevel,
   }) {
     return ActionItemWithMetadata(
       id: id ?? this.id,
@@ -88,6 +98,8 @@ class ActionItemWithMetadata {
       exported: exported ?? this.exported,
       exportDate: exportDate ?? this.exportDate,
       exportPlatform: exportPlatform ?? this.exportPlatform,
+      sortOrder: sortOrder ?? this.sortOrder,
+      indentLevel: indentLevel ?? this.indentLevel,
     );
   }
 }

--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -31,14 +31,8 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
   final ScrollController _scrollController = ScrollController();
   final AppReviewService _appReviewService = AppReviewService();
 
-  // Track indent levels for each task (task id -> indent level 0-3)
-  final Map<String, int> _indentLevels = {};
-
   // Task -> goal mapping
   final Map<String, String> _taskGoalLinks = {};
-
-  // Track custom order for each category (category -> list of item ids)
-  final Map<TaskCategory, List<String>> _categoryOrder = {};
 
   // Track the item being hovered over during drag
   String? _hoveredItemId;
@@ -61,7 +55,6 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
   void initState() {
     super.initState();
     _scrollController.addListener(_onScroll);
-    _loadCategoryOrder();
     _loadTaskGoalLinks();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       if (!mounted) return;
@@ -69,21 +62,6 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
       final provider = Provider.of<ActionItemsProvider>(context, listen: false);
       if (provider.actionItems.isEmpty) {
         provider.fetchActionItems(showShimmer: true);
-      }
-    });
-  }
-
-  void _loadCategoryOrder() {
-    final savedOrder = SharedPreferencesUtil().taskCategoryOrder;
-    setState(() {
-      for (final entry in savedOrder.entries) {
-        try {
-          final category = TaskCategory.values.firstWhere(
-            (c) => c.name == entry.key,
-            orElse: () => TaskCategory.noDeadline,
-          );
-          _categoryOrder[category] = entry.value;
-        } catch (_) {}
       }
     });
   }
@@ -130,14 +108,6 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
       if (goal.id == goalId) return goal.title;
     }
     return null;
-  }
-
-  void _saveCategoryOrder() {
-    final Map<String, List<String>> toSave = {};
-    for (final entry in _categoryOrder.entries) {
-      toSave[entry.key.name] = entry.value;
-    }
-    SharedPreferencesUtil().taskCategoryOrder = toSave;
   }
 
   @override
@@ -302,56 +272,55 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     provider.updateActionItemDueDate(item, newDueDate);
   }
 
-  int _getIndentLevel(String itemId) {
-    return _indentLevels[itemId] ?? 0;
+  int _getIndentLevel(ActionItemWithMetadata item) {
+    return item.indentLevel;
   }
 
   void _incrementIndent(String itemId) {
-    setState(() {
-      final current = _indentLevels[itemId] ?? 0;
-      if (current < 3) {
-        _indentLevels[itemId] = current + 1;
-      }
-    });
+    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
+    final item = provider.actionItems.where((i) => i.id == itemId).firstOrNull;
+    if (item == null) return;
+    final current = item.indentLevel;
+    if (current < 3) {
+      provider.updateItemIndentLevel(itemId, current + 1);
+    }
     HapticFeedback.lightImpact();
   }
 
   void _decrementIndent(String itemId) {
-    setState(() {
-      final current = _indentLevels[itemId] ?? 0;
-      if (current > 0) {
-        _indentLevels[itemId] = current - 1;
-      }
-    });
+    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
+    final item = provider.actionItems.where((i) => i.id == itemId).firstOrNull;
+    if (item == null) return;
+    final current = item.indentLevel;
+    if (current > 0) {
+      provider.updateItemIndentLevel(itemId, current - 1);
+    }
     HapticFeedback.lightImpact();
   }
 
-  // Get ordered items for a category, respecting custom order
+  // Get ordered items for a category, respecting sort_order from model
   List<ActionItemWithMetadata> _getOrderedItems(
     TaskCategory category,
     List<ActionItemWithMetadata> items,
   ) {
-    final order = _categoryOrder[category];
-    if (order == null || order.isEmpty) {
-      return items;
-    }
-
-    // Sort items based on custom order, new items go at the end
-    final orderedItems = <ActionItemWithMetadata>[];
-    final itemMap = {for (var item in items) item.id: item};
-
-    // Add items in custom order
-    for (final id in order) {
-      if (itemMap.containsKey(id)) {
-        orderedItems.add(itemMap[id]!);
-        itemMap.remove(id);
+    final sorted = List<ActionItemWithMetadata>.from(items);
+    sorted.sort((a, b) {
+      // Items with sortOrder > 0 come first, sorted ascending
+      if (a.sortOrder > 0 && b.sortOrder > 0) {
+        return a.sortOrder.compareTo(b.sortOrder);
       }
-    }
-
-    // Add any remaining items (new ones not in custom order)
-    orderedItems.addAll(itemMap.values);
-
-    return orderedItems;
+      if (a.sortOrder > 0) return -1;
+      if (b.sortOrder > 0) return 1;
+      // Fallback: sort by dueAt then createdAt
+      final aDue = a.dueAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final bDue = b.dueAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final dueCmp = aDue.compareTo(bDue);
+      if (dueCmp != 0) return dueCmp;
+      final aCreated = a.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      final bCreated = b.createdAt ?? DateTime.fromMillisecondsSinceEpoch(0);
+      return aCreated.compareTo(bCreated);
+    });
+    return sorted;
   }
 
   // Reorder item within category
@@ -362,32 +331,29 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     TaskCategory category,
     List<ActionItemWithMetadata> categoryItems,
   ) {
+    // Build the new order as a list of IDs
+    final order = categoryItems.map((i) => i.id).toList();
+    order.remove(draggedItem.id);
+
+    final targetIndex = order.indexOf(targetItemId);
+    if (targetIndex != -1) {
+      final insertIndex = insertAbove ? targetIndex : targetIndex + 1;
+      order.insert(insertIndex, draggedItem.id);
+    } else {
+      order.add(draggedItem.id);
+    }
+
+    // Assign sequential sort_order values
+    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
+    final Map<String, int> updates = {};
+    for (int i = 0; i < order.length; i++) {
+      updates[order[i]] = (i + 1) * 1000;
+    }
+    provider.batchUpdateSortOrders(updates);
+
     setState(() {
-      // Initialize category order if needed
-      if (!_categoryOrder.containsKey(category)) {
-        _categoryOrder[category] = categoryItems.map((i) => i.id).toList();
-      }
-
-      final order = _categoryOrder[category]!;
-
-      // Remove dragged item from its current position
-      order.remove(draggedItem.id);
-
-      // Find target position
-      final targetIndex = order.indexOf(targetItemId);
-      if (targetIndex != -1) {
-        // Insert above or below target
-        final insertIndex = insertAbove ? targetIndex : targetIndex + 1;
-        order.insert(insertIndex, draggedItem.id);
-      } else {
-        // Target not found, add at end
-        order.add(draggedItem.id);
-      }
-
-      // Clear hover state
       _hoveredItemId = null;
     });
-    _saveCategoryOrder();
     HapticFeedback.mediumImpact();
   }
 
@@ -773,21 +739,18 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     TaskCategory category,
     List<ActionItemWithMetadata> categoryItems,
   ) {
+    final order = categoryItems.map((i) => i.id).toList();
+    order.remove(draggedItem.id);
+    order.insert(0, draggedItem.id);
+
+    final provider = Provider.of<ActionItemsProvider>(context, listen: false);
+    final Map<String, int> updates = {};
+    for (int i = 0; i < order.length; i++) {
+      updates[order[i]] = (i + 1) * 1000;
+    }
+    provider.batchUpdateSortOrders(updates);
+
     setState(() {
-      // Initialize category order if needed
-      if (!_categoryOrder.containsKey(category)) {
-        _categoryOrder[category] = categoryItems.map((i) => i.id).toList();
-      }
-
-      final order = _categoryOrder[category]!;
-
-      // Remove dragged item from its current position
-      order.remove(draggedItem.id);
-
-      // Insert at first position
-      order.insert(0, draggedItem.id);
-
-      // Clear hover state
       _hoveredItemId = null;
     });
     HapticFeedback.mediumImpact();
@@ -799,7 +762,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     required TaskCategory category,
     required List<ActionItemWithMetadata> categoryItems,
   }) {
-    final indentLevel = _getIndentLevel(item.id);
+    final indentLevel = _getIndentLevel(item);
     final indentWidth = indentLevel * 28.0;
     final isHovered = _hoveredItemId == item.id;
 
@@ -1056,7 +1019,7 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
     ActionItemsProvider provider,
     double indentWidth,
   ) {
-    final indentLevel = _getIndentLevel(item.id);
+    final indentLevel = _getIndentLevel(item);
     final goalTitle = _getGoalTitleForTask(item);
 
     return GestureDetector(

--- a/app/lib/providers/action_items_provider.dart
+++ b/app/lib/providers/action_items_provider.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/foundation.dart';
 
 import 'package:omi/backend/http/api/action_items.dart' as api;
+import 'package:omi/backend/preferences.dart';
 import 'package:omi/backend/schema/schema.dart';
 import 'package:omi/services/notifications/action_item_notification_handler.dart';
 import 'package:omi/utils/logger.dart';
@@ -27,6 +28,12 @@ class ActionItemsProvider extends ChangeNotifier {
   Timer? _refreshDebounceTimer;
   DateTime? _lastRefreshTime;
   static const Duration _refreshCooldown = Duration(seconds: 30);
+
+  // Debounced persistence for sort order and indent level
+  final Map<String, int> _pendingSortUpdates = {};
+  final Map<String, int> _pendingIndentUpdates = {};
+  Timer? _sortDebounce;
+  Timer? _indentDebounce;
 
   // Multi-selection state
   bool _isSelectionMode = false;
@@ -103,6 +110,27 @@ class ActionItemsProvider extends ChangeNotifier {
 
   void _preload() async {
     await fetchActionItems();
+    _migrateCategoryOrderFromPrefs();
+  }
+
+  /// One-time migration: convert SharedPreferences taskCategoryOrder to sort_order on items
+  Future<void> _migrateCategoryOrderFromPrefs() async {
+    final savedOrder = SharedPreferencesUtil().taskCategoryOrder;
+    if (savedOrder.isEmpty) return;
+
+    final Map<String, int> sortUpdates = {};
+    for (final entry in savedOrder.entries) {
+      final ids = entry.value;
+      for (int i = 0; i < ids.length; i++) {
+        sortUpdates[ids[i]] = (i + 1) * 1000;
+      }
+    }
+
+    if (sortUpdates.isNotEmpty) {
+      batchUpdateSortOrders(sortUpdates);
+      // Clear old prefs after migration
+      SharedPreferencesUtil().taskCategoryOrder = {};
+    }
   }
 
   void setLoading(bool value) {
@@ -325,6 +353,66 @@ class ActionItemsProvider extends ChangeNotifier {
     }
   }
 
+  // Sort order and indent level persistence
+
+  void _updateItemInPlace(String id, {int? sortOrder, int? indentLevel}) {
+    final index = _actionItems.indexWhere((item) => item.id == id);
+    if (index != -1) {
+      _actionItems[index] = _actionItems[index].copyWith(
+        sortOrder: sortOrder,
+        indentLevel: indentLevel,
+      );
+    }
+  }
+
+  void updateItemSortOrder(String id, int sortOrder) {
+    _updateItemInPlace(id, sortOrder: sortOrder);
+    _pendingSortUpdates[id] = sortOrder;
+    notifyListeners();
+    _sortDebounce?.cancel();
+    _sortDebounce = Timer(const Duration(milliseconds: 500), _flushSortUpdates);
+  }
+
+  void updateItemIndentLevel(String id, int indentLevel) {
+    _updateItemInPlace(id, indentLevel: indentLevel);
+    _pendingIndentUpdates[id] = indentLevel;
+    notifyListeners();
+    _indentDebounce?.cancel();
+    _indentDebounce = Timer(const Duration(milliseconds: 500), _flushIndentUpdates);
+  }
+
+  void batchUpdateSortOrders(Map<String, int> updates) {
+    for (final entry in updates.entries) {
+      _updateItemInPlace(entry.key, sortOrder: entry.value);
+      _pendingSortUpdates[entry.key] = entry.value;
+    }
+    notifyListeners();
+    _sortDebounce?.cancel();
+    _sortDebounce = Timer(const Duration(milliseconds: 500), _flushSortUpdates);
+  }
+
+  Future<void> _flushSortUpdates() async {
+    if (_pendingSortUpdates.isEmpty) return;
+    final updates = Map<String, int>.from(_pendingSortUpdates);
+    _pendingSortUpdates.clear();
+
+    final items = updates.entries
+        .map((e) => {'id': e.key, 'sort_order': e.value})
+        .toList();
+    await api.batchUpdateActionItems(items);
+  }
+
+  Future<void> _flushIndentUpdates() async {
+    if (_pendingIndentUpdates.isEmpty) return;
+    final updates = Map<String, int>.from(_pendingIndentUpdates);
+    _pendingIndentUpdates.clear();
+
+    final items = updates.entries
+        .map((e) => {'id': e.key, 'indent_level': e.value})
+        .toList();
+    await api.batchUpdateActionItems(items);
+  }
+
   ActionItemWithMetadata? _findAndUpdateItemState(String itemId, bool newState) {
     final mainIndex = _actionItems.indexWhere((item) => item.id == itemId);
     if (mainIndex != -1) {
@@ -487,6 +575,10 @@ class ActionItemsProvider extends ChangeNotifier {
   @override
   void dispose() {
     _refreshDebounceTimer?.cancel();
+    _sortDebounce?.cancel();
+    _indentDebounce?.cancel();
+    _flushSortUpdates();
+    _flushIndentUpdates();
     super.dispose();
   }
 }


### PR DESCRIPTION
## Summary
- Add `sort_order` and `indent_level` fields to action item model (backend + Flutter)
- Add `PATCH /v1/action-items/batch` endpoint for efficient bulk updates of sort order and indentation
- Replace local widget state (`_indentLevels` map) and SharedPreferences (`taskCategoryOrder`) with Firestore-persisted fields
- Debounced saves (500ms) in the Flutter provider for smooth UX during drag-and-drop reordering and indent changes

## Test plan
- [x] Create tasks, reorder via drag-and-drop, indent via swipe gesture
- [x] Kill and restart app — verify order and indentation persist
- [x] Batch endpoint returns 200 OK in backend logs
- [ ] Verify same order appears on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)