### PR TITLE
ci: add dedicated helm upgrade workflow for backend-listen

### DIFF
--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -1,0 +1,74 @@
+name: Upgrade Backend Listen Helm Chart
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Select the environment to deploy to'
+        required: true
+        default: 'development'
+      branch:
+        description: 'Branch to deploy from'
+        required: true
+        default: 'main'
+
+env:
+  REGION: us-central1
+
+jobs:
+  helm-upgrade:
+    environment: ${{ github.event.inputs.environment }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate Environment Input
+        run: |
+          if [[ "${{ github.event.inputs.environment }}" != "development" && "${{ github.event.inputs.environment }}" != "prod" ]]; then
+            echo "Invalid environment: ${{ github.event.inputs.environment }}. Must be 'development' or 'prod'."
+            exit 1
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Google Auth
+        id: auth
+        uses: 'google-github-actions/auth@v2'
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Connect to GKE cluster
+        run: |
+          curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg
+          echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+          sudo apt-get update && sudo apt-get install google-cloud-cli-gke-gcloud-auth-plugin -y
+          gcloud container clusters get-credentials ${{ vars.GKE_CLUSTER }} --region ${{ env.REGION }} --project ${{ vars.GCP_PROJECT_ID }}
+
+      - name: Helm diff (dry run)
+        run: |
+          echo "=== Current release values ==="
+          helm -n ${{ vars.ENV }}-omi-backend get values ${{ vars.ENV }}-omi-backend-listen || echo "No existing release found"
+          echo ""
+          echo "=== Dry run upgrade ==="
+          helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-listen \
+            ./backend/charts/backend-listen \
+            -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml \
+            --dry-run
+
+      - name: Upgrade backend-listen Helm chart
+        run: |
+          helm -n ${{ vars.ENV }}-omi-backend upgrade --install ${{ vars.ENV }}-omi-backend-listen \
+            ./backend/charts/backend-listen \
+            -f ./backend/charts/backend-listen/${{ vars.ENV }}_omi_backend_listen_values.yaml
+
+      - name: Verify rollout
+        run: |
+          kubectl -n ${{ vars.ENV }}-omi-backend rollout status deploy/${{ vars.ENV }}-omi-backend-listen --timeout=300s
+
+      - name: Show pod status
+        if: always()
+        run: |
+          kubectl -n ${{ vars.ENV }}-omi-backend get pods -l app=${{ vars.ENV }}-omi-backend-listen --no-headers


### PR DESCRIPTION
## Summary
- Adds a new manual `workflow_dispatch` workflow (`gcp_backend_listen_helm.yml`) that runs `helm upgrade --install` for backend-listen
- The existing `gcp_backend.yml` only does `kubectl rollout restart` for backend-listen, which **does not apply Helm value changes** (HPA settings, env vars, resource limits, etc.)
- Includes a dry-run diff step before applying for visibility on risky changes
- Includes rollout status verification and pod status on failure

## Why
PRs that modify `backend/charts/backend-listen/` values (e.g. #4931 VAD gate) need a way to apply those chart changes in prod. Without this, merged chart value changes sit in the repo but never get deployed.

## Verification

### Dev run #22428093337 (pre-Greptile fixes)
- Helm dry-run: passed
- Helm upgrade --install: passed
- Verify rollout: `deployment "dev-omi-backend-listen" successfully rolled out`
- Show pod status: `No resources found` — expected, dev has 0 backend-listen pods

### Greptile review → fixed in #5153
| Suggestion | Valid? | Evidence |
|---|---|---|
| Branch input not used | **YES** | `actions/checkout@v4` without `ref:` ignores `branch` input |
| Wrong pod label selector | **YES** | `app=` matches 0 pods; `app.kubernetes.io/instance=` matches 26 pods in prod |
| Missing Helm install step | **Cosmetic** | Dev run succeeded without it — `ubuntu-latest` has Helm pre-installed. Added for consistency |

### Dev run #22428285184 (post-fix, with #5153 merged)
- All steps passed, workflow completed successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)