### PR TITLE
Add deprecation banner to Flutter desktop app

### DIFF
--- a/app/lib/desktop/desktop_app.dart
+++ b/app/lib/desktop/desktop_app.dart
@@ -6,6 +6,7 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 
 import 'package:provider/provider.dart';
+import 'package:url_launcher/url_launcher.dart';
 
 import 'package:omi/backend/preferences.dart';
 import 'package:omi/desktop/pages/desktop_home_wrapper.dart';
@@ -14,38 +15,95 @@ import 'package:omi/pages/persona/persona_profile.dart';
 import 'package:omi/providers/auth_provider.dart';
 
 /// @deprecated Use the native Swift macOS app at /desktop/ instead.
-class DesktopApp extends StatelessWidget {
+class DesktopApp extends StatefulWidget {
   const DesktopApp({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return Consumer<AuthenticationProvider>(
-      builder: (context, authProvider, child) {
-        // DEBUG: Log routing decision
-        final isSignedIn = authProvider.isSignedIn();
-        final onboardingCompleted = SharedPreferencesUtil().onboardingCompleted;
-        final currentUser = FirebaseAuth.instance.currentUser;
-        print('DEBUG DesktopApp: isSignedIn=$isSignedIn, onboardingCompleted=$onboardingCompleted');
-        print('DEBUG DesktopApp: currentUser=${currentUser?.uid}, isAnonymous=${currentUser?.isAnonymous}');
+  State<DesktopApp> createState() => _DesktopAppState();
+}
 
-        if (isSignedIn) {
-          if (onboardingCompleted) {
-            print('DEBUG DesktopApp: -> DesktopHomePageWrapper');
-            return const DesktopHomePageWrapper();
-          } else {
-            print('DEBUG DesktopApp: -> DesktopOnboardingWrapper (not completed)');
-            return const DesktopOnboardingWrapper();
-          }
-        } else if (SharedPreferencesUtil().hasOmiDevice == false &&
-            SharedPreferencesUtil().hasPersonaCreated &&
-            SharedPreferencesUtil().verifiedPersonaId != null) {
-          print('DEBUG DesktopApp: -> PersonaProfilePage');
-          return const PersonaProfilePage();
-        } else {
-          print('DEBUG DesktopApp: -> DesktopOnboardingWrapper (not signed in)');
-          return const DesktopOnboardingWrapper();
-        }
-      },
+class _DesktopAppState extends State<DesktopApp> {
+  bool _showDeprecationBanner = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        if (_showDeprecationBanner)
+          Container(
+            width: double.infinity,
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 10),
+            color: const Color(0xFFDC2626),
+            child: Row(
+              children: [
+                const Icon(Icons.warning_amber_rounded, color: Colors.white, size: 20),
+                const SizedBox(width: 10),
+                Expanded(
+                  child: Row(
+                    children: [
+                      const Text(
+                        'This app is deprecated. Please migrate to the ',
+                        style: TextStyle(color: Colors.white, fontSize: 13, fontWeight: FontWeight.w500),
+                      ),
+                      MouseRegion(
+                        cursor: SystemMouseCursors.click,
+                        child: GestureDetector(
+                          onTap: () => launchUrl(Uri.parse('https://macos.omi.me')),
+                          child: const Text(
+                            'v2 Desktop app',
+                            style: TextStyle(
+                              color: Colors.white,
+                              fontSize: 13,
+                              fontWeight: FontWeight.w700,
+                              decoration: TextDecoration.underline,
+                              decorationColor: Colors.white,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                MouseRegion(
+                  cursor: SystemMouseCursors.click,
+                  child: GestureDetector(
+                    onTap: () => setState(() => _showDeprecationBanner = false),
+                    child: const Icon(Icons.close, color: Colors.white, size: 18),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        Expanded(
+          child: Consumer<AuthenticationProvider>(
+            builder: (context, authProvider, child) {
+              final isSignedIn = authProvider.isSignedIn();
+              final onboardingCompleted = SharedPreferencesUtil().onboardingCompleted;
+              final currentUser = FirebaseAuth.instance.currentUser;
+              print('DEBUG DesktopApp: isSignedIn=$isSignedIn, onboardingCompleted=$onboardingCompleted');
+              print('DEBUG DesktopApp: currentUser=${currentUser?.uid}, isAnonymous=${currentUser?.isAnonymous}');
+
+              if (isSignedIn) {
+                if (onboardingCompleted) {
+                  print('DEBUG DesktopApp: -> DesktopHomePageWrapper');
+                  return const DesktopHomePageWrapper();
+                } else {
+                  print('DEBUG DesktopApp: -> DesktopOnboardingWrapper (not completed)');
+                  return const DesktopOnboardingWrapper();
+                }
+              } else if (SharedPreferencesUtil().hasOmiDevice == false &&
+                  SharedPreferencesUtil().hasPersonaCreated &&
+                  SharedPreferencesUtil().verifiedPersonaId != null) {
+                print('DEBUG DesktopApp: -> PersonaProfilePage');
+                return const PersonaProfilePage();
+              } else {
+                print('DEBUG DesktopApp: -> DesktopOnboardingWrapper (not signed in)');
+                return const DesktopOnboardingWrapper();
+              }
+            },
+          ),
+        ),
+      ],
     );
   }
 }


### PR DESCRIPTION
## Summary
- Adds a red closable banner at the top of the Flutter desktop app with the message: "This app is deprecated. Please migrate to the v2 Desktop app"
- "v2 Desktop app" links to https://macos.omi.me
- Banner is dismissible via an X button
- Shows on all screens (onboarding, home, etc.) since it's placed in `DesktopApp`

## Test plan
- [ ] Verify banner appears at the top of the desktop app on launch
- [ ] Verify clicking "v2 Desktop app" opens https://macos.omi.me
- [ ] Verify clicking the X button dismisses the banner
- [ ] Verify mobile layout is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)