### PR TITLE
Use PAT token to auto-merge desktop changelog PRs

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -94,8 +94,13 @@ jobs:
 
       - name: Create and auto-merge PR to sync changelog back to main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "PAT_TOKEN is not configured; cannot auto-merge changelog PR."
+            exit 1
+          fi
+
           VERSION="${{ steps.version.outputs.version }}"
           BRANCH="changelog/v${VERSION}"
 


### PR DESCRIPTION
Use PAT_TOKEN for gh CLI auth in desktop_auto_release changelog sync step so admin merge can bypass review requirements.