### PR TITLE
fix: address greptile review on backend-listen helm workflow

### DIFF
--- a/.github/workflows/gcp_backend_listen_helm.yml
+++ b/.github/workflows/gcp_backend_listen_helm.yml
@@ -33,6 +33,11 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Install Helm
+        uses: azure/setup-helm@v3
 
       - name: Google Auth
         id: auth
@@ -71,4 +76,4 @@ jobs:
       - name: Show pod status
         if: always()
         run: |
-          kubectl -n ${{ vars.ENV }}-omi-backend get pods -l app=${{ vars.ENV }}-omi-backend-listen --no-headers
+          kubectl -n ${{ vars.ENV }}-omi-backend get pods -l app.kubernetes.io/instance=${{ vars.ENV }}-omi-backend-listen --no-headers


### PR DESCRIPTION
## Summary
Fixes three issues caught by Greptile review on #5152:

- **Branch input not used** — checkout now respects `branch` input parameter
- **Wrong pod label selector** — changed from `app=` to `app.kubernetes.io/instance=` to match Helm chart labels
- **Missing Helm install step** — added `azure/setup-helm@v3` for consistency with other workflows

## Verification

Validated each Greptile suggestion against the live cluster before applying:

| Suggestion | Valid? | Evidence |
|---|---|---|
| Branch input not used | **YES** | `actions/checkout@v4` without `ref:` ignores `branch` input, always checks out default branch |
| Wrong pod label selector (`app=` → `app.kubernetes.io/instance=`) | **YES** | `kubectl get pods -l app=prod-omi-backend-listen` → **0 pods**; `kubectl get pods -l app.kubernetes.io/instance=prod-omi-backend-listen` → **26 pods**. Chart uses standard Helm selector labels, not `app=` |
| Missing Helm install step | **Cosmetic only** | Dev run #22428093337 succeeded without it — `ubuntu-latest` runners have Helm pre-installed. Added for explicitness/consistency with other workflows |

### Pre-fix dev run (workflow #22428093337)
- Helm dry-run: passed
- Helm upgrade --install: passed
- Verify rollout: `deployment "dev-omi-backend-listen" successfully rolled out`
- Show pod status: `No resources found` — expected, dev has 0 backend-listen pods

🤖 Generated with [Claude Code](https://claude.com/claude-code)