### PR TITLE
Bump build number +772 → +773 for Codemagic deploy

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.526+772
+version: 1.0.526+773
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bumps build number from +772 to +773 to trigger Codemagic iOS TestFlight + Android builds
- Required after prerelease PR #5529 merged app changes (#5497 token refresh fix)

## Context
PR #5529 merged three cost-cutting fixes including #5497 (app-only token refresh infinite retry fix). Codemagic skips if the build number is already on TestFlight, so this bump is needed to deploy the app changes.

## Test plan
- [ ] Codemagic `ios-internal-auto` / `android-internal-auto` workflows trigger on merge
- [ ] Build uploads to TestFlight / internal track

_by AI for @beastoin_