### PR TITLE
fix: use branch input in backend deploy workflow checkout

### DIFF
--- a/.github/workflows/gcp_backend.yml
+++ b/.github/workflows/gcp_backend.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Google Auth
         id: auth


### PR DESCRIPTION
## Summary
- Adds `ref: ${{ github.event.inputs.branch }}` to the `actions/checkout@v4` step in `gcp_backend.yml`
- Without this, the "Branch to deploy from" input was cosmetic — checkout always used the workflow dispatch ref (branch dropdown), not the text input

## Root cause
`actions/checkout@v4` defaults to the ref that triggered the workflow. For `workflow_dispatch`, that's the branch selected in the UI dropdown at the top of the "Run workflow" dialog. The `branch` text input field was defined but never wired to the checkout step.

This caused a dev deploy of PR #4931 (VAD gate) to build from `main` instead of `development`, resulting in `vad_gate.py` missing from the container image.

## Verification
- Deployed with `--ref development` workaround → image built correctly from development branch
- Verified on dev cluster: `vad_gate.py` import OK, `VAD_GATE_MODE=active` set
- Kenji smoke test passed: VAD state machine cycling, 3 transcripts from 30s real speech, zero errors
- Same fix already applied to `gcp_backend_listen_helm.yml` in #5153

## Test plan
- [x] Dev deploy with `--ref development` workaround confirmed correct branch checkout
- [x] Dev smoke test passed (kenji confirmed, evidence on PR #4931)
- [ ] After merge: run workflow with `branch=development` input (without `--ref`) and confirm correct branch is checked out

🤖 Generated with [Claude Code](https://claude.com/claude-code)