### PR TITLE
feat(backend): generate daily summaries in user's preferred language

### DIFF
--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -3,7 +3,6 @@ from typing import List
 import pytz
 from langchain_core.prompts import ChatPromptTemplate
 import database.users as users_db
-from database.users import get_user_language_preference
 from models.conversation import Structured, Conversation
 from models.other import Person
 from utils.llm.clients import parser, llm_mini, llm_medium_experiment
@@ -83,7 +82,7 @@ def summarize_experience_text(text: str, text_source_spec: str = None) -> Struct
 
 def get_conversation_summary(uid: str, memories: List[Conversation]) -> str:
     user_name, memories_str = get_prompt_memories(uid)
-    user_language = get_user_language_preference(uid)
+    user_language = users_db.get_user_language_preference(uid)
 
     all_person_ids = []
     for m in memories:
@@ -144,7 +143,7 @@ def generate_comprehensive_daily_summary(
     user_name, memories_str = get_prompt_memories(uid)
 
     # Get user's language preference for generating summary in their language
-    user_language = get_user_language_preference(uid)
+    user_language = users_db.get_user_language_preference(uid)
 
     all_person_ids = []
     for m in conversations:


### PR DESCRIPTION
closes #4928 

## Summary
- Daily summaries were always generated in English regardless of the user's app language setting
- Now reads the user's language preference (`get_user_language_preference`) and instructs the LLM to generate the entire summary in that language
- Applies to both `generate_comprehensive_daily_summary` (structured daily summary with headline, overview, highlights, etc.) and `get_conversation_summary` (action items summary)
- No change for English users or users without a language preference set

## Changes
- `backend/utils/llm/external_integrations.py`
  - Import `get_user_language_preference` from `database.users`
  - `get_conversation_summary`: look up user language and inject instruction into prompt
  - `generate_comprehensive_daily_summary`: look up user language and append a RULES entry requiring all output in that language

## Test plan
- [ ] Verify a user with language set to `ja` receives daily summary entirely in Japanese
- [ ] Verify a user with language set to `en` (or unset) still receives summary in English
- [ ] Backend tests pass (`backend/test.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)