### PR TITLE
fix: guard against non-numeric speaker label crashing TranscriptSegment

### DIFF
--- a/app/lib/backend/schema/transcript_segment.dart
+++ b/app/lib/backend/schema/transcript_segment.dart
@@ -55,7 +55,8 @@ class TranscriptSegment {
     this.speechProfileProcessed = true,
     this.sttProvider,
   }) {
-    speakerId = speaker != null ? int.parse(speaker!.split('_')[1]) : 0;
+    final parts = speaker?.split('_') ?? [];
+    speakerId = parts.length > 1 ? (int.tryParse(parts[1]) ?? 0) : 0;
   }
 
   @override


### PR DESCRIPTION
## Summary

- **Line of Code:** 

https://github.com/BasedHardware/omi/blob/96da1b0f51636bd968d17ae7cd21da135314125d/app/lib/backend/schema/transcript_segment.dart#L58

- **Cause:** `speaker` from the API can arrive as `"SPEAKER_None"` (Python's `None` serialized into a string). `int.parse("None")` throws a `FormatException`, crashing the app on conversation load.
- **Fix:** Replaced `int.parse` with `int.tryParse(...) ?? 0` and guarded the split index — same pattern already used for `start`/`end` in the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)