### PR TITLE
Swift desktop: path updates, decoder hardening, no-ops (#5302 Day 3)

### DIFF
--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -405,14 +405,10 @@ extension APIClient {
         return response.count
     }
 
-    /// Gets the count of AI chat messages from PostHog
+    /// Gets the count of AI chat messages
     func getChatMessageCount() async throws -> Int {
-        struct CountResponse: Decodable {
-            let count: Int
-        }
-
-        let response: CountResponse = try await get("v1/users/stats/chat-messages")
-        return response.count
+        // No-op: chat-messages stats endpoint not available in Python backend
+        return 0
     }
 
     /// Merges multiple conversations into a new conversation
@@ -581,7 +577,7 @@ struct ServerConversation: Codable, Identifiable, Equatable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         id = try container.decode(String.self, forKey: .id)
-        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
         startedAt = try container.decodeIfPresent(Date.self, forKey: .startedAt)
         finishedAt = try container.decodeIfPresent(Date.self, forKey: .finishedAt)
         structured = try container.decode(Structured.self, forKey: .structured)
@@ -1454,13 +1450,25 @@ struct UserProfile: Codable {
 // MARK: - Action Items API
 
 /// Response wrapper for paginated action items list
-struct ActionItemsListResponse: Codable {
+struct ActionItemsListResponse: Decodable {
     let items: [TaskActionItem]
     let hasMore: Bool
 
     enum CodingKeys: String, CodingKey {
+        case actionItems = "action_items"
         case items
         case hasMore = "has_more"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        hasMore = try container.decodeIfPresent(Bool.self, forKey: .hasMore) ?? false
+        // Python action_items endpoint returns "action_items"; staged-tasks returns "items"
+        if let actionItems = try container.decodeIfPresent([TaskActionItem].self, forKey: .actionItems) {
+            items = actionItems
+        } else {
+            items = try container.decodeIfPresent([TaskActionItem].self, forKey: .items) ?? []
+        }
     }
 }
 
@@ -1890,17 +1898,6 @@ extension APIClient {
         return try await post("v1/staged-tasks/promote")
     }
 
-    /// One-time migration of existing AI tasks to staged_tasks
-    func migrateStagedTasks() async throws {
-        struct StatusResponse: Decodable { let status: String }
-        let _: StatusResponse = try await post("v1/staged-tasks/migrate")
-    }
-
-    /// Migrate conversation-extracted action items (no source field) to staged_tasks
-    func migrateConversationItemsToStaged() async throws {
-        struct MigrateResponse: Decodable { let status: String; let migrated: Int; let deleted: Int }
-        let _: MigrateResponse = try await post("v1/staged-tasks/migrate-conversation-items")
-    }
 }
 
 /// Response for staged task promotion
@@ -3148,13 +3145,12 @@ extension APIClient {
 
     /// Regenerates persona prompt from current public memories
     func regeneratePersonaPrompt() async throws -> GeneratePromptResponse {
-        struct EmptyRequest: Encodable {}
-        return try await post("v1/personas/generate-prompt", body: EmptyRequest())
+        return try await get("v1/app/generate-prompts")
     }
 
     /// Checks if a username is available
     func checkPersonaUsername(_ username: String) async throws -> UsernameAvailableResponse {
-        return try await get("v1/personas/check-username?username=\(username)")
+        return try await get("v1/apps/check-username?username=\(username)")
     }
 }
 
@@ -3252,9 +3248,27 @@ struct GeneratePromptResponse: Codable {
 }
 
 /// Response for username availability check
-struct UsernameAvailableResponse: Codable {
+struct UsernameAvailableResponse: Decodable {
     let available: Bool
-    let username: String
+    let username: String?
+    let isTaken: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case available, username
+        case isTaken = "is_taken"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        username = try container.decodeIfPresent(String.self, forKey: .username)
+        isTaken = try container.decodeIfPresent(Bool.self, forKey: .isTaken)
+        // Python returns is_taken; Rust returned available. Support both.
+        if let isTaken = isTaken {
+            available = !isTaken
+        } else {
+            available = try container.decodeIfPresent(Bool.self, forKey: .available) ?? true
+        }
+    }
 }
 
 // MARK: - User Settings API
@@ -4087,7 +4101,7 @@ extension APIClient {
         }
 
         let body = InitialMessageRequest(sessionId: sessionId, appId: appId)
-        return try await post("v2/chat/initial-message", body: body)
+        return try await post("v2/initial-message", body: body)
     }
 
     /// Generate a title for a chat session based on its messages
@@ -4236,31 +4250,51 @@ extension APIClient {
     // MARK: - Agent VM
 
     struct AgentProvisionResponse: Decodable {
-        let status: String
-        let vmName: String
+        let hasVm: Bool
+        let status: String?
+        let vmName: String?
         let ip: String?
-        let authToken: String
-        let agentStatus: String
+        let authToken: String?
+        let agentStatus: String?
+
+        enum CodingKeys: String, CodingKey {
+            case hasVm = "has_vm"
+            case status
+            case vmName = "vm_name"
+            case ip
+            case authToken = "auth_token"
+            case agentStatus = "agent_status"
+        }
     }
 
     /// Provision a cloud agent VM for the current user (fire-and-forget)
     func provisionAgentVM() async throws -> AgentProvisionResponse {
-        return try await post("v2/agent/provision")
+        return try await post("v1/agent/vm-ensure")
     }
 
     struct AgentStatusResponse: Decodable {
-        let vmName: String
-        let zone: String
+        let hasVm: Bool
+        let vmName: String?
+        let zone: String?
         let ip: String?
-        let status: String
-        let authToken: String
-        let createdAt: String
+        let status: String?
+        let authToken: String?
+        let createdAt: String?
         let lastQueryAt: String?
+
+        enum CodingKeys: String, CodingKey {
+            case hasVm = "has_vm"
+            case vmName = "vm_name"
+            case zone, ip, status
+            case authToken = "auth_token"
+            case createdAt = "created_at"
+            case lastQueryAt = "last_query_at"
+        }
     }
 
     /// Get current agent VM status
     func getAgentStatus() async throws -> AgentStatusResponse? {
-        return try await get("v2/agent/status")
+        return try await get("v1/agent/vm-status")
     }
 }
 
@@ -4365,41 +4399,13 @@ extension APIClient {
         costUsd: Double,
         account: String = "omi"
     ) async {
-        struct Req: Encodable {
-            let input_tokens: Int
-            let output_tokens: Int
-            let cache_read_tokens: Int
-            let cache_write_tokens: Int
-            let total_tokens: Int
-            let cost_usd: Double
-            let account: String
-        }
-        struct Res: Decodable { let status: String }
-        do {
-            let _: Res = try await post("v1/users/me/llm-usage", body: Req(
-                input_tokens: inputTokens,
-                output_tokens: outputTokens,
-                cache_read_tokens: cacheReadTokens,
-                cache_write_tokens: cacheWriteTokens,
-                total_tokens: totalTokens,
-                cost_usd: costUsd,
-                account: account
-            ))
-        } catch {
-            log("APIClient: LLM usage record failed: \(error.localizedDescription)")
-        }
+        // No-op: LLM usage tracking endpoint not available in Python backend
+        log("APIClient: recordLlmUsage no-op (endpoint removed)")
     }
 
     func fetchTotalOmiAICost() async -> Double? {
-        struct Res: Decodable { let total_cost_usd: Double }
-        do {
-            log("APIClient: Fetching total Omi AI cost from backend")
-            let res: Res = try await get("v1/users/me/llm-usage/total")
-            log("APIClient: Total Omi AI cost from backend: $\(String(format: "%.4f", res.total_cost_usd))")
-            return res.total_cost_usd
-        } catch {
-            log("APIClient: LLM total cost fetch failed: \(error.localizedDescription)")
-            return nil
-        }
+        // No-op: LLM usage total endpoint not available in Python backend
+        log("APIClient: fetchTotalOmiAICost no-op (endpoint removed)")
+        return nil
     }
 }

