### PR TITLE
fix(ci): pusher deploy workflow ignores branch input

### DIFF
--- a/.github/workflows/gcp_backend_pusher.yml
+++ b/.github/workflows/gcp_backend_pusher.yml
@@ -42,6 +42,8 @@ jobs:
 
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
 
       - name: Google Auth
         id: auth


### PR DESCRIPTION
## Summary
- Add `ref: ${{ github.event.inputs.branch }}` to the checkout step in `gcp_backend_pusher.yml`
- Without this, the workflow always checks out the default branch regardless of the `branch` input parameter

## Context
Discovered during PR #5238 deployment: the pusher workflow built from `main` instead of `development` even when `branch=development` was specified. The backend workflow (`gcp_backend.yml`) already has this parameter, but the pusher workflow was missing it.

## Test plan
- [x] Verified fix works on `development` branch (commit b18a975) — pusher deployed correctly with `--ref development`
- [x] Compared with `gcp_backend.yml` which has the same checkout pattern

Closes #5246

_by AI for @beastoin_