### PR TITLE
fix(web): use real Apple logo and 10X better text in sidebar banner

### DIFF
--- a/web/app/src/components/layout/Sidebar.tsx
+++ b/web/app/src/components/layout/Sidebar.tsx
@@ -25,8 +25,16 @@ import {
   Mic,
   MessageSquare,
   Smartphone,
-  Apple,
 } from 'lucide-react';
+
+// Apple logo SVG component
+function AppleLogo({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.71 19.5c-.83 1.24-1.71 2.45-3.05 2.47-1.34.03-1.77-.79-3.29-.79-1.53 0-2 .77-3.27.82-1.31.05-2.3-1.32-3.14-2.53C4.25 17 2.94 12.45 4.7 9.39c.87-1.52 2.43-2.48 4.12-2.51 1.28-.02 2.5.87 3.29.87.78 0 2.26-1.07 3.8-.91.65.03 2.47.26 3.64 1.98-.09.06-2.17 1.28-2.15 3.81.03 3.02 2.65 4.03 2.68 4.04-.03.07-.42 1.44-1.38 2.83M13 3.5c.73-.83 1.94-1.46 2.94-1.5.13 1.17-.34 2.35-1.04 3.19-.69.85-1.83 1.51-2.95 1.42-.15-1.15.41-2.35 1.05-3.11z" />
+    </svg>
+  );
+}
 
 // Discord icon SVG component
 function DiscordIcon({ className }: { className?: string }) {
@@ -392,9 +400,8 @@ export function Sidebar({
         {!mobileAppDismissed && (() => {
           const isMac = typeof navigator !== 'undefined' && /Mac/.test(navigator.userAgent);
           const bannerHref = isMac ? 'https://macos.omi.me/' : 'https://onelink.to/rbsrxc';
-          const bannerTitle = isMac ? 'Omi is 10x more useful on macOS' : 'Take Omi with you';
+          const bannerTitle = isMac ? 'Omi is 10X better on macOS' : 'Take Omi with you';
           const bannerSubtitle = isMac ? 'Try Omi on macOS' : 'Try Omi on your phone';
-          const BannerIcon = isMac ? Apple : Smartphone;
           return (
             <div className={cn('px-3 pb-2', !showText && 'px-2')}>
               <a
@@ -407,7 +414,7 @@ export function Sidebar({
                 )}
               >
                 <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-white/[0.08]">
-                  <BannerIcon className="w-4 h-4 text-text-tertiary" />
+                  {isMac ? <AppleLogo className="w-4 h-4 text-text-tertiary" /> : <Smartphone className="w-4 h-4 text-text-tertiary" />}
                 </div>
                 {showText && (
                   <div className="min-w-0">


### PR DESCRIPTION
## Summary
- Replace lucide Apple icon with actual Apple logo SVG
- Change text from "10x more useful" to "10X better"

🤖 Generated with [Claude Code](https://claude.com/claude-code)