### PR TITLE
feat: add completion screen to mobile onboarding

### DIFF
--- a/app/lib/pages/onboarding/complete_screen.dart
+++ b/app/lib/pages/onboarding/complete_screen.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+
+class OnboardingCompleteScreen extends StatefulWidget {
+  final VoidCallback onComplete;
+
+  const OnboardingCompleteScreen({super.key, required this.onComplete});
+
+  @override
+  State<OnboardingCompleteScreen> createState() => _OnboardingCompleteScreenState();
+}
+
+class _OnboardingCompleteScreenState extends State<OnboardingCompleteScreen> with SingleTickerProviderStateMixin {
+  late AnimationController _fadeController;
+  late Animation<double> _fadeAnimation;
+  late Animation<double> _scaleAnimation;
+  late Animation<double> _slideAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _fadeController = AnimationController(
+      duration: const Duration(milliseconds: 800),
+      vsync: this,
+    );
+
+    _fadeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _fadeController, curve: Curves.easeOut),
+    );
+
+    _scaleAnimation = Tween<double>(begin: 0.5, end: 1.0).animate(
+      CurvedAnimation(parent: _fadeController, curve: Curves.elasticOut),
+    );
+
+    _slideAnimation = Tween<double>(begin: 50.0, end: 0.0).animate(
+      CurvedAnimation(parent: _fadeController, curve: Curves.easeOut),
+    );
+
+    Future.delayed(const Duration(milliseconds: 200), () {
+      if (mounted) _fadeController.forward();
+    });
+  }
+
+  @override
+  void dispose() {
+    _fadeController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.black,
+      width: double.infinity,
+      height: double.infinity,
+      child: SafeArea(
+        child: AnimatedBuilder(
+          animation: _fadeController,
+          builder: (context, child) {
+            return FadeTransition(
+              opacity: _fadeAnimation,
+              child: Transform.translate(
+                offset: Offset(0, _slideAnimation.value),
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 40),
+                  child: Column(
+                    children: [
+                      const Spacer(flex: 3),
+                      ScaleTransition(
+                        scale: _scaleAnimation,
+                        child: Container(
+                          width: 72,
+                          height: 72,
+                          decoration: BoxDecoration(
+                            color: const Color(0xFF1A1A1A),
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: const Icon(
+                            Icons.check_rounded,
+                            color: Colors.white,
+                            size: 36,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 32),
+                      const Text(
+                        'You are all set!',
+                        style: TextStyle(
+                          color: Colors.white,
+                          fontSize: 30,
+                          fontWeight: FontWeight.bold,
+                          height: 1.2,
+                          fontFamily: 'Manrope',
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                      const SizedBox(height: 16),
+                      RichText(
+                        textAlign: TextAlign.center,
+                        text: TextSpan(
+                          style: TextStyle(
+                            color: Colors.white.withValues(alpha: 0.5),
+                            fontSize: 17,
+                            height: 1.5,
+                            fontFamily: 'Manrope',
+                          ),
+                          children: const [
+                            TextSpan(text: 'Just use Omi in the background for '),
+                            TextSpan(
+                              text: '2\u00A0days',
+                              style: TextStyle(color: Color(0xFF9B59B6)),
+                            ),
+                            TextSpan(text: ' and you\'ll start getting useful feedback after!'),
+                          ],
+                        ),
+                      ),
+                      const Spacer(flex: 3),
+                      SizedBox(
+                        width: double.infinity,
+                        height: 56,
+                        child: ElevatedButton(
+                          onPressed: widget.onComplete,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: Colors.white,
+                            foregroundColor: Colors.black,
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(28),
+                            ),
+                            elevation: 0,
+                          ),
+                          child: const Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: [
+                              Text(
+                                'Start Using Omi',
+                                style: TextStyle(
+                                  fontSize: 18,
+                                  fontWeight: FontWeight.w600,
+                                  fontFamily: 'Manrope',
+                                ),
+                              ),
+                              SizedBox(width: 8),
+                              Icon(Icons.arrow_forward_rounded, size: 20),
+                            ],
+                          ),
+                        ),
+                      ),
+                      const SizedBox(height: 32),
+                    ],
+                  ),
+                ),
+              ),
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -49,8 +49,7 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
         await LanguageSelectionDialog.show(context);
       }
     });
-    SharedPreferencesUtil().onboardingCompleted = true;
-    updateUserOnboardingState(completed: true);
+    // Onboarding completion is now handled by the completion screen
   }
 
   @override

--- a/app/lib/pages/onboarding/wrapper.dart
+++ b/app/lib/pages/onboarding/wrapper.dart
@@ -15,6 +15,7 @@ import 'package:omi/pages/onboarding/found_omi/found_omi_widget.dart';
 import 'package:omi/pages/onboarding/name/name_widget.dart';
 import 'package:omi/pages/onboarding/permissions/permissions_widget.dart';
 import 'package:omi/pages/onboarding/primary_language/primary_language_widget.dart';
+import 'package:omi/pages/onboarding/complete_screen.dart';
 import 'package:omi/pages/onboarding/speech_profile_widget.dart';
 import 'package:omi/pages/onboarding/user_review_page.dart';
 import 'package:omi/providers/home_provider.dart';
@@ -45,9 +46,10 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
   static const int kWelcomePage = 6;
   static const int kFindDevicesPage = 7;
   static const int kSpeechProfilePage = 8; // Speech profile with questions (requires device)
+  static const int kCompletePage = 9; // "You're all set" completion screen
 
   // Special index values used in comparisons
-  static const List<int> kHiddenHeaderPages = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8];
+  static const List<int> kHiddenHeaderPages = [-1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
   TabController? _controller;
   late AnimationController _backgroundAnimationController;
@@ -60,7 +62,7 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
   void initState() {
     _speechProfileProvider = SpeechProfileProvider();
     _controller = TabController(
-        length: 9, vsync: this); // Auth, Name, Lang, FoundOmi, Permissions, Review, Welcome, FindDevices, SpeechProfile
+        length: 10, vsync: this); // Auth, Name, Lang, FoundOmi, Permissions, Review, Welcome, FindDevices, SpeechProfile, Complete
     _controller!.addListener(() {
       setState(() {});
       // Update background image when page changes
@@ -147,6 +149,9 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
       case kSpeechProfilePage:
         newImage = Assets.images.onboardingBg3.path;
         break;
+      case kCompletePage:
+        newImage = Assets.images.onboardingBg6.path;
+        break;
       default:
         newImage = Assets.images.onboardingBg1.path;
         break;
@@ -193,6 +198,8 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
         return Assets.images.onboardingBg6.path;
       case kSpeechProfilePage:
         return Assets.images.onboardingBg3.path;
+      case kCompletePage:
+        return Assets.images.onboardingBg6.path;
       default:
         return null;
     }
@@ -252,22 +259,23 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
         value: _speechProfileProvider!,
         child: SpeechProfileWidget(
           goNext: () {
-            // Speech profile complete, finish onboarding
-            SharedPreferencesUtil().onboardingCompleted = true;
-            updateUserOnboardingState(completed: true);
             MixpanelManager().onboardingStepCompleted('Speech Profile');
-            PaintingBinding.instance.imageCache.clear();
-            routeToPage(context, const HomePageWrapper(), replace: true);
+            _controller!.animateTo(kCompletePage);
           },
           onSkip: () {
-            // Skip speech profile, finish onboarding
-            SharedPreferencesUtil().onboardingCompleted = true;
-            updateUserOnboardingState(completed: true);
             MixpanelManager().onboardingStepCompleted('Speech Profile Skipped');
-            PaintingBinding.instance.imageCache.clear();
-            routeToPage(context, const HomePageWrapper(), replace: true);
+            _controller!.animateTo(kCompletePage);
           },
         ),
+      ),
+      OnboardingCompleteScreen(
+        onComplete: () {
+          SharedPreferencesUtil().onboardingCompleted = true;
+          updateUserOnboardingState(completed: true);
+          MixpanelManager().onboardingCompleted();
+          PaintingBinding.instance.imageCache.clear();
+          routeToPage(context, const HomePageWrapper(), replace: true);
+        },
       ),
     ];
 
