### PR TITLE
Fix: Action items FAB position

### DIFF
--- a/app/lib/pages/action_items/action_items_page.dart
+++ b/app/lib/pages/action_items/action_items_page.dart
@@ -174,8 +174,9 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
   }
 
   Widget _buildFab() {
-    return Padding(
-      padding: const EdgeInsets.only(bottom: 48.0),
+    return Positioned(
+      right: 20,
+      bottom: 100,
       child: FloatingActionButton(
         heroTag: 'action_items_fab',
         onPressed: () {
@@ -375,22 +376,26 @@ class _ActionItemsPageState extends State<ActionItemsPage> with AutomaticKeepAli
 
         return Scaffold(
           backgroundColor: Theme.of(context).colorScheme.primary,
-          floatingActionButton: _buildFab(),
-          body: GestureDetector(
-            onTap: () {},
-            child: RefreshIndicator(
-              onRefresh: () async {
-                HapticFeedback.mediumImpact();
-                return provider.forceRefreshActionItems();
-              },
-              color: Colors.deepPurple,
-              backgroundColor: Colors.white,
-              child: provider.isLoading && provider.actionItems.isEmpty
-                  ? _buildLoadingState()
-                  : categorizedItems.values.every((l) => l.isEmpty)
-                      ? _buildEmptyTasksList()
-                      : _buildTasksList(categorizedItems, provider),
-            ),
+          body: Stack(
+            children: [
+              GestureDetector(
+                onTap: () {},
+                child: RefreshIndicator(
+                  onRefresh: () async {
+                    HapticFeedback.mediumImpact();
+                    return provider.forceRefreshActionItems();
+                  },
+                  color: Colors.deepPurple,
+                  backgroundColor: Colors.white,
+                  child: provider.isLoading && provider.actionItems.isEmpty
+                      ? _buildLoadingState()
+                      : categorizedItems.values.every((l) => l.isEmpty)
+                          ? _buildEmptyTasksList()
+                          : _buildTasksList(categorizedItems, provider),
+                ),
+              ),
+              _buildFab(),
+            ],
           ),
         );
       },


### PR DESCRIPTION
## Summary
- Fixed the floating action button (FAB) position on the Action Items page by replacing `Scaffold.floatingActionButton` with a `Stack` + `Positioned` widget approach for consistent placement across platforms

## Before
![Image](https://github.com/user-attachments/assets/7e8a0f13-4a20-4a06-bba5-22f1901a7eae)

## After (Android)
![Image](https://github.com/user-attachments/assets/468bc7bf-b49d-4698-9178-1ed15d6a99a4)

## After (iOS)
<img width="1206" height="2622" alt="Image" src="https://github.com/user-attachments/assets/9df547d0-9f56-40c0-b276-7eac8703ea8d" />

## Test plan
- [x] Verify FAB position on Android
- [x] Verify FAB position on iOS
- [x] Verify FAB tap opens create action item flow
- [x] Verify scroll and refresh still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)