### PR TITLE
Fix screen activity timestamp query format

### DIFF
--- a/backend/database/screen_activity.py
+++ b/backend/database/screen_activity.py
@@ -52,10 +52,11 @@ def get_screen_activity(
     query = collection_ref.order_by('timestamp', direction=firestore.Query.ASCENDING)
 
     if start_date:
-        ts = start_date.isoformat() if isinstance(start_date, datetime) else start_date
+        # Timestamps stored as 'YYYY-MM-DD HH:MM:SS.mmm' strings — must match format for comparison
+        ts = start_date.strftime('%Y-%m-%d %H:%M:%S.000') if isinstance(start_date, datetime) else start_date
         query = query.where(filter=firestore.FieldFilter('timestamp', '>=', ts))
     if end_date:
-        ts = end_date.isoformat() if isinstance(end_date, datetime) else end_date
+        ts = end_date.strftime('%Y-%m-%d %H:%M:%S.999') if isinstance(end_date, datetime) else end_date
         query = query.where(filter=firestore.FieldFilter('timestamp', '<=', ts))
     if app_filter:
         query = query.where(filter=firestore.FieldFilter('appName', '==', app_filter))


### PR DESCRIPTION
## Summary
- Fix Firestore query returning zero results for screen activity
- Timestamps stored as `'2026-02-27 06:48:38.479'` (space separator) but queries used `.isoformat()` which produces `'2026-02-27T00:00:00+00:00'` (T separator)
- Firestore lexicographic string comparison: space (ASCII 32) < T (ASCII 84), so `>=` filter never matched

## Test plan
- [x] Verified fix locally against Firestore — returns 10 results where previously returned 0
- [ ] Deploy to dev/prod and test via Flutter chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)