### PR TITLE
Log model name on session start

### DIFF
--- a/desktop/agent-cloud/agent.mjs
+++ b/desktop/agent-cloud/agent.mjs
@@ -588,6 +588,7 @@ function startPersistentSession(send, log) {
     session_id: "",
   });
 
+  log(`Starting persistent session with model: ${options.model}`);
   const q = query({ prompt: messageQueue, options });
 
   // Session state


### PR DESCRIPTION
## Summary
- Log which model is used when a persistent session starts, for easier deploy verification

## Test plan
- [x] Check VM logs for `Starting persistent session with model: claude-sonnet-4-6`

🤖 Generated with [Claude Code](https://claude.com/claude-code)