### PR TITLE
Disable system audio capture by default to prevent crackling

### DIFF
--- a/desktop/Desktop/Sources/Audio/AudioSourceManager.swift
+++ b/desktop/Desktop/Sources/Audio/AudioSourceManager.swift
@@ -97,6 +97,11 @@ final class AudioSourceManager: ObservableObject {
     // MARK: - Initialization
 
     private init() {
+        // System audio capture disabled by default — the aggregate device it creates
+        // causes clock drift vs the output device, producing periodic crackling/artifacts
+        // in all system audio (music, calls, etc.). Users can opt in via:
+        //   defaults write <bundleID> disableSystemAudioCapture -bool false
+        UserDefaults.standard.register(defaults: ["disableSystemAudioCapture": true])
         setupBindings()
     }
 


### PR DESCRIPTION
## Summary
- Disables system audio capture (process tap + aggregate device) by default
- The aggregate device created by `SystemAudioCaptureService` runs on its own clock, which drifts vs the output device — `coreaudiod` compensates with periodic sample insertions/drops, causing ~8ms crackling bursts audible in all system audio (music, calls, etc.)
- Users can re-enable via `defaults write <bundleID> disableSystemAudioCapture -bool false`

## Analysis
Audio analysis of a crackling recording showed:
- **~8ms periodic phase discontinuities** (350-390 samples at 48kHz) matching CoreAudio IO buffer boundaries
- Both stereo channels affected simultaneously (59-68% correlation)
- Spectral peak at **125Hz** (1/8ms) confirming aggregate device callback frequency
- Waveform shape: phase discontinuity (not dropout/clip) — classic clock drift correction pattern

## Test plan
- [ ] Play music with Omi running — verify no crackling
- [ ] Verify mic transcription still works normally
- [ ] Verify `defaults write <bundleID> disableSystemAudioCapture -bool false` re-enables system audio capture

🤖 Generated with [Claude Code](https://claude.com/claude-code)