### PR TITLE
Desktop: use dev Firebase config for dev builds

### DIFF
--- a/backend/models/message_event.py
+++ b/backend/models/message_event.py
@@ -181,3 +181,21 @@ class SegmentsDeletedEvent(MessageEvent):
         j["type"] = self.event_type
         del j["event_type"]
         return j
+
+
+# Desktop proactive AI events (Phase 2 — #5396)
+
+
+class FocusResultEvent(MessageEvent):
+    event_type: str = "focus_result"
+    frame_id: str
+    status: str
+    app_or_site: str
+    description: str
+    message: Optional[str] = None
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j

--- a/backend/models/message_event.py
+++ b/backend/models/message_event.py
@@ -199,3 +199,84 @@ class FocusResultEvent(MessageEvent):
         j["type"] = self.event_type
         del j["event_type"]
         return j
+
+
+class TasksExtractedEvent(MessageEvent):
+    event_type: str = "tasks_extracted"
+    frame_id: str
+    tasks: List = []
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j
+
+
+class MemoriesExtractedEvent(MessageEvent):
+    event_type: str = "memories_extracted"
+    frame_id: str
+    memories: List = []
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j
+
+
+class AdviceExtractedEvent(MessageEvent):
+    event_type: str = "advice_extracted"
+    frame_id: str
+    advice: Optional[Any] = None
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j
+
+
+class LiveNoteEvent(MessageEvent):
+    event_type: str = "live_note"
+    text: str
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j
+
+
+class ProfileUpdatedEvent(MessageEvent):
+    event_type: str = "profile_updated"
+    profile_text: str
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j
+
+
+class RerankCompleteEvent(MessageEvent):
+    event_type: str = "rerank_complete"
+    updated_tasks: List = []
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j
+
+
+class DedupCompleteEvent(MessageEvent):
+    event_type: str = "dedup_complete"
+    deleted_ids: List = []
+    reason: str = ""
+
+    def to_json(self):
+        j = self.model_dump(mode="json")
+        j["type"] = self.event_type
+        del j["event_type"]
+        return j

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -51,6 +51,7 @@ from models.conversation import (
 )
 from models.message_event import (
     ConversationEvent,
+    FocusResultEvent,
     FREEMIUM_ACTION_SETUP_ON_DEVICE_STT,
     FreemiumThresholdReachedEvent,
     LastConversationEvent,
@@ -100,6 +101,7 @@ from utils.stt.speaker_embedding import (
     SPEAKER_MATCH_THRESHOLD,
 )
 from utils.speaker_sample_migration import maybe_migrate_person_samples
+from utils.desktop.focus import analyze_focus
 from utils.log_sanitizer import sanitize, sanitize_pii
 
 logger = logging.getLogger(__name__)
@@ -2127,6 +2129,38 @@ async def _stream_handler(
                                 logger.info(
                                     f"Speaker assignment ignored: missing speaker_id/person_id/person_name. {uid} {session_id}"
                                 )
+                        # Desktop proactive AI — screen_frame analysis (#5396)
+                        elif json_data.get('type') == 'screen_frame':
+                            frame_id = json_data.get('frame_id', '')
+                            image_b64 = json_data.get('image_b64', '')
+                            analyze_types = json_data.get('analyze', [])
+                            if image_b64 and 'focus' in analyze_types:
+                                async def _handle_focus(fid, img, app, wtitle):
+                                    try:
+                                        result = await analyze_focus(
+                                            uid=uid,
+                                            image_b64=img,
+                                            app_name=app,
+                                            window_title=wtitle,
+                                        )
+                                        _send_message_event(FocusResultEvent(
+                                            frame_id=fid,
+                                            status=result['status'],
+                                            app_or_site=result['app_or_site'],
+                                            description=result['description'],
+                                            message=result.get('message'),
+                                        ))
+                                    except Exception as focus_err:
+                                        logger.error(f"Focus analysis failed: {focus_err} {uid} {session_id}")
+
+                                spawn(_handle_focus(
+                                    frame_id,
+                                    image_b64,
+                                    json_data.get('app_name', ''),
+                                    json_data.get('window_title', ''),
+                                ))
+                            elif not image_b64:
+                                logger.warning(f"screen_frame missing image_b64 {uid} {session_id}")
                     except json.JSONDecodeError:
                         logger.info(
                             f"Received non-json text message: {sanitize(message.get('text'))} {uid} {session_id}"

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -50,17 +50,24 @@ from models.conversation import (
     TranscriptSegment,
 )
 from models.message_event import (
+    AdviceExtractedEvent,
     ConversationEvent,
+    DedupCompleteEvent,
     FocusResultEvent,
     FREEMIUM_ACTION_SETUP_ON_DEVICE_STT,
     FreemiumThresholdReachedEvent,
     LastConversationEvent,
+    LiveNoteEvent,
+    MemoriesExtractedEvent,
     MessageEvent,
     MessageServiceStatusEvent,
     PhotoDescribedEvent,
     PhotoProcessingEvent,
+    ProfileUpdatedEvent,
+    RerankCompleteEvent,
     SegmentsDeletedEvent,
     SpeakerLabelSuggestionEvent,
+    TasksExtractedEvent,
     TranslationEvent,
 )
 from models.transcript_segment import Translation
@@ -101,7 +108,13 @@ from utils.stt.speaker_embedding import (
     SPEAKER_MATCH_THRESHOLD,
 )
 from utils.speaker_sample_migration import maybe_migrate_person_samples
+from utils.desktop.advice import generate_advice
 from utils.desktop.focus import analyze_focus
+from utils.desktop.live_notes import generate_live_note
+from utils.desktop.memories import extract_memories
+from utils.desktop.profile import generate_profile
+from utils.desktop.task_ops import dedup_tasks, rerank_tasks
+from utils.desktop.tasks import extract_tasks
 from utils.log_sanitizer import sanitize, sanitize_pii
 
 logger = logging.getLogger(__name__)
@@ -2134,33 +2147,93 @@ async def _stream_handler(
                             frame_id = json_data.get('frame_id', '')
                             image_b64 = json_data.get('image_b64', '')
                             analyze_types = json_data.get('analyze', [])
-                            if image_b64 and 'focus' in analyze_types:
-                                async def _handle_focus(fid, img, app, wtitle):
-                                    try:
-                                        result = await analyze_focus(
-                                            uid=uid,
-                                            image_b64=img,
-                                            app_name=app,
-                                            window_title=wtitle,
-                                        )
-                                        _send_message_event(FocusResultEvent(
-                                            frame_id=fid,
-                                            status=result['status'],
-                                            app_or_site=result['app_or_site'],
-                                            description=result['description'],
-                                            message=result.get('message'),
-                                        ))
-                                    except Exception as focus_err:
-                                        logger.error(f"Focus analysis failed: {focus_err} {uid} {session_id}")
-
-                                spawn(_handle_focus(
-                                    frame_id,
-                                    image_b64,
-                                    json_data.get('app_name', ''),
-                                    json_data.get('window_title', ''),
-                                ))
-                            elif not image_b64:
+                            sf_app = json_data.get('app_name', '')
+                            sf_wtitle = json_data.get('window_title', '')
+                            if not image_b64:
                                 logger.warning(f"screen_frame missing image_b64 {uid} {session_id}")
+                            else:
+                                # Fan out to parallel handlers per analyze type
+                                if 'focus' in analyze_types:
+                                    async def _handle_focus(fid, img, app, wtitle):
+                                        try:
+                                            result = await analyze_focus(uid=uid, image_b64=img, app_name=app, window_title=wtitle)
+                                            _send_message_event(FocusResultEvent(
+                                                frame_id=fid, status=result['status'], app_or_site=result['app_or_site'],
+                                                description=result['description'], message=result.get('message'),
+                                            ))
+                                        except Exception as e:
+                                            logger.error(f"Focus analysis failed: {e} {uid} {session_id}")
+                                    spawn(_handle_focus(frame_id, image_b64, sf_app, sf_wtitle))
+
+                                if 'tasks' in analyze_types:
+                                    async def _handle_tasks(fid, img, app, wtitle):
+                                        try:
+                                            result = await extract_tasks(uid=uid, image_b64=img, app_name=app, window_title=wtitle)
+                                            _send_message_event(TasksExtractedEvent(frame_id=fid, tasks=result.get('tasks', [])))
+                                        except Exception as e:
+                                            logger.error(f"Task extraction failed: {e} {uid} {session_id}")
+                                    spawn(_handle_tasks(frame_id, image_b64, sf_app, sf_wtitle))
+
+                                if 'memories' in analyze_types:
+                                    async def _handle_memories(fid, img, app, wtitle):
+                                        try:
+                                            result = await extract_memories(uid=uid, image_b64=img, app_name=app, window_title=wtitle)
+                                            _send_message_event(MemoriesExtractedEvent(frame_id=fid, memories=result.get('memories', [])))
+                                        except Exception as e:
+                                            logger.error(f"Memory extraction failed: {e} {uid} {session_id}")
+                                    spawn(_handle_memories(frame_id, image_b64, sf_app, sf_wtitle))
+
+                                if 'advice' in analyze_types:
+                                    async def _handle_advice(fid, img, app, wtitle):
+                                        try:
+                                            result = await generate_advice(uid=uid, image_b64=img, app_name=app, window_title=wtitle)
+                                            _send_message_event(AdviceExtractedEvent(
+                                                frame_id=fid, advice=result.get('advice'),
+                                            ))
+                                        except Exception as e:
+                                            logger.error(f"Advice generation failed: {e} {uid} {session_id}")
+                                    spawn(_handle_advice(frame_id, image_b64, sf_app, sf_wtitle))
+
+                        # Desktop proactive AI — text-only message types (#5396)
+                        elif json_data.get('type') == 'live_notes_text':
+                            async def _handle_live_notes(text, ctx):
+                                try:
+                                    result = await generate_live_note(text=text, session_context=ctx)
+                                    if result.get('text'):
+                                        _send_message_event(LiveNoteEvent(text=result['text']))
+                                except Exception as e:
+                                    logger.error(f"Live note generation failed: {e} {uid} {session_id}")
+                            spawn(_handle_live_notes(json_data.get('text', ''), json_data.get('session_context', '')))
+
+                        elif json_data.get('type') == 'profile_request':
+                            async def _handle_profile():
+                                try:
+                                    result = await generate_profile(uid=uid)
+                                    _send_message_event(ProfileUpdatedEvent(profile_text=result['profile_text']))
+                                except Exception as e:
+                                    logger.error(f"Profile generation failed: {e} {uid} {session_id}")
+                            spawn(_handle_profile())
+
+                        elif json_data.get('type') == 'task_rerank':
+                            async def _handle_rerank():
+                                try:
+                                    result = await rerank_tasks(uid=uid)
+                                    _send_message_event(RerankCompleteEvent(updated_tasks=result['updated_tasks']))
+                                except Exception as e:
+                                    logger.error(f"Task reranking failed: {e} {uid} {session_id}")
+                            spawn(_handle_rerank())
+
+                        elif json_data.get('type') == 'task_dedup':
+                            async def _handle_dedup():
+                                try:
+                                    result = await dedup_tasks(uid=uid)
+                                    _send_message_event(DedupCompleteEvent(
+                                        deleted_ids=result['deleted_ids'], reason=result['reason'],
+                                    ))
+                                except Exception as e:
+                                    logger.error(f"Task dedup failed: {e} {uid} {session_id}")
+                            spawn(_handle_dedup())
+
                     except json.JSONDecodeError:
                         logger.info(
                             f"Received non-json text message: {sanitize(message.get('text'))} {uid} {session_id}"

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -37,3 +37,9 @@ pytest tests/unit/test_desktop_updates.py -v
 pytest tests/unit/test_translation_optimization.py -v
 pytest tests/unit/test_conversation_source_unknown.py -v
 pytest tests/unit/test_desktop_focus.py -v
+pytest tests/unit/test_desktop_tasks.py -v
+pytest tests/unit/test_desktop_memories.py -v
+pytest tests/unit/test_desktop_advice.py -v
+pytest tests/unit/test_desktop_live_notes.py -v
+pytest tests/unit/test_desktop_profile.py -v
+pytest tests/unit/test_desktop_task_ops.py -v

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -36,3 +36,4 @@ pytest tests/unit/test_pusher_heartbeat.py -v
 pytest tests/unit/test_desktop_updates.py -v
 pytest tests/unit/test_translation_optimization.py -v
 pytest tests/unit/test_conversation_source_unknown.py -v
+pytest tests/unit/test_desktop_focus.py -v

--- a/backend/tests/unit/test_desktop_advice.py
+++ b/backend/tests/unit/test_desktop_advice.py
@@ -1,0 +1,159 @@
+"""Tests for desktop advice handler (Phase 2 — #5396)."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault('firebase_admin.auth', MagicMock())
+sys.modules.setdefault('firebase_admin.firestore', MagicMock())
+sys.modules.setdefault('database._client', MagicMock())
+_mock_clients = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _mock_clients)
+
+from utils.desktop.advice import (
+    AdviceResult,
+    ADVICE_SYSTEM_PROMPT,
+    _build_advice_context,
+    generate_advice,
+)
+from models.message_event import AdviceExtractedEvent
+
+
+class TestAdviceResultModel:
+    def test_advice_with_content(self):
+        r = AdviceResult(has_advice=True, content="Take a break", category="health", confidence=0.8)
+        assert r.has_advice is True
+        assert r.content == "Take a break"
+        assert r.category == "health"
+
+    def test_no_advice(self):
+        r = AdviceResult(has_advice=False, confidence=0.1)
+        assert r.has_advice is False
+        assert r.content is None
+        assert r.category is None
+
+    def test_confidence_bounds(self):
+        with pytest.raises(Exception):
+            AdviceResult(has_advice=True, confidence=2.0)
+
+
+class TestAdviceExtractedEvent:
+    def test_event_with_advice(self):
+        event = AdviceExtractedEvent(
+            frame_id="frame789",
+            advice={"content": "Try dark mode", "category": "productivity", "confidence": 0.7},
+        )
+        data = event.to_json()
+        assert data["type"] == "advice_extracted"
+        assert data["frame_id"] == "frame789"
+        assert data["advice"]["content"] == "Try dark mode"
+
+    def test_event_no_advice(self):
+        event = AdviceExtractedEvent(frame_id="frame789", advice=None)
+        data = event.to_json()
+        assert data["advice"] is None
+
+
+class TestBuildAdviceContext:
+    @patch('utils.desktop.advice.get_action_items')
+    @patch('utils.desktop.advice.get_user_goals')
+    def test_goals_and_tasks_in_context(self, mock_goals, mock_tasks):
+        mock_goals.return_value = [{'title': 'Ship v2'}]
+        mock_tasks.return_value = [{'description': 'Write tests'}]
+        ctx = _build_advice_context("uid1")
+        assert "Ship v2" in ctx
+        assert "Write tests" in ctx
+
+    @patch('utils.desktop.advice.get_action_items')
+    @patch('utils.desktop.advice.get_user_goals')
+    def test_empty_context(self, mock_goals, mock_tasks):
+        mock_goals.return_value = []
+        mock_tasks.return_value = []
+        ctx = _build_advice_context("uid1")
+        assert ctx == ""
+
+    @patch('utils.desktop.advice.get_action_items')
+    @patch('utils.desktop.advice.get_user_goals')
+    def test_graceful_on_errors(self, mock_goals, mock_tasks):
+        mock_goals.side_effect = Exception("DB error")
+        mock_tasks.side_effect = Exception("DB error")
+        ctx = _build_advice_context("uid1")
+        assert ctx == ""
+
+    @patch('utils.desktop.advice.get_action_items')
+    @patch('utils.desktop.advice.get_user_goals')
+    def test_goals_fallback_to_description(self, mock_goals, mock_tasks):
+        mock_goals.return_value = [{'description': 'Fallback goal'}]
+        mock_tasks.return_value = []
+        ctx = _build_advice_context("uid1")
+        assert "Fallback goal" in ctx
+
+
+class TestGenerateAdvice:
+    @patch('utils.desktop.advice._build_advice_context')
+    @patch('utils.desktop.advice.llm_gemini_flash')
+    def test_returns_advice(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=AdviceResult(
+                has_advice=True,
+                content="Consider using a linter",
+                category="productivity",
+                confidence=0.75,
+            )
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            generate_advice("uid1", "base64img", "VS Code", "main.py")
+        )
+        assert result["has_advice"] is True
+        assert result["advice"]["content"] == "Consider using a linter"
+        assert result["advice"]["category"] == "productivity"
+
+    @patch('utils.desktop.advice._build_advice_context')
+    @patch('utils.desktop.advice.llm_gemini_flash')
+    def test_no_advice(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=AdviceResult(has_advice=False, confidence=0.1)
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            generate_advice("uid1", "base64img")
+        )
+        assert result["has_advice"] is False
+        assert result["advice"] is None
+
+    @patch('utils.desktop.advice._build_advice_context')
+    @patch('utils.desktop.advice.llm_gemini_flash')
+    def test_includes_app_info(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=AdviceResult(has_advice=False, confidence=0.1)
+        )
+        asyncio.get_event_loop().run_until_complete(
+            generate_advice("uid1", "base64img", "Chrome", "Stack Overflow")
+        )
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        human_msg = call_args[1]
+        text_content = human_msg.content[0]["text"]
+        assert "Chrome" in text_content
+        assert "Stack Overflow" in text_content
+
+
+class TestAdviceSystemPrompt:
+    def test_includes_categories(self):
+        assert "productivity" in ADVICE_SYSTEM_PROMPT
+        assert "mistake_prevention" in ADVICE_SYSTEM_PROMPT
+        assert "health" in ADVICE_SYSTEM_PROMPT
+        assert "goal_alignment" in ADVICE_SYSTEM_PROMPT
+
+    def test_includes_tone_guidance(self):
+        assert "TONE" in ADVICE_SYSTEM_PROMPT

--- a/backend/tests/unit/test_desktop_focus.py
+++ b/backend/tests/unit/test_desktop_focus.py
@@ -1,0 +1,382 @@
+"""Tests for desktop focus analysis (Phase 2 — #5396)."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Mock heavy dependencies before any project imports
+sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault('firebase_admin.auth', MagicMock())
+sys.modules.setdefault('firebase_admin.firestore', MagicMock())
+sys.modules.setdefault('database._client', MagicMock())
+_mock_clients = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _mock_clients)
+
+# Now safe to import
+from utils.desktop.focus import FocusResult, FOCUS_SYSTEM_PROMPT, _build_context
+from models.message_event import FocusResultEvent
+
+# --- FocusResult model tests ---
+
+
+class TestFocusResultModel:
+    def test_focus_result_focused(self):
+        result = FocusResult(
+            status="focused",
+            app_or_site="VS Code",
+            description="Writing Python code",
+            message="Great focus!",
+        )
+        assert result.status == "focused"
+        assert result.app_or_site == "VS Code"
+        assert result.description == "Writing Python code"
+        assert result.message == "Great focus!"
+
+    def test_focus_result_distracted(self):
+        result = FocusResult(
+            status="distracted",
+            app_or_site="YouTube",
+            description="Watching videos",
+            message="Time to refocus!",
+        )
+        assert result.status == "distracted"
+        assert result.app_or_site == "YouTube"
+
+    def test_focus_result_message_optional(self):
+        result = FocusResult(
+            status="focused",
+            app_or_site="Terminal",
+            description="Running tests",
+        )
+        assert result.message is None
+
+    def test_focus_result_message_none_explicit(self):
+        result = FocusResult(
+            status="focused",
+            app_or_site="Terminal",
+            description="Running tests",
+            message=None,
+        )
+        assert result.message is None
+
+
+# --- FocusResultEvent tests ---
+
+
+class TestFocusResultEvent:
+    def test_focus_result_event_to_json(self):
+        event = FocusResultEvent(
+            frame_id="abc-123",
+            status="focused",
+            app_or_site="VS Code",
+            description="Writing code",
+            message="Keep it up!",
+        )
+        j = event.to_json()
+        assert j["type"] == "focus_result"
+        assert j["frame_id"] == "abc-123"
+        assert j["status"] == "focused"
+        assert j["app_or_site"] == "VS Code"
+        assert j["description"] == "Writing code"
+        assert j["message"] == "Keep it up!"
+        assert "event_type" not in j
+
+    def test_focus_result_event_null_message(self):
+        event = FocusResultEvent(
+            frame_id="def-456",
+            status="distracted",
+            app_or_site="Twitter",
+            description="Browsing feed",
+        )
+        j = event.to_json()
+        assert j["type"] == "focus_result"
+        assert j["message"] is None
+
+    def test_focus_result_event_default_type(self):
+        event = FocusResultEvent(
+            frame_id="x",
+            status="focused",
+            app_or_site="Code",
+            description="Working",
+        )
+        assert event.event_type == "focus_result"
+
+
+# --- Context building tests ---
+
+
+class TestBuildContext:
+    @patch('utils.desktop.focus.get_memories', return_value=[])
+    @patch('utils.desktop.focus.get_action_items', return_value=[])
+    @patch('utils.desktop.focus.get_user_goals', return_value=[])
+    def test_empty_context(self, mock_goals, mock_tasks, mock_memories):
+        result = _build_context("test-uid")
+        assert result == ""
+
+    @patch('utils.desktop.focus.get_memories', return_value=[])
+    @patch('utils.desktop.focus.get_action_items', return_value=[])
+    @patch(
+        'utils.desktop.focus.get_user_goals',
+        return_value=[
+            {"title": "Ship Phase 2"},
+            {"title": "Learn Rust"},
+        ],
+    )
+    def test_goals_in_context(self, mock_goals, mock_tasks, mock_memories):
+        result = _build_context("test-uid")
+        assert "Active Goals:" in result
+        assert "Ship Phase 2" in result
+        assert "Learn Rust" in result
+
+    @patch('utils.desktop.focus.get_memories', return_value=[])
+    @patch(
+        'utils.desktop.focus.get_action_items',
+        return_value=[
+            {"description": "Fix login bug"},
+            {"description": "Review PR #42"},
+        ],
+    )
+    @patch('utils.desktop.focus.get_user_goals', return_value=[])
+    def test_tasks_in_context(self, mock_goals, mock_tasks, mock_memories):
+        result = _build_context("test-uid")
+        assert "Current Tasks:" in result
+        assert "Fix login bug" in result
+        assert "Review PR #42" in result
+
+    @patch(
+        'utils.desktop.focus.get_memories',
+        return_value=[
+            {"structured": {"title": "Learned about WebSockets"}},
+        ],
+    )
+    @patch('utils.desktop.focus.get_action_items', return_value=[])
+    @patch('utils.desktop.focus.get_user_goals', return_value=[])
+    def test_memories_in_context(self, mock_goals, mock_tasks, mock_memories):
+        result = _build_context("test-uid")
+        assert "Recent Memories:" in result
+        assert "Learned about WebSockets" in result
+
+    @patch('utils.desktop.focus.get_memories', side_effect=Exception("DB error"))
+    @patch('utils.desktop.focus.get_action_items', side_effect=Exception("DB error"))
+    @patch('utils.desktop.focus.get_user_goals', side_effect=Exception("DB error"))
+    def test_context_graceful_on_errors(self, mock_goals, mock_tasks, mock_memories):
+        result = _build_context("test-uid")
+        assert result == ""
+
+    @patch('utils.desktop.focus.get_memories', return_value=[])
+    @patch('utils.desktop.focus.get_action_items', return_value=[])
+    @patch(
+        'utils.desktop.focus.get_user_goals',
+        return_value=[
+            {"description": "Goal without title"},
+        ],
+    )
+    def test_goals_fallback_to_description(self, mock_goals, mock_tasks, mock_memories):
+        result = _build_context("test-uid")
+        assert "Goal without title" in result
+
+    @patch(
+        'utils.desktop.focus.get_memories',
+        return_value=[
+            {"content": "Memory without structured field"},
+        ],
+    )
+    @patch('utils.desktop.focus.get_action_items', return_value=[])
+    @patch('utils.desktop.focus.get_user_goals', return_value=[])
+    def test_memories_fallback_to_content(self, mock_goals, mock_tasks, mock_memories):
+        result = _build_context("test-uid")
+        assert "Memory without structured field" in result
+
+
+# --- analyze_focus integration tests ---
+
+
+class TestAnalyzeFocus:
+    @patch('utils.desktop.focus._build_context', return_value="")
+    @patch('utils.desktop.focus.llm_gemini_flash')
+    def test_analyze_focus_returns_result(self, mock_llm, mock_ctx):
+        from utils.desktop.focus import analyze_focus
+
+        mock_parser = MagicMock()
+        mock_parser.ainvoke = AsyncMock(
+            return_value=FocusResult(
+                status="focused",
+                app_or_site="VS Code",
+                description="Editing Python",
+                message="Nice work!",
+            )
+        )
+        mock_llm.with_structured_output.return_value = mock_parser
+
+        result = asyncio.get_event_loop().run_until_complete(
+            analyze_focus(uid="test", image_b64="base64data", app_name="VS Code", window_title="main.py")
+        )
+
+        assert result["status"] == "focused"
+        assert result["app_or_site"] == "VS Code"
+        assert result["description"] == "Editing Python"
+        assert result["message"] == "Nice work!"
+
+    @patch('utils.desktop.focus._build_context', return_value="Active Goals:\n- Ship code")
+    @patch('utils.desktop.focus.llm_gemini_flash')
+    def test_analyze_focus_includes_context_in_prompt(self, mock_llm, mock_ctx):
+        from utils.desktop.focus import analyze_focus
+
+        mock_parser = MagicMock()
+        mock_parser.ainvoke = AsyncMock(
+            return_value=FocusResult(
+                status="distracted",
+                app_or_site="Twitter",
+                description="Browsing",
+            )
+        )
+        mock_llm.with_structured_output.return_value = mock_parser
+
+        asyncio.get_event_loop().run_until_complete(analyze_focus(uid="test", image_b64="data"))
+
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        human_msg = call_args[1]
+        prompt_text = human_msg.content[0]["text"]
+        assert "Active Goals:" in prompt_text
+
+    @patch('utils.desktop.focus._build_context', return_value="")
+    @patch('utils.desktop.focus.llm_gemini_flash')
+    def test_analyze_focus_includes_history(self, mock_llm, mock_ctx):
+        from utils.desktop.focus import analyze_focus
+
+        mock_parser = MagicMock()
+        mock_parser.ainvoke = AsyncMock(
+            return_value=FocusResult(
+                status="focused",
+                app_or_site="Terminal",
+                description="Running tests",
+            )
+        )
+        mock_llm.with_structured_output.return_value = mock_parser
+
+        asyncio.get_event_loop().run_until_complete(
+            analyze_focus(
+                uid="test",
+                image_b64="data",
+                history="1. [focused] VS Code: Writing code",
+            )
+        )
+
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        human_msg = call_args[1]
+        prompt_text = human_msg.content[0]["text"]
+        assert "Recent activity" in prompt_text
+
+    @patch('utils.desktop.focus._build_context', return_value="")
+    @patch('utils.desktop.focus.llm_gemini_flash')
+    def test_analyze_focus_includes_app_and_window(self, mock_llm, mock_ctx):
+        from utils.desktop.focus import analyze_focus
+
+        mock_parser = MagicMock()
+        mock_parser.ainvoke = AsyncMock(
+            return_value=FocusResult(
+                status="focused",
+                app_or_site="Safari",
+                description="Reading docs",
+            )
+        )
+        mock_llm.with_structured_output.return_value = mock_parser
+
+        asyncio.get_event_loop().run_until_complete(
+            analyze_focus(uid="test", image_b64="data", app_name="Safari", window_title="MDN Web Docs")
+        )
+
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        human_msg = call_args[1]
+        prompt_text = human_msg.content[0]["text"]
+        assert "Safari" in prompt_text
+        assert "MDN Web Docs" in prompt_text
+
+    @patch('utils.desktop.focus._build_context', return_value="")
+    @patch('utils.desktop.focus.llm_gemini_flash')
+    def test_analyze_focus_sends_image_as_base64(self, mock_llm, mock_ctx):
+        from utils.desktop.focus import analyze_focus
+
+        mock_parser = MagicMock()
+        mock_parser.ainvoke = AsyncMock(
+            return_value=FocusResult(
+                status="focused",
+                app_or_site="Code",
+                description="Coding",
+            )
+        )
+        mock_llm.with_structured_output.return_value = mock_parser
+
+        asyncio.get_event_loop().run_until_complete(analyze_focus(uid="test", image_b64="FAKE_BASE64_IMAGE"))
+
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        human_msg = call_args[1]
+        image_part = human_msg.content[1]
+        assert image_part["type"] == "image_url"
+        assert "FAKE_BASE64_IMAGE" in image_part["image_url"]["url"]
+
+    @patch('utils.desktop.focus._build_context', return_value="")
+    @patch('utils.desktop.focus.llm_gemini_flash')
+    def test_analyze_focus_sends_system_prompt(self, mock_llm, mock_ctx):
+        from utils.desktop.focus import analyze_focus
+
+        mock_parser = MagicMock()
+        mock_parser.ainvoke = AsyncMock(
+            return_value=FocusResult(
+                status="focused",
+                app_or_site="Code",
+                description="Coding",
+            )
+        )
+        mock_llm.with_structured_output.return_value = mock_parser
+
+        asyncio.get_event_loop().run_until_complete(analyze_focus(uid="test", image_b64="data"))
+
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        system_msg = call_args[0]
+        assert FOCUS_SYSTEM_PROMPT in system_msg.content
+
+    @patch('utils.desktop.focus._build_context', return_value="")
+    @patch('utils.desktop.focus.llm_gemini_flash')
+    def test_analyze_focus_distracted_result(self, mock_llm, mock_ctx):
+        from utils.desktop.focus import analyze_focus
+
+        mock_parser = MagicMock()
+        mock_parser.ainvoke = AsyncMock(
+            return_value=FocusResult(
+                status="distracted",
+                app_or_site="Reddit",
+                description="Scrolling r/programming",
+                message="Back to work!",
+            )
+        )
+        mock_llm.with_structured_output.return_value = mock_parser
+
+        result = asyncio.get_event_loop().run_until_complete(analyze_focus(uid="test", image_b64="data"))
+
+        assert result["status"] == "distracted"
+        assert result["app_or_site"] == "Reddit"
+        assert result["message"] == "Back to work!"
+
+
+# --- System prompt content tests ---
+
+
+class TestFocusSystemPrompt:
+    def test_prompt_includes_focused_criteria(self):
+        assert "Code editors" in FOCUS_SYSTEM_PROMPT
+
+    def test_prompt_includes_distracted_criteria(self):
+        assert "YouTube" in FOCUS_SYSTEM_PROMPT
+        assert "Twitter" in FOCUS_SYSTEM_PROMPT
+
+    def test_prompt_warns_about_log_text(self):
+        assert "log text" in FOCUS_SYSTEM_PROMPT
+
+    def test_prompt_mentions_context_aware(self):
+        assert "CONTEXT-AWARE" in FOCUS_SYSTEM_PROMPT
+
+    def test_prompt_coaching_message_guidance(self):
+        assert "100 characters max" in FOCUS_SYSTEM_PROMPT

--- a/backend/tests/unit/test_desktop_live_notes.py
+++ b/backend/tests/unit/test_desktop_live_notes.py
@@ -1,0 +1,99 @@
+"""Tests for desktop live notes handler (Phase 2 — #5396)."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault('firebase_admin.auth', MagicMock())
+sys.modules.setdefault('firebase_admin.firestore', MagicMock())
+sys.modules.setdefault('database._client', MagicMock())
+_mock_clients = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _mock_clients)
+
+from utils.desktop.live_notes import (
+    LiveNoteResult,
+    LIVE_NOTES_SYSTEM_PROMPT,
+    generate_live_note,
+)
+from models.message_event import LiveNoteEvent
+
+
+class TestLiveNoteResultModel:
+    def test_note_with_text(self):
+        r = LiveNoteResult(text="Key decision: ship by Friday")
+        assert r.text == "Key decision: ship by Friday"
+
+    def test_empty_note(self):
+        r = LiveNoteResult(text="")
+        assert r.text == ""
+
+
+class TestLiveNoteEvent:
+    def test_event_structure(self):
+        event = LiveNoteEvent(text="Meeting note content")
+        data = event.to_json()
+        assert data["type"] == "live_note"
+        assert data["text"] == "Meeting note content"
+
+
+class TestGenerateLiveNote:
+    @patch('utils.desktop.live_notes.llm_mini')
+    def test_returns_note(self, mock_llm):
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=LiveNoteResult(text="- Decision: use Redis for caching")
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            generate_live_note("We decided to use Redis for caching the API responses")
+        )
+        assert result["text"] == "- Decision: use Redis for caching"
+
+    @patch('utils.desktop.live_notes.llm_mini')
+    def test_empty_result(self, mock_llm):
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(return_value=LiveNoteResult(text=""))
+        result = asyncio.get_event_loop().run_until_complete(
+            generate_live_note("um yeah so like um")
+        )
+        assert result["text"] == ""
+
+    @patch('utils.desktop.live_notes.llm_mini')
+    def test_includes_session_context(self, mock_llm):
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(return_value=LiveNoteResult(text="note"))
+        asyncio.get_event_loop().run_until_complete(
+            generate_live_note("transcript text", session_context="Sprint planning")
+        )
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        human_msg = call_args[1]
+        assert "Sprint planning" in human_msg.content
+
+    @patch('utils.desktop.live_notes.llm_mini')
+    def test_sends_system_prompt(self, mock_llm):
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(return_value=LiveNoteResult(text=""))
+        asyncio.get_event_loop().run_until_complete(
+            generate_live_note("test text")
+        )
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        sys_msg = call_args[0]
+        assert LIVE_NOTES_SYSTEM_PROMPT in sys_msg.content
+
+
+class TestLiveNotesSystemPrompt:
+    def test_includes_condensation_rules(self):
+        assert "Condense" in LIVE_NOTES_SYSTEM_PROMPT
+
+    def test_includes_word_limit(self):
+        assert "200 words" in LIVE_NOTES_SYSTEM_PROMPT
+
+    def test_includes_preservation_rules(self):
+        assert "names" in LIVE_NOTES_SYSTEM_PROMPT
+        assert "decisions" in LIVE_NOTES_SYSTEM_PROMPT

--- a/backend/tests/unit/test_desktop_memories.py
+++ b/backend/tests/unit/test_desktop_memories.py
@@ -1,0 +1,150 @@
+"""Tests for desktop memory extraction handler (Phase 2 — #5396)."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault('firebase_admin.auth', MagicMock())
+sys.modules.setdefault('firebase_admin.firestore', MagicMock())
+sys.modules.setdefault('database._client', MagicMock())
+_mock_clients = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _mock_clients)
+
+from utils.desktop.memories import (
+    ExtractedMemory,
+    MemoryExtractionResult,
+    MEMORY_SYSTEM_PROMPT,
+    _build_memory_context,
+    extract_memories,
+)
+from models.message_event import MemoriesExtractedEvent
+
+
+class TestExtractedMemoryModel:
+    def test_memory_all_fields(self):
+        m = ExtractedMemory(content="User prefers dark mode", category="system", confidence=0.95)
+        assert m.content == "User prefers dark mode"
+        assert m.category == "system"
+        assert m.confidence == 0.95
+
+    def test_memory_interesting_category(self):
+        m = ExtractedMemory(content="AI tip from article", category="interesting", confidence=0.7)
+        assert m.category == "interesting"
+
+    def test_confidence_bounds(self):
+        with pytest.raises(Exception):
+            ExtractedMemory(content="test", category="system", confidence=1.5)
+
+
+class TestMemoryExtractionResult:
+    def test_result_with_memories(self):
+        result = MemoryExtractionResult(
+            memories=[ExtractedMemory(content="Fact 1", category="system", confidence=0.8)]
+        )
+        assert len(result.memories) == 1
+
+    def test_result_empty(self):
+        result = MemoryExtractionResult()
+        assert result.memories == []
+
+
+class TestMemoriesExtractedEvent:
+    def test_event_structure(self):
+        event = MemoriesExtractedEvent(
+            frame_id="frame456",
+            memories=[{"content": "Test fact", "category": "system", "confidence": 0.9}],
+        )
+        data = event.to_json()
+        assert data["type"] == "memories_extracted"
+        assert data["frame_id"] == "frame456"
+        assert len(data["memories"]) == 1
+
+
+class TestBuildMemoryContext:
+    @patch('utils.desktop.memories.get_memories')
+    def test_existing_memories_in_context(self, mock_get):
+        mock_get.return_value = [
+            {'structured': {'content': 'User likes Python'}},
+            {'content': 'Fallback content'},
+        ]
+        ctx = _build_memory_context("uid1")
+        assert "User likes Python" in ctx
+        assert "Fallback content" in ctx
+        assert "DO NOT extract duplicates" in ctx
+
+    @patch('utils.desktop.memories.get_memories')
+    def test_empty_context(self, mock_get):
+        mock_get.return_value = []
+        ctx = _build_memory_context("uid1")
+        assert ctx == ""
+
+    @patch('utils.desktop.memories.get_memories')
+    def test_graceful_on_errors(self, mock_get):
+        mock_get.side_effect = Exception("DB error")
+        ctx = _build_memory_context("uid1")
+        assert ctx == ""
+
+
+class TestExtractMemories:
+    @patch('utils.desktop.memories._build_memory_context')
+    @patch('utils.desktop.memories.llm_gemini_flash')
+    def test_extract_returns_memories(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=MemoryExtractionResult(
+                memories=[
+                    ExtractedMemory(content="User works on Omi project", category="system", confidence=0.85),
+                ]
+            )
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            extract_memories("uid1", "base64img", "VS Code", "omi/main.py")
+        )
+        assert len(result["memories"]) == 1
+        assert result["memories"][0]["content"] == "User works on Omi project"
+        assert result["memories"][0]["category"] == "system"
+
+    @patch('utils.desktop.memories._build_memory_context')
+    @patch('utils.desktop.memories.llm_gemini_flash')
+    def test_extract_empty_result(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(return_value=MemoryExtractionResult())
+        result = asyncio.get_event_loop().run_until_complete(
+            extract_memories("uid1", "base64img")
+        )
+        assert result["memories"] == []
+
+    @patch('utils.desktop.memories._build_memory_context')
+    @patch('utils.desktop.memories.llm_gemini_flash')
+    def test_sends_image_and_system_prompt(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(return_value=MemoryExtractionResult())
+        asyncio.get_event_loop().run_until_complete(
+            extract_memories("uid1", "testimg64")
+        )
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        sys_msg = call_args[0]
+        human_msg = call_args[1]
+        assert MEMORY_SYSTEM_PROMPT in sys_msg.content
+        assert human_msg.content[1]["image_url"]["url"] == "data:image/jpeg;base64,testimg64"
+
+
+class TestMemorySystemPrompt:
+    def test_includes_extraction_rules(self):
+        assert "EXTRACTION RULES" in MEMORY_SYSTEM_PROMPT
+
+    def test_includes_dedup(self):
+        assert "DEDUPLICATION" in MEMORY_SYSTEM_PROMPT
+
+    def test_includes_categories(self):
+        assert "system" in MEMORY_SYSTEM_PROMPT
+        assert "interesting" in MEMORY_SYSTEM_PROMPT

--- a/backend/tests/unit/test_desktop_profile.py
+++ b/backend/tests/unit/test_desktop_profile.py
@@ -1,0 +1,103 @@
+"""Tests for desktop profile generation handler (Phase 2 — #5396)."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault('firebase_admin.auth', MagicMock())
+sys.modules.setdefault('firebase_admin.firestore', MagicMock())
+sys.modules.setdefault('database._client', MagicMock())
+_mock_clients = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _mock_clients)
+
+from utils.desktop.profile import (
+    ProfileResult,
+    PROFILE_SYSTEM_PROMPT,
+    generate_profile,
+)
+from models.message_event import ProfileUpdatedEvent
+
+
+class TestProfileResultModel:
+    def test_profile_text(self):
+        r = ProfileResult(profile_text="The user is a backend engineer focused on Python.")
+        assert "backend engineer" in r.profile_text
+
+
+class TestProfileUpdatedEvent:
+    def test_event_structure(self):
+        event = ProfileUpdatedEvent(profile_text="User profile text")
+        data = event.to_json()
+        assert data["type"] == "profile_updated"
+        assert data["profile_text"] == "User profile text"
+
+
+class TestGenerateProfile:
+    @patch('utils.desktop.profile.get_memories')
+    @patch('utils.desktop.profile.get_action_items')
+    @patch('utils.desktop.profile.get_user_goals')
+    @patch('utils.desktop.profile.llm_mini')
+    def test_generates_profile(self, mock_llm, mock_goals, mock_tasks, mock_memories):
+        mock_goals.return_value = [{'title': 'Ship v2'}]
+        mock_tasks.return_value = [{'description': 'Fix auth bug'}]
+        mock_memories.return_value = [{'structured': {'content': 'User prefers Python'}}]
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=ProfileResult(profile_text="The user is a developer focused on shipping v2.")
+        )
+        result = asyncio.get_event_loop().run_until_complete(generate_profile("uid1"))
+        assert "developer" in result["profile_text"]
+
+    @patch('utils.desktop.profile.get_memories')
+    @patch('utils.desktop.profile.get_action_items')
+    @patch('utils.desktop.profile.get_user_goals')
+    def test_no_data_returns_default(self, mock_goals, mock_tasks, mock_memories):
+        mock_goals.return_value = []
+        mock_tasks.return_value = []
+        mock_memories.return_value = []
+        result = asyncio.get_event_loop().run_until_complete(generate_profile("uid1"))
+        assert "No data available" in result["profile_text"]
+
+    @patch('utils.desktop.profile.get_memories')
+    @patch('utils.desktop.profile.get_action_items')
+    @patch('utils.desktop.profile.get_user_goals')
+    @patch('utils.desktop.profile.llm_mini')
+    def test_graceful_on_db_errors(self, mock_llm, mock_goals, mock_tasks, mock_memories):
+        mock_goals.side_effect = Exception("DB error")
+        mock_tasks.side_effect = Exception("DB error")
+        mock_memories.side_effect = Exception("DB error")
+        result = asyncio.get_event_loop().run_until_complete(generate_profile("uid1"))
+        assert "No data available" in result["profile_text"]
+
+    @patch('utils.desktop.profile.get_memories')
+    @patch('utils.desktop.profile.get_action_items')
+    @patch('utils.desktop.profile.get_user_goals')
+    @patch('utils.desktop.profile.llm_mini')
+    def test_includes_goals_in_prompt(self, mock_llm, mock_goals, mock_tasks, mock_memories):
+        mock_goals.return_value = [{'title': 'Learn Rust'}]
+        mock_tasks.return_value = []
+        mock_memories.return_value = []
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=ProfileResult(profile_text="Profile text")
+        )
+        asyncio.get_event_loop().run_until_complete(generate_profile("uid1"))
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        human_msg = call_args[1]
+        assert "Learn Rust" in human_msg.content
+
+
+class TestProfileSystemPrompt:
+    def test_third_person_format(self):
+        assert "third person" in PROFILE_SYSTEM_PROMPT
+
+    def test_word_limit(self):
+        assert "300 words" in PROFILE_SYSTEM_PROMPT
+
+    def test_factual_requirement(self):
+        assert "factual" in PROFILE_SYSTEM_PROMPT

--- a/backend/tests/unit/test_desktop_task_ops.py
+++ b/backend/tests/unit/test_desktop_task_ops.py
@@ -1,0 +1,175 @@
+"""Tests for desktop task operations (rerank + dedup) handlers (Phase 2 — #5396)."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault('firebase_admin.auth', MagicMock())
+sys.modules.setdefault('firebase_admin.firestore', MagicMock())
+sys.modules.setdefault('database._client', MagicMock())
+_mock_clients = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _mock_clients)
+
+from utils.desktop.task_ops import (
+    RankedTask,
+    RerankResult,
+    DedupGroup,
+    DedupResult,
+    RERANK_SYSTEM_PROMPT,
+    DEDUP_SYSTEM_PROMPT,
+    rerank_tasks,
+    dedup_tasks,
+)
+from models.message_event import RerankCompleteEvent, DedupCompleteEvent
+
+
+# --- Rerank tests ---
+
+
+class TestRankedTaskModel:
+    def test_ranked_task(self):
+        t = RankedTask(id="task1", new_position=1)
+        assert t.id == "task1"
+        assert t.new_position == 1
+
+
+class TestRerankResult:
+    def test_rerank_result(self):
+        r = RerankResult(updated_tasks=[RankedTask(id="t1", new_position=1)])
+        assert len(r.updated_tasks) == 1
+
+
+class TestRerankCompleteEvent:
+    def test_event_structure(self):
+        event = RerankCompleteEvent(updated_tasks=[{"id": "t1", "new_position": 1}])
+        data = event.to_json()
+        assert data["type"] == "rerank_complete"
+        assert len(data["updated_tasks"]) == 1
+
+
+class TestRerankTasks:
+    @patch('utils.desktop.task_ops.get_action_items')
+    @patch('utils.desktop.task_ops.llm_mini')
+    def test_rerank_returns_order(self, mock_llm, mock_get):
+        mock_get.return_value = [
+            {'id': 't1', 'description': 'Low priority', 'priority': 'low'},
+            {'id': 't2', 'description': 'Urgent fix', 'priority': 'high', 'due_at': '2026-03-08'},
+        ]
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=RerankResult(
+                updated_tasks=[
+                    RankedTask(id="t2", new_position=1),
+                    RankedTask(id="t1", new_position=2),
+                ]
+            )
+        )
+        result = asyncio.get_event_loop().run_until_complete(rerank_tasks("uid1"))
+        assert result["updated_tasks"][0]["id"] == "t2"
+        assert result["updated_tasks"][0]["new_position"] == 1
+
+    @patch('utils.desktop.task_ops.get_action_items')
+    def test_rerank_empty_tasks(self, mock_get):
+        mock_get.return_value = []
+        result = asyncio.get_event_loop().run_until_complete(rerank_tasks("uid1"))
+        assert result["updated_tasks"] == []
+
+    @patch('utils.desktop.task_ops.get_action_items')
+    def test_rerank_db_error(self, mock_get):
+        mock_get.side_effect = Exception("DB error")
+        result = asyncio.get_event_loop().run_until_complete(rerank_tasks("uid1"))
+        assert result["updated_tasks"] == []
+
+
+# --- Dedup tests ---
+
+
+class TestDedupGroupModel:
+    def test_dedup_group(self):
+        g = DedupGroup(keep_id="t1", delete_ids=["t2", "t3"], reason="Same task")
+        assert g.keep_id == "t1"
+        assert len(g.delete_ids) == 2
+
+
+class TestDedupResult:
+    def test_dedup_with_groups(self):
+        r = DedupResult(groups=[DedupGroup(keep_id="t1", delete_ids=["t2"], reason="Duplicate")])
+        assert len(r.groups) == 1
+
+    def test_dedup_no_groups(self):
+        r = DedupResult()
+        assert r.groups == []
+
+
+class TestDedupCompleteEvent:
+    def test_event_structure(self):
+        event = DedupCompleteEvent(deleted_ids=["t2", "t3"], reason="Duplicate tasks")
+        data = event.to_json()
+        assert data["type"] == "dedup_complete"
+        assert data["deleted_ids"] == ["t2", "t3"]
+        assert data["reason"] == "Duplicate tasks"
+
+
+class TestDedupTasks:
+    @patch('utils.desktop.task_ops.get_action_items')
+    @patch('utils.desktop.task_ops.llm_mini')
+    def test_dedup_finds_duplicates(self, mock_llm, mock_get):
+        mock_get.return_value = [
+            {'id': 't1', 'description': 'Call John'},
+            {'id': 't2', 'description': 'Phone John'},
+            {'id': 't3', 'description': 'Write report'},
+        ]
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=DedupResult(
+                groups=[DedupGroup(keep_id="t1", delete_ids=["t2"], reason="Same action: contact John")]
+            )
+        )
+        result = asyncio.get_event_loop().run_until_complete(dedup_tasks("uid1"))
+        assert result["deleted_ids"] == ["t2"]
+        assert "contact John" in result["reason"]
+
+    @patch('utils.desktop.task_ops.get_action_items')
+    @patch('utils.desktop.task_ops.llm_mini')
+    def test_dedup_no_duplicates(self, mock_llm, mock_get):
+        mock_get.return_value = [
+            {'id': 't1', 'description': 'Task A'},
+            {'id': 't2', 'description': 'Task B'},
+        ]
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(return_value=DedupResult())
+        result = asyncio.get_event_loop().run_until_complete(dedup_tasks("uid1"))
+        assert result["deleted_ids"] == []
+        assert result["reason"] == "No duplicates found"
+
+    @patch('utils.desktop.task_ops.get_action_items')
+    def test_dedup_too_few_tasks(self, mock_get):
+        mock_get.return_value = [{'id': 't1', 'description': 'Only one'}]
+        result = asyncio.get_event_loop().run_until_complete(dedup_tasks("uid1"))
+        assert result["deleted_ids"] == []
+        assert "Not enough" in result["reason"]
+
+    @patch('utils.desktop.task_ops.get_action_items')
+    def test_dedup_db_error(self, mock_get):
+        mock_get.side_effect = Exception("DB error")
+        result = asyncio.get_event_loop().run_until_complete(dedup_tasks("uid1"))
+        assert result["deleted_ids"] == []
+        assert "Failed" in result["reason"]
+
+
+class TestRerankSystemPrompt:
+    def test_includes_rules(self):
+        assert "RULES" in RERANK_SYSTEM_PROMPT
+        assert "deadlines" in RERANK_SYSTEM_PROMPT
+
+
+class TestDedupSystemPrompt:
+    def test_includes_rules(self):
+        assert "RULES" in DEDUP_SYSTEM_PROMPT
+        assert "duplicates" in DEDUP_SYSTEM_PROMPT.lower()

--- a/backend/tests/unit/test_desktop_tasks.py
+++ b/backend/tests/unit/test_desktop_tasks.py
@@ -1,0 +1,238 @@
+"""Tests for desktop task extraction handler (Phase 2 — #5396)."""
+
+import asyncio
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Mock heavy dependencies before any project imports
+sys.modules.setdefault('firebase_admin', MagicMock())
+sys.modules.setdefault('firebase_admin.auth', MagicMock())
+sys.modules.setdefault('firebase_admin.firestore', MagicMock())
+sys.modules.setdefault('database._client', MagicMock())
+_mock_clients = MagicMock()
+sys.modules.setdefault('utils.llm.clients', _mock_clients)
+
+from utils.desktop.tasks import (
+    ExtractedTask,
+    TaskExtractionResult,
+    TASK_SYSTEM_PROMPT,
+    _build_task_context,
+    extract_tasks,
+)
+from models.message_event import TasksExtractedEvent
+
+
+class TestExtractedTaskModel:
+    def test_task_with_all_fields(self):
+        task = ExtractedTask(
+            title="Review pull request 42 for authentication changes",
+            description="Check auth middleware",
+            priority="high",
+            tags=["code-review", "auth"],
+            source_app="GitHub",
+            inferred_deadline="2026-03-10",
+            confidence=0.9,
+            source_category="direct_request",
+        )
+        assert task.title == "Review pull request 42 for authentication changes"
+        assert task.priority == "high"
+        assert task.confidence == 0.9
+
+    def test_task_defaults(self):
+        task = ExtractedTask(
+            title="Update the README with new API docs",
+            priority="low",
+            confidence=0.5,
+        )
+        assert task.description == ""
+        assert task.tags == []
+        assert task.source_app == ""
+        assert task.inferred_deadline is None
+        assert task.source_category == "reactive"
+
+    def test_task_confidence_bounds(self):
+        with pytest.raises(Exception):
+            ExtractedTask(title="Test", priority="high", confidence=1.5)
+        with pytest.raises(Exception):
+            ExtractedTask(title="Test", priority="high", confidence=-0.1)
+
+
+class TestTaskExtractionResult:
+    def test_result_with_tasks(self):
+        result = TaskExtractionResult(
+            has_new_tasks=True,
+            tasks=[
+                ExtractedTask(title="Call John about the project deadline", priority="high", confidence=0.8),
+            ],
+            context_summary="Slack messages",
+            current_activity="Reading messages",
+        )
+        assert result.has_new_tasks is True
+        assert len(result.tasks) == 1
+
+    def test_result_no_tasks(self):
+        result = TaskExtractionResult(
+            has_new_tasks=False,
+            context_summary="IDE open",
+            current_activity="Coding",
+        )
+        assert result.has_new_tasks is False
+        assert result.tasks == []
+
+
+class TestTasksExtractedEvent:
+    def test_event_structure(self):
+        event = TasksExtractedEvent(
+            frame_id="frame123",
+            tasks=[{"title": "Test task", "priority": "high"}],
+        )
+        data = event.to_json()
+        assert data["type"] == "tasks_extracted"
+        assert data["frame_id"] == "frame123"
+        assert len(data["tasks"]) == 1
+
+
+class TestBuildTaskContext:
+    @patch('utils.desktop.tasks.get_action_items')
+    def test_active_tasks_in_context(self, mock_get):
+        mock_get.return_value = [
+            {'description': 'Write tests', 'due_at': '2026-03-10'},
+            {'description': 'Fix bug'},
+        ]
+        ctx = _build_task_context("uid1")
+        assert "Write tests" in ctx
+        assert "Due: 2026-03-10" in ctx
+        assert "Fix bug" in ctx
+        assert "Pending" in ctx
+
+    @patch('utils.desktop.tasks.get_action_items')
+    def test_completed_tasks_in_context(self, mock_get):
+        mock_get.side_effect = [
+            [],  # active tasks
+            [{'description': 'Done task'}],  # completed tasks
+        ]
+        ctx = _build_task_context("uid1")
+        assert "Done task" in ctx
+        assert "Completed" in ctx
+
+    @patch('utils.desktop.tasks.get_action_items')
+    def test_empty_context(self, mock_get):
+        mock_get.return_value = []
+        ctx = _build_task_context("uid1")
+        assert ctx == ""
+
+    @patch('utils.desktop.tasks.get_action_items')
+    def test_graceful_on_errors(self, mock_get):
+        mock_get.side_effect = Exception("DB error")
+        ctx = _build_task_context("uid1")
+        assert ctx == ""
+
+
+class TestExtractTasks:
+    @patch('utils.desktop.tasks._build_task_context')
+    @patch('utils.desktop.tasks.llm_gemini_flash')
+    def test_extract_tasks_returns_result(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=TaskExtractionResult(
+                has_new_tasks=True,
+                tasks=[
+                    ExtractedTask(
+                        title="Review pull request 42 for auth changes",
+                        priority="high",
+                        confidence=0.9,
+                        source_app="GitHub",
+                    )
+                ],
+                context_summary="GitHub PR page",
+                current_activity="Reviewing code",
+            )
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            extract_tasks("uid1", "base64img", "Chrome", "GitHub PR")
+        )
+        assert result["has_new_tasks"] is True
+        assert len(result["tasks"]) == 1
+        assert result["tasks"][0]["title"] == "Review pull request 42 for auth changes"
+        assert result["tasks"][0]["source_app"] == "GitHub"
+
+    @patch('utils.desktop.tasks._build_task_context')
+    @patch('utils.desktop.tasks.llm_gemini_flash')
+    def test_extract_tasks_no_tasks(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=TaskExtractionResult(
+                has_new_tasks=False,
+                context_summary="Desktop idle",
+                current_activity="Nothing",
+            )
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            extract_tasks("uid1", "base64img")
+        )
+        assert result["has_new_tasks"] is False
+        assert result["tasks"] == []
+
+    @patch('utils.desktop.tasks._build_task_context')
+    @patch('utils.desktop.tasks.llm_gemini_flash')
+    def test_source_app_fallback(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = ""
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=TaskExtractionResult(
+                has_new_tasks=True,
+                tasks=[
+                    ExtractedTask(
+                        title="Send email to team about deadline update",
+                        priority="medium",
+                        confidence=0.7,
+                        source_app="",  # empty
+                    )
+                ],
+            )
+        )
+        result = asyncio.get_event_loop().run_until_complete(
+            extract_tasks("uid1", "base64img", "Slack", "General")
+        )
+        # Falls back to app_name when source_app is empty
+        assert result["tasks"][0]["source_app"] == "Slack"
+
+    @patch('utils.desktop.tasks._build_task_context')
+    @patch('utils.desktop.tasks.llm_gemini_flash')
+    def test_includes_context_in_prompt(self, mock_llm, mock_ctx):
+        mock_ctx.return_value = "Existing active tasks:\n- Write tests [Pending]"
+        mock_parser = MagicMock()
+        mock_llm.with_structured_output.return_value = mock_parser
+        mock_parser.ainvoke = AsyncMock(
+            return_value=TaskExtractionResult(has_new_tasks=False)
+        )
+        asyncio.get_event_loop().run_until_complete(
+            extract_tasks("uid1", "base64img", "VS Code", "main.py")
+        )
+        call_args = mock_parser.ainvoke.call_args[0][0]
+        human_msg = call_args[1]
+        text_content = human_msg.content[0]["text"]
+        assert "Write tests" in text_content
+        assert "VS Code" in text_content
+
+
+class TestTaskSystemPrompt:
+    def test_prompt_includes_dedup_rules(self):
+        assert "DEDUPLICATION" in TASK_SYSTEM_PROMPT
+
+    def test_prompt_includes_priority_guidelines(self):
+        assert "high" in TASK_SYSTEM_PROMPT
+        assert "medium" in TASK_SYSTEM_PROMPT
+        assert "low" in TASK_SYSTEM_PROMPT
+
+    def test_prompt_includes_source_categories(self):
+        assert "direct_request" in TASK_SYSTEM_PROMPT
+        assert "self_generated" in TASK_SYSTEM_PROMPT
+        assert "calendar_driven" in TASK_SYSTEM_PROMPT

--- a/backend/utils/desktop/advice.py
+++ b/backend/utils/desktop/advice.py
@@ -1,0 +1,115 @@
+import logging
+from typing import Optional
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from database.goals import get_user_goals
+from database.action_items import get_action_items
+from utils.llm.clients import llm_gemini_flash
+
+logger = logging.getLogger(__name__)
+
+ADVICE_SYSTEM_PROMPT = """\
+You are a proactive assistant that offers brief, actionable advice based on what the user \
+is currently doing on their screen. Your advice should be contextual and helpful.
+
+ADVICE RULES:
+- Only offer advice when you can provide genuinely useful, specific guidance
+- Advice must relate to what's visible on screen
+- Keep it short (1-2 sentences max)
+- Be actionable — tell the user something they can DO, not just observe
+- Consider the user's goals and tasks when forming advice
+- ~70% of screenshots need NO advice — return null when nothing useful to say
+
+TONE:
+- Direct and casual, not formal
+- Helpful, not preachy
+- Specific to what you see, not generic productivity tips
+
+CATEGORIES:
+- productivity: efficiency tips, workflow improvements
+- mistake_prevention: catching potential errors or oversights
+- learning: suggesting resources or approaches
+- health: break reminders, posture, eye strain (only if clearly needed)
+- goal_alignment: connecting current activity to stated goals"""
+
+
+class AdviceResult(BaseModel):
+    has_advice: bool = Field(description="Whether advice is warranted")
+    content: Optional[str] = Field(default=None, description="The advice (1-2 sentences, null if none)")
+    category: Optional[str] = Field(
+        default=None, description="productivity|mistake_prevention|learning|health|goal_alignment"
+    )
+    confidence: float = Field(ge=0.0, le=1.0, description="Confidence this advice is useful")
+
+
+def _build_advice_context(uid: str) -> str:
+    """Build user context for advice generation."""
+    parts = []
+
+    try:
+        goals = get_user_goals(uid, limit=5)
+        if goals:
+            goal_lines = [f"- {g.get('title', g.get('description', ''))}" for g in goals]
+            parts.append("User's goals:\n" + "\n".join(goal_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch goals for advice: {e}")
+
+    try:
+        tasks = get_action_items(uid, completed=False, limit=10)
+        if tasks:
+            task_lines = [f"- {t.get('description', '')}" for t in tasks[:10]]
+            parts.append("Current tasks:\n" + "\n".join(task_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch tasks for advice: {e}")
+
+    return "\n\n".join(parts) if parts else ""
+
+
+async def generate_advice(
+    uid: str,
+    image_b64: str,
+    app_name: str = "",
+    window_title: str = "",
+) -> dict:
+    """Generate contextual advice from a screenshot using vision LLM.
+
+    Returns:
+        Dict with has_advice, content, category, confidence (or nulls if no advice)
+    """
+    advice_context = _build_advice_context(uid)
+
+    prompt_parts = []
+    if advice_context:
+        prompt_parts.append(advice_context)
+    if app_name or window_title:
+        prompt_parts.append(f"Current app: {app_name}, Window: {window_title}")
+    prompt_parts.append("Based on this screenshot, do you have any specific, actionable advice?")
+
+    prompt_text = "\n\n".join(prompt_parts)
+
+    with_parser = llm_gemini_flash.with_structured_output(AdviceResult)
+    result = await with_parser.ainvoke(
+        [
+            SystemMessage(content=ADVICE_SYSTEM_PROMPT),
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": prompt_text},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}},
+                ]
+            ),
+        ]
+    )
+
+    if not result.has_advice:
+        return {"has_advice": False, "advice": None}
+
+    return {
+        "has_advice": True,
+        "advice": {
+            "content": result.content,
+            "category": result.category,
+            "confidence": result.confidence,
+        },
+    }

--- a/backend/utils/desktop/focus.py
+++ b/backend/utils/desktop/focus.py
@@ -1,0 +1,149 @@
+import logging
+from typing import Optional
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from database.goals import get_user_goals
+from database.action_items import get_action_items
+from database.memories import get_memories
+from utils.llm.clients import llm_gemini_flash
+
+logger = logging.getLogger(__name__)
+
+# Match the desktop FocusAssistant's ScreenAnalysis schema
+FOCUS_SYSTEM_PROMPT = """You are a focus coach. Analyze the PRIMARY/MAIN window in screenshots to determine \
+if the user is focused or distracted.
+
+IMPORTANT: Look at the MAIN APPLICATION WINDOW, not log text or terminal output. \
+If you see a code editor with logs that mention "YouTube" - that's just log text, \
+the user is CODING, not on YouTube. Text in logs/terminals mentioning a site does \
+NOT mean the user is on that site.
+
+CONTEXT-AWARE ANALYSIS:
+Each request may include the user's active goals, current tasks, recent memories, \
+and analysis history. Use this context when available, but DO NOT let it prevent you \
+from flagging obvious distractions.
+
+- GOALS & TASKS: If the user's screen activity clearly relates to their active \
+goals or current tasks, they are FOCUSED.
+- HISTORY: Use recent analysis history to notice patterns, acknowledge transitions, \
+and vary your responses.
+
+Set status to "distracted" if the PRIMARY window is:
+- YouTube, Twitch, Netflix, TikTok (actual video site visible, not just text mentioning it)
+- Social media feeds: Twitter/X, Instagram, Facebook, Reddit (casual browsing, not researching)
+- News sites, entertainment sites, games
+- Any content consumption with no clear work purpose
+
+Set status to "focused" if the PRIMARY window is:
+- Code editors, IDEs, terminals, command line
+- Documents, spreadsheets, slides, design tools
+- Email, work chat (Slack, Teams), research
+- Browsing that is clearly work-related (Stack Overflow, docs, PRs, Jira, etc.)
+
+When in doubt, lean toward "distracted" — it's better to nudge the user once too \
+often than to silently let them drift.
+
+Always provide a short coaching message (100 characters max for notification banner):
+- If distracted: Create a unique nudge to refocus. Vary your approach — be playful, \
+direct, or motivational.
+- If focused: Acknowledge their work with variety — don't just say "Nice focus!" \
+every time."""
+
+
+class FocusResult(BaseModel):
+    status: str = Field(description='Focus status: "focused" or "distracted"')
+    app_or_site: str = Field(description="Primary app or site in focus")
+    description: str = Field(description="Brief description of what the user is doing")
+    message: Optional[str] = Field(default=None, description="Short coaching message (max 100 chars)")
+
+
+def _build_context(uid: str) -> str:
+    """Build context from user's goals, tasks, and memories (server-side)."""
+    parts = []
+
+    # Goals (up to 10)
+    try:
+        goals = get_user_goals(uid, limit=10)
+        if goals:
+            goal_lines = [f"- {g.get('title', g.get('description', ''))}" for g in goals]
+            parts.append("Active Goals:\n" + "\n".join(goal_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch goals for context: {e}")
+
+    # Tasks (up to 50, not completed)
+    try:
+        tasks = get_action_items(uid, completed=False, limit=50)
+        if tasks:
+            task_lines = [f"- {t.get('description', '')}" for t in tasks[:50]]
+            parts.append("Current Tasks:\n" + "\n".join(task_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch tasks for context: {e}")
+
+    # Recent memories (up to 20, core category)
+    try:
+        memories = get_memories(uid, limit=20, categories=['core'])
+        if memories:
+            mem_lines = [f"- {m.get('structured', {}).get('title', m.get('content', ''))}" for m in memories[:20]]
+            parts.append("Recent Memories:\n" + "\n".join(mem_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch memories for context: {e}")
+
+    return "\n\n".join(parts) if parts else ""
+
+
+async def analyze_focus(
+    uid: str,
+    image_b64: str,
+    app_name: str = "",
+    window_title: str = "",
+    history: str = "",
+) -> dict:
+    """Analyze a screenshot for focus status using vision LLM.
+
+    Args:
+        uid: User ID for fetching context
+        image_b64: Base64-encoded JPEG screenshot
+        app_name: Name of the foreground app
+        window_title: Window title
+        history: Formatted recent analysis history
+
+    Returns:
+        Dict with type, frame_id, status, app_or_site, description, message
+    """
+    # Build context from user data
+    context = _build_context(uid)
+
+    # Assemble prompt
+    prompt_parts = []
+    if context:
+        prompt_parts.append(context)
+    if history:
+        prompt_parts.append(f"Recent activity (oldest to newest):\n{history}")
+    if app_name or window_title:
+        prompt_parts.append(f"Current app: {app_name}, Window: {window_title}")
+    prompt_parts.append("Now analyze this screenshot:")
+
+    prompt_text = "\n\n".join(prompt_parts)
+
+    # Call vision LLM with structured output
+    with_parser = llm_gemini_flash.with_structured_output(FocusResult)
+    result = await with_parser.ainvoke(
+        [
+            SystemMessage(content=FOCUS_SYSTEM_PROMPT),
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": prompt_text},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}},
+                ]
+            ),
+        ]
+    )
+
+    return {
+        "status": result.status,
+        "app_or_site": result.app_or_site,
+        "description": result.description,
+        "message": result.message,
+    }

--- a/backend/utils/desktop/live_notes.py
+++ b/backend/utils/desktop/live_notes.py
@@ -1,0 +1,55 @@
+import logging
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from utils.llm.clients import llm_mini
+
+logger = logging.getLogger(__name__)
+
+LIVE_NOTES_SYSTEM_PROMPT = """\
+You are a live note-taking assistant. Given a transcript segment, generate a concise, \
+well-structured note that captures the key information.
+
+RULES:
+- Condense transcript into clear, readable notes
+- Preserve important details: names, numbers, decisions, action items
+- Remove filler words, repetition, and hesitation
+- Use bullet points for multiple items
+- Keep notes under 200 words
+- If the transcript is too short or contains no meaningful content, return empty string"""
+
+
+class LiveNoteResult(BaseModel):
+    text: str = Field(description="The generated note (empty string if no meaningful content)")
+
+
+async def generate_live_note(
+    text: str,
+    session_context: str = "",
+) -> dict:
+    """Generate a live note from transcript text.
+
+    Args:
+        text: Transcript text to summarize
+        session_context: Optional session context
+
+    Returns:
+        Dict with text field (the note)
+    """
+    prompt_parts = []
+    if session_context:
+        prompt_parts.append(f"Session context: {session_context}")
+    prompt_parts.append(f"Transcript:\n{text}")
+
+    prompt_text = "\n\n".join(prompt_parts)
+
+    with_parser = llm_mini.with_structured_output(LiveNoteResult)
+    result = await with_parser.ainvoke(
+        [
+            SystemMessage(content=LIVE_NOTES_SYSTEM_PROMPT),
+            HumanMessage(content=prompt_text),
+        ]
+    )
+
+    return {"text": result.text}

--- a/backend/utils/desktop/memories.py
+++ b/backend/utils/desktop/memories.py
@@ -1,0 +1,100 @@
+import logging
+from typing import List, Optional
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from database.memories import get_memories
+from utils.llm.clients import llm_gemini_flash
+
+logger = logging.getLogger(__name__)
+
+MEMORY_SYSTEM_PROMPT = """\
+You are a memory extraction assistant. Analyze screenshots to identify facts, insights, \
+or noteworthy information worth remembering about the user or their context.
+
+EXTRACTION RULES:
+- Extract facts ABOUT the user: preferences, projects, people they work with, decisions, realizations
+- Extract useful external information: advice, tips, insights from what they're reading
+- Maximum 3 memories per screenshot
+- Each memory should be a concise, standalone fact
+- Skip trivial or transient information (UI state, loading screens, timestamps)
+- ~80% of screenshots contain NO memorable information — return empty list when nothing stands out
+
+DEDUPLICATION:
+- Compare against existing memories provided in context
+- If a fact is already known, skip it
+- Only extract genuinely NEW information
+
+CATEGORIES:
+- system: Facts about the user (preferences, opinions, network, projects, habits)
+- interesting: External wisdom or advice from others (articles, conversations, tips)"""
+
+
+class ExtractedMemory(BaseModel):
+    content: str = Field(description="Concise statement of the fact or insight")
+    category: str = Field(description="system or interesting")
+    confidence: float = Field(ge=0.0, le=1.0, description="Extraction confidence")
+
+
+class MemoryExtractionResult(BaseModel):
+    memories: List[ExtractedMemory] = Field(default_factory=list, description="Extracted memories (empty if none)")
+
+
+def _build_memory_context(uid: str) -> str:
+    """Build existing memories context for deduplication."""
+    try:
+        existing = get_memories(uid, limit=30, categories=['system', 'interesting'])
+        if existing:
+            lines = []
+            for m in existing:
+                content = m.get('structured', {}).get('content', m.get('content', ''))
+                if content:
+                    lines.append(f"- {content}")
+            if lines:
+                return "Existing memories (DO NOT extract duplicates):\n" + "\n".join(lines)
+    except Exception as e:
+        logger.warning(f"Failed to fetch existing memories: {e}")
+    return ""
+
+
+async def extract_memories(
+    uid: str,
+    image_b64: str,
+    app_name: str = "",
+    window_title: str = "",
+) -> dict:
+    """Extract memories from a screenshot using vision LLM.
+
+    Returns:
+        Dict with memories list (each has content, category, confidence)
+    """
+    memory_context = _build_memory_context(uid)
+
+    prompt_parts = []
+    if memory_context:
+        prompt_parts.append(memory_context)
+    if app_name or window_title:
+        prompt_parts.append(f"Current app: {app_name}, Window: {window_title}")
+    prompt_parts.append("Analyze this screenshot for noteworthy facts or insights:")
+
+    prompt_text = "\n\n".join(prompt_parts)
+
+    with_parser = llm_gemini_flash.with_structured_output(MemoryExtractionResult)
+    result = await with_parser.ainvoke(
+        [
+            SystemMessage(content=MEMORY_SYSTEM_PROMPT),
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": prompt_text},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}},
+                ]
+            ),
+        ]
+    )
+
+    return {
+        "memories": [
+            {"content": m.content, "category": m.category, "confidence": m.confidence} for m in result.memories
+        ]
+    }

--- a/backend/utils/desktop/profile.py
+++ b/backend/utils/desktop/profile.py
@@ -1,0 +1,79 @@
+import logging
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from database.memories import get_memories
+from database.action_items import get_action_items
+from database.goals import get_user_goals
+from utils.llm.clients import llm_mini
+
+logger = logging.getLogger(__name__)
+
+PROFILE_SYSTEM_PROMPT = """\
+You are generating a concise user profile summary based on their data (goals, tasks, memories). \
+This profile helps other AI assistants understand who the user is and what they care about.
+
+FORMAT:
+- Write in third person ("The user...")
+- Include: professional focus, key projects, communication style, preferences
+- Keep under 300 words
+- Be factual — only include what's supported by the data
+- If data is sparse, keep the profile short rather than speculating"""
+
+
+class ProfileResult(BaseModel):
+    profile_text: str = Field(description="The generated user profile summary")
+
+
+async def generate_profile(uid: str) -> dict:
+    """Generate a user profile from their goals, tasks, and memories.
+
+    Returns:
+        Dict with profile_text
+    """
+    parts = []
+
+    try:
+        goals = get_user_goals(uid, limit=10)
+        if goals:
+            goal_lines = [f"- {g.get('title', g.get('description', ''))}" for g in goals]
+            parts.append("Goals:\n" + "\n".join(goal_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch goals for profile: {e}")
+
+    try:
+        tasks = get_action_items(uid, completed=False, limit=30)
+        if tasks:
+            task_lines = [f"- {t.get('description', '')}" for t in tasks[:30]]
+            parts.append("Active tasks:\n" + "\n".join(task_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch tasks for profile: {e}")
+
+    try:
+        memories = get_memories(uid, limit=30, categories=['system'])
+        if memories:
+            mem_lines = []
+            for m in memories:
+                content = m.get('structured', {}).get('content', m.get('content', ''))
+                if content:
+                    mem_lines.append(f"- {content}")
+            if mem_lines:
+                parts.append("Known facts:\n" + "\n".join(mem_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch memories for profile: {e}")
+
+    if not parts:
+        return {"profile_text": "No data available to generate profile."}
+
+    data_text = "\n\n".join(parts)
+
+    with_parser = llm_mini.with_structured_output(ProfileResult)
+    result = await with_parser.ainvoke(
+        [
+            SystemMessage(content=PROFILE_SYSTEM_PROMPT),
+            HumanMessage(content=f"Generate a user profile from this data:\n\n{data_text}"),
+        ]
+    )
+
+    return {"profile_text": result.profile_text}

--- a/backend/utils/desktop/task_ops.py
+++ b/backend/utils/desktop/task_ops.py
@@ -1,0 +1,141 @@
+import logging
+from typing import List
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from database.action_items import get_action_items
+from utils.llm.clients import llm_mini
+
+logger = logging.getLogger(__name__)
+
+# --- Task Reranking ---
+
+RERANK_SYSTEM_PROMPT = """\
+You are a task prioritization assistant. Given a list of tasks, rerank them by importance \
+and urgency. Consider deadlines, dependencies, and impact.
+
+RULES:
+- Most important/urgent tasks first
+- Tasks with approaching deadlines rank higher
+- Blocking tasks rank higher than blocked tasks
+- Return the same task IDs in new order"""
+
+
+class RankedTask(BaseModel):
+    id: str = Field(description="Task ID")
+    new_position: int = Field(description="New position (1 = most important)")
+
+
+class RerankResult(BaseModel):
+    updated_tasks: List[RankedTask] = Field(description="Tasks in new priority order")
+
+
+async def rerank_tasks(uid: str) -> dict:
+    """Rerank user's active tasks by priority.
+
+    Returns:
+        Dict with updated_tasks list
+    """
+    try:
+        tasks = get_action_items(uid, completed=False, limit=50)
+    except Exception as e:
+        logger.error(f"Failed to fetch tasks for reranking: {e}")
+        return {"updated_tasks": []}
+
+    if not tasks:
+        return {"updated_tasks": []}
+
+    task_lines = []
+    for t in tasks:
+        tid = t.get('id', '')
+        desc = t.get('description', '')
+        due = t.get('due_at', '')
+        priority = t.get('priority', 'medium')
+        due_str = f", Due: {due}" if due else ""
+        task_lines.append(f"- ID: {tid} | {desc} | Priority: {priority}{due_str}")
+
+    task_text = "\n".join(task_lines)
+
+    with_parser = llm_mini.with_structured_output(RerankResult)
+    result = await with_parser.ainvoke(
+        [
+            SystemMessage(content=RERANK_SYSTEM_PROMPT),
+            HumanMessage(content=f"Rerank these tasks by importance:\n\n{task_text}"),
+        ]
+    )
+
+    return {"updated_tasks": [{"id": t.id, "new_position": t.new_position} for t in result.updated_tasks]}
+
+
+# --- Task Deduplication ---
+
+DEDUP_SYSTEM_PROMPT = """\
+You are a task deduplication assistant. Identify semantically duplicate tasks and decide \
+which to keep and which to delete.
+
+RULES:
+- Two tasks are duplicates if they describe the same action, even with different wording
+- "Call John" and "Phone John" are duplicates
+- "Review PR #42" and "Look at pull request 42" are duplicates
+- Keep the more specific/detailed version
+- Keep the one with a deadline if only one has one
+- Keep the more recently created one if equally specific
+- Only flag true duplicates — similar but distinct tasks should both be kept"""
+
+
+class DedupGroup(BaseModel):
+    keep_id: str = Field(description="ID of the task to keep")
+    delete_ids: List[str] = Field(description="IDs of duplicate tasks to remove")
+    reason: str = Field(description="Why these are duplicates")
+
+
+class DedupResult(BaseModel):
+    groups: List[DedupGroup] = Field(default_factory=list, description="Duplicate groups (empty if no duplicates)")
+
+
+async def dedup_tasks(uid: str) -> dict:
+    """Find and resolve duplicate tasks.
+
+    Returns:
+        Dict with deleted_ids and reason
+    """
+    try:
+        tasks = get_action_items(uid, completed=False, limit=100)
+    except Exception as e:
+        logger.error(f"Failed to fetch tasks for dedup: {e}")
+        return {"deleted_ids": [], "reason": "Failed to fetch tasks"}
+
+    if len(tasks) < 2:
+        return {"deleted_ids": [], "reason": "Not enough tasks to deduplicate"}
+
+    task_lines = []
+    for t in tasks:
+        tid = t.get('id', '')
+        desc = t.get('description', '')
+        due = t.get('due_at', '')
+        created = t.get('created_at', '')
+        due_str = f", Due: {due}" if due else ""
+        created_str = f", Created: {created}" if created else ""
+        task_lines.append(f"- ID: {tid} | {desc}{due_str}{created_str}")
+
+    task_text = "\n".join(task_lines)
+
+    with_parser = llm_mini.with_structured_output(DedupResult)
+    result = await with_parser.ainvoke(
+        [
+            SystemMessage(content=DEDUP_SYSTEM_PROMPT),
+            HumanMessage(content=f"Find duplicate tasks:\n\n{task_text}"),
+        ]
+    )
+
+    all_deleted = []
+    reasons = []
+    for group in result.groups:
+        all_deleted.extend(group.delete_ids)
+        reasons.append(group.reason)
+
+    return {
+        "deleted_ids": all_deleted,
+        "reason": "; ".join(reasons) if reasons else "No duplicates found",
+    }

--- a/backend/utils/desktop/tasks.py
+++ b/backend/utils/desktop/tasks.py
@@ -1,0 +1,156 @@
+import logging
+from typing import List, Optional
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from pydantic import BaseModel, Field
+
+from database.action_items import get_action_items
+from utils.llm.clients import llm_gemini_flash
+
+logger = logging.getLogger(__name__)
+
+TASK_SYSTEM_PROMPT = """\
+You are a task extraction assistant. Analyze screenshots to identify actionable tasks, \
+requests, or to-dos visible on screen.
+
+EXTRACTION RULES:
+- Only extract tasks that are clearly visible and actionable
+- Title must be 6+ words, verb-first, naming a specific person/project/artifact + concrete action
+- Skip vague or generic items ("do something", "check this")
+- ~90% of screenshots contain NO new task — use no_tasks when nothing actionable is found
+
+DEDUPLICATION:
+- Compare against the user's existing tasks provided in context
+- If a task is semantically similar to an existing one (even with different wording), skip it
+- "Call John" and "Phone John" are duplicates
+- "Finish report by Friday" and "Complete report by end of week" are duplicates
+- When in doubt, err on treating as duplicate (DON'T extract)
+
+PRIORITY GUIDELINES:
+- high: urgent deadlines, blocking requests, error fixes
+- medium: normal work tasks, follow-ups
+- low: nice-to-haves, ideas, non-urgent items
+
+SOURCE CATEGORIES:
+- direct_request: someone asked the user to do something (message, meeting, mention)
+- self_generated: user's own idea, reminder, or goal subtask
+- calendar_driven: event preparation, recurring task, deadline
+- reactive: error response, notification, observation
+- external_system: from project tools, alerts, documentation"""
+
+
+class ExtractedTask(BaseModel):
+    title: str = Field(description="Verb-first title, 6+ words, specific person/project + concrete action")
+    description: str = Field(default="", description="Additional context if needed")
+    priority: str = Field(description="high, medium, or low")
+    tags: List[str] = Field(default_factory=list, description="1-3 relevant tags")
+    source_app: str = Field(default="", description="App where task was found")
+    inferred_deadline: Optional[str] = Field(default=None, description="yyyy-MM-dd format or null")
+    confidence: float = Field(ge=0.0, le=1.0, description="Extraction confidence")
+    source_category: str = Field(
+        default="reactive", description="direct_request|self_generated|calendar_driven|reactive|external_system"
+    )
+
+
+class TaskExtractionResult(BaseModel):
+    has_new_tasks: bool = Field(description="Whether any new tasks were found")
+    tasks: List[ExtractedTask] = Field(default_factory=list, description="Extracted tasks (empty if none)")
+    context_summary: str = Field(default="", description="Brief summary of what user is viewing")
+    current_activity: str = Field(default="", description="What user is actively doing")
+
+
+def _build_task_context(uid: str) -> str:
+    """Build existing tasks context for deduplication."""
+    parts = []
+
+    try:
+        # Active tasks (not completed) for dedup
+        active_tasks = get_action_items(uid, completed=False, limit=50)
+        if active_tasks:
+            task_lines = []
+            for t in active_tasks:
+                desc = t.get('description', '')
+                due = t.get('due_at', '')
+                due_str = f" (Due: {due})" if due else ""
+                task_lines.append(f"- {desc}{due_str} [Pending]")
+            parts.append("Existing active tasks (DO NOT extract duplicates):\n" + "\n".join(task_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch active tasks for dedup: {e}")
+
+    try:
+        # Recently completed tasks (last 10) for dedup
+        completed_tasks = get_action_items(uid, completed=True, limit=10)
+        if completed_tasks:
+            task_lines = [f"- {t.get('description', '')} [Completed]" for t in completed_tasks[:10]]
+            parts.append("Recently completed tasks:\n" + "\n".join(task_lines))
+    except Exception as e:
+        logger.warning(f"Failed to fetch completed tasks: {e}")
+
+    return "\n\n".join(parts) if parts else ""
+
+
+async def extract_tasks(
+    uid: str,
+    image_b64: str,
+    app_name: str = "",
+    window_title: str = "",
+) -> dict:
+    """Extract tasks from a screenshot using vision LLM.
+
+    Args:
+        uid: User ID for fetching existing tasks (dedup)
+        image_b64: Base64-encoded JPEG screenshot
+        app_name: Name of the foreground app
+        window_title: Window title
+
+    Returns:
+        Dict with has_new_tasks, tasks list, context_summary, current_activity
+    """
+    # Pre-fetch existing tasks for dedup context
+    task_context = _build_task_context(uid)
+
+    # Assemble prompt
+    prompt_parts = []
+    if task_context:
+        prompt_parts.append(task_context)
+    if app_name or window_title:
+        prompt_parts.append(f"Current app: {app_name}, Window: {window_title}")
+    prompt_parts.append("Analyze this screenshot for actionable tasks:")
+
+    prompt_text = "\n\n".join(prompt_parts)
+
+    # Call vision LLM with structured output
+    with_parser = llm_gemini_flash.with_structured_output(TaskExtractionResult)
+    result = await with_parser.ainvoke(
+        [
+            SystemMessage(content=TASK_SYSTEM_PROMPT),
+            HumanMessage(
+                content=[
+                    {"type": "text", "text": prompt_text},
+                    {"type": "image_url", "image_url": {"url": f"data:image/jpeg;base64,{image_b64}"}},
+                ]
+            ),
+        ]
+    )
+
+    tasks_list = []
+    for task in result.tasks:
+        tasks_list.append(
+            {
+                "title": task.title,
+                "description": task.description,
+                "priority": task.priority,
+                "tags": task.tags,
+                "source_app": task.source_app or app_name,
+                "inferred_deadline": task.inferred_deadline,
+                "confidence": task.confidence,
+                "source_category": task.source_category,
+            }
+        )
+
+    return {
+        "has_new_tasks": result.has_new_tasks and len(tasks_list) > 0,
+        "tasks": tasks_list,
+        "context_summary": result.context_summary,
+        "current_activity": result.current_activity,
+    }

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -77,7 +77,12 @@ class AuthService {
            let key = dict["API_KEY"] as? String {
             return key
         }
-        return "AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"  // fallback to prod
+        // Dev builds must not silently fall back to prod credentials
+        let isDev = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
+        if isDev {
+            log("AuthService: FATAL — GoogleService-Info.plist missing or has no API_KEY in dev build")
+        }
+        return "AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"  // fallback to prod (prod builds only)
     }()
 
     // MARK: - User Name Properties

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -78,9 +78,8 @@ class AuthService {
             return key
         }
         // Dev builds must not silently fall back to prod credentials
-        let isDev = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
-        if isDev {
-            log("AuthService: FATAL — GoogleService-Info.plist missing or has no API_KEY in dev build")
+        if Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true {
+            fatalError("AuthService: GoogleService-Info.plist missing or has no API_KEY in dev build — check that run.sh copied GoogleService-Info-Dev.plist")
         }
         return "AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"  // fallback to prod (prod builds only)
     }()

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -70,8 +70,15 @@ class AuthService {
     private let kAuthTokenExpiry = "auth_tokenExpiry"
     private let kAuthTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
 
-    // Firebase Web API key (from GoogleService-Info.plist)
-    private let firebaseApiKey = "AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"
+    // Firebase Web API key (read from active GoogleService-Info.plist at runtime)
+    private let firebaseApiKey: String = {
+        if let path = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+           let dict = NSDictionary(contentsOfFile: path),
+           let key = dict["API_KEY"] as? String {
+            return key
+        }
+        return "AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"  // fallback to prod
+    }()
 
     // MARK: - User Name Properties
 

--- a/desktop/Desktop/Sources/GoogleService-Info-Dev.plist
+++ b/desktop/Desktop/Sources/GoogleService-Info-Dev.plist
@@ -9,17 +9,17 @@
 	<key>ANDROID_CLIENT_ID</key>
 	<string>208440318997-1ek8tj5oa9ljmnh8tgehk27nqpivivbf.apps.googleusercontent.com</string>
 	<key>API_KEY</key>
-	<string>AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8</string>
+	<string>AIzaSyBK-G7KmEoC72mR10gmQyb2NFBbZyDvcqM</string>
 	<key>GCM_SENDER_ID</key>
-	<string>208440318997</string>
+	<string>1031333818730</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
 	<string>com.omi.desktop-dev</string>
 	<key>PROJECT_ID</key>
-	<string>based-hardware</string>
+	<string>based-hardware-dev</string>
 	<key>STORAGE_BUCKET</key>
-	<string>based-hardware.firebasestorage.app</string>
+	<string>based-hardware-dev.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -31,6 +31,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:208440318997:ios:a1906bb92fe244810e421c</string>
+	<string>1:1031333818730:ios:3bea63d8e4f41dbfafb513</string>
 </dict>
 </plist>

--- a/desktop/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
+++ b/desktop/Desktop/Sources/LiveNotes/LiveNotesMonitor.swift
@@ -45,22 +45,11 @@ class LiveNotesMonitor: ObservableObject {
     /// Existing notes for context (to avoid repetition)
     private var existingNotesContext: [String] = []
 
-    /// GeminiClient for AI generation (lazily initialized)
-    private var geminiClient: GeminiClient?
+    /// Backend service for AI generation (injected via configure())
+    private var backendService: BackendProactiveService?
 
     /// Cancellables for subscriptions
     private var cancellables = Set<AnyCancellable>()
-
-    /// AI prompt for note generation (from m13v/meeting)
-    private let noteGenerationPrompt = """
-        generate a single, concise note about what happened in this segment.
-        be factual and specific.
-        focus on the key point or action item.
-        keep it a few word sentence.
-        do not use quotes.
-        do not use wrapping words like "discussion on", jump straight into note.
-        avoid repeating information from existing notes.
-        """
 
     private init() {
         // Subscribe to transcript changes
@@ -70,6 +59,12 @@ class LiveNotesMonitor: ObservableObject {
                 self?.handleSegmentsUpdate(segments)
             }
             .store(in: &cancellables)
+    }
+
+    /// Configure with backend service (call before startSession)
+    func configure(backendService: BackendProactiveService) {
+        self.backendService = backendService
+        log("LiveNotesMonitor: Configured with BackendProactiveService")
     }
 
     // MARK: - Session Lifecycle
@@ -85,15 +80,8 @@ class LiveNotesMonitor: ObservableObject {
         lastProcessedSegmentEnd = nil
         existingNotesContext = []
 
-        // Initialize Gemini client if not already done
-        if geminiClient == nil {
-            do {
-                // Use Gemini 3 Pro for better note generation quality
-                geminiClient = try GeminiClient(model: "gemini-pro-latest")
-                log("LiveNotesMonitor: GeminiClient initialized with gemini-pro-latest")
-            } catch {
-                logError("LiveNotesMonitor: Failed to initialize GeminiClient", error: error)
-            }
+        if backendService == nil {
+            log("LiveNotesMonitor: WARNING — backendService not configured, AI notes disabled")
         }
 
         // Load any existing notes from DB (for crash recovery)
@@ -252,10 +240,10 @@ class LiveNotesMonitor: ObservableObject {
         }
     }
 
-    /// Generate an AI note from recent transcript
+    /// Generate an AI note from recent transcript via backend
     private func generateNote(from segments: [SpeakerSegment]) {
         guard let sessionId = currentSessionId,
-              let client = geminiClient,
+              let service = backendService,
               !isGenerating else { return }
 
         isGenerating = true
@@ -265,34 +253,21 @@ class LiveNotesMonitor: ObservableObject {
         let segmentStartOrder = max(0, currentSegmentOrder - 3)
         let segmentEndOrder = currentSegmentOrder
 
-        // Build context from existing notes
-        let existingNotesText = existingNotesContext.isEmpty
-            ? "No existing notes yet."
+        // Build session context from existing notes
+        let sessionContext = existingNotesContext.isEmpty
+            ? ""
             : "Existing notes:\n" + existingNotesContext.map { "- \($0)" }.joined(separator: "\n")
-
-        let prompt = """
-            Transcript segment:
-            \(recentText)
-
-            \(existingNotesText)
-
-            \(noteGenerationPrompt)
-            """
 
         Task {
             do {
-                let response = try await client.sendTextRequest(
-                    prompt: prompt,
-                    systemPrompt: "You are a concise note-taker. Generate a single short note (3-10 words) about the key point in the transcript. Do not use quotes. Be direct and specific."
-                )
+                let noteText = try await service.generateLiveNote(text: recentText, sessionContext: sessionContext)
 
-                // Clean up the response
-                let noteText = response
+                let cleaned = noteText
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                     .replacingOccurrences(of: "\"", with: "")
                     .replacingOccurrences(of: "'", with: "")
 
-                guard !noteText.isEmpty else {
+                guard !cleaned.isEmpty else {
                     await MainActor.run { self.isGenerating = false }
                     return
                 }
@@ -300,7 +275,7 @@ class LiveNotesMonitor: ObservableObject {
                 // Save to DB
                 let record = try await NoteStorage.shared.createNote(
                     sessionId: sessionId,
-                    text: noteText,
+                    text: cleaned,
                     isAiGenerated: true,
                     segmentStartOrder: segmentStartOrder,
                     segmentEndOrder: segmentEndOrder
@@ -309,8 +284,7 @@ class LiveNotesMonitor: ObservableObject {
                 if let note = record.toLiveNote() {
                     await MainActor.run {
                         self.notes.append(note)
-                        self.existingNotesContext.append(noteText)
-                        // Trim context to prevent unbounded growth (keep most recent notes)
+                        self.existingNotesContext.append(cleaned)
                         if self.existingNotesContext.count > self.maxExistingNotesContext {
                             self.existingNotesContext.removeFirst(self.existingNotesContext.count - self.maxExistingNotesContext)
                         }
@@ -321,7 +295,6 @@ class LiveNotesMonitor: ObservableObject {
                     await MainActor.run { self.isGenerating = false }
                 }
             } catch let dbError as DatabaseError where dbError.resultCode == .SQLITE_CONSTRAINT {
-                // Session was deleted during async AI generation — not an error
                 log("LiveNotesMonitor: Session \(sessionId) deleted during note generation, skipping")
                 await MainActor.run { self.isGenerating = false }
             } catch {

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Advice/AdviceAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Advice/AdviceAssistant.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import GRDB
 
@@ -19,7 +18,7 @@ actor AdviceAssistant: ProactiveAssistant {
 
     // MARK: - Properties
 
-    private let geminiClient: GeminiClient
+    private let backendService: BackendProactiveService
     private var isRunning = false
     private var lastAnalysisTime: Date = .distantPast
     private var previousAdvice: [ExtractedAdvice] = [] // Dedup window for advice context
@@ -32,15 +31,6 @@ actor AdviceAssistant: ProactiveAssistant {
     private var processingTask: Task<Void, Never>?
     private let frameSignal: AsyncStream<Void>
     private let frameSignalContinuation: AsyncStream<Void>.Continuation
-
-    /// Get the current system prompt from settings (accessed on MainActor for thread safety)
-    private var systemPrompt: String {
-        get async {
-            await MainActor.run {
-                AdviceAssistantSettings.shared.analysisPrompt
-            }
-        }
-    }
 
     /// Get the extraction interval from settings
     private var extractionInterval: TimeInterval {
@@ -62,9 +52,8 @@ actor AdviceAssistant: ProactiveAssistant {
 
     // MARK: - Initialization
 
-    init(apiKey: String? = nil) throws {
-        // Use Gemini 3.1 Pro for better advice quality (3-pro-preview retires March 9, 2026)
-        self.geminiClient = try GeminiClient(apiKey: apiKey, model: "gemini-pro-latest")
+    init(backendService: BackendProactiveService) {
+        self.backendService = backendService
 
         let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
         self.frameSignal = stream
@@ -138,25 +127,6 @@ actor AdviceAssistant: ProactiveAssistant {
         }
 
         log("Advice assistant stopped")
-    }
-
-    // MARK: - Test Analysis (for test runner)
-
-    /// Run the extraction pipeline on arbitrary JPEG data without side effects (no saving, no events).
-    /// Used by the test runner to replay past screenshots.
-    /// `screenshotTime` anchors the activity summary to the screenshot's actual timestamp.
-    /// Returns (result, sqlQueryCount) where sqlQueryCount is the number of execute_sql tool calls made.
-    func testAnalyze(jpegData: Data, appName: String, windowTitle: String? = nil, screenshotTime: Date) async throws -> (AdviceExtractionResult?, Int) {
-        let interval = await extractionInterval
-        let lookbackStart = screenshotTime.addingTimeInterval(-interval)
-        return try await runAdviceExtraction(
-            jpegData: nil,
-            appName: appName,
-            windowTitle: windowTitle,
-            referenceTime: screenshotTime,
-            lookbackStart: lookbackStart,
-            trackSqlCount: true
-        )
     }
 
     // MARK: - ProactiveAssistant Protocol Methods
@@ -379,62 +349,34 @@ actor AdviceAssistant: ProactiveAssistant {
         pendingFrame = nil
     }
 
-    // MARK: - Image Processing
+    // MARK: - Test Analysis (for test runner)
 
-    /// Resize and compress an image for Gemini analysis (max 1280px wide, JPEG quality 0.4)
-    private static func compressForGemini(_ data: Data) -> Data? {
-        guard let source = CGImageSourceCreateWithData(data as CFData, nil),
-              let cgImage = CGImageSourceCreateImageAtIndex(source, 0, nil) else { return nil }
-
-        let maxWidth = 1280
-        let width = cgImage.width
-        let height = cgImage.height
-        let scale = width > maxWidth ? Double(maxWidth) / Double(width) : 1.0
-        let newWidth = Int(Double(width) * scale)
-        let newHeight = Int(Double(height) * scale)
-
-        guard let context = CGContext(
-            data: nil, width: newWidth, height: newHeight,
-            bitsPerComponent: 8, bytesPerRow: 0,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
-        ) else { return nil }
-
-        context.interpolationQuality = .high
-        context.draw(cgImage, in: CGRect(x: 0, y: 0, width: newWidth, height: newHeight))
-
-        guard let resized = context.makeImage() else { return nil }
-
-        let mutableData = NSMutableData()
-        guard let dest = CGImageDestinationCreateWithData(mutableData as CFMutableData, "public.jpeg" as CFString, 1, nil) else { return nil }
-        CGImageDestinationAddImage(dest, resized, [kCGImageDestinationLossyCompressionQuality: 0.4] as CFDictionary)
-        guard CGImageDestinationFinalize(dest) else { return nil }
-        return mutableData as Data
+    /// Run extraction via backend for test runner. Returns (result, 0) for compatibility.
+    func testAnalyze(jpegData: Data, appName: String, windowTitle: String? = nil, screenshotTime: Date) async throws -> (AdviceExtractionResult?, Int) {
+        let base64 = autoreleasepool { jpegData.base64EncodedString() }
+        let backendResult = try await backendService.generateAdvice(
+            imageBase64: base64, appName: appName, windowTitle: windowTitle ?? ""
+        )
+        guard let adviceDict = backendResult.advice as? [String: Any] else {
+            return (AdviceExtractionResult(hasAdvice: false, advice: nil, contextSummary: "Analyzed \(appName)", currentActivity: ""), 0)
+        }
+        let hasAdvice = adviceDict["has_advice"] as? Bool ?? !adviceDict.isEmpty
+        guard hasAdvice, let adviceText = adviceDict["content"] as? String ?? adviceDict["advice"] as? String, !adviceText.isEmpty else {
+            return (AdviceExtractionResult(hasAdvice: false, advice: nil, contextSummary: "Analyzed \(appName)", currentActivity: ""), 0)
+        }
+        let categoryStr = adviceDict["category"] as? String ?? "other"
+        let category = AdviceCategory(rawValue: categoryStr) ?? .other
+        let confidence = adviceDict["confidence"] as? Double ?? 0.5
+        let advice = ExtractedAdvice(
+            advice: adviceText, headline: adviceDict["headline"] as? String,
+            reasoning: adviceDict["reasoning"] as? String, category: category,
+            sourceApp: appName, confidence: confidence
+        )
+        let result = AdviceExtractionResult(hasAdvice: true, advice: advice, contextSummary: "Analyzed \(appName)", currentActivity: "")
+        return (result, 0)
     }
 
-    // MARK: - Helpers
-
-    /// Get user's preferred language, cached for 1 hour
-    private func getUserLanguage() async -> String? {
-        // Return cached value if fresh (< 1 hour)
-        if let cached = cachedLanguage, Date().timeIntervalSince(languageFetchedAt) < 3600 {
-            return cached
-        }
-
-        do {
-            let response = try await APIClient.shared.getUserLanguage()
-            let lang = response.language
-            cachedLanguage = lang
-            languageFetchedAt = Date()
-            return lang.isEmpty ? nil : lang
-        } catch {
-            // Fall back to transcription language setting
-            let fallback = await MainActor.run { AssistantSettings.shared.transcriptionLanguage }
-            return fallback.isEmpty || fallback == "en" ? nil : fallback
-        }
-    }
-
-    // MARK: - Analysis
+    // MARK: - Backend Analysis (Phase 2 thin client)
 
     private func processFrame(_ frame: CapturedFrame) async {
         guard await isEnabled else { return }
@@ -443,7 +385,6 @@ actor AdviceAssistant: ProactiveAssistant {
                 return
             }
 
-            // Handle the result with screenshot ID for SQLite storage
             await handleResultWithScreenshot(result, screenshotId: frame.screenshotId, windowTitle: frame.windowTitle) { type, data in
                 Task { @MainActor in
                     AssistantCoordinator.shared.sendEvent(type: type, data: data)
@@ -455,549 +396,68 @@ actor AdviceAssistant: ProactiveAssistant {
     }
 
     private func extractAdvice(from frame: CapturedFrame) async throws -> AdviceExtractionResult? {
-        let now = Date()
-        // Cap lookback: since last analysis or max 1 hour ago
-        let lookbackStart = max(lastAnalysisTime, now.addingTimeInterval(-3600))
-        let (result, _) = try await runAdviceExtraction(
-            jpegData: nil,
+        let base64 = autoreleasepool { frame.jpegData.base64EncodedString() }
+        let backendResult = try await backendService.generateAdvice(
+            imageBase64: base64,
             appName: frame.appName,
-            windowTitle: frame.windowTitle,
-            referenceTime: now,
-            lookbackStart: lookbackStart,
-            trackSqlCount: false
+            windowTitle: frame.windowTitle ?? ""
         )
-        return result
-    }
 
-    // MARK: - Core Extraction (shared by production + test)
-
-    /// Two-phase advice extraction:
-    /// Phase 1 (text-only): Activity summary + SQL investigation loop. Model investigates via
-    ///   execute_sql, then calls `request_screenshot` with an ID and its findings so far.
-    /// Phase 2 (single vision call): Load the chosen screenshot + Phase 1 findings → single
-    ///   Gemini call with image → provide_advice or no_advice.
-    /// Returns (result, sqlQueryCount).
-    private func runAdviceExtraction(
-        jpegData: Data?,
-        appName: String,
-        windowTitle: String?,
-        referenceTime: Date,
-        lookbackStart: Date,
-        trackSqlCount: Bool
-    ) async throws -> (AdviceExtractionResult?, Int) {
-        var sqlCount = 0
-
-        // Build prompt with current context
-        let timeFormatter = DateFormatter()
-        timeFormatter.dateFormat = "h:mm a, EEEE"
-        var prompt = "CURRENT APP: \(appName)."
-        if let windowTitle = windowTitle, !windowTitle.isEmpty {
-            prompt += " Window: \"\(windowTitle)\"."
-        }
-        prompt += " Time: \(timeFormatter.string(from: referenceTime))."
-
-        // Add activity summary from database, anchored to the reference time
-        let elapsed = referenceTime.timeIntervalSince(lookbackStart)
-        log("Advice: Activity lookback: \(String(format: "%.0f", elapsed))s (\(lookbackStart) to \(referenceTime))")
-        let activitySummary = await buildActivitySummary(from: lookbackStart, to: referenceTime)
-        if !activitySummary.isEmpty {
-            prompt += "\n\n" + activitySummary
-            log("Advice: --- ACTIVITY SUMMARY ---\n\(activitySummary)")
-        } else {
-            log("Advice: --- ACTIVITY SUMMARY --- (empty, no screenshots in range)")
-        }
-
-        // Add user profile for context
-        if let profile = await AIUserProfileService.shared.getLatestProfile() {
-            prompt += "\n\nUSER PROFILE (who this user is):\n"
-            prompt += profile.profileText + "\n"
-        }
-
-        // Add previous advice for dedup
-        if !previousAdvice.isEmpty {
-            prompt += "\n\nPREVIOUSLY PROVIDED ADVICE (do not repeat these or semantically similar):\n"
-            let adviceToInclude = previousAdvice.prefix(maxAdviceInPrompt)
-            for (index, advice) in adviceToInclude.enumerated() {
-                prompt += "\(index + 1). \(advice.advice)"
-                if let reasoning = advice.reasoning {
-                    prompt += " (Reasoning: \(reasoning))"
-                }
-                prompt += "\n"
-            }
-            prompt += "\nOnly provide advice if there's a genuinely NEW non-obvious insight not covered above."
-        } else {
-            prompt += "\n\nOnly provide advice if there's something specific and non-obvious that would help."
-        }
-
-        prompt += "\n\nInvestigate the activity summary. Scan OCR from the TOP 3-5 apps (not just the dominant one) — the best insights often come from browsers, communication apps, and notes, not just the app with the most screenshots. Skip apps with < 10 screenshots. When you've identified the most interesting screenshot, call request_screenshot with the ID and your findings. Or call no_advice if nothing qualifies."
-
-        log("Advice: --- PROMPT ---\n\(prompt)")
-
-        // Build system prompt
-        var currentSystemPrompt = await systemPrompt
-        if let language = await getUserLanguage(), language != "en" {
-            currentSystemPrompt += "\n\nIMPORTANT: Respond in the user's preferred language: \(language)"
-        }
-        currentSystemPrompt += "\n\nDATABASE SCHEMA for execute_sql:\nscreenshots table columns: id INTEGER, timestamp TEXT, appName TEXT, windowTitle TEXT, ocrText TEXT, focusStatus TEXT"
-
-        // =============================================
-        // PHASE 1: Text-only investigation loop
-        // =============================================
-
-        let phase1Tools = buildPhase1Tools()
-        var contents: [GeminiImageToolRequest.Content] = [
-            GeminiImageToolRequest.Content(
-                role: "user",
-                parts: [GeminiImageToolRequest.Part(text: prompt)]
+        // Parse backend response into AdviceExtractionResult
+        guard let adviceDict = backendResult.advice as? [String: Any] else {
+            return AdviceExtractionResult(
+                hasAdvice: false,
+                advice: nil,
+                contextSummary: "Analyzed \(frame.appName)",
+                currentActivity: ""
             )
-        ]
-
-        let client = self.geminiClient
-        var chosenScreenshotId: Int64?
-        var investigationFindings: String?
-
-        for iteration in 0..<7 {
-            let iterContents = contents
-            let iterSystemPrompt = currentSystemPrompt
-            let iterTools = [phase1Tools]
-            let iterForce = iteration == 0
-            let result: ToolChatResult
-            do {
-                result = try await withThrowingTimeout(seconds: 120) {
-                    try await client.sendImageToolLoop(
-                        contents: iterContents,
-                        systemPrompt: iterSystemPrompt,
-                        tools: iterTools,
-                        forceToolCall: iterForce
-                    )
-                }
-            } catch {
-                log("Advice: Phase 1 failed on iteration \(iteration): \(error.localizedDescription)")
-                throw error
-            }
-
-            guard let toolCall = result.toolCalls.first else {
-                log("Advice: Phase 1 — no tool call on iteration \(iteration), breaking")
-                break
-            }
-
-            switch toolCall.name {
-            case "execute_sql":
-                let query = toolCall.arguments["query"] as? String ?? ""
-                sqlCount += 1
-                log("Advice: P1 execute_sql iter \(iteration): \(query)")
-                let sqlToolCall = ToolCall(name: "execute_sql", arguments: ["query": query], thoughtSignature: nil)
-                let resultStr = await ChatToolExecutor.execute(sqlToolCall)
-                let truncated = resultStr.count > 2000 ? String(resultStr.prefix(2000)) + "... (truncated)" : resultStr
-                log("Advice: P1 sql result (\(resultStr.count) chars): \(truncated)")
-
-                contents.append(GeminiImageToolRequest.Content(
-                    role: "model",
-                    parts: [GeminiImageToolRequest.Part(
-                        functionCall: .init(name: toolCall.name, args: ["query": query]),
-                        thoughtSignature: toolCall.thoughtSignature
-                    )]
-                ))
-                contents.append(GeminiImageToolRequest.Content(
-                    role: "user",
-                    parts: [GeminiImageToolRequest.Part(functionResponse: .init(
-                        name: toolCall.name,
-                        response: .init(result: resultStr)
-                    ))]
-                ))
-                continue
-
-            case "request_screenshot":
-                let findings = toolCall.arguments["findings"] as? String ?? ""
-                investigationFindings = findings
-                if let idInt = toolCall.arguments["screenshot_id"] as? Int {
-                    chosenScreenshotId = Int64(idInt)
-                } else if let idInt64 = toolCall.arguments["screenshot_id"] as? Int64 {
-                    chosenScreenshotId = idInt64
-                } else if let idStr = toolCall.arguments["screenshot_id"] as? String, let parsed = Int64(idStr) {
-                    chosenScreenshotId = parsed
-                } else if let idDouble = toolCall.arguments["screenshot_id"] as? Double {
-                    chosenScreenshotId = Int64(idDouble)
-                }
-                log("Advice: P1 request_screenshot iter \(iteration): id=\(chosenScreenshotId ?? 0), findings=\(findings.prefix(200))")
-                break // Exit phase 1
-
-            case "no_advice":
-                let contextSummary = toolCall.arguments["context_summary"] as? String ?? "No context"
-                let currentActivity = toolCall.arguments["current_activity"] as? String ?? "Unknown"
-                log("Advice: P1 no_advice — \(contextSummary)")
-                return (AdviceExtractionResult(
-                    hasAdvice: false,
-                    advice: nil,
-                    contextSummary: contextSummary,
-                    currentActivity: currentActivity
-                ), sqlCount)
-
-            default:
-                log("Advice: P1 unknown tool: \(toolCall.name), breaking")
-                break
-            }
-
-            // Break out of loop if request_screenshot was called
-            if chosenScreenshotId != nil { break }
         }
 
-        // If Phase 1 exhausted without choosing a screenshot, no advice
-        guard let screenshotId = chosenScreenshotId, let findings = investigationFindings else {
-            log("Advice: Phase 1 exhausted without request_screenshot")
-            return (nil, sqlCount)
-        }
-
-        // =============================================
-        // PHASE 2: Single vision call with chosen screenshot
-        // =============================================
-
-        log("Advice: Phase 2 — loading screenshot \(screenshotId)")
-
-        // Load the screenshot image
-        let imageData: Data
-        do {
-            guard let screenshot = try await RewindDatabase.shared.getScreenshot(id: screenshotId) else {
-                log("Advice: P2 screenshot not in DB: \(screenshotId)")
-                return (nil, sqlCount)
-            }
-            // Check active chunk
-            if screenshot.usesVideoStorage, let chunk = screenshot.videoChunkPath {
-                let activeChunk = await VideoChunkEncoder.shared.currentChunkPath
-                if chunk == activeChunk {
-                    log("Advice: P2 screenshot is in active chunk, skipping")
-                    return (nil, sqlCount)
-                }
-            }
-            let rawData = try await RewindStorage.shared.loadScreenshotData(for: screenshot)
-            imageData = Self.compressForGemini(rawData) ?? rawData
-            log("Advice: P2 loaded \(imageData.count) bytes (\(rawData.count) raw) from \(screenshot.appName)")
-        } catch {
-            log("Advice: P2 screenshot load failed: \(error.localizedDescription)")
-            return (nil, sqlCount)
-        }
-
-        // Build Phase 2 prompt — compact findings + image + cross-reference instruction
-        let phase2Prompt = """
-            INVESTIGATION FINDINGS:
-            \(findings)
-
-            The screenshot below is from the app/window identified during investigation.
-
-            Before giving advice, CROSS-REFERENCE your findings:
-            - Use execute_sql to check if this issue was resolved in later screenshots
-            - Check if the user moved on to something else (the issue may be stale)
-            - Verify the context is still relevant by looking at nearby timestamps
-
-            Then call provide_advice if the insight is still valid, or no_advice if it was resolved or is no longer relevant.
-            """
-
-        let phase2Tools = buildPhase2Tools()
-        let base64 = imageData.base64EncodedString()
-        var phase2Contents: [GeminiImageToolRequest.Content] = [
-            GeminiImageToolRequest.Content(
-                role: "user",
-                parts: [
-                    GeminiImageToolRequest.Part(text: phase2Prompt),
-                    GeminiImageToolRequest.Part(mimeType: "image/jpeg", data: base64),
-                ]
+        let hasAdvice = adviceDict["has_advice"] as? Bool ?? !adviceDict.isEmpty
+        guard hasAdvice else {
+            return AdviceExtractionResult(
+                hasAdvice: false,
+                advice: nil,
+                contextSummary: "Analyzed \(frame.appName)",
+                currentActivity: ""
             )
-        ]
-
-        // Phase 2 loop — model can cross-reference via SQL before deciding
-        for p2Iteration in 0..<5 {
-            let p2Contents = phase2Contents
-            let p2SystemPrompt = currentSystemPrompt
-            let p2Tools = [phase2Tools]
-            let p2Force = p2Iteration == 0
-            let phase2Result: ToolChatResult
-            do {
-                phase2Result = try await withThrowingTimeout(seconds: 120) {
-                    try await client.sendImageToolLoop(
-                        contents: p2Contents,
-                        systemPrompt: p2SystemPrompt,
-                        tools: p2Tools,
-                        forceToolCall: p2Force
-                    )
-                }
-            } catch {
-                log("Advice: Phase 2 failed on iteration \(p2Iteration): \(error.localizedDescription)")
-                throw error
-            }
-
-            guard let toolCall = phase2Result.toolCalls.first else {
-                log("Advice: Phase 2 — no tool call on iteration \(p2Iteration), breaking")
-                break
-            }
-
-            switch toolCall.name {
-            case "execute_sql":
-                let query = toolCall.arguments["query"] as? String ?? ""
-                sqlCount += 1
-                log("Advice: P2 execute_sql iter \(p2Iteration): \(query)")
-                let sqlToolCall = ToolCall(name: "execute_sql", arguments: ["query": query], thoughtSignature: nil)
-                let resultStr = await ChatToolExecutor.execute(sqlToolCall)
-                let truncated = resultStr.count > 2000 ? String(resultStr.prefix(2000)) + "... (truncated)" : resultStr
-                log("Advice: P2 sql result (\(resultStr.count) chars): \(truncated)")
-
-                phase2Contents.append(GeminiImageToolRequest.Content(
-                    role: "model",
-                    parts: [GeminiImageToolRequest.Part(
-                        functionCall: .init(name: toolCall.name, args: ["query": query]),
-                        thoughtSignature: toolCall.thoughtSignature
-                    )]
-                ))
-                phase2Contents.append(GeminiImageToolRequest.Content(
-                    role: "user",
-                    parts: [GeminiImageToolRequest.Part(functionResponse: .init(
-                        name: toolCall.name,
-                        response: .init(result: resultStr)
-                    ))]
-                ))
-                continue
-
-            case "provide_advice":
-                log("Advice: P2 provide_advice (after \(p2Iteration) cross-reference iterations)")
-                return (parseProvideAdvice(toolCall), sqlCount)
-
-            case "no_advice":
-                let contextSummary = toolCall.arguments["context_summary"] as? String ?? "No context"
-                let currentActivity = toolCall.arguments["current_activity"] as? String ?? "Unknown"
-                log("Advice: P2 no_advice — \(contextSummary)")
-                return (AdviceExtractionResult(
-                    hasAdvice: false,
-                    advice: nil,
-                    contextSummary: contextSummary,
-                    currentActivity: currentActivity
-                ), sqlCount)
-
-            default:
-                log("Advice: P2 unexpected tool: \(toolCall.name)")
-                break
-            }
-            break // Break on unexpected tool
-        }
-        return (nil, sqlCount)
-    }
-
-    // MARK: - Activity Summary
-
-    /// Query the screenshots table to build a summary of recent activity.
-    /// - `from`: lower bound (e.g. last analysis time or screenshot.timestamp - interval)
-    /// - `to`: upper bound (e.g. now or the screenshot's timestamp)
-    private func buildActivitySummary(from lookbackStart: Date, to referenceTime: Date) async -> String {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            return ""
         }
 
-        do {
-            return try await dbQueue.read { db in
-                // Pass Date objects directly — GRDB encodes them as UTC strings
-                // matching the stored format. Manual DateFormatter uses local timezone
-                // which causes mismatches.
-                let rows = try Row.fetchAll(db, sql: """
-                    SELECT appName, windowTitle, COUNT(*) as count,
-                           MIN(timestamp) as first_seen, MAX(timestamp) as last_seen
-                    FROM screenshots
-                    WHERE timestamp >= ? AND timestamp <= ?
-                      AND appName IS NOT NULL AND appName != ''
-                    GROUP BY appName, windowTitle
-                    ORDER BY count DESC
-                    LIMIT 30
-                    """, arguments: [lookbackStart, referenceTime])
-
-                if rows.isEmpty {
-                    return ""
-                }
-
-                let totalScreenshots = rows.reduce(0) { $0 + (($1["count"] as? Int64).map(Int.init) ?? ($1["count"] as? Int) ?? 0) }
-                let elapsedMin = referenceTime.timeIntervalSince(lookbackStart) / 60.0
-
-                let timeOnlyFormatter = DateFormatter()
-                timeOnlyFormatter.dateFormat = "HH:mm:ss"
-
-                var lines: [String] = []
-                lines.append("ACTIVITY SUMMARY (last \(Int(elapsedMin)) min, \(totalScreenshots) screenshots):")
-                lines.append("Time range: \(timeOnlyFormatter.string(from: lookbackStart)) – \(timeOnlyFormatter.string(from: referenceTime))")
-                lines.append("")
-                lines.append("App | Window | Screenshots | Est. Duration")
-                lines.append(String(repeating: "-", count: 60))
-
-                for row in rows {
-                    let app = row["appName"] as? String ?? "Unknown"
-                    let window = row["windowTitle"] as? String ?? ""
-                    let count = (row["count"] as? Int64).map(Int.init) ?? (row["count"] as? Int) ?? 0
-                    let estMinutes = String(format: "%.1f", Double(count) / 60.0)
-                    let windowDisplay = window.isEmpty ? "(no title)" : String(window.prefix(50))
-                    lines.append("\(app) | \(windowDisplay) | \(count) | \(estMinutes) min")
-                }
-
-                let summary = lines.joined(separator: "\n")
-                log("Advice: Activity summary (last \(Int(elapsedMin)) min, \(totalScreenshots) screenshots)")
-                return summary
-            }
-        } catch {
-            logError("Advice: Failed to build activity summary", error: error)
-            return ""
+        let adviceText = adviceDict["content"] as? String ?? adviceDict["advice"] as? String ?? ""
+        guard !adviceText.isEmpty else {
+            return AdviceExtractionResult(
+                hasAdvice: false,
+                advice: nil,
+                contextSummary: "Analyzed \(frame.appName)",
+                currentActivity: ""
+            )
         }
-    }
 
-    // MARK: - Tool Definitions
-
-    /// Phase 1 tools: text-only investigation (execute_sql, request_screenshot, no_advice)
-    private func buildPhase1Tools() -> GeminiTool {
-        GeminiTool(functionDeclarations: [
-            GeminiTool.FunctionDeclaration(
-                name: "execute_sql",
-                description: "Execute a SQL query on the local database to investigate screen activity. The screenshots table has: id INTEGER, timestamp TEXT, appName TEXT, windowTitle TEXT, ocrText TEXT, focusStatus TEXT. Use this to read OCR text from interesting windows, check what the user was doing, etc. SELECT queries only. Auto-limited to 200 rows.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "query": .init(type: "string", description: "SQL SELECT query to execute on the screenshots table")
-                    ],
-                    required: ["query"]
-                )
-            ),
-            GeminiTool.FunctionDeclaration(
-                name: "request_screenshot",
-                description: "Request to view a specific screenshot. Call this when you've found something interesting via SQL and want to see the actual screen. Provide the screenshot ID and a summary of your findings so far. The screenshot will be shown to you for final analysis.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "screenshot_id": .init(type: "integer", description: "The screenshot ID from the screenshots table"),
-                        "findings": .init(type: "string", description: "Summary of what you found during investigation — what app, what OCR text caught your attention, and what you suspect might be worth advising about")
-                    ],
-                    required: ["screenshot_id", "findings"]
-                )
-            ),
-            GeminiTool.FunctionDeclaration(
-                name: "no_advice",
-                description: "Call this when there is nothing worth advising about. Nothing qualifies as a specific, non-obvious insight. This ends the analysis.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "context_summary": .init(type: "string", description: "Brief summary of what user is looking at"),
-                        "current_activity": .init(type: "string", description: "High-level description of user's activity")
-                    ],
-                    required: ["context_summary", "current_activity"]
-                )
-            ),
-        ])
-    }
-
-    /// Phase 2 tools: vision call with screenshot + SQL cross-referencing (execute_sql, provide_advice, no_advice)
-    private func buildPhase2Tools() -> GeminiTool {
-        GeminiTool(functionDeclarations: [
-            GeminiTool.FunctionDeclaration(
-                name: "execute_sql",
-                description: "Cross-reference your findings by querying the database. Use this to check if an issue was resolved in later screenshots, verify context across time, or look up related activity. The screenshots table has: id INTEGER, timestamp TEXT, appName TEXT, windowTitle TEXT, ocrText TEXT, focusStatus TEXT. SELECT queries only.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "query": .init(type: "string", description: "SQL SELECT query to execute on the screenshots table")
-                    ],
-                    required: ["query"]
-                )
-            ),
-            GeminiTool.FunctionDeclaration(
-                name: "provide_advice",
-                description: "Call this when you have a specific, non-obvious insight for the user based on the screenshot and your investigation findings. You should cross-reference first using execute_sql to verify the issue is still relevant.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "advice": .init(type: "string", description: "The advice text (1-2 sentences, max 100 chars). Start with what you noticed, then why it matters."),
-                        "headline": .init(type: "string", description: "Ultra-short observation (max 5 words) for notification preview. E.g. 'Draft saved in /tmp', 'Credentials visible in terminal'"),
-                        "reasoning": .init(type: "string", description: "Brief explanation of why this advice is relevant"),
-                        "category": .init(type: "string", description: "Category of advice", enumValues: ["productivity", "communication", "learning", "other"]),
-                        "source_app": .init(type: "string", description: "App where context was observed"),
-                        "confidence": .init(type: "number", description: "Confidence score 0.0-1.0. 0.90+: preventing clear mistake. 0.75-0.89: highly relevant non-obvious tip. 0.60-0.74: useful but user might know."),
-                        "context_summary": .init(type: "string", description: "Brief summary of what user is looking at"),
-                        "current_activity": .init(type: "string", description: "High-level description of user's activity")
-                    ],
-                    required: ["advice", "headline", "category", "source_app", "confidence", "context_summary", "current_activity"]
-                )
-            ),
-            GeminiTool.FunctionDeclaration(
-                name: "no_advice",
-                description: "Call this when the screenshot doesn't reveal anything worth advising about, or when cross-referencing shows the issue was already resolved.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "context_summary": .init(type: "string", description: "Brief summary of what user is looking at"),
-                        "current_activity": .init(type: "string", description: "High-level description of user's activity")
-                    ],
-                    required: ["context_summary", "current_activity"]
-                )
-            ),
-        ])
-    }
-
-    // MARK: - Parse Tool Results
-
-    /// Parse the provide_advice tool call into an AdviceExtractionResult
-    private func parseProvideAdvice(_ toolCall: ToolCall) -> AdviceExtractionResult {
-        let adviceText = toolCall.arguments["advice"] as? String ?? ""
-        let headline = toolCall.arguments["headline"] as? String
-        let reasoning = toolCall.arguments["reasoning"] as? String
-        let categoryStr = toolCall.arguments["category"] as? String ?? "other"
+        let categoryStr = adviceDict["category"] as? String ?? "other"
         let category = AdviceCategory(rawValue: categoryStr) ?? .other
-        let sourceApp = toolCall.arguments["source_app"] as? String ?? ""
-        let contextSummary = toolCall.arguments["context_summary"] as? String ?? ""
-        let currentActivity = toolCall.arguments["current_activity"] as? String ?? ""
-
         let confidence: Double
-        if let confValue = toolCall.arguments["confidence"] as? Double {
+        if let confValue = adviceDict["confidence"] as? Double {
             confidence = confValue
-        } else if let confInt = toolCall.arguments["confidence"] as? Int {
+        } else if let confInt = adviceDict["confidence"] as? Int {
             confidence = Double(confInt)
-        } else if let confStr = toolCall.arguments["confidence"] as? String, let parsed = Double(confStr) {
-            confidence = parsed
         } else {
             confidence = 0.5
         }
 
         let advice = ExtractedAdvice(
             advice: adviceText,
-            headline: headline,
-            reasoning: reasoning,
+            headline: adviceDict["headline"] as? String,
+            reasoning: adviceDict["reasoning"] as? String,
             category: category,
-            sourceApp: sourceApp,
+            sourceApp: frame.appName,
             confidence: confidence
         )
 
-        log("Advice: --- PROVIDE_ADVICE ---")
-        log("Advice:   advice: \(adviceText)")
-        log("Advice:   headline: \(headline ?? "(none)")")
-        log("Advice:   reasoning: \(reasoning ?? "(none)")")
-        log("Advice:   category: \(categoryStr)")
-        log("Advice:   source_app: \(sourceApp)")
-        log("Advice:   confidence: \(confidence)")
-        log("Advice:   context: \(contextSummary)")
-        log("Advice:   activity: \(currentActivity)")
         return AdviceExtractionResult(
             hasAdvice: true,
             advice: advice,
-            contextSummary: contextSummary,
-            currentActivity: currentActivity
+            contextSummary: adviceDict["context_summary"] as? String ?? "Analyzed \(frame.appName)",
+            currentActivity: adviceDict["current_activity"] as? String ?? ""
         )
-    }
-}
-
-// MARK: - Timeout Helper
-
-/// Run an async operation with a timeout. Throws `CancellationError` if the timeout expires.
-private func withThrowingTimeout<T: Sendable>(seconds: Double, operation: @escaping @Sendable () async throws -> T) async throws -> T {
-    try await withThrowingTaskGroup(of: T.self) { group in
-        group.addTask {
-            try await operation()
-        }
-        group.addTask {
-            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-            throw CancellationError()
-        }
-        // First task to complete wins; cancel the other
-        let result = try await group.next()!
-        group.cancelAll()
-        return result
     }
 }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -17,7 +17,7 @@ actor FocusAssistant: ProactiveAssistant {
 
     // MARK: - Properties
 
-    private let geminiClient: GeminiClient
+    private let backendService: BackendProactiveService
     private let onAlert: (String) -> Void
     private let onStatusChange: ((FocusStatus) -> Void)?
     private let onRefocus: (() -> Void)?
@@ -34,12 +34,6 @@ actor FocusAssistant: ProactiveAssistant {
     private var pendingTasks: Set<Task<Void, Never>> = []
     private let maxPendingTasks = 3
     private var currentApp: String?
-
-    // MARK: - Context Cache
-    // Cached context from local DB (goals, tasks, memories) to enrich focus analysis
-    private var cachedContextString: String?
-    private var contextCacheTime: Date?
-    private let contextCacheDuration: TimeInterval = 120  // 2 minutes
 
     // MARK: - Smart Analysis Filtering
     // Skip analysis when user is focused on the same context (app + window title)
@@ -58,25 +52,16 @@ actor FocusAssistant: ProactiveAssistant {
     private var consecutiveErrorCount = 0
     private var errorBackoffEndTime: Date?
 
-    /// Get the current system prompt from settings (accessed on MainActor for thread safety)
-    private var systemPrompt: String {
-        get async {
-            await MainActor.run {
-                FocusAssistantSettings.shared.analysisPrompt
-            }
-        }
-    }
-
     // MARK: - Initialization
 
     init(
-        apiKey: String? = nil,
+        backendService: BackendProactiveService,
         onAlert: @escaping (String) -> Void = { _ in },
         onStatusChange: ((FocusStatus) -> Void)? = nil,
         onRefocus: (() -> Void)? = nil,
         onDistraction: (() -> Void)? = nil
-    ) throws {
-        self.geminiClient = try GeminiClient(apiKey: apiKey)
+    ) {
+        self.backendService = backendService
         self.onAlert = onAlert
         self.onStatusChange = onStatusChange
         self.onRefocus = onRefocus
@@ -299,8 +284,6 @@ actor FocusAssistant: ProactiveAssistant {
         analysisCooldownEndTime = nil
         consecutiveErrorCount = 0
         errorBackoffEndTime = nil
-        cachedContextString = nil
-        contextCacheTime = nil
 
         // Clear cooldown in UI
         await MainActor.run {
@@ -353,99 +336,26 @@ actor FocusAssistant: ProactiveAssistant {
     /// Run analysis on a screenshot with no side effects (no saving, no state updates, no notifications).
     /// Used by the test runner GUI and CLI.
     func testAnalyze(jpegData: Data, appName: String) async throws -> ScreenAnalysis? {
-        return try await analyzeScreenshot(jpegData: jpegData)
+        return try await analyzeScreenshot(jpegData: jpegData, appName: appName, windowTitle: nil)
     }
 
     /// Reset test history — call before starting a test run to get a clean slate.
     func resetTestHistory() {
-        testAnalysisHistory.removeAll()
+        // History is now tracked server-side; no-op on client
     }
 
     /// Run analysis with accumulating history across calls (simulates production behavior).
-    /// Each result is appended to a separate test history buffer so the model sees prior decisions.
+    /// History is tracked server-side per WebSocket session, so this is equivalent to testAnalyze.
     func testAnalyzeWithHistory(jpegData: Data, appName: String) async throws -> ScreenAnalysis? {
-        let result = try await analyzeScreenshotWithHistory(jpegData: jpegData, history: testAnalysisHistory)
-        if let result = result {
-            testAnalysisHistory.append(result)
-            if testAnalysisHistory.count > maxHistorySize {
-                testAnalysisHistory.removeFirst()
-            }
-        }
-        return result
-    }
-
-    /// Separate history buffer for test runs (doesn't pollute production history)
-    private var testAnalysisHistory: [ScreenAnalysis] = []
-
-    /// Variant of analyzeScreenshot that accepts an explicit history array
-    private func analyzeScreenshotWithHistory(jpegData: Data, history: [ScreenAnalysis]) async throws -> ScreenAnalysis? {
-        let context = await refreshContext()
-
-        // Format provided history
-        var historyText = ""
-        if !history.isEmpty {
-            var lines = ["Recent activity (oldest to newest):"]
-            for (i, past) in history.enumerated() {
-                lines.append("\(i + 1). [\(past.status.rawValue)] \(past.appOrSite): \(past.description)")
-                if let message = past.message {
-                    lines.append("   Message: \(message)")
-                }
-            }
-            historyText = lines.joined(separator: "\n")
-        }
-
-        var promptParts: [String] = []
-        if !context.isEmpty {
-            promptParts.append(context)
-        }
-        if !historyText.isEmpty {
-            promptParts.append(historyText)
-        }
-        promptParts.append("Now analyze this new screenshot:")
-        let prompt = promptParts.joined(separator: "\n\n")
-
-        let currentSystemPrompt = await systemPrompt
-
-        let responseSchema = GeminiRequest.GenerationConfig.ResponseSchema(
-            type: "object",
-            properties: [
-                "status": .init(type: "string", enum: ["focused", "distracted"], description: "Whether the user is focused or distracted"),
-                "app_or_site": .init(type: "string", enum: nil, description: "The app or website visible"),
-                "description": .init(type: "string", enum: nil, description: "Brief description of what's on screen"),
-                "message": .init(type: "string", enum: nil, description: "Coaching message")
-            ],
-            required: ["status", "app_or_site", "description"]
-        )
-
-        let responseText = try await geminiClient.sendRequest(
-            prompt: prompt,
-            imageData: jpegData,
-            systemPrompt: currentSystemPrompt,
-            responseSchema: responseSchema
-        )
-
-        return try JSONDecoder().decode(ScreenAnalysis.self, from: Data(responseText.utf8))
+        return try await analyzeScreenshot(jpegData: jpegData, appName: appName, windowTitle: nil)
     }
 
     // MARK: - Analysis
 
-    private func formatHistory() -> String {
-        guard !analysisHistory.isEmpty else { return "" }
-
-        var lines = ["Recent activity (oldest to newest):"]
-        for (i, past) in analysisHistory.enumerated() {
-            lines.append("\(i + 1). [\(past.status.rawValue)] \(past.appOrSite): \(past.description)")
-            if let message = past.message {
-                lines.append("   Message: \(message)")
-            }
-        }
-        return lines.joined(separator: "\n")
-    }
-
     private func processFrame(_ frame: CapturedFrame) async {
         guard await isEnabled else { return }
         do {
-            guard let analysis = try await analyzeScreenshot(jpegData: frame.jpegData) else {
+            guard let analysis = try await analyzeScreenshot(jpegData: frame.jpegData, appName: frame.appName, windowTitle: frame.windowTitle) else {
                 return
             }
 
@@ -585,118 +495,14 @@ actor FocusAssistant: ProactiveAssistant {
         }
     }
 
-    /// Refresh context from local DB (goals, tasks, memories) with caching
-    private func refreshContext() async -> String {
-        // Return cached context if fresh
-        if let cached = cachedContextString,
-           let cacheTime = contextCacheTime,
-           Date().timeIntervalSince(cacheTime) < contextCacheDuration {
-            return cached
-        }
-
-        var sections: [String] = []
-
-        // AI User Profile
-        do {
-            if let profile = await AIUserProfileService.shared.getLatestProfile() {
-                sections.append("USER PROFILE (who this user is):\n\(profile.profileText)")
-            }
-        }
-
-        // Time context
-        let formatter = DateFormatter()
-        formatter.dateFormat = "EEEE, MMMM d, yyyy 'at' h:mm a"
-        sections.append("TIME CONTEXT:\n\(formatter.string(from: Date()))")
-
-        // Active goals
-        do {
-            let goals = try await GoalStorage.shared.getLocalGoals(activeOnly: true)
-            if !goals.isEmpty {
-                var lines = ["ACTIVE GOALS:"]
-                for (i, goal) in goals.prefix(10).enumerated() {
-                    let desc = goal.description.map { " - \($0)" } ?? ""
-                    lines.append("\(i + 1). \(goal.title)\(desc)")
-                }
-                sections.append(lines.joined(separator: "\n"))
-            }
-        } catch {
-            logError("Focus: Failed to load goals for context", error: error)
-        }
-
-        // Top tasks by importance
-        do {
-            let tasks = try await ActionItemStorage.shared.getTopRelevanceTasks(limit: 50)
-            if !tasks.isEmpty {
-                var lines = ["CURRENT TASKS (by importance):"]
-                for (i, task) in tasks.enumerated() {
-                    let priority = task.priority ?? "medium"
-                    lines.append("\(i + 1). [\(priority)] \(task.description)")
-                }
-                sections.append(lines.joined(separator: "\n"))
-            }
-        } catch {
-            logError("Focus: Failed to load tasks for context", error: error)
-        }
-
-        // Recent memories
-        do {
-            let memories = try await MemoryStorage.shared.getLocalMemories(limit: 50, category: "core")
-            if !memories.isEmpty {
-                var lines = ["RECENT MEMORIES:"]
-                for (i, memory) in memories.enumerated() {
-                    lines.append("\(i + 1). \(memory.content)")
-                }
-                sections.append(lines.joined(separator: "\n"))
-            }
-        } catch {
-            logError("Focus: Failed to load memories for context", error: error)
-        }
-
-        let contextString = sections.joined(separator: "\n\n")
-        cachedContextString = contextString
-        contextCacheTime = Date()
-        return contextString
-    }
-
-    private func analyzeScreenshot(jpegData: Data) async throws -> ScreenAnalysis? {
-        // Refresh context from local DB
-        let context = await refreshContext()
-
-        // Build prompt with context + history
-        let historyText = formatHistory()
-        var promptParts: [String] = []
-        if !context.isEmpty {
-            promptParts.append(context)
-        }
-        if !historyText.isEmpty {
-            promptParts.append(historyText)
-        }
-        promptParts.append("Now analyze this new screenshot:")
-        let prompt = promptParts.joined(separator: "\n\n")
-
-        // Get current system prompt from settings
-        let currentSystemPrompt = await systemPrompt
-
-        // Build response schema
-        let responseSchema = GeminiRequest.GenerationConfig.ResponseSchema(
-            type: "object",
-            properties: [
-                "status": .init(type: "string", enum: ["focused", "distracted"], description: "Whether the user is focused or distracted"),
-                "app_or_site": .init(type: "string", enum: nil, description: "The app or website visible"),
-                "description": .init(type: "string", enum: nil, description: "Brief description of what's on screen"),
-                "message": .init(type: "string", enum: nil, description: "Coaching message")
-            ],
-            required: ["status", "app_or_site", "description"]
+    private func analyzeScreenshot(jpegData: Data, appName: String, windowTitle: String?) async throws -> ScreenAnalysis? {
+        let base64 = jpegData.base64EncodedString()
+        let result = try await backendService.analyzeFocus(
+            imageBase64: base64,
+            appName: appName,
+            windowTitle: windowTitle ?? ""
         )
-
-        let responseText = try await geminiClient.sendRequest(
-            prompt: prompt,
-            imageData: jpegData,
-            systemPrompt: currentSystemPrompt,
-            responseSchema: responseSchema
-        )
-
-        return try JSONDecoder().decode(ScreenAnalysis.self, from: Data(responseText.utf8))
+        return result
     }
 
     // MARK: - Storage

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -17,7 +17,7 @@ actor MemoryAssistant: ProactiveAssistant {
 
     // MARK: - Properties
 
-    private let geminiClient: GeminiClient
+    private let backendService: BackendProactiveService
     private var isRunning = false
     private var lastAnalysisTime: Date = .distantPast
     private var previousMemories: [ExtractedMemory] = [] // Last 20 extracted memories for deduplication
@@ -27,15 +27,6 @@ actor MemoryAssistant: ProactiveAssistant {
     private var processingTask: Task<Void, Never>?
     private let frameSignal: AsyncStream<Void>
     private let frameSignalContinuation: AsyncStream<Void>.Continuation
-
-    /// Get the current system prompt from settings (accessed on MainActor for thread safety)
-    private var systemPrompt: String {
-        get async {
-            await MainActor.run {
-                MemoryAssistantSettings.shared.analysisPrompt
-            }
-        }
-    }
 
     /// Get the extraction interval from settings
     private var extractionInterval: TimeInterval {
@@ -57,9 +48,8 @@ actor MemoryAssistant: ProactiveAssistant {
 
     // MARK: - Initialization
 
-    init(apiKey: String? = nil) throws {
-        // Use Gemini 3 Pro for better memory extraction quality
-        self.geminiClient = try GeminiClient(apiKey: apiKey, model: "gemini-pro-latest")
+    init(backendService: BackendProactiveService) {
+        self.backendService = backendService
 
         let (stream, continuation) = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
         self.frameSignal = stream
@@ -340,61 +330,40 @@ actor MemoryAssistant: ProactiveAssistant {
     }
 
     private func extractMemories(from jpegData: Data, appName: String) async throws -> MemoryExtractionResult? {
-        // Build context with previous memories for deduplication
-        var prompt = "Analyze this screenshot from \(appName).\n\n"
-
-        if !previousMemories.isEmpty {
-            prompt += "RECENTLY EXTRACTED MEMORIES (do not re-extract these or semantically similar ones):\n"
-            for (index, memory) in previousMemories.enumerated() {
-                prompt += "\(index + 1). [\(memory.category.rawValue)] \(memory.content)\n"
-            }
-            prompt += "\nLook for NEW memories that are NOT already in the list above."
-        } else {
-            prompt += "Look for memories to extract (system facts about the user, or interesting wisdom from others)."
-        }
-
-        // Get current system prompt from settings
-        let currentSystemPrompt = await systemPrompt
-
-        // Build response schema for memory extraction
-        let memoryProperties: [String: GeminiRequest.GenerationConfig.ResponseSchema.Property] = [
-            "content": .init(type: "string", description: "The memory content (max 15 words)"),
-            "category": .init(type: "string", enum: ["system", "interesting"], description: "Memory category"),
-            "source_app": .init(type: "string", description: "App where memory was found"),
-            "confidence": .init(type: "number", description: "Confidence score 0.0-1.0")
-        ]
-
-        let responseSchema = GeminiRequest.GenerationConfig.ResponseSchema(
-            type: "object",
-            properties: [
-                "has_new_memory": .init(type: "boolean", description: "True if new memories were found"),
-                "memories": .init(
-                    type: "array",
-                    description: "Array of extracted memories (0-3 max)",
-                    items: .init(
-                        type: "object",
-                        properties: memoryProperties,
-                        required: ["content", "category", "source_app", "confidence"]
-                    )
-                ),
-                "context_summary": .init(type: "string", description: "Brief summary of what user is looking at"),
-                "current_activity": .init(type: "string", description: "High-level description of user's activity")
-            ],
-            required: ["has_new_memory", "memories", "context_summary", "current_activity"]
+        let base64 = autoreleasepool { jpegData.base64EncodedString() }
+        let backendResult = try await backendService.extractMemories(
+            imageBase64: base64,
+            appName: appName,
+            windowTitle: ""
         )
 
-        do {
-            let responseText = try await geminiClient.sendRequest(
-                prompt: prompt,
-                imageData: jpegData,
-                systemPrompt: currentSystemPrompt,
-                responseSchema: responseSchema
+        // Parse backend response into MemoryExtractionResult
+        let memories: [ExtractedMemory] = backendResult.memories.compactMap { dict in
+            guard let content = dict["content"] as? String, !content.isEmpty else { return nil }
+            let categoryStr = dict["category"] as? String ?? "system"
+            let category: ExtractedMemoryCategory = categoryStr == "interesting" ? .interesting : .system
+            let sourceApp = dict["source_app"] as? String ?? appName
+            let confidence: Double
+            if let confValue = dict["confidence"] as? Double {
+                confidence = confValue
+            } else if let confInt = dict["confidence"] as? Int {
+                confidence = Double(confInt)
+            } else {
+                confidence = 0.5
+            }
+            return ExtractedMemory(
+                content: content,
+                category: category,
+                sourceApp: sourceApp,
+                confidence: confidence
             )
-
-            return try JSONDecoder().decode(MemoryExtractionResult.self, from: Data(responseText.utf8))
-        } catch {
-            logError("Memory analysis error", error: error)
-            return nil
         }
+
+        return MemoryExtractionResult(
+            hasNewMemory: !memories.isEmpty,
+            memories: memories,
+            contextSummary: "Analyzed \(appName)",
+            currentActivity: ""
+        )
     }
 }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-/// Task extraction assistant that identifies tasks and action items from screen content
-/// Uses single-stage Gemini tool calling with vector + FTS5 search for deduplication
+/// Task extraction assistant that identifies tasks and action items from screen content.
+/// Phase 2: sends screenshots to backend via WebSocket, receives structured task results.
 actor TaskAssistant: ProactiveAssistant {
     // MARK: - ProactiveAssistant Protocol
 
@@ -18,7 +18,7 @@ actor TaskAssistant: ProactiveAssistant {
 
     // MARK: - Properties
 
-    private let geminiClient: GeminiClient
+    private let backendService: BackendProactiveService
     private var isRunning = false
     private var previousTasks: [ExtractedTask] = [] // Last 10 extracted tasks for context
     private let maxPreviousTasks = 10
@@ -40,11 +40,6 @@ actor TaskAssistant: ProactiveAssistant {
     private var fallbackTimerTask: Task<Void, Never>?
     /// Timestamp of last context switch yield, for throttling rapid switches
     private var lastContextSwitchYieldTime: Date = .distantPast
-
-    // Cached goals (refreshed every 5 minutes)
-    private var cachedGoals: [Goal] = []
-    private var lastGoalsRefresh: Date = .distantPast
-    private let goalsRefreshInterval: TimeInterval = 300
 
     // MARK: - Due Date Helpers
 
@@ -114,15 +109,6 @@ actor TaskAssistant: ProactiveAssistant {
         return calendar.date(bySettingHour: 23, minute: 59, second: 0, of: startOfDay) ?? startOfDay
     }
 
-    /// Get the current system prompt from settings (accessed on MainActor for thread safety)
-    private var systemPrompt: String {
-        get async {
-            await MainActor.run {
-                TaskAssistantSettings.shared.analysisPrompt
-            }
-        }
-    }
-
     /// Get the extraction interval from settings
     private var extractionInterval: TimeInterval {
         get async {
@@ -143,9 +129,8 @@ actor TaskAssistant: ProactiveAssistant {
 
     // MARK: - Initialization
 
-    init(apiKey: String? = nil) throws {
-        // Use Gemini 3 Pro for better task extraction quality
-        self.geminiClient = try GeminiClient(apiKey: apiKey, model: "gemini-pro-latest")
+    init(backendService: BackendProactiveService) {
+        self.backendService = backendService
 
         let (stream, continuation) = AsyncStream.makeStream(of: TriggerEvent.self, bufferingPolicy: .bufferingNewest(1))
         self.triggerStream = stream
@@ -221,11 +206,17 @@ actor TaskAssistant: ProactiveAssistant {
 
     // MARK: - Test Analysis (for test runner)
 
-    /// Run the extraction pipeline on arbitrary JPEG data without side effects (no saving, no events).
-    /// Used by the test runner to replay past screenshots.
-    /// Returns (result, searchCount) where searchCount is the number of search tool calls made.
+    /// Run extraction via backend for test runner. Returns (result, 0) for compatibility.
     func testAnalyze(jpegData: Data, appName: String) async throws -> (TaskExtractionResult?, Int) {
-        return try await extractTaskSingleStage(from: jpegData, appName: appName)
+        let base64 = autoreleasepool { jpegData.base64EncodedString() }
+        let backendResult = try await backendService.extractTasks(
+            imageBase64: base64, appName: appName, windowTitle: ""
+        )
+        if backendResult.tasks.isEmpty {
+            return (TaskExtractionResult(hasNewTask: false, task: nil, contextSummary: "Analyzed \(appName)", currentActivity: ""), 0)
+        }
+        let result = parseBackendTask(backendResult.tasks[0], appName: appName)
+        return (result, 0)
     }
 
     // MARK: - ProactiveAssistant Protocol Methods
@@ -579,7 +570,7 @@ actor TaskAssistant: ProactiveAssistant {
         latestFrame = nil
     }
 
-    // MARK: - Single-Stage Analysis with Tool Calling
+    // MARK: - Backend Analysis (Phase 2 thin client)
 
     private func processFrame(_ frame: CapturedFrame) async {
         let enabled = await isEnabled
@@ -590,613 +581,88 @@ actor TaskAssistant: ProactiveAssistant {
 
         log("Task: Analyzing frame from \(frame.appName)...")
         do {
-            let (result, searchCount) = try await extractTaskSingleStage(from: frame.jpegData, appName: frame.appName)
-            guard let result = result else {
-                log("Task: Analysis returned no result")
-                return
-            }
+            let base64 = autoreleasepool { frame.jpegData.base64EncodedString() }
+            let backendResult = try await backendService.extractTasks(
+                imageBase64: base64,
+                appName: frame.appName,
+                windowTitle: frame.windowTitle ?? ""
+            )
 
-            log("Task: Analysis complete - hasNewTask: \(result.hasNewTask), context: \(result.contextSummary), searches: \(searchCount)")
-
-            await handleResultWithScreenshot(result, screenshotId: frame.screenshotId, appName: frame.appName, windowTitle: frame.windowTitle) { type, data in
+            let sendEvent: (String, [String: Any]) -> Void = { type, data in
                 Task { @MainActor in
                     AssistantCoordinator.shared.sendEvent(type: type, data: data)
                 }
+            }
+
+            if backendResult.tasks.isEmpty {
+                let result = TaskExtractionResult(
+                    hasNewTask: false, task: nil,
+                    contextSummary: "Analyzed \(frame.appName)",
+                    currentActivity: ""
+                )
+                log("Task: Analysis returned no tasks")
+                await handleResultWithScreenshot(result, screenshotId: frame.screenshotId, appName: frame.appName, windowTitle: frame.windowTitle, sendEvent: sendEvent)
+                return
+            }
+
+            log("Task: Analysis complete - \(backendResult.tasks.count) task(s)")
+
+            for taskDict in backendResult.tasks {
+                let result = parseBackendTask(taskDict, appName: frame.appName)
+                await handleResultWithScreenshot(result, screenshotId: frame.screenshotId, appName: frame.appName, windowTitle: frame.windowTitle, sendEvent: sendEvent)
             }
         } catch {
             logError("Task extraction error", error: error)
         }
     }
 
-    /// Loop-based extraction: image analysis + iterative tool calling for search + terminal tool for decision
-    /// Returns (result, searchCount) where searchCount is the number of search tool calls made.
-    private func extractTaskSingleStage(from jpegData: Data, appName: String) async throws -> (TaskExtractionResult?, Int) {
-        // 1. Gather context
-        let context = await refreshContext()
-
-        // 2. Build prompt with injected context
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy-MM-dd (EEEE)"
-        let todayStr = dateFormatter.string(from: Date())
-
-        var prompt = "Screenshot from \(appName). Today is \(todayStr). Analyze this screenshot for any unaddressed request directed at the user.\n\n"
-
-        // For messaging apps, add an extra reminder about conversation analysis
-        let messagingApps: Set<String> = ["Telegram", "WhatsApp", "\u{200E}WhatsApp", "Messages", "Slack", "Discord"]
-        if messagingApps.contains(appName) {
-            prompt += """
-            REMINDER — THIS IS A MESSAGING APP:
-            - If this screenshot shows a chat sidebar/conversation list rather than an open conversation, SKIP entirely.
-            - If it shows an open conversation, read the FULL conversation flow between the user and the other person.
-            - LEFT-SIDE messages = from the other person. RIGHT-SIDE/colored = from the user.
-            - PRIORITY: Look for where the user AGREED or COMMITTED to doing something the other person asked.
-              Example: Other person says "Can you send me the report?" → User replies "Sure, will do" → Extract task: "Send [person] the report"
-            - ALSO: Look for incoming requests the user hasn't responded to yet.
-            - The task title should describe what was asked for, naming the other person in the conversation.
-
-            """
+    /// Parse a raw task dict from the backend into a TaskExtractionResult.
+    private func parseBackendTask(_ dict: [String: Any], appName: String) -> TaskExtractionResult {
+        let title = dict["title"] as? String ?? ""
+        let description = dict["description"] as? String
+        let priorityStr = dict["priority"] as? String ?? "medium"
+        let priority = TaskPriority(rawValue: priorityStr) ?? .medium
+        let tags = (dict["tags"] as? [String]) ?? []
+        let sourceApp = dict["source_app"] as? String ?? appName
+        let inferredDeadline = dict["inferred_deadline"] as? String
+        let confidence: Double
+        if let confValue = dict["confidence"] as? Double {
+            confidence = confValue
+        } else if let confInt = dict["confidence"] as? Int {
+            confidence = Double(confInt)
+        } else {
+            confidence = 0.5
+        }
+        let sourceCategory = dict["source_category"] as? String ?? "other"
+        let sourceSubcategory = dict["source_subcategory"] as? String ?? "other"
+        let relevanceScore: Int?
+        if let scoreValue = dict["relevance_score"] as? Int {
+            relevanceScore = scoreValue
+        } else if let scoreDouble = dict["relevance_score"] as? Double {
+            relevanceScore = Int(scoreDouble)
+        } else {
+            relevanceScore = nil
         }
 
-        // Inject AI user profile for context
-        if let profile = await AIUserProfileService.shared.getLatestProfile() {
-            prompt += "USER PROFILE (who this user is — use for context, not as a task source):\n"
-            prompt += profile.profileText + "\n\n"
-        }
+        let task = ExtractedTask(
+            title: title,
+            description: description?.isEmpty == true ? nil : description,
+            priority: priority,
+            sourceApp: sourceApp,
+            inferredDeadline: inferredDeadline?.isEmpty == true ? nil : inferredDeadline,
+            confidence: confidence,
+            tags: tags,
+            sourceCategory: sourceCategory,
+            sourceSubcategory: sourceSubcategory,
+            relevanceScore: relevanceScore
+        )
 
-        if !context.activeTasks.isEmpty {
-            // Get score range for context
-            let scoreRange = try? await ActionItemStorage.shared.getRelevanceScoreRange()
-            let rangeStr = scoreRange.map { "Score range: \($0.min)–\($0.max). " } ?? ""
-
-            prompt += "ACTIVE TASKS (user is already tracking these — each has a relevance_score where 1 = most important, higher numbers = less important):\n"
-            prompt += "\(rangeStr)Use these scores to place any new task appropriately.\n"
-            for (i, task) in context.activeTasks.enumerated() {
-                let pri = task.priority.map { " [\($0)]" } ?? ""
-                let score = task.relevanceScore.map { " [score:\($0)]" } ?? ""
-                prompt += "\(i + 1).\(score) \(task.description)\(pri)\n"
-            }
-            prompt += "\n"
-        }
-
-        if !context.completedTasks.isEmpty {
-            prompt += "RECENTLY COMPLETED TASKS (user engaged with these — this is the kind of task the user finds valuable. Extract similar types of tasks, just not exact duplicates of these specific ones):\n"
-            for (i, task) in context.completedTasks.enumerated() {
-                prompt += "\(i + 1). \(task.description)\n"
-            }
-            prompt += "\n"
-        }
-
-        if !context.deletedTasks.isEmpty {
-            prompt += "USER-DELETED TASKS (user explicitly rejected these — do not re-extract similar):\n"
-            for (i, task) in context.deletedTasks.enumerated() {
-                prompt += "\(i + 1). \(task.description)\n"
-            }
-            prompt += "\n"
-        }
-
-        if !context.goals.isEmpty {
-            prompt += "ACTIVE GOALS:\n"
-            for (i, goal) in context.goals.enumerated() {
-                prompt += "\(i + 1). \(goal.title)"
-                if let desc = goal.description {
-                    prompt += " — \(desc)"
-                }
-                prompt += "\n"
-            }
-            prompt += "\n"
-        }
-
-        prompt += """
-        Analyze this screenshot. If you see a potential request, search for duplicates first.
-        If there is clearly no request on screen (~90% of screenshots), call no_task_found immediately.
-        """
-
-        // 3. Define 5 tools
-        let tools = GeminiTool(functionDeclarations: [
-            GeminiTool.FunctionDeclaration(
-                name: "search_similar",
-                description: "Search for semantically similar existing tasks using vector similarity. Call this when you see a potential request and want to check for duplicates.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "query": .init(type: "string", description: "A concise description of the potential task to search for")
-                    ],
-                    required: ["query"]
-                )
-            ),
-            GeminiTool.FunctionDeclaration(
-                name: "search_keywords",
-                description: "Search for existing tasks matching specific keywords. Use this for precise keyword-based matching complementing vector search.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "query": .init(type: "string", description: "Keywords to search for in existing tasks")
-                    ],
-                    required: ["query"]
-                )
-            ),
-            GeminiTool.FunctionDeclaration(
-                name: "no_task_found",
-                description: "Call this when there is no actionable request on screen. This is the most common outcome (~90% of screenshots). Use for: code editors, terminals, settings, media players, dashboards, or any screen without a direct request from another person or AI.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "context_summary": .init(type: "string", description: "Brief summary of what the user is looking at"),
-                        "current_activity": .init(type: "string", description: "What the user is actively doing")
-                    ],
-                    required: ["context_summary", "current_activity"]
-                )
-            ),
-            GeminiTool.FunctionDeclaration(
-                name: "extract_task",
-                description: "Extract a new task that is not already tracked. Call ONLY after searching for duplicates. All fields are required.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "title": .init(type: "string", description: "Verb-first task title, 6–15 words. MUST name a specific person/project/artifact and a concrete action. If you can't write 6+ specific words, call no_task_found instead."),
-                        "description": .init(type: "string", description: "Additional context about the task. Empty string if none."),
-                        "priority": .init(type: "string", description: "Task priority", enumValues: ["high", "medium", "low"]),
-                        "tags": .init(type: "array", description: "1-3 relevant tags", items: .init(type: "string")),
-                        "source_app": .init(type: "string", description: "App where the task was found"),
-                        "inferred_deadline": .init(type: "string", description: "Deadline in yyyy-MM-dd format (e.g. '2025-10-04'). Resolve relative references like 'Thursday' or 'next week' to an actual date. Empty string if no deadline."),
-                        "confidence": .init(type: "number", description: "Confidence score 0.0-1.0"),
-                        "context_summary": .init(type: "string", description: "Brief summary of what user is looking at"),
-                        "current_activity": .init(type: "string", description: "What the user is actively doing"),
-                        "source_category": .init(type: "string", description: "Where the task originated", enumValues: ["direct_request", "self_generated", "calendar_driven", "reactive", "external_system", "other"]),
-                        "source_subcategory": .init(type: "string", description: "Specific origin within category", enumValues: ["message", "meeting", "mention", "commitment", "idea", "reminder", "goal_subtask", "event_prep", "recurring", "deadline", "error", "notification", "observation", "project_tool", "alert", "documentation", "other"]),
-                        "relevance_score": .init(type: "integer", description: "Where this task ranks relative to existing tasks. Look at the relevance_score values of existing active tasks and assign a score that places this task appropriately. 1 = most important/urgent, higher numbers = less important. Must be a positive integer.")
-                    ],
-                    required: ["title", "description", "priority", "tags", "source_app", "inferred_deadline", "confidence", "context_summary", "current_activity", "source_category", "source_subcategory", "relevance_score"]
-                )
-            ),
-            GeminiTool.FunctionDeclaration(
-                name: "reject_task",
-                description: "Reject task extraction — the potential task is a duplicate, already completed, or was previously rejected by the user. Call after searching confirms this.",
-                parameters: GeminiTool.FunctionDeclaration.Parameters(
-                    type: "object",
-                    properties: [
-                        "reason": .init(type: "string", description: "Why this task was rejected (e.g. 'duplicate of existing active task', 'already completed')"),
-                        "context_summary": .init(type: "string", description: "Brief summary of what user is looking at"),
-                        "current_activity": .init(type: "string", description: "What the user is actively doing")
-                    ],
-                    required: ["reason", "context_summary", "current_activity"]
-                )
-            )
-        ])
-
-        // 4. Get system prompt
-        let currentSystemPrompt = await systemPrompt
-
-        // 5. Build initial contents
-        // Wrap base64 encoding in autoreleasepool — Swift concurrency doesn't
-        // drain autorelease pools, causing bridged NSString objects to accumulate.
-        var contents: [GeminiImageToolRequest.Content] = autoreleasepool {
-            let base64Data = jpegData.base64EncodedString()
-            return [
-                GeminiImageToolRequest.Content(
-                    role: "user",
-                    parts: [
-                        GeminiImageToolRequest.Part(text: prompt),
-                        GeminiImageToolRequest.Part(mimeType: "image/jpeg", data: base64Data)
-                    ]
-                )
-            ]
-        }
-
-        // 6. Tool-calling loop (max 5 iterations)
-        var searchCount = 0
-
-        for iteration in 0..<5 {
-            let result = try await geminiClient.sendImageToolLoop(
-                contents: contents,
-                systemPrompt: currentSystemPrompt,
-                tools: [tools],
-                forceToolCall: iteration == 0
-            )
-
-            guard let toolCall = result.toolCalls.first else {
-                log("Task: No tool call received on iteration \(iteration), breaking")
-                break
-            }
-
-            switch toolCall.name {
-            case "no_task_found":
-                let contextSummary = toolCall.arguments["context_summary"] as? String ?? "No task on screen"
-                let currentActivity = toolCall.arguments["current_activity"] as? String ?? "Unknown"
-                log("Task: no_task_found — \(contextSummary)")
-                return (TaskExtractionResult(
-                    hasNewTask: false,
-                    task: nil,
-                    contextSummary: contextSummary,
-                    currentActivity: currentActivity
-                ), searchCount)
-
-            case "extract_task":
-                let title = toolCall.arguments["title"] as? String ?? ""
-                let contextSummary = toolCall.arguments["context_summary"] as? String ?? ""
-                let currentActivity = toolCall.arguments["current_activity"] as? String ?? ""
-
-                // --- Hard validation: reject vague titles and ask the model to retry ---
-                let titleWords = title.split(separator: " ").count
-                let validationError = Self.validateTaskTitle(title, wordCount: titleWords)
-                if let error = validationError {
-                    log("Task: Title rejected (\(error)): \"\(title)\"")
-
-                    // Feed rejection back into the loop so the model can retry with more specifics
-                    contents.append(GeminiImageToolRequest.Content(
-                        role: "model",
-                        parts: [GeminiImageToolRequest.Part(
-                            functionCall: .init(name: toolCall.name, args: toolCall.arguments as? [String: String] ?? ["title": title]),
-                            thoughtSignature: toolCall.thoughtSignature
-                        )]
-                    ))
-                    contents.append(GeminiImageToolRequest.Content(
-                        role: "user",
-                        parts: [GeminiImageToolRequest.Part(functionResponse: .init(
-                            name: toolCall.name,
-                            response: .init(result: """
-                                REJECTED: \(error). \
-                                Your title was: "\(title)" (\(titleWords) words). \
-                                Either rewrite with 6+ words including a specific person/project name and concrete action, \
-                                or call no_task_found if you cannot be more specific.
-                                """)
-                        ))]
-                    ))
-                    continue
-                }
-
-                let description = toolCall.arguments["description"] as? String
-                let priorityStr = toolCall.arguments["priority"] as? String ?? "medium"
-                let priority = TaskPriority(rawValue: priorityStr) ?? .medium
-                let tags: [String]
-                if let tagArray = toolCall.arguments["tags"] as? [Any] {
-                    tags = tagArray.compactMap { $0 as? String }
-                } else {
-                    tags = []
-                }
-                let sourceApp = toolCall.arguments["source_app"] as? String ?? appName
-                let inferredDeadline = toolCall.arguments["inferred_deadline"] as? String
-                let confidence: Double
-                if let confValue = toolCall.arguments["confidence"] as? Double {
-                    confidence = confValue
-                } else if let confInt = toolCall.arguments["confidence"] as? Int {
-                    confidence = Double(confInt)
-                } else {
-                    confidence = 0.5
-                }
-                let sourceCategory = toolCall.arguments["source_category"] as? String ?? "other"
-                let sourceSubcategory = toolCall.arguments["source_subcategory"] as? String ?? "other"
-                let relevanceScore: Int?
-                if let scoreValue = toolCall.arguments["relevance_score"] as? Int {
-                    relevanceScore = scoreValue
-                } else if let scoreDouble = toolCall.arguments["relevance_score"] as? Double {
-                    relevanceScore = Int(scoreDouble)
-                } else {
-                    relevanceScore = nil
-                }
-
-                let task = ExtractedTask(
-                    title: title,
-                    description: description?.isEmpty == true ? nil : description,
-                    priority: priority,
-                    sourceApp: sourceApp,
-                    inferredDeadline: inferredDeadline?.isEmpty == true ? nil : inferredDeadline,
-                    confidence: confidence,
-                    tags: tags,
-                    sourceCategory: sourceCategory,
-                    sourceSubcategory: sourceSubcategory,
-                    relevanceScore: relevanceScore
-                )
-
-                log("Task: extract_task — \"\(title)\" (confidence: \(confidence), priority: \(priorityStr), score: \(relevanceScore.map { String($0) } ?? "nil"))")
-                return (TaskExtractionResult(
-                    hasNewTask: true,
-                    task: task,
-                    contextSummary: contextSummary,
-                    currentActivity: currentActivity
-                ), searchCount)
-
-            case "reject_task":
-                let reason = toolCall.arguments["reason"] as? String ?? "Unknown reason"
-                let contextSummary = toolCall.arguments["context_summary"] as? String ?? ""
-                let currentActivity = toolCall.arguments["current_activity"] as? String ?? ""
-                log("Task: reject_task — \(reason)")
-                return (TaskExtractionResult(
-                    hasNewTask: false,
-                    task: nil,
-                    contextSummary: contextSummary,
-                    currentActivity: currentActivity
-                ), searchCount)
-
-            case "search_similar":
-                let query = toolCall.arguments["query"] as? String ?? ""
-                searchCount += 1
-                log("Task: search_similar query: \"\(query)\"")
-                let searchResults = await executeVectorSearch(query: query)
-                log("Task: Vector search returned \(searchResults.count) results")
-
-                let searchResultsJson: String
-                if let data = try? JSONEncoder().encode(searchResults),
-                   let json = String(data: data, encoding: .utf8) {
-                    searchResultsJson = json
-                } else {
-                    searchResultsJson = "[]"
-                }
-
-                // Append model's tool call + function response to contents
-                contents.append(GeminiImageToolRequest.Content(
-                    role: "model",
-                    parts: [GeminiImageToolRequest.Part(
-                        functionCall: .init(name: toolCall.name, args: ["query": query]),
-                        thoughtSignature: toolCall.thoughtSignature
-                    )]
-                ))
-                contents.append(GeminiImageToolRequest.Content(
-                    role: "user",
-                    parts: [GeminiImageToolRequest.Part(functionResponse: .init(
-                        name: toolCall.name,
-                        response: .init(result: searchResultsJson)
-                    ))]
-                ))
-                continue
-
-            case "search_keywords":
-                let query = toolCall.arguments["query"] as? String ?? ""
-                searchCount += 1
-                log("Task: search_keywords query: \"\(query)\"")
-                let searchResults = await executeKeywordSearch(query: query)
-                log("Task: Keyword search returned \(searchResults.count) results")
-
-                let searchResultsJson: String
-                if let data = try? JSONEncoder().encode(searchResults),
-                   let json = String(data: data, encoding: .utf8) {
-                    searchResultsJson = json
-                } else {
-                    searchResultsJson = "[]"
-                }
-
-                // Append model's tool call + function response to contents
-                contents.append(GeminiImageToolRequest.Content(
-                    role: "model",
-                    parts: [GeminiImageToolRequest.Part(
-                        functionCall: .init(name: toolCall.name, args: ["query": query]),
-                        thoughtSignature: toolCall.thoughtSignature
-                    )]
-                ))
-                contents.append(GeminiImageToolRequest.Content(
-                    role: "user",
-                    parts: [GeminiImageToolRequest.Part(functionResponse: .init(
-                        name: toolCall.name,
-                        response: .init(result: searchResultsJson)
-                    ))]
-                ))
-                continue
-
-            default:
-                log("Task: Unknown tool call: \(toolCall.name), breaking")
-                break
-            }
-        }
-
-        log("Task: Completed in \(searchCount) searches (loop exhausted without terminal tool)")
-        return (nil, searchCount)
-    }
-
-    // MARK: - Title Validation
-
-    /// Validates a task title for minimum specificity. Returns an error message if invalid, nil if OK.
-    private static func validateTaskTitle(_ title: String, wordCount: Int) -> String? {
-        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Must not be empty
-        if trimmed.isEmpty {
-            return "Title is empty"
-        }
-
-        // Minimum 6 words
-        if wordCount < 6 {
-            return "Title too short (\(wordCount) words, minimum 6)"
-        }
-
-        // Reject titles that are purely generic verbs with no specifics
-        let genericPatterns: [String] = [
-            "investigate", "check logs", "clean up", "look into",
-            "look through", "update to", "fix the", "review the",
-            "check the", "modify the", "track the"
-        ]
-        let lowered = trimmed.lowercased()
-        for pattern in genericPatterns {
-            // If the entire title is just a generic pattern (possibly with 1-2 filler words), reject
-            if lowered == pattern || (wordCount <= 4 && lowered.hasPrefix(pattern)) {
-                return "Title too generic (matches vague pattern '\(pattern)')"
-            }
-        }
-
-        // Must contain at least one capitalized proper noun (person, project, app name)
-        // Heuristic: after the first word (verb), there should be at least one word starting with uppercase
-        let words = trimmed.split(separator: " ")
-        let hasProperNoun = words.dropFirst().contains { word in
-            guard let first = word.first else { return false }
-            return first.isUppercase
-        }
-        if !hasProperNoun {
-            return "Title lacks a specific name (person, project, or app) — no proper nouns found after the verb"
-        }
-
-        return nil
-    }
-
-    // MARK: - Context & Search
-
-    /// Refresh context from local SQLite + cached goals
-    private func refreshContext() async -> TaskExtractionContext {
-        var topRelevanceTasks: [(id: Int64, description: String, priority: String?, relevanceScore: Int?)] = []
-        var recentTasks: [(id: Int64, description: String, priority: String?, relevanceScore: Int?)] = []
-        var completedTasks: [(id: Int64, description: String)] = []
-        var deletedTasks: [(id: Int64, description: String)] = []
-
-        // Query both action_items (promoted + manual) and staged_tasks for full context
-        do {
-            topRelevanceTasks = try await ActionItemStorage.shared.getTopRelevanceTasks(limit: 30)
-        } catch {
-            logError("Task: Failed to load top relevance tasks", error: error)
-        }
-
-        do {
-            recentTasks = try await ActionItemStorage.shared.getRecentActiveTasks(limit: 30)
-        } catch {
-            logError("Task: Failed to load recent tasks", error: error)
-        }
-
-        // Also include staged tasks for dedup context
-        do {
-            let stagedTasks = try await StagedTaskStorage.shared.getAllStagedTasks(limit: 30)
-            let stagedAsTuples = stagedTasks.map { task in
-                (id: Int64(0), description: task.description, priority: task.priority, relevanceScore: task.relevanceScore)
-            }
-            recentTasks.append(contentsOf: stagedAsTuples)
-        } catch {
-            logError("Task: Failed to load staged tasks for context", error: error)
-        }
-
-        // Merge: top relevance tasks first, then recent ones not already included
-        let topIds = Set(topRelevanceTasks.map { $0.id })
-        let activeTasks = topRelevanceTasks + recentTasks.filter { !topIds.contains($0.id) }
-
-        do {
-            completedTasks = try await ActionItemStorage.shared.getRecentCompletedTasks(limit: 10)
-        } catch {
-            logError("Task: Failed to load completed tasks", error: error)
-        }
-
-        do {
-            deletedTasks = try await ActionItemStorage.shared.getRecentDeletedTasks(limit: 10, deletedBy: "user")
-        } catch {
-            logError("Task: Failed to load deleted tasks", error: error)
-        }
-
-        // Refresh goals if stale
-        let timeSinceGoals = Date().timeIntervalSince(lastGoalsRefresh)
-        if timeSinceGoals >= goalsRefreshInterval {
-            do {
-                cachedGoals = try await APIClient.shared.getGoals()
-                lastGoalsRefresh = Date()
-                log("Task: Refreshed \(cachedGoals.count) goals")
-            } catch {
-                logError("Task: Failed to refresh goals", error: error)
-            }
-        }
-
-        return TaskExtractionContext(
-            activeTasks: activeTasks,
-            completedTasks: completedTasks,
-            deletedTasks: deletedTasks,
-            goals: cachedGoals
+        return TaskExtractionResult(
+            hasNewTask: true,
+            task: task,
+            contextSummary: dict["context_summary"] as? String ?? "Analyzed \(appName)",
+            currentActivity: dict["current_activity"] as? String ?? ""
         )
     }
 
-    /// Execute vector similarity search
-    private func executeVectorSearch(query: String) async -> [TaskSearchResult] {
-        var results: [TaskSearchResult] = []
-
-        do {
-            let queryEmbedding = try await EmbeddingService.shared.embed(text: query)
-            let vectorResults = await EmbeddingService.shared.searchSimilar(query: queryEmbedding, topK: 10)
-
-            for result in vectorResults where result.similarity > 0.3 {
-                if let record = try await ActionItemStorage.shared.getActionItem(id: result.id) {
-                    let status: String
-                    if record.deleted { status = "deleted" }
-                    else if record.completed { status = "completed" }
-                    else { status = "active" }
-
-                    results.append(TaskSearchResult(
-                        id: result.id,
-                        description: record.description,
-                        status: status,
-                        similarity: Double(result.similarity),
-                        matchType: "vector",
-                        relevanceScore: record.relevanceScore
-                    ))
-                } else if let staged = try await StagedTaskStorage.shared.getStagedTask(id: result.id) {
-                    // Fallback: ID belongs to a staged task (shared embedding index)
-                    let status: String
-                    if staged.deleted { status = "deleted" }
-                    else if staged.completed { status = "completed" }
-                    else { status = "active" }
-
-                    results.append(TaskSearchResult(
-                        id: result.id,
-                        description: staged.description,
-                        status: status,
-                        similarity: Double(result.similarity),
-                        matchType: "vector",
-                        relevanceScore: staged.relevanceScore
-                    ))
-                }
-            }
-        } catch {
-            logError("Task: Vector search failed", error: error)
-        }
-
-        return results.sorted { ($0.similarity ?? 0) > ($1.similarity ?? 0) }
-    }
-
-    /// Execute FTS5 keyword search (searches both action_items and staged_tasks)
-    private func executeKeywordSearch(query: String) async -> [TaskSearchResult] {
-        var results: [TaskSearchResult] = []
-
-        do {
-            let words = query.components(separatedBy: .whitespaces)
-                .map { $0.filter { $0.isLetter || $0.isNumber } }  // Strip FTS5 special chars (- : * " etc.)
-                .filter { $0.count >= 3 }
-            let ftsQuery = words.map { "\($0)*" }.joined(separator: " OR ")
-
-            if !ftsQuery.isEmpty {
-                // Search action_items (promoted + manual)
-                let ftsResults = try await ActionItemStorage.shared.searchFTS(
-                    query: ftsQuery,
-                    limit: 10,
-                    includeCompleted: true,
-                    includeDeleted: true
-                )
-
-                for result in ftsResults {
-                    let status: String
-                    if result.deleted { status = "deleted" }
-                    else if result.completed { status = "completed" }
-                    else { status = "active" }
-
-                    results.append(TaskSearchResult(
-                        id: result.id,
-                        description: result.description,
-                        status: status,
-                        similarity: nil,
-                        matchType: "fts",
-                        relevanceScore: result.relevanceScore
-                    ))
-                }
-
-                // Also search staged_tasks
-                let stagedResults = try await StagedTaskStorage.shared.searchFTS(
-                    query: ftsQuery,
-                    limit: 10
-                )
-                for result in stagedResults {
-                    results.append(TaskSearchResult(
-                        id: result.id,
-                        description: result.description,
-                        status: "active",
-                        similarity: nil,
-                        matchType: "fts",
-                        relevanceScore: result.relevanceScore
-                    ))
-                }
-            }
-        } catch {
-            logError("Task: FTS search failed", error: error)
-        }
-
-        return results
-    }
 }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskDeduplicationService.swift
@@ -6,7 +6,7 @@ import Foundation
 actor TaskDeduplicationService {
     static let shared = TaskDeduplicationService()
 
-    private var geminiClient: GeminiClient?
+    private var backendService: BackendProactiveService?
     private var timer: Task<Void, Never>?
     private var isRunning = false
     private var lastRunTime: Date?
@@ -17,13 +17,11 @@ actor TaskDeduplicationService {
     private let cooldownSeconds: TimeInterval = 1800    // 30-min cooldown
     private let minimumTaskCount = 3
 
-    private init() {
-        do {
-            self.geminiClient = try GeminiClient(model: "gemini-pro-latest")
-        } catch {
-            log("TaskDedup: Failed to initialize GeminiClient: \(error)")
-            self.geminiClient = nil
-        }
+    private init() {}
+
+    /// Set the backend service for Phase 2 server-side deduplication.
+    func configure(backendService: BackendProactiveService) {
+        self.backendService = backendService
     }
 
     // MARK: - Lifecycle
@@ -67,210 +65,42 @@ actor TaskDeduplicationService {
     // MARK: - Deduplication Logic
 
     private func runDeduplication() async {
-        guard let client = geminiClient else {
-            log("TaskDedup: Skipping - Gemini client not initialized")
+        guard let service = backendService else {
+            log("TaskDedup: Skipping - backend service not configured")
             return
         }
 
         lastRunTime = Date()
-        log("TaskDedup: Starting deduplication run on staged tasks")
+        log("TaskDedup: Starting server-side deduplication")
 
-        // 1. Fetch staged tasks (not yet promoted to action items)
-        let tasks: [TaskActionItem]
         do {
-            let response = try await APIClient.shared.getStagedTasks(limit: 200)
-            tasks = response.items
-        } catch {
-            log("TaskDedup: Failed to fetch staged tasks: \(error)")
-            return
-        }
+            let result = try await service.deduplicateTasks()
 
-        guard tasks.count >= minimumTaskCount else {
-            log("TaskDedup: Only \(tasks.count) staged tasks, skipping (minimum: \(minimumTaskCount))")
-            return
-        }
-
-        log("TaskDedup: Analyzing \(tasks.count) staged tasks for duplicates")
-
-        // 2. Send all tasks to Gemini in a single call
-        let totalDeleted = await analyzeAndDeleteDuplicates(tasks: tasks, client: client)
-
-        log("TaskDedup: Run complete. Hard-deleted \(totalDeleted) duplicate staged tasks.")
-    }
-
-    private func analyzeAndDeleteDuplicates(tasks: [TaskActionItem], client: GeminiClient) async -> Int {
-        // Build task list for prompt
-        let taskDescriptions = tasks.map { task -> String in
-            var parts = ["ID: \(task.id)", "Description: \(task.description)"]
-            if let due = task.dueAt {
-                parts.append("Due: \(ISO8601DateFormatter().string(from: due))")
-            }
-            if let priority = task.priority {
-                parts.append("Priority: \(priority)")
-            }
-            if let source = task.source {
-                parts.append("Source: \(source)")
-            }
-            parts.append("Created: \(ISO8601DateFormatter().string(from: task.createdAt))")
-            return parts.joined(separator: "\n")
-        }.joined(separator: "\n")
-
-        let prompt = """
-        Analyze the following tasks for semantic duplicates. Two tasks are duplicates if they \
-        refer to the same action, even if worded differently.
-
-        Tasks:
-        \(taskDescriptions)
-
-        For each group of duplicates, pick the best task to KEEP based on these criteria (in order):
-        1. Most descriptive/specific wording
-        2. Has a due date over one that doesn't
-        3. Higher priority set (high > medium > low > none)
-        4. More reliable source (manual > transcription > screenshot)
-        5. Most recently created
-
-        Only flag tasks as duplicates if you are confident they refer to the same action. \
-        When in doubt, do NOT flag as duplicates.
-        """
-
-        let systemPrompt = """
-        You are a task deduplication assistant. You identify semantically duplicate tasks \
-        and choose the best one to keep. Be conservative - only flag clear duplicates. \
-        Return has_duplicates: false if no duplicates are found.
-        """
-
-        let responseSchema = GeminiRequest.GenerationConfig.ResponseSchema(
-            type: "object",
-            properties: [
-                "has_duplicates": .init(type: "boolean", description: "Whether any duplicate groups were found"),
-                "duplicate_groups": .init(
-                    type: "array",
-                    description: "Groups of duplicate tasks",
-                    items: .init(
-                        type: "object",
-                        properties: [
-                            "keep_id": .init(type: "string", description: "ID of the task to keep"),
-                            "delete_ids": .init(
-                                type: "array",
-                                description: "IDs of tasks to delete",
-                                items: .init(type: "string", properties: nil, required: nil)
-                            ),
-                            "reason": .init(type: "string", description: "Why these tasks are duplicates and which was kept")
-                        ],
-                        required: ["keep_id", "delete_ids", "reason"]
-                    )
-                )
-            ],
-            required: ["has_duplicates", "duplicate_groups"]
-        )
-
-        // Call Gemini
-        let responseText: String
-        do {
-            responseText = try await client.sendRequest(
-                prompt: prompt,
-                systemPrompt: systemPrompt,
-                responseSchema: responseSchema
-            )
-        } catch {
-            log("TaskDedup: Gemini request failed: \(error)")
-            return 0
-        }
-
-        // Parse response
-        guard let data = responseText.data(using: .utf8) else {
-            log("TaskDedup: Failed to convert response to data")
-            return 0
-        }
-
-        let result: DedupResponse
-        do {
-            result = try JSONDecoder().decode(DedupResponse.self, from: data)
-        } catch {
-            log("TaskDedup: Failed to parse response: \(error)")
-            return 0
-        }
-
-        guard result.hasDuplicates, !result.duplicateGroups.isEmpty else {
-            log("TaskDedup: No duplicates found in batch of \(tasks.count) staged tasks")
-            return 0
-        }
-
-        // Validate and delete
-        let validTaskIDs = Set(tasks.map { $0.id })
-        let taskLookup = Dictionary(tasks.map { ($0.id, $0) }, uniquingKeysWith: { _, latest in latest })
-        var deletedCount = 0
-
-        for group in result.duplicateGroups {
-            // Safety: verify all IDs exist in our input
-            guard validTaskIDs.contains(group.keepId) else {
-                log("TaskDedup: Skipping group - keep_id '\(group.keepId)' not in input set")
-                continue
+            if result.deletedIds.isEmpty {
+                log("TaskDedup: No duplicates found")
+                return
             }
 
-            let validDeleteIds = group.deleteIds.filter { validTaskIDs.contains($0) }
-            if validDeleteIds.count != group.deleteIds.count {
-                log("TaskDedup: Some delete IDs not in input set, filtering")
-            }
+            log("TaskDedup: Server deleted \(result.deletedIds.count) duplicates. Reason: \(result.reason)")
 
-            guard !validDeleteIds.isEmpty else { continue }
-
-            let keptTask = taskLookup[group.keepId]
-
-            for deleteId in validDeleteIds {
-                let deletedTask = taskLookup[deleteId]
-
-                // Log to SQLite
+            // Log each deletion locally
+            for deleteId in result.deletedIds {
                 let logRecord = TaskDedupLogRecord(
                     deletedTaskId: deleteId,
-                    deletedDescription: deletedTask?.description ?? "unknown",
-                    keptTaskId: group.keepId,
-                    keptDescription: keptTask?.description ?? "unknown",
-                    reason: group.reason,
+                    deletedDescription: "server-side dedup",
+                    keptTaskId: "",
+                    keptDescription: "",
+                    reason: result.reason,
                     deletedAt: Date()
                 )
-
                 do {
                     try await ProactiveStorage.shared.insertDedupLogRecord(logRecord)
                 } catch {
                     log("TaskDedup: Failed to log deletion record: \(error)")
                 }
-
-                // Hard-delete staged task from backend
-                do {
-                    try await APIClient.shared.deleteStagedTask(id: deleteId)
-                    deletedCount += 1
-                    log("TaskDedup: Hard-deleted staged task '\(deletedTask?.description ?? deleteId)' (kept: '\(keptTask?.description ?? group.keepId)') - \(group.reason)")
-                } catch {
-                    log("TaskDedup: Failed to delete staged task \(deleteId) on backend: \(error)")
-                }
             }
-        }
-
-        return deletedCount
-    }
-}
-
-// MARK: - Response Models
-
-private struct DedupResponse: Codable {
-    let hasDuplicates: Bool
-    let duplicateGroups: [DuplicateGroup]
-
-    enum CodingKeys: String, CodingKey {
-        case hasDuplicates = "has_duplicates"
-        case duplicateGroups = "duplicate_groups"
-    }
-
-    struct DuplicateGroup: Codable {
-        let keepId: String
-        let deleteIds: [String]
-        let reason: String
-
-        enum CodingKeys: String, CodingKey {
-            case keepId = "keep_id"
-            case deleteIds = "delete_ids"
-            case reason
+        } catch {
+            log("TaskDedup: Server deduplication failed: \(error)")
         }
     }
 }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPrioritizationService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPrioritizationService.swift
@@ -7,7 +7,7 @@ import Foundation
 actor TaskPrioritizationService {
     static let shared = TaskPrioritizationService()
 
-    private var geminiClient: GeminiClient?
+    private var backendService: BackendProactiveService?
     private var timer: Task<Void, Never>?
     private var isRunning = false
     private(set) var isScoringInProgress = false
@@ -29,19 +29,17 @@ actor TaskPrioritizationService {
         // Restore persisted timestamps
         self.lastFullRunTime = UserDefaults.standard.object(forKey: Self.fullRunKey) as? Date
 
-        do {
-            self.geminiClient = try GeminiClient(model: "gemini-pro-latest")
-        } catch {
-            log("TaskPrioritize: Failed to initialize GeminiClient: \(error)")
-            self.geminiClient = nil
-        }
-
         if let last = self.lastFullRunTime {
             let hoursAgo = Int(Date().timeIntervalSince(last) / 3600)
             log("TaskPrioritize: Last full rescore was \(hoursAgo)h ago")
         } else {
             log("TaskPrioritize: No previous full rescore recorded")
         }
+    }
+
+    /// Set the backend service for Phase 2 server-side reranking.
+    func configure(backendService: BackendProactiveService) {
+        self.backendService = backendService
     }
 
     // MARK: - Lifecycle
@@ -101,187 +99,48 @@ actor TaskPrioritizationService {
 
     // MARK: - Full Rescore (Hourly)
 
-    /// Send ALL staged tasks to Gemini, get back only the ones that need re-ranking
+    /// Request server-side reranking via backend WebSocket.
     private func runFullRescore() async {
         guard !isScoringInProgress else {
             log("TaskPrioritize: [FULL] Skipping — scoring already in progress")
             return
         }
-        guard let client = geminiClient else {
-            log("TaskPrioritize: Skipping full rescore — Gemini client not initialized")
+        guard let service = backendService else {
+            log("TaskPrioritize: Skipping full rescore — backend service not configured")
             return
         }
 
         isScoringInProgress = true
         defer { isScoringInProgress = false }
 
-        log("TaskPrioritize: [FULL] Starting hourly rescore of staged tasks")
+        log("TaskPrioritize: [FULL] Starting server-side rescore")
 
-        // Get ALL staged tasks (not action_items)
-        let allTasks: [TaskActionItem]
         do {
-            allTasks = try await StagedTaskStorage.shared.getAllStagedTasks(limit: 10000)
-        } catch {
-            log("TaskPrioritize: [FULL] Failed to fetch staged tasks: \(error)")
-            return
-        }
+            let result = try await service.rerankTasks()
 
-        log("TaskPrioritize: [FULL] Found \(allTasks.count) staged tasks")
-
-        guard allTasks.count >= minimumTaskCount else {
-            log("TaskPrioritize: [FULL] Only \(allTasks.count) staged tasks, skipping")
-            lastFullRunTime = Date()
-            return
-        }
-
-        // Fetch context
-        let (referenceContext, profile, goals) = await fetchContext()
-
-        // Build the current ranking: tasks ordered by relevanceScore ASC (1 = top)
-        let sortedTasks = allTasks.sorted { a, b in
-            let scoreA = a.relevanceScore ?? Int.max
-            let scoreB = b.relevanceScore ?? Int.max
-            return scoreA < scoreB
-        }
-
-        // Build task list for the prompt with current positions
-        let taskLines = sortedTasks.enumerated().map { (index, task) -> String in
-            var parts = ["\(index + 1). [id:\(task.id)] \(task.description)"]
-            if let priority = task.priority {
-                parts.append("[\(priority)]")
+            if result.updatedTasks.isEmpty {
+                log("TaskPrioritize: [FULL] No tasks need re-ranking, current order is good")
+                lastFullRunTime = Date()
+                return
             }
-            if let due = task.dueAt {
-                let formatter = ISO8601DateFormatter()
-                parts.append("[due: \(formatter.string(from: due))]")
+
+            // Parse server response into reranking tuples
+            let reranks: [(backendId: String, newPosition: Int)] = result.updatedTasks.compactMap { dict in
+                guard let id = dict["id"] as? String,
+                      let newPos = dict["new_position"] as? Int else { return nil }
+                return (backendId: id, newPosition: newPos)
             }
-            return parts.joined(separator: " ")
-        }.joined(separator: "\n")
 
-        // Build context sections
-        var contextParts: [String] = []
-
-        if let profile = profile, !profile.isEmpty {
-            contextParts.append("USER PROFILE:\n\(profile)")
-        }
-
-        if !goals.isEmpty {
-            let goalsText = goals.enumerated().map { (i, goal) in
-                var text = "\(i + 1). \(goal.title)"
-                if let desc = goal.description {
-                    text += " — \(desc)"
+            if !reranks.isEmpty {
+                do {
+                    try await StagedTaskStorage.shared.applySelectiveReranking(reranks)
+                    log("TaskPrioritize: [FULL] Applied server re-ranking for \(reranks.count) staged tasks")
+                } catch {
+                    log("TaskPrioritize: [FULL] Failed to apply re-ranking: \(error)")
                 }
-                text += " (\(Int(goal.progress))% complete)"
-                return text
-            }.joined(separator: "\n")
-            contextParts.append("ACTIVE GOALS:\n\(goalsText)")
-        }
-
-        if !referenceContext.isEmpty {
-            contextParts.append(referenceContext)
-        }
-
-        let contextSection = contextParts.isEmpty ? "" : contextParts.joined(separator: "\n\n") + "\n\n"
-
-        let prompt = """
-        Review the user's staged task list (ranked 1 = most important, \(sortedTasks.count) = least important).
-
-        Identify tasks that are MISRANKED — tasks whose current position doesn't match their actual importance.
-        Only return tasks that need to move. Do NOT return tasks that are already well-positioned.
-
-        Consider:
-        1. Alignment with the user's goals and current priorities
-        2. Time urgency (due date proximity)
-        3. Actionability — specific tasks rank higher than vague ones
-        4. Real-world importance (financial, health, commitments to others)
-        5. Most AI-extracted tasks are noise — push vague/irrelevant tasks down
-
-        \(contextSection)CURRENT TASK RANKING (1 = most important):
-        \(taskLines)
-
-        Return ONLY the tasks that need re-ranking, with their new position numbers.
-        New positions should be relative to the current list size (1 to \(sortedTasks.count)).
-        """
-
-        let systemPrompt = """
-        You are a task prioritization assistant. You review a ranked task list and identify \
-        tasks that are misranked. Be selective — only return tasks that genuinely need to move. \
-        If the ranking looks reasonable, return an empty list. Be decisive about pushing noise \
-        and vague tasks down and promoting urgent, goal-aligned tasks up.
-        """
-
-        let responseSchema = GeminiRequest.GenerationConfig.ResponseSchema(
-            type: "object",
-            properties: [
-                "reranked_tasks": .init(
-                    type: "array",
-                    description: "Tasks that need to be moved, with new positions",
-                    items: .init(
-                        type: "object",
-                        properties: [
-                            "task_id": .init(type: "string", description: "The task ID"),
-                            "new_position": .init(type: "integer", description: "New rank position (1 = most important)")
-                        ],
-                        required: ["task_id", "new_position"]
-                    )
-                ),
-                "reasoning": .init(type: "string", description: "Brief explanation of major ranking changes")
-            ],
-            required: ["reranked_tasks", "reasoning"]
-        )
-
-        log("TaskPrioritize: [FULL] Sending \(sortedTasks.count) staged tasks to Gemini")
-
-        let responseText: String
-        do {
-            responseText = try await client.sendRequest(
-                prompt: prompt,
-                systemPrompt: systemPrompt,
-                responseSchema: responseSchema
-            )
-        } catch {
-            log("TaskPrioritize: [FULL] Gemini request failed: \(error)")
-            return
-        }
-
-        let truncated = responseText.prefix(500)
-        log("TaskPrioritize: [FULL] Gemini response (\(responseText.count) chars): \(truncated)\(responseText.count > 500 ? "..." : "")")
-
-        guard let data = responseText.data(using: .utf8) else {
-            log("TaskPrioritize: [FULL] Failed to convert response to data")
-            return
-        }
-
-        let result: ReRankingResponse
-        do {
-            result = try JSONDecoder().decode(ReRankingResponse.self, from: data)
-        } catch {
-            log("TaskPrioritize: [FULL] Failed to parse re-ranking response: \(error)")
-            return
-        }
-
-        log("TaskPrioritize: [FULL] Gemini returned \(result.rerankedTasks.count) tasks to re-rank")
-        if !result.reasoning.isEmpty {
-            log("TaskPrioritize: [FULL] Reasoning: \(result.reasoning.prefix(300))")
-        }
-
-        // Validate: only keep task IDs that exist in our list
-        let validIds = Set(allTasks.map { $0.id })
-        let validReranks = result.rerankedTasks.filter { validIds.contains($0.taskId) }
-
-        if validReranks.count != result.rerankedTasks.count {
-            log("TaskPrioritize: [FULL] Filtered out \(result.rerankedTasks.count - validReranks.count) invalid task IDs")
-        }
-
-        if !validReranks.isEmpty {
-            let reranks = validReranks.map { (backendId: $0.taskId, newPosition: $0.newPosition) }
-            do {
-                try await StagedTaskStorage.shared.applySelectiveReranking(reranks)
-                log("TaskPrioritize: [FULL] Applied selective re-ranking for \(validReranks.count) staged tasks")
-            } catch {
-                log("TaskPrioritize: [FULL] Failed to apply re-ranking: \(error)")
             }
-        } else {
-            log("TaskPrioritize: [FULL] No tasks need re-ranking, current order is good")
+        } catch {
+            log("TaskPrioritize: [FULL] Server reranking failed: \(error)")
         }
 
         lastFullRunTime = Date()
@@ -304,68 +163,4 @@ actor TaskPrioritizationService {
         }
     }
 
-    // MARK: - Shared Context Fetching
-
-    private func fetchContext() async -> (referenceContext: String, profile: String?, goals: [Goal]) {
-        let userProfile = await AIUserProfileService.shared.getLatestProfile()
-
-        let goals: [Goal]
-        do {
-            goals = try await APIClient.shared.getGoals()
-        } catch {
-            log("TaskPrioritize: Failed to fetch goals: \(error)")
-            goals = []
-        }
-
-        let referenceTasks: [TaskActionItem]
-        do {
-            referenceTasks = try await ActionItemStorage.shared.getLocalActionItems(
-                limit: 100,
-                completed: true
-            )
-        } catch {
-            log("TaskPrioritize: Failed to fetch reference tasks: \(error)")
-            referenceTasks = []
-        }
-        let referenceContext = buildReferenceContext(referenceTasks)
-
-        return (referenceContext, userProfile?.profileText, goals)
-    }
-
-    // MARK: - Context Builders
-
-    private func buildReferenceContext(_ tasks: [TaskActionItem]) -> String {
-        guard !tasks.isEmpty else { return "" }
-
-        let completed = tasks.filter { !($0.description.isEmpty) }.prefix(50)
-        guard !completed.isEmpty else { return "" }
-
-        let lines = completed.map { task -> String in
-            "- [completed] \(task.description)"
-        }.joined(separator: "\n")
-
-        return "TASKS THE USER HAS COMPLETED (for reference — do NOT rank these):\n\(lines)"
-    }
-}
-
-// MARK: - Response Models
-
-private struct ReRankingResponse: Codable {
-    let rerankedTasks: [ReRankedTask]
-    let reasoning: String
-
-    struct ReRankedTask: Codable {
-        let taskId: String
-        let newPosition: Int
-
-        enum CodingKeys: String, CodingKey {
-            case taskId = "task_id"
-            case newPosition = "new_position"
-        }
-    }
-
-    enum CodingKeys: String, CodingKey {
-        case rerankedTasks = "reranked_tasks"
-        case reasoning
-    }
 }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Core/BackendProactiveService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Core/BackendProactiveService.swift
@@ -1,0 +1,358 @@
+import Foundation
+
+/// WebSocket client for desktop proactive AI via /v4/listen.
+/// Sends typed JSON messages (screen_frame, etc.) and routes typed responses
+/// (focus_result, etc.) back to callers via async continuations.
+///
+/// This is the Phase 2 replacement for direct GeminiClient calls — all LLM
+/// processing happens server-side; the client just sends screenshots and
+/// receives structured results.
+class BackendProactiveService {
+
+    // MARK: - Types
+
+    enum ServiceError: LocalizedError {
+        case missingAPIURL
+        case authFailed(String)
+        case notConnected
+        case timeout
+        case serverError(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .missingAPIURL: return "OMI_API_URL not set"
+            case .authFailed(let reason): return "Auth failed: \(reason)"
+            case .notConnected: return "Backend WebSocket not connected"
+            case .timeout: return "Request timed out"
+            case .serverError(let msg): return "Server error: \(msg)"
+            }
+        }
+    }
+
+    // MARK: - Properties
+
+    private var webSocketTask: URLSessionWebSocketTask?
+    private var urlSession: URLSession?
+    private(set) var isConnected = false
+    private var shouldReconnect = false
+    private var reconnectAttempts = 0
+    private let maxReconnectAttempts = 10
+    private var reconnectTask: Task<Void, Never>?
+
+    // Keepalive
+    private var keepaliveTask: Task<Void, Never>?
+    private let keepaliveInterval: TimeInterval = 30.0
+
+    // Pending request continuations keyed by frame_id
+    private var pendingFocusRequests: [String: CheckedContinuation<ScreenAnalysis, Error>] = [:]
+    private let requestLock = NSLock()
+    private let requestTimeout: TimeInterval = 30.0
+
+    // MARK: - Connection
+
+    func connect() {
+        shouldReconnect = true
+        reconnectAttempts = 0
+        startConnect()
+    }
+
+    func disconnect() {
+        shouldReconnect = false
+        reconnectTask?.cancel()
+        reconnectTask = nil
+        keepaliveTask?.cancel()
+        keepaliveTask = nil
+
+        isConnected = false
+        webSocketTask?.cancel(with: .normalClosure, reason: nil)
+        webSocketTask = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+
+        // Cancel all pending requests
+        cancelAllPending(error: ServiceError.notConnected)
+
+        log("BackendProactiveService: Disconnected")
+    }
+
+    // MARK: - Public API
+
+    /// Send a screen_frame for focus analysis and wait for the focus_result response.
+    func analyzeFocus(
+        imageBase64: String,
+        appName: String,
+        windowTitle: String
+    ) async throws -> ScreenAnalysis {
+        guard isConnected else {
+            throw ServiceError.notConnected
+        }
+
+        let frameId = UUID().uuidString
+
+        let message: [String: Any] = [
+            "type": "screen_frame",
+            "frame_id": frameId,
+            "image_b64": imageBase64,
+            "app_name": appName,
+            "window_title": windowTitle,
+            "analyze": ["focus"],
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: message)
+        guard let jsonString = String(data: jsonData, encoding: .utf8) else {
+            throw ServiceError.serverError("Failed to encode message")
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            requestLock.lock()
+            pendingFocusRequests[frameId] = continuation
+            requestLock.unlock()
+
+            webSocketTask?.send(.string(jsonString)) { [weak self] error in
+                if let error = error {
+                    self?.requestLock.lock()
+                    let cont = self?.pendingFocusRequests.removeValue(forKey: frameId)
+                    self?.requestLock.unlock()
+                    cont?.resume(throwing: error)
+                }
+            }
+
+            // Timeout guard
+            Task { [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64((self?.requestTimeout ?? 30.0) * 1_000_000_000))
+                self?.requestLock.lock()
+                let cont = self?.pendingFocusRequests.removeValue(forKey: frameId)
+                self?.requestLock.unlock()
+                cont?.resume(throwing: ServiceError.timeout)
+            }
+        }
+    }
+
+    // MARK: - Connection Internals
+
+    private func startConnect() {
+        guard let baseURL = Self.getBaseURL() else {
+            log("BackendProactiveService: OMI_API_URL not set")
+            return
+        }
+
+        Task {
+            do {
+                let idToken = try await AuthService.shared.getIdToken()
+                await connectWithToken(baseURL: baseURL, token: idToken)
+            } catch {
+                logError("BackendProactiveService: Failed to get ID token", error: error)
+                handleDisconnection()
+            }
+        }
+    }
+
+    private func connectWithToken(baseURL: String, token: String) async {
+        let wsURL = baseURL
+            .replacingOccurrences(of: "https://", with: "wss://")
+            .replacingOccurrences(of: "http://", with: "ws://")
+        let base = wsURL.hasSuffix("/") ? wsURL : wsURL + "/"
+
+        // Connect to /v4/listen with source=desktop — same endpoint as audio,
+        // but we only send JSON messages (no audio data)
+        var components = URLComponents(string: "\(base)v4/listen")!
+        components.queryItems = [
+            URLQueryItem(name: "source", value: "desktop"),
+            URLQueryItem(name: "sample_rate", value: "16000"),
+            URLQueryItem(name: "codec", value: "pcm16"),
+            URLQueryItem(name: "channels", value: "1"),
+            URLQueryItem(name: "language", value: "en"),
+        ]
+
+        guard let url = components.url else {
+            log("BackendProactiveService: Invalid URL")
+            return
+        }
+
+        log("BackendProactiveService: Connecting to \(url.absoluteString)")
+
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.timeoutInterval = 30
+
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForResource = 0
+        urlSession = URLSession(configuration: configuration)
+        webSocketTask = urlSession?.webSocketTask(with: request)
+        webSocketTask?.resume()
+
+        receiveMessage()
+
+        // Confirm connection after short delay
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self = self, self.webSocketTask?.state == .running else {
+                self?.handleDisconnection()
+                return
+            }
+            self.isConnected = true
+            self.reconnectAttempts = 0
+            self.startKeepalive()
+            log("BackendProactiveService: Connected")
+        }
+    }
+
+    private func startKeepalive() {
+        keepaliveTask?.cancel()
+        keepaliveTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: UInt64((self?.keepaliveInterval ?? 30.0) * 1_000_000_000))
+                guard !Task.isCancelled, let self = self, self.isConnected else { break }
+                self.sendKeepalive()
+            }
+        }
+    }
+
+    private func sendKeepalive() {
+        guard isConnected, let ws = webSocketTask else { return }
+        ws.send(.string("{\"type\": \"KeepAlive\"}")) { [weak self] error in
+            if let error = error {
+                logError("BackendProactiveService: Keepalive error", error: error)
+                self?.handleDisconnection()
+            }
+        }
+    }
+
+    private func handleDisconnection() {
+        guard isConnected || shouldReconnect else { return }
+
+        isConnected = false
+        keepaliveTask?.cancel()
+        keepaliveTask = nil
+        webSocketTask?.cancel(with: .goingAway, reason: nil)
+        webSocketTask = nil
+        urlSession?.invalidateAndCancel()
+        urlSession = nil
+
+        cancelAllPending(error: ServiceError.notConnected)
+
+        if shouldReconnect && reconnectAttempts < maxReconnectAttempts {
+            reconnectAttempts += 1
+            let delay = min(pow(2.0, Double(reconnectAttempts)), 32.0)
+            log("BackendProactiveService: Reconnecting in \(delay)s (attempt \(reconnectAttempts))")
+
+            reconnectTask = Task {
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                guard !Task.isCancelled, self.shouldReconnect else { return }
+                self.startConnect()
+            }
+        } else if reconnectAttempts >= maxReconnectAttempts {
+            log("BackendProactiveService: Max reconnect attempts reached")
+        }
+    }
+
+    // MARK: - Message Handling
+
+    private func receiveMessage() {
+        webSocketTask?.receive { [weak self] result in
+            guard let self = self else { return }
+
+            switch result {
+            case .success(let message):
+                self.handleMessage(message)
+                self.receiveMessage()
+            case .failure(let error):
+                guard self.isConnected else { return }
+                logError("BackendProactiveService: Receive error", error: error)
+                self.handleDisconnection()
+            }
+        }
+    }
+
+    private func handleMessage(_ message: URLSessionWebSocketTask.Message) {
+        let text: String
+        switch message {
+        case .string(let s):
+            text = s
+        case .data(let data):
+            guard let s = String(data: data, encoding: .utf8) else { return }
+            text = s
+        @unknown default:
+            return
+        }
+
+        // Skip heartbeat
+        if text == "ping" { return }
+
+        guard let data = text.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let type = json["type"] as? String else {
+            return
+        }
+
+        switch type {
+        case "focus_result":
+            handleFocusResult(data)
+        default:
+            // Other event types (memory_created, etc.) — ignore for now
+            break
+        }
+    }
+
+    private func handleFocusResult(_ data: Data) {
+        guard let response = try? JSONDecoder().decode(FocusResultResponse.self, from: data) else {
+            log("BackendProactiveService: Failed to decode focus_result")
+            return
+        }
+
+        let analysis = ScreenAnalysis(
+            status: FocusStatus(rawValue: response.status) ?? .focused,
+            appOrSite: response.appOrSite,
+            description: response.description,
+            message: response.message
+        )
+
+        requestLock.lock()
+        let continuation = pendingFocusRequests.removeValue(forKey: response.frameId)
+        requestLock.unlock()
+
+        continuation?.resume(returning: analysis)
+    }
+
+    // MARK: - Helpers
+
+    private func cancelAllPending(error: Error) {
+        requestLock.lock()
+        let pending = pendingFocusRequests
+        pendingFocusRequests.removeAll()
+        requestLock.unlock()
+
+        for (_, continuation) in pending {
+            continuation.resume(throwing: error)
+        }
+    }
+
+    private static func getBaseURL() -> String? {
+        if let cString = getenv("OMI_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty {
+            return url
+        }
+        if let envURL = ProcessInfo.processInfo.environment["OMI_API_URL"], !envURL.isEmpty {
+            return envURL
+        }
+        return nil
+    }
+}
+
+// MARK: - Response Models
+
+private struct FocusResultResponse: Decodable {
+    let type: String
+    let frameId: String
+    let status: String
+    let appOrSite: String
+    let description: String
+    let message: String?
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case frameId = "frame_id"
+        case status
+        case appOrSite = "app_or_site"
+        case description
+        case message
+    }
+}

--- a/desktop/Desktop/Sources/ProactiveAssistants/Core/BackendProactiveService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Core/BackendProactiveService.swift
@@ -43,10 +43,21 @@ class BackendProactiveService {
     private var keepaliveTask: Task<Void, Never>?
     private let keepaliveInterval: TimeInterval = 30.0
 
-    // Pending request continuations keyed by frame_id
+    // Pending continuations keyed by frame_id (vision handlers)
     private var pendingFocusRequests: [String: CheckedContinuation<ScreenAnalysis, Error>] = [:]
+    private var pendingTasksRequests: [String: CheckedContinuation<TasksExtractedResult, Error>] = [:]
+    private var pendingMemoriesRequests: [String: CheckedContinuation<MemoriesExtractedResult, Error>] = [:]
+    private var pendingAdviceRequests: [String: CheckedContinuation<AdviceExtractedResult, Error>] = [:]
+
+    // Pending continuations for text-only handlers (one outstanding per type)
+    private var pendingLiveNote: CheckedContinuation<String, Error>?
+    private var pendingProfile: CheckedContinuation<String, Error>?
+    private var pendingRerank: CheckedContinuation<RerankExtractedResult, Error>?
+    private var pendingDedup: CheckedContinuation<DedupExtractedResult, Error>?
+
     private let requestLock = NSLock()
     private let requestTimeout: TimeInterval = 30.0
+    private let textRequestTimeout: TimeInterval = 60.0
 
     // MARK: - Connection
 
@@ -69,62 +80,190 @@ class BackendProactiveService {
         urlSession?.invalidateAndCancel()
         urlSession = nil
 
-        // Cancel all pending requests
         cancelAllPending(error: ServiceError.notConnected)
-
         log("BackendProactiveService: Disconnected")
     }
 
-    // MARK: - Public API
+    // MARK: - Vision Handlers (screen_frame)
 
     /// Send a screen_frame for focus analysis and wait for the focus_result response.
-    func analyzeFocus(
-        imageBase64: String,
-        appName: String,
-        windowTitle: String
-    ) async throws -> ScreenAnalysis {
-        guard isConnected else {
-            throw ServiceError.notConnected
-        }
-
+    func analyzeFocus(imageBase64: String, appName: String, windowTitle: String) async throws -> ScreenAnalysis {
+        guard isConnected else { throw ServiceError.notConnected }
         let frameId = UUID().uuidString
-
-        let message: [String: Any] = [
-            "type": "screen_frame",
-            "frame_id": frameId,
-            "image_b64": imageBase64,
-            "app_name": appName,
-            "window_title": windowTitle,
-            "analyze": ["focus"],
-        ]
-
-        let jsonData = try JSONSerialization.data(withJSONObject: message)
-        guard let jsonString = String(data: jsonData, encoding: .utf8) else {
-            throw ServiceError.serverError("Failed to encode message")
-        }
+        let jsonString = try buildScreenFrameJSON(frameId: frameId, analyzeTypes: ["focus"], imageBase64: imageBase64, appName: appName, windowTitle: windowTitle)
 
         return try await withCheckedThrowingContinuation { continuation in
             requestLock.lock()
             pendingFocusRequests[frameId] = continuation
             requestLock.unlock()
+            sendAndTimeout(jsonString: jsonString, frameId: frameId, timeout: requestTimeout,
+                           remove: { self.pendingFocusRequests.removeValue(forKey: $0) })
+        }
+    }
 
-            webSocketTask?.send(.string(jsonString)) { [weak self] error in
-                if let error = error {
-                    self?.requestLock.lock()
-                    let cont = self?.pendingFocusRequests.removeValue(forKey: frameId)
-                    self?.requestLock.unlock()
-                    cont?.resume(throwing: error)
-                }
-            }
+    /// Send a screen_frame for task extraction.
+    func extractTasks(imageBase64: String, appName: String, windowTitle: String) async throws -> TasksExtractedResult {
+        guard isConnected else { throw ServiceError.notConnected }
+        let frameId = UUID().uuidString
+        let jsonString = try buildScreenFrameJSON(frameId: frameId, analyzeTypes: ["tasks"], imageBase64: imageBase64, appName: appName, windowTitle: windowTitle)
 
-            // Timeout guard
-            Task { [weak self] in
-                try? await Task.sleep(nanoseconds: UInt64((self?.requestTimeout ?? 30.0) * 1_000_000_000))
+        return try await withCheckedThrowingContinuation { continuation in
+            requestLock.lock()
+            pendingTasksRequests[frameId] = continuation
+            requestLock.unlock()
+            sendAndTimeout(jsonString: jsonString, frameId: frameId, timeout: requestTimeout,
+                           remove: { self.pendingTasksRequests.removeValue(forKey: $0) })
+        }
+    }
+
+    /// Send a screen_frame for memory extraction.
+    func extractMemories(imageBase64: String, appName: String, windowTitle: String) async throws -> MemoriesExtractedResult {
+        guard isConnected else { throw ServiceError.notConnected }
+        let frameId = UUID().uuidString
+        let jsonString = try buildScreenFrameJSON(frameId: frameId, analyzeTypes: ["memories"], imageBase64: imageBase64, appName: appName, windowTitle: windowTitle)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            requestLock.lock()
+            pendingMemoriesRequests[frameId] = continuation
+            requestLock.unlock()
+            sendAndTimeout(jsonString: jsonString, frameId: frameId, timeout: requestTimeout,
+                           remove: { self.pendingMemoriesRequests.removeValue(forKey: $0) })
+        }
+    }
+
+    /// Send a screen_frame for advice generation.
+    func generateAdvice(imageBase64: String, appName: String, windowTitle: String) async throws -> AdviceExtractedResult {
+        guard isConnected else { throw ServiceError.notConnected }
+        let frameId = UUID().uuidString
+        let jsonString = try buildScreenFrameJSON(frameId: frameId, analyzeTypes: ["advice"], imageBase64: imageBase64, appName: appName, windowTitle: windowTitle)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            requestLock.lock()
+            pendingAdviceRequests[frameId] = continuation
+            requestLock.unlock()
+            sendAndTimeout(jsonString: jsonString, frameId: frameId, timeout: requestTimeout,
+                           remove: { self.pendingAdviceRequests.removeValue(forKey: $0) })
+        }
+    }
+
+    // MARK: - Text-Only Handlers
+
+    /// Send transcript text for live note generation.
+    func generateLiveNote(text: String, sessionContext: String = "") async throws -> String {
+        guard isConnected else { throw ServiceError.notConnected }
+        let jsonString = try buildJSON(["type": "live_notes_text", "text": text, "session_context": sessionContext])
+
+        return try await withCheckedThrowingContinuation { continuation in
+            requestLock.lock()
+            pendingLiveNote = continuation
+            requestLock.unlock()
+            sendAndTimeoutSingle(jsonString: jsonString, timeout: textRequestTimeout,
+                                 remove: { let c = self.pendingLiveNote; self.pendingLiveNote = nil; return c })
+        }
+    }
+
+    /// Request profile generation (server fetches user data from Firestore).
+    func requestProfile() async throws -> String {
+        guard isConnected else { throw ServiceError.notConnected }
+        let jsonString = try buildJSON(["type": "profile_request"])
+
+        return try await withCheckedThrowingContinuation { continuation in
+            requestLock.lock()
+            pendingProfile = continuation
+            requestLock.unlock()
+            sendAndTimeoutSingle(jsonString: jsonString, timeout: textRequestTimeout,
+                                 remove: { let c = self.pendingProfile; self.pendingProfile = nil; return c })
+        }
+    }
+
+    /// Request task reranking (server fetches tasks from Firestore).
+    func rerankTasks() async throws -> RerankExtractedResult {
+        guard isConnected else { throw ServiceError.notConnected }
+        let jsonString = try buildJSON(["type": "task_rerank"])
+
+        return try await withCheckedThrowingContinuation { continuation in
+            requestLock.lock()
+            pendingRerank = continuation
+            requestLock.unlock()
+            sendAndTimeoutSingle(jsonString: jsonString, timeout: textRequestTimeout,
+                                 remove: { let c = self.pendingRerank; self.pendingRerank = nil; return c })
+        }
+    }
+
+    /// Request task deduplication (server fetches tasks from Firestore).
+    func deduplicateTasks() async throws -> DedupExtractedResult {
+        guard isConnected else { throw ServiceError.notConnected }
+        let jsonString = try buildJSON(["type": "task_dedup"])
+
+        return try await withCheckedThrowingContinuation { continuation in
+            requestLock.lock()
+            pendingDedup = continuation
+            requestLock.unlock()
+            sendAndTimeoutSingle(jsonString: jsonString, timeout: textRequestTimeout,
+                                 remove: { let c = self.pendingDedup; self.pendingDedup = nil; return c })
+        }
+    }
+
+    // MARK: - Send Helpers
+
+    private func buildScreenFrameJSON(frameId: String, analyzeTypes: [String], imageBase64: String, appName: String, windowTitle: String) throws -> String {
+        try buildJSON([
+            "type": "screen_frame",
+            "frame_id": frameId,
+            "image_b64": imageBase64,
+            "app_name": appName,
+            "window_title": windowTitle,
+            "analyze": analyzeTypes,
+        ])
+    }
+
+    private func buildJSON(_ dict: [String: Any]) throws -> String {
+        let data = try JSONSerialization.data(withJSONObject: dict)
+        guard let str = String(data: data, encoding: .utf8) else {
+            throw ServiceError.serverError("Failed to encode message")
+        }
+        return str
+    }
+
+    /// Send JSON and set up timeout for frame_id-keyed continuations.
+    private func sendAndTimeout<T>(jsonString: String, frameId: String, timeout: TimeInterval,
+                                   remove: @escaping (String) -> CheckedContinuation<T, Error>?) {
+        webSocketTask?.send(.string(jsonString)) { [weak self] error in
+            if let error = error {
                 self?.requestLock.lock()
-                let cont = self?.pendingFocusRequests.removeValue(forKey: frameId)
+                let cont = remove(frameId)
                 self?.requestLock.unlock()
-                cont?.resume(throwing: ServiceError.timeout)
+                cont?.resume(throwing: error)
             }
+        }
+
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            self?.requestLock.lock()
+            let cont = remove(frameId)
+            self?.requestLock.unlock()
+            cont?.resume(throwing: ServiceError.timeout)
+        }
+    }
+
+    /// Send JSON and set up timeout for single-slot continuations.
+    private func sendAndTimeoutSingle<T>(jsonString: String, timeout: TimeInterval,
+                                         remove: @escaping () -> CheckedContinuation<T, Error>?) {
+        webSocketTask?.send(.string(jsonString)) { [weak self] error in
+            if let error = error {
+                self?.requestLock.lock()
+                let cont = remove()
+                self?.requestLock.unlock()
+                cont?.resume(throwing: error)
+            }
+        }
+
+        Task { [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(timeout * 1_000_000_000))
+            self?.requestLock.lock()
+            let cont = remove()
+            self?.requestLock.unlock()
+            cont?.resume(throwing: ServiceError.timeout)
         }
     }
 
@@ -153,8 +292,6 @@ class BackendProactiveService {
             .replacingOccurrences(of: "http://", with: "ws://")
         let base = wsURL.hasSuffix("/") ? wsURL : wsURL + "/"
 
-        // Connect to /v4/listen with source=desktop — same endpoint as audio,
-        // but we only send JSON messages (no audio data)
         var components = URLComponents(string: "\(base)v4/listen")!
         components.queryItems = [
             URLQueryItem(name: "source", value: "desktop"),
@@ -183,7 +320,6 @@ class BackendProactiveService {
 
         receiveMessage()
 
-        // Confirm connection after short delay
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
             guard let self = self, self.webSocketTask?.state == .running else {
                 self?.handleDisconnection()
@@ -275,7 +411,6 @@ class BackendProactiveService {
             return
         }
 
-        // Skip heartbeat
         if text == "ping" { return }
 
         guard let data = text.data(using: .utf8),
@@ -286,44 +421,132 @@ class BackendProactiveService {
 
         switch type {
         case "focus_result":
-            handleFocusResult(data)
+            handleFocusResult(json)
+        case "tasks_extracted":
+            handleTasksExtracted(json)
+        case "memories_extracted":
+            handleMemoriesExtracted(json)
+        case "advice_extracted":
+            handleAdviceExtracted(json)
+        case "live_note":
+            handleLiveNote(json)
+        case "profile_updated":
+            handleProfileUpdated(json)
+        case "rerank_complete":
+            handleRerankComplete(json)
+        case "dedup_complete":
+            handleDedupComplete(json)
         default:
-            // Other event types (memory_created, etc.) — ignore for now
             break
         }
     }
 
-    private func handleFocusResult(_ data: Data) {
-        guard let response = try? JSONDecoder().decode(FocusResultResponse.self, from: data) else {
-            log("BackendProactiveService: Failed to decode focus_result")
-            return
-        }
+    // MARK: - Response Handlers
 
+    private func handleFocusResult(_ json: [String: Any]) {
+        guard let frameId = json["frame_id"] as? String else { return }
         let analysis = ScreenAnalysis(
-            status: FocusStatus(rawValue: response.status) ?? .focused,
-            appOrSite: response.appOrSite,
-            description: response.description,
-            message: response.message
+            status: FocusStatus(rawValue: json["status"] as? String ?? "focused") ?? .focused,
+            appOrSite: json["app_or_site"] as? String ?? "",
+            description: json["description"] as? String ?? "",
+            message: json["message"] as? String
         )
-
         requestLock.lock()
-        let continuation = pendingFocusRequests.removeValue(forKey: response.frameId)
+        let cont = pendingFocusRequests.removeValue(forKey: frameId)
         requestLock.unlock()
+        cont?.resume(returning: analysis)
+    }
 
-        continuation?.resume(returning: analysis)
+    private func handleTasksExtracted(_ json: [String: Any]) {
+        guard let frameId = json["frame_id"] as? String else { return }
+        let tasks = (json["tasks"] as? [[String: Any]]) ?? []
+        let result = TasksExtractedResult(frameId: frameId, tasks: tasks)
+        requestLock.lock()
+        let cont = pendingTasksRequests.removeValue(forKey: frameId)
+        requestLock.unlock()
+        cont?.resume(returning: result)
+    }
+
+    private func handleMemoriesExtracted(_ json: [String: Any]) {
+        guard let frameId = json["frame_id"] as? String else { return }
+        let memories = (json["memories"] as? [[String: Any]]) ?? []
+        let result = MemoriesExtractedResult(frameId: frameId, memories: memories)
+        requestLock.lock()
+        let cont = pendingMemoriesRequests.removeValue(forKey: frameId)
+        requestLock.unlock()
+        cont?.resume(returning: result)
+    }
+
+    private func handleAdviceExtracted(_ json: [String: Any]) {
+        guard let frameId = json["frame_id"] as? String else { return }
+        let result = AdviceExtractedResult(frameId: frameId, advice: json["advice"])
+        requestLock.lock()
+        let cont = pendingAdviceRequests.removeValue(forKey: frameId)
+        requestLock.unlock()
+        cont?.resume(returning: result)
+    }
+
+    private func handleLiveNote(_ json: [String: Any]) {
+        let text = json["text"] as? String ?? ""
+        requestLock.lock()
+        let cont = pendingLiveNote
+        pendingLiveNote = nil
+        requestLock.unlock()
+        cont?.resume(returning: text)
+    }
+
+    private func handleProfileUpdated(_ json: [String: Any]) {
+        let profileText = json["profile_text"] as? String ?? ""
+        requestLock.lock()
+        let cont = pendingProfile
+        pendingProfile = nil
+        requestLock.unlock()
+        cont?.resume(returning: profileText)
+    }
+
+    private func handleRerankComplete(_ json: [String: Any]) {
+        let updatedTasks = (json["updated_tasks"] as? [[String: Any]]) ?? []
+        let result = RerankExtractedResult(updatedTasks: updatedTasks)
+        requestLock.lock()
+        let cont = pendingRerank
+        pendingRerank = nil
+        requestLock.unlock()
+        cont?.resume(returning: result)
+    }
+
+    private func handleDedupComplete(_ json: [String: Any]) {
+        let deletedIds = (json["deleted_ids"] as? [String]) ?? []
+        let reason = json["reason"] as? String ?? ""
+        let result = DedupExtractedResult(deletedIds: deletedIds, reason: reason)
+        requestLock.lock()
+        let cont = pendingDedup
+        pendingDedup = nil
+        requestLock.unlock()
+        cont?.resume(returning: result)
     }
 
     // MARK: - Helpers
 
     private func cancelAllPending(error: Error) {
         requestLock.lock()
-        let pending = pendingFocusRequests
-        pendingFocusRequests.removeAll()
+        let focus = pendingFocusRequests; pendingFocusRequests.removeAll()
+        let tasks = pendingTasksRequests; pendingTasksRequests.removeAll()
+        let memories = pendingMemoriesRequests; pendingMemoriesRequests.removeAll()
+        let advice = pendingAdviceRequests; pendingAdviceRequests.removeAll()
+        let liveNote = pendingLiveNote; pendingLiveNote = nil
+        let profile = pendingProfile; pendingProfile = nil
+        let rerank = pendingRerank; pendingRerank = nil
+        let dedup = pendingDedup; pendingDedup = nil
         requestLock.unlock()
 
-        for (_, continuation) in pending {
-            continuation.resume(throwing: error)
-        }
+        for (_, c) in focus { c.resume(throwing: error) }
+        for (_, c) in tasks { c.resume(throwing: error) }
+        for (_, c) in memories { c.resume(throwing: error) }
+        for (_, c) in advice { c.resume(throwing: error) }
+        liveNote?.resume(throwing: error)
+        profile?.resume(throwing: error)
+        rerank?.resume(throwing: error)
+        dedup?.resume(throwing: error)
     }
 
     private static func getBaseURL() -> String? {
@@ -337,22 +560,33 @@ class BackendProactiveService {
     }
 }
 
-// MARK: - Response Models
+// MARK: - Result Types
 
-private struct FocusResultResponse: Decodable {
-    let type: String
+/// Tasks extracted from a screen_frame analysis.
+struct TasksExtractedResult {
     let frameId: String
-    let status: String
-    let appOrSite: String
-    let description: String
-    let message: String?
+    let tasks: [[String: Any]]  // Raw task dicts from backend
+}
 
-    enum CodingKeys: String, CodingKey {
-        case type
-        case frameId = "frame_id"
-        case status
-        case appOrSite = "app_or_site"
-        case description
-        case message
-    }
+/// Memories extracted from a screen_frame analysis.
+struct MemoriesExtractedResult {
+    let frameId: String
+    let memories: [[String: Any]]  // Raw memory dicts from backend
+}
+
+/// Advice extracted from a screen_frame analysis.
+struct AdviceExtractedResult {
+    let frameId: String
+    let advice: Any?  // Raw advice from backend (dict or null)
+}
+
+/// Task reranking result.
+struct RerankExtractedResult {
+    let updatedTasks: [[String: Any]]  // [{id, new_position}, ...]
+}
+
+/// Task deduplication result.
+struct DedupExtractedResult {
+    let deletedIds: [String]
+    let reason: String
 }

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -314,62 +314,58 @@ public class ProactiveAssistantsPlugin: NSObject {
         proactiveService.connect()
         backendProactiveService = proactiveService
 
-        do {
-            focusAssistant = FocusAssistant(
-                backendService: proactiveService,
-                onAlert: { [weak self] message in
-                    self?.sendEvent(type: "alert", data: ["message": message])
-                },
-                onStatusChange: { [weak self] status in
-                    Task { @MainActor in
-                        self?.lastStatus = status
-                        self?.sendEvent(type: "statusChange", data: ["status": status.rawValue])
-                    }
-                },
-                onRefocus: {
-                    Task { @MainActor in
-                        OverlayService.shared.showGlowAroundActiveWindow(colorMode: .focused)
-                    }
-                },
-                onDistraction: {
-                    Task { @MainActor in
-                        OverlayService.shared.showGlowAroundActiveWindow(colorMode: .distracted)
-                    }
+        focusAssistant = FocusAssistant(
+            backendService: proactiveService,
+            onAlert: { [weak self] message in
+                self?.sendEvent(type: "alert", data: ["message": message])
+            },
+            onStatusChange: { [weak self] status in
+                Task { @MainActor in
+                    self?.lastStatus = status
+                    self?.sendEvent(type: "statusChange", data: ["status": status.rawValue])
                 }
-            )
-
-            if let focus = focusAssistant {
-                AssistantCoordinator.shared.register(focus)
+            },
+            onRefocus: {
+                Task { @MainActor in
+                    OverlayService.shared.showGlowAroundActiveWindow(colorMode: .focused)
+                }
+            },
+            onDistraction: {
+                Task { @MainActor in
+                    OverlayService.shared.showGlowAroundActiveWindow(colorMode: .distracted)
+                }
             }
+        )
 
-            taskAssistant = try TaskAssistant()
+        if let focus = focusAssistant {
+            AssistantCoordinator.shared.register(focus)
+        }
 
-            if let task = taskAssistant {
-                AssistantCoordinator.shared.register(task)
-            }
+        taskAssistant = TaskAssistant(backendService: proactiveService)
 
-            Task { await TaskDeduplicationService.shared.start() }
-            Task { await TaskPrioritizationService.shared.start() }
-            Task { await TaskPromotionService.shared.start() }
+        if let task = taskAssistant {
+            AssistantCoordinator.shared.register(task)
+        }
 
-            adviceAssistant = try AdviceAssistant()
+        // Configure text-only services with backend service
+        Task { await TaskDeduplicationService.shared.configure(backendService: proactiveService) }
+        Task { await TaskPrioritizationService.shared.configure(backendService: proactiveService) }
+        Task { await AIUserProfileService.shared.configure(backendService: proactiveService) }
 
-            if let advice = adviceAssistant {
-                AssistantCoordinator.shared.register(advice)
-            }
+        Task { await TaskDeduplicationService.shared.start() }
+        Task { await TaskPrioritizationService.shared.start() }
+        Task { await TaskPromotionService.shared.start() }
 
-            memoryAssistant = try MemoryAssistant()
+        adviceAssistant = AdviceAssistant(backendService: proactiveService)
 
-            if let memory = memoryAssistant {
-                AssistantCoordinator.shared.register(memory)
-            }
+        if let advice = adviceAssistant {
+            AssistantCoordinator.shared.register(advice)
+        }
 
-        } catch {
-            log("ProactiveAssistantsPlugin: Failed to initialize assistants: \(error.localizedDescription)")
-            logError("ProactiveAssistantsPlugin: Assistant initialization failed", error: error)
-            isStartingMonitoring = false
-            completion(false, error.localizedDescription)
-            return
+        memoryAssistant = MemoryAssistant(backendService: proactiveService)
+
+        if let memory = memoryAssistant {
+            AssistantCoordinator.shared.register(memory)
         }
 
         // Get initial app state

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -14,6 +14,7 @@ public class ProactiveAssistantsPlugin: NSObject {
 
     private var screenCaptureService: ScreenCaptureService?
     private var windowMonitor: WindowMonitor?
+    private var backendProactiveService: BackendProactiveService?
     private var focusAssistant: FocusAssistant?
 
     /// Public read-only accessor for memory diagnostics
@@ -308,8 +309,14 @@ public class ProactiveAssistantsPlugin: NSObject {
         // Initialize services
         screenCaptureService = ScreenCaptureService()
 
+        // Start backend proactive AI WebSocket (Phase 2 — server-side LLM)
+        let proactiveService = BackendProactiveService()
+        proactiveService.connect()
+        backendProactiveService = proactiveService
+
         do {
-            focusAssistant = try FocusAssistant(
+            focusAssistant = FocusAssistant(
+                backendService: proactiveService,
                 onAlert: { [weak self] message in
                     self?.sendEvent(type: "alert", data: ["message": message])
                 },
@@ -448,6 +455,8 @@ public class ProactiveAssistantsPlugin: NSObject {
             }
         }
 
+        backendProactiveService?.disconnect()
+        backendProactiveService = nil
         focusAssistant = nil
         taskAssistant = nil
         adviceAssistant = nil

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -351,6 +351,7 @@ public class ProactiveAssistantsPlugin: NSObject {
         Task { await TaskDeduplicationService.shared.configure(backendService: proactiveService) }
         Task { await TaskPrioritizationService.shared.configure(backendService: proactiveService) }
         Task { await AIUserProfileService.shared.configure(backendService: proactiveService) }
+        Task { await LiveNotesMonitor.shared.configure(backendService: proactiveService) }
 
         Task { await TaskDeduplicationService.shared.start() }
         Task { await TaskPrioritizationService.shared.start() }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/AIUserProfileService.swift
@@ -34,7 +34,7 @@ extension AIUserProfileRecord: TableDocumented {
 actor AIUserProfileService {
     static let shared = AIUserProfileService()
 
-    private let model = "gemini-pro-latest"
+    private var backendService: BackendProactiveService?
     private let maxProfileLength = 10000
 
     /// Whether profile generation is currently in progress
@@ -46,6 +46,11 @@ actor AIUserProfileService {
     /// Invalidate cached DB queue (called on user switch / sign-out)
     func invalidateCache() {
         _dbQueue = nil
+    }
+
+    /// Set the backend service for Phase 2 server-side profile generation.
+    func configure(backendService: BackendProactiveService) {
+        self.backendService = backendService
     }
 
     // MARK: - Database Access
@@ -211,312 +216,40 @@ actor AIUserProfileService {
         }) ?? []
     }
 
-    /// Generate a new AI user profile from all available data sources
+    /// Generate a new AI user profile via backend WebSocket.
+    /// The backend fetches all user data from Firestore and generates the profile server-side.
     func generateProfile() async throws -> AIUserProfileRecord {
         guard !isGenerating else {
             throw ProfileError.alreadyGenerating
         }
+        guard let service = backendService else {
+            throw ProfileError.databaseNotAvailable
+        }
         isGenerating = true
         defer { isGenerating = false }
 
-        log("AIUserProfileService: Starting profile generation")
+        log("AIUserProfileService: Requesting server-side profile generation")
 
-        // 1. Fetch all data sources in parallel
-        let (memories, tasks, goals, conversations, messages) = await fetchDataSources()
-
-        // 2. Count total data items
-        let dataSourcesUsed = memories.count + tasks.count + goals.count + conversations.count + messages.count
-        log("AIUserProfileService: Fetched \(dataSourcesUsed) data items (memories=\(memories.count), tasks=\(tasks.count), goals=\(goals.count), convos=\(conversations.count), messages=\(messages.count))")
-
-        guard dataSourcesUsed > 0 else {
-            throw ProfileError.insufficientData
-        }
-
-        // 3. Build prompt
-        let prompt = buildPrompt(memories: memories, tasks: tasks, goals: goals, conversations: conversations, messages: messages)
-
-        // 4. Call Gemini
-        let gemini = try GeminiClient(model: model)
-        let systemPrompt = """
-        You are generating a structured user profile that will be injected as context into AI pipelines \
-        (task extraction, goal extraction, memory extraction) that analyze the user's screen and audio activity.
-
-        OUTPUT FORMAT:
-        - A flat list of factual statements, one per line, prefixed with "- "
-        - Each statement must be a concrete fact directly supported by the provided data
-        - No prose, no paragraphs, no headers, no markdown formatting
-        - No adjectives like "passionate", "dedicated", "impressive"
-        - Write in third person ("User works at...", not "You work at...")
-
-        WHAT TO INCLUDE (only if clearly supported by the data):
-        - Full name, role, company, industry
-        - Current projects and what tools/apps they use for each
-        - Key people they interact with (names, roles, relationship)
-        - Active goals and their progress
-        - Recurring meetings, deadlines, routines
-        - Communication platforms they use (Slack, email, iMessage, etc.)
-        - Technical stack, programming languages, frameworks
-        - Topics they frequently discuss or research
-        - Pending tasks and commitments to others
-        - Time zone, work schedule patterns
-
-        CRITICAL RULES:
-        - ONLY include facts that are directly evidenced in the provided data
-        - If a category has no supporting data, skip it entirely — do not guess or infer
-        - Do NOT hallucinate names, roles, companies, or relationships not present in the data
-        - Do NOT add personality descriptions or subjective assessments
-        - When uncertain, omit rather than speculate
-        - NEVER fabricate email addresses, phone numbers, URLs, or contact information
-        - The provided data contains NO email addresses — do not invent any
-        - If you cannot find a piece of information verbatim in the data, do not include it
-
-        The output MUST be under 2000 characters total.
-        """
-
-        let stageOneText = try await gemini.sendTextRequest(prompt: prompt, systemPrompt: systemPrompt)
-        log("AIUserProfileService: Stage 1 complete (\(stageOneText.count) chars)")
-
-        // 5. Stage 2 — Consolidate with past profiles for holistic view
-        let pastProfiles = await getAllProfiles(limit: 5)
-        let finalText: String
-        if pastProfiles.isEmpty {
-            finalText = stageOneText
-        } else {
-            let consolidationPrompt = buildConsolidationPrompt(
-                newProfile: stageOneText,
-                pastProfiles: pastProfiles
-            )
-            let consolidationSystemPrompt = """
-            You are merging a newly generated user profile with historical profiles to create \
-            one holistic, up-to-date user profile. This profile is injected as context into AI pipelines \
-            (task extraction, goal extraction, memory extraction) that analyze the user's screen and audio activity.
-
-            OUTPUT FORMAT:
-            - A flat list of factual statements, one per line, prefixed with "- "
-            - Each statement must be a concrete fact
-            - No prose, no paragraphs, no headers, no markdown formatting
-            - No adjectives or subjective assessments
-            - Write in third person
-
-            MERGE RULES:
-            - The NEW profile reflects today's data and takes priority for current state
-            - Past profiles provide historical context — retain facts that are still relevant
-            - If a fact from the past contradicts the new profile, use the new one
-            - Remove outdated information (completed tasks, past deadlines, old routines)
-            - Keep stable facts (name, role, company, key relationships, tech stack)
-            - Accumulate knowledge: if past profiles mention people, projects, or patterns \
-              not in today's data, keep them if they seem ongoing
-            - Do NOT hallucinate — only include facts present in the provided profiles
-            - Do NOT add commentary about changes or evolution over time
-
-            The output MUST be under 2000 characters total.
-            """
-            finalText = try await gemini.sendTextRequest(
-                prompt: consolidationPrompt,
-                systemPrompt: consolidationSystemPrompt
-            )
-            log("AIUserProfileService: Stage 2 consolidation complete (\(finalText.count) chars)")
-        }
-
-        // 6. Truncate if needed
-        let truncated = String(finalText.prefix(maxProfileLength))
+        let profileText = try await service.requestProfile()
+        let truncated = String(profileText.prefix(maxProfileLength))
         let generatedAt = Date()
 
-        // 6. Save to database
+        log("AIUserProfileService: Received profile from backend (\(truncated.count) chars)")
+
+        // Save to local database
         let db = try await ensureDB()
         let record = AIUserProfileRecord(
             profileText: truncated,
-            dataSourcesUsed: dataSourcesUsed,
-            backendSynced: false,
+            dataSourcesUsed: 0,
+            backendSynced: true,  // Backend already has it
             generatedAt: generatedAt
         )
         try await db.write { database in
             try record.insert(database)
         }
 
-        // 7. Sync to backend (fire-and-forget)
-        let recordId = record.id
-        Task {
-            do {
-                try await APIClient.shared.syncAIUserProfile(
-                    profileText: truncated,
-                    generatedAt: generatedAt,
-                    dataSourcesUsed: dataSourcesUsed
-                )
-                // Mark as synced
-                if let id = recordId, let db = try? await self.ensureDB() {
-                    _ = try? await db.write { database in
-                        try database.execute(
-                            sql: "UPDATE ai_user_profiles SET backendSynced = 1 WHERE id = ?",
-                            arguments: [id]
-                        )
-                    }
-                }
-                log("AIUserProfileService: Synced profile to backend")
-            } catch {
-                log("AIUserProfileService: Failed to sync profile to backend: \(error.localizedDescription)")
-            }
-        }
-
-        log("AIUserProfileService: Profile generated successfully (\(truncated.count) chars, \(dataSourcesUsed) data items)")
+        log("AIUserProfileService: Profile saved to local DB")
         return record
-    }
-
-    // MARK: - Data Fetching
-
-    private func fetchDataSources() async -> (
-        memories: [String],
-        tasks: [String],
-        goals: [String],
-        conversations: [String],
-        messages: [String]
-    ) {
-        async let memoriesTask = fetchMemories()
-        async let tasksTask = fetchTasks()
-        async let goalsTask = fetchGoals()
-        async let conversationsTask = fetchConversations()
-        async let messagesTask = fetchMessages()
-
-        let memories = await memoriesTask
-        let tasks = await tasksTask
-        let goals = await goalsTask
-        let conversations = await conversationsTask
-        let messages = await messagesTask
-
-        return (memories, tasks, goals, conversations, messages)
-    }
-
-    private func fetchMemories() async -> [String] {
-        do {
-            let memories = try await APIClient.shared.getMemories(limit: 100)
-            return memories.map { "[\($0.category.rawValue)] \($0.content)" }
-        } catch {
-            log("AIUserProfileService: Failed to fetch memories: \(error.localizedDescription)")
-            return []
-        }
-    }
-
-    private func fetchTasks() async -> [String] {
-        do {
-            let response = try await APIClient.shared.getActionItems(limit: 50)
-            return response.items.map { item in
-                let status = item.completed ? "done" : "todo"
-                let priority = item.priority ?? "medium"
-                return "[\(status)/\(priority)] \(item.description)"
-            }
-        } catch {
-            log("AIUserProfileService: Failed to fetch tasks: \(error.localizedDescription)")
-            return []
-        }
-    }
-
-    private func fetchGoals() async -> [String] {
-        do {
-            let goals = try await APIClient.shared.getGoals()
-            return goals.filter { $0.isActive }.map { goal in
-                let progress = goal.targetValue > 0 ? Int((goal.currentValue / goal.targetValue) * 100) : 0
-                return "\(goal.title) (\(progress)% complete)"
-            }
-        } catch {
-            log("AIUserProfileService: Failed to fetch goals: \(error.localizedDescription)")
-            return []
-        }
-    }
-
-    private func fetchConversations() async -> [String] {
-        do {
-            let sevenDaysAgo = Calendar.current.date(byAdding: .day, value: -7, to: Date())
-            let conversations = try await APIClient.shared.getConversations(
-                limit: 20,
-                startDate: sevenDaysAgo
-            )
-            return conversations.compactMap { convo in
-                let title = convo.structured.title
-                let summary = convo.structured.overview
-                guard !title.isEmpty else { return nil }
-                return "\(title): \(summary)"
-            }
-        } catch {
-            log("AIUserProfileService: Failed to fetch conversations: \(error.localizedDescription)")
-            return []
-        }
-    }
-
-    private func fetchMessages() async -> [String] {
-        do {
-            let messages = try await APIClient.shared.getMessages(limit: 30)
-            return messages.map { "[\($0.sender)] \($0.text)" }
-        } catch {
-            log("AIUserProfileService: Failed to fetch messages: \(error.localizedDescription)")
-            return []
-        }
-    }
-
-    // MARK: - Prompt Building
-
-    private func buildPrompt(
-        memories: [String],
-        tasks: [String],
-        goals: [String],
-        conversations: [String],
-        messages: [String]
-    ) -> String {
-        var sections: [String] = []
-
-        if !memories.isEmpty {
-            sections.append("## Memories about the user\n\(memories.joined(separator: "\n"))")
-        }
-
-        if !tasks.isEmpty {
-            sections.append("## Recent tasks\n\(tasks.joined(separator: "\n"))")
-        }
-
-        if !goals.isEmpty {
-            sections.append("## Active goals\n\(goals.joined(separator: "\n"))")
-        }
-
-        if !conversations.isEmpty {
-            sections.append("## Recent conversations (past 7 days)\n\(conversations.joined(separator: "\n"))")
-        }
-
-        if !messages.isEmpty {
-            sections.append("## Recent AI chat messages\n\(messages.joined(separator: "\n"))")
-        }
-
-        return """
-        Generate a factual user profile from the following data. \
-        Output a flat list of concrete facts (one per line, prefixed with "- "). \
-        This profile will be used as context for AI pipelines that analyze the user's screen and audio activity \
-        to extract tasks, goals, and memories. Focus on facts that help identify who is who, what projects are active, \
-        and what the user's current priorities are. Under 2000 characters.
-
-        \(sections.joined(separator: "\n\n"))
-        """
-    }
-
-    private func buildConsolidationPrompt(
-        newProfile: String,
-        pastProfiles: [AIUserProfileRecord]
-    ) -> String {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateStyle = .medium
-        dateFormatter.timeStyle = .none
-
-        var pastSection = ""
-        for profile in pastProfiles {
-            let dateStr = dateFormatter.string(from: profile.generatedAt)
-            pastSection += "--- Profile from \(dateStr) ---\n\(profile.profileText)\n\n"
-        }
-
-        return """
-        Merge the following into one holistic user profile. Under 2000 characters.
-
-        === NEW PROFILE (generated today from latest data) ===
-        \(newProfile)
-
-        === PAST PROFILES (oldest to newest, up to 5) ===
-        \(pastSection)
-        """
     }
 
     // MARK: - Errors

--- a/desktop/Desktop/Sources/ProactiveAssistants/UI/AdviceTestRunnerWindow.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/UI/AdviceTestRunnerWindow.swift
@@ -441,17 +441,9 @@ struct AdviceTestRunnerView: View {
                 adviceAssistant = existing
                 log("AdviceTestRunner: Using existing AdviceAssistant from coordinator")
             } else {
-                do {
-                    adviceAssistant = try AdviceAssistant()
-                    log("AdviceTestRunner: Created fresh AdviceAssistant instance")
-                } catch {
-                    log("AdviceTestRunner: ERROR - Failed to create AdviceAssistant: \(error)")
-                    await MainActor.run {
-                        statusMessage = "Failed to create Advice Assistant: \(error.localizedDescription)"
-                        isRunning = false
-                    }
-                    return
-                }
+                let service = BackendProactiveService(); service.connect()
+                adviceAssistant = AdviceAssistant(backendService: service)
+                log("AdviceTestRunner: Created fresh AdviceAssistant instance")
             }
 
             // Get excluded apps
@@ -647,12 +639,8 @@ enum AdviceTestRunner {
         if let existing = coordAssistant as? AdviceAssistant {
             adviceAssistant = existing
         } else {
-            do {
-                adviceAssistant = try AdviceAssistant()
-            } catch {
-                log("AdviceTestCLI: ERROR — Failed to create AdviceAssistant: \(error)")
-                return
-            }
+            let service = BackendProactiveService(); service.connect()
+            adviceAssistant = AdviceAssistant(backendService: service)
         }
 
         // Get excluded apps

--- a/desktop/Desktop/Sources/ProactiveAssistants/UI/FocusTestRunnerWindow.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/UI/FocusTestRunnerWindow.swift
@@ -637,12 +637,9 @@ enum FocusTestRunner {
         if let existing = coordAssistant as? FocusAssistant {
             focusAssistant = existing
         } else {
-            do {
-                focusAssistant = try FocusAssistant()
-            } catch {
-                log("FocusTestCLI: ERROR — Failed to create FocusAssistant: \(error)")
-                return
-            }
+            let service = BackendProactiveService()
+            service.connect()
+            focusAssistant = FocusAssistant(backendService: service)
         }
 
         // Get excluded apps

--- a/desktop/dev.sh
+++ b/desktop/dev.sh
@@ -85,8 +85,12 @@ cp Desktop/Info.plist "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $APP_NAME" "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 omi-computer-dev" "$APP_BUNDLE/Contents/Info.plist"
 
-# Copy GoogleService-Info.plist for Firebase
-cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
+# Copy GoogleService-Info.plist for Firebase (dev version for com.omi.desktop-dev)
+if [ -f "Desktop/Sources/GoogleService-Info-Dev.plist" ]; then
+    cp -f Desktop/Sources/GoogleService-Info-Dev.plist "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+else
+    cp -f Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
+fi
 
 # Copy resource bundle (contains app assets like herologo.png, omi-with-rope-no-padding.webp, etc.)
 SWIFT_BUILD_DIR="Desktop/.build/debug"

--- a/desktop/reset-and-run.sh
+++ b/desktop/reset-and-run.sh
@@ -381,8 +381,12 @@ cp Desktop/Info.plist "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $APP_NAME" "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 omi-computer-dev" "$APP_BUNDLE/Contents/Info.plist"
 
-# Copy GoogleService-Info.plist for Firebase
-cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
+# Copy GoogleService-Info.plist for Firebase (dev version for com.omi.desktop-dev)
+if [ -f "Desktop/Sources/GoogleService-Info-Dev.plist" ]; then
+    cp -f Desktop/Sources/GoogleService-Info-Dev.plist "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+else
+    cp -f Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
+fi
 
 # Copy .env.app (app runtime secrets only) and add API URL
 if [ -f ".env.app" ]; then


### PR DESCRIPTION
## Summary
- Swap `GoogleService-Info-Dev.plist` from prod (`based-hardware`) to dev (`based-hardware-dev`) Firebase project
- Read `API_KEY` from the active plist at runtime instead of hardcoding the prod key in `AuthService.swift`
- Fix `dev.sh` and `reset-and-run.sh` to also copy the dev plist (they were copying prod)

## Changes
| File | Change |
|------|--------|
| `GoogleService-Info-Dev.plist` | API_KEY, PROJECT_ID, STORAGE_BUCKET, GCM_SENDER_ID, GOOGLE_APP_ID → dev values |
| `AuthService.swift` | Read `API_KEY` from bundle GoogleService-Info.plist at runtime (fallback: prod key) |
| `dev.sh` | Copy dev plist instead of prod (matches `run.sh` logic) |
| `reset-and-run.sh` | Copy dev plist instead of prod (matches `run.sh` logic) |

## How it works
- `run.sh`, `dev.sh`, `reset-and-run.sh` (dev builds) copy GoogleService-Info-Dev.plist as GoogleService-Info.plist into the app bundle
- `build.sh` (prod builds) copies GoogleService-Info.plist (prod) into the bundle
- AuthService reads whichever plist is in the bundle: dev key for dev builds, prod key for prod builds
- Zero impact on prod: GoogleService-Info.plist (prod) is unchanged

## CODEx review findings addressed
- Script parity: dev.sh and reset-and-run.sh now use same dev plist logic as run.sh
- Prod fallback in AuthService: intentional safety net
- CLIENT_ID/REVERSED_CLIENT_ID still use prod project number: out of scope per issue #5536

## Test plan
- [ ] ./run.sh builds Omi Dev with based-hardware-dev Firebase
- [ ] ./dev.sh builds Omi Dev with based-hardware-dev Firebase
- [ ] Auth flow works against dev Firebase
- [ ] Prod plist unchanged, build.sh still uses prod Firebase

Fixes #5536

_by AI for @beastoin_