### PR TITLE
Fix dashboard tasks not updating on completion toggle

### DIFF
--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -533,10 +533,9 @@ class TasksStore: ObservableObject {
 
         // Force reconciliation on initial load to clean up tasks deleted on other devices.
         // This bypasses the 5-minute throttle since the first load should always reconcile.
+        // Awaited inline (not in a detached Task) so loadDashboardTasks() sees clean data.
         if lastReconciliationDate == nil {
-            Task {
-                await forceReconcileOnLoad()
-            }
+            await forceReconcileOnLoad()
         }
     }
 
@@ -1131,7 +1130,10 @@ class TasksStore: ObservableObject {
             incompleteTasks.insert(updatedTask, at: 0)
         }
 
-        // 4. Call API in background, revert on failure
+        // 5. Refresh dashboard arrays immediately (SQLite was already updated in step 1)
+        await loadDashboardTasks()
+
+        // 6. Call API in background, revert on failure
         do {
             let apiResult = try await APIClient.shared.updateActionItem(
                 id: task.id,


### PR DESCRIPTION
## Summary
- Fix task completion toggle on Dashboard not visually updating — `toggleTask()` updated `incompleteTasks` but not the dashboard-specific arrays (`overdueTasks`/`todaysTasks`/`tasksWithoutDueDate`). Now calls `loadDashboardTasks()` immediately after the optimistic SQLite update, before the API call.
- Fix stale/old tasks showing on Dashboard — `forceReconcileOnLoad()` was running in a detached `Task`, so `loadDashboardTasks()` could render before reconciliation cleaned up tasks deleted on other devices. Now awaited inline.

## Test plan
- [ ] Click a task checkbox on Dashboard → task should disappear immediately
- [ ] Dashboard and Tasks page should show the same set of incomplete tasks
- [ ] Tasks deleted on mobile should not appear on Dashboard after app restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)