### PR TITLE
fix: dashboard chart sizing + onboarding welcome task & notification

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Components/DailyScoreWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/DailyScoreWidget.swift
@@ -23,64 +23,62 @@ struct ScoreWidget: View {
         }
     }
 
+    private let gaugeWidth: CGFloat = 140
+    private var gaugeHeight: CGFloat { gaugeWidth / 2 }
+    private let lineWidth: CGFloat = 12
+    private let fontSize: CGFloat = 28
+
     var body: some View {
-        GeometryReader { geometry in
-            let gaugeWidth = min(geometry.size.width * 0.55, 180)
-            let gaugeHeight = gaugeWidth / 2
-            let lineWidth = max(gaugeWidth * 0.085, 8)
-            let fontSize = max(gaugeWidth * 0.2, 18)
+        VStack(spacing: 12) {
+            // Semicircle gauge
+            ZStack {
+                // Background arc
+                SemicircleShape()
+                    .stroke(OmiColors.backgroundQuaternary, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                    .frame(width: gaugeWidth, height: gaugeHeight)
 
-            VStack(spacing: 12) {
-                // Semicircle gauge
-                ZStack {
-                    // Background arc
-                    SemicircleShape()
-                        .stroke(OmiColors.backgroundQuaternary, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-                        .frame(width: gaugeWidth, height: gaugeHeight)
+                // Progress arc
+                SemicircleShape()
+                    .trim(from: 0, to: min(weeklyScore.score / 100, 1.0))
+                    .stroke(scoreColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
+                    .frame(width: gaugeWidth, height: gaugeHeight)
+                    .animation(.easeInOut(duration: 0.3), value: weeklyScore.score)
 
-                    // Progress arc
-                    SemicircleShape()
-                        .trim(from: 0, to: min(weeklyScore.score / 100, 1.0))
-                        .stroke(scoreColor, style: StrokeStyle(lineWidth: lineWidth, lineCap: .round))
-                        .frame(width: gaugeWidth, height: gaugeHeight)
-                        .animation(.easeInOut(duration: 0.3), value: weeklyScore.score)
+                // Score text
+                VStack(spacing: 2) {
+                    Text("\(Int(weeklyScore.score))%")
+                        .scaledFont(size: fontSize, weight: .bold)
+                        .foregroundColor(OmiColors.textPrimary)
+                        .contentTransition(.numericText())
+                }
+                .offset(y: gaugeHeight * 0.14)
+            }
 
-                    // Score text
-                    VStack(spacing: 2) {
-                        Text("\(Int(weeklyScore.score))%")
-                            .scaledFont(size: fontSize, weight: .bold)
-                            .foregroundColor(OmiColors.textPrimary)
+            // Task count and subtitle
+            VStack(spacing: 4) {
+                if weeklyScore.hasTasks {
+                    HStack(spacing: 4) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .scaledFont(size: 12)
+                            .foregroundColor(scoreColor)
+                        Text("\(weeklyScore.completedTasks) of \(weeklyScore.totalTasks) tasks completed")
+                            .scaledMonospacedDigitFont(size: 12)
+                            .foregroundColor(OmiColors.textTertiary)
                             .contentTransition(.numericText())
                     }
-                    .offset(y: gaugeHeight * 0.14)
+                } else {
+                    Text("No tasks this week")
+                        .scaledFont(size: 12)
+                        .foregroundColor(OmiColors.textTertiary)
                 }
 
-                // Task count and subtitle
-                VStack(spacing: 4) {
-                    if weeklyScore.hasTasks {
-                        HStack(spacing: 4) {
-                            Image(systemName: "checkmark.circle.fill")
-                                .scaledFont(size: 12)
-                                .foregroundColor(scoreColor)
-                            Text("\(weeklyScore.completedTasks) of \(weeklyScore.totalTasks) tasks completed")
-                                .scaledMonospacedDigitFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                                .contentTransition(.numericText())
-                        }
-                    } else {
-                        Text("No tasks this week")
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Text("Last 7 days")
-                        .scaledFont(size: 10)
-                        .foregroundColor(OmiColors.textQuaternary)
-                }
+                Text("Last 7 days")
+                    .scaledFont(size: 10)
+                    .foregroundColor(OmiColors.textQuaternary)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .padding(20)
         }
+        .frame(maxWidth: .infinity)
+        .padding(20)
         .background(
             RoundedRectangle(cornerRadius: 16)
                 .fill(OmiColors.backgroundTertiary.opacity(0.5))


### PR DESCRIPTION
## Summary
- **ScoreWidget chart fix**: Removed `GeometryReader` that prevented the semicircle gauge from having intrinsic size in the Grid layout, causing it to clip. Replaced with fixed proportional dimensions (140pt gauge, 12pt stroke, 28pt font) that auto-size correctly.
- **Onboarding welcome task**: After completing onboarding, automatically creates a task "Run Omi for two days to start receiving helpful advice" with today's due date so it shows on the dashboard immediately.
- **Onboarding welcome notification**: Sends a macOS notification 2s after onboarding: "You're all set! Just go back to your work and run me in the background. I'll start sending you useful advice during your day."

## Test plan
- [ ] Complete onboarding on a fresh macOS account and verify the welcome task appears in the dashboard Tasks section
- [ ] Verify the welcome notification is delivered after onboarding
- [ ] Verify the ScoreWidget gauge renders correctly at various window sizes without clipping

🤖 Generated with [Claude Code](https://claude.com/claude-code)