### PR TITLE
Fix onboarding reset to clear backend chat history

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -2492,6 +2492,17 @@ class AppState: ObservableObject {
         OnboardingChatPersistence.clear()
         log("Cleared onboarding chat persistence")
 
+        // Clear persisted backend chat messages so onboarding does not resume old history.
+        // Onboarding currently uses the default chat message stream.
+        Task {
+            do {
+                _ = try await APIClient.shared.deleteMessages()
+                log("Cleared backend chat messages")
+            } catch {
+                logError("Failed to clear backend chat messages during onboarding reset", error: error)
+            }
+        }
+
         // Clear all local user data: database, screenshots, videos, knowledge graph, etc.
         let dataKeys = [
             "omi.focus.sessions",

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -3773,7 +3773,7 @@ struct SettingsContentView: View {
                     appState.resetOnboardingAndRestart()
                 }
             } message: {
-                Text("This will reset all permissions and restart the app. You'll need to grant permissions again during setup.")
+                Text("This will reset all permissions, clear chat history, and restart the app. You'll need to grant permissions again during setup.")
             }
         }
     }


### PR DESCRIPTION
## Summary
- clear backend chat messages during Reset Onboarding so old onboarding history does not reappear
- keep existing local onboarding/user-data reset behavior
- update reset warning copy to explicitly mention chat history is cleared

## Test
- manual desktop flow: Settings > Advanced > Reset Onboarding