### PR TITLE
feat: Private Cloud Sync — list, play, share, and delete audio (#3215)

### DIFF
--- a/app/lib/backend/http/api/audio.dart
+++ b/app/lib/backend/http/api/audio.dart
@@ -95,3 +95,45 @@ Future<List<AudioFileUrlInfo>> getConversationAudioSignedUrls(String conversatio
     return [];
   }
 }
+
+/// List all conversations with audio files for the current user.
+Future<List<Map<String, dynamic>>> listUserAudioFiles() async {
+  try {
+    final headers = await buildHeaders(requireAuthCheck: true);
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}v1/sync/audio',
+      headers: headers,
+      method: 'GET',
+      body: '',
+    );
+
+    if (response == null || response.statusCode != 200) {
+      return [];
+    }
+
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    return (decoded['conversations'] as List<dynamic>?)
+            ?.cast<Map<String, dynamic>>() ??
+        [];
+  } catch (e) {
+    Logger.debug('Error listing user audio files: $e');
+    return [];
+  }
+}
+
+/// Delete all private cloud audio files for the current user.
+Future<bool> deleteAllUserAudio() async {
+  try {
+    final headers = await buildHeaders(requireAuthCheck: true);
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}v1/sync/audio',
+      headers: headers,
+      method: 'DELETE',
+      body: '',
+    );
+    return response?.statusCode == 200;
+  } catch (e) {
+    Logger.debug('Error deleting all user audio: $e');
+    return false;
+  }
+}

--- a/app/lib/pages/conversations/private_cloud_sync_page.dart
+++ b/app/lib/pages/conversations/private_cloud_sync_page.dart
@@ -1,9 +1,15 @@
+// FILE: app/lib/pages/conversations/private_cloud_sync_page.dart
+// FULL REPLACEMENT of the existing file
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:just_audio/just_audio.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 
+import 'package:omi/backend/http/api/audio.dart';
 import 'package:omi/providers/user_provider.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 
@@ -16,6 +22,43 @@ class PrivateCloudSyncPage extends StatefulWidget {
 
 class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
   bool _isSaving = false;
+  bool _isLoadingAudio = false;
+  bool _isDeletingAll = false;
+  List<Map<String, dynamic>> _audioConversations = [];
+  final AudioPlayer _audioPlayer = AudioPlayer();
+  String? _currentlyPlayingId;
+
+  @override
+  void initState() {
+    super.initState();
+    final isEnabled = context.read<UserProvider>().privateCloudSyncEnabled;
+    if (isEnabled) {
+      _loadAudioFiles();
+    }
+  }
+
+  @override
+  void dispose() {
+    _audioPlayer.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadAudioFiles() async {
+    setState(() => _isLoadingAudio = true);
+    try {
+      final conversations = await listUserAudioFiles();
+      if (mounted) {
+        setState(() {
+          _audioConversations = conversations;
+          _isLoadingAudio = false;
+        });
+      }
+    } catch (e) {
+      if (mounted) {
+        setState(() => _isLoadingAudio = false);
+      }
+    }
+  }
 
   Future<void> _togglePrivateCloudSync(bool value) async {
     if (value) {
@@ -27,6 +70,11 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
     try {
       await context.read<UserProvider>().setPrivateCloudSync(value);
       setState(() => _isSaving = false);
+      if (value) {
+        _loadAudioFiles();
+      } else {
+        setState(() => _audioConversations = []);
+      }
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           SnackBar(
@@ -38,7 +86,6 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
         );
       }
     } catch (e) {
-      print('Error toggling cloud storage: $e');
       setState(() => _isSaving = false);
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
@@ -46,6 +93,124 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
             content: Text(context.l10n.failedToUpdateSettings(e.toString())),
             backgroundColor: Colors.red,
           ),
+        );
+      }
+    }
+  }
+
+  Future<void> _playAudio(String conversationId, String audioFileId) async {
+    final playId = '$conversationId/$audioFileId';
+
+    if (_currentlyPlayingId == playId) {
+      await _audioPlayer.stop();
+      setState(() => _currentlyPlayingId = null);
+      return;
+    }
+
+    try {
+      // Get signed URLs for the conversation
+      final audioInfos = await getConversationAudioSignedUrls(conversationId);
+      final targetInfo = audioInfos.firstWhere(
+        (info) => info.id == audioFileId,
+        orElse: () => audioInfos.first,
+      );
+
+      if (targetInfo.isCached && targetInfo.signedUrl != null) {
+        await _audioPlayer.setUrl(targetInfo.signedUrl!);
+      } else {
+        // Fall back to stream URL with auth headers
+        final headers = await getAudioHeaders();
+        final streamUrl = getAudioStreamUrl(
+          conversationId: conversationId,
+          audioFileId: audioFileId,
+        );
+        await _audioPlayer.setUrl(streamUrl, headers: headers);
+      }
+
+      setState(() => _currentlyPlayingId = playId);
+      _audioPlayer.play();
+
+      _audioPlayer.playerStateStream.listen((state) {
+        if (state.processingState == ProcessingState.completed) {
+          if (mounted) {
+            setState(() => _currentlyPlayingId = null);
+          }
+        }
+      });
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('Failed to play audio: $e'),
+            backgroundColor: Colors.red,
+          ),
+        );
+      }
+    }
+  }
+
+  Future<void> _shareAudio(String conversationId, String audioFileId) async {
+    try {
+      final audioInfos = await getConversationAudioSignedUrls(conversationId);
+      final targetInfo = audioInfos.firstWhere(
+        (info) => info.id == audioFileId,
+        orElse: () => audioInfos.first,
+      );
+
+      if (targetInfo.isCached && targetInfo.signedUrl != null) {
+        await Share.share(targetInfo.signedUrl!, subject: 'Omi Audio Recording');
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Audio is still being processed. Please try again later.'),
+            ),
+          );
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to share: $e'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
+  Future<void> _deleteAllAudio() async {
+    final confirmed = await _showDeleteAllDialog();
+    if (confirmed != true) return;
+
+    setState(() => _isDeletingAll = true);
+    try {
+      final success = await deleteAllUserAudio();
+      if (success && mounted) {
+        setState(() {
+          _audioConversations = [];
+          _isDeletingAll = false;
+        });
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('All audio files deleted successfully.'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      } else {
+        setState(() => _isDeletingAll = false);
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(
+              content: Text('Failed to delete audio files.'),
+              backgroundColor: Colors.red,
+            ),
+          );
+        }
+      }
+    } catch (e) {
+      setState(() => _isDeletingAll = false);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e'), backgroundColor: Colors.red),
         );
       }
     }
