### PR TITLE
fix: Remove duplicate iOS foreground notifications

### DIFF
--- a/app/lib/services/notifications/notification_service_fcm.dart
+++ b/app/lib/services/notifications/notification_service_fcm.dart
@@ -207,7 +207,7 @@ class _FCMNotificationService implements NotificationInterface {
   void clearNotification(int id) => _awesomeNotifications.cancel(id);
 
   bool _shouldShowForegroundNotificationOnFCMMessageReceived() {
-    return Platform.isAndroid || Platform.isIOS;
+    return Platform.isAndroid;
   }
 
   @override


### PR DESCRIPTION
## Summary
- Reverts the `Platform.isIOS` addition to `_shouldShowForegroundNotificationOnFCMMessageReceived()` from #5137
- AwesomeNotifications' native `willPresent` delegate already displays FCM notifications on iOS in the foreground (calls `completionHandler([.alert, .badge, .sound])` for non-AwesomeNotifications notifications)
- The `Platform.isIOS` change created a **second** local notification via AwesomeNotifications, causing duplicates
- The actual fix for missing proactive notifications was cleaning 9 stale FCM tokens for the affected user

## Test plan
- [ ] Verify proactive notifications appear exactly once on iOS (no duplicates)
- [ ] Verify notifications still appear when app is in foreground on iOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)