### PR TITLE
fix: restore Python desktop download endpoint, add isLive metadata to Codemagic releases

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2403,7 +2403,11 @@ workflows:
           gsutil -h "Content-Disposition:attachment; filename=\"Omi Beta.dmg\"" \
             cp "$DMG_PATH" "$GCS_BUCKET/releases/v${VERSION}/Omi.Beta.dmg"
           echo "Uploaded: $GCS_BUCKET/releases/v${VERSION}/Omi.Beta.dmg"
-          echo "(Run promote_release.sh to update the latest/ pointer when promoting to stable)"
+
+          # Update latest/ pointer so macos.omi.me always serves the newest build
+          gsutil -h "Content-Disposition:attachment; filename=\"Omi Beta.dmg\"" \
+            cp "$GCS_BUCKET/releases/v${VERSION}/Omi.Beta.dmg" "$GCS_BUCKET/latest/Omi.Beta.dmg"
+          echo "Updated: $GCS_BUCKET/latest/Omi.Beta.dmg"
 
       - name: Register release in Firestore
         script: |


### PR DESCRIPTION
Fixes #5296

## Summary

`macos.omi.me` serves a stale DMG (last updated Feb 23). Root cause: the active Codemagic workflow doesn't set `isLive` metadata in GitHub release bodies, so the Python backend's `_get_live_desktop_releases()` returns empty for all new Swift releases. This was worked around by redirecting to a Rust backend, adding unnecessary complexity.

This PR restores the Python backend as the source of truth and fixes the metadata gap.

## Changes

### `codemagic.yaml` — Add `KEY_VALUE_START` metadata to release notes
The `omi-desktop-swift-release` workflow (line 2373) generates release notes without the `KEY_VALUE_START` block that the Python backend parses. The old workflow (line ~1586) had it. Added `isLive: true` and `edSignature` back so `_get_live_desktop_releases()` works for new releases.

### `backend/routers/updates.py` — Restore direct GitHub resolution
Replaced the Rust backend redirect (added in `24e4bcc5d` by matt as a workaround) with direct resolution from GitHub releases. Finds the latest published desktop release with a DMG asset — no `isLive` gate needed for the download endpoint, no Firestore dependency, no Rust hop.

### `codemagic.yaml` — Copy DMG to GCS `latest/` path
Added fallback: after uploading versioned DMG, also copy to `latest/Omi.Beta.dmg` so the current static LB redirect still works until updated.

## After merge + deploy

One manual step: Update GCP LB URL map `custom-domains-49a4`, change `macos-omi-me` path matcher redirect from static GCS to `api.omi.me/v2/desktop/download/latest` (use 302, not 301).

## Test plan

- [ ] After deploy, verify `curl -I api.omi.me/v2/desktop/download/latest` returns 302 to a recent DMG
- [ ] Update LB redirect for `macos.omi.me`
- [ ] Verify `macos.omi.me` serves the latest build
- [ ] Verify next Codemagic release sets `isLive: true` in GitHub release body


🤖 Generated with [Claude Code](https://claude.com/claude-code)