### PR TITLE
Sync desktop/ from omi-desktop (0a880683)

### DIFF
--- a/desktop/Desktop/Sources/Chat/ACPBridge.swift
+++ b/desktop/Desktop/Sources/Chat/ACPBridge.swift
@@ -284,6 +284,7 @@ actor ACPBridge {
         mode: String? = nil,
         model: String? = nil,
         resume: String? = nil,
+        imageData: Data? = nil,
         onTextDelta: @escaping TextDeltaHandler,
         onToolCall: @escaping ToolCallHandler,
         onToolActivity: @escaping ToolActivityHandler,
@@ -313,6 +314,9 @@ actor ACPBridge {
         }
         if let resume = resume {
             queryDict["resume"] = resume
+        }
+        if let imageData = imageData {
+            queryDict["imageBase64"] = imageData.base64EncodedString()
         }
 
         let jsonData = try JSONSerialization.data(withJSONObject: queryDict)

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -69,6 +69,19 @@ struct FloatingControlBarView: View {
                 .transition(.opacity)
             }
         }
+        .overlay(alignment: .bottomTrailing) {
+            if state.showingAIConversation {
+                ZStack {
+                    ResizeHandleView(targetWindow: window)
+                        .frame(width: 20, height: 20)
+                    ResizeGripShape()
+                        .foregroundStyle(.white.opacity(0.3))
+                        .frame(width: 14, height: 14)
+                        .allowsHitTesting(false)
+                }
+                .padding(4)
+            }
+        }
         .clipped()
         .onHover { hovering in
             // Resize window BEFORE updating SwiftUI state on expand so the expanded

--- a/desktop/Desktop/Sources/FloatingControlBar/ResizeHandleView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ResizeHandleView.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+import AppKit
+
+// MARK: - Resize Handle NSViewRepresentable
+
+/// NSViewRepresentable that adds a bottom-right corner resize handle.
+/// Always active — not gated by the draggableBarEnabled toggle.
+struct ResizeHandleView: NSViewRepresentable {
+    weak var targetWindow: NSWindow?
+
+    func makeNSView(context: Context) -> ResizeHandleNSView {
+        let view = ResizeHandleNSView()
+        view.targetWindow = targetWindow
+        return view
+    }
+
+    func updateNSView(_ nsView: ResizeHandleNSView, context: Context) {
+        nsView.targetWindow = targetWindow
+    }
+}
+
+class ResizeHandleNSView: NSView {
+    weak var targetWindow: NSWindow?
+    private var initialMouseLocation: NSPoint = .zero
+    private var initialWindowFrame: NSRect = .zero
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .crosshair)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        initialMouseLocation = NSEvent.mouseLocation
+        initialWindowFrame = targetWindow?.frame ?? .zero
+        (targetWindow as? FloatingControlBarWindow)?.isUserResizing = true
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        (targetWindow as? FloatingControlBarWindow)?.isUserResizing = false
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard let window = targetWindow else { return }
+        let current = NSEvent.mouseLocation
+        let deltaX = current.x - initialMouseLocation.x
+        let deltaY = current.y - initialMouseLocation.y
+
+        // Anchor top-left: keep frame.maxY fixed, expand right and down.
+        let minW: CGFloat = 430
+        let minH: CGFloat = 250
+        let newWidth  = max(minW, initialWindowFrame.width  + deltaX)
+        let newHeight = max(minH, initialWindowFrame.height - deltaY) // screen-y up = drag down = height grows
+
+        let newOriginY = initialWindowFrame.maxY - newHeight
+        window.setFrame(
+            NSRect(x: initialWindowFrame.minX, y: newOriginY, width: newWidth, height: newHeight),
+            display: true
+        )
+    }
+
+    override var acceptsFirstResponder: Bool { false }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+}
+
+// MARK: - Resize Grip Visual
+
+/// Three staggered diagonal dots — standard macOS resize-grip indicator.
+struct ResizeGripShape: View {
+    var body: some View {
+        Canvas { context, size in
+            let r: CGFloat = 1.5
+            let positions: [(CGFloat, CGFloat)] = [
+                (size.width - r * 2, r * 2),
+                (size.width - r * 2 - 4, r * 2 + 4),
+                (size.width - r * 2 - 8, r * 2 + 8),
+            ]
+            for (cx, cy) in positions {
+                let rect = CGRect(x: cx - r, y: cy - r, width: r * 2, height: r * 2)
+                context.fill(Path(ellipseIn: rect), with: .foreground)
+            }
+        }
+    }
+}

