### PR TITLE
Cloud agent chat: persistent sessions, fix blocking saves, dedup text, switch to Sonnet

### DIFF
--- a/desktop/agent-cloud/agent.mjs
+++ b/desktop/agent-cloud/agent.mjs
@@ -553,7 +553,7 @@ function startPersistentSession(send, log) {
   const sessionAbort = new AbortController();
 
   const options = {
-    model: "claude-opus-4-6",
+    model: "claude-sonnet-4-6",
     abortController: sessionAbort,
     systemPrompt: defaultSystemPrompt,
     allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebSearch", "WebFetch"],


### PR DESCRIPTION
## Summary
- Fix agent-proxy blocking event forwarding on multi-query sessions (vm_to_phone save was blocking with `await`, changed to fire-and-forget)
- Fix duplicate text in agent chat responses (assistant handler was re-sending text already streamed via stream_event)
- Switch VM agent model from Opus to Sonnet for faster responses
- Add agent chat debugging pipeline docs to ai-chat-debug skill
- Persistent Claude session via streaming input mode (AsyncMessageQueue)

## Test plan
- [x] Tested second query on same WS connection — events flow immediately, no timeout
- [x] Verified on TestFlight device via agent chat logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)