### PR TITLE
Add missing params to /v4/web/listen for desktop STT migration

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2390,9 +2390,11 @@ async def web_listen_handler(
     source: Optional[str] = None,
     custom_stt: str = 'disabled',
     onboarding: str = 'disabled',
+    speaker_auto_assign: str = 'disabled',
+    vad_gate: str = '',
 ):
     """
-    WebSocket endpoint for web browser clients using first-message authentication.
+    WebSocket endpoint for web browser and desktop clients using first-message authentication.
 
     First message must be: {"type": "auth", "token": "<firebase_token>"}
     Response: {"type": "auth_response", "success": true/false}
@@ -2436,6 +2438,8 @@ async def web_listen_handler(
     # Proceed with streaming (websocket already accepted, uid already validated)
     custom_stt_mode = CustomSttMode.enabled if custom_stt == 'enabled' else CustomSttMode.disabled
     onboarding_mode = onboarding == 'enabled'
+    speaker_auto_assign_enabled = speaker_auto_assign == 'enabled'
+    vad_gate_override = vad_gate if vad_gate in ('enabled', 'disabled') else None
 
     await _stream_handler(
         websocket,
@@ -2450,5 +2454,7 @@ async def web_listen_handler(
         source=source,
         custom_stt_mode=custom_stt_mode,
         onboarding_mode=onboarding_mode,
+        speaker_auto_assign_enabled=speaker_auto_assign_enabled,
+        vad_gate_override=vad_gate_override,
     )
     logger.info(f"web_listen_handler ended {uid}")

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -36,3 +36,14 @@ pytest tests/unit/test_pusher_heartbeat.py -v
 pytest tests/unit/test_desktop_updates.py -v
 pytest tests/unit/test_translation_optimization.py -v
 pytest tests/unit/test_conversation_source_unknown.py -v
+pytest tests/unit/test_auth_routes.py -v
+pytest tests/unit/test_from_segments.py -v
+pytest tests/unit/test_desktop_chat.py -v
+pytest tests/unit/test_screen_activity_sync.py -v
+pytest tests/unit/test_assistant_settings_ai_profile.py -v
+pytest tests/unit/test_focus_sessions.py -v
+pytest tests/unit/test_advice.py -v
+pytest tests/unit/test_staged_tasks.py -v
+pytest tests/unit/test_chat_generate_title.py -v
+pytest tests/unit/test_conversations_count.py -v
+pytest tests/unit/test_web_listen_params.py -v

--- a/backend/tests/unit/test_web_listen_params.py
+++ b/backend/tests/unit/test_web_listen_params.py
@@ -1,0 +1,223 @@
+"""Tests for /v4/web/listen parameter parity with /v4/listen.
+
+Verifies that speaker_auto_assign and vad_gate params are accepted
+and passed through to _stream_handler (issue #5393).
+"""
+
+import asyncio
+import inspect
+import json
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+for mod_name in [
+    'firebase_admin',
+    'firebase_admin.auth',
+    'firebase_admin.firestore',
+    'firebase_admin.messaging',
+    'google.cloud',
+    'google.cloud.exceptions',
+    'google.cloud.firestore',
+    'google.cloud.firestore_v1',
+    'google.cloud.firestore_v1.base_query',
+    'google.cloud.firestore_v1.query',
+    'google.cloud.storage',
+    'google.cloud.storage.blob',
+    'google.cloud.storage.bucket',
+    'google.auth',
+    'google.auth.transport',
+    'google.auth.transport.requests',
+    'google.oauth2',
+    'google.oauth2.service_account',
+    'pinecone',
+    'typesense',
+    'openai',
+    'langchain_openai',
+]:
+    sys.modules.setdefault(mod_name, MagicMock())
+
+from routers.transcribe import listen_handler, web_listen_handler, _stream_handler
+
+
+class TestWebListenParamParity:
+    """Ensure /v4/web/listen accepts the same params as /v4/listen."""
+
+    def _get_param_names(self, func):
+        """Extract parameter names from a function signature, excluding 'self'."""
+        sig = inspect.signature(func)
+        return {name for name in sig.parameters if name != 'self'}
+
+    def test_web_listen_has_speaker_auto_assign(self):
+        """web_listen_handler must accept speaker_auto_assign param."""
+        params = self._get_param_names(web_listen_handler)
+        assert 'speaker_auto_assign' in params
+
+    def test_web_listen_has_vad_gate(self):
+        """web_listen_handler must accept vad_gate param."""
+        params = self._get_param_names(web_listen_handler)
+        assert 'vad_gate' in params
+
+    def test_stream_handler_has_speaker_auto_assign_enabled(self):
+        """_stream_handler must accept speaker_auto_assign_enabled param."""
+        params = self._get_param_names(_stream_handler)
+        assert 'speaker_auto_assign_enabled' in params
+
+    def test_stream_handler_has_vad_gate_override(self):
+        """_stream_handler must accept vad_gate_override param."""
+        params = self._get_param_names(_stream_handler)
+        assert 'vad_gate_override' in params
+
+    def test_param_parity_between_listen_and_web_listen(self):
+        """All params in /v4/listen should also be in /v4/web/listen (except uid, stt_service)."""
+        listen_params = self._get_param_names(listen_handler)
+        web_listen_params = self._get_param_names(web_listen_handler)
+
+        # uid is handled via first-message auth in web_listen, not query param
+        # stt_service is not exposed to web clients (auto-selected)
+        expected_missing = {'uid', 'stt_service'}
+
+        missing = listen_params - web_listen_params - expected_missing
+        assert missing == set(), f"web_listen_handler is missing params: {missing}"
+
+    def test_speaker_auto_assign_default(self):
+        """speaker_auto_assign should default to 'disabled'."""
+        sig = inspect.signature(web_listen_handler)
+        default = sig.parameters['speaker_auto_assign'].default
+        assert default == 'disabled'
+
+    def test_vad_gate_default(self):
+        """vad_gate should default to empty string (auto)."""
+        sig = inspect.signature(web_listen_handler)
+        default = sig.parameters['vad_gate'].default
+        assert default == ''
+
+    def test_stream_handler_accepts_all_needed_kwargs(self):
+        """_stream_handler signature must include all kwargs that web_listen passes."""
+        stream_params = self._get_param_names(_stream_handler)
+        required_kwargs = {
+            'websocket',
+            'uid',
+            'language',
+            'sample_rate',
+            'codec',
+            'channels',
+            'include_speech_profile',
+            'stt_service',
+            'conversation_timeout',
+            'source',
+            'custom_stt_mode',
+            'onboarding_mode',
+            'speaker_auto_assign_enabled',
+            'vad_gate_override',
+        }
+        missing = required_kwargs - stream_params
+        assert missing == set(), f"_stream_handler is missing params: {missing}"
+
+
+class TestWebListenParamConversion:
+    """Test that string params are correctly converted to typed values."""
+
+    def test_speaker_auto_assign_enabled_conversion(self):
+        """'enabled' string should convert to True boolean."""
+        speaker_auto_assign = 'enabled'
+        result = speaker_auto_assign == 'enabled'
+        assert result is True
+
+    def test_speaker_auto_assign_disabled_conversion(self):
+        """'disabled' string should convert to False boolean."""
+        speaker_auto_assign = 'disabled'
+        result = speaker_auto_assign == 'enabled'
+        assert result is False
+
+    def test_vad_gate_enabled_conversion(self):
+        """'enabled' should pass through as override."""
+        vad_gate = 'enabled'
+        result = vad_gate if vad_gate in ('enabled', 'disabled') else None
+        assert result == 'enabled'
+
+    def test_vad_gate_disabled_conversion(self):
+        """'disabled' should pass through as override."""
+        vad_gate = 'disabled'
+        result = vad_gate if vad_gate in ('enabled', 'disabled') else None
+        assert result == 'disabled'
+
+    def test_vad_gate_empty_conversion(self):
+        """Empty string should convert to None (no override)."""
+        vad_gate = ''
+        result = vad_gate if vad_gate in ('enabled', 'disabled') else None
+        assert result is None
+
+    def test_vad_gate_invalid_conversion(self):
+        """Invalid value should convert to None (no override)."""
+        vad_gate = 'foobar'
+        result = vad_gate if vad_gate in ('enabled', 'disabled') else None
+        assert result is None
+
+
+class TestWebListenStreamHandlerIntegration:
+    """Integration tests: verify web_listen_handler passes correct kwargs to _stream_handler."""
+
+    @pytest.mark.asyncio
+    async def test_speaker_auto_assign_enabled_passed_to_stream_handler(self):
+        """When speaker_auto_assign=enabled, _stream_handler gets speaker_auto_assign_enabled=True."""
+        mock_ws = AsyncMock()
+        mock_ws.accept = AsyncMock()
+        # First message: auth token
+        mock_ws.receive = AsyncMock(
+            return_value={'type': 'websocket.receive', 'text': json.dumps({"type": "auth", "token": "test-token"})}
+        )
+        mock_ws.send_json = AsyncMock()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(
+                    websocket=mock_ws,
+                    speaker_auto_assign='enabled',
+                    vad_gate='enabled',
+                )
+                mock_stream.assert_called_once()
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['speaker_auto_assign_enabled'] is True
+                assert kwargs[1]['vad_gate_override'] == 'enabled'
+
+    @pytest.mark.asyncio
+    async def test_defaults_passed_to_stream_handler(self):
+        """Default params (disabled/empty) produce False/None in _stream_handler call."""
+        mock_ws = AsyncMock()
+        mock_ws.accept = AsyncMock()
+        mock_ws.receive = AsyncMock(
+            return_value={'type': 'websocket.receive', 'text': json.dumps({"type": "auth", "token": "test-token"})}
+        )
+        mock_ws.send_json = AsyncMock()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws)
+                mock_stream.assert_called_once()
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['speaker_auto_assign_enabled'] is False
+                assert kwargs[1]['vad_gate_override'] is None
+
+    @pytest.mark.asyncio
+    async def test_source_desktop_passed_through(self):
+        """source=desktop is forwarded to _stream_handler."""
+        mock_ws = AsyncMock()
+        mock_ws.accept = AsyncMock()
+        mock_ws.receive = AsyncMock(
+            return_value={'type': 'websocket.receive', 'text': json.dumps({"type": "auth", "token": "test-token"})}
+        )
+        mock_ws.send_json = AsyncMock()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, source='desktop')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['source'] == 'desktop'

--- a/backend/tests/unit/test_web_listen_params.py
+++ b/backend/tests/unit/test_web_listen_params.py
@@ -277,3 +277,25 @@ class TestWebListenBoundaryInputs:
                 await web_listen_handler(websocket=mock_ws, speaker_auto_assign='')
                 kwargs = mock_stream.call_args
                 assert kwargs[1]['speaker_auto_assign_enabled'] is False
+
+    @pytest.mark.asyncio
+    async def test_speaker_auto_assign_whitespace_treated_as_disabled(self):
+        """Whitespace-only speaker_auto_assign should produce False."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, speaker_auto_assign='  ')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['speaker_auto_assign_enabled'] is False
+
+    @pytest.mark.asyncio
+    async def test_vad_gate_explicit_empty_becomes_none(self):
+        """Explicit vad_gate='' (query param ?vad_gate=) should produce None."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, vad_gate='')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['vad_gate_override'] is None

--- a/backend/tests/unit/test_web_listen_params.py
+++ b/backend/tests/unit/test_web_listen_params.py
@@ -122,59 +122,23 @@ class TestWebListenParamParity:
         assert missing == set(), f"_stream_handler is missing params: {missing}"
 
 
-class TestWebListenParamConversion:
-    """Test that string params are correctly converted to typed values."""
-
-    def test_speaker_auto_assign_enabled_conversion(self):
-        """'enabled' string should convert to True boolean."""
-        speaker_auto_assign = 'enabled'
-        result = speaker_auto_assign == 'enabled'
-        assert result is True
-
-    def test_speaker_auto_assign_disabled_conversion(self):
-        """'disabled' string should convert to False boolean."""
-        speaker_auto_assign = 'disabled'
-        result = speaker_auto_assign == 'enabled'
-        assert result is False
-
-    def test_vad_gate_enabled_conversion(self):
-        """'enabled' should pass through as override."""
-        vad_gate = 'enabled'
-        result = vad_gate if vad_gate in ('enabled', 'disabled') else None
-        assert result == 'enabled'
-
-    def test_vad_gate_disabled_conversion(self):
-        """'disabled' should pass through as override."""
-        vad_gate = 'disabled'
-        result = vad_gate if vad_gate in ('enabled', 'disabled') else None
-        assert result == 'disabled'
-
-    def test_vad_gate_empty_conversion(self):
-        """Empty string should convert to None (no override)."""
-        vad_gate = ''
-        result = vad_gate if vad_gate in ('enabled', 'disabled') else None
-        assert result is None
-
-    def test_vad_gate_invalid_conversion(self):
-        """Invalid value should convert to None (no override)."""
-        vad_gate = 'foobar'
-        result = vad_gate if vad_gate in ('enabled', 'disabled') else None
-        assert result is None
-
-
 class TestWebListenStreamHandlerIntegration:
     """Integration tests: verify web_listen_handler passes correct kwargs to _stream_handler."""
 
-    @pytest.mark.asyncio
-    async def test_speaker_auto_assign_enabled_passed_to_stream_handler(self):
-        """When speaker_auto_assign=enabled, _stream_handler gets speaker_auto_assign_enabled=True."""
+    def _make_mock_ws(self):
+        """Create a mock WebSocket with auth message pre-configured."""
         mock_ws = AsyncMock()
         mock_ws.accept = AsyncMock()
-        # First message: auth token
         mock_ws.receive = AsyncMock(
             return_value={'type': 'websocket.receive', 'text': json.dumps({"type": "auth", "token": "test-token"})}
         )
         mock_ws.send_json = AsyncMock()
+        return mock_ws
+
+    @pytest.mark.asyncio
+    async def test_speaker_auto_assign_enabled_passed_to_stream_handler(self):
+        """When speaker_auto_assign=enabled, _stream_handler gets speaker_auto_assign_enabled=True."""
+        mock_ws = self._make_mock_ws()
 
         with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
             with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
@@ -191,12 +155,7 @@ class TestWebListenStreamHandlerIntegration:
     @pytest.mark.asyncio
     async def test_defaults_passed_to_stream_handler(self):
         """Default params (disabled/empty) produce False/None in _stream_handler call."""
-        mock_ws = AsyncMock()
-        mock_ws.accept = AsyncMock()
-        mock_ws.receive = AsyncMock(
-            return_value={'type': 'websocket.receive', 'text': json.dumps({"type": "auth", "token": "test-token"})}
-        )
-        mock_ws.send_json = AsyncMock()
+        mock_ws = self._make_mock_ws()
 
         with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
             with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
@@ -209,15 +168,112 @@ class TestWebListenStreamHandlerIntegration:
     @pytest.mark.asyncio
     async def test_source_desktop_passed_through(self):
         """source=desktop is forwarded to _stream_handler."""
-        mock_ws = AsyncMock()
-        mock_ws.accept = AsyncMock()
-        mock_ws.receive = AsyncMock(
-            return_value={'type': 'websocket.receive', 'text': json.dumps({"type": "auth", "token": "test-token"})}
-        )
-        mock_ws.send_json = AsyncMock()
+        mock_ws = self._make_mock_ws()
 
         with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
             with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
                 await web_listen_handler(websocket=mock_ws, source='desktop')
                 kwargs = mock_stream.call_args
                 assert kwargs[1]['source'] == 'desktop'
+
+    @pytest.mark.asyncio
+    async def test_vad_gate_disabled_passed_to_stream_handler(self):
+        """When vad_gate=disabled, _stream_handler gets vad_gate_override='disabled'."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, vad_gate='disabled')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['vad_gate_override'] == 'disabled'
+
+    @pytest.mark.asyncio
+    async def test_speaker_auto_assign_disabled_explicit(self):
+        """Explicit speaker_auto_assign=disabled produces False."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, speaker_auto_assign='disabled')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['speaker_auto_assign_enabled'] is False
+
+
+class TestWebListenBoundaryInputs:
+    """Boundary tests: non-canonical inputs are handled safely by the handler."""
+
+    def _make_mock_ws(self):
+        """Create a mock WebSocket with auth message pre-configured."""
+        mock_ws = AsyncMock()
+        mock_ws.accept = AsyncMock()
+        mock_ws.receive = AsyncMock(
+            return_value={'type': 'websocket.receive', 'text': json.dumps({"type": "auth", "token": "test-token"})}
+        )
+        mock_ws.send_json = AsyncMock()
+        return mock_ws
+
+    @pytest.mark.asyncio
+    async def test_speaker_auto_assign_invalid_string_treated_as_disabled(self):
+        """Non-canonical value 'foobar' for speaker_auto_assign should produce False."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, speaker_auto_assign='foobar')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['speaker_auto_assign_enabled'] is False
+
+    @pytest.mark.asyncio
+    async def test_speaker_auto_assign_uppercase_treated_as_disabled(self):
+        """Uppercase 'ENABLED' should not match — only lowercase 'enabled' is valid."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, speaker_auto_assign='ENABLED')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['speaker_auto_assign_enabled'] is False
+
+    @pytest.mark.asyncio
+    async def test_vad_gate_invalid_string_becomes_none(self):
+        """Non-canonical value 'foobar' for vad_gate should produce None."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, vad_gate='foobar')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['vad_gate_override'] is None
+
+    @pytest.mark.asyncio
+    async def test_vad_gate_uppercase_becomes_none(self):
+        """Uppercase 'ENABLED' should not match — only lowercase is valid."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, vad_gate='ENABLED')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['vad_gate_override'] is None
+
+    @pytest.mark.asyncio
+    async def test_vad_gate_whitespace_becomes_none(self):
+        """Whitespace-only vad_gate should produce None (not a valid override)."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, vad_gate='  ')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['vad_gate_override'] is None
+
+    @pytest.mark.asyncio
+    async def test_speaker_auto_assign_empty_treated_as_disabled(self):
+        """Empty string for speaker_auto_assign should produce False."""
+        mock_ws = self._make_mock_ws()
+
+        with patch('routers.transcribe.auth.get_current_user_uid_from_ws_message', return_value='uid-test'):
+            with patch('routers.transcribe._stream_handler', new_callable=AsyncMock) as mock_stream:
+                await web_listen_handler(websocket=mock_ws, speaker_auto_assign='')
+                kwargs = mock_stream.call_args
+                assert kwargs[1]['speaker_auto_assign_enabled'] is False


### PR DESCRIPTION
## Summary
- Add `speaker_auto_assign` and `vad_gate` query params to `/v4/web/listen` WebSocket handler for param parity with `/v4/listen`
- Convert string params to typed values for `_stream_handler`: `speaker_auto_assign='enabled'` → `speaker_auto_assign_enabled=True`, `vad_gate` in ('enabled','disabled') → passthrough, else `None`
- 21 unit tests: 8 param parity, 5 integration (handler → _stream_handler kwargs), 8 boundary (invalid strings, uppercase, whitespace, empty)

## Context
Issue #5393 — Desktop app bundles DEEPGRAM_API_KEY in plain text. Phase 1 routes desktop STT through backend `/v4/web/listen` instead. This PR ensures the endpoint has feature parity with `/v4/listen` so desktop clients get the same speaker assignment and VAD gate controls.

## Test plan
- [x] 21 tests in `tests/unit/test_web_listen_params.py` — all pass
- [x] Test file added to `test.sh`
- [x] `TestWebListenParamParity`: signature parity, defaults, required kwargs
- [x] `TestWebListenStreamHandlerIntegration`: enabled/disabled/default params forwarded correctly
- [x] `TestWebListenBoundaryInputs`: foobar, ENABLED, whitespace, empty string for both params
- [x] No tautological tests — all exercise real handler code path
- [x] CP7 reviewer: PR_APPROVED_LGTM
- [x] CP8 tester: TESTS_APPROVED

## Files changed
- `backend/routers/transcribe.py` — 2 params added to `web_listen_handler`, conversion + passthrough to `_stream_handler`
- `backend/tests/unit/test_web_listen_params.py` — NEW, 21 tests
- `backend/test.sh` — added test entry

## Review cycle changes
- Round 1: Replaced 6 tautological conversion tests with integration tests exercising real handler
- Round 2: Added whitespace boundary test for speaker_auto_assign, explicit vad_gate='' test

Closes #5393 (backend portion — desktop Swift PR from @ren pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_