--- a/desktop/Desktop/Sources/MainWindow/Components/SelectableMarkdown.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/SelectableMarkdown.swift
@@ -48,11 +48,11 @@ struct SelectableMarkdown: View {
                 }
             }
         }
-        .onChange(of: text) { newText in
+        .onChange(of: text) { _, newText in
             cachedSegments = Self.splitSegments(newText)
             attrCache.removeAll()
         }
-        .onChange(of: fontScale) { _ in
+        .onChange(of: fontScale) {
             // Font scale changed — cached attributed strings are stale
             attrCache.removeAll()
             cachedFontScale = 0

--- a/desktop/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -766,11 +766,11 @@ struct ChatBubble: View {
         }
         .frame(maxWidth: .infinity, alignment: message.sender == .user ? .trailing : .leading)
         .onHover { isHovering = $0 }
-        .onChange(of: message.contentBlocks.count) { _ in
+        .onChange(of: message.contentBlocks.count) {
             // Refresh grouped blocks when new blocks are added (e.g. tool calls)
             cachedGroupedBlocks = ContentBlockGroup.group(message.contentBlocks)
         }
-        .onChange(of: message.text) { _ in
+        .onChange(of: message.text) {
             // Refresh grouped blocks when text content changes within existing blocks
             // (streaming appends to the last text block without changing count)
             cachedGroupedBlocks = ContentBlockGroup.group(message.contentBlocks)

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -1708,7 +1708,7 @@ class ChatProvider: ObservableObject {
     /// - Parameters:
     ///   - text: The message text
     ///   - model: Optional model override for this query (e.g. "claude-sonnet-4-6" for floating bar)
-    func sendMessage(_ text: String, model: String? = nil, isFollowUp: Bool = false, systemPromptSuffix: String? = nil) async {
+    func sendMessage(_ text: String, model: String? = nil, isFollowUp: Bool = false, systemPromptSuffix: String? = nil, imageData: Data? = nil) async {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return }
 
@@ -1860,6 +1860,7 @@ class ChatProvider: ObservableObject {
                 cwd: workingDirectory,
                 mode: chatMode.rawValue,
                 model: model ?? modelOverride,
+                imageData: imageData,
                 onTextDelta: textDeltaHandler,
                 onToolCall: toolCallHandler,
                 onToolActivity: toolActivityHandler,

--- a/desktop/acp-bridge/src/index.ts
+++ b/desktop/acp-bridge/src/index.ts
@@ -726,9 +726,15 @@ async function handleQuery(msg: QueryMessage): Promise<void> {
 
     // Send the prompt — retry with fresh session if stale
     const sendPrompt = async (): Promise<void> => {
+      const promptBlocks: Array<Record<string, unknown>> = [];
+      if (msg.imageBase64) {
+        promptBlocks.push({ type: "image", data: msg.imageBase64, mimeType: "image/jpeg" });
+      }
+      promptBlocks.push({ type: "text", text: fullPrompt });
+
       const promptResult = (await acpRequest("session/prompt", {
         sessionId,
-        prompt: [{ type: "text", text: fullPrompt }],
+        prompt: promptBlocks,
       })) as {
         stopReason: string;
         // Populated by patched-acp-entry.mjs intercepting SDKResultSuccess

--- a/desktop/acp-bridge/src/protocol.ts
+++ b/desktop/acp-bridge/src/protocol.ts
@@ -12,6 +12,7 @@ export interface QueryMessage {
   mode?: "ask" | "act";
   model?: string;
   resume?: string;
+  imageBase64?: string;
 }
 
 export interface ToolResultMessage {


### PR DESCRIPTION
Automated sync from omi-desktop at 0a880683.

This PR was created by the sync pipeline.

> **Note:** Rebased onto current main to resolve merge conflicts. Conflicts resolved:
> - `FloatingControlBarWindow.swift`: took sync version (loads screenshot as image data instead of file path string)
> - `SelectableMarkdown.swift`: took sync version (updated `.onChange` to new 2-param API)
> - `ChatPage.swift`: took sync version (updated `.onChange` to zero-arg API)