### PR TITLE
Bump build number to 763 for TestFlight deploy

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.525+762
+version: 1.0.525+763
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Build 762 was already uploaded to App Store Connect — Apple silently rejects duplicate build numbers, causing the TestFlight deploy to no-op. Bumping to 763 to unblock the deploy.