### PR TITLE
Improve onboarding flow, goal normalization, and file scan guidance

### DIFF
--- a/desktop/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/Desktop/Sources/Chat/ChatPrompts.swift
@@ -686,26 +686,31 @@ struct ChatPrompts {
     Be specific: name their company, role, projects. Skip a search if you already know enough.
     After EACH search, call `save_knowledge_graph` with the new entities you discovered (company, role, projects, etc.) and edges connecting them to existing nodes.
 
-    STEP 3 — FILE SCAN
-    Tell the user you'll scan their files, then call `scan_files`. A folder access guide image is shown automatically in the UI.
-    This tool BLOCKS until the scan is complete. macOS will show folder access dialogs — the guide image helps the user know to click Allow.
-    If any folders were denied access, tell the user and call `scan_files` again after they allow.
-    After the scan, call `save_knowledge_graph` with tools, languages, and frameworks found in the file scan results (5-15 nodes).
-
-    STEP 4 — FILE DISCOVERIES + FOLLOW-UP
-    Share 1-2 specific observations connecting web research + file findings (1 sentence each), then END your message with an explicit question.
-    CRITICAL: Your message text MUST end with a question mark. Don't just state observations — ASK the user something.
-    Bad: "I see screenpipe repos, RAG workshops, and VS Code extensions."
-    Good: "I see screenpipe repos, RAG workshops, and VS Code extensions. What's your top goal right now?"
-    Then call `ask_followup` with 2-4 quick-reply options that are meaningful answers to YOUR question.
-    - Ask for ONE top monthly goal, not project names.
-    - Offer 3 options based on discovered context plus one typed option.
+    STEP 3 — MONTHLY GOAL (BEFORE SCAN)
+    Ask for ONE top monthly goal first.
+    Then call `ask_followup` with 2-4 concrete options and one typed option.
     Example: ask_followup(question: "What's your top one goal this month?", options: ["Ship [specific project]", "Improve [specific skill/workflow]", "I'll type my own"])
-    The options should be inferred from their files/web context, not generic.
-    WAIT for the user to reply (click a button or type).
-    After the user replies, call `save_knowledge_graph` with the chosen goal as a concept node connected to the user.
+    WAIT for user reply (button or typed).
+    After reply, call `save_knowledge_graph` with the chosen goal as a concept node connected to the user.
 
-    STEP 5 — PRIVACY NOTE + PERMISSIONS
+    STEP 4 — FILE SCAN (AFTER GOAL)
+    Tell the user you'll scan files (including Apple Notes), then call `scan_files`. A folder access guide image is shown automatically in the UI.
+    This tool BLOCKS until the scan is complete. macOS may show folder access dialogs — the guide image helps the user click Allow.
+    If any folders were denied access, tell the user and call `scan_files` again after they allow.
+    After scan, call `save_knowledge_graph` with tools, languages, frameworks, and notable notes/projects found (5-20 nodes).
+
+    STEP 5 — FILE DISCOVERIES + TASK CANDIDATES
+    Share 1-2 specific observations connecting web research + goal + file findings.
+    Then identify up to 2-3 candidate tasks that could help the user's monthly goal.
+    RULES:
+    - Prefer existing tasks found in scan results if clearly relevant.
+    - Suggest NEW tasks only when confidence is high.
+    - If confidence is low or no good task candidates exist, do NOT invent tasks.
+    If you found confident task candidates, present them with `ask_followup` (2-4 options, include at least one typed option) and WAIT for the user's reply.
+    If confidence is low or no good task candidates exist, ask manually: "What is your goal for today?" with `ask_followup` (2-4 options, include at least one typed option), then WAIT for the user's reply.
+    After the reply, call `save_knowledge_graph` with today's goal/task context as concept nodes connected to the user.
+
+    STEP 6 — PRIVACY NOTE + PERMISSIONS
     Before asking for any permissions, send a trust-building message about data ownership. Example:
     "Quick note — your data stays on your machine, and Omi is fully open-source. You own everything."
     This is important — say it BEFORE the first permission request. It builds trust right when the user is about to grant sensitive access.
@@ -738,14 +743,14 @@ struct ChatPrompts {
     Example for microphone:
     ask_followup(question: "Mic access lets me transcribe your conversations and give real-time advice.", options: ["Grant Microphone", "Why?", "Skip"])
 
-    STEP 6 — COMPLETE (MANDATORY TOOL CALL)
+    STEP 7 — COMPLETE (MANDATORY TOOL CALL)
     You MUST call `complete_onboarding` — without this tool call, the user is STUCK and cannot proceed.
     Call the tool FIRST, then send an expectation-setting message like:
     "You're all set! Just use Omi in the background for a couple days — it gets smarter the more it learns about you."
-    This manages expectations so the user knows Omi needs time to become useful. Then move to Step 7.
+    This manages expectations so the user knows Omi needs time to become useful. Then move to Step 8.
     NEVER skip this tool call.
 
-    STEP 7 — DEEP DIVE (keep the conversation going)
+    STEP 8 — DEEP DIVE (keep the conversation going)
     After the expectation-setting message, keep asking the user questions to build a richer knowledge graph.
     The "Continue to App" button appears in the background — the user can click it whenever they want, but meanwhile keep them engaged.
 
@@ -775,8 +780,9 @@ struct ChatPrompts {
 
     **scan_files**: Scan the user's files and return results. BLOCKING — waits for the scan to finish.
     - No parameters.
-    - Scans ~/Downloads, ~/Documents, ~/Desktop, ~/Developer, ~/Projects, /Applications.
+    - Scans ~/Downloads, ~/Documents, ~/Desktop, ~/Developer, ~/Projects, /Applications, and Apple Notes storage folders.
     - Returns file type breakdown, projects, recent files, installed apps.
+    - Returns existing task candidates when available, so you can connect tasks to the user's goals.
     - Also reports which folders were DENIED access (user didn't click Allow on the macOS dialog).
     - If folders were denied, tell the user to click Allow, then call scan_files AGAIN to pick up those folders.
 

--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -653,19 +653,76 @@ struct OnboardingChatView: View {
         let lower = text.lowercased()
         return lower.contains("top one goal")
             || lower.contains("top goal")
+            || lower.contains("#1 goal")
+            || lower.contains("number 1 goal")
+            || lower.contains("goal this month")
+            || lower.contains("what's your #1 goal")
             || lower.contains("top priority")
             || lower.contains("priority right now")
     }
 
     private func isTypeYourOwnOption(_ text: String) -> Bool {
         let lower = text.lowercased()
-        return lower.contains("type my own") || lower.contains("i'll type my own") || lower.contains("i’ll type my own")
+        return lower.contains("type my own")
+            || lower.contains("i'll type my own")
+            || lower.contains("i’ll type my own")
+            || lower.contains("i'll type it")
+            || lower.contains("i’ll type it")
+            || lower.contains("type it")
     }
 
     private func normalizedGoalTitle(_ text: String) -> String {
         text
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .replacingOccurrences(of: "\n", with: " ")
+    }
+
+    private func heuristicGoalTitle(_ text: String) -> String {
+        var cleaned = normalizedGoalTitle(text)
+        let lower = cleaned.lowercased()
+        let prefixes = [
+            "my goal is ",
+            "goal is ",
+            "my goal: ",
+            "goal: ",
+            "i want to ",
+            "i wanna ",
+            "i need to ",
+            "i will ",
+            "i'm going to ",
+        ]
+        for prefix in prefixes where lower.hasPrefix(prefix) {
+            cleaned = String(cleaned.dropFirst(prefix.count))
+            break
+        }
+        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func fallbackGoalConfig(from title: String) -> (goalType: GoalType, targetValue: Double, unit: String?) {
+        let lower = title.lowercased()
+        let pattern = #"\b(\d+(?:\.\d+)?)\s*(k|m|b)?\s*(users?|customers?|clients?|sales?|revenue|downloads?)?\b"#
+        if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+           let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower)) {
+            let numberRange = match.range(at: 1)
+            let suffixRange = match.range(at: 2)
+            let unitRange = match.range(at: 3)
+            if let numberSwiftRange = Range(numberRange, in: lower),
+               let baseNumber = Double(lower[numberSwiftRange]) {
+                var multiplier = 1.0
+                if let suffixSwiftRange = Range(suffixRange, in: lower) {
+                    switch lower[suffixSwiftRange] {
+                    case "k": multiplier = 1_000
+                    case "m": multiplier = 1_000_000
+                    case "b": multiplier = 1_000_000_000
+                    default: break
+                    }
+                }
+                let unit: String? = Range(unitRange, in: lower).map { String(lower[$0]) }
+                return (.numeric, max(baseNumber * multiplier, 1), unit)
+            }
+        }
+
+        return (.boolean, 1, nil)
     }
 
     private func shouldSkipGoalCreation(_ title: String) -> Bool {
@@ -680,25 +737,33 @@ struct OnboardingChatView: View {
     }
 
     private func maybeCreateGoal(from rawText: String, source: String) async {
-        let title = normalizedGoalTitle(rawText)
+        let rawTitle = normalizedGoalTitle(rawText)
+        guard !shouldSkipGoalCreation(rawTitle) else { return }
+
+        let aiNormalized = await GoalsAIService.shared.normalizeOnboardingGoalInput(rawTitle)
+        let title = aiNormalized?.title ?? heuristicGoalTitle(rawTitle)
         guard !shouldSkipGoalCreation(title) else { return }
 
-            let dedupeKey = title.lowercased()
-            guard !createdGoalTitles.contains(dedupeKey) else { return }
+        let config: (goalType: GoalType, targetValue: Double, unit: String?) =
+            aiNormalized.map { (goalType: $0.goalType, targetValue: $0.targetValue, unit: $0.unit) }
+            ?? fallbackGoalConfig(from: title)
+        let dedupeKey = title.lowercased()
+        guard !createdGoalTitles.contains(dedupeKey) else { return }
 
         do {
             let goal = try await APIClient.shared.createGoal(
                 title: title,
                 description: "Added from onboarding",
-                goalType: .boolean,
-                targetValue: 1,
+                goalType: config.goalType,
+                targetValue: config.targetValue,
                 currentValue: 0,
+                unit: config.unit,
                 source: "onboarding_\(source)"
             )
             _ = try? await GoalStorage.shared.syncServerGoal(goal)
             createdGoalTitles.insert(dedupeKey)
             awaitingGoalInput = false
-            log("OnboardingChat: Created goal from onboarding input: \(title)")
+            log("OnboardingChat: Created goal from onboarding input: \(title) (\(config.goalType.rawValue), target: \(config.targetValue))")
         } catch {
             logError("OnboardingChat: Failed to create goal from onboarding input", error: error)
         }

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -8,13 +8,14 @@ struct OnboardingView: View {
     @ObservedObject var chatProvider: ChatProvider
     var onComplete: (() -> Void)? = nil
     @AppStorage("onboardingStep") private var currentStep = 0
+    @AppStorage("onboardingVideoStepMigrationDone") private var hasMigratedOnboardingSteps = false
     @StateObject private var graphViewModel = MemoryGraphViewModel()
     @State private var graphHasData = false
     @State private var showTrustPreview = true
     @State private var showGraphHints = false
     @State private var hintsHovered = false
 
-    let steps = ["Video", "Chat", "Notifications", "FloatingBar", "VoiceInput", "Tasks"]
+    let steps = ["Chat", "Notifications", "FloatingBar", "VoiceInput", "Tasks"]
 
     var body: some View {
         ZStack {
@@ -44,13 +45,22 @@ struct OnboardingView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
-            // If currentStep is beyond the 6-step flow (0-5), clamp to last step
-            if currentStep > 5 {
-                currentStep = 5
+            // One-time migration after removing the dedicated video step:
+            // old indices (0-5) become new indices (0-4), shifting all non-zero steps down by 1.
+            if !hasMigratedOnboardingSteps {
+                if currentStep > 0 {
+                    currentStep -= 1
+                }
+                hasMigratedOnboardingSteps = true
+            }
+
+            // If currentStep is beyond the 5-step flow (0-4), clamp to last step.
+            if currentStep > 4 {
+                currentStep = 4
             }
         }
         .task {
-            // Pre-warm the ACP bridge during the video step
+            // Pre-warm the ACP bridge before the chat step starts.
             await chatProvider.warmupBridge()
         }
     }
@@ -58,45 +68,18 @@ struct OnboardingView: View {
     private var onboardingContent: some View {
         Group {
             if currentStep == 0 {
-                // Step 0: Full-window video
-                ZStack {
-                    OnboardingVideoView()
-                        .aspectRatio(16.0 / 9.0, contentMode: .fit)
-                        .frame(maxWidth: 960)
-                        .clipShape(RoundedRectangle(cornerRadius: 16))
-
-                    VStack {
-                        Spacer()
-                        Button(action: {
-                            AnalyticsManager.shared.onboardingStepCompleted(step: 0, stepName: "Video")
-                            currentStep = 1
-                        }) {
-                            Text("Continue")
-                                .font(.system(size: 15, weight: .semibold))
-                                .foregroundColor(.white)
-                                .frame(maxWidth: 220)
-                                .padding(.vertical, 12)
-                                .background(OmiColors.purplePrimary)
-                                .cornerRadius(12)
-                        }
-                        .buttonStyle(.plain)
-                        .padding(.bottom, 32)
-                    }
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if currentStep == 1 {
-                // Step 1: Interactive AI Chat + Live Knowledge Graph
+                // Step 0: Interactive AI Chat + Live Knowledge Graph
                 HStack(spacing: 0) {
                     OnboardingChatView(
                         appState: appState,
                         chatProvider: chatProvider,
                         graphViewModel: graphViewModel,
                         onComplete: {
-                            AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "Chat")
-                            currentStep = 2
+                            AnalyticsManager.shared.onboardingStepCompleted(step: 0, stepName: "Chat")
+                            currentStep = 1
                         },
                         onSkip: {
-                            currentStep = 2
+                            currentStep = 1
                         }
                     )
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -168,52 +151,52 @@ struct OnboardingView: View {
                         }
                     }
                 }
-            } else if currentStep == 2 {
-                // Step 2: Smart Notifications Demo
+            } else if currentStep == 1 {
+                // Step 1: Smart Notifications Demo
                 OnboardingNotificationStepView(
                     appState: appState,
                     onContinue: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "Notifications")
-                        currentStep = 3
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "Notifications")
+                        currentStep = 2
                     },
                     onSkip: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "Notifications_Skipped")
-                        currentStep = 3
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "Notifications_Skipped")
+                        currentStep = 2
                     }
                 )
-            } else if currentStep == 3 {
-                // Step 3: Floating Bar Demo
+            } else if currentStep == 2 {
+                // Step 2: Floating Bar Demo
                 OnboardingFloatingBarDemoView(
                     appState: appState,
                     chatProvider: chatProvider,
                     onComplete: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "FloatingBar")
-                        currentStep = 4
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "FloatingBar")
+                        currentStep = 3
                     },
                     onSkip: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "FloatingBar_Skipped")
-                        currentStep = 4
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "FloatingBar_Skipped")
+                        currentStep = 3
                     }
                 )
