### PR TITLE
fix(desktop): honor clear_due_at when cleaning task deadlines

### DIFF
--- a/desktop/Backend-Rust/src/models/action_item.rs
+++ b/desktop/Backend-Rust/src/models/action_item.rs
@@ -84,6 +84,9 @@ pub struct UpdateActionItemRequest {
     pub description: Option<String>,
     /// New due date
     pub due_at: Option<DateTime<Utc>>,
+    /// Explicitly clear due date (required because due_at=null and missing are both None in Rust)
+    #[serde(default)]
+    pub clear_due_at: Option<bool>,
     /// New priority: "high", "medium", "low"
     pub priority: Option<String>,
     /// New category: "work", "personal", "health", etc.

--- a/desktop/Backend-Rust/src/routes/action_items.rs
+++ b/desktop/Backend-Rust/src/routes/action_items.rs
@@ -180,6 +180,7 @@ async fn update_action_item(
             request.completed,
             request.description.as_deref(),
             request.due_at,
+            request.clear_due_at.unwrap_or(false),
             request.priority.as_deref(),
             request.category.as_deref(),
             request.goal_id.as_deref(),

--- a/desktop/Backend-Rust/src/routes/staged_tasks.rs
+++ b/desktop/Backend-Rust/src/routes/staged_tasks.rs
@@ -431,6 +431,7 @@ async fn migrate_ai_tasks(
                     None,
                     Some(&prefixed),
                     None,
+                    false,
                     None,
                     None,
                     None,

--- a/desktop/Backend-Rust/src/services/firestore.rs
+++ b/desktop/Backend-Rust/src/services/firestore.rs
@@ -2165,6 +2165,7 @@ impl FirestoreService {
         completed: Option<bool>,
         description: Option<&str>,
         due_at: Option<DateTime<Utc>>,
+        clear_due_at: bool,
         priority: Option<&str>,
         category: Option<&str>,
         goal_id: Option<&str>,
@@ -2198,7 +2199,10 @@ impl FirestoreService {
             fields["description"] = json!({"stringValue": d});
         }
 
-        if let Some(due) = due_at {
+        if clear_due_at {
+            field_paths.push("due_at");
+            fields["due_at"] = json!({"nullValue": null});
+        } else if let Some(due) = due_at {
             field_paths.push("due_at");
             fields["due_at"] = json!({"timestampValue": due.to_rfc3339()});
         }

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -1551,6 +1551,7 @@ extension APIClient {
             let description: String?
             let dueAt: String?
             let includeDueAt: Bool
+            let clearDueAt: Bool
             let priority: String?
             let metadata: String?
             let goalId: String?
@@ -1560,6 +1561,7 @@ extension APIClient {
             enum CodingKeys: String, CodingKey {
                 case completed, description, priority, metadata
                 case dueAt = "due_at"
+                case clearDueAt = "clear_due_at"
                 case goalId = "goal_id"
                 case relevanceScore = "relevance_score"
                 case recurrenceRule = "recurrence_rule"
@@ -1575,6 +1577,9 @@ extension APIClient {
                     } else {
                         try container.encodeNil(forKey: .dueAt)
                     }
+                }
+                if clearDueAt {
+                    try container.encode(true, forKey: .clearDueAt)
                 }
                 try container.encodeIfPresent(priority, forKey: .priority)
                 try container.encodeIfPresent(metadata, forKey: .metadata)
@@ -1600,6 +1605,7 @@ extension APIClient {
             description: description,
             dueAt: dueAt.map { formatter.string(from: $0) },
             includeDueAt: clearDueAt || dueAt != nil,
+            clearDueAt: clearDueAt,
             priority: priority,
             metadata: metadataString,
             goalId: goalId,


### PR DESCRIPTION
Root cause: Rust backend couldn't distinguish due_at omitted vs due_at null, so clean-today optimistic UI updates were reverted on refresh.\n\nThis adds explicit clear_due_at handling across Desktop APIClient + Rust backend update path, and clears due_at in Firestore when requested.