### PR TITLE
Fix onboarding chat flow

### DIFF
--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -141,11 +141,8 @@ struct OnboardingChatView: View {
                 ScrollView {
                     VStack(spacing: 16) {
                         ForEach(chatProvider.messages) { message in
-                            // Hide the initial "Hi, I just installed omi!" message
-                            if !(message.sender == .user && message.text == "Hi, I just installed omi!") {
                                 OnboardingChatBubble(message: message)
                                     .id(message.id)
-                            }
                         }
 
                         // Parallel exploration card (appears after scan_files)
@@ -449,14 +446,7 @@ struct OnboardingChatView: View {
         ChatToolExecutor.onCompleteOnboarding = {
             onboardingCompleted = true
         }
-        ChatToolExecutor.onQuickReplyOptions = { question, options in
-            // If the AI's question isn't already in the last message, add it
-            if !question.isEmpty {
-                let lastAIText = chatProvider.messages.last(where: { $0.sender == .ai })?.text ?? ""
-                if !lastAIText.contains(question) {
-                    chatProvider.messages.append(ChatMessage(text: question, sender: .ai))
-                }
-            }
+        ChatToolExecutor.onQuickReplyOptions = { options in
             quickReplyOptions = options
         }
         ChatToolExecutor.onKnowledgeGraphUpdated = { [weak graphViewModel] in

--- a/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -12,8 +12,8 @@ class ChatToolExecutor {
     static var onboardingAppState: AppState?
     /// Called when AI invokes complete_onboarding
     static var onCompleteOnboarding: (() -> Void)?
-    /// Called when AI invokes ask_followup — delivers question text and quick-reply options to the UI
-    static var onQuickReplyOptions: ((_ question: String, _ options: [String]) -> Void)?
+    /// Called when AI invokes ask_followup — delivers quick-reply options to the UI
+    static var onQuickReplyOptions: ((_ options: [String]) -> Void)?
     /// Called when AI invokes save_knowledge_graph — notifies the graph view to update
     static var onKnowledgeGraphUpdated: (() -> Void)?
     /// Called when scan_files completes — used to kick off parallel exploration
@@ -844,8 +844,8 @@ class ChatToolExecutor {
         }
         let options = (args["options"] as? [String]) ?? []
 
-        // Notify the UI to render the question and quick-reply buttons
-        onQuickReplyOptions?(question, options)
+        // Notify the UI to render quick-reply buttons
+        onQuickReplyOptions?(options)
 
         return "Presented to user: \"\(question)\" with options: \(options.joined(separator: ", "))"
     }


### PR DESCRIPTION
## Summary
- Revert ask_followup to original simple callback (no blocking, no question duplication)
- Remove chat message preloading — let chat flow naturally when user reaches chat step
- Show "Hi, I just installed omi!" message in chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)