### PR TITLE
Upgrade standard chat model from gpt-4.1 to gpt-5.2

### DIFF
--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -35,9 +35,9 @@ llm_high_stream = ChatOpenAI(
     temperature=1,
     callbacks=[_usage_callback],
 )
-llm_medium = ChatOpenAI(model='gpt-4.1', callbacks=[_usage_callback])
+llm_medium = ChatOpenAI(model='gpt-5.2', callbacks=[_usage_callback])
 llm_medium_stream = ChatOpenAI(
-    model='gpt-4.1',
+    model='gpt-5.2',
     streaming=True,
     stream_options={"include_usage": True},
     callbacks=[_usage_callback],


### PR DESCRIPTION
## Summary
- Upgrades `llm_medium` and `llm_medium_stream` from `gpt-4.1` to `gpt-5.2`
- Only affects the standard (no-context) chat path (~20% of chat traffic)
- Agentic path remains on `gpt-5.1`

## Test plan
- [ ] Send a standard chat message and verify response quality
- [ ] Verify streaming works correctly
- [ ] Monitor costs via LLM usage tracking after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)