--- a/desktop/Desktop/Sources/AgentVMService.swift
+++ b/desktop/Desktop/Sources/AgentVMService.swift
@@ -23,26 +23,28 @@ actor AgentVMService {
             do {
                 let status = try await APIClient.shared.getAgentStatus()
                 if let status = status, status.status == "ready", let ip = status.ip {
-                    log("AgentVMService: VM already ready — vmName=\(status.vmName) ip=\(ip)")
+                    let token = status.authToken ?? ""
+                    log("AgentVMService: VM already ready — vmName=\(status.vmName ?? "unknown") ip=\(ip)")
                     // Only upload if the VM doesn't have a database yet
-                    if await checkVMNeedsDatabase(vmIP: ip, authToken: status.authToken) {
-                        await uploadDatabase(vmIP: ip, authToken: status.authToken)
+                    if await checkVMNeedsDatabase(vmIP: ip, authToken: token) {
+                        await uploadDatabase(vmIP: ip, authToken: token)
                     } else {
                         log("AgentVMService: VM already has database, skipping upload")
                     }
-                    await startIncrementalSync(vmIP: ip, authToken: status.authToken)
+                    await startIncrementalSync(vmIP: ip, authToken: token)
                     return
                 }
                 if let status = status,
                    status.status == "provisioning" || status.status == "stopped" {
-                    log("AgentVMService: VM is \(status.status), polling until ready...")
+                    log("AgentVMService: VM is \(status.status ?? "unknown"), polling until ready...")
                     if let result = await pollUntilReady(maxAttempts: 30, intervalSeconds: 5),
                        let ip = result.ip {
+                        let token = result.authToken ?? ""
                         log("AgentVMService: VM became ready — ip=\(ip)")
-                        if await checkVMNeedsDatabase(vmIP: ip, authToken: result.authToken) {
-                            await uploadDatabase(vmIP: ip, authToken: result.authToken)
+                        if await checkVMNeedsDatabase(vmIP: ip, authToken: token) {
+                            await uploadDatabase(vmIP: ip, authToken: token)
                         }
-                        await startIncrementalSync(vmIP: ip, authToken: result.authToken)
+                        await startIncrementalSync(vmIP: ip, authToken: token)
                     }
                     return
                 }
@@ -76,7 +78,7 @@ actor AgentVMService {
         let provisionResult: APIClient.AgentProvisionResponse
         do {
             provisionResult = try await APIClient.shared.provisionAgentVM()
-            log("AgentVMService: Provision response — vmName=\(provisionResult.vmName) status=\(provisionResult.status) ip=\(provisionResult.ip ?? "none")")
+            log("AgentVMService: Provision response — vmName=\(provisionResult.vmName ?? "unknown") status=\(provisionResult.status ?? "unknown") ip=\(provisionResult.ip ?? "none")")
         } catch {
             log("AgentVMService: Provision failed — \(error.localizedDescription)")
             return
@@ -84,14 +86,14 @@ actor AgentVMService {
 
         // Step 2: Poll until VM is ready with an IP
         var vmIP = provisionResult.ip
-        var authToken = provisionResult.authToken
+        var authToken = provisionResult.authToken ?? ""
 
-        if vmIP == nil || provisionResult.agentStatus == "provisioning" {
+        if vmIP == nil || provisionResult.status == "provisioning" {
             log("AgentVMService: Waiting for VM to be ready...")
             let pollResult = await pollUntilReady(maxAttempts: 30, intervalSeconds: 5)
             if let result = pollResult {
                 vmIP = result.ip
-                authToken = result.authToken
+                authToken = result.authToken ?? ""
                 log("AgentVMService: VM ready — ip=\(vmIP ?? "none")")
             } else {
                 log("AgentVMService: VM did not become ready in time")
@@ -111,7 +113,7 @@ actor AgentVMService {
         await startIncrementalSync(vmIP: ip, authToken: authToken)
     }
 
-    /// Poll GET /v2/agent/status until status is "ready" and IP is available.
+    /// Poll GET /v1/agent/vm-status until status is "ready" and IP is available.
     private func pollUntilReady(maxAttempts: Int, intervalSeconds: UInt64) async -> APIClient.AgentStatusResponse? {
         for attempt in 1...maxAttempts {
             do {

--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -448,8 +448,6 @@ class TasksStore: ObservableObject {
         // Then retry pushing any locally-created tasks that failed to sync
         Task {
             await performFullSyncIfNeeded()
-            await migrateAITasksToStagedIfNeeded()
-            await migrateConversationItemsToStagedIfNeeded()
             await retryUnsyncedItems()
         }
         // Backfill relevance scores for unscored tasks (independent of full sync)
@@ -805,69 +803,6 @@ class TasksStore: ObservableObject {
 
         } catch {
             logError("TasksStore: Full sync failed (will retry next launch)", error: error)
-        }
-    }
-
-    /// In-memory guard to prevent duplicate migration calls within the same app session
-    private static var isMigrating = false
-
-    /// One-time migration: tell backend to move excess AI tasks to staged_tasks subcollection.
-    /// The SQLite migration handles local data; this handles Firestore.
-    /// Sets the flag optimistically before the request to avoid retry loops on timeout.
-    private func migrateAITasksToStagedIfNeeded() async {
-        let userId = UserDefaults.standard.string(forKey: "auth_userId") ?? "unknown"
-        let migrationKey = "stagedTasksMigrationCompleted_v4_\(userId)"
-
-        guard !UserDefaults.standard.bool(forKey: migrationKey) else {
-            log("TasksStore: Staged tasks migration already completed for user \(userId)")
-            return
-        }
-
-        // In-memory guard: loadTasks() can be called from multiple pages
-        guard !Self.isMigrating else {
-            log("TasksStore: Staged tasks migration already in progress, skipping")
-            return
-        }
-        Self.isMigrating = true
-
-        // Set flag optimistically — the migration is idempotent and safe to skip on re-run.
-        // This prevents infinite retry loops when the backend succeeds but the client times out.
-        UserDefaults.standard.set(true, forKey: migrationKey)
-
-        log("TasksStore: Starting staged tasks backend migration for user \(userId)")
-
-        do {
-            try await APIClient.shared.migrateStagedTasks()
-            log("TasksStore: Staged tasks backend migration completed")
-        } catch {
-            log("TasksStore: Staged tasks backend migration fired (may complete in background): \(error.localizedDescription)")
-        }
-        Self.isMigrating = false
-    }
-
-    /// One-time migration of conversation-extracted action items (no source field) to staged_tasks.
-    /// These were created by the old save_action_items path that bypassed the staging pipeline.
-    private func migrateConversationItemsToStagedIfNeeded() async {
-        let userId = UserDefaults.standard.string(forKey: "auth_userId") ?? "unknown"
-        let migrationKey = "conversationItemsMigrationCompleted_v4_\(userId)"
-
-        guard !UserDefaults.standard.bool(forKey: migrationKey) else { return }
-
-        UserDefaults.standard.set(true, forKey: migrationKey)
-        log("TasksStore: Starting conversation items migration for user \(userId)")
-
-        do {
-            try await APIClient.shared.migrateConversationItemsToStaged()
-            log("TasksStore: Conversation items migration completed, resetting full sync to clean up local SQLite")
-
-            // Reset full sync flag so it re-runs and marks migrated items as staged locally
-            let syncKey = "tasksFullSyncCompleted_v9_\(userId)"
-            UserDefaults.standard.set(false, forKey: syncKey)
-
-            // Run full sync now to clean up local SQLite
-            await performFullSyncIfNeeded()
-        } catch {
-            log("TasksStore: Conversation items migration fired (may complete in background): \(error.localizedDescription)")
         }
     }
 


### PR DESCRIPTION
## Summary
Sub-PR for #5302 desktop migration Day 3 — Swift client adaptation for Python backend.

**Path updates (5 endpoints):**
- `v2/chat/initial-message` → `v2/initial-message`
- `v2/agent/provision` → `v1/agent/vm-ensure`
- `v2/agent/status` → `v1/agent/vm-status`
- `v1/personas/check-username` → `v1/apps/check-username`
- `v1/personas/generate-prompt` → `v1/app/generate-prompts` (POST→GET)

**Decoder hardening:**
- `ServerConversation.createdAt`: `decodeIfPresent` with `Date()` fallback
- `ActionItemsListResponse`: custom decoder tries `"action_items"` then `"items"` key (Python action-items vs staged-tasks endpoints)
- `AgentProvisionResponse`/`AgentStatusResponse`: fields made optional, added `hasVm` field for Python's minimal response shape
- `UsernameAvailableResponse`: supports both `is_taken` (Python) and `available` (Rust) via custom decoder

**Graceful no-ops (3 endpoints removed from Python):**
- `recordLlmUsage()` → no-op with log
- `fetchTotalOmiAICost()` → returns nil immediately
- `getChatMessageCount()` → returns 0 immediately

**Remove staged-tasks migration (no longer needed):**
- Removed `migrateStagedTasks()` and `migrateConversationItemsToStaged()` from APIClient
- Removed migration callers and helper functions from TasksStore

## Files changed
- `desktop/Desktop/Sources/APIClient.swift` — all path/decoder/no-op changes
- `desktop/Desktop/Sources/AgentVMService.swift` — adapt to optional AgentVM response fields
- `desktop/Desktop/Sources/Stores/TasksStore.swift` — remove migration functions and callers

## Notes
- `regeneratePersonaPrompt()` now points to `v1/app/generate-prompts` (GET). The response shape differs from the old `v1/personas/generate-prompt` — may need attention if called.
- AgentVM endpoints (`vm-ensure`, `vm-status`) return minimal `{has_vm, status}` from Python vs full VM details from Rust. The service gracefully degrades but won't have `authToken`/`ip` until those are added to Python responses.

## Test plan
- [ ] Verify Swift compiles (no build errors from optional changes)
- [ ] Mac Mini desktop test: app launches, no crash on startup
- [ ] Verify action items load (ActionItemsListResponse decoder)
- [ ] Verify username check works on persona page

🤖 Generated with [Claude Code](https://claude.com/claude-code)