### PR TITLE
fix(conversations): eliminate N+1 photo queries from list endpoints

### DIFF
--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -268,6 +268,56 @@ def get_conversations_without_photos(
     return conversations
 
 
+def get_conversations_lite(
+    uid: str,
+    limit: int = 100,
+    offset: int = 0,
+    include_discarded: bool = False,
+    statuses: List[str] = [],
+    start_date: Optional[datetime] = None,
+    end_date: Optional[datetime] = None,
+    categories: Optional[List[str]] = None,
+    folder_id: Optional[str] = None,
+    starred: Optional[bool] = None,
+):
+    """
+    Lightweight conversation listing: no photo subcollection queries, no transcript
+    decryption/decompression.  Returns dicts with transcript_segments=[] and photos=[].
+    """
+    conversations_ref = db.collection('users').document(uid).collection(conversations_collection)
+    if not include_discarded:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
+    if len(statuses) > 0:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
+
+    if categories:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('structured.category', 'in', categories))
+
+    if folder_id:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id))
+
+    if starred is not None:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('starred', '==', starred))
+
+    if start_date:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '>=', start_date))
+    if end_date:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '<=', end_date))
+
+    conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
+    conversations_ref = conversations_ref.limit(limit).offset(offset)
+
+    conversations = []
+    for doc in conversations_ref.stream():
+        data = doc.to_dict()
+        # Strip heavy fields that are not needed for list views
+        data['transcript_segments'] = []
+        data.pop('transcript_segments_compressed', None)
+        data['photos'] = []
+        conversations.append(data)
+    return conversations
+
+
 def iter_all_conversations(uid: str, batch_size: int = 400, include_discarded: bool = True):
     """Yield all conversations for a user, decrypted, in batches. Used for streaming data export."""
     conversations_ref = db.collection('users').document(uid).collection(conversations_collection)

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -133,7 +133,7 @@ def get_conversations(
     if len(statuses) == 0:
         statuses = "processing,completed"
 
-    conversations = conversations_db.get_conversations_without_photos(
+    conversations = conversations_db.get_conversations_lite(
         uid,
         limit,
         offset,

--- a/backend/routers/conversations.py
+++ b/backend/routers/conversations.py
@@ -133,17 +133,32 @@ def get_conversations(
     if len(statuses) == 0:
         statuses = "processing,completed"
 
-    conversations = conversations_db.get_conversations_lite(
-        uid,
-        limit,
-        offset,
-        include_discarded=include_discarded,
-        statuses=statuses.split(",") if len(statuses) > 0 else [],
-        start_date=start_date,
-        end_date=end_date,
-        folder_id=folder_id,
-        starred=starred,
-    )
+    # limit=1 calls (e.g. in-progress recovery) need full hydration (transcript, photos).
+    # Only skip the expensive N+1 photo/transcript work for multi-item list fetches.
+    if limit > 1:
+        conversations = conversations_db.get_conversations_lite(
+            uid,
+            limit,
+            offset,
+            include_discarded=include_discarded,
+            statuses=statuses.split(",") if len(statuses) > 0 else [],
+            start_date=start_date,
+            end_date=end_date,
+            folder_id=folder_id,
+            starred=starred,
+        )
+    else:
+        conversations = conversations_db.get_conversations(
+            uid,
+            limit,
+            offset,
+            include_discarded=include_discarded,
+            statuses=statuses.split(",") if len(statuses) > 0 else [],
+            start_date=start_date,
+            end_date=end_date,
+            folder_id=folder_id,
+            starred=starred,
+        )
 
     for conv in conversations:
         if conv.get('is_locked', False):

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -748,25 +748,33 @@ def get_conversations(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid category {str(e)}")
 
-    conversations = conversations_db.get_conversations(
-        uid,
-        limit,
-        offset,
-        include_discarded=False,
-        statuses=["completed"],
-        start_date=start_date,
-        end_date=end_date,
-        categories=[c.value for c in category_list],
-    )
+    if include_transcript:
+        conversations = conversations_db.get_conversations(
+            uid,
+            limit,
+            offset,
+            include_discarded=False,
+            statuses=["completed"],
+            start_date=start_date,
+            end_date=end_date,
+            categories=[c.value for c in category_list],
+        )
+    else:
+        conversations = conversations_db.get_conversations_lite(
+            uid,
+            limit,
+            offset,
+            include_discarded=False,
+            statuses=["completed"],
+            start_date=start_date,
+            end_date=end_date,
+            categories=[c.value for c in category_list],
+        )
 
     # Filter out locked conversations completely
     unlocked_conversations = [conv for conv in conversations if not conv.get('is_locked', False)]
 
-    # Remove transcript_segments if not requested
-    if not include_transcript:
-        for conv in unlocked_conversations:
-            conv.pop('transcript_segments', None)
-    else:
+    if include_transcript:
         _add_speaker_names_to_segments(uid, unlocked_conversations)
 
     return unlocked_conversations

--- a/backend/routers/mcp.py
+++ b/backend/routers/mcp.py
@@ -172,7 +172,7 @@ def get_conversations(
     except ValueError as e:
         raise HTTPException(status_code=400, detail=f"Invalid category {str(e)}")
 
-    conversations = conversations_db.get_conversations(
+    conversations = conversations_db.get_conversations_lite(
         uid,
         limit,
         offset,

--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -241,7 +241,7 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
             except ValueError:
                 pass
 
-        conversations = conversations_db.get_conversations(
+        conversations = conversations_db.get_conversations_lite(
             user_id,
             limit,
             offset,

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -42,3 +42,6 @@ pytest tests/unit/test_pusher_private_cloud_data_protection.py -v
 pytest tests/unit/test_storage_upload_audio_chunk_data_protection.py -v
 pytest tests/unit/test_people_conversations_500s.py -v
 pytest tests/unit/test_firestore_read_ops_cache.py -v
+pytest tests/unit/test_conversations_lite_db.py -v
+pytest tests/unit/test_conversations_router_branching.py -v
+pytest tests/unit/test_mcp_and_developer_conversations_lite.py -v

--- a/backend/tests/unit/test_conversations_lite_db.py
+++ b/backend/tests/unit/test_conversations_lite_db.py
@@ -1,8 +1,10 @@
 """
 Tests for get_conversations_lite() in database/conversations.py.
 Verifies that the lite function strips heavy fields and applies all filters.
+Imports the REAL production function via importlib to avoid Firestore init.
 """
 
+import importlib.util
 import os
 import sys
 import types
@@ -14,80 +16,70 @@ os.environ.setdefault(
 )
 
 
-def _stub_module(name: str) -> types.ModuleType:
-    mod = types.ModuleType(name)
-    sys.modules[name] = mod
-    return mod
+def _ensure_mock_module(name: str):
+    """Ensure a MagicMock module exists in sys.modules (supports 'from X import Y')."""
+    if name not in sys.modules:
+        mod = MagicMock()
+        mod.__path__ = []
+        mod.__name__ = name
+        mod.__loader__ = None
+        mod.__spec__ = None
+        mod.__package__ = name if '.' not in name else name.rsplit('.', 1)[0]
+        sys.modules[name] = mod
+    return sys.modules[name]
 
 
-# Stub database package and submodules to avoid Firestore init.
-if "database" not in sys.modules:
-    database_mod = _stub_module("database")
-    database_mod.__path__ = []
-else:
-    database_mod = sys.modules["database"]
-
-for submodule in ["_client", "redis_db", "auth", "users", "memories", "conversations", "apps"]:
-    full_name = f"database.{submodule}"
-    if full_name not in sys.modules:
-        mod = _stub_module(full_name)
-        setattr(database_mod, submodule, mod)
-
-# Set up mock Firestore client
-client_mod = sys.modules["database._client"]
+# Stub _client with mock db BEFORE database.conversations can import it
 mock_db = MagicMock()
-client_mod.db = mock_db
-client_mod.document_id_from_seed = MagicMock(return_value="doc-id")
 
-# Set up conversations_collection constant
-conv_mod = sys.modules["database.conversations"]
-conv_mod.conversations_collection = "conversations"
+_ensure_mock_module("database")
+sys.modules["database"].__path__ = getattr(sys.modules["database"], '__path__', [])
 
-# Now we can import the real function — re-exec the module with our stubs
-from google.cloud import firestore
-from google.cloud.firestore_v1.base_query import FieldFilter
+client_stub = _ensure_mock_module("database._client")
+client_stub.db = mock_db
+client_stub.document_id_from_seed = MagicMock(return_value="doc-id")
+
+# Stub database.users and database.helpers
+_ensure_mock_module("database.users")
 
 
-def get_conversations_lite(
-    uid,
-    limit=100,
-    offset=0,
-    include_discarded=False,
-    statuses=None,
-    start_date=None,
-    end_date=None,
-    categories=None,
-    folder_id=None,
-    starred=None,
-):
-    """Mirror of database.conversations.get_conversations_lite for testing."""
-    if statuses is None:
-        statuses = []
-    conversations_ref = mock_db.collection('users').document(uid).collection('conversations')
-    if not include_discarded:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
-    if len(statuses) > 0:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
-    if categories:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('structured.category', 'in', categories))
-    if folder_id:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id))
-    if starred is not None:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('starred', '==', starred))
-    if start_date:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '>=', start_date))
-    if end_date:
-        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '<=', end_date))
-    conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
-    conversations_ref = conversations_ref.limit(limit).offset(offset)
-    conversations = []
-    for doc in conversations_ref.stream():
-        data = doc.to_dict()
-        data['transcript_segments'] = []
-        data.pop('transcript_segments_compressed', None)
-        data['photos'] = []
-        conversations.append(data)
-    return conversations
+def _passthrough(*args, **kwargs):
+    """No-op decorator factory: @decorator(...) returns identity decorator."""
+    return lambda f: f
+
+
+# Stub helpers with real passthrough decorators (database.conversations uses them at import time)
+helpers_mod = types.ModuleType("database.helpers")
+helpers_mod.set_data_protection_level = _passthrough
+helpers_mod.prepare_for_write = _passthrough
+helpers_mod.prepare_for_read = _passthrough
+helpers_mod.with_photos = _passthrough
+sys.modules["database.helpers"] = helpers_mod
+
+# Stub utils modules (must be MagicMock to support 'from X import Y')
+for name in [
+    "utils",
+    "utils.other",
+    "utils.other.hume",
+    "utils.other.storage",
+    "utils.encryption",
+]:
+    _ensure_mock_module(name)
+
+# Load the REAL database/conversations.py using importlib
+_conv_path = os.path.join(os.path.dirname(__file__), '..', '..', 'database', 'conversations.py')
+_conv_path = os.path.abspath(_conv_path)
+
+# Remove any stale entry so we get the real module
+if "database.conversations" in sys.modules:
+    del sys.modules["database.conversations"]
+
+spec = importlib.util.spec_from_file_location("database.conversations", _conv_path)
+conv_module = importlib.util.module_from_spec(spec)
+sys.modules["database.conversations"] = conv_module
+spec.loader.exec_module(conv_module)
+
+get_conversations_lite = conv_module.get_conversations_lite
 
 
 def _make_fake_doc(data: dict):

--- a/backend/tests/unit/test_conversations_lite_db.py
+++ b/backend/tests/unit/test_conversations_lite_db.py
@@ -1,0 +1,171 @@
+"""
+Tests for get_conversations_lite() in database/conversations.py.
+Verifies that the lite function strips heavy fields and applies all filters.
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _stub_module(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+# Stub database package and submodules to avoid Firestore init.
+if "database" not in sys.modules:
+    database_mod = _stub_module("database")
+    database_mod.__path__ = []
+else:
+    database_mod = sys.modules["database"]
+
+for submodule in ["_client", "redis_db", "auth", "users", "memories", "conversations", "apps"]:
+    full_name = f"database.{submodule}"
+    if full_name not in sys.modules:
+        mod = _stub_module(full_name)
+        setattr(database_mod, submodule, mod)
+
+# Set up mock Firestore client
+client_mod = sys.modules["database._client"]
+mock_db = MagicMock()
+client_mod.db = mock_db
+client_mod.document_id_from_seed = MagicMock(return_value="doc-id")
+
+# Set up conversations_collection constant
+conv_mod = sys.modules["database.conversations"]
+conv_mod.conversations_collection = "conversations"
+
+# Now we can import the real function — re-exec the module with our stubs
+from google.cloud import firestore
+from google.cloud.firestore_v1.base_query import FieldFilter
+
+
+def get_conversations_lite(
+    uid,
+    limit=100,
+    offset=0,
+    include_discarded=False,
+    statuses=None,
+    start_date=None,
+    end_date=None,
+    categories=None,
+    folder_id=None,
+    starred=None,
+):
+    """Mirror of database.conversations.get_conversations_lite for testing."""
+    if statuses is None:
+        statuses = []
+    conversations_ref = mock_db.collection('users').document(uid).collection('conversations')
+    if not include_discarded:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
+    if len(statuses) > 0:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('status', 'in', statuses))
+    if categories:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('structured.category', 'in', categories))
+    if folder_id:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('folder_id', '==', folder_id))
+    if starred is not None:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('starred', '==', starred))
+    if start_date:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '>=', start_date))
+    if end_date:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('created_at', '<=', end_date))
+    conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
+    conversations_ref = conversations_ref.limit(limit).offset(offset)
+    conversations = []
+    for doc in conversations_ref.stream():
+        data = doc.to_dict()
+        data['transcript_segments'] = []
+        data.pop('transcript_segments_compressed', None)
+        data['photos'] = []
+        conversations.append(data)
+    return conversations
+
+
+def _make_fake_doc(data: dict):
+    doc = MagicMock()
+    doc.to_dict.return_value = data
+    return doc
+
+
+def _setup_mock_ref():
+    mock_ref = MagicMock()
+    mock_ref.where.return_value = mock_ref
+    mock_ref.order_by.return_value = mock_ref
+    mock_ref.limit.return_value = mock_ref
+    mock_ref.offset.return_value = mock_ref
+    mock_db.collection.return_value.document.return_value.collection.return_value = mock_ref
+    return mock_ref
+
+
+class TestGetConversationsLite:
+    def test_strips_heavy_fields(self):
+        """transcript_segments=[], photos=[], transcript_segments_compressed removed."""
+        mock_ref = _setup_mock_ref()
+        fake_data = {
+            'id': 'conv_1',
+            'structured': {'title': 'Test', 'overview': 'Overview', 'category': 'personal'},
+            'transcript_segments': [{'text': 'secret data', 'speaker_id': 0, 'start': 0.0, 'end': 1.0}],
+            'transcript_segments_compressed': b'\x00\x01\x02',
+            'photos': [{'url': 'https://example.com/photo.jpg'}],
+            'discarded': False,
+            'status': 'completed',
+            'created_at': None,
+        }
+        mock_ref.stream.return_value = [_make_fake_doc(dict(fake_data))]
+
+        result = get_conversations_lite('uid_1', limit=10, offset=0)
+
+        assert len(result) == 1
+        conv = result[0]
+        assert conv['transcript_segments'] == []
+        assert conv['photos'] == []
+        assert 'transcript_segments_compressed' not in conv
+        assert conv['id'] == 'conv_1'
+        assert conv['structured']['title'] == 'Test'
+
+    def test_applies_all_filters(self):
+        """All filter parameters are forwarded to Firestore queries."""
+        from datetime import datetime
+
+        mock_ref = _setup_mock_ref()
+        mock_ref.stream.return_value = []
+
+        start = datetime(2026, 1, 1)
+        end = datetime(2026, 1, 31)
+
+        get_conversations_lite(
+            'uid_1',
+            limit=25,
+            offset=10,
+            include_discarded=False,
+            statuses=['completed'],
+            start_date=start,
+            end_date=end,
+            categories=['personal'],
+            folder_id='folder_abc',
+            starred=True,
+        )
+
+        where_calls = mock_ref.where.call_args_list
+        assert len(where_calls) == 7  # discarded + status + category + folder + starred + start + end
+        mock_ref.order_by.assert_called_once()
+        mock_ref.limit.assert_called_once_with(25)
+        mock_ref.offset.assert_called_once_with(10)
+
+    def test_include_discarded_true_skips_filter(self):
+        """When include_discarded=True, the discarded filter is NOT applied."""
+        mock_ref = _setup_mock_ref()
+        mock_ref.stream.return_value = []
+
+        get_conversations_lite('uid_1', include_discarded=True)
+
+        assert mock_ref.where.call_count == 0

--- a/backend/tests/unit/test_conversations_router_branching.py
+++ b/backend/tests/unit/test_conversations_router_branching.py
@@ -2,11 +2,11 @@
 Tests for the limit-based branching in GET /v1/conversations.
 limit=1 uses full get_conversations() (in-progress recovery needs transcripts).
 limit>1 uses get_conversations_lite() (list view optimization).
+Imports the REAL router function via module stubbing to avoid Firestore init.
 """
 
 import os
 import sys
-import types
 from unittest.mock import MagicMock, patch
 
 os.environ.setdefault(
@@ -15,20 +15,23 @@ os.environ.setdefault(
 )
 
 
-def _stub_module(name: str) -> types.ModuleType:
-    mod = types.ModuleType(name)
-    sys.modules[name] = mod
-    return mod
+def _ensure_mock_module(name: str):
+    """Ensure a MagicMock module exists in sys.modules."""
+    if name not in sys.modules:
+        mod = MagicMock()
+        mod.__path__ = []
+        mod.__name__ = name
+        mod.__loader__ = None
+        mod.__spec__ = None
+        mod.__package__ = name if '.' not in name else name.rsplit('.', 1)[0]
+        sys.modules[name] = mod
+    return sys.modules[name]
 
 
-# Stub database package and submodules to avoid Firestore init.
-if "database" not in sys.modules:
-    database_mod = _stub_module("database")
-    database_mod.__path__ = []
-else:
-    database_mod = sys.modules["database"]
-
-for submodule in [
+# Stub database and utility modules to avoid Firestore init
+_ensure_mock_module("database")
+sys.modules["database"].__path__ = getattr(sys.modules["database"], '__path__', [])
+for sub in [
     "_client",
     "redis_db",
     "auth",
@@ -40,131 +43,131 @@ for submodule in [
     "action_items",
     "mcp_api_key",
 ]:
-    full_name = f"database.{submodule}"
-    if full_name not in sys.modules:
-        mod = _stub_module(full_name)
-        setattr(database_mod, submodule, mod)
+    _ensure_mock_module(f"database.{sub}")
 
-# Set up mock Firestore client
-client_mod = sys.modules["database._client"]
-client_mod.db = MagicMock()
-client_mod.document_id_from_seed = MagicMock(return_value="doc-id")
-
-# Stub out heavy utility modules
 for name in [
+    "utils",
     "utils.apps",
+    "utils.llm",
     "utils.llm.memories",
+    "utils.conversations",
     "utils.conversations.process_conversation",
+    "utils.conversations.search",
+    "utils.conversations.location",
+    "utils.llm.conversation_processing",
+    "utils.llm.external_integrations",
     "utils.notifications",
     "utils.webhooks",
-    "utils.llm.external_integrations",
+    "utils.retrieval",
     "utils.retrieval.rag",
+    "utils.other",
     "utils.other.hume",
+    "utils.other.endpoints",
+    "utils.other.storage",
+    "utils.encryption",
+    "utils.speaker_identification",
+    "utils.app_integrations",
+    "dependencies",
 ]:
-    if name not in sys.modules:
-        _stub_module(name)
+    _ensure_mock_module(name)
 
-# Mock conversations_db at module scope so routers.conversations can import it
-mock_conv_db = MagicMock()
-sys.modules["database.conversations"] = mock_conv_db
+# Force reimport so routers.conversations picks up stubs
+if "routers.conversations" in sys.modules:
+    del sys.modules["routers.conversations"]
 
-
-def _call_get_conversations(limit, statuses="completed", offset=0):
-    """Simulate the router's get_conversations branching logic."""
-    # Replicate the exact branching from routers/conversations.py
-    uid = 'test_uid'
-    include_discarded = False
-    start_date = None
-    end_date = None
-    folder_id = None
-    starred = None
-
-    if len(statuses) == 0:
-        statuses = "processing,completed"
-
-    if limit > 1:
-        conversations = mock_conv_db.get_conversations_lite(
-            uid,
-            limit,
-            offset,
-            include_discarded=include_discarded,
-            statuses=statuses.split(",") if len(statuses) > 0 else [],
-            start_date=start_date,
-            end_date=end_date,
-            folder_id=folder_id,
-            starred=starred,
-        )
-    else:
-        conversations = mock_conv_db.get_conversations(
-            uid,
-            limit,
-            offset,
-            include_discarded=include_discarded,
-            statuses=statuses.split(",") if len(statuses) > 0 else [],
-            start_date=start_date,
-            end_date=end_date,
-            folder_id=folder_id,
-            starred=starred,
-        )
-
-    for conv in conversations:
-        if conv.get('is_locked', False):
-            conv['structured']['action_items'] = []
-            conv['structured']['events'] = []
-            conv['apps_results'] = []
-            conv['plugins_results'] = []
-            conv['suggested_summarization_apps'] = []
-    return conversations
+from routers.conversations import get_conversations  # noqa: E402
 
 
 class TestConversationsRouterBranching:
-    def setup_method(self):
-        mock_conv_db.reset_mock()
-
-    def test_limit_1_uses_full_hydration(self):
+    @patch('routers.conversations.conversations_db')
+    def test_limit_1_uses_full_hydration(self, mock_db):
         """limit=1 calls get_conversations() for in-progress recovery (needs transcripts)."""
-        mock_conv_db.get_conversations.return_value = [{'id': 'c1', 'is_locked': False}]
+        mock_db.get_conversations.return_value = [{'id': 'c1', 'is_locked': False}]
 
-        result = _call_get_conversations(limit=1, statuses="in_progress")
+        result = get_conversations(
+            limit=1,
+            offset=0,
+            statuses="in_progress",
+            include_discarded=False,
+            start_date=None,
+            end_date=None,
+            folder_id=None,
+            starred=None,
+            uid='test_uid',
+        )
 
-        mock_conv_db.get_conversations.assert_called_once()
-        mock_conv_db.get_conversations_lite.assert_not_called()
+        mock_db.get_conversations.assert_called_once()
+        mock_db.get_conversations_lite.assert_not_called()
         assert len(result) == 1
 
-    def test_limit_2_uses_lite(self):
+    @patch('routers.conversations.conversations_db')
+    def test_limit_2_uses_lite(self, mock_db):
         """limit=2 calls get_conversations_lite() (list optimization)."""
-        mock_conv_db.get_conversations_lite.return_value = [
+        mock_db.get_conversations_lite.return_value = [
             {'id': 'c1', 'is_locked': False},
             {'id': 'c2', 'is_locked': False},
         ]
 
-        result = _call_get_conversations(limit=2)
+        result = get_conversations(
+            limit=2,
+            offset=0,
+            statuses="completed",
+            include_discarded=False,
+            start_date=None,
+            end_date=None,
+            folder_id=None,
+            starred=None,
+            uid='test_uid',
+        )
 
-        mock_conv_db.get_conversations_lite.assert_called_once()
-        mock_conv_db.get_conversations.assert_not_called()
+        mock_db.get_conversations_lite.assert_called_once()
+        mock_db.get_conversations.assert_not_called()
         assert len(result) == 2
 
-    def test_limit_100_uses_lite(self):
+    @patch('routers.conversations.conversations_db')
+    def test_limit_100_uses_lite(self, mock_db):
         """limit=100 (default) uses lite path."""
-        mock_conv_db.get_conversations_lite.return_value = []
+        mock_db.get_conversations_lite.return_value = []
 
-        _call_get_conversations(limit=100)
+        get_conversations(
+            limit=100,
+            offset=0,
+            statuses="completed",
+            include_discarded=False,
+            start_date=None,
+            end_date=None,
+            folder_id=None,
+            starred=None,
+            uid='test_uid',
+        )
 
-        mock_conv_db.get_conversations_lite.assert_called_once()
-        mock_conv_db.get_conversations.assert_not_called()
+        mock_db.get_conversations_lite.assert_called_once()
+        mock_db.get_conversations.assert_not_called()
 
-    def test_empty_statuses_defaults_to_processing_completed(self):
+    @patch('routers.conversations.conversations_db')
+    def test_empty_statuses_defaults_to_processing_completed(self, mock_db):
         """Empty statuses string defaults to 'processing,completed'."""
-        mock_conv_db.get_conversations_lite.return_value = []
+        mock_db.get_conversations_lite.return_value = []
 
-        _call_get_conversations(limit=25, statuses="")
+        get_conversations(
+            limit=25,
+            offset=0,
+            statuses="",
+            include_discarded=False,
+            start_date=None,
+            end_date=None,
+            folder_id=None,
+            starred=None,
+            uid='test_uid',
+        )
 
-        call_kwargs = mock_conv_db.get_conversations_lite.call_args
+        call_kwargs = mock_db.get_conversations_lite.call_args
         assert call_kwargs[1]['statuses'] == ['processing', 'completed']
 
-    def test_locked_conversations_stripped(self):
+    @patch('routers.conversations.conversations_db')
+    def test_locked_conversations_stripped(self, mock_db):
         """Locked conversations have sensitive fields stripped."""
-        mock_conv_db.get_conversations_lite.return_value = [
+        mock_db.get_conversations_lite.return_value = [
             {
                 'id': 'c1',
                 'is_locked': True,
@@ -175,7 +178,17 @@ class TestConversationsRouterBranching:
             },
         ]
 
-        result = _call_get_conversations(limit=10)
+        result = get_conversations(
+            limit=10,
+            offset=0,
+            statuses="completed",
+            include_discarded=False,
+            start_date=None,
+            end_date=None,
+            folder_id=None,
+            starred=None,
+            uid='test_uid',
+        )
 
         assert result[0]['structured']['action_items'] == []
         assert result[0]['structured']['events'] == []

--- a/backend/tests/unit/test_conversations_router_branching.py
+++ b/backend/tests/unit/test_conversations_router_branching.py
@@ -1,0 +1,184 @@
+"""
+Tests for the limit-based branching in GET /v1/conversations.
+limit=1 uses full get_conversations() (in-progress recovery needs transcripts).
+limit>1 uses get_conversations_lite() (list view optimization).
+"""
+
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+def _stub_module(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+# Stub database package and submodules to avoid Firestore init.
+if "database" not in sys.modules:
+    database_mod = _stub_module("database")
+    database_mod.__path__ = []
+else:
+    database_mod = sys.modules["database"]
+
+for submodule in [
+    "_client",
+    "redis_db",
+    "auth",
+    "users",
+    "memories",
+    "conversations",
+    "apps",
+    "vector_db",
+    "action_items",
+    "mcp_api_key",
+]:
+    full_name = f"database.{submodule}"
+    if full_name not in sys.modules:
+        mod = _stub_module(full_name)
+        setattr(database_mod, submodule, mod)
+
+# Set up mock Firestore client
+client_mod = sys.modules["database._client"]
+client_mod.db = MagicMock()
+client_mod.document_id_from_seed = MagicMock(return_value="doc-id")
+
+# Stub out heavy utility modules
+for name in [
+    "utils.apps",
+    "utils.llm.memories",
+    "utils.conversations.process_conversation",
+    "utils.notifications",
+    "utils.webhooks",
+    "utils.llm.external_integrations",
+    "utils.retrieval.rag",
+    "utils.other.hume",
+]:
+    if name not in sys.modules:
+        _stub_module(name)
+
+# Mock conversations_db at module scope so routers.conversations can import it
+mock_conv_db = MagicMock()
+sys.modules["database.conversations"] = mock_conv_db
+
+
+def _call_get_conversations(limit, statuses="completed", offset=0):
+    """Simulate the router's get_conversations branching logic."""
+    # Replicate the exact branching from routers/conversations.py
+    uid = 'test_uid'
+    include_discarded = False
+    start_date = None
+    end_date = None
+    folder_id = None
+    starred = None
+
+    if len(statuses) == 0:
+        statuses = "processing,completed"
+
+    if limit > 1:
+        conversations = mock_conv_db.get_conversations_lite(
+            uid,
+            limit,
+            offset,
+            include_discarded=include_discarded,
+            statuses=statuses.split(",") if len(statuses) > 0 else [],
+            start_date=start_date,
+            end_date=end_date,
+            folder_id=folder_id,
+            starred=starred,
+        )
+    else:
+        conversations = mock_conv_db.get_conversations(
+            uid,
+            limit,
+            offset,
+            include_discarded=include_discarded,
+            statuses=statuses.split(",") if len(statuses) > 0 else [],
+            start_date=start_date,
+            end_date=end_date,
+            folder_id=folder_id,
+            starred=starred,
+        )
+
+    for conv in conversations:
+        if conv.get('is_locked', False):
+            conv['structured']['action_items'] = []
+            conv['structured']['events'] = []
+            conv['apps_results'] = []
+            conv['plugins_results'] = []
+            conv['suggested_summarization_apps'] = []
+    return conversations
+
+
+class TestConversationsRouterBranching:
+    def setup_method(self):
+        mock_conv_db.reset_mock()
+
+    def test_limit_1_uses_full_hydration(self):
+        """limit=1 calls get_conversations() for in-progress recovery (needs transcripts)."""
+        mock_conv_db.get_conversations.return_value = [{'id': 'c1', 'is_locked': False}]
+
+        result = _call_get_conversations(limit=1, statuses="in_progress")
+
+        mock_conv_db.get_conversations.assert_called_once()
+        mock_conv_db.get_conversations_lite.assert_not_called()
+        assert len(result) == 1
+
+    def test_limit_2_uses_lite(self):
+        """limit=2 calls get_conversations_lite() (list optimization)."""
+        mock_conv_db.get_conversations_lite.return_value = [
+            {'id': 'c1', 'is_locked': False},
+            {'id': 'c2', 'is_locked': False},
+        ]
+
+        result = _call_get_conversations(limit=2)
+
+        mock_conv_db.get_conversations_lite.assert_called_once()
+        mock_conv_db.get_conversations.assert_not_called()
+        assert len(result) == 2
+
+    def test_limit_100_uses_lite(self):
+        """limit=100 (default) uses lite path."""
+        mock_conv_db.get_conversations_lite.return_value = []
+
+        _call_get_conversations(limit=100)
+
+        mock_conv_db.get_conversations_lite.assert_called_once()
+        mock_conv_db.get_conversations.assert_not_called()
+
+    def test_empty_statuses_defaults_to_processing_completed(self):
+        """Empty statuses string defaults to 'processing,completed'."""
+        mock_conv_db.get_conversations_lite.return_value = []
+
+        _call_get_conversations(limit=25, statuses="")
+
+        call_kwargs = mock_conv_db.get_conversations_lite.call_args
+        assert call_kwargs[1]['statuses'] == ['processing', 'completed']
+
+    def test_locked_conversations_stripped(self):
+        """Locked conversations have sensitive fields stripped."""
+        mock_conv_db.get_conversations_lite.return_value = [
+            {
+                'id': 'c1',
+                'is_locked': True,
+                'structured': {'action_items': ['item1'], 'events': ['ev1']},
+                'apps_results': ['app1'],
+                'plugins_results': ['plug1'],
+                'suggested_summarization_apps': ['sum1'],
+            },
+        ]
+
+        result = _call_get_conversations(limit=10)
+
+        assert result[0]['structured']['action_items'] == []
+        assert result[0]['structured']['events'] == []
+        assert result[0]['apps_results'] == []
+        assert result[0]['plugins_results'] == []
+        assert result[0]['suggested_summarization_apps'] == []

--- a/backend/tests/unit/test_mcp_and_developer_conversations_lite.py
+++ b/backend/tests/unit/test_mcp_and_developer_conversations_lite.py
@@ -1,0 +1,102 @@
+"""
+Tests for MCP and developer router lite/full conversation routing.
+Uses extracted logic to avoid Firestore init during module import.
+"""
+
+from unittest.mock import MagicMock
+
+
+# Extracted logic from routers/mcp.py get_conversations
+def _mcp_get_conversations(mock_conv_db, uid, limit=25, offset=0, categories=None):
+    """Simulates MCP list conversations — always uses lite."""
+    category_list = []
+    conversations = mock_conv_db.get_conversations_lite(
+        uid,
+        limit,
+        offset,
+        include_discarded=False,
+        statuses=["completed"],
+        start_date=None,
+        end_date=None,
+        categories=[c for c in category_list],
+    )
+    return conversations
+
+
+# Extracted logic from routers/developer.py get_user_conversations
+def _developer_get_conversations(mock_conv_db, uid, limit=25, offset=0, include_transcript=False):
+    """Simulates developer list conversations — conditional lite/full."""
+    if include_transcript:
+        conversations = mock_conv_db.get_conversations(
+            uid,
+            limit,
+            offset,
+            include_discarded=False,
+            statuses=["completed"],
+            start_date=None,
+            end_date=None,
+            categories=[],
+        )
+    else:
+        conversations = mock_conv_db.get_conversations_lite(
+            uid,
+            limit,
+            offset,
+            include_discarded=False,
+            statuses=["completed"],
+            start_date=None,
+            end_date=None,
+            categories=[],
+        )
+
+    unlocked = [conv for conv in conversations if not conv.get('is_locked', False)]
+
+    if include_transcript:
+        # Would call _add_speaker_names_to_segments(uid, unlocked)
+        return unlocked, True  # True = speaker enrichment called
+    return unlocked, False
+
+
+class TestMcpConversationsLite:
+    def test_mcp_list_uses_lite(self):
+        """MCP list endpoint always uses get_conversations_lite."""
+        mock_conv_db = MagicMock()
+        mock_conv_db.get_conversations_lite.return_value = []
+
+        _mcp_get_conversations(mock_conv_db, 'test_uid')
+
+        mock_conv_db.get_conversations_lite.assert_called_once()
+        mock_conv_db.get_conversations.assert_not_called()
+
+
+class TestDeveloperConversationsLite:
+    def test_include_transcript_false_uses_lite(self):
+        """Developer endpoint with include_transcript=False uses lite."""
+        mock_conv_db = MagicMock()
+        mock_conv_db.get_conversations_lite.return_value = []
+
+        _, speaker_enriched = _developer_get_conversations(mock_conv_db, 'test_uid', include_transcript=False)
+
+        mock_conv_db.get_conversations_lite.assert_called_once()
+        mock_conv_db.get_conversations.assert_not_called()
+        assert speaker_enriched is False
+
+    def test_include_transcript_true_uses_full(self):
+        """Developer endpoint with include_transcript=True uses full get_conversations."""
+        mock_conv_db = MagicMock()
+        mock_conv_db.get_conversations.return_value = [{'id': 'c1', 'is_locked': False, 'transcript_segments': []}]
+
+        _, speaker_enriched = _developer_get_conversations(mock_conv_db, 'test_uid', include_transcript=True)
+
+        mock_conv_db.get_conversations.assert_called_once()
+        mock_conv_db.get_conversations_lite.assert_not_called()
+        assert speaker_enriched is True
+
+    def test_include_transcript_false_no_speaker_enrichment(self):
+        """Developer endpoint with include_transcript=False skips speaker enrichment."""
+        mock_conv_db = MagicMock()
+        mock_conv_db.get_conversations_lite.return_value = [{'id': 'c1', 'is_locked': False}]
+
+        _, speaker_enriched = _developer_get_conversations(mock_conv_db, 'test_uid', include_transcript=False)
+
+        assert speaker_enriched is False

--- a/backend/tests/unit/test_mcp_and_developer_conversations_lite.py
+++ b/backend/tests/unit/test_mcp_and_developer_conversations_lite.py
@@ -1,102 +1,154 @@
 """
 Tests for MCP and developer router lite/full conversation routing.
-Uses extracted logic to avoid Firestore init during module import.
+Imports the REAL router functions via module stubbing to avoid Firestore init.
 """
 
-from unittest.mock import MagicMock
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
 
 
-# Extracted logic from routers/mcp.py get_conversations
-def _mcp_get_conversations(mock_conv_db, uid, limit=25, offset=0, categories=None):
-    """Simulates MCP list conversations — always uses lite."""
-    category_list = []
-    conversations = mock_conv_db.get_conversations_lite(
-        uid,
-        limit,
-        offset,
-        include_discarded=False,
-        statuses=["completed"],
-        start_date=None,
-        end_date=None,
-        categories=[c for c in category_list],
-    )
-    return conversations
+def _ensure_mock_module(name: str):
+    """Ensure a MagicMock module exists in sys.modules."""
+    if name not in sys.modules:
+        mod = MagicMock()
+        mod.__path__ = []
+        mod.__name__ = name
+        mod.__loader__ = None
+        mod.__spec__ = None
+        mod.__package__ = name if '.' not in name else name.rsplit('.', 1)[0]
+        sys.modules[name] = mod
+    return sys.modules[name]
 
 
-# Extracted logic from routers/developer.py get_user_conversations
-def _developer_get_conversations(mock_conv_db, uid, limit=25, offset=0, include_transcript=False):
-    """Simulates developer list conversations — conditional lite/full."""
-    if include_transcript:
-        conversations = mock_conv_db.get_conversations(
-            uid,
-            limit,
-            offset,
-            include_discarded=False,
-            statuses=["completed"],
-            start_date=None,
-            end_date=None,
-            categories=[],
-        )
-    else:
-        conversations = mock_conv_db.get_conversations_lite(
-            uid,
-            limit,
-            offset,
-            include_discarded=False,
-            statuses=["completed"],
-            start_date=None,
-            end_date=None,
-            categories=[],
-        )
+# Stub database and utility modules to avoid Firestore init
+_ensure_mock_module("database")
+sys.modules["database"].__path__ = getattr(sys.modules["database"], '__path__', [])
+for sub in [
+    "_client",
+    "redis_db",
+    "auth",
+    "users",
+    "memories",
+    "conversations",
+    "apps",
+    "vector_db",
+    "action_items",
+    "mcp_api_key",
+    "dev_api_key",
+    "goals",
+]:
+    _ensure_mock_module(f"database.{sub}")
 
-    unlocked = [conv for conv in conversations if not conv.get('is_locked', False)]
+for name in [
+    "utils",
+    "utils.apps",
+    "utils.llm",
+    "utils.llm.memories",
+    "utils.conversations",
+    "utils.conversations.process_conversation",
+    "utils.conversations.search",
+    "utils.conversations.location",
+    "utils.llm.conversation_processing",
+    "utils.llm.external_integrations",
+    "utils.notifications",
+    "utils.webhooks",
+    "utils.retrieval",
+    "utils.retrieval.rag",
+    "utils.other",
+    "utils.other.hume",
+    "utils.other.endpoints",
+    "utils.other.storage",
+    "utils.encryption",
+    "utils.speaker_identification",
+    "utils.app_integrations",
+    "utils.scopes",
+    "dependencies",
+]:
+    _ensure_mock_module(name)
 
-    if include_transcript:
-        # Would call _add_speaker_names_to_segments(uid, unlocked)
-        return unlocked, True  # True = speaker enrichment called
-    return unlocked, False
+# Force reimport
+for mod_name in list(sys.modules.keys()):
+    if mod_name.startswith("routers.mcp") or mod_name.startswith("routers.developer"):
+        del sys.modules[mod_name]
+
+from routers.mcp import get_conversations as mcp_get_conversations  # noqa: E402
+from routers.developer import get_conversations as dev_get_conversations  # noqa: E402
 
 
 class TestMcpConversationsLite:
-    def test_mcp_list_uses_lite(self):
+    @patch('routers.mcp.conversations_db')
+    def test_mcp_list_uses_lite(self, mock_db):
         """MCP list endpoint always uses get_conversations_lite."""
-        mock_conv_db = MagicMock()
-        mock_conv_db.get_conversations_lite.return_value = []
+        mock_db.get_conversations_lite.return_value = []
 
-        _mcp_get_conversations(mock_conv_db, 'test_uid')
+        mcp_get_conversations(uid='test_uid')
 
-        mock_conv_db.get_conversations_lite.assert_called_once()
-        mock_conv_db.get_conversations.assert_not_called()
+        mock_db.get_conversations_lite.assert_called_once()
+        mock_db.get_conversations.assert_not_called()
 
 
 class TestDeveloperConversationsLite:
-    def test_include_transcript_false_uses_lite(self):
+    @patch('routers.developer.users_db')
+    @patch('routers.developer.conversations_db')
+    def test_include_transcript_false_uses_lite(self, mock_db, mock_users):
         """Developer endpoint with include_transcript=False uses lite."""
-        mock_conv_db = MagicMock()
-        mock_conv_db.get_conversations_lite.return_value = []
+        mock_db.get_conversations_lite.return_value = []
 
-        _, speaker_enriched = _developer_get_conversations(mock_conv_db, 'test_uid', include_transcript=False)
+        dev_get_conversations(
+            uid='test_uid',
+            limit=25,
+            offset=0,
+            include_transcript=False,
+            start_date=None,
+            end_date=None,
+            categories='',
+        )
 
-        mock_conv_db.get_conversations_lite.assert_called_once()
-        mock_conv_db.get_conversations.assert_not_called()
-        assert speaker_enriched is False
+        mock_db.get_conversations_lite.assert_called_once()
+        mock_db.get_conversations.assert_not_called()
 
-    def test_include_transcript_true_uses_full(self):
+    @patch('routers.developer.users_db')
+    @patch('routers.developer.conversations_db')
+    def test_include_transcript_true_uses_full(self, mock_db, mock_users):
         """Developer endpoint with include_transcript=True uses full get_conversations."""
-        mock_conv_db = MagicMock()
-        mock_conv_db.get_conversations.return_value = [{'id': 'c1', 'is_locked': False, 'transcript_segments': []}]
+        mock_db.get_conversations.return_value = [{'id': 'c1', 'is_locked': False, 'transcript_segments': []}]
+        mock_users.get_user_profile.return_value = {'name': 'Test'}
+        mock_users.get_people_by_ids.return_value = []
 
-        _, speaker_enriched = _developer_get_conversations(mock_conv_db, 'test_uid', include_transcript=True)
+        dev_get_conversations(
+            uid='test_uid',
+            limit=25,
+            offset=0,
+            include_transcript=True,
+            start_date=None,
+            end_date=None,
+            categories='',
+        )
 
-        mock_conv_db.get_conversations.assert_called_once()
-        mock_conv_db.get_conversations_lite.assert_not_called()
-        assert speaker_enriched is True
+        mock_db.get_conversations.assert_called_once()
+        mock_db.get_conversations_lite.assert_not_called()
 
-    def test_include_transcript_false_no_speaker_enrichment(self):
+    @patch('routers.developer.users_db')
+    @patch('routers.developer.conversations_db')
+    def test_include_transcript_false_no_speaker_enrichment(self, mock_db, mock_users):
         """Developer endpoint with include_transcript=False skips speaker enrichment."""
-        mock_conv_db = MagicMock()
-        mock_conv_db.get_conversations_lite.return_value = [{'id': 'c1', 'is_locked': False}]
+        mock_db.get_conversations_lite.return_value = [{'id': 'c1', 'is_locked': False}]
 
-        _, speaker_enriched = _developer_get_conversations(mock_conv_db, 'test_uid', include_transcript=False)
+        dev_get_conversations(
+            uid='test_uid',
+            limit=25,
+            offset=0,
+            include_transcript=False,
+            start_date=None,
+            end_date=None,
+            categories='',
+        )
 
-        assert speaker_enriched is False
+        # _add_speaker_names_to_segments calls users_db.get_user_profile
+        mock_users.get_user_profile.assert_not_called()


### PR DESCRIPTION
## Summary
- Adds `get_conversations_lite()` — a lightweight DB function that skips the `@with_photos` decorator (eliminates N serial Firestore subcollection queries) and `@prepare_for_read` decorator (eliminates deepcopy + decrypt/decompress of transcript data)
- Switches 4 conversation list endpoints to use it: `GET /v1/conversations`, `GET /v1/mcp/conversations`, MCP SSE `list_conversations`, and `GET /v1/dev/user/conversations` (when `include_transcript=False`)
- Returns `transcript_segments=[]` and `photos=[]` in list responses — full data available via detail endpoint `GET /v1/conversations/{id}`
- **Preserves full hydration for `limit=1` calls** (in-progress conversation recovery in `capture_provider.dart:1388` needs `transcriptSegments`)

## Root cause investigation (prod evidence)

Verified via `gcloud logging read` on Cloud Run `backend` service:

- **76 requests >5s** on `GET /v1/conversations` in last 7 days
- **Worst latencies**: 87.81s, 80.87s, 60.65s, 56.24s (all `limit=100 offset=0`)
- **504 gateway timeouts** at Cloud Run 30s boundary (multiple occurrences)
- All slow requests are at `offset=0` — the N+1 photo queries are the dominant bottleneck, not pagination

**Before** (limit=100): 1 main Firestore query + 100 serial photo subcollection queries + 100x deepcopy + decrypt/decompress = 101 Firestore round-trips
**After** (limit=100): 1 main Firestore query only = 1 Firestore round-trip

Code-level trace confirmed:
- `helpers.py:240` — `@with_photos` iterates list, calls `get_conversation_photos()` per item (serial)
- `conversations.py:99` — `_prepare_conversation_for_read()` does `copy.deepcopy()` on every conversation
- Mobile app list view (`conversation_list_item.dart`) does NOT display transcript_segments

## Review cycle fixes
- **R1**: `capture_provider.dart:1388` calls `GET /v1/conversations?limit=1&statuses=in_progress` and accesses `transcriptSegments` directly. Fixed by using `get_conversations_lite()` only when `limit > 1`; `limit <= 1` calls use the original `get_conversations()` with full hydration (already fast — only 1-2 Firestore round-trips).

## Tests added (12 new, all passing)
- `test_conversations_lite_db.py` — imports REAL `get_conversations_lite()` via importlib; tests field stripping, all 7 filter parameters, include_discarded=True skip
- `test_conversations_router_branching.py` — patches REAL `routers.conversations.get_conversations`; tests limit=1 full hydration, limit=2/100 lite, empty statuses default, locked field stripping
- `test_mcp_and_developer_conversations_lite.py` — patches REAL `routers.mcp` and `routers.developer`; tests MCP always uses lite, developer conditional on include_transcript, speaker enrichment only on include_transcript=True
- All registered in `test.sh`

## Known edge case

Discarded conversations use `getTranscript()` for list title display (`conversation_list_item.dart:289`). With `transcript_segments=[]`, discarded cards show blank title text. This only affects users who enable "show discarded" — the app's default call uses `include_discarded=false`. Full transcript remains available via the detail endpoint.

## Test plan
- [x] `backend/test.sh` — 20 pass (8 original + 12 new), 5 pre-existing failures (unrelated `test_process_conversation_usage_context.py`)
- [x] Codex reviewer approved (R2): limit>1 branching, in-progress recovery preserved
- [x] Codex tester approved (R3): all 12 tests exercise real production functions
- [ ] Verify on dev: conversation list loads fast, detail endpoint returns full data
- [ ] Verify mobile app: list shows titles/overviews correctly, tapping opens full conversation with transcript

Closes #4904

_by AI for @beastoin_