### PR TITLE
feat(desktop): limit tasks widget to top 3 tasks

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
@@ -50,15 +50,20 @@ struct TasksWidget: View {
                 .frame(maxWidth: .infinity)
                 .padding(.vertical, 20)
             } else {
+                let maxVisible = 3
+                let todayVisible = min(combinedTodayTasks.count, maxVisible)
+                let remaining = maxVisible - todayVisible
+                let noDueDateVisible = min(recentTasks.count, remaining)
+
                 ScrollView {
                     VStack(spacing: 16) {
                         // Today section (includes overdue tasks, like Flutter)
-                        if !combinedTodayTasks.isEmpty {
+                        if todayVisible > 0 {
                             TaskSectionView(
                                 title: "Today",
                                 titleColor: OmiColors.textSecondary,
                                 icon: "calendar",
-                                tasks: Array(combinedTodayTasks.prefix(3)),
+                                tasks: Array(combinedTodayTasks.prefix(todayVisible)),
                                 totalCount: combinedTodayTasks.count,
                                 showDueDate: true,
                                 onToggle: onToggleCompletion
@@ -66,12 +71,12 @@ struct TasksWidget: View {
                         }
 
                         // Recent tasks without due date
-                        if !recentTasks.isEmpty {
+                        if noDueDateVisible > 0 {
                             TaskSectionView(
                                 title: "No Due Date",
                                 titleColor: OmiColors.textSecondary,
                                 icon: "tray",
-                                tasks: Array(recentTasks.prefix(3)),
+                                tasks: Array(recentTasks.prefix(noDueDateVisible)),
                                 totalCount: recentTasks.count,
                                 showDueDate: false,
                                 onToggle: onToggleCompletion


### PR DESCRIPTION
## Summary
- Limits the dashboard Tasks widget to show only 3 tasks total (across Today and No Due Date sections), instead of 3 per section
- Today tasks take priority; remaining slots go to No Due Date tasks

## Test plan
- [ ] Verify widget shows max 3 tasks when there are tasks in both sections
- [ ] Verify all 3 slots go to Today section when it has 3+ tasks
- [ ] Verify No Due Date tasks fill remaining slots when Today has fewer than 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)