### PR TITLE
fix(app): remove kReleaseMode guard from TestFlight detection

### DIFF
--- a/app/lib/utils/environment_detector.dart
+++ b/app/lib/utils/environment_detector.dart
@@ -8,7 +8,6 @@ class EnvironmentDetector {
 
   static Future<bool> isTestFlight() async {
     if (!Platform.isIOS) return false;
-    if (!kReleaseMode) return false;
     try {
       final bool result = await _channel.invokeMethod('isTestFlight');
       return result;


### PR DESCRIPTION
## Summary
- Remove the `kReleaseMode` check from `EnvironmentDetector.isTestFlight()` that was preventing TestFlight detection when Codemagic builds in profile/debug mode
- The native iOS `sandboxReceipt` check is sufficient on its own to detect TestFlight
- This is why the API Environment section wasn't showing in the TestFlight build from PR #5163

## Test plan
- [ ] Merge and trigger new Codemagic TestFlight build
- [ ] Verify API Environment section appears at bottom of Developer Settings on TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)