### PR TITLE
Fix Apple Watch app not appearing on iPhone

### DIFF
--- a/app/ios/Runner.xcodeproj/project.pbxproj
+++ b/app/ios/Runner.xcodeproj/project.pbxproj
@@ -59,10 +59,11 @@
 		};
 		422906722E75A21E00F49E67 /* Embed Watch Content */ = {
 			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 8;
+			buildActionMask = 2147483647;
 			dstPath = "$(CONTENTS_FOLDER_PATH)/Watch";
 			dstSubfolderSpec = 16;
 			files = (
+				42A7BA3E2E788BD400138969 /* omiWatchApp.app in Embed Watch Content */,
 			);
 			name = "Embed Watch Content";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -311,6 +312,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				42A7BA3D2E788BD400138969 /* PBXTargetDependency */,
 			);
 			name = Runner;
 			productName = Runner;


### PR DESCRIPTION
## Summary
- Re-enabled the Apple Watch app embedding in the iOS build by fixing three issues in the Xcode project:
  - Added `omiWatchApp.app` back to the **Embed Watch Content** build phase (was empty)
  - Added `omiWatchApp` as a **target dependency** on the Runner target (was missing, so the watch app was never built)
  - Changed `buildActionMask` from `8` (install builds only) to `2147483647` (all builds) so the embed phase runs during debug builds

## Test plan
- [x] Build and install the app on a physical iPhone
- [x] Open the Watch app on the iPhone and verify omi appears as an available app
- [x] Install the watch app and verify it launches on Apple Watch
- [ ] Verify simulator builds still work (watch app is excluded via `EXCLUDED_SOURCE_FILE_NAMES`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)