### PR TITLE
fix(desktop): deleted goals reappear after app restart

### DIFF
--- a/desktop/Desktop/Sources/Rewind/Core/GoalStorage.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/GoalStorage.swift
@@ -76,19 +76,34 @@ actor GoalStorage {
 
     // MARK: - Sync Operations
 
-    /// Batch upsert from API response
+    /// Batch upsert from API response — server is source of truth.
+    /// Goals not present in the server response are hard-deleted locally.
     func syncServerGoals(_ goals: [Goal]) async throws {
         let db = try await ensureInitialized()
 
+        let serverIds = Set(goals.map { $0.id })
+
         try await db.write { database in
+            // Upsert goals from server
             for goal in goals {
                 if var existingRecord = try GoalRecord
                     .filter(Column("backendId") == goal.id)
                     .fetchOne(database) {
                     existingRecord.updateFrom(goal)
+                    existingRecord.deleted = false
                     try existingRecord.update(database)
                 } else {
                     _ = try GoalRecord.from(goal).inserted(database)
+                }
+            }
+
+            // Remove local records that no longer exist on server
+            let localRecords = try GoalRecord
+                .filter(Column("backendId") != nil)
+                .fetchAll(database)
+            for record in localRecords {
+                if let backendId = record.backendId, !serverIds.contains(backendId) {
+                    try record.delete(database)
                 }
             }
         }


### PR DESCRIPTION
## Summary
- `syncServerGoals()` now treats the server response as source of truth
- Goals present on server are upserted locally (with `deleted` flag reset)
- Local records whose `backendId` is absent from the server response are hard-deleted
- Fixes bug where deleted goals would reappear after restarting the app

## Test plan
- [ ] Delete a goal from the dashboard
- [ ] Restart the app
- [ ] Verify the deleted goal does not reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)