### PR TITLE
Fix: use --arch instead of --triple for Swift universal build in Codemagic

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1983,9 +1983,9 @@ workflows:
           # Unset TOOLCHAINS to use Xcode's default toolchain (avoids Swift version conflicts)
           unset TOOLCHAINS
           echo "Building arm64..."
-          xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx
+          xcrun swift build -c release --package-path Desktop --arch arm64
           echo "Building x86_64..."
-          xcrun swift build -c release --package-path Desktop --triple x86_64-apple-macosx
+          xcrun swift build -c release --package-path Desktop --arch x86_64
 
       - name: Create universal app bundle
         script: |


### PR DESCRIPTION
`--triple arm64-apple-macosx` on Xcode 16.4 running on an arm64 host (mac_mini_m2) places the binary in `.build/release/` (native, non-arch-prefixed) instead of `.build/arm64-apple-macosx/release/`. This caused the "Create universal app bundle" step to fail immediately with "ERROR: Missing built binaries".

**Fix**: Replace `--triple arch-apple-macosx` with `--arch arm64` / `--arch x86_64`, which reliably outputs to `.build/arm64-apple-macosx/release/` and `.build/x86_64-apple-macosx/release/` regardless of host architecture.