### PR TITLE
Fix macos.omi.me serving stale DMG — restore isLive metadata + Python download endpoint

### DIFF
--- a/backend/routers/updates.py
+++ b/backend/routers/updates.py
@@ -5,7 +5,7 @@ from xml.etree.ElementTree import Element, SubElement, tostring
 from xml.dom import minidom
 
 from fastapi import APIRouter, HTTPException, Header, Query
-from fastapi.responses import Response
+from fastapi.responses import RedirectResponse, Response
 
 from routers.firmware import get_omi_github_releases, extract_key_value_pairs
 from database.redis_db import delete_generic_cache
@@ -345,21 +345,26 @@ async def get_desktop_appcast_xml(platform: str = Query(default="macos", regex="
 async def download_latest_desktop_release(platform: str = Query(default="macos", regex="^(macos|windows|linux)$")):
     """
     Get the download URL for the latest desktop release installer.
-    Delegates to the desktop backend service which tracks releases via Firestore.
+    Resolves the latest live release from GitHub and redirects to the DMG asset.
 
     Args:
         platform: Target platform (macos, windows, or linux)
 
     Returns:
-        Redirect to the desktop backend download endpoint
+        Redirect to the installer download URL (DMG for macOS)
     """
-    from fastapi.responses import RedirectResponse
+    desktop_releases = await _get_live_desktop_releases(platform)
+    if not desktop_releases:
+        raise HTTPException(status_code=404, detail=f"No live desktop releases found for platform: {platform}")
 
-    desktop_backend_url = os.getenv(
-        "DESKTOP_BACKEND_URL",
-        "https://desktop-backend-hhibjajaja-uc.a.run.app",
-    )
-    return RedirectResponse(url=f"{desktop_backend_url}/download", status_code=302)
+    # Find DMG asset in the latest release
+    latest = desktop_releases[0]["release"]
+    for asset in latest.get("assets", []):
+        name = asset.get("name", "")
+        if name.endswith(".dmg"):
+            return RedirectResponse(url=asset["browser_download_url"], status_code=302)
+
+    raise HTTPException(status_code=404, detail="No DMG installer found in latest release")
 
 
 @router.post("/v2/desktop/clear-cache")

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2377,7 +2377,13 @@ workflows:
 
           ### Downloads
           - **DMG Installer**: For fresh installs, download the DMG below
-          - **Auto-Update**: Existing users will receive this update automatically via Sparkle"
+          - **Auto-Update**: Existing users will receive this update automatically via Sparkle
+
+          <!-- KEY_VALUE_START
+          isLive: true
+          edSignature: ${ED_SIGNATURE}
+          changelog: $(echo "$CHANGELOG_MD" | sed 's/^- //' | tr '\n' '|' | sed 's/|$//')
+          KEY_VALUE_END -->"
 
           # Safe re-run: delete existing release if it exists
           gh release view "$CM_TAG" --repo "$GITHUB_REPO" &>/dev/null && \
@@ -2403,7 +2409,10 @@ workflows:
           gsutil -h "Content-Disposition:attachment; filename=\"Omi Beta.dmg\"" \
             cp "$DMG_PATH" "$GCS_BUCKET/releases/v${VERSION}/Omi.Beta.dmg"
           echo "Uploaded: $GCS_BUCKET/releases/v${VERSION}/Omi.Beta.dmg"
-          echo "(Run promote_release.sh to update the latest/ pointer when promoting to stable)"
+
+          # Always update latest/ pointer so macos.omi.me serves the newest build
+          gsutil cp "$GCS_BUCKET/releases/v${VERSION}/Omi.Beta.dmg" "$GCS_BUCKET/latest/Omi.Beta.dmg"
+          echo "Updated: $GCS_BUCKET/latest/Omi.Beta.dmg"
 
       - name: Register release in Firestore
         script: |


### PR DESCRIPTION
## Summary
Fixes #5296 — `macos.omi.me` serves a stale DMG (Feb 23) instead of the latest build.

**Root cause:** The active Codemagic `omi-desktop-swift-release` workflow creates GitHub releases without the `KEY_VALUE_START` metadata block that Python's `_get_live_desktop_releases()` needs to find live releases. As a workaround, the Python `/v2/desktop/download/latest` endpoint was replaced with a redirect to the Rust desktop backend, but Rust `/download` only serves `channel="stable"` releases — and all Codemagic releases register as `channel="staging"`.

**Changes:**
- **codemagic.yaml**: Add `<!-- KEY_VALUE_START ... KEY_VALUE_END -->` block with `isLive: true`, `edSignature`, and `changelog` to release notes template
- **codemagic.yaml**: Add GCS `latest/` copy step after versioned upload so `macos.omi.me` fallback always points to newest build
- **backend/routers/updates.py**: Restore `/v2/desktop/download/latest` to resolve latest live release from GitHub and redirect to DMG asset directly (removes Rust backend redirect)

**Post-merge manual step:** Update GCP URL map `custom-domains-49a4` host rule `macos-omi-me` to redirect to `api.omi.me/v2/desktop/download/latest`.

## Test plan
- [ ] Verify `extract_key_value_pairs()` correctly parses the new `KEY_VALUE_START` block from a GitHub release body
- [ ] Verify `/v2/desktop/download/latest` returns 302 redirect to GitHub DMG asset URL
- [ ] After next Codemagic release: confirm GCS `latest/Omi.Beta.dmg` is updated
- [ ] After LB update: confirm `macos.omi.me` serves latest DMG

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_by AI for @beastoin_