### PR TITLE
feat(web): add Take Omi with you banner to sidebar

### DIFF
--- a/web/app/src/components/layout/Sidebar.tsx
+++ b/web/app/src/components/layout/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   Bell,
   Mic,
   MessageSquare,
+  Smartphone,
 } from 'lucide-react';
 
 // Discord icon SVG component
@@ -124,6 +125,7 @@ export function Sidebar({
   const [isExpanded, setIsExpanded] = useState(false);
   const [isHeaderHovered, setIsHeaderHovered] = useState(false);
   const [isTemporaryExpand, setIsTemporaryExpand] = useState(false);
+  const [mobileAppDismissed, setMobileAppDismissed] = useState(false);
   const isDesktop = useIsDesktop();
   const sidebarRef = useRef<HTMLElement>(null);
   const userMenuRef = useRef<HTMLDivElement>(null);
@@ -133,6 +135,9 @@ export function Sidebar({
     const saved = localStorage.getItem('sidebar-expanded');
     if (saved === 'true') {
       setIsExpanded(true);
+    }
+    if (localStorage.getItem('mobile-app-banner-dismissed') === 'true') {
+      setMobileAppDismissed(true);
     }
   }, []);
 
@@ -381,6 +386,45 @@ export function Sidebar({
 
         {/* Spacer to push footer to bottom */}
         <div className="flex-1" />
+
+        {/* Take Omi with you - Mobile App Banner */}
+        {!mobileAppDismissed && (
+          <div className={cn('px-3 pb-2', !showText && 'px-2')}>
+            <a
+              href="https://apps.apple.com/us/app/omi-ai-wearable/id6502156163"
+              target="_blank"
+              rel="noopener noreferrer"
+              className={cn(
+                'relative flex items-center gap-3 rounded-xl bg-bg-tertiary/50 transition-colors hover:bg-bg-tertiary',
+                showText ? 'p-3 pr-9' : 'justify-center p-3'
+              )}
+            >
+              <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-white/[0.08]">
+                <Smartphone className="w-4 h-4 text-text-tertiary" />
+              </div>
+              {showText && (
+                <div className="min-w-0">
+                  <p className="text-sm font-medium text-text-primary">Take Omi with you</p>
+                  <p className="text-xs text-text-quaternary">Try Omi on your phone</p>
+                </div>
+              )}
+              {showText && (
+                <button
+                  onClick={(e) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    setMobileAppDismissed(true);
+                    localStorage.setItem('mobile-app-banner-dismissed', 'true');
+                  }}
+                  className="absolute right-2 top-1/2 -translate-y-1/2 rounded-full p-1 text-text-quaternary transition-colors hover:bg-white/[0.08] hover:text-text-tertiary"
+                  aria-label="Dismiss"
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              )}
+            </a>
+          </div>
+        )}
 
         {/* Feedback & Discord links */}
         <div className={cn('pb-2', showText ? 'px-3' : 'px-2')}>


### PR DESCRIPTION
## Summary
- Adds a dismissible "Take Omi with you" banner in the dashboard sidebar above the Feedback/Discord links
- Links to the iOS App Store listing
- Dismiss state persisted via localStorage
- Collapses gracefully when sidebar is collapsed (icon only)

## Test plan
- [x] Verified banner appears above Feedback button in expanded sidebar
- [x] Verified dismiss button works and persists across page reloads
- [x] Verified collapsed sidebar shows only the phone icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)