### PR TITLE
Fix duplicate ios-prod-testflight key in codemagic.yaml

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -543,6 +543,9 @@ workflows:
           - Internal
           - Discord Folks
         submit_to_app_store: false
+
+  macos-prod-appstore:
+    name: Release macOS to App Store
     instance_type: mac_mini_m2
     max_build_duration: 120
     integrations:


### PR DESCRIPTION
## Summary
- The macOS App Store workflow was accidentally defined under the same `ios-prod-testflight` YAML key as the actual iOS TestFlight workflow
- In YAML, duplicate keys cause the last definition to win, so triggering "Release iOS to Testflight" in Codemagic would run the macOS workflow instead
- This caused the build to fail with: `cp: macos/Config/Prod/GoogleService-Info.plist: No such file or directory` because the macOS Firebase config step has no relevance to an iOS build
- Fixed by renaming the macOS workflow to its own unique key `macos-prod-appstore`

## Test plan
- [ ] Trigger "Release iOS to Testflight" workflow in Codemagic and verify it runs the correct iOS workflow (uses `--platforms="android,ios"`, not `--platforms="macos"`)
- [ ] Verify the new `macos-prod-appstore` workflow appears separately in Codemagic
- [ ] Validate YAML syntax is correct (verified locally with `python3 -c "import yaml; yaml.safe_load(...)"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)