### PR TITLE
fix(notifications): handle FCM background/terminated notification tap navigation

### DIFF
--- a/app/lib/services/notifications.dart
+++ b/app/lib/services/notifications.dart
@@ -60,6 +60,11 @@ class NotificationUtil {
     _handleAppLinkOrDeepLink(receivedAction.payload!);
   }
 
+  /// Public entry point for programmatic deep-link navigation (e.g. FCM background/terminated tap)
+  static void handleNavigateTo(String route) {
+    _handleAppLinkOrDeepLink({'navigate_to': route});
+  }
+
   static void _handleAppLinkOrDeepLink(Map<String, dynamic> payload) async {
     // Always ensure that all plugins was initialized
     // TODO: for what?

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -275,23 +275,19 @@ class _FCMNotificationService implements NotificationInterface {
       }
     });
 
-    // Background state: app in background, user taps a push notification
-    FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+    void handleNotificationTap(RemoteMessage? message) {
+      if (message == null) return;
       final navigateTo = message.data['navigate_to'];
-      if (navigateTo != null && navigateTo.toString().isNotEmpty) {
-        NotificationUtil.handleNavigateTo(navigateTo.toString());
+      if (navigateTo is String && navigateTo.isNotEmpty) {
+        NotificationUtil.handleNavigateTo(navigateTo);
       }
-    });
+    }
+
+    // Background state: app in background, user taps a push notification
+    FirebaseMessaging.onMessageOpenedApp.listen(handleNotificationTap);
 
     // Terminated state: app was killed and opened via notification tap
-    FirebaseMessaging.instance.getInitialMessage().then((RemoteMessage? message) {
-      if (message != null) {
-        final navigateTo = message.data['navigate_to'];
-        if (navigateTo != null && navigateTo.toString().isNotEmpty) {
-          NotificationUtil.handleNavigateTo(navigateTo.toString());
-        }
-      }
-    });
+    FirebaseMessaging.instance.getInitialMessage().then(handleNotificationTap);
   }
 
   final _serverMessageStreamController = StreamController<ServerMessage>.broadcast();

--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -13,6 +13,7 @@ import 'package:flutter_timezone/flutter_timezone.dart';
 
 import 'package:omi/backend/http/api/notifications.dart';
 import 'package:omi/backend/schema/message.dart';
+import 'package:omi/services/notifications.dart' show NotificationUtil;
 import 'package:omi/services/notifications/action_item_notification_handler.dart';
 import 'package:omi/services/notifications/important_conversation_notification_handler.dart';
 import 'package:omi/services/notifications/merge_notification_handler.dart';
@@ -271,6 +272,24 @@ class _FCMNotificationService implements NotificationInterface {
       if (noti != null && _shouldShowForegroundNotificationOnFCMMessageReceived()) {
         _showForegroundNotification(noti: noti, layout: NotificationLayout.BigText);
         return;
+      }
+    });
+
+    // Background state: app in background, user taps a push notification
+    FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+      final navigateTo = message.data['navigate_to'];
+      if (navigateTo != null && navigateTo.toString().isNotEmpty) {
+        NotificationUtil.handleNavigateTo(navigateTo.toString());
+      }
+    });
+
+    // Terminated state: app was killed and opened via notification tap
+    FirebaseMessaging.instance.getInitialMessage().then((RemoteMessage? message) {
+      if (message != null) {
+        final navigateTo = message.data['navigate_to'];
+        if (navigateTo != null && navigateTo.toString().isNotEmpty) {
+          NotificationUtil.handleNavigateTo(navigateTo.toString());
+        }
       }
     });
   }


### PR DESCRIPTION
## Problem
Fixes #5126

When a user taps an Omi response push notification:
- From **background state**: app opens to the last screen instead of the conversation
- From **terminated state**: same issue — app opens but doesn't navigate

## Root Cause
The Flutter app was missing two FCM handlers in `notification_service_fcm.dart`:
1. `FirebaseMessaging.onMessageOpenedApp` — fires when user taps a notification while app is in the background
2. `FirebaseMessaging.instance.getInitialMessage()` — fires when app is launched from a killed state via notification tap

The backend already sends `navigate_to` (e.g. `/chat/omi`) in the FCM data payload — the app just never read it on tap.

## Changes
- **`notification_service_fcm.dart`**: Added `onMessageOpenedApp` listener and `getInitialMessage()` call in `listenForMessages()`
- **`notifications.dart`**: Exposed `NotificationUtil.handleNavigateTo(String route)` as a public static method (wraps existing `_handleAppLinkOrDeepLink`)

## Testing
1. Send yourself a chat message via the Omi app
2. Put app in background → tap the notification → should navigate to the conversation
3. Kill the app → tap the notification → app should open directly to the conversation