### PR TITLE
fix: pass user's configured name to transcript formatter for summary …

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -404,10 +404,10 @@ class Conversation(BaseModel):
 
         return "\n\n---------------------\n\n".join(result).strip()
 
-    def get_transcript(self, include_timestamps: bool, people: List[Person] = None) -> str:
+    def get_transcript(self, include_timestamps: bool, people: List[Person] = None, user_name: str = None) -> str:
         # Warn: missing transcript for workflow source, external integration source
         return TranscriptSegment.segments_as_string(
-            self.transcript_segments, include_timestamps=include_timestamps, people=people
+            self.transcript_segments, include_timestamps=include_timestamps, people=people, user_name=user_name
         )
 
     def get_photos_descriptions(self, include_timestamps: bool = False) -> str:
@@ -450,9 +450,9 @@ class CreateConversation(BaseModel):
     processing_conversation_id: Optional[str] = None
     calendar_meeting_context: Optional[CalendarMeetingContext] = None
 
-    def get_transcript(self, include_timestamps: bool, people: List[Person] = None) -> str:
+    def get_transcript(self, include_timestamps: bool, people: List[Person] = None, user_name: str = None) -> str:
         return TranscriptSegment.segments_as_string(
-            self.transcript_segments, include_timestamps=include_timestamps, people=people
+            self.transcript_segments, include_timestamps=include_timestamps, people=people, user_name=user_name
         )
 
     def get_person_ids(self) -> List[str]:

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -11,6 +11,7 @@ from typing import Union, Tuple, List, Optional
 from fastapi import HTTPException
 
 from database import redis_db
+from database.auth import get_user_name
 import database.memories as memories_db
 import database.conversations as conversations_db
 import database.notifications as notification_db
@@ -85,6 +86,10 @@ def _get_structured(
     try:
         tz = notification_db.get_user_time_zone(uid)
 
+        # Fetch the user's configured display name so transcripts use real names
+        # instead of the generic "User" placeholder during summary generation.
+        user_name = get_user_name(uid, use_default=False)
+
         # Fetch existing action items from past 2 days for deduplication
         existing_action_items = None
         try:
@@ -139,7 +144,7 @@ def _get_structured(
             # not supported conversation source
             raise HTTPException(status_code=400, detail=f'Invalid conversation source: {conversation.text_source}')
 
-        transcript_text = conversation.get_transcript(False, people=people)
+        transcript_text = conversation.get_transcript(False, people=people, user_name=user_name)
 
         # For re-processing, we don't discard, just re-structure.
         if force_process:
@@ -290,6 +295,9 @@ def _trigger_apps(
     language_code: str = 'en',
     people: List[Person] = None,
 ):
+    # Fetch user's configured display name for transcript formatting
+    user_name = get_user_name(uid, use_default=False)
+
     # Get default apps for auto-selection
     default_apps = get_default_conversation_summarized_apps()
     default_apps_dict = {app.id: app for app in default_apps}
@@ -345,7 +353,7 @@ def _trigger_apps(
     def execute_app(app):
         with track_usage(uid, Features.CONVERSATION_APPS):
             result = get_app_result(
-                conversation.get_transcript(False, people=people), conversation.photos, app, language_code=language_code
+                conversation.get_transcript(False, people=people, user_name=user_name), conversation.photos, app, language_code=language_code
             ).strip()
         conversation.apps_results.append(AppResult(app_id=app.id, content=result))
         if not is_reprocess:

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -82,13 +82,10 @@ def _get_structured(
     conversation: Union[Conversation, CreateConversation, ExternalIntegrationCreateConversation],
     force_process: bool = False,
     people: List[Person] = None,
+    user_name: str = None,
 ) -> Tuple[Structured, bool]:
     try:
         tz = notification_db.get_user_time_zone(uid)
-
-        # Fetch the user's configured display name so transcripts use real names
-        # instead of the generic "User" placeholder during summary generation.
-        user_name = get_user_name(uid, use_default=False)
 
         # Fetch existing action items from past 2 days for deduplication
         existing_action_items = None
@@ -294,10 +291,8 @@ def _trigger_apps(
     app_id: Optional[str] = None,
     language_code: str = 'en',
     people: List[Person] = None,
+    user_name: str = None,
 ):
-    # Fetch user's configured display name for transcript formatting
-    user_name = get_user_name(uid, use_default=False)
-
     # Get default apps for auto-selection
     default_apps = get_default_conversation_summarized_apps()
     default_apps_dict = {app.id: app for app in default_apps}
@@ -639,7 +634,11 @@ def process_conversation(
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))
         people = [Person(**p) for p in people_data]
 
-    structured, discarded = _get_structured(uid, language_code, conversation, force_process, people=people)
+    # Fetch user's display name once and pass through to avoid duplicate network calls.
+    # Falls back to None (→ 'User') when no name is configured.
+    user_name = get_user_name(uid, use_default=False)
+
+    structured, discarded = _get_structured(uid, language_code, conversation, force_process, people=people, user_name=user_name)
     conversation = _get_conversation_obj(uid, structured, conversation)
 
     # AI-based folder assignment
@@ -698,7 +697,7 @@ def process_conversation(
             record_usage(uid, insights_gained=insights_gained)
 
         _trigger_apps(
-            uid, conversation, is_reprocess=is_reprocess, app_id=app_id, language_code=language_code, people=people
+            uid, conversation, is_reprocess=is_reprocess, app_id=app_id, language_code=language_code, people=people, user_name=user_name
         )
         (
             threading.Thread(


### PR DESCRIPTION
…generation

When generating conversation summaries, the transcript passed to the LLM was using the generic 'User' placeholder instead of the user's actual configured name (e.g. 'Stephen' instead of 'User').

Root cause: TranscriptSegment.segments_as_string() accepts a user_name parameter but get_transcript() never forwarded it, so it always defaulted to 'User'.

Fix:
- Add user_name param to Conversation.get_transcript() and CreateConversation.get_transcript() and pass it through to segments_as_string()
- In _get_structured() and _trigger_apps(), fetch the user's display name via get_user_name(uid) (Redis-cached, fast) and pass it to get_transcript()

Result: summaries now say 'Stephen: ...' instead of 'User: ...' when the user has configured their name in app settings.

Fixes #5319