### PR TITLE
Fix: build x86_64 first so arm64 binary lands in .build/release/ for lipo

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1982,21 +1982,20 @@ workflows:
           mkdir -p "$BUILD_DIR"
           # Unset TOOLCHAINS to use Xcode's default toolchain (avoids Swift version conflicts)
           unset TOOLCHAINS
-          echo "Building arm64..."
-          xcrun swift build -c release --package-path Desktop --arch arm64
-          # On Codemagic mac_mini_m2 (native arm64 host), the arm64 binary lands in
-          # .build/release/ instead of .build/arm64-apple-macosx/release/.
-          # Save it now before the x86_64 build overwrites .build/release/.
-          mkdir -p "Desktop/.build/arm64-apple-macosx/release"
-          cp -R "Desktop/.build/release/." "Desktop/.build/arm64-apple-macosx/release/"
-          echo "Saved arm64 outputs to arm64-apple-macosx/release/"
+          # Build x86_64 FIRST: outputs to both .build/release/ and .build/x86_64-apple-macosx/release/
+          # Build arm64 SECOND: overwrites .build/release/ with arm64 binary
+          # Result: .build/release/ = arm64, .build/x86_64-apple-macosx/release/ = x86_64
+          # (x86_64-apple-macosx/release/ is not touched by the arm64 build)
           echo "Building x86_64..."
           xcrun swift build -c release --package-path Desktop --arch x86_64
+          echo "Building arm64..."
+          xcrun swift build -c release --package-path Desktop --arch arm64
 
       - name: Create universal app bundle
         script: |
-          # Both binaries are now in their arch-specific directories (matching release.sh)
-          ARM64_BINARY="Desktop/.build/arm64-apple-macosx/release/$BINARY_NAME"
+          # arm64 built last → binary in .build/release/ (native arch, no arch-prefix subdir)
+          # x86_64 built first → binary in .build/x86_64-apple-macosx/release/ (persists, not overwritten)
+          ARM64_BINARY="Desktop/.build/release/$BINARY_NAME"
           X86_64_BINARY="Desktop/.build/x86_64-apple-macosx/release/$BINARY_NAME"
 
           if [ ! -f "$ARM64_BINARY" ] || [ ! -f "$X86_64_BINARY" ]; then
@@ -2020,8 +2019,8 @@ workflows:
 
           cp Desktop/Info.plist "$APP_BUNDLE/Contents/Info.plist"
 
-          # Copy Sparkle framework (saved from arm64 build before x86_64 overwrote .build/release/)
-          SPARKLE_FW="Desktop/.build/arm64-apple-macosx/release/Sparkle.framework"
+          # Sparkle is in .build/release/ (from the arm64 build, which ran last)
+          SPARKLE_FW="Desktop/.build/release/Sparkle.framework"
           if [ ! -d "$SPARKLE_FW" ]; then
             echo "ERROR: Sparkle.framework not found at $SPARKLE_FW"
             exit 1
@@ -2039,7 +2038,7 @@ workflows:
           cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
 
           # Copy SPM resource bundle (app assets: permissions.gif, herologo.png, etc.)
-          SWIFT_BUILD_DIR="Desktop/.build/arm64-apple-macosx/release"
+          SWIFT_BUILD_DIR="Desktop/.build/release"
           RESOURCE_BUNDLE="$SWIFT_BUILD_DIR/Omi Computer_Omi Computer.bundle"
           if [ -d "$RESOURCE_BUNDLE" ]; then
             cp -R "$RESOURCE_BUNDLE" "$APP_BUNDLE/Contents/Resources/"


### PR DESCRIPTION
## Root Cause

On Codemagic mac_mini_m2:
- `--arch arm64` (native) → outputs binary **only** to `.build/release/`
- `--arch x86_64` (cross) → outputs binary to **both** `.build/release/` AND `.build/x86_64-apple-macosx/release/`

Previously building arm64 first, x86_64 second meant `.build/release/` ended up with an x86_64 binary (overwritten), making lipo fail with "same architectures".

## Fix

**Swap build order**: x86_64 first, arm64 second.

- `.build/release/` = arm64 binary (last build overwrites)  
- `.build/x86_64-apple-macosx/release/` = x86_64 binary (persists, arm64 build doesn't touch it)

lipo gets two different-arch binaries → universal binary ✓

No copying, no workarounds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)