### PR TITLE
Allow unauthenticated access to desktop-backend Cloud Run

### DIFF
--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -56,6 +56,7 @@ jobs:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          flags: '--allow-unauthenticated'
           env_vars: |
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json


### PR DESCRIPTION
## Summary
- Add `--allow-unauthenticated` flag to desktop backend Cloud Run deploy workflow
- Without this, Cloud Run IAM returns 403 on all requests before they reach the Rust backend
- The backend handles auth at the application level via Firebase tokens (same pattern as the Python backend)

Follows up on #5310. Already applied manually via `gcloud run services add-iam-policy-binding` — this ensures future deploys preserve the setting.

**Health check confirmed working:**
```
$ curl https://desktop-backend-dt5lrfkkoa-uc.a.run.app/health
{"status":"healthy","service":"omi-desktop-backend","version":"0.1.0"}
```

## Test plan
- [x] Health endpoint responds 200 after manual IAM fix
- [ ] Next workflow deploy preserves unauthenticated access

_by AI for @beastoin_