### PR TITLE
Fix desktop auto-release on protected main

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -9,6 +9,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   tag-release:
@@ -86,11 +87,36 @@ jobs:
           git add desktop/CHANGELOG.json
           git commit -m "chore: consolidate changelog for v${VERSION}" || echo "No changelog changes to commit"
 
-          # Push changelog commit directly to main.
-          # This commit only touches desktop/CHANGELOG.json and won't retrigger this workflow due path filters.
-          git push origin HEAD:main
-
-          # Tag the commit that includes the consolidated changelog.
-          # NOTE: commit message must NOT contain [skip ci] — Codemagic uses this tag to trigger builds.
+          # Tag the changelog commit first; Codemagic uses this tag to trigger builds.
+          # NOTE: commit message must NOT contain [skip ci].
           git tag "$RELEASE_TAG"
           git push origin "$RELEASE_TAG"
+
+      - name: Create and auto-merge PR to sync changelog back to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          BRANCH="changelog/v${VERSION}"
+
+          git checkout -B "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
+
+          PR_NUMBER=$(gh pr list \
+            --head "$BRANCH" \
+            --base main \
+            --state open \
+            --json number \
+            --jq '.[0].number')
+
+          if [ -z "$PR_NUMBER" ]; then
+            PR_URL=$(gh pr create \
+              --title "Update CHANGELOG.json for v${VERSION} [skip ci]" \
+              --body "Auto-generated: consolidates unreleased entries into v${VERSION} and clears the unreleased array." \
+              --base main \
+              --head "$BRANCH")
+            PR_NUMBER=$(echo "$PR_URL" | awk -F/ '{print $NF}')
+          fi
+
+          # Prefer auto-merge when branch protection requires checks/reviews; fallback to immediate merge.
+          gh pr merge "$PR_NUMBER" --merge --auto || gh pr merge "$PR_NUMBER" --merge


### PR DESCRIPTION
Restores PR-based changelog sync and enables auto-merge flow so protected main does not block release tagging.