### PR TITLE
[web]/fix: stop sidebar layout jump on route change

### DIFF
--- a/web/app/src/components/layout/Sidebar.tsx
+++ b/web/app/src/components/layout/Sidebar.tsx
@@ -223,13 +223,14 @@ export function Sidebar({
           transform: !isDesktop ? `translateX(${isOpen ? 0 : -280}px)` : undefined,
           // Desktop: set width directly
           width: isDesktop ? sidebarWidth : 280,
+          willChange: !isDesktop ? 'transform' : undefined,
         }}
         className={cn(
           'bg-bg-secondary border-r border-white/[0.04]',
           'flex flex-col flex-shrink-0',
           // Mobile: fixed overlay with slide transition
           'fixed top-0 left-0 bottom-0 z-50',
-          'transition-[transform,width] duration-150 ease-out',
+          'transition-transform duration-150 ease-out lg:transition-none',
           // Desktop: relative in flow
           'lg:relative lg:z-auto'
         )}
@@ -362,12 +363,12 @@ export function Sidebar({
                   }}
                   title={!showText ? (showComingSoon ? `${item.label} (Coming Soon)` : item.label) : undefined}
                   className={cn(
-                    'flex items-center rounded-xl',
-                    'transition-all duration-150',
+                    'flex items-center rounded-xl border-l-[3px]',
+                    'transition-colors duration-150',
                     showText ? 'gap-3 px-4 py-3' : 'justify-center p-3',
                     isActive
                       ? 'bg-purple-primary/10 text-purple-primary border-l-[3px] border-purple-primary'
-                      : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary',
+                      : 'text-text-secondary hover:bg-bg-tertiary hover:text-text-primary border-transparent',
                     showComingSoon && 'opacity-60'
                   )}
                 >


### PR DESCRIPTION
## Sidebar stability fix
## Summary

- Prevent horizontal shift of sidebar items by reserving border space  
- Replace `transition-all` with `transition-colors` to avoid layout animation  
- Disable unnecessary desktop transforms and transitions  

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/34bf0f32-236d-4591-bc8a-5e68cbf3740b) | ![After](https://github.com/user-attachments/assets/7b667ac0-a681-43e2-86b7-013f0772f8bb) |

Please review this🙌 
 @neooriginal @thinhx 
 
 #### Next
Record button alignment still needs additional code changes.  
I’ll address this in a **separate PR**.