### PR TITLE
fix(integrations): reduce external app webhook timeouts

### DIFF
--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -125,8 +125,8 @@ def trigger_external_integrations(uid: str, conversation: Conversation) -> list:
             response = requests.post(
                 url,
                 json=payload,
-                timeout=30,
-            )  # TODO: failing?
+                timeout=10,
+            )
             if response.status_code != 200:
                 print('App integration failed', app.id, 'status:', response.status_code, 'result:', response.text[:100])
                 return
@@ -424,7 +424,7 @@ def _trigger_realtime_audio_bytes(uid: str, sample_rate: int, data: bytearray):
         url = app.external_integration.webhook_url
         url += f'?sample_rate={sample_rate}&uid={uid}'
         try:
-            response = requests.post(url, data=data, headers={'Content-Type': 'application/octet-stream'}, timeout=15)
+            response = requests.post(url, data=data, headers={'Content-Type': 'application/octet-stream'}, timeout=5)
             print('trigger_realtime_audio_bytes', app.id, 'status:', response.status_code)
         except Exception as e:
             print(f"Plugin integration error: {e}")
@@ -497,7 +497,7 @@ def _trigger_realtime_integrations(uid: str, segments: List[dict], conversation_
             url += '?uid=' + uid
 
         try:
-            response = requests.post(url, json={"session_id": uid, "segments": segments}, timeout=10)
+            response = requests.post(url, json={"session_id": uid, "segments": segments}, timeout=5)
             if response.status_code != 200:
                 print(
                     'trigger_realtime_integrations',


### PR DESCRIPTION
## Summary

Reduce external app integration webhook timeouts to prevent pipeline backpressure:

| Function | Before | After | Why |
|----------|--------|-------|-----|
| `trigger_external_integrations` | 30s | 10s | Conversation created webhook — 30s blocks thread holding full Conversation object |
| `trigger_realtime_audio_bytes` | 15s | 5s | Realtime audio streaming — long timeout stalls audio pipeline |
| `trigger_realtime_integrations` | 10s | 5s | Realtime transcript — shorter budget for streaming path |

All three functions spawn threads per app and `join()` all — a single slow app blocks the entire pipeline for that user. The old timeouts (especially 30s) cause backpressure that feeds into queue growth and memory pressure.

Part of #4825 (Fix 3/3). Follow-up to PR #4784.

## Test plan

- [ ] Verify app integrations still receive webhooks for normal-speed apps
- [ ] Verify slow apps timeout gracefully without crashing
- [ ] Monitor for increased timeout errors in logs (expected for slow external apps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)