### PR TITLE
chore(app): bump build number to 759 for TestFlight fix

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.525+758
+version: 1.0.525+759
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bump build number from 758 to 759 so Codemagic uploads a new TestFlight build
- Build 758 is already on TestFlight but doesn't include the kReleaseMode fix (PR #5198)
- This bump triggers a new build that includes the fix

## Context
PR #5198 removed the `kReleaseMode` guard from TestFlight detection, but the Codemagic build script skips uploads when the build number already exists on TestFlight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)