### PR TITLE
Fix allowBluetoothHFP compile error in PhoneCallsPlugin

### DIFF
--- a/app/ios/Runner/PhoneCallsPlugin.swift
+++ b/app/ios/Runner/PhoneCallsPlugin.swift
@@ -351,7 +351,7 @@ extension PhoneCallsPlugin: CXProviderDelegate {
             try audioSession.setCategory(
                 .playAndRecord,
                 mode: .voiceChat,
-                options: [.allowBluetoothHFP, .allowBluetoothA2DP, .defaultToSpeaker]
+                options: [.allowBluetooth, .allowBluetoothA2DP, .defaultToSpeaker]
             )
             try audioSession.setPreferredSampleRate(48000)
             try audioSession.setPreferredIOBufferDuration(0.020)


### PR DESCRIPTION
## Summary
- `AVAudioSession.CategoryOptions` has no member `allowBluetoothHFP` — replaced with `allowBluetooth` which covers HFP profile when used with `.playAndRecord` category and `.voiceChat` mode.

## Test plan
- [ ] Verify iOS build compiles successfully
- [ ] Test phone call audio routes to Bluetooth headset

🤖 Generated with [Claude Code](https://claude.com/claude-code)