### PR TITLE
Fix Android deep links broken across all notification types

### DIFF
--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -69,7 +69,7 @@ class _AppShellState extends State<AppShell> {
       return;
     }
 
-    if (uri.pathSegments.first == 'apps') {
+    if (uri.pathSegments.first == 'apps' && uri.pathSegments.length > 1) {
       if (mounted) {
         var app = await context.read<AppProvider>().getAppFromId(uri.pathSegments[1]);
         if (app != null) {
@@ -333,8 +333,14 @@ class _AppShellState extends State<AppShell> {
   @override
   void initState() {
     super.initState();
-    initDeepLinks();
-    WidgetsBinding.instance.addPostFrameCallback((_) => _initializeProviders());
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await _initializeProviders();
+      // Start deep link handling AFTER providers are ready,
+      // so getInitialLink() doesn't race against cache loading (#4763)
+      if (mounted) {
+        initDeepLinks();
+      }
+    });
   }
 
   Future<void> _initializeProviders() async {

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -246,7 +246,11 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
       }
 
       switch (pageAlias) {
+        case "action-items":
+          homePageIdx = 1;
+          break;
         case "memories":
+        case "facts":
           homePageIdx = 2;
           break;
         case "apps":
@@ -412,6 +416,9 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
               );
             }
           });
+          break;
+        case "action-items":
+          // Tab index already set to 1 (ActionItemsPage) above
           break;
         default:
       }

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -218,10 +218,11 @@ class _FCMNotificationService implements NotificationInterface {
 
       // Plugin
       if (data.isNotEmpty) {
-        late Map<String, String> payload = <String, String>{};
-        payload.addAll({
-          "navigate_to": data['navigate_to'] ?? "",
-        });
+        final Map<String, String> payload = <String, String>{};
+        final navigateTo = data['navigate_to'];
+        if (navigateTo != null && navigateTo.toString().isNotEmpty) {
+          payload['navigate_to'] = navigateTo.toString();
+        }
 
         // Handle action item data messages
         final messageType = data['type'];


### PR DESCRIPTION
## Summary
- **Race condition fix**: `initDeepLinks()` now waits for `_initializeProviders()` to complete before firing, preventing cold-start deep link failures (#4763)
- **Bounds check**: `/apps` deep link now validates `pathSegments.length > 1` before accessing index [1], preventing crash on malformed URLs (#4762)
- **Missing routes**: Added `action-items` (tab 1) and `facts` (tab 2) cases to home page navigation switch so task reminder and fact notifications actually navigate
- **Empty string fallback**: FCM `navigate_to` payload no longer defaults to `""` — only added when present and non-empty, so the tap handler's null check properly short-circuits

## Root Cause Analysis
All 4 bugs contributed to #4799 ("Android deep links broken across all notification types"):

| Bug | Impact | Files |
|-----|--------|-------|
| Race condition | ALL URL-based deep links fail on cold start | `app_shell.dart` |
| No bounds check | `/apps` crashes on malformed URL | `app_shell.dart` |
| Missing routes | Task reminders + fact notifications go nowhere | `home/page.dart` |
| Empty string fallback | Notifications without `navigate_to` route to home instead of being ignored | `notification_service_fcm.dart` |

## Test plan
- [ ] Cold start: tap notification when app is killed → should navigate to correct page
- [ ] Warm start: tap notification when app is in background → should navigate to correct page
- [ ] `/apps` deep link with malformed URL → should not crash
- [ ] Task reminder notification → should navigate to Action Items tab
- [ ] Notification without `navigate_to` → should not navigate away from current page

Fixes #4799
Fixes #4763
Fixes #4762

🤖 Generated with [Claude Code](https://claude.com/claude-code)