### PR TITLE
macOS: add Delete Account & Data flow + backend endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,11 @@ These rules apply to Codex when working in this repository.
 
 - Install pre-commit hook: `ln -s -f ../../scripts/pre-commit .git/hooks/pre-commit`
 
+## Safety Rules
+
+- Never kill, stop, or restart the production macOS app (`/Applications/omi.app`, bundle id `com.omi.computer-macos`) during local development or testing.
+- Development scripts/commands must target only dev app processes (for example `Omi Dev.app` / `com.omi.desktop-dev`), never production.
+
 ## Coding Guidelines
 
 ### Backend

--- a/desktop/Backend-Rust/src/routes/users.rs
+++ b/desktop/Backend-Rust/src/routes/users.rs
@@ -4,10 +4,11 @@
 use axum::{
     extract::{Query, State},
     http::StatusCode,
-    routing::get,
+    routing::{delete, get},
     Json, Router,
 };
 use serde::Deserialize;
+use std::collections::HashSet;
 
 use crate::auth::AuthUser;
 use crate::models::{
@@ -17,6 +18,7 @@ use crate::models::{
     UpdateTranscriptionPreferencesRequest, UpdateUserProfileRequest, UserLanguage, UserProfile,
     UserSettingsStatusResponse, AssistantSettingsData,
 };
+use crate::services::firestore::{LLM_USAGE_SUBCOLLECTION, SCREEN_ACTIVITY_SUBCOLLECTION};
 use crate::AppState;
 
 // ============================================================================
@@ -554,6 +556,302 @@ async fn update_assistant_settings(
 }
 
 // ============================================================================
+// Account Deletion
+// ============================================================================
+
+/// DELETE /v1/users/delete-account
+/// Deletes all server-side data for the authenticated user and then deletes Firebase Auth account.
+async fn delete_account(
+    State(state): State<AppState>,
+    user: AuthUser,
+) -> Result<Json<UserSettingsStatusResponse>, StatusCode> {
+    tracing::info!("Deleting account and all data for user {}", user.uid);
+
+    // Conversations
+    let conversations = state
+        .firestore
+        .get_conversations(&user.uid, 5000, 0, true, &[], None, None, None, None)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list conversations during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    for conversation in conversations {
+        state
+            .firestore
+            .delete_conversation(&user.uid, &conversation.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete conversation {}: {}", conversation.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Action items
+    let action_items = state
+        .firestore
+        .get_action_items(
+            &user.uid, 5000, 0, None, None, None, None, None, None, None, Some(true),
+        )
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list action items during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    for item in action_items {
+        state
+            .firestore
+            .delete_action_item(&user.uid, &item.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete action item {}: {}", item.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Staged tasks
+    let staged_tasks = state
+        .firestore
+        .get_staged_tasks(&user.uid, 5000, 0)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list staged tasks during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    for task in staged_tasks {
+        state
+            .firestore
+            .delete_staged_task(&user.uid, &task.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete staged task {}: {}", task.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Memories
+    state
+        .firestore
+        .delete_all_memories(&user.uid)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete all memories during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Focus sessions
+    let focus_sessions = state
+        .firestore
+        .get_focus_sessions(&user.uid, 5000, 0, None)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list focus sessions during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    for session in focus_sessions {
+        state
+            .firestore
+            .delete_focus_session(&user.uid, &session.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete focus session {}: {}", session.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Advice
+    let advice_items = state
+        .firestore
+        .get_advice(&user.uid, 5000, 0, None, true)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list advice during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    for advice in advice_items {
+        state
+            .firestore
+            .delete_advice(&user.uid, &advice.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete advice {}: {}", advice.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Messages
+    state
+        .firestore
+        .delete_messages(&user.uid, None)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete messages during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Chat sessions
+    let chat_sessions = state
+        .firestore
+        .get_chat_sessions(&user.uid, None, 5000, 0, None)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list chat sessions during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    for session in chat_sessions {
+        state
+            .firestore
+            .delete_chat_session(&user.uid, &session.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete chat session {}: {}", session.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Folders
+    let folders = state.firestore.get_folders(&user.uid).await.map_err(|e| {
+        tracing::error!("Failed to list folders during delete-account: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    for folder in folders {
+        state
+            .firestore
+            .delete_folder(&user.uid, &folder.id, None)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete folder {}: {}", folder.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Goals (active + completed)
+    let mut goal_ids = HashSet::new();
+    let active_goals = state.firestore.get_user_goals(&user.uid, 5000).await.map_err(|e| {
+        tracing::error!("Failed to list active goals during delete-account: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    let completed_goals = state
+        .firestore
+        .get_completed_goals(&user.uid, 5000)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to list completed goals during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    for goal in active_goals {
+        goal_ids.insert(goal.id);
+    }
+    for goal in completed_goals {
+        goal_ids.insert(goal.id);
+    }
+    for goal_id in goal_ids {
+        state
+            .firestore
+            .delete_goal(&user.uid, &goal_id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete goal {}: {}", goal_id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // People
+    let people = state.firestore.get_people(&user.uid).await.map_err(|e| {
+        tracing::error!("Failed to list people during delete-account: {}", e);
+        StatusCode::INTERNAL_SERVER_ERROR
+    })?;
+    for person in people {
+        state
+            .firestore
+            .delete_person(&user.uid, &person.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete person {}: {}", person.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Persona
+    if let Some(persona) = state
+        .firestore
+        .get_user_persona(&user.uid)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to get user persona during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?
+    {
+        state
+            .firestore
+            .delete_persona(&persona.id)
+            .await
+            .map_err(|e| {
+                tracing::error!("Failed to delete persona {}: {}", persona.id, e);
+                StatusCode::INTERNAL_SERVER_ERROR
+            })?;
+    }
+
+    // Knowledge graph
+    state
+        .firestore
+        .delete_kg_data(&user.uid)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete knowledge graph during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Subcollections not otherwise covered
+    state
+        .firestore
+        .delete_all_documents_in_subcollection(&user.uid, SCREEN_ACTIVITY_SUBCOLLECTION)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete screen activity during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    state
+        .firestore
+        .delete_all_documents_in_subcollection(&user.uid, LLM_USAGE_SUBCOLLECTION)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete llm usage during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Delete root users/{uid} document after subcollections are purged
+    state
+        .firestore
+        .delete_user_root_document(&user.uid)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete root user document during delete-account: {}", e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    // Delete Firebase Auth account via admin API (service account OAuth).
+    let project_id = state
+        .config
+        .firebase_project_id
+        .clone()
+        .unwrap_or_else(|| "based-hardware".to_string());
+    state
+        .firestore
+        .delete_firebase_auth_user(&project_id, &user.uid)
+        .await
+        .map_err(|e| {
+            tracing::error!("Failed to delete Firebase Auth account for {}: {}", user.uid, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    tracing::info!("Account deletion completed for user {}", user.uid);
+    Ok(Json(UserSettingsStatusResponse {
+        status: "ok".to_string(),
+    }))
+}
+
+// ============================================================================
 // Router
 // ============================================================================
 
@@ -601,4 +899,6 @@ pub fn users_routes() -> Router<AppState> {
             "/v1/users/assistant-settings",
             get(get_assistant_settings).patch(update_assistant_settings),
         )
+        // Account deletion
+        .route("/v1/users/delete-account", delete(delete_account))
 }

--- a/desktop/Backend-Rust/src/services/firestore.rs
+++ b/desktop/Backend-Rust/src/services/firestore.rs
@@ -7120,6 +7120,131 @@ impl FirestoreService {
         Ok(count)
     }
 
+    /// Delete all documents in a user subcollection and return deleted count.
+    pub async fn delete_all_documents_in_subcollection(
+        &self,
+        uid: &str,
+        subcollection: &str,
+    ) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+        let parent = format!("{}/{}/{}", self.base_url(), USERS_COLLECTION, uid);
+        let query = json!({
+            "structuredQuery": {
+                "from": [{"collectionId": subcollection}],
+                "limit": 5000
+            }
+        });
+
+        let response = self
+            .build_request(reqwest::Method::POST, &format!("{}:runQuery", parent))
+            .await?
+            .json(&query)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            return Err(format!("Firestore query error for {}: {}", subcollection, error_text).into());
+        }
+
+        let results: Vec<Value> = response.json().await?;
+        let mut deleted = 0usize;
+
+        for result in results {
+            let Some(name) = result
+                .get("document")
+                .and_then(|d| d.get("name"))
+                .and_then(|n| n.as_str())
+            else {
+                continue;
+            };
+
+            let Some(doc_id) = name.rsplit('/').next() else {
+                continue;
+            };
+
+            let url = format!(
+                "{}/{}/{}/{}/{}",
+                self.base_url(),
+                USERS_COLLECTION,
+                uid,
+                subcollection,
+                doc_id
+            );
+
+            let delete_response = self
+                .build_request(reqwest::Method::DELETE, &url)
+                .await?
+                .send()
+                .await?;
+
+            if delete_response.status().is_success() || delete_response.status() == reqwest::StatusCode::NOT_FOUND {
+                deleted += 1;
+            } else {
+                let error_text = delete_response.text().await?;
+                return Err(format!("Firestore delete error for {}/{}: {}", subcollection, doc_id, error_text).into());
+            }
+        }
+
+        tracing::info!("Deleted {} docs from {}/{}", deleted, uid, subcollection);
+        Ok(deleted)
+    }
+
+    /// Delete the user root document (`users/{uid}`).
+    pub async fn delete_user_root_document(
+        &self,
+        uid: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let url = format!("{}/{}/{}", self.base_url(), USERS_COLLECTION, uid);
+
+        let response = self
+            .build_request(reqwest::Method::DELETE, &url)
+            .await?
+            .send()
+            .await?;
+
+        if !response.status().is_success() && response.status() != reqwest::StatusCode::NOT_FOUND {
+            let error_text = response.text().await?;
+            return Err(format!("Firestore delete user root error: {}", error_text).into());
+        }
+
+        tracing::info!("Deleted user root doc for {}", uid);
+        Ok(())
+    }
+
+    /// Delete Firebase Auth user by UID using service-account OAuth (admin path).
+    pub async fn delete_firebase_auth_user(
+        &self,
+        project_id: &str,
+        uid: &str,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let access_token = self.get_access_token().await?;
+        let url = format!(
+            "https://identitytoolkit.googleapis.com/v1/projects/{}/accounts:delete",
+            project_id
+        );
+
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(access_token)
+            .json(&json!({ "localId": uid }))
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let error_text = response.text().await?;
+            // Idempotent delete: if auth user is already gone, treat as success.
+            if error_text.contains("USER_NOT_FOUND") {
+                tracing::info!("Firebase Auth user {} already deleted", uid);
+                return Ok(());
+            }
+            return Err(format!("Firebase admin accounts:delete failed: {}", error_text).into());
+        }
+
+        tracing::info!("Deleted Firebase Auth user {}", uid);
+        Ok(())
+    }
+
     /// Update a message's rating (thumbs up/down)
     /// rating: 1 = thumbs up, -1 = thumbs down, None = clear rating
     pub async fn update_message_rating(

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -3418,6 +3418,11 @@ extension APIClient {
         let _: UserProfileResponse = try await patch("v1/users/profile", body: body)
     }
 
+    /// Deletes the authenticated user's account and all server data.
+    func deleteAccount() async throws {
+        try await delete("v1/users/delete-account")
+    }
+
     // MARK: - Assistant Settings API
 
     /// Fetches assistant settings from the backend

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -270,6 +270,9 @@ struct SettingsContentView: View {
 
     @State private var showResetOnboardingAlert: Bool = false
     @State private var showRescanFilesAlert: Bool = false
+    @State private var showDeleteAccountAlert: Bool = false
+    @State private var isDeletingAccount: Bool = false
+    @State private var deleteAccountError: String?
 
     init(
         appState: AppState,
@@ -1507,32 +1510,84 @@ struct SettingsContentView: View {
     private var accountSection: some View {
         VStack(spacing: 20) {
             settingsCard(settingId: "account.account") {
-                HStack(spacing: 16) {
-                    Image(systemName: "person.circle.fill")
-                        .scaledFont(size: 40)
-                        .foregroundColor(OmiColors.textTertiary)
+                VStack(alignment: .leading, spacing: 14) {
+                    HStack(spacing: 16) {
+                        Image(systemName: "person.circle.fill")
+                            .scaledFont(size: 40)
+                            .foregroundColor(OmiColors.textTertiary)
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text(AuthService.shared.displayName.isEmpty ? "User" : AuthService.shared.displayName)
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(AuthService.shared.displayName.isEmpty ? "User" : AuthService.shared.displayName)
+                                .scaledFont(size: 16, weight: .semibold)
+                                .foregroundColor(OmiColors.textPrimary)
 
-                        if let email = AuthState.shared.userEmail {
-                            Text(email)
+                            if let email = AuthState.shared.userEmail {
+                                Text(email)
+                                    .scaledFont(size: 13)
+                                    .foregroundColor(OmiColors.textTertiary)
+                            }
+                        }
+
+                        Spacer()
+
+                        Button("Sign Out") {
+                            appState.stopTranscription()
+                            ProactiveAssistantsPlugin.shared.stopMonitoring()
+                            try? AuthService.shared.signOut()
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(isDeletingAccount)
+                    }
+
+                    Divider()
+                        .overlay(OmiColors.backgroundQuaternary)
+
+                    HStack(alignment: .center, spacing: 16) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text("Delete Account & Data")
+                                .scaledFont(size: 15, weight: .semibold)
+                                .foregroundColor(OmiColors.error)
+
+                            Text("Permanently deletes server data, clears local data for this account, resets onboarding, and signs you out.")
                                 .scaledFont(size: 13)
                                 .foregroundColor(OmiColors.textTertiary)
                         }
+
+                        Spacer()
+
+                        Button(action: {
+                            AnalyticsManager.shared.deleteAccountClicked()
+                            showDeleteAccountAlert = true
+                        }) {
+                            if isDeletingAccount {
+                                ProgressView()
+                                    .controlSize(.small)
+                            } else {
+                                Text("Delete")
+                                    .scaledFont(size: 13, weight: .semibold)
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .tint(OmiColors.error)
+                        .disabled(isDeletingAccount)
                     }
 
-                    Spacer()
-
-                    Button("Sign Out") {
-                        appState.stopTranscription()
-                        ProactiveAssistantsPlugin.shared.stopMonitoring()
-                        try? AuthService.shared.signOut()
+                    if let deleteAccountError {
+                        Text(deleteAccountError)
+                            .scaledFont(size: 12)
+                            .foregroundColor(OmiColors.warning)
                     }
-                    .buttonStyle(.bordered)
                 }
+            }
+            .alert("Delete Account and Data?", isPresented: $showDeleteAccountAlert) {
+                Button("Cancel", role: .cancel) {
+                    AnalyticsManager.shared.deleteAccountCancelled()
+                }
+                Button("Delete Permanently", role: .destructive) {
+                    deleteAccountAndData()
+                }
+            } message: {
+                Text("This cannot be undone. Your account, chat history, and all server data will be permanently deleted. Local data for this account will be cleared and you'll return to onboarding.")
             }
 
 //            settingsCard {
@@ -4577,6 +4632,36 @@ struct SettingsContentView: View {
                 )
             } catch {
                 logError("Failed to update transcription preferences", error: error)
+            }
+        }
+    }
+
+    private func deleteAccountAndData() {
+        guard !isDeletingAccount else { return }
+
+        deleteAccountError = nil
+        isDeletingAccount = true
+        AnalyticsManager.shared.deleteAccountConfirmed()
+
+        Task {
+            do {
+                try await APIClient.shared.deleteAccount()
+                await MainActor.run {
+                    appState.stopTranscription()
+                    ProactiveAssistantsPlugin.shared.stopMonitoring()
+                    do {
+                        try AuthService.shared.signOut()
+                        isDeletingAccount = false
+                    } catch {
+                        deleteAccountError = "Account deleted, but sign out failed: \(error.localizedDescription)"
+                        isDeletingAccount = false
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    deleteAccountError = "Failed to delete account: \(error.localizedDescription)"
+                    isDeletingAccount = false
+                }
             }
         }
     }

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -80,6 +80,12 @@ struct OMIApp: App {
 
     /// Window title with version number (different for rewind mode)
     private var windowTitle: String {
+        // Keep a distinct title in dev builds so users can visually distinguish
+        // dev and production windows during side-by-side testing.
+        if Bundle.main.bundleIdentifier == "com.omi.desktop-dev" {
+            return Self.launchMode == .rewind ? "Omi Rewind Dev" : "Omi Dev"
+        }
+
         let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
         let baseName = Self.launchMode == .rewind ? "omi Rewind" : UpdateChannel.appDisplayName
         return version.isEmpty ? baseName : "\(baseName) v\(version)"

--- a/desktop/dev.sh
+++ b/desktop/dev.sh
@@ -104,7 +104,11 @@ else
     touch "$APP_BUNDLE/Contents/Resources/.env"
 fi
 # Set API URL to tunnel for development (overrides production default)
-echo "OMI_API_URL=$TUNNEL_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
+    sed -i '' "s|^OMI_API_URL=.*|OMI_API_URL=$TUNNEL_URL|" "$APP_BUNDLE/Contents/Resources/.env"
+else
+    echo "OMI_API_URL=$TUNNEL_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+fi
 echo "Using backend: $TUNNEL_URL"
 
 # Copy app icon
@@ -126,8 +130,14 @@ if [ -n "$SIGN_IDENTITY" ]; then
     echo "Signing with: $SIGN_IDENTITY"
     codesign --force --options runtime --entitlements Desktop/Omi.entitlements --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
 else
-    echo "Warning: No signing identity found. Using ad-hoc (permissions will reset each build)."
-    codesign --force --deep --sign - "$APP_BUNDLE"
+    echo ""
+    echo "ERROR: No signing identity found. Ad-hoc signing causes macOS to reset"
+    echo "       Screen Recording permissions for ALL Omi apps (including prod/beta)."
+    echo ""
+    echo "  Fix: Install an Apple Development certificate in Keychain Access,"
+    echo "       or set OMI_SIGN_IDENTITY to a valid identity."
+    echo ""
+    exit 1
 fi
 
 echo "Dev build complete: $APP_BUNDLE"

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -84,7 +84,7 @@ step "Cleaning up conflicting app bundles..."
 # Clean old build names from local build dir
 rm -rf "$BUILD_DIR/Omi Computer.app" 2>/dev/null
 CONFLICTING_APPS=(
-    "/Applications/Omi Computer.app"
+    "/Applications/Omi Dev.app"
     "$HOME/Desktop/Omi Dev.app"
     "$HOME/Downloads/Omi Dev.app"
     "$(dirname "$0")/../app/build/macos/Build/Products/Debug/Omi.app"
@@ -96,8 +96,8 @@ for app in "${CONFLICTING_APPS[@]}"; do
         rm -rf "$app"
     fi
 done
-# Also remove any "Omi Computer.app" nested inside Flutter builds (any config: Debug/Release/Release-prod/etc.)
-find "$(dirname "$0")/../app/build" -name "Omi Computer.app" -type d -exec rm -rf {} + 2>/dev/null || true
+# Also remove any stale dev app bundles nested inside Flutter builds.
+find "$(dirname "$0")/../app/build" -name "Omi Dev.app" -type d -exec rm -rf {} + 2>/dev/null || true
 # Kill stale "Omi Dev.app" bundles from other repo clones (e.g. ~/omi-desktop/)
 # These confuse LaunchServices and get launched instead of /Applications/Omi Dev.app
 find "$HOME" -maxdepth 4 -name "Omi Dev.app" -type d -not -path "$APP_BUNDLE" -not -path "$APP_PATH" 2>/dev/null | while read stale; do
@@ -114,14 +114,29 @@ step "Starting Rust backend..."
 cd "$BACKEND_DIR"
 
 # Copy .env if not present
-if [ ! -f ".env" ] && [ -f "../Backend/.env" ]; then
+if [ ! -f ".env" ] && [ -f "../backend/.env" ]; then
+    cp "../backend/.env" ".env"
+elif [ ! -f ".env" ] && [ -f "../Backend/.env" ]; then
     cp "../Backend/.env" ".env"
 fi
 
 # Symlink google-credentials.json if not present
-if [ ! -f "google-credentials.json" ] && [ -f "../Backend/google-credentials.json" ]; then
+if [ ! -f "google-credentials.json" ] && [ -f "../backend/google-credentials.json" ]; then
+    ln -sf "../backend/google-credentials.json" "google-credentials.json"
+elif [ ! -f "google-credentials.json" ] && [ -f "../Backend/google-credentials.json" ]; then
     ln -sf "../Backend/google-credentials.json" "google-credentials.json"
 fi
+
+# Force local backend to use prod Firestore credentials for testing.
+CREDS_PATH="$BACKEND_DIR/google-credentials.json"
+if [ ! -f "$CREDS_PATH" ]; then
+    echo "Missing credentials file: $CREDS_PATH"
+    exit 1
+fi
+export GOOGLE_APPLICATION_CREDENTIALS="$CREDS_PATH"
+export FIREBASE_PROJECT_ID="${FIREBASE_PROJECT_ID:-based-hardware}"
+substep "Using Firestore creds: $GOOGLE_APPLICATION_CREDENTIALS"
+substep "Using Firebase project: $FIREBASE_PROJECT_ID"
 
 # Build if binary doesn't exist or source is newer
 if [ ! -f "target/release/omi-desktop-backend" ] || [ -n "$(find src -newer target/release/omi-desktop-backend 2>/dev/null)" ]; then
@@ -252,7 +267,11 @@ elif [ -f ".env.app" ]; then
 else
     touch "$APP_BUNDLE/Contents/Resources/.env"
 fi
-echo "OMI_API_URL=$TUNNEL_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
+    sed -i '' "s|^OMI_API_URL=.*|OMI_API_URL=$TUNNEL_URL|" "$APP_BUNDLE/Contents/Resources/.env"
+else
+    echo "OMI_API_URL=$TUNNEL_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+fi
 
 substep "Copying app icon"
 cp -f omi_icon.icns "$APP_BUNDLE/Contents/Resources/OmiIcon.icns" 2>/dev/null || true
@@ -331,8 +350,15 @@ if [ -n "$SIGN_IDENTITY" ]; then
     substep "Signing app bundle"
     codesign --force --options runtime --entitlements "$EFFECTIVE_ENTITLEMENTS" --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
 else
-    substep "Warning: No signing identity found. Using ad-hoc (permissions will reset each build)."
-    codesign --force --deep --sign - "$APP_BUNDLE"
+    echo ""
+    echo "ERROR: No signing identity found. Ad-hoc signing causes macOS to reset"
+    echo "       Screen Recording permissions for ALL Omi apps (including prod/beta)."
+    echo ""
+    echo "  Fix: Install an Apple Development certificate in Keychain Access,"
+    echo "       or set OMI_SIGN_IDENTITY to a valid identity:"
+    echo "       OMI_SIGN_IDENTITY=\"Apple Development: you@example.com\" ./run.sh"
+    echo ""
+    exit 1
 fi
 
 step "Removing quarantine attributes..."


### PR DESCRIPTION
## Summary
- add **Delete Account & Data** action in macOS Settings > Profile/Account
- call new desktop backend endpoint `DELETE /v1/users/delete-account`
- implement server-side account purge for user-scoped data + delete Firebase Auth user (idempotent on `USER_NOT_FOUND`)
- sign out and return user to clean onboarding state after successful deletion
- make dev app title explicit (`Omi Dev`) and harden dev scripts for local backend/prod Firebase testing
- add AGENTS safety rule to never kill production `/Applications/omi.app` during dev runs

## Verification
- `cargo build --release` in `desktop/Backend-Rust`
- `swift build` in `desktop/Desktop`

## Notes
- PR intentionally contains only the account-deletion + dev-launch safety fixes from this workstream, excluding unrelated local edits.