### PR TITLE
fix(desktop): clean conversation rows with emoji + time

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/ConversationRowView.swift
@@ -293,27 +293,44 @@ struct ConversationRowView: View {
             // Emoji
             Text(conversation.structured.emoji.isEmpty ? "💬" : conversation.structured.emoji)
                 .scaledFont(size: 16)
-                .frame(width: 28, height: 28)
+                .frame(width: 32, height: 32)
                 .background(
                     RoundedRectangle(cornerRadius: 8)
                         .fill(OmiColors.backgroundTertiary)
                 )
 
-            // Title
-            Text(conversation.title)
-                .scaledFont(size: 14, weight: .medium)
-                .foregroundColor(OmiColors.textPrimary)
-                .lineLimit(1)
+            // Title + metadata below
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(spacing: 8) {
+                    Text(conversation.title)
+                        .scaledFont(size: 14, weight: .medium)
+                        .foregroundColor(OmiColors.textPrimary)
+                        .lineLimit(1)
 
-            // New badge
-            if isNewlyCreated {
-                NewBadge()
-            }
+                    if isNewlyCreated {
+                        NewBadge()
+                    }
 
-            // Inline action buttons (show on hover)
-            if isHovering && !isMultiSelectMode {
-                inlineActionButtons
-                    .transition(.opacity)
+                    // Inline action buttons (show on hover)
+                    if isHovering && !isMultiSelectMode {
+                        inlineActionButtons
+                            .transition(.opacity)
+                    }
+                }
+
+                HStack(spacing: 6) {
+                    Text(formattedTimestamp)
+                        .scaledFont(size: 12)
+                        .foregroundColor(OmiColors.textTertiary)
+
+                    Text("·")
+                        .scaledFont(size: 12)
+                        .foregroundColor(OmiColors.textQuaternary)
+
+                    Text(conversation.formattedDuration)
+                        .scaledFont(size: 12)
+                        .foregroundColor(OmiColors.textTertiary)
+                }
             }
 
             Spacer()
@@ -328,36 +345,9 @@ struct ConversationRowView: View {
                     .opacity(isStarring ? 0.5 : 1.0)
             }
             .buttonStyle(.plain)
-
-            // Source label (hide on hover to make room)
-            if !isHovering {
-                Text(sourceLabel)
-                    .scaledFont(size: 10, weight: .medium)
-                    .foregroundColor(OmiColors.textQuaternary)
-            }
-
-            // Folder label
-            if !isHovering, let folderName = folderName {
-                Text(folderName)
-                    .scaledFont(size: 10, weight: .medium)
-                    .foregroundColor(OmiColors.textQuaternary)
-                    .lineLimit(1)
-            }
-
-            // Time
-            Text(formattedTimestamp)
-                .scaledFont(size: 12)
-                .foregroundColor(OmiColors.textTertiary)
-
-            // Duration (hide on hover to make room)
-            if !isHovering {
-                Text(conversation.formattedDuration)
-                    .scaledFont(size: 11)
-                    .foregroundColor(OmiColors.textQuaternary)
-            }
         }
         .padding(.horizontal, 10)
-        .padding(.vertical, 12)
+        .padding(.vertical, 10)
         .background(
             RoundedRectangle(cornerRadius: 8)
                 .fill(isSelected ? OmiColors.purplePrimary.opacity(0.2) : (isHovering ? OmiColors.backgroundTertiary : (isNewlyCreated ? OmiColors.purplePrimary.opacity(0.15) : OmiColors.backgroundSecondary)))
@@ -369,7 +359,7 @@ struct ConversationRowView: View {
         .contentShape(Rectangle())
     }
 
-    // MARK: - Expanded Row (title + overview)
+    // MARK: - Expanded Row (title + time/duration)
 
     private var expandedRowContent: some View {
         HStack(spacing: 12) {
@@ -380,15 +370,23 @@ struct ConversationRowView: View {
                     .foregroundColor(isSelected ? OmiColors.purplePrimary : OmiColors.textTertiary)
             }
 
-            // Emoji, Title, and overview
-            VStack(alignment: .leading, spacing: 4) {
+            // Emoji
+            Text(conversation.structured.emoji.isEmpty ? "💬" : conversation.structured.emoji)
+                .scaledFont(size: 18)
+                .frame(width: 36, height: 36)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(OmiColors.backgroundTertiary)
+                )
+
+            // Title + time/duration below
+            VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 8) {
                     Text(conversation.title)
                         .scaledFont(size: 15, weight: .medium)
                         .foregroundColor(OmiColors.textPrimary)
                         .lineLimit(1)
 
-                    // New badge
                     if isNewlyCreated {
                         NewBadge()
                     }
@@ -398,19 +396,20 @@ struct ConversationRowView: View {
                         inlineActionButtons
                             .transition(.opacity)
                     }
-
-                    if conversation.structured.title.isEmpty && !isHovering {
-                        Text("(\(conversation.id.prefix(8))...)")
-                            .scaledFont(size: 11, design: .monospaced)
-                            .foregroundColor(OmiColors.textQuaternary)
-                    }
                 }
 
-                if !conversation.overview.isEmpty {
-                    Text(conversation.overview)
-                        .scaledFont(size: 13)
+                HStack(spacing: 6) {
+                    Text(formattedTimestamp)
+                        .scaledFont(size: 12)
                         .foregroundColor(OmiColors.textTertiary)
-                        .lineLimit(2)
+
+                    Text("·")
+                        .scaledFont(size: 12)
+                        .foregroundColor(OmiColors.textQuaternary)
+
+                    Text(conversation.formattedDuration)
+                        .scaledFont(size: 12)
+                        .foregroundColor(OmiColors.textTertiary)
                 }
             }
 
@@ -426,36 +425,6 @@ struct ConversationRowView: View {
                     .opacity(isStarring ? 0.5 : 1.0)
             }
             .buttonStyle(.plain)
-
-            // Time, duration, and source
-            VStack(alignment: .trailing, spacing: 4) {
-                HStack(spacing: 6) {
-                    if !isHovering {
-                        Text(sourceLabel)
-                            .scaledFont(size: 10, weight: .medium)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Text(formattedTimestamp)
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
-                }
-
-                if !isHovering {
-                    HStack(spacing: 6) {
-                        if let folderName = folderName {
-                            Text(folderName)
-                                .scaledFont(size: 11, weight: .medium)
-                                .foregroundColor(OmiColors.textQuaternary)
-                                .lineLimit(1)
-                        }
-
-                        Text(conversation.formattedDuration)
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textQuaternary)
-                    }
-                }
-            }
         }
         .padding(12)
         .background(


### PR DESCRIPTION
## Summary
- Remove summary/overview subtitle from conversation rows
- Add emoji icon in rounded square to the left of each conversation
- Show title on first line, time + duration on second line
- Applies to both compact (dashboard widget) and expanded (conversations page) views

## Test plan
- [x] Built and ran app
- [x] Verified conversation rows show emoji, title, time · duration

🤖 Generated with [Claude Code](https://claude.com/claude-code)