### PR TITLE
[web]/fix: profile menu closes correctly on outside click

### DIFF
--- a/web/app/src/components/layout/Sidebar.tsx
+++ b/web/app/src/components/layout/Sidebar.tsx
@@ -152,13 +152,15 @@ export function Sidebar({
 
   // Click outside handler to close menu and collapse if temporary
   useEffect(() => {
-    if (!showUserMenu || !isTemporaryExpand) return;
+    if (!showUserMenu) return;
 
     const handleClickOutside = (e: MouseEvent) => {
       if (userMenuRef.current && !userMenuRef.current.contains(e.target as Node)) {
         setShowUserMenu(false);
-        setIsExpanded(false);
-        setIsTemporaryExpand(false);
+        if (isTemporaryExpand) {
+          setIsExpanded(false);
+          setIsTemporaryExpand(false);
+        }
       }
     };
 


### PR DESCRIPTION
## Summary

* Fix profile dropdown not closing when sidebar is permanently expanded
* Register outside-click listener whenever the user menu is open
* Collapse sidebar only if it was temporarily expanded on outside click

## Before
https://github.com/user-attachments/assets/f59da19c-981b-41e1-9a11-700d381d4320

## After
https://github.com/user-attachments/assets/17563091-29fe-4de4-aaf2-c7a89f21b4ef

Please review this🙌
@neooriginal 
