### PR TITLE
Fix: use desktop_secrets group in omi-desktop-swift-release Codemagic workflow

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1818,10 +1818,7 @@ workflows:
   # Trigger: push a tag like v0.0.10+10-macos to BasedHardware/omi
   #   git tag v0.0.10+10-macos && git push origin v0.0.10+10-macos
   #
-  # Required CodeMagic secret group "omi_desktop":
-  #   MACOS_DEVELOPER_ID_P12          — base64 .p12 (Developer ID Application: Matthew Diakonov S6DP5HF77G)
-  #   MACOS_DEVELOPER_ID_P12_PASSWORD — .p12 password
-  #   MACOS_DEVELOPER_ID_PROFILE      — base64 provisioning profile
+  # Required CodeMagic secret group "desktop_secrets":
   #   SPARKLE_PRIVATE_KEY             — EdDSA private key for Sparkle auto-update signing
   #   RELEASE_SECRET                  — shared secret for Firestore release registration API
   #   GCP_SERVICE_ACCOUNT_KEY         — base64 GCP service account JSON
@@ -1832,11 +1829,14 @@ workflows:
   #   RESEND_API_KEY
   #   SENTRY_AUTH_TOKEN, SENTRY_ADMIN_UID, SENTRY_WEBHOOK_SECRET
   #   REDIS_DB_HOST, REDIS_DB_PORT, REDIS_DB_PASSWORD
+  #   NOTE: MACOS_DEVELOPER_ID_P12/P12_PASSWORD must NOT be in this group — they live in appstore_credentials
   #
   # Re-uses from existing groups:
   #   app_env:            GEMINI_API_KEY, GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET
   #   appstore_credentials: APP_STORE_CONNECT_PRIVATE_KEY, APP_STORE_CONNECT_KEY_IDENTIFIER,
-  #                         APP_STORE_CONNECT_ISSUER_ID (used for notarization)
+  #                         APP_STORE_CONNECT_ISSUER_ID (notarization),
+  #                         MACOS_DEVELOPER_ID_P12 — base64 .p12 (Developer ID Application: Based Hardware INC 9536L8KLMP)
+  #                         MACOS_DEVELOPER_ID_P12_PASSWORD
   # ============================================
   omi-desktop-swift-release:
     name: Release OMI Desktop (Swift)
@@ -1847,7 +1847,7 @@ workflows:
         - app_env
         - firebase
         - appstore_credentials
-        - omi_desktop
+        - desktop_secrets
       vars:
         BINARY_NAME: "Omi Computer"
         APP_NAME: "Omi Beta"


### PR DESCRIPTION
The `omi-desktop-swift-release` Codemagic workflow referenced a non-existent group `omi_desktop`, causing builds to fail immediately with "unknown variable group(s): omi_desktop".

**Fix**: Change the group reference from `omi_desktop` → `desktop_secrets` (the group that actually contains all the variables).

**Root cause**: Variables were added to the `desktop_secrets` group in Codemagic app settings, but the YAML was never updated to match.