### PR TITLE
chore(desktop): trigger auto-release verification

### DIFF
--- a/desktop/.auto-release-trigger
+++ b/desktop/.auto-release-trigger
@@ -1,1 +1,2 @@
 Auto-release trigger after workflow fix (2026-03-07T23:07:04Z)
+trigger-2 2026-03-07T23:09:26Z


### PR DESCRIPTION
Second trigger after workflow merge-fallback fix; used to verify successful end-to-end release automation.