-            } else if currentStep == 4 {
-                // Step 4: Voice Input Demo
+            } else if currentStep == 3 {
+                // Step 3: Voice Input Demo
                 OnboardingVoiceInputDemoView(
                     appState: appState,
                     chatProvider: chatProvider,
                     onComplete: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "VoiceInput")
-                        currentStep = 5
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "VoiceInput")
+                        currentStep = 4
                     },
                     onSkip: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "VoiceInput_Skipped")
-                        currentStep = 5
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "VoiceInput_Skipped")
+                        currentStep = 4
                     }
                 )
             } else {
-                // Step 5: Tasks
+                // Step 4: Tasks
                 OnboardingTasksStepView(
                     onComplete: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 5, stepName: "Tasks")
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "Tasks")
                         handleOnboardingComplete()
                     }
                 )
@@ -307,27 +290,48 @@ struct OnboardingView: View {
 
 private struct OnboardingTrustPreviewCard: View {
     var body: some View {
-        VStack(spacing: 20) {
-            VStack(spacing: 10) {
-                ZStack {
-                    Circle()
-                        .fill(OmiColors.purplePrimary.opacity(0.15))
-                        .frame(width: 72, height: 72)
-                        .blur(radius: 12)
-                    Image(systemName: "shield.lefthalf.filled")
-                        .font(.system(size: 30, weight: .semibold))
-                        .foregroundStyle(OmiColors.purpleLightGradient)
-                }
+        VStack(spacing: 24) {
+            OnboardingVideoView(cornerRadius: 14)
+                .aspectRatio(16.0 / 9.0, contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 16)
+                        .stroke(OmiColors.backgroundQuaternary.opacity(0.35), lineWidth: 1)
+                )
 
+            Rectangle()
+                .fill(
+                    LinearGradient(
+                        colors: [
+                            OmiColors.backgroundQuaternary.opacity(0),
+                            OmiColors.backgroundQuaternary.opacity(0.4),
+                            OmiColors.backgroundQuaternary.opacity(0)
+                        ],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
+                .frame(height: 1)
+                .padding(.horizontal, 20)
+
+            HStack(spacing: 8) {
+                Image(systemName: "shield.lefthalf.filled")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(OmiColors.purplePrimary.opacity(0.9))
                 Text("Trust & Privacy")
-                    .font(.system(size: 24, weight: .bold))
-                    .foregroundColor(OmiColors.textPrimary)
-
-                Text("omi protects your data.")
-                    .font(.system(size: 13))
+                    .font(.system(size: 17, weight: .medium))
+                    .foregroundColor(OmiColors.textSecondary)
+                    .lineLimit(1)
+                Text("omi protects your data")
+                    .font(.system(size: 15, weight: .regular))
                     .foregroundColor(OmiColors.textTertiary)
-                    .multilineTextAlignment(.center)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
             }
+            .padding(.top, 2)
+            .padding(.bottom, 6)
+            .frame(maxWidth: .infinity, alignment: .center)
 
             VStack(spacing: 10) {
                 trustRow(icon: "chevron.left.forwardslash.chevron.right", title: "Open Source", detail: "Code is ")
@@ -343,12 +347,8 @@ private struct OnboardingTrustPreviewCard: View {
                             .stroke(OmiColors.purplePrimary.opacity(0.25), lineWidth: 1)
                     )
             )
-
-            Text("Your memory chart appears here next.")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundColor(OmiColors.textQuaternary)
         }
-        .frame(maxWidth: 560)
+        .frame(maxWidth: .infinity)
         .padding(.vertical, 24)
     }
 
@@ -391,12 +391,19 @@ private struct OnboardingTrustPreviewCard: View {
 // MARK: - Onboarding Video View
 
 struct OnboardingVideoView: NSViewRepresentable {
+    var cornerRadius: CGFloat = 12
+
     func makeCoordinator() -> Coordinator {
         Coordinator()
     }
 
     func makeNSView(context: Context) -> AVPlayerView {
         let playerView = AVPlayerView()
+        playerView.wantsLayer = true
+        playerView.layer?.cornerRadius = cornerRadius
+        playerView.layer?.cornerCurve = .continuous
+        playerView.layer?.masksToBounds = true
+        playerView.videoGravity = .resizeAspect
         if let url = Bundle.resourceBundle.url(forResource: "omi-demo", withExtension: "mp4") {
             let player = AVPlayer(url: url)
             playerView.player = player
@@ -416,7 +423,9 @@ struct OnboardingVideoView: NSViewRepresentable {
         return playerView
     }
 
-    func updateNSView(_ nsView: AVPlayerView, context: Context) {}
+    func updateNSView(_ nsView: AVPlayerView, context: Context) {
+        nsView.layer?.cornerRadius = cornerRadius
+    }
 
     class Coordinator: NSObject {
         var player: AVPlayer?

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalsAIService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalsAIService.swift
@@ -6,12 +6,89 @@ actor GoalsAIService {
 
   private var geminiClient: GeminiClient?
 
+  struct NormalizedGoalInput {
+    let title: String
+    let goalType: GoalType
+    let targetValue: Double
+    let unit: String?
+  }
+
   private init() {
     do {
       self.geminiClient = try GeminiClient(model: "gemini-pro-latest")
     } catch {
       log("GoalsAIService: Failed to initialize GeminiClient: \(error)")
       self.geminiClient = nil
+    }
+  }
+
+  /// Response schema for normalizing ad-hoc onboarding goal text.
+  private var onboardingGoalNormalizationSchema: GeminiRequest.GenerationConfig.ResponseSchema {
+    GeminiRequest.GenerationConfig.ResponseSchema(
+      type: "object",
+      properties: [
+        "title": .init(type: "string", description: "Concise goal title without filler words"),
+        "goal_type": .init(type: "string", enum: ["boolean", "scale", "numeric"]),
+        "target_value": .init(type: "number", description: "Numeric target value"),
+        "unit": .init(type: "string", description: "Optional unit like users, sales, hours"),
+      ],
+      required: ["title", "goal_type", "target_value"]
+    )
+  }
+
+  /// Normalize free-form onboarding goal input into structured goal fields.
+  /// Example: "My goal is 200k users" -> title: "200k users", goalType: .numeric, targetValue: 200000, unit: "users"
+  func normalizeOnboardingGoalInput(_ rawInput: String) async -> NormalizedGoalInput? {
+    guard let client = geminiClient else { return nil }
+
+    struct Response: Codable {
+      let title: String
+      let goalType: String
+      let targetValue: Double
+      let unit: String?
+
+      enum CodingKeys: String, CodingKey {
+        case title, unit
+        case goalType = "goal_type"
+        case targetValue = "target_value"
+      }
+    }
+
+    let prompt = """
+    Normalize this onboarding goal input into clean structured fields.
+
+    Input: "\(rawInput)"
+
+    Rules:
+    - Remove conversational filler like "my goal is", "i want to", "i need to".
+    - Keep title short and noun/action focused.
+    - If a numeric target is explicit (e.g., 200k, 10M), use goal_type=numeric and expand value (200k -> 200000).
+    - If no explicit number, use goal_type=boolean and target_value=1.
+    - Return JSON only.
+    """
+
+    do {
+      let responseText = try await client.sendRequest(
+        prompt: prompt,
+        systemPrompt: "You clean and structure user goal text for product onboarding.",
+        responseSchema: onboardingGoalNormalizationSchema
+      )
+
+      guard let data = responseText.data(using: .utf8) else { return nil }
+      let parsed = try JSONDecoder().decode(Response.self, from: data)
+      guard let type = GoalType(rawValue: parsed.goalType) else { return nil }
+      let title = parsed.title.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !title.isEmpty else { return nil }
+
+      return NormalizedGoalInput(
+        title: title,
+        goalType: type,
+        targetValue: parsed.targetValue > 0 ? parsed.targetValue : 1,
+        unit: parsed.unit?.trimmingCharacters(in: .whitespacesAndNewlines)
+      )
+    } catch {
+      log("GoalsAI: normalizeOnboardingGoalInput failed: \(error.localizedDescription)")
+      return nil
     }
   }
 

--- a/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -597,35 +597,61 @@ class ChatToolExecutor {
     private static func executeScanFiles(_ args: [String: Any]) async -> String {
         let fm = FileManager.default
         let homeDir = fm.homeDirectoryForCurrentUser
-        let foldersToScan = ["Downloads", "Documents", "Desktop", "Developer", "Projects"]
-            .map { homeDir.appendingPathComponent($0) }
-            .filter { fm.fileExists(atPath: $0.path) }
+        let scanTargets: [(label: String, pathForUser: String, url: URL)] = {
+            var targets: [(String, String, URL)] = []
 
-        let applicationsURL = URL(fileURLWithPath: "/Applications")
-        var allFolders = foldersToScan
-        if fm.fileExists(atPath: applicationsURL.path) {
-            allFolders.append(applicationsURL)
-        }
+            let homeFolders = ["Downloads", "Documents", "Desktop", "Developer", "Projects"]
+            for folder in homeFolders {
+                let url = homeDir.appendingPathComponent(folder)
+                if fm.fileExists(atPath: url.path) {
+                    targets.append((folder, "~/\(folder)", url))
+                }
+            }
+
+            let applicationsURL = URL(fileURLWithPath: "/Applications")
+            if fm.fileExists(atPath: applicationsURL.path) {
+                targets.append(("Applications", "/Applications", applicationsURL))
+            }
+
+            // Apple Notes local stores (container + group container)
+            let notesCandidates: [(String, String, URL)] = [
+                (
+                    "Apple Notes (Container)",
+                    "~/Library/Containers/com.apple.Notes/Data/Library/Notes",
+                    homeDir.appendingPathComponent("Library/Containers/com.apple.Notes/Data/Library/Notes")
+                ),
+                (
+                    "Apple Notes (Group)",
+                    "~/Library/Group Containers/group.com.apple.notes",
+                    homeDir.appendingPathComponent("Library/Group Containers/group.com.apple.notes")
+                ),
+            ]
+            for candidate in notesCandidates where fm.fileExists(atPath: candidate.2.path) {
+                targets.append(candidate)
+            }
+
+            return targets
+        }()
 
         // Pre-check folder access — this triggers macOS TCC dialogs
         var deniedFolders: [String] = []
         var accessibleFolders: [URL] = []
-        for folder in allFolders {
+        for target in scanTargets {
             do {
                 _ = try fm.contentsOfDirectory(
-                    at: folder,
+                    at: target.url,
                     includingPropertiesForKeys: [.fileSizeKey],
                     options: [.skipsHiddenFiles]
                 )
-                accessibleFolders.append(folder)
+                accessibleFolders.append(target.url)
             } catch {
                 let nsError = error as NSError
                 if nsError.domain == NSCocoaErrorDomain && nsError.code == 257 {
                     // Permission denied — TCC dialog was shown or already denied
-                    deniedFolders.append(folder.lastPathComponent)
+                    deniedFolders.append(target.pathForUser)
                 } else {
                     // Other error (e.g. folder doesn't exist) — skip silently
-                    log("FileIndexer: Pre-check failed for \(folder.lastPathComponent): \(error.localizedDescription)")
+                    log("FileIndexer: Pre-check failed for \(target.label): \(error.localizedDescription)")
                 }
             }
         }
@@ -644,7 +670,7 @@ class ChatToolExecutor {
             out += "\n\n## FOLDER ACCESS DENIED\n"
             out += "The following folders were NOT scanned because the user didn't grant access:\n"
             for folder in deniedFolders {
-                out += "- ~/\(folder)\n"
+                out += "- \(folder)\n"
             }
             out += "\nTell the user to click 'Allow' on the macOS dialogs, then call scan_files again to pick up those folders."
         }
@@ -736,6 +762,31 @@ class ChatToolExecutor {
                     let appNames = apps.compactMap { ($0["filename"] as? String)?.replacingOccurrences(of: ".app", with: "") }
                     out += appNames.joined(separator: ", ")
                     out += "\n"
+                }
+
+                let taskCandidates = try Row.fetchAll(db, sql: """
+                    SELECT description, priority, source
+                    FROM action_items
+                    WHERE deleted = 0 AND completed = 0
+                    ORDER BY
+                        CASE priority
+                            WHEN 'high' THEN 0
+                            WHEN 'medium' THEN 1
+                            ELSE 2
+                        END,
+                        COALESCE(relevanceScore, 999) ASC,
+                        createdAt DESC
+                    LIMIT 8
+                """)
+
+                if !taskCandidates.isEmpty {
+                    out += "\n## Existing Task Candidates\n"
+                    for row in taskCandidates {
+                        let description = row["description"] as? String ?? ""
+                        let priority = row["priority"] as? String ?? "normal"
+                        let source = row["source"] as? String ?? "unknown"
+                        out += "- [\(priority)] \(description) (source: \(source))\n"
+                    }
                 }
 
                 log("Tool get_file_scan_results: \(totalCount) files, \(projectIndicators.count) projects, \(apps.count) apps")

--- a/desktop/acp-bridge/src/omi-tools-stdio.ts
+++ b/desktop/acp-bridge/src/omi-tools-stdio.ts
@@ -245,7 +245,7 @@ Use after finding the task with execute_sql. Pass the backendId from the action_
   },
   {
     name: "scan_files",
-    description: `Scan the user's files. BLOCKING — waits for the scan to complete before returning. Scans ~/Downloads, ~/Documents, ~/Desktop, ~/Developer, ~/Projects, /Applications. Returns file type breakdown, project indicators, recent files, installed apps. Also reports which folders were DENIED access by macOS. If folders were denied, call again after the user grants access.`,
+    description: `Scan the user's files. BLOCKING — waits for the scan to complete before returning. Scans ~/Downloads, ~/Documents, ~/Desktop, ~/Developer, ~/Projects, /Applications, and Apple Notes storage folders when available. Returns file type breakdown, project indicators, recent files, installed apps, and existing task candidates when available. Also reports which folders were DENIED access by macOS. If folders were denied, call again after the user grants access.`,
     inputSchema: {
       type: "object" as const,
       properties: {},


### PR DESCRIPTION
## Summary
- move onboarding to chat-first flow and keep trust/video panel behavior aligned
- improve onboarding goal detection/normalization and goal creation from typed answers
- update onboarding prompt flow to ask monthly goal before scan and only ask daily-goal fallback when task candidates are low-confidence
- include Apple Notes paths in scan targets and surface existing task candidates in scan results

## Verification
- swift build (desktop/Desktop)