### PR TITLE
Bump version to 1.0.526+768 for TestFlight

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.525+767
+version: 1.0.526+768
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bump marketing version `1.0.525` → `1.0.526` and build number `767` → `768`
- Apple closed the `1.0.525` pre-release train — new builds cannot be submitted under that version
- Error: `Invalid Pre-Release Train. The train version '1.0.525' is closed for new build submissions`
- This opens a new TestFlight train so Codemagic iOS builds can upload successfully

## Changes
- `app/pubspec.yaml`: `version: 1.0.525+767` → `version: 1.0.526+768`

## Test plan
- [ ] Merge triggers Codemagic `ios-internal-auto` workflow
- [ ] iOS build uploads to TestFlight under new `1.0.526` train