### PR TITLE
fix: prevent WAL files from getting future timestamps during SD card sync

### DIFF
--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -295,7 +295,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
 
     List<List<int>> bytesData = [];
     var bytesLeft = 0;
-    var chunkSize = sdcardChunkSizeSecs * 100;
+    var chunkSize = sdcardChunkSizeSecs * wal.codec.getFramesPerSecond();
     await _storageStream?.cancel();
     final completer = Completer<bool>();
     bool hasError = false;
@@ -361,10 +361,10 @@ class SDCardWalSyncImpl implements SDCardWalSync {
       if (bytesData.length - bytesLeft >= chunkSize) {
         var chunk = bytesData.sublist(bytesLeft, bytesLeft + chunkSize);
         bytesLeft += chunkSize;
-        timerStart += sdcardChunkSizeSecs;
         try {
           var file = await _flushToDisk(wal, chunk, timerStart);
           await callback(file, offset, timerStart);
+          timerStart += sdcardChunkSizeSecs;
         } catch (e) {
           Logger.debug('Error in callback during chunking: $e');
           hasError = true;
@@ -397,7 +397,6 @@ class SDCardWalSyncImpl implements SDCardWalSync {
 
     if (!hasError && bytesLeft < bytesData.length - 1) {
       var chunk = bytesData.sublist(bytesLeft);
-      timerStart += sdcardChunkSizeSecs;
       var file = await _flushToDisk(wal, chunk, timerStart);
       await callback(file, offset, timerStart);
     }
@@ -1139,10 +1138,10 @@ class SDCardWalSyncImpl implements SDCardWalSync {
       while (bytesData.length - bytesLeft >= chunkSize) {
         var chunk = bytesData.sublist(bytesLeft, bytesLeft + chunkSize);
         bytesLeft += chunkSize;
-        timerStart += sdcardChunkSizeSecs;
         try {
           var file = await _flushToDisk(wal, chunk, timerStart);
           await _registerSingleChunk(wal, file, timerStart);
+          timerStart += sdcardChunkSizeSecs;
         } catch (e) {
           Logger.debug('SDCardWalSync WiFi: Error flushing chunk: $e');
         }
@@ -1151,7 +1150,6 @@ class SDCardWalSyncImpl implements SDCardWalSync {
       // Flush any remaining frames
       if (bytesLeft < bytesData.length) {
         var chunk = bytesData.sublist(bytesLeft);
-        timerStart += sdcardChunkSizeSecs;
         try {
           var file = await _flushToDisk(wal, chunk, timerStart);
           await _registerSingleChunk(wal, file, timerStart);

--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -1141,9 +1141,10 @@ class SDCardWalSyncImpl implements SDCardWalSync {
         try {
           var file = await _flushToDisk(wal, chunk, timerStart);
           await _registerSingleChunk(wal, file, timerStart);
-          timerStart += sdcardChunkSizeSecs;
         } catch (e) {
           Logger.debug('SDCardWalSync WiFi: Error flushing chunk: $e');
+        } finally {
+          timerStart += sdcardChunkSizeSecs;
         }
       }
 


### PR DESCRIPTION
## Problem

WAL files created during SD card sync sometimes get **future timestamps**. The backend rejects files with future dates, causing users to get stuck in an infinite sync loop — WALs can never be synced because their timestamps are in the future.

## Root Causes

### 1. timerStart incremented before first chunk flush
In both BLE and WiFi chunk loops, `timerStart += sdcardChunkSizeSecs` (60s) was executed **before** the first chunk was written. This shifted every chunk's timestamp 60 seconds into the future.

### 2. Remainder chunk adds unnecessary 60 seconds
After the chunk loop, any remaining partial data also added a full 60 seconds to `timerStart`, even though the data might contain only a few seconds of audio. Combined with issue #1, this caused the final timestamp to overshoot `DateTime.now()`.

**Example:** 65 seconds of audio → timerStart starts at `now - 65`, increments total 120s → final timestamp = `now + 55` (55 seconds in the future!)

### 3. BLE path hardcoded 100 fps
`chunkSize = sdcardChunkSizeSecs * 100` assumed 100 fps, but the production Omi device uses opusFS320 codec at 50 fps. This made BLE chunks contain 120s of audio while timestamps only advanced 60s, creating wrong timestamp ranges. The WiFi path already used `wal.codec.getFramesPerSecond()` correctly.

## Fix

1. **Move** `timerStart += sdcardChunkSizeSecs` to **after** the flush call in both BLE and WiFi chunk loops
2. **Remove** `timerStart += sdcardChunkSizeSecs` from remainder handling in both paths (timerStart is already correct after the loop)
3. **Replace** hardcoded `100` with `wal.codec.getFramesPerSecond()` in BLE chunk size calculation

Minimal diff: 1 file changed, 3 insertions, 5 deletions.