@@ -307,11 +315,12 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                     _controller!.index == kPermissionsPage ||
                     _controller!.index == kUserReviewPage ||
                     _controller!.index == kWelcomePage ||
-                    _controller!.index == kSpeechProfilePage
+                    _controller!.index == kSpeechProfilePage ||
+                    _controller!.index == kCompletePage
                 ? Stack(
                     children: [
-                      // Animated background image (skip for welcome page)
-                      if (_controller!.index != kWelcomePage)
+                      // Animated background image (skip for welcome and complete pages)
+                      if (_controller!.index != kWelcomePage && _controller!.index != kCompletePage)
                         FadeTransition(
                           opacity: _backgroundFadeAnimation,
                           child: Container(
@@ -332,32 +341,33 @@ class _OnboardingWrapperState extends State<OnboardingWrapper> with TickerProvid
                         ),
                       // Page component (no transition for content)
                       pages[_controller!.index],
-                      // Progress dots for name, language, permissions, user review, and welcome pages
-                      Padding(
-                        padding: const EdgeInsets.fromLTRB(16, 56, 16, 0),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: List.generate(
-                            8,
-                            (index) {
-                              int pageIndex = index + 1; // Name=1, Lang=2, ..., Speech=8
-                              return Container(
-                                margin: const EdgeInsets.symmetric(horizontal: 4.0),
-                                width: pageIndex == _controller!.index ? 12.0 : 8.0,
-                                height: pageIndex == _controller!.index ? 12.0 : 8.0,
-                                decoration: BoxDecoration(
-                                  color: pageIndex <= _controller!.index
-                                      ? Theme.of(context).colorScheme.secondary
-                                      : Colors.grey.shade400,
-                                  shape: BoxShape.circle,
-                                ),
-                              );
-                            },
+                      // Progress dots (hidden on complete page)
+                      if (_controller!.index != kCompletePage)
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(16, 56, 16, 0),
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            children: List.generate(
+                              8,
+                              (index) {
+                                int pageIndex = index + 1; // Name=1, Lang=2, ..., Speech=8
+                                return Container(
+                                  margin: const EdgeInsets.symmetric(horizontal: 4.0),
+                                  width: pageIndex == _controller!.index ? 12.0 : 8.0,
+                                  height: pageIndex == _controller!.index ? 12.0 : 8.0,
+                                  decoration: BoxDecoration(
+                                    color: pageIndex <= _controller!.index
+                                        ? Theme.of(context).colorScheme.secondary
+                                        : Colors.grey.shade400,
+                                    shape: BoxShape.circle,
+                                  ),
+                                );
+                              },
+                            ),
                           ),
                         ),
-                      ),
-                      // Back button for language and permissions pages
-                      if (_controller!.index > kNamePage)
+                      // Back button (hidden on complete page)
+                      if (_controller!.index > kNamePage && _controller!.index != kCompletePage)
                         Padding(
                           padding: const EdgeInsets.fromLTRB(16, 40, 0, 0),
                           child: Align(


### PR DESCRIPTION
## Summary
- Adds a "You're all set!" completion screen as the final step of mobile onboarding
- Shows after speech profile (whether completed or skipped)
- "2 days" highlighted in purple to emphasize the timeline
- Removes premature onboarding completion marking from speech profile widget

## Test plan
- [x] Tested on iOS simulator - completion screen displays correctly
- [x] Verified skip speech profile → shows completion screen
- [x] Verified "Start Using Omi" button navigates to home

🤖 Generated with [Claude Code](https://claude.com/claude-code)