### PR TITLE
feat: TestFlight → dev backend with dual-project Firebase auth

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -59,6 +59,17 @@ extension FlutterError: Error {}
       self?.handleMethodCall(call, result: result)
     }
     
+    // Create environment detection method channel (TestFlight detection)
+    let envChannel = FlutterMethodChannel(name: "com.omi/environment", binaryMessenger: controller!.binaryMessenger)
+    envChannel.setMethodCallHandler { (call, result) in
+      if call.method == "isTestFlight" {
+        let isTestFlight = Bundle.main.appStoreReceiptURL?.lastPathComponent == "sandboxReceipt"
+        result(isTestFlight)
+      } else {
+        result(FlutterMethodNotImplemented)
+      }
+    }
+
     // Create Apple Reminders method channel
     appleRemindersChannel = FlutterMethodChannel(name: "com.omi.apple_reminders", binaryMessenger: controller!.binaryMessenger)
     appleRemindersChannel?.setMethodCallHandler { [weak self] (call, result) in

--- a/app/lib/env/env.dart
+++ b/app/lib/env/env.dart
@@ -2,9 +2,14 @@ import 'package:omi/env/dev_env.dart';
 
 abstract class Env {
   static late final EnvFields _instance;
+  static String? _apiBaseUrlOverride;
 
   static void init([EnvFields? instance]) {
     _instance = instance ?? DevEnv() as EnvFields;
+  }
+
+  static void overrideApiBaseUrl(String url) {
+    _apiBaseUrlOverride = url;
   }
 
   static String? get openAIAPIKey => _instance.openAIAPIKey;
@@ -12,7 +17,7 @@ abstract class Env {
   static String? get mixpanelProjectToken => _instance.mixpanelProjectToken;
 
   // static String? get apiBaseUrl => 'https://omi-backend.ngrok.app/';
-  static String? get apiBaseUrl => _instance.apiBaseUrl;
+  static String? get apiBaseUrl => _apiBaseUrlOverride ?? _instance.apiBaseUrl;
 
   static String? get growthbookApiKey => _instance.growthbookApiKey;
 

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:ui';
 
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -68,6 +69,7 @@ import 'package:omi/services/notifications/important_conversation_notification_h
 import 'package:omi/services/notifications/merge_notification_handler.dart';
 import 'package:omi/services/services.dart';
 import 'package:omi/utils/analytics/growthbook.dart';
+import 'package:omi/utils/environment_detector.dart';
 import 'package:omi/utils/debug_log_manager.dart';
 import 'package:omi/utils/debugging/crashlytics_manager.dart';
 import 'package:omi/utils/enums.dart';
@@ -132,6 +134,12 @@ Future _init() async {
     } else {
       Env.init(DevEnv());
     }
+  }
+
+  // Override API URL for TestFlight builds (prod flavor running in sandbox)
+  if (F.env == Environment.prod && kReleaseMode && await EnvironmentDetector.isTestFlight()) {
+    Env.overrideApiBaseUrl('https://api.omiapi.com/');
+    debugPrint('TestFlight detected: using dev backend (api.omiapi.com)');
   }
 
   FlutterForegroundTask.initCommunicationPort();

--- a/app/lib/utils/environment_detector.dart
+++ b/app/lib/utils/environment_detector.dart
@@ -1,0 +1,17 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+
+class EnvironmentDetector {
+  static const _channel = MethodChannel('com.omi/environment');
+
+  static Future<bool> isTestFlight() async {
+    if (!Platform.isIOS) return false;
+    try {
+      final result = await _channel.invokeMethod<bool>('isTestFlight');
+      return result ?? false;
+    } on PlatformException {
+      return false;
+    }
+  }
+}

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -2,10 +2,10 @@ from typing import List, Optional
 
 from fastapi import Depends, HTTPException, Security
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
-from firebase_admin import auth
 
 import database.mcp_api_key as mcp_api_key_db
 import database.dev_api_key as dev_api_key_db
+from utils.firebase_auth import verify_firebase_token
 from utils.scopes import Scopes, has_scope
 
 bearer_scheme = HTTPBearer()
@@ -18,7 +18,7 @@ async def get_current_user_id(
         raise HTTPException(status_code=401, detail="Not authenticated")
     try:
         id_token = credentials.credentials
-        decoded_token = auth.verify_id_token(id_token)
+        decoded_token = verify_firebase_token(id_token)
         return decoded_token["uid"]
     except Exception as e:
         print(f"Error verifying Firebase ID token: {e}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -43,6 +43,7 @@ from routers import (
     agent_tools,
 )
 
+from utils.firebase_auth import init_prod_firebase_auth
 from utils.other.timeout import TimeoutMiddleware
 from utils.observability import log_langsmith_status
 
@@ -55,6 +56,8 @@ if os.environ.get('SERVICE_ACCOUNT_JSON'):
     firebase_admin.initialize_app(credentials)
 else:
     firebase_admin.initialize_app()
+
+init_prod_firebase_auth()
 
 app = FastAPI()
 

--- a/backend/routers/oauth.py
+++ b/backend/routers/oauth.py
@@ -8,8 +8,9 @@ import requests
 
 from database.apps import get_app_by_id_db
 from database.redis_db import enable_app, increase_app_installs_count
-from utils.apps import is_user_app_enabled, get_is_user_paid_app, is_tester
 from models.app import App as AppModel, ActionType
+from utils.apps import is_user_app_enabled, get_is_user_paid_app, is_tester
+from utils.firebase_auth import verify_firebase_token
 
 router = APIRouter(
     tags=["oauth"],
@@ -112,7 +113,7 @@ async def oauth_authorize(
 @router.post("/v1/oauth/token")
 async def oauth_token(firebase_id_token: str = Form(...), app_id: str = Form(...), state: Optional[str] = Form(None)):
     try:
-        decoded_token = firebase_admin.auth.verify_id_token(firebase_id_token)
+        decoded_token = verify_firebase_token(firebase_id_token)
         uid = decoded_token['uid']
     except firebase_admin.auth.InvalidIdTokenError as e:
         raise HTTPException(status_code=401, detail=f"Invalid Firebase ID token: {e}")

--- a/backend/utils/firebase_auth.py
+++ b/backend/utils/firebase_auth.py
@@ -1,0 +1,51 @@
+import os
+
+import firebase_admin
+from firebase_admin import auth
+
+_prod_auth_app = None
+
+
+def init_prod_firebase_auth():
+    """Initialize a secondary Firebase app for verifying prod Firebase tokens on the dev backend.
+
+    When PROD_FIREBASE_PROJECT_ID is set (e.g. 'based-hardware'), this creates a second
+    Firebase app that can verify tokens from the prod Firebase project. This allows the
+    dev backend to accept requests from TestFlight users who authenticate against the
+    prod Firebase project.
+
+    Token verification only uses the project ID (to check aud/iss claims) and Google's
+    public signing keys — no prod service account credentials are needed.
+    """
+    global _prod_auth_app
+    prod_project_id = os.environ.get('PROD_FIREBASE_PROJECT_ID')
+    if not prod_project_id:
+        return
+
+    try:
+        default_app = firebase_admin.get_app()
+        _prod_auth_app = firebase_admin.initialize_app(
+            default_app.credential,
+            options={'projectId': prod_project_id},
+            name='prod-auth',
+        )
+        print(f"Initialized prod Firebase auth app for project: {prod_project_id}")
+    except Exception as e:
+        print(f"Warning: Failed to initialize prod Firebase auth app: {e}")
+
+
+def verify_firebase_token(token: str) -> dict:
+    """Verify a Firebase ID token, trying the default project first, then the prod project.
+
+    Returns the decoded token dict.
+    Raises the original exception if all verification attempts fail.
+    """
+    try:
+        return auth.verify_id_token(token)
+    except Exception as default_error:
+        if _prod_auth_app is not None:
+            try:
+                return auth.verify_id_token(token, app=_prod_auth_app)
+            except Exception:
+                pass
+        raise default_error

--- a/backend/utils/other/endpoints.py
+++ b/backend/utils/other/endpoints.py
@@ -7,6 +7,8 @@ from fastapi import Request
 from firebase_admin import auth
 from firebase_admin.auth import InvalidIdTokenError
 
+from utils.firebase_auth import verify_firebase_token
+
 
 def get_user(uid: str):
     user = auth.get_user(uid)
@@ -33,7 +35,7 @@ def verify_token(token: str) -> str:
 
     # Verify Firebase token
     try:
-        decoded_token = auth.verify_id_token(token)
+        decoded_token = verify_firebase_token(token)
         return decoded_token['uid']
     except InvalidIdTokenError:
         if os.getenv('LOCAL_DEVELOPMENT') == 'true':


### PR DESCRIPTION
## Summary
- TestFlight builds (prod flavor) automatically use the dev backend (`api.omiapi.com`), App Store installs use prod backend (`api.omi.me`)
- **Fixes the auth issue from #4875**: The dev backend now accepts tokens from the prod Firebase project (`based-hardware`) in addition to its own (`based-hardware-dev`)

## What went wrong with #4875
The original PR pointed TestFlight to the dev backend, but the dev backend's `auth.verify_id_token()` rejected tokens from the prod Firebase project. All API calls returned 401.

## How this fixes it

### Backend: dual-project Firebase token verification
- New `backend/utils/firebase_auth.py` — when `PROD_FIREBASE_PROJECT_ID` env var is set, initializes a second Firebase app with that project ID
- `verify_firebase_token()` tries the default app first, falls back to the prod app
- Updated `dependencies.py`, `utils/other/endpoints.py`, `routers/oauth.py` to use the new function
- **No prod credentials needed** — `verify_id_token` only uses the project ID (for `aud`/`iss` claims) and Google's public signing keys

### App: runtime TestFlight detection (same as #4875)
- Native iOS method channel checks `Bundle.main.appStoreReceiptURL` for `sandboxReceipt`
- `Env.overrideApiBaseUrl()` switches to dev backend at startup
- Only activates when: prod flavor + release mode + TestFlight detected

## Deployment requirement
Set `PROD_FIREBASE_PROJECT_ID=based-hardware` on the dev backend (`api.omiapi.com`). On the prod backend, this env var should NOT be set (single-project verification only).

## Behavior matrix
| Build | Backend |
|-------|---------|
| Dev flavor (any) | `api.omiapi.com` (from DevEnv) |
| Prod release on TestFlight | `api.omiapi.com` (overridden at runtime) |
| Prod release on App Store | `api.omi.me` (default from ProdEnv) |
| Prod debug builds | `api.omi.me` (no override) |

## Test plan
- [x] `app/test.sh` — 29/29 pass
- [x] `backend/test.sh` — 215/216 pass (1 pre-existing failure in `test_daily_summary_race_condition`)
- [ ] Deploy backend with `PROD_FIREBASE_PROJECT_ID=based-hardware` to dev
- [ ] TestFlight build → verify tasks/memories load via dev backend
- [ ] App Store build → verify still uses prod backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)