### PR TITLE
Add staging case to UpdateChannel enum

### DIFF
--- a/desktop/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/Desktop/Sources/UpdaterViewModel.swift
@@ -6,11 +6,13 @@ import Sparkle
 enum UpdateChannel: String, CaseIterable {
     case stable = "stable"
     case beta = "beta"
+    case staging = "staging"
 
     var displayName: String {
         switch self {
         case .stable: return "Stable"
         case .beta: return "Beta"
+        case .staging: return "Staging"
         }
     }
 
@@ -18,6 +20,7 @@ enum UpdateChannel: String, CaseIterable {
         switch self {
         case .stable: return "Recommended for most users"
         case .beta: return "Early access to new features"
+        case .staging: return "Internal testing builds"
         }
     }
 }


### PR DESCRIPTION
## Summary
- The UpdateChannel enum only had `stable` and `beta` cases — `staging` was missing
- `UpdateChannel(rawValue: "staging")` returned nil, silently failing the channel sync
- Users assigned to staging channel via Firestore could never actually get switched

## Test plan
- [ ] Set user's desktop_update_channel to "staging" in Firestore
- [ ] Verify app Settings shows "Staging" after opening Settings