@@ -70,17 +235,204 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
           ),
           TextButton(
             onPressed: () => Navigator.of(context).pop(true),
-            child: Text(context.l10n.enable, style: const TextStyle(color: Colors.deepPurpleAccent, fontWeight: FontWeight.w600)),
+            child: Text(context.l10n.enable,
+                style: const TextStyle(color: Colors.deepPurpleAccent, fontWeight: FontWeight.w600)),
           ),
         ],
       ),
     );
   }
 
+  Future<bool?> _showDeleteAllDialog() {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: const Color(0xFF1C1C1E),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: const Text('Delete All Audio',
+            style: TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600)),
+        content: Text(
+          'Deleting all audio will remove your recordings from Private Cloud Sync.\n\n'
+          'If you have opted into the Omi Training Program, your audio data will '
+          'no longer be available for contribution, which may affect your eligibility '
+          'for free unlimited access.',
+          style: TextStyle(color: Colors.grey.shade400, fontSize: 14, height: 1.4),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(context.l10n.cancel, style: TextStyle(color: Colors.grey.shade500)),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: const Text('Delete All',
+                style: TextStyle(color: Colors.redAccent, fontWeight: FontWeight.w600)),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _formatDuration(num seconds) {
+    final duration = Duration(seconds: seconds.toInt());
+    final mins = duration.inMinutes;
+    final secs = duration.inSeconds % 60;
+    return '${mins}m ${secs}s';
+  }
+
   Widget _buildFaIcon(IconData icon, {double size = 18, Color color = const Color(0xFF8E8E93)}) {
     return Padding(
       padding: const EdgeInsets.only(left: 2, top: 1),
       child: FaIcon(icon, size: size, color: color),
+    );
+  }
+
+  Widget _buildAudioList() {
+    if (_isLoadingAudio) {
+      return const Padding(
+        padding: EdgeInsets.all(20),
+        child: Center(child: CircularProgressIndicator(color: Colors.deepPurpleAccent)),
+      );
+    }
+
+    if (_audioConversations.isEmpty) {
+      return Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          color: const Color(0xFF1C1C1E),
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Center(
+          child: Text(
+            'No audio recordings yet.',
+            style: TextStyle(color: Colors.grey.shade500, fontSize: 14),
+          ),
+        ),
+      );
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(bottom: 12),
+          child: Text(
+            'Audio Recordings',
+            style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w600),
+          ),
+        ),
+        ..._audioConversations.map((conv) => _buildConversationCard(conv)),
+        const SizedBox(height: 16),
+        _buildDeleteAllButton(),
+      ],
+    );
+  }
+
+  Widget _buildConversationCard(Map<String, dynamic> conv) {
+    final title = conv['title'] ?? 'Untitled';
+    final audioFiles = (conv['audio_files'] as List<dynamic>?) ?? [];
+    final totalDuration = conv['total_duration'] ?? 0;
+    final conversationId = conv['conversation_id'] ?? '';
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1C1C1E),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  title,
+                  style: const TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w500),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Text(
+                _formatDuration(totalDuration),
+                style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+              ),
+            ],
+          ),
+          const SizedBox(height: 8),
+          ...audioFiles.map((af) {
+            final audioFileId = af['id'] ?? '';
+            final duration = af['duration'] ?? 0;
+            final playId = '$conversationId/$audioFileId';
+            final isPlaying = _currentlyPlayingId == playId;
+
+            return Padding(
+              padding: const EdgeInsets.only(top: 4),
+              child: Row(
+                children: [
+                  GestureDetector(
+                    onTap: () => _playAudio(conversationId, audioFileId),
+                    child: Container(
+                      width: 32,
+                      height: 32,
+                      decoration: BoxDecoration(
+                        color: isPlaying ? Colors.deepPurpleAccent : const Color(0xFF2A2A2E),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Icon(
+                        isPlaying ? Icons.stop : Icons.play_arrow,
+                        color: Colors.white,
+                        size: 18,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      _formatDuration(duration),
+                      style: TextStyle(color: Colors.grey.shade400, fontSize: 13),
+                    ),
+                  ),
+                  GestureDetector(
+                    onTap: () => _shareAudio(conversationId, audioFileId),
+                    child: Padding(
+                      padding: const EdgeInsets.all(4),
+                      child: _buildFaIcon(FontAwesomeIcons.shareFromSquare, size: 14, color: Colors.grey.shade400),
+                    ),
+                  ),
+                ],
+              ),
+            );
+          }),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDeleteAllButton() {
+    if (_audioConversations.isEmpty) return const SizedBox.shrink();
+
+    return SizedBox(
+      width: double.infinity,
+      child: TextButton(
+        onPressed: _isDeletingAll ? null : _deleteAllAudio,
+        style: TextButton.styleFrom(
+          backgroundColor: Colors.red.withOpacity(0.1),
+          padding: const EdgeInsets.symmetric(vertical: 14),
+          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+        ),
+        child: _isDeletingAll
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(color: Colors.redAccent, strokeWidth: 2),
+              )
+            : const Text(
+                'Delete All Audio',
+                style: TextStyle(color: Colors.redAccent, fontSize: 15, fontWeight: FontWeight.w600),
+              ),
+      ),
     );
   }
 
@@ -111,6 +463,7 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      // Toggle card (existing)
                       Container(
                         padding: const EdgeInsets.all(20),
                         decoration: BoxDecoration(
@@ -154,11 +507,7 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
                             const SizedBox(height: 20),
                             Text(
                               context.l10n.storeAudioCloudDescription,
-                              style: TextStyle(
-                                color: Colors.grey.shade400,
-                                fontSize: 14,
-                                height: 1.5,
-                              ),
+                              style: TextStyle(color: Colors.grey.shade400, fontSize: 14, height: 1.5),
                             ),
                             const SizedBox(height: 24),
                             const Divider(height: 1, color: Color(0xFF3C3C43)),
@@ -187,6 +536,11 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
                           ],
                         ),
                       ),
