### PR TITLE
fix(conversations): eliminate N+1 photo queries and transcript decryption from list endpoints

### DIFF
--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -133,7 +133,7 @@ def get_conversations(
     if len(statuses) == 0:
         statuses = "processing,completed"
 
-    conversations = conversations_db.get_conversations(
+    conversations = conversations_db.get_conversations_lite(
         uid,
         limit,
         offset,

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -748,25 +748,33 @@ def get_conversations(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid category {str(e)}")
 
-    conversations = conversations_db.get_conversations(
-        uid,
-        limit,
-        offset,
-        include_discarded=False,
-        statuses=["completed"],
-        start_date=start_date,
-        end_date=end_date,
-        categories=[c.value for c in category_list],
-    )
+    if include_transcript:
+        conversations = conversations_db.get_conversations(
+            uid,
+            limit,
+            offset,
+            include_discarded=False,
+            statuses=["completed"],
+            start_date=start_date,
+            end_date=end_date,
+            categories=[c.value for c in category_list],
+        )
+    else:
+        conversations = conversations_db.get_conversations_lite(
+            uid,
+            limit,
+            offset,
+            include_discarded=False,
+            statuses=["completed"],
+            start_date=start_date,
+            end_date=end_date,
+            categories=[c.value for c in category_list],
+        )
 
     # Filter out locked conversations completely
     unlocked_conversations = [conv for conv in conversations if not conv.get('is_locked', False)]
 
-    # Remove transcript_segments if not requested
-    if not include_transcript:
-        for conv in unlocked_conversations:
-            conv.pop('transcript_segments', None)
-    else:
+    if include_transcript:
         _add_speaker_names_to_segments(uid, unlocked_conversations)
 
     return unlocked_conversations

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -172,7 +172,7 @@ def get_conversations(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid category {str(e)}")
 
-    conversations = conversations_db.get_conversations(
+    conversations = conversations_db.get_conversations_lite(
         uid,
         limit,
         offset,

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -241,7 +241,7 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
             except ValueError:
                 pass
 
-        conversations = conversations_db.get_conversations(
+        conversations = conversations_db.get_conversations_lite(
             user_id,
             limit,
             offset,


### PR DESCRIPTION
## Summary
- Adds `get_conversations_lite()` — a lightweight DB function that skips the `@with_photos` decorator (eliminates 100 serial Firestore subcollection queries per request) and `@prepare_for_read` decorator (eliminates deepcopy + decrypt/decompress of transcript data)
- Switches all 4 conversation list endpoints to use it: `GET /v1/conversations`, `GET /v1/mcp/conversations`, MCP SSE `list_conversations`, and `GET /v1/dev/user/conversations` (when `include_transcript=False`)
- Returns `transcript_segments=[]` and `photos=[]` in list responses — these heavy fields are still available via the detail endpoint `GET /v1/conversations/{id}`

## Impact
For a user with 100 conversations at offset=0:
- **Before**: 1 main query + 100 photo subcollection queries + 100× deepcopy + decrypt/decompress = 101 serial Firestore round-trips
- **After**: 1 main query only = 1 Firestore round-trip

Estimated latency reduction from 6.5-14s (minimum) to <1s for the common case. Eliminates the 504 gateway timeouts reported in #4904.

## Test plan
- [x] `backend/test.sh` — 8 pass, 5 pre-existing failures (unrelated `test_process_conversation_usage_context.py`)
- [ ] Verify on dev: conversation list loads fast, detail endpoint still returns full data
- [ ] Verify mobile app displays conversations correctly (title, overview, category, action items visible; transcript available on tap)

Closes #4904

🤖 Generated with [Claude Code](https://claude.com/claude-code)