### PR TITLE
Fix Sentry beforeSend build error + database schema in exploration

### DIFF
--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -198,7 +198,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             options.maxBreadcrumbs = 100
             options.beforeSend = { event in
                 // Allow user feedback through from all builds (dev + prod)
-                if event.message?.formatted?.hasPrefix("User Report") == true { return event }
+                if event.message?.formatted.hasPrefix("User Report") == true { return event }
                 // Never send other events from dev builds — they pollute production Sentry data
                 if isDev { return nil }
                 // Filter out HTTP errors targeting the dev tunnel — noise when the tunnel is down


### PR DESCRIPTION
## Summary
- Fix compile error in `OmiApp.swift` — optional chaining on non-optional `String` (`formatted?.hasPrefix` → `formatted.hasPrefix`) that broke the v0.11.35 release build
- Include database schema in onboarding exploration prompt for richer context

## Test plan
- [ ] Verify release build succeeds on Codemagic
- [ ] Verify Sentry feedback reports go through from dev builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)