### PR TITLE
Fix: normalize arm64 binary path after --arch arm64 build on native M2 host

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1984,6 +1984,16 @@ workflows:
           unset TOOLCHAINS
           echo "Building arm64..."
           xcrun swift build -c release --package-path Desktop --arch arm64
+          # On native arm64 host (M2), --arch arm64 outputs to .build/release/ not .build/arm64-apple-macosx/release/
+          # Normalize to arch-specific path so downstream steps find the binary consistently
+          if [ -f "Desktop/.build/release/$BINARY_NAME" ] && [ ! -f "Desktop/.build/arm64-apple-macosx/release/$BINARY_NAME" ]; then
+            echo "Normalizing arm64 output to arch-specific path..."
+            mkdir -p "Desktop/.build/arm64-apple-macosx/release"
+            cp "Desktop/.build/release/$BINARY_NAME" "Desktop/.build/arm64-apple-macosx/release/$BINARY_NAME"
+            # Also copy Sparkle.framework and resource bundle if present
+            [ -d "Desktop/.build/release/Sparkle.framework" ] && cp -R "Desktop/.build/release/Sparkle.framework" "Desktop/.build/arm64-apple-macosx/release/" || true
+            [ -d "Desktop/.build/release/Omi Computer_Omi Computer.bundle" ] && cp -R "Desktop/.build/release/Omi Computer_Omi Computer.bundle" "Desktop/.build/arm64-apple-macosx/release/" || true
+          fi
           echo "Building x86_64..."
           xcrun swift build -c release --package-path Desktop --arch x86_64
 


### PR DESCRIPTION
## Problem

On Codemagic mac_mini_m2 with Xcode 16.4, `xcrun swift build --arch arm64` outputs the binary to `.build/release/` (the native arch path) instead of `.build/arm64-apple-macosx/release/`. This caused the "Create universal app bundle" step to fail with `ERROR: Missing built binaries` every time.

The `x86_64` cross-compilation correctly outputs to `.build/x86_64-apple-macosx/release/`, so only the arm64 binary was missing.

## Fix

After the arm64 build, detect if the binary landed in `release/` instead of `arm64-apple-macosx/release/` and copy it to the expected location. Also copies `Sparkle.framework` and the SPM resource bundle if present.

This is the fourth fix attempt in this release pipeline:
1. ✅ Group name: `omi_desktop` → `desktop_secrets`
2. ✅ Build flags: `--triple` → `--arch` 
3. ✅ This fix: normalize arm64 output path