### PR TITLE
Bump build number to 767 for TestFlight deploy

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.525+766
+version: 1.0.525+767
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bumps app build number from +766 to +767 to trigger Codemagic TestFlight + Android internal builds
- Required because PR #5459 (multipart 401 retry, Firestore cache, people/conversations fix) merged app/ changes without a build number bump
- Without this, Codemagic skips the upload since +766 was already built

## Test plan
- [ ] Codemagic `ios-internal-auto` triggers and uploads to TestFlight
- [ ] Codemagic `android-internal-auto` triggers and uploads

_by AI for @beastoin_