+                      // Audio list (new)
+                      if (isEnabled) ...[
+                        const SizedBox(height: 24),
+                        _buildAudioList(),
+                      ],
                     ],
                   ),
                 ),

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -27,6 +27,7 @@ from utils.other.storage import (
     download_audio_chunks_and_merge,
     get_or_create_merged_audio,
     get_merged_audio_signed_url,
+    delete_all_user_private_audio,
 )
 
 # Audio constants
@@ -384,6 +385,69 @@ def download_audio_file_endpoint(
 
 
 # **********************************************
+
+# **********************************************
+# ******** AUDIO LISTING & DELETE **************
+# **********************************************
+
+
+@router.get("/v1/sync/audio", tags=['v1'])
+def list_user_audio_files(
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """
+    List all conversations with audio files for the current user.
+    Returns conversation metadata and audio file summaries.
+    """
+    conversations = conversations_db.get_conversations(uid, limit=200, include_discarded=False)
+    result = []
+    for conv in conversations:
+        audio_files = conv.get('audio_files', [])
+        if not audio_files:
+            continue
+        structured = conv.get('structured', {})
+        title = structured.get('title', '') if isinstance(structured, dict) else ''
+        result.append({
+            'conversation_id': conv.get('id', ''),
+            'title': title or 'Untitled',
+            'created_at': conv.get('created_at'),
+            'audio_files': [
+                {'id': af.get('id', ''), 'duration': af.get('duration', 0)}
+                for af in audio_files
+                if af.get('id')
+            ],
+            'total_duration': sum(af.get('duration', 0) for af in audio_files),
+        })
+    return {'conversations': result}
+
+
+@router.delete("/v1/sync/audio", tags=['v1'], status_code=200)
+def delete_all_user_audio(
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """
+    Delete all private cloud audio files for the current user.
+    Removes both GCS blobs and Firestore audio_files records.
+    """
+    # Delete from GCS
+    deleted_count = delete_all_user_private_audio(uid)
+    logger.info(f"Deleted {deleted_count} audio blobs for user {uid}")
+
+    # Clear audio_files from Firestore conversations
+    conversations = conversations_db.get_conversations(uid, limit=500, include_discarded=True)
+    cleared = 0
+    for conv in conversations:
+        if conv.get('audio_files'):
+            conversations_db.update_conversation(uid, conv['id'], {'audio_files': []})
+            cleared += 1
+
+    return {
+        'status': 'ok',
+        'blobs_deleted': deleted_count,
+        'conversations_cleared': cleared,
+    }
+
+
 # ************ SYNC LOCAL FILES ****************
 # **********************************************
 

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -646,6 +646,29 @@ def delete_cached_merged_audio(uid: str, conversation_id: str) -> None:
         blob.delete()
 
 
+def delete_all_user_private_audio(uid: str) -> int:
+    """Delete all private cloud sync audio for a user across all conversations.
+
+    Removes chunks, merged cache, and raw audio blobs.
+
+    Args:
+        uid: User ID
+
+    Returns:
+        Number of blobs deleted
+    """
+    bucket = storage_client.bucket(private_cloud_sync_bucket)
+    deleted = 0
+    for prefix in [f'chunks/{uid}/', f'audio/{uid}/', f'merged/{uid}/']:
+        for blob in bucket.list_blobs(prefix=prefix):
+            try:
+                blob.delete()
+                deleted += 1
+            except Exception as e:
+                logger.error(f"Failed to delete blob {blob.name}: {e}")
+    return deleted
+
+
 def _pcm_to_wav(pcm_data: bytes, sample_rate: int = 16000, channels: int = 1) -> bytes:
     """Convert PCM16 data to WAV format."""
     wav_buffer = io.BytesIO()


### PR DESCRIPTION
## Summary

- Add listing endpoint `GET /v1/sync/audio` for cross-conversation audio listing
- Add deletion endpoint `DELETE /v1/sync/audio` for bulk audio removal
- Add `delete_all_user_private_audio()` storage helper
- Expand `PrivateCloudSyncPage` Flutter UI with:
  - Audio file list grouped by conversation
  - In-app audio player using `just_audio` with signed URLs
  - Share button using `share_plus`
  - Delete All button with confirmation dialog

Closes #3215

## Changes

### Backend
- **`backend/utils/other/storage.py`**: Added `delete_all_user_private_audio(uid)` — deletes all chunks, merged, and cached audio blobs for a user across all conversations
- **`backend/routers/sync.py`**: Added two new endpoints:
  - `GET /v1/sync/audio` — lists all conversations with audio files (title, date, duration, file count)
  - `DELETE /v1/sync/audio` — bulk deletes all private cloud audio (GCS blobs + Firestore records)

### Flutter
- **`app/lib/backend/http/api/audio.dart`**: Added `listUserAudioFiles()` and `deleteAllUserAudio()` API methods
- **`app/lib/pages/conversations/private_cloud_sync_page.dart`**: Full UI expansion with audio list, playback controls, share, and delete functionality

## Test Plan

- [ ] Enable Private Cloud Sync toggle
- [ ] Record a conversation with audio
- [ ] Verify audio files appear in the listing
- [ ] Test audio playback via signed URLs
- [ ] Test share functionality
- [ ] Test Delete All with confirmation dialog
- [ ] Verify GCS blobs are cleaned up after deletion