### PR TITLE
Stop run.sh from deleting production omi app

### DIFF
--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -85,11 +85,7 @@ step "Cleaning up conflicting app bundles..."
 rm -rf "$BUILD_DIR/Omi Computer.app" 2>/dev/null
 CONFLICTING_APPS=(
     "/Applications/Omi Computer.app"
-    "/Applications/Omi.app/Contents/MacOS/Omi Computer.app"
-    "/Applications/Omi.app"
-    "$HOME/Desktop/Omi.app"
     "$HOME/Desktop/Omi Dev.app"
-    "$HOME/Downloads/Omi.app"
     "$HOME/Downloads/Omi Dev.app"
     "$(dirname "$0")/../app/build/macos/Build/Products/Debug/Omi.app"
     "$(dirname "$0")/../app/build/macos/Build/Products/Release/Omi.app"


### PR DESCRIPTION
## Summary
- run.sh cleanup list included `/Applications/Omi.app` which matches `/Applications/omi.app` on case-insensitive APFS, deleting the production install whenever dev environment starts
- Removed entries that could delete prod/beta app bundles while keeping safe cleanup of old build names and stale dev copies


🤖 Generated with [Claude Code](https://claude.com/claude-code)