### PR TITLE
Unify share icon to FontAwesomeIcons.share across all platforms

### DIFF
--- a/app/lib/desktop/pages/apps/widgets/desktop_app_detail.dart
+++ b/app/lib/desktop/pages/apps/widgets/desktop_app_detail.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 
 import 'package:cached_network_image/cached_network_image.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:collection/collection.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 import 'package:provider/provider.dart';
@@ -359,7 +360,7 @@ class _DesktopAppDetailState extends State<DesktopAppDetail> with SingleTickerPr
               if (!app.private)
                 _buildActionButton(
                   responsive,
-                  icon: Icons.share_rounded,
+                  icon: FontAwesomeIcons.share,
                   onTap: () => _handleShareTap(),
                 ),
 

--- a/app/lib/desktop/pages/memories/widgets/desktop_memory_graph.dart
+++ b/app/lib/desktop/pages/memories/widgets/desktop_memory_graph.dart
@@ -3,6 +3,8 @@ import 'dart:io';
 import 'dart:math';
 import 'dart:ui' as ui;
 
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
@@ -552,7 +554,7 @@ class DesktopMemoryGraphWidgetState extends State<DesktopMemoryGraphWidget>
                 ),
                 const Spacer(),
                 OmiIconButton(
-                  icon: Icons.share,
+                  icon: FontAwesomeIcons.share,
                   onPressed: shareGraph,
                   style: OmiIconButtonStyle.outline,
                 ),

--- a/app/lib/pages/action_items/widgets/action_item_form_sheet.dart
+++ b/app/lib/pages/action_items/widgets/action_item_form_sheet.dart
@@ -5,6 +5,7 @@ import 'package:flutter/services.dart';
 import 'package:calendar_date_picker2/calendar_date_picker2.dart';
 import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:share_plus/share_plus.dart';
 
 import 'package:omi/backend/http/api/action_items.dart' as action_items_api;
@@ -317,7 +318,7 @@ class _ActionItemFormSheetState extends State<ActionItemFormSheet> {
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       IconButton(
-                        icon: Icon(Icons.share_outlined, color: Colors.grey.shade400),
+                        icon: FaIcon(FontAwesomeIcons.share, color: Colors.grey.shade400, size: 16),
                         onPressed: _shareActionItem,
                       ),
                       IconButton(

--- a/app/lib/pages/chat/widgets/ai_message.dart
+++ b/app/lib/pages/chat/widgets/ai_message.dart
@@ -1262,7 +1262,7 @@ class _MessageActionBarState extends State<MessageActionBar> {
           const SizedBox(width: 20),
           // Share button
           _buildActionButton(
-            icon: FontAwesomeIcons.shareNodes,
+            icon: FontAwesomeIcons.share,
             onTap: () async {
               HapticFeedback.lightImpact();
               await Share.share(widget.messageText);

--- a/app/lib/pages/chat/widgets/message_action_menu.dart
+++ b/app/lib/pages/chat/widgets/message_action_menu.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
 import 'markdown_message_widget.dart';
@@ -60,7 +61,7 @@ class MessageActionMenu extends StatelessWidget {
             ),
             _buildActionButton(
               title: context.l10n.share,
-              icon: Icons.share,
+              icon: FontAwesomeIcons.share,
               onTap: onShare,
             ),
             if (onThumbsDown != null) ...[

--- a/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
+++ b/app/lib/pages/conversations/wal_item_detail/wal_item_detail_page.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:provider/provider.dart';
 import 'package:omi/backend/preferences.dart';
@@ -698,7 +699,7 @@ class _WalItemDetailPageState extends State<WalItemDetailPage> {
               ),
             ] else ...[
               ListTile(
-                leading: const Icon(Icons.share, color: Colors.white),
+                leading: const FaIcon(FontAwesomeIcons.share, color: Colors.white, size: 18),
                 title: Text(context.l10n.shareRecording, style: Theme.of(sheetContext).textTheme.bodyMedium),
                 onTap: () {
                   Navigator.pop(sheetContext);

--- a/app/lib/pages/memories/widgets/memory_graph_page.dart
+++ b/app/lib/pages/memories/widgets/memory_graph_page.dart
@@ -4,6 +4,8 @@ import 'dart:math';
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
+import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
@@ -537,7 +539,7 @@ class _MemoryGraphPageState extends State<MemoryGraphPage> with SingleTickerProv
         ),
         actions: [
           IconButton(
-            icon: const Icon(Icons.share),
+            icon: const FaIcon(FontAwesomeIcons.share, size: 20),
             onPressed: _shareGraph,
           ),
         ],


### PR DESCRIPTION
## Summary
- Replace inconsistent share icons (`Icons.share`, `Icons.share_outlined`, `Icons.share_rounded`, `FontAwesomeIcons.shareNodes`) with a single `FontAwesomeIcons.share` across mobile, desktop, and all features
- 7 files updated for consistent share icon across the entire app
- `font_awesome_flutter` package already in pubspec.yaml — no new dependencies

## Files Changed
| File | Before | After |
|------|--------|-------|
| `action_item_form_sheet.dart` | `Icons.share_outlined` | `FontAwesomeIcons.share` |
| `ai_message.dart` | `FontAwesomeIcons.shareNodes` | `FontAwesomeIcons.share` |
| `message_action_menu.dart` | `Icons.share` | `FontAwesomeIcons.share` |
| `memory_graph_page.dart` | `Icons.share` | `FontAwesomeIcons.share` |
| `wal_item_detail_page.dart` | `Icons.share` | `FontAwesomeIcons.share` |
| `desktop_memory_graph.dart` | `Icons.share` | `FontAwesomeIcons.share` |
| `desktop_app_detail.dart` | `Icons.share_rounded` | `FontAwesomeIcons.share` |

## Note
- `wrapped_2025_page.dart` keeps `Icons.ios_share` (platform-native share sheet icon, intentional)
- `conversation_detail/page.dart` already used `FontAwesomeIcons.share` — no change needed

## Test plan
- [ ] Verify share icon renders correctly on action items form sheet
- [ ] Verify share icon in chat message action bar
- [ ] Verify share icon in memory graph (mobile + desktop)
- [ ] Verify share icon in WAL item detail
- [ ] Verify share icon in desktop app detail

🤖 Generated with [Claude Code](https://claude.com/claude-code)