### PR TITLE
fix: Show proactive notifications on iOS when app is in foreground

### DIFF
--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -206,9 +206,8 @@ class _FCMNotificationService implements NotificationInterface {
   @override
   void clearNotification(int id) => _awesomeNotifications.cancel(id);
 
-  // FIXME: Causes the different behavior on android and iOS
   bool _shouldShowForegroundNotificationOnFCMMessageReceived() {
-    return Platform.isAndroid;
+    return Platform.isAndroid || Platform.isIOS;
   }
 
   @override


### PR DESCRIPTION
## Summary
- Proactive (mentor) notifications were invisible on iOS because `_shouldShowForegroundNotificationOnFCMMessageReceived()` only returned `true` for Android
- Since proactive notifications fire during real-time audio streaming, the iOS app is always in the foreground — so the notification was silently routed to the in-app chat stream with no system notification shown
- Also cleaned up 9 stale iOS FCM tokens for the affected user directly in Firestore

## Test plan
- [ ] Verify proactive notifications appear as system notifications on iOS when app is in foreground
- [ ] Verify other notification types (action items, merge, reminders) still work correctly (they use early-return handlers unaffected by this change)
- [ ] Verify Android behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)