### PR TITLE
Update Discord links to discord.omi.me

### DIFF
--- a/docs/doc/developer/apps/Submitting.mdx
+++ b/docs/doc/developer/apps/Submitting.mdx
@@ -204,7 +204,7 @@ Apps that violate these guidelines will be rejected or removed from the store.
     Keep your app current with new features and improvements
   </Step>
   <Step title="Join the Community" icon="discord">
-    Connect with other developers in the [Omi Discord](https://discord.gg/omi) for support and collaboration
+    Connect with other developers in the [Omi Discord](http://discord.omi.me) for support and collaboration
   </Step>
 </Steps>
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -140,7 +140,7 @@
   "footer": {
     "socials": {
       "github": "https://github.com/BasedHardware/omi",
-      "discord": "https://discord.com/invite/omi",
+      "discord": "http://discord.omi.me",
       "x": "https://x.com/omedotme",
       "linkedin": "https://www.linkedin.com/company/omi-ai/",
       "instagram": "https://www.instagram.com/based_hardware/"

--- a/web/app/src/components/layout/Sidebar.tsx
+++ b/web/app/src/components/layout/Sidebar.tsx
@@ -463,7 +463,7 @@ export function Sidebar({
             {showText && <span className="text-sm">Feedback</span>}
           </a>
           <a
-            href="https://discord.gg/omidotme"
+            href="http://discord.omi.me"
             target="_blank"
             rel="noopener noreferrer"
             title={!showText ? 'Discord' : undefined}

--- a/web/app/src/components/ui/BetaRibbon.tsx
+++ b/web/app/src/components/ui/BetaRibbon.tsx
@@ -39,7 +39,7 @@ export function BetaRibbon() {
           <span>Feedback</span>
         </a>
         <a
-          href="https://discord.gg/omidotme"
+          href="http://discord.omi.me"
           target="_blank"
           rel="noopener noreferrer"
           className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-bg-tertiary/80 backdrop-blur-sm text-text-tertiary hover:text-purple-primary hover:bg-bg-tertiary transition-colors text-xs"

--- a/web/app/src/components/ui/BetaWelcomeModal.tsx
+++ b/web/app/src/components/ui/BetaWelcomeModal.tsx
@@ -160,7 +160,7 @@ export function BetaWelcomeModal() {
                     <span>feedback.omi.me</span>
                   </a>
                   <a
-                    href="https://discord.gg/omidotme"
+                    href="http://discord.omi.me"
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-1.5 text-sm text-text-tertiary hover:text-purple-primary transition-colors"


### PR DESCRIPTION
## Summary
- Standardize all Discord links to use `discord.omi.me` instead of various `discord.gg` and `discord.com/invite` URLs
- Updated in docs footer, app submission guide, web app sidebar, beta ribbon, and beta welcome modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)