### PR TITLE
Desktop: remove prod Firebase credentials from git, inject at CI

### DIFF
--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -96,6 +96,7 @@ async def auth_callback_google(
             "request": request,
             "code": auth_code,
             "state": session_data['state'] or '',
+            "redirect_uri": session_data.get('redirect_uri', 'omi://auth/callback'),
         },
     )
 
@@ -134,6 +135,7 @@ async def auth_callback_apple_post(
             "request": request,
             "code": auth_code,
             "state": session_data['state'] or '',
+            "redirect_uri": session_data.get('redirect_uri', 'omi://auth/callback'),
         },
     )
 

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -16,7 +16,7 @@ from fastapi.templating import Jinja2Templates
 import pathlib
 import firebase_admin.auth
 from database.redis_db import set_auth_session, get_auth_session, set_auth_code, get_auth_code, delete_auth_code
-from utils.log_sanitizer import sanitize
+from utils.log_sanitizer import sanitize, sanitize_pii
 import logging
 
 logger = logging.getLogger(__name__)
@@ -424,27 +424,23 @@ async def _generate_custom_token(provider: str, id_token: str, access_token: str
                     f"Firebase REST API sign-in failed (status={response.status_code}), falling back to Admin SDK"
                 )
 
-        # Fallback: decode id_token JWT and look up/create user via Admin SDK
+        # Fallback: verify id_token via Admin SDK and look up/create user
         if not firebase_uid:
-            parts = id_token.split('.')
-            if len(parts) < 2:
-                raise Exception("Invalid id_token format")
-            payload_b64 = parts[1] + '=' * (4 - len(parts[1]) % 4)
-            token_payload = json.loads(base64.urlsafe_b64decode(payload_b64))
-            email = token_payload.get('email')
+            verified_token = firebase_admin.auth.verify_id_token(id_token)
+            email = verified_token.get('email')
             if not email:
-                raise Exception("No email in id_token")
+                raise Exception("No email in verified id_token")
 
             # Look up existing Firebase user by email
             try:
                 user = firebase_admin.auth.get_user_by_email(email)
                 firebase_uid = user.uid
-                logger.info(f"Found existing Firebase user for {email}, UID: {firebase_uid}")
+                logger.info(f"Found existing Firebase user for {sanitize_pii(email)}, UID: {firebase_uid}")
             except firebase_admin.auth.UserNotFoundError:
                 # Create new Firebase user
                 user = firebase_admin.auth.create_user(email=email, email_verified=True)
                 firebase_uid = user.uid
-                logger.info(f"Created new Firebase user for {email}, UID: {firebase_uid}")
+                logger.info(f"Created new Firebase user for {sanitize_pii(email)}, UID: {firebase_uid}")
 
         if not firebase_uid:
             raise Exception("No Firebase UID obtained")

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -3,6 +3,7 @@ import uuid
 import json
 import hashlib
 import time
+import base64
 import requests
 import jwt
 from typing import Optional
@@ -386,47 +387,67 @@ async def _generate_custom_token(provider: str, id_token: str, access_token: str
     Works with any bundle ID - perfect for multiple developers
     """
     try:
-        # Get Firebase API Key from environment
+        firebase_uid = None
+
+        # Try REST API first (works when FIREBASE_API_KEY has no app restrictions)
         firebase_api_key = os.getenv('FIREBASE_API_KEY')
-        if not firebase_api_key:
-            raise Exception("FIREBASE_API_KEY not configured")
+        if firebase_api_key:
+            sign_in_url = f"https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key={firebase_api_key}"
 
-        # Sign in with OAuth credential using Firebase Auth REST API
-        sign_in_url = f"https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key={firebase_api_key}"
+            if provider == 'google':
+                post_body = f'id_token={id_token}&providerId=google.com'
+                if access_token:
+                    post_body += f'&access_token={access_token}'
+            elif provider == 'apple':
+                post_body = f'id_token={id_token}&providerId=apple.com'
+                if access_token:
+                    post_body += f'&access_token={access_token}'
+            else:
+                raise Exception(f"Unsupported provider: {provider}")
 
-        # Prepare the postBody based on provider
-        if provider == 'google':
-            post_body = f'id_token={id_token}&providerId=google.com'
-            if access_token:
-                post_body += f'&access_token={access_token}'
-        elif provider == 'apple':
-            post_body = f'id_token={id_token}&providerId=apple.com'
-            if access_token:
-                post_body += f'&access_token={access_token}'
-        else:
-            raise Exception(f"Unsupported provider: {provider}")
+            payload = {
+                'postBody': post_body,
+                'requestUri': 'http://localhost',
+                'returnIdpCredential': True,
+                'returnSecureToken': True,
+            }
 
-        payload = {
-            'postBody': post_body,
-            'requestUri': 'http://localhost',
-            'returnIdpCredential': True,
-            'returnSecureToken': True,
-        }
+            response = requests.post(sign_in_url, json=payload)
 
-        # Call Firebase Auth REST API to sign in
-        response = requests.post(sign_in_url, json=payload)
+            if response.status_code == 200:
+                result = response.json()
+                firebase_uid = result.get('localId')
+                if firebase_uid:
+                    logger.info(f"Firebase sign-in successful for {provider}, UID: {firebase_uid}")
+            else:
+                logger.warning(
+                    f"Firebase REST API sign-in failed (status={response.status_code}), falling back to Admin SDK"
+                )
 
-        if response.status_code != 200:
-            logger.error(f"Firebase sign-in failed: {sanitize(response.text)}")
-            raise Exception(f"Firebase sign-in failed: status={response.status_code}")
+        # Fallback: decode id_token JWT and look up/create user via Admin SDK
+        if not firebase_uid:
+            parts = id_token.split('.')
+            if len(parts) < 2:
+                raise Exception("Invalid id_token format")
+            payload_b64 = parts[1] + '=' * (4 - len(parts[1]) % 4)
+            token_payload = json.loads(base64.urlsafe_b64decode(payload_b64))
+            email = token_payload.get('email')
+            if not email:
+                raise Exception("No email in id_token")
 
-        result = response.json()
-        firebase_uid = result.get('localId')
+            # Look up existing Firebase user by email
+            try:
+                user = firebase_admin.auth.get_user_by_email(email)
+                firebase_uid = user.uid
+                logger.info(f"Found existing Firebase user for {email}, UID: {firebase_uid}")
+            except firebase_admin.auth.UserNotFoundError:
+                # Create new Firebase user
+                user = firebase_admin.auth.create_user(email=email, email_verified=True)
+                firebase_uid = user.uid
+                logger.info(f"Created new Firebase user for {email}, UID: {firebase_uid}")
 
         if not firebase_uid:
-            raise Exception("No Firebase UID returned from sign-in")
-
-        logger.info(f"Firebase sign-in successful for {provider}, UID: {firebase_uid}")
+            raise Exception("No Firebase UID obtained")
 
         # Create custom token for this UID
         custom_token = firebase_admin.auth.create_custom_token(firebase_uid)

--- a/backend/routers/auth.py
+++ b/backend/routers/auth.py
@@ -44,6 +44,11 @@ async def auth_authorize(
     if provider not in ['google', 'apple']:
         raise HTTPException(status_code=400, detail="Unsupported provider")
 
+    # Validate redirect_uri against allowed app URL schemes
+    ALLOWED_REDIRECT_SCHEMES = ('omi://', 'omi-computer://', 'omi-computer-dev://')
+    if not redirect_uri or not any(redirect_uri.startswith(s) for s in ALLOWED_REDIRECT_SCHEMES):
+        raise HTTPException(status_code=400, detail="Invalid redirect_uri: must use an allowed app URL scheme")
+
     # Store session for auth flow
     session_id = str(uuid.uuid4())
     session_data = {
@@ -96,7 +101,7 @@ async def auth_callback_google(
             "request": request,
             "code": auth_code,
             "state": session_data['state'] or '',
-            "redirect_uri": session_data.get('redirect_uri', 'omi://auth/callback'),
+            "redirect_uri": session_data.get('redirect_uri') or 'omi://auth/callback',
         },
     )
 
@@ -135,7 +140,7 @@ async def auth_callback_apple_post(
             "request": request,
             "code": auth_code,
             "state": session_data['state'] or '',
-            "redirect_uri": session_data.get('redirect_uri', 'omi://auth/callback'),
+            "redirect_uri": session_data.get('redirect_uri') or 'omi://auth/callback',
         },
     )
 

--- a/backend/templates/auth_callback.html
+++ b/backend/templates/auth_callback.html
@@ -109,17 +109,28 @@
             messageElement.textContent = 'Please close this window and try again.';
         } else if (code) {
             // Build the custom scheme redirect URL using the redirect_uri from the auth session
-            const redirectUri = "{{ redirect_uri }}";
+            const redirectUri = {{ redirect_uri|tojson }};
+
+            // Validate redirect scheme before use (defense-in-depth; server also validates)
+            const ALLOWED_SCHEMES = ['omi://', 'omi-computer://', 'omi-computer-dev://'];
+            const isAllowedScheme = ALLOWED_SCHEMES.some(s => redirectUri.startsWith(s));
+            if (!isAllowedScheme) {
+                errorElement.textContent = 'Invalid redirect scheme.';
+                spinnerElement.style.display = 'none';
+                messageElement.textContent = 'Please close this window and try again.';
+            }
+
             let redirectUrl = redirectUri + '?code=' + encodeURIComponent(code);
             if (state) {
                 redirectUrl += '&state=' + encodeURIComponent(state);
             }
 
             // Set up manual link
-            manualLinkElement.href = redirectUrl;
+            manualLinkElement.href = isAllowedScheme ? redirectUrl : '#';
 
             // Attempt automatic redirect
             try {
+                if (!isAllowedScheme) throw new Error('Blocked redirect to disallowed scheme');
                 console.log('Redirecting to:', redirectUrl);
                 window.location.href = redirectUrl;
 

--- a/backend/templates/auth_callback.html
+++ b/backend/templates/auth_callback.html
@@ -108,8 +108,9 @@
             spinnerElement.style.display = 'none';
             messageElement.textContent = 'Please close this window and try again.';
         } else if (code) {
-            // Build the custom scheme redirect URL
-            let redirectUrl = 'omi://auth/callback?code=' + encodeURIComponent(code);
+            // Build the custom scheme redirect URL using the redirect_uri from the auth session
+            const redirectUri = "{{ redirect_uri }}";
+            let redirectUrl = redirectUri + '?code=' + encodeURIComponent(code);
             if (state) {
                 redirectUrl += '&state=' + encodeURIComponent(state);
             }

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2108,6 +2108,7 @@ workflows:
           # Copy Firebase config (prod plist injected from CI secret, dev fallback in git)
           if [ -n "$MACOS_GOOGLE_SERVICE_INFO_PLIST" ]; then
             echo "$MACOS_GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+            plutil -lint "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist" || { echo "ERROR: Decoded GoogleService-Info.plist is invalid"; exit 1; }
             echo "Injected prod GoogleService-Info.plist from CI secret"
           else
             echo "ERROR: MACOS_GOOGLE_SERVICE_INFO_PLIST not set — refusing release build without prod Firebase config"

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2104,8 +2104,14 @@ workflows:
           # Copy app icon
           [ -f "omi_icon.icns" ] && cp omi_icon.icns "$APP_BUNDLE/Contents/Resources/OmiIcon.icns"
 
-          # Copy Firebase config
-          cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
+          # Copy Firebase config (prod plist injected from CI secret, dev fallback in git)
+          if [ -n "$MACOS_GOOGLE_SERVICE_INFO_PLIST" ]; then
+            echo "$MACOS_GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+            echo "Injected prod GoogleService-Info.plist from CI secret"
+          else
+            cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
+            echo "WARNING: Using dev GoogleService-Info.plist (MACOS_GOOGLE_SERVICE_INFO_PLIST not set)"
+          fi
 
           # Copy SPM resource bundle (app assets: permissions.gif, herologo.png, etc.)
           # Use x86_64 arch path; fallback to arm64

--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1841,6 +1841,7 @@ workflows:
   #   RESEND_API_KEY
   #   SENTRY_AUTH_TOKEN, SENTRY_ADMIN_UID, SENTRY_WEBHOOK_SECRET
   #   REDIS_DB_HOST, REDIS_DB_PORT, REDIS_DB_PASSWORD
+  #   MACOS_GOOGLE_SERVICE_INFO_PLIST — base64-encoded prod GoogleService-Info.plist (Firebase config)
   #   NOTE: MACOS_DEVELOPER_ID_P12/P12_PASSWORD must NOT be in this group — they live in appstore_credentials
   #
   # Re-uses from existing groups:
@@ -2109,8 +2110,8 @@ workflows:
             echo "$MACOS_GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
             echo "Injected prod GoogleService-Info.plist from CI secret"
           else
-            cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
-            echo "WARNING: Using dev GoogleService-Info.plist (MACOS_GOOGLE_SERVICE_INFO_PLIST not set)"
+            echo "ERROR: MACOS_GOOGLE_SERVICE_INFO_PLIST not set — refusing release build without prod Firebase config"
+            exit 1
           fi
 
           # Copy SPM resource bundle (app assets: permissions.gif, herologo.png, etc.)

--- a/desktop/.claude/skills/cloud/SKILL.md
+++ b/desktop/.claude/skills/cloud/SKILL.md
@@ -19,9 +19,8 @@ Manage the OMI Desktop Rust backend deployed on Google Cloud Run.
 
 ### Service URLs
 
-Both URLs point to the same service:
-- `https://desktop-backend-hhibjajaja-uc.a.run.app`
-- `https://desktop-backend-208440318997.us-central1.run.app`
+Cloud Run service URLs (check GCP Console for current URLs):
+- The backend service name is `desktop-backend` in the project's Cloud Run
 
 ## Quick Commands
 

--- a/desktop/.claude/skills/local-backend-test/SKILL.md
+++ b/desktop/.claude/skills/local-backend-test/SKILL.md
@@ -19,13 +19,13 @@ The backend requires a valid Firebase ID token. This skill:
 
 ## Default User
 
-- **UID**: `bdYYRztuRfheEcjSxMdYnDyDeF13` (Matthew, i@m13v.com)
+- **UID**: read from local Firebase project (test user)
 
 ## Get a Firebase ID Token
 
 ```bash
 cd /Users/matthewdi/omi/backend && source venv/bin/activate && python3 -u -c "
-import firebase_admin, requests, json
+import firebase_admin, requests, json, os
 from firebase_admin import credentials, auth
 
 cred = credentials.Certificate('google-credentials.json')
@@ -36,9 +36,15 @@ uid = 'bdYYRztuRfheEcjSxMdYnDyDeF13'
 custom_token = auth.create_custom_token(uid)
 token_str = custom_token.decode() if isinstance(custom_token, bytes) else custom_token
 
+# Read API key from env or .env file (never hardcode)
+api_key = os.environ.get('FIREBASE_API_KEY', '')
+if not api_key:
+    print('ERROR: Set FIREBASE_API_KEY env var', file=__import__('sys').stderr)
+    exit(1)
+
 # Exchange for ID token
 resp = requests.post(
-    'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8',
+    f'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key={api_key}',
     json={'token': token_str, 'returnSecureToken': True}
 )
 if resp.status_code == 200:
@@ -55,14 +61,15 @@ Replace `ENDPOINT` with the desired path (e.g., `/v1/action-items?deleted=true`)
 
 ```bash
 cd /Users/matthewdi/omi/backend && source venv/bin/activate && TOKEN=$(python3 -u -c "
-import firebase_admin, requests
+import firebase_admin, requests, os
 from firebase_admin import credentials, auth
 cred = credentials.Certificate('google-credentials.json')
 try: firebase_admin.initialize_app(cred)
 except ValueError: pass
 ct = auth.create_custom_token('bdYYRztuRfheEcjSxMdYnDyDeF13')
 ts = ct.decode() if isinstance(ct, bytes) else ct
-r = requests.post('https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8', json={'token': ts, 'returnSecureToken': True})
+api_key = os.environ.get('FIREBASE_API_KEY', '')
+r = requests.post(f'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key={api_key}', json={'token': ts, 'returnSecureToken': True})
 print(r.json()['idToken'])
 " 2>/dev/null) && curl -s "http://localhost:8080/ENDPOINT" -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
 ```
@@ -98,8 +105,8 @@ curl -s "http://localhost:8080/v3/memories?limit=5" -H "Authorization: Bearer $T
 
 - **Backend URL**: `http://localhost:8080` (started via `Backend-Rust/run.sh`)
 - **Tunnel URL**: `https://omi-dev.m13v.com` (Cloudflare tunnel, also started by run.sh)
-- **Firebase Project**: `based-hardware`
-- **API Key**: `AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8`
+- **Firebase Project**: Set via `FIREBASE_PROJECT_ID` env var in Backend-Rust/.env
+- **API Key**: Set via `FIREBASE_API_KEY` env var (never hardcode)
 - **Credentials**: `/Users/matthewdi/omi/backend/google-credentials.json`
 - **Backend .env**: `/Users/matthewdi/omi-desktop/Backend-Rust/.env`
 

--- a/desktop/.env.example
+++ b/desktop/.env.example
@@ -1,25 +1,27 @@
-# Desktop macOS App — Environment Variables
-# Copy to desktop/Backend-Rust/.env (loaded by run.sh into the app bundle)
+# Desktop macOS App — Runtime Environment Variables
+#
+# This file documents the env vars bundled into the Swift app at build time.
+# For local dev: copy to .env.app (run.sh/dev.sh auto-inject OMI_API_URL and AUTH_BACKEND_URL)
+# For CI/release: base64-encode as OMI_DESKTOP_APP_ENV Codemagic secret
 #
 # The Swift app reads .env from these locations (first match wins):
 #   1. App bundle: Contents/Resources/.env
 #   2. Current directory: ./.env
 #   3. Home directory: ~/.omi.env
 #
-# run.sh automatically copies Backend-Rust/.env into the app bundle.
+# Firebase API key is NOT an env var — it's read from GoogleService-Info.plist
+# (dev plist in git, prod plist injected at CI via MACOS_GOOGLE_SERVICE_INFO_PLIST secret)
 
 # ─── Required ────────────────────────────────────────────────────────
 
-# Backend API URL — where the Rust backend is running
-# Local dev:  http://localhost:8080
-# VPS dev:    http://<tailscale-ip>:9080
-# Cloud Run:  https://desktop-backend-dt5lrfkkoa-uc.a.run.app
-# Production: https://api.omi.me
+# Rust desktop backend URL — data API (conversations, memories, etc.)
+# Local dev: http://localhost:8080 (run.sh sets this automatically)
+# Production: Cloud Run URL for desktop-backend service
 OMI_API_URL=http://localhost:8080
 
-# Auth backend URL — used by Swift app for OAuth flow
-# Local dev: http://localhost:8080 (same as OMI_API_URL)
-# Production: set to prod Cloud Run URL
+# Rust desktop backend URL — OAuth flow (/v1/auth/authorize, /v1/auth/token)
+# Local dev: http://localhost:8080 (run.sh sets this automatically)
+# Production: Cloud Run URL for desktop-backend service
 AUTH_BACKEND_URL=http://localhost:8080
 
 # DeepGram API key — required for real-time transcription

--- a/desktop/.env.example
+++ b/desktop/.env.example
@@ -17,6 +17,15 @@
 # Production: https://api.omi.me
 OMI_API_URL=http://localhost:8080
 
+# Auth backend URL — used by Swift app for OAuth flow
+# Local dev: http://localhost:8080 (same as OMI_API_URL)
+# Production: set to prod Cloud Run URL
+AUTH_BACKEND_URL=http://localhost:8080
+
+# Firebase Web API key — required for token refresh and signInWithCustomToken
+# Get from Firebase Console → Project settings → Web API key
+FIREBASE_API_KEY=
+
 # DeepGram API key — required for real-time transcription
 DEEPGRAM_API_KEY=
 

--- a/desktop/.env.example
+++ b/desktop/.env.example
@@ -22,10 +22,6 @@ OMI_API_URL=http://localhost:8080
 # Production: set to prod Cloud Run URL
 AUTH_BACKEND_URL=http://localhost:8080
 
-# Firebase Web API key — required for token refresh and signInWithCustomToken
-# Get from Firebase Console → Project settings → Web API key
-FIREBASE_API_KEY=
-
 # DeepGram API key — required for real-time transcription
 DEEPGRAM_API_KEY=
 

--- a/desktop/.env.example
+++ b/desktop/.env.example
@@ -14,14 +14,16 @@
 
 # ─── Required ────────────────────────────────────────────────────────
 
-# Rust desktop backend URL — data API (conversations, memories, etc.)
+# Desktop backend API URL — conversations, memories, screen capture, AI agent
+# This is the Rust "desktop-backend" Cloud Run service (NOT the Python backend at api.omi.me)
 # Local dev: http://localhost:8080 (run.sh sets this automatically)
-# Production: Cloud Run URL for desktop-backend service
+# Production: https://desktop-backend-hhibjajaja-uc.a.run.app
 OMI_API_URL=http://localhost:8080
 
-# Rust desktop backend URL — OAuth flow (/v1/auth/authorize, /v1/auth/token)
-# Local dev: http://localhost:8080 (run.sh sets this automatically)
-# Production: Cloud Run URL for desktop-backend service
+# Desktop auth service URL — OAuth flow (/v1/auth/authorize, /v1/auth/token)
+# This is the "omi-desktop-auth" Cloud Run service — DIFFERENT from OMI_API_URL in prod
+# Local dev: http://localhost:8080 (run.sh sets this automatically — same Rust binary serves both)
+# Production: https://omi-desktop-auth-hhibjajaja-uc.a.run.app
 AUTH_BACKEND_URL=http://localhost:8080
 
 # DeepGram API key — required for real-time transcription

--- a/desktop/.env.example
+++ b/desktop/.env.example
@@ -14,16 +14,15 @@
 
 # ─── Required ────────────────────────────────────────────────────────
 
-# Desktop backend API URL — conversations, memories, screen capture, AI agent
-# This is the Rust "desktop-backend" Cloud Run service (NOT the Python backend at api.omi.me)
+# Desktop Rust backend URL — conversations, memories, screen capture, AI agent
 # Local dev: http://localhost:8080 (run.sh sets this automatically)
 # Production: https://desktop-backend-hhibjajaja-uc.a.run.app
 OMI_API_URL=http://localhost:8080
 
-# Desktop auth service URL — OAuth flow (/v1/auth/authorize, /v1/auth/token)
-# This is the "omi-desktop-auth" Cloud Run service — DIFFERENT from OMI_API_URL in prod
-# Local dev: http://localhost:8080 (run.sh sets this automatically — same Rust binary serves both)
-# Production: https://omi-desktop-auth-hhibjajaja-uc.a.run.app
+# Auth backend URL — OAuth flow (/v1/auth/authorize, /v1/auth/token)
+# Points to the Python backend (api.omi.me) which handles auth for all platforms
+# Local dev: http://localhost:8080 (run.sh sets this — local Rust backend serves auth too)
+# Production: https://api.omi.me
 AUTH_BACKEND_URL=http://localhost:8080
 
 # DeepGram API key — required for real-time transcription

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -58,9 +58,9 @@ pub struct Config {
     pub pinecone_api_key: Option<String>,
     /// Pinecone host URL (e.g. https://index-name-xxx.svc.environment.pinecone.io)
     pub pinecone_host: Option<String>,
-    /// GCE project ID for AgentVM provisioning (defaults to "based-hardware")
+    /// GCE project ID for AgentVM provisioning (defaults to "based-hardware-dev")
     pub gce_project_id: String,
-    /// GCE source image for AgentVM (defaults to "projects/based-hardware/global/images/family/omi-agent")
+    /// GCE source image for AgentVM (defaults to "projects/{gce_project_id}/global/images/family/omi-agent")
     pub gce_source_image: String,
     /// GCS bucket for agent startup script (defaults to "based-hardware-agent")
     pub agent_gcs_bucket: String,
@@ -110,19 +110,19 @@ impl Config {
                 let p = env::var("GCE_PROJECT_ID")
                     .or_else(|_| env::var("FIREBASE_PROJECT_ID"))
                     .or_else(|_| env::var("GCP_PROJECT_ID"))
-                    .unwrap_or_else(|_| "based-hardware".to_string());
+                    .unwrap_or_else(|_| "based-hardware-dev".to_string());
                 p
             },
             gce_source_image: {
                 let gce_proj = env::var("GCE_PROJECT_ID")
                     .or_else(|_| env::var("FIREBASE_PROJECT_ID"))
                     .or_else(|_| env::var("GCP_PROJECT_ID"))
-                    .unwrap_or_else(|_| "based-hardware".to_string());
+                    .unwrap_or_else(|_| "based-hardware-dev".to_string());
                 env::var("GCE_SOURCE_IMAGE")
                     .unwrap_or_else(|_| format!("projects/{}/global/images/family/omi-agent", gce_proj))
             },
             agent_gcs_bucket: env::var("AGENT_GCS_BUCKET")
-                .unwrap_or_else(|_| "based-hardware-agent".to_string()),
+                .unwrap_or_else(|_| "based-hardware-dev-agent".to_string()),
         }
     }
 

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -156,3 +156,130 @@ impl Config {
         })
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Env var tests must run serially to avoid races
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_config_env_vars() {
+        for key in &[
+            "PORT", "GEMINI_API_KEY", "GOOGLE_APPLICATION_CREDENTIALS",
+            "FIREBASE_PROJECT_ID", "FIREBASE_API_KEY", "GCP_PROJECT_ID",
+            "GCE_PROJECT_ID", "GCE_SOURCE_IMAGE", "AGENT_GCS_BUCKET",
+            "BASE_API_URL", "APPLE_CLIENT_ID", "APPLE_TEAM_ID",
+            "APPLE_KEY_ID", "APPLE_PRIVATE_KEY", "GOOGLE_CLIENT_ID",
+            "GOOGLE_CLIENT_SECRET", "ENCRYPTION_SECRET", "REDIS_DB_HOST",
+            "REDIS_DB_PORT", "REDIS_DB_PASSWORD", "POSTHOG_PERSONAL_API_KEY",
+            "POSTHOG_PROJECT_ID", "SENTRY_WEBHOOK_SECRET", "SENTRY_AUTH_TOKEN",
+            "SENTRY_ADMIN_UID", "CRISP_PLUGIN_IDENTIFIER", "CRISP_PLUGIN_KEY",
+            "CRISP_WEBSITE_ID", "PINECONE_API_KEY", "PINECONE_HOST",
+        ] {
+            env::remove_var(key);
+        }
+    }
+
+    #[test]
+    fn test_defaults_use_dev_project() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_config_env_vars();
+
+        let config = Config::from_env();
+
+        // All defaults must point to dev, never prod
+        assert_eq!(config.gce_project_id, "based-hardware-dev");
+        assert_eq!(config.agent_gcs_bucket, "based-hardware-dev-agent");
+        assert!(config.gce_source_image.contains("based-hardware-dev"));
+        assert!(!config.gce_project_id.contains("based-hardware-prod"));
+        assert!(config.firebase_project_id.is_none(), "no default firebase project without env var");
+    }
+
+    #[test]
+    fn test_gce_project_id_precedence() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_config_env_vars();
+
+        // GCE_PROJECT_ID takes priority
+        env::set_var("GCE_PROJECT_ID", "gce-proj");
+        env::set_var("FIREBASE_PROJECT_ID", "fb-proj");
+        env::set_var("GCP_PROJECT_ID", "gcp-proj");
+        let config = Config::from_env();
+        assert_eq!(config.gce_project_id, "gce-proj");
+
+        // Without GCE_PROJECT_ID, falls back to FIREBASE_PROJECT_ID
+        env::remove_var("GCE_PROJECT_ID");
+        let config = Config::from_env();
+        assert_eq!(config.gce_project_id, "fb-proj");
+
+        // Without both, falls back to GCP_PROJECT_ID
+        env::remove_var("FIREBASE_PROJECT_ID");
+        let config = Config::from_env();
+        assert_eq!(config.gce_project_id, "gcp-proj");
+
+        clear_config_env_vars();
+    }
+
+    #[test]
+    fn test_firebase_project_id_precedence() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_config_env_vars();
+
+        // FIREBASE_PROJECT_ID takes priority
+        env::set_var("FIREBASE_PROJECT_ID", "fb-proj");
+        env::set_var("GCP_PROJECT_ID", "gcp-proj");
+        let config = Config::from_env();
+        assert_eq!(config.firebase_project_id, Some("fb-proj".to_string()));
+
+        // Falls back to GCP_PROJECT_ID
+        env::remove_var("FIREBASE_PROJECT_ID");
+        let config = Config::from_env();
+        assert_eq!(config.firebase_project_id, Some("gcp-proj".to_string()));
+
+        clear_config_env_vars();
+    }
+
+    #[test]
+    fn test_port_default_and_override() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_config_env_vars();
+
+        let config = Config::from_env();
+        assert_eq!(config.port, 8080);
+
+        env::set_var("PORT", "9090");
+        let config = Config::from_env();
+        assert_eq!(config.port, 9090);
+
+        // Invalid port falls back to default
+        env::set_var("PORT", "not-a-number");
+        let config = Config::from_env();
+        assert_eq!(config.port, 8080);
+
+        clear_config_env_vars();
+    }
+
+    #[test]
+    fn test_no_prod_defaults_anywhere() {
+        let _lock = ENV_LOCK.lock().unwrap();
+        clear_config_env_vars();
+
+        let config = Config::from_env();
+
+        // Ensure no field defaults to prod project
+        let gce = &config.gce_project_id;
+        let gce_img = &config.gce_source_image;
+        let bucket = &config.agent_gcs_bucket;
+
+        assert!(!gce.contains("based-hardware-prod"), "gce_project_id must not default to prod");
+        assert!(!gce_img.contains("based-hardware-prod"), "gce_source_image must not default to prod");
+        assert!(!bucket.contains("based-hardware-prod"), "agent_gcs_bucket must not default to prod");
+
+        // Also verify no bare "based-hardware" without -dev suffix
+        // (the old prod default was just "based-hardware")
+        assert_ne!(gce.as_str(), "based-hardware", "gce_project_id must not default to prod 'based-hardware'");
+        assert_ne!(bucket.as_str(), "based-hardware-agent", "agent_gcs_bucket must not default to prod");
+    }
+}

--- a/desktop/Backend-Rust/src/main.rs
+++ b/desktop/Backend-Rust/src/main.rs
@@ -96,7 +96,7 @@ async fn main() {
 
     // Initialize Firebase Auth
     let firebase_auth = Arc::new(FirebaseAuth::new(
-        config.firebase_project_id.clone().unwrap_or_else(|| "based-hardware".to_string()),
+        config.firebase_project_id.clone().unwrap_or_else(|| "based-hardware-dev".to_string()),
     ));
 
     // Refresh Firebase keys with retry (transient network failures at startup)
@@ -128,13 +128,13 @@ async fn main() {
 
     // Initialize Firestore
     let firestore = match FirestoreService::new(
-        config.firebase_project_id.clone().unwrap_or_else(|| "based-hardware".to_string()),
+        config.firebase_project_id.clone().unwrap_or_else(|| "based-hardware-dev".to_string()),
         config.encryption_secret.clone(),
     ).await {
         Ok(fs) => Arc::new(fs),
         Err(e) => {
             tracing::warn!("Failed to initialize Firestore: {} - using placeholder", e);
-            Arc::new(FirestoreService::new("based-hardware".to_string(), config.encryption_secret.clone()).await.unwrap())
+            Arc::new(FirestoreService::new("based-hardware-dev".to_string(), config.encryption_secret.clone()).await.unwrap())
         }
     };
 

--- a/desktop/Backend-Rust/src/routes/auth.rs
+++ b/desktop/Backend-Rust/src/routes/auth.rs
@@ -652,14 +652,52 @@ async fn generate_custom_token(
 
     tracing::info!("Firebase sign-in successful, UID: {}", firebase_uid);
 
-    // For custom token generation, we need Firebase Admin SDK
-    // In Rust, we'd need to use the service account to create a custom token
-    // For now, return an error indicating this needs server-side implementation
-    // The Python version uses firebase_admin.auth.create_custom_token()
+    // Generate Firebase custom token using service account credentials
+    let creds_path = state.config.google_application_credentials.as_ref()
+        .ok_or("GOOGLE_APPLICATION_CREDENTIALS not configured")?;
 
-    // TODO: Implement custom token generation using service account
-    // This requires signing a JWT with the service account private key
-    Err("Custom token generation requires Firebase Admin SDK - not yet implemented in Rust".into())
+    let creds_json = std::fs::read_to_string(creds_path)
+        .map_err(|e| format!("Failed to read service account credentials: {}", e))?;
+
+    #[derive(Deserialize)]
+    struct SaCreds {
+        client_email: String,
+        private_key: String,
+    }
+
+    let sa: SaCreds = serde_json::from_str(&creds_json)
+        .map_err(|e| format!("Failed to parse service account credentials: {}", e))?;
+
+    let now = Utc::now().timestamp();
+
+    #[derive(Serialize)]
+    struct CustomTokenClaims {
+        iss: String,
+        sub: String,
+        aud: String,
+        iat: i64,
+        exp: i64,
+        uid: String,
+    }
+
+    let claims = CustomTokenClaims {
+        iss: sa.client_email.clone(),
+        sub: sa.client_email.clone(),
+        aud: "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit".to_string(),
+        iat: now,
+        exp: now + 3600,
+        uid: firebase_uid.clone(),
+    };
+
+    let header = Header::new(Algorithm::RS256);
+    let key = EncodingKey::from_rsa_pem(sa.private_key.as_bytes())
+        .map_err(|e| format!("Failed to parse service account private key: {}", e))?;
+
+    let custom_token = encode(&header, &claims, &key)
+        .map_err(|e| format!("Failed to sign custom token: {}", e))?;
+
+    tracing::info!("Generated custom token for UID: {}", firebase_uid);
+    Ok(custom_token)
 }
 
 fn render_auth_callback(code: &str, state: &str, redirect_uri: &str, error: Option<&str>) -> String {

--- a/desktop/Backend-Rust/src/routes/auth.rs
+++ b/desktop/Backend-Rust/src/routes/auth.rs
@@ -134,6 +134,8 @@ pub struct TokenRequest {
     code: String,
     /// OAuth redirect_uri - validated against the original authorization request
     redirect_uri: String,
+    #[serde(default)]
+    use_custom_token: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -144,6 +146,8 @@ pub struct TokenResponse {
     provider_id: String,
     token_type: String,
     expires_in: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    custom_token: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -377,14 +381,22 @@ async fn auth_token(
     }
 
     let provider_id = credentials.provider_id.clone();
-    let response = TokenResponse {
+    let mut response = TokenResponse {
         provider: credentials.provider.clone(),
         id_token: credentials.id_token.clone(),
         access_token: credentials.access_token.clone(),
         provider_id,
         token_type: "Bearer".to_string(),
         expires_in: 3600,
+        custom_token: None,
     };
+
+    if form.use_custom_token {
+        match generate_custom_token(&state, &credentials).await {
+            Ok(token) => response.custom_token = Some(token),
+            Err(e) => tracing::warn!("Failed to generate custom token: {}", e),
+        }
+    }
 
     Ok(Json(response))
 }
@@ -573,6 +585,119 @@ fn generate_apple_client_secret(
         error: "jwt_error".to_string(),
         message: format!("Failed to generate Apple client secret: {}", e),
     })
+}
+
+async fn generate_custom_token(
+    state: &AuthState,
+    credentials: &OAuthCredentials,
+) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    let firebase_api_key = state.config.firebase_api_key.as_ref()
+        .ok_or("FIREBASE_API_KEY not configured")?;
+
+    // Sign in with OAuth credential using Firebase Auth REST API
+    let sign_in_url = format!(
+        "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key={}",
+        firebase_api_key
+    );
+
+    let provider_id = match credentials.provider.as_str() {
+        "google" => "google.com",
+        "apple" => "apple.com",
+        _ => return Err(format!("Unsupported provider: {}", credentials.provider).into()),
+    };
+
+    let mut post_body = format!("id_token={}&providerId={}", credentials.id_token, provider_id);
+    if let Some(access_token) = &credentials.access_token {
+        post_body.push_str(&format!("&access_token={}", access_token));
+    }
+
+    #[derive(Serialize)]
+    struct SignInRequest {
+        #[serde(rename = "postBody")]
+        post_body: String,
+        #[serde(rename = "requestUri")]
+        request_uri: String,
+        #[serde(rename = "returnIdpCredential")]
+        return_idp_credential: bool,
+        #[serde(rename = "returnSecureToken")]
+        return_secure_token: bool,
+    }
+
+    let response = state
+        .http_client
+        .post(&sign_in_url)
+        .json(&SignInRequest {
+            post_body,
+            request_uri: "http://localhost".to_string(),
+            return_idp_credential: true,
+            return_secure_token: true,
+        })
+        .send()
+        .await?;
+
+    if !response.status().is_success() {
+        let error = response.text().await?;
+        tracing::error!("Firebase sign-in failed: {}", error);
+        return Err("Firebase sign-in failed".into());
+    }
+
+    #[derive(Deserialize)]
+    struct SignInResponse {
+        #[serde(rename = "localId")]
+        local_id: String,
+    }
+
+    let result: SignInResponse = response.json().await?;
+    let firebase_uid = result.local_id;
+
+    tracing::info!("Firebase sign-in successful, UID: {}", firebase_uid);
+
+    // Generate Firebase custom token using service account credentials
+    let creds_path = state.config.google_application_credentials.as_ref()
+        .ok_or("GOOGLE_APPLICATION_CREDENTIALS not configured")?;
+
+    let creds_json = std::fs::read_to_string(creds_path)
+        .map_err(|e| format!("Failed to read service account credentials: {}", e))?;
+
+    #[derive(Deserialize)]
+    struct SaCreds {
+        client_email: String,
+        private_key: String,
+    }
+
+    let sa: SaCreds = serde_json::from_str(&creds_json)
+        .map_err(|e| format!("Failed to parse service account credentials: {}", e))?;
+
+    let now = Utc::now().timestamp();
+
+    #[derive(Serialize)]
+    struct CustomTokenClaims {
+        iss: String,
+        sub: String,
+        aud: String,
+        iat: i64,
+        exp: i64,
+        uid: String,
+    }
+
+    let claims = CustomTokenClaims {
+        iss: sa.client_email.clone(),
+        sub: sa.client_email.clone(),
+        aud: "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit".to_string(),
+        iat: now,
+        exp: now + 3600,
+        uid: firebase_uid.clone(),
+    };
+
+    let header = Header::new(Algorithm::RS256);
+    let key = EncodingKey::from_rsa_pem(sa.private_key.as_bytes())
+        .map_err(|e| format!("Failed to parse service account private key: {}", e))?;
+
+    let custom_token = encode(&header, &claims, &key)
+        .map_err(|e| format!("Failed to sign custom token: {}", e))?;
+
+    tracing::info!("Generated custom token for UID: {}", firebase_uid);
+    Ok(custom_token)
 }
 
 fn render_auth_callback(code: &str, state: &str, redirect_uri: &str, error: Option<&str>) -> String {

--- a/desktop/Backend-Rust/src/routes/auth.rs
+++ b/desktop/Backend-Rust/src/routes/auth.rs
@@ -134,6 +134,7 @@ pub struct TokenRequest {
     code: String,
     /// OAuth redirect_uri - validated against the original authorization request
     redirect_uri: String,
+    /// Legacy field, ignored — Firebase tokens are always returned
     #[serde(default)]
     use_custom_token: bool,
 }
@@ -141,13 +142,18 @@ pub struct TokenRequest {
 #[derive(Debug, Serialize)]
 pub struct TokenResponse {
     provider: String,
+    /// Firebase ID token (for API calls)
+    firebase_id_token: String,
+    /// Firebase refresh token (for token renewal)
+    refresh_token: String,
+    /// Firebase user ID
+    firebase_uid: String,
+    /// Provider-specific ID token (Google/Apple)
     id_token: String,
     access_token: Option<String>,
     provider_id: String,
     token_type: String,
     expires_in: i64,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    custom_token: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -380,23 +386,25 @@ async fn auth_token(
         });
     }
 
+    // Sign in with Firebase using the OAuth credentials (uses FIREBASE_API_KEY env var)
+    let firebase_result = sign_in_with_firebase(&state, &credentials).await
+        .map_err(|e| ErrorResponse {
+            error: "firebase_signin_failed".to_string(),
+            message: format!("Firebase sign-in failed: {}", e),
+        })?;
+
     let provider_id = credentials.provider_id.clone();
-    let mut response = TokenResponse {
+    let response = TokenResponse {
         provider: credentials.provider.clone(),
+        firebase_id_token: firebase_result.id_token,
+        refresh_token: firebase_result.refresh_token,
+        firebase_uid: firebase_result.local_id,
         id_token: credentials.id_token.clone(),
         access_token: credentials.access_token.clone(),
         provider_id,
         token_type: "Bearer".to_string(),
         expires_in: 3600,
-        custom_token: None,
     };
-
-    if form.use_custom_token {
-        match generate_custom_token(&state, &credentials).await {
-            Ok(token) => response.custom_token = Some(token),
-            Err(e) => tracing::warn!("Failed to generate custom token: {}", e),
-        }
-    }
 
     Ok(Json(response))
 }
@@ -587,14 +595,22 @@ fn generate_apple_client_secret(
     })
 }
 
-async fn generate_custom_token(
+struct FirebaseSignInResult {
+    id_token: String,
+    refresh_token: String,
+    local_id: String,
+}
+
+/// Sign in with Firebase using OAuth credentials via signInWithIdp REST API.
+/// Uses FIREBASE_API_KEY env var. Returns Firebase tokens directly — no custom
+/// token generation needed.
+async fn sign_in_with_firebase(
     state: &AuthState,
     credentials: &OAuthCredentials,
-) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+) -> Result<FirebaseSignInResult, Box<dyn std::error::Error + Send + Sync>> {
     let firebase_api_key = state.config.firebase_api_key.as_ref()
         .ok_or("FIREBASE_API_KEY not configured")?;
 
-    // Sign in with OAuth credential using Firebase Auth REST API
     let sign_in_url = format!(
         "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key={}",
         firebase_api_key
@@ -643,61 +659,22 @@ async fn generate_custom_token(
 
     #[derive(Deserialize)]
     struct SignInResponse {
+        #[serde(rename = "idToken")]
+        id_token: String,
+        #[serde(rename = "refreshToken")]
+        refresh_token: String,
         #[serde(rename = "localId")]
         local_id: String,
     }
 
     let result: SignInResponse = response.json().await?;
-    let firebase_uid = result.local_id;
+    tracing::info!("Firebase sign-in successful, UID: {}", result.local_id);
 
-    tracing::info!("Firebase sign-in successful, UID: {}", firebase_uid);
-
-    // Generate Firebase custom token using service account credentials
-    let creds_path = state.config.google_application_credentials.as_ref()
-        .ok_or("GOOGLE_APPLICATION_CREDENTIALS not configured")?;
-
-    let creds_json = std::fs::read_to_string(creds_path)
-        .map_err(|e| format!("Failed to read service account credentials: {}", e))?;
-
-    #[derive(Deserialize)]
-    struct SaCreds {
-        client_email: String,
-        private_key: String,
-    }
-
-    let sa: SaCreds = serde_json::from_str(&creds_json)
-        .map_err(|e| format!("Failed to parse service account credentials: {}", e))?;
-
-    let now = Utc::now().timestamp();
-
-    #[derive(Serialize)]
-    struct CustomTokenClaims {
-        iss: String,
-        sub: String,
-        aud: String,
-        iat: i64,
-        exp: i64,
-        uid: String,
-    }
-
-    let claims = CustomTokenClaims {
-        iss: sa.client_email.clone(),
-        sub: sa.client_email.clone(),
-        aud: "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit".to_string(),
-        iat: now,
-        exp: now + 3600,
-        uid: firebase_uid.clone(),
-    };
-
-    let header = Header::new(Algorithm::RS256);
-    let key = EncodingKey::from_rsa_pem(sa.private_key.as_bytes())
-        .map_err(|e| format!("Failed to parse service account private key: {}", e))?;
-
-    let custom_token = encode(&header, &claims, &key)
-        .map_err(|e| format!("Failed to sign custom token: {}", e))?;
-
-    tracing::info!("Generated custom token for UID: {}", firebase_uid);
-    Ok(custom_token)
+    Ok(FirebaseSignInResult {
+        id_token: result.id_token,
+        refresh_token: result.refresh_token,
+        local_id: result.local_id,
+    })
 }
 
 fn render_auth_callback(code: &str, state: &str, redirect_uri: &str, error: Option<&str>) -> String {

--- a/desktop/Backend-Rust/src/routes/auth.rs
+++ b/desktop/Backend-Rust/src/routes/auth.rs
@@ -134,21 +134,11 @@ pub struct TokenRequest {
     code: String,
     /// OAuth redirect_uri - validated against the original authorization request
     redirect_uri: String,
-    /// Legacy field, ignored — Firebase tokens are always returned
-    #[serde(default)]
-    use_custom_token: bool,
 }
 
 #[derive(Debug, Serialize)]
 pub struct TokenResponse {
     provider: String,
-    /// Firebase ID token (for API calls)
-    firebase_id_token: String,
-    /// Firebase refresh token (for token renewal)
-    refresh_token: String,
-    /// Firebase user ID
-    firebase_uid: String,
-    /// Provider-specific ID token (Google/Apple)
     id_token: String,
     access_token: Option<String>,
     provider_id: String,
@@ -386,19 +376,9 @@ async fn auth_token(
         });
     }
 
-    // Sign in with Firebase using the OAuth credentials (uses FIREBASE_API_KEY env var)
-    let firebase_result = sign_in_with_firebase(&state, &credentials).await
-        .map_err(|e| ErrorResponse {
-            error: "firebase_signin_failed".to_string(),
-            message: format!("Firebase sign-in failed: {}", e),
-        })?;
-
     let provider_id = credentials.provider_id.clone();
     let response = TokenResponse {
         provider: credentials.provider.clone(),
-        firebase_id_token: firebase_result.id_token,
-        refresh_token: firebase_result.refresh_token,
-        firebase_uid: firebase_result.local_id,
         id_token: credentials.id_token.clone(),
         access_token: credentials.access_token.clone(),
         provider_id,
@@ -592,88 +572,6 @@ fn generate_apple_client_secret(
     encode(&header, &claims, &key).map_err(|e| ErrorResponse {
         error: "jwt_error".to_string(),
         message: format!("Failed to generate Apple client secret: {}", e),
-    })
-}
-
-struct FirebaseSignInResult {
-    id_token: String,
-    refresh_token: String,
-    local_id: String,
-}
-
-/// Sign in with Firebase using OAuth credentials via signInWithIdp REST API.
-/// Uses FIREBASE_API_KEY env var. Returns Firebase tokens directly — no custom
-/// token generation needed.
-async fn sign_in_with_firebase(
-    state: &AuthState,
-    credentials: &OAuthCredentials,
-) -> Result<FirebaseSignInResult, Box<dyn std::error::Error + Send + Sync>> {
-    let firebase_api_key = state.config.firebase_api_key.as_ref()
-        .ok_or("FIREBASE_API_KEY not configured")?;
-
-    let sign_in_url = format!(
-        "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key={}",
-        firebase_api_key
-    );
-
-    let provider_id = match credentials.provider.as_str() {
-        "google" => "google.com",
-        "apple" => "apple.com",
-        _ => return Err(format!("Unsupported provider: {}", credentials.provider).into()),
-    };
-
-    let mut post_body = format!("id_token={}&providerId={}", credentials.id_token, provider_id);
-    if let Some(access_token) = &credentials.access_token {
-        post_body.push_str(&format!("&access_token={}", access_token));
-    }
-
-    #[derive(Serialize)]
-    struct SignInRequest {
-        #[serde(rename = "postBody")]
-        post_body: String,
-        #[serde(rename = "requestUri")]
-        request_uri: String,
-        #[serde(rename = "returnIdpCredential")]
-        return_idp_credential: bool,
-        #[serde(rename = "returnSecureToken")]
-        return_secure_token: bool,
-    }
-
-    let response = state
-        .http_client
-        .post(&sign_in_url)
-        .json(&SignInRequest {
-            post_body,
-            request_uri: "http://localhost".to_string(),
-            return_idp_credential: true,
-            return_secure_token: true,
-        })
-        .send()
-        .await?;
-
-    if !response.status().is_success() {
-        let error = response.text().await?;
-        tracing::error!("Firebase sign-in failed: {}", error);
-        return Err("Firebase sign-in failed".into());
-    }
-
-    #[derive(Deserialize)]
-    struct SignInResponse {
-        #[serde(rename = "idToken")]
-        id_token: String,
-        #[serde(rename = "refreshToken")]
-        refresh_token: String,
-        #[serde(rename = "localId")]
-        local_id: String,
-    }
-
-    let result: SignInResponse = response.json().await?;
-    tracing::info!("Firebase sign-in successful, UID: {}", result.local_id);
-
-    Ok(FirebaseSignInResult {
-        id_token: result.id_token,
-        refresh_token: result.refresh_token,
-        local_id: result.local_id,
     })
 }
 

--- a/desktop/Backend-Rust/src/routes/auth.rs
+++ b/desktop/Backend-Rust/src/routes/auth.rs
@@ -652,52 +652,14 @@ async fn generate_custom_token(
 
     tracing::info!("Firebase sign-in successful, UID: {}", firebase_uid);
 
-    // Generate Firebase custom token using service account credentials
-    let creds_path = state.config.google_application_credentials.as_ref()
-        .ok_or("GOOGLE_APPLICATION_CREDENTIALS not configured")?;
+    // For custom token generation, we need Firebase Admin SDK
+    // In Rust, we'd need to use the service account to create a custom token
+    // For now, return an error indicating this needs server-side implementation
+    // The Python version uses firebase_admin.auth.create_custom_token()
 
-    let creds_json = std::fs::read_to_string(creds_path)
-        .map_err(|e| format!("Failed to read service account credentials: {}", e))?;
-
-    #[derive(Deserialize)]
-    struct SaCreds {
-        client_email: String,
-        private_key: String,
-    }
-
-    let sa: SaCreds = serde_json::from_str(&creds_json)
-        .map_err(|e| format!("Failed to parse service account credentials: {}", e))?;
-
-    let now = Utc::now().timestamp();
-
-    #[derive(Serialize)]
-    struct CustomTokenClaims {
-        iss: String,
-        sub: String,
-        aud: String,
-        iat: i64,
-        exp: i64,
-        uid: String,
-    }
-
-    let claims = CustomTokenClaims {
-        iss: sa.client_email.clone(),
-        sub: sa.client_email.clone(),
-        aud: "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit".to_string(),
-        iat: now,
-        exp: now + 3600,
-        uid: firebase_uid.clone(),
-    };
-
-    let header = Header::new(Algorithm::RS256);
-    let key = EncodingKey::from_rsa_pem(sa.private_key.as_bytes())
-        .map_err(|e| format!("Failed to parse service account private key: {}", e))?;
-
-    let custom_token = encode(&header, &claims, &key)
-        .map_err(|e| format!("Failed to sign custom token: {}", e))?;
-
-    tracing::info!("Generated custom token for UID: {}", firebase_uid);
-    Ok(custom_token)
+    // TODO: Implement custom token generation using service account
+    // This requires signing a JWT with the service account private key
+    Err("Custom token generation requires Firebase Admin SDK - not yet implemented in Rust".into())
 }
 
 fn render_auth_callback(code: &str, state: &str, redirect_uri: &str, error: Option<&str>) -> String {

--- a/desktop/Backend-Rust/src/routes/users.rs
+++ b/desktop/Backend-Rust/src/routes/users.rs
@@ -835,7 +835,7 @@ async fn delete_account(
         .config
         .firebase_project_id
         .clone()
-        .unwrap_or_else(|| "based-hardware".to_string());
+        .unwrap_or_else(|| "based-hardware-dev".to_string());
     state
         .firestore
         .delete_firebase_auth_user(&project_id, &user.uid)

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -43,8 +43,16 @@ class AuthService {
     private var appleSignInDelegate: AppleSignInDelegate?
 
     // API Configuration
-    // Production: Cloud Run backend
-    private let apiBaseURL: String = "https://omi-desktop-auth-208440318997.us-central1.run.app/"
+    // Auth backend URL: read from GoogleService-Info.plist AUTH_BACKEND_URL key,
+    // falls back to local dev backend. Prod URL injected at CI via plist.
+    private var apiBaseURL: String {
+        if let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+           let plistDict = NSDictionary(contentsOfFile: plistPath),
+           let url = plistDict["AUTH_BACKEND_URL"] as? String {
+            return url.hasSuffix("/") ? url : url + "/"
+        }
+        return "http://localhost:8080/"
+    }
     private var redirectURI: String {
         return "\(urlScheme)://auth/callback"
     }
@@ -74,14 +82,14 @@ class AuthService {
     private let kAuthTokenExpiry = "auth_tokenExpiry"
     private let kAuthTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
 
-    // Firebase Web API key (read from bundled GoogleService-Info.plist, falls back to prod)
+    // Firebase Web API key (read from bundled GoogleService-Info.plist)
     private var firebaseApiKey: String {
         if let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
            let plistDict = NSDictionary(contentsOfFile: plistPath),
            let apiKey = plistDict["API_KEY"] as? String {
             return apiKey
         }
-        return "AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"
+        fatalError("GoogleService-Info.plist missing or has no API_KEY — cannot authenticate")
     }
 
     // MARK: - User Name Properties

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -1,5 +1,6 @@
 import Foundation
 @preconcurrency import FirebaseAuth
+import FirebaseCore
 import CryptoKit
 import AppKit
 import AuthenticationServices
@@ -84,13 +85,13 @@ class AuthService {
     private let kAuthTokenExpiry = "auth_tokenExpiry"
     private let kAuthTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
 
-    // Firebase Web API key from FIREBASE_API_KEY env var (use getenv to pick up setenv from .env loading).
-    // Returns empty string if missing — callers surface auth errors to user.
+    // Firebase Web API key — derived from GoogleService-Info.plist via FirebaseApp.
+    // No env var needed; key comes from whatever plist Firebase was configured with.
     private var firebaseApiKey: String {
-        if let cString = getenv("FIREBASE_API_KEY"), let apiKey = String(validatingUTF8: cString), !apiKey.isEmpty {
+        if let apiKey = FirebaseApp.app()?.options.apiKey, !apiKey.isEmpty {
             return apiKey
         }
-        NSLog("OMI AUTH ERROR: FIREBASE_API_KEY environment variable not set — auth will fail")
+        NSLog("OMI AUTH ERROR: Firebase not configured or API_KEY missing from GoogleService-Info.plist")
         return ""
     }
 

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -43,12 +43,18 @@ class AuthService {
     private var appleSignInDelegate: AppleSignInDelegate?
 
     // API Configuration
-    // Auth backend URL from AUTH_BACKEND_URL env var, falls back to localhost for dev.
+    // Auth backend URL from AUTH_BACKEND_URL env var.
+    // Dev builds fall back to localhost; prod builds log error and disable auth.
     private var apiBaseURL: String {
         if let url = ProcessInfo.processInfo.environment["AUTH_BACKEND_URL"], !url.isEmpty {
             return url.hasSuffix("/") ? url : url + "/"
         }
-        return "http://localhost:8080/"
+        let isDev = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
+        if isDev {
+            return "http://localhost:8080/"
+        }
+        NSLog("OMI AUTH ERROR: AUTH_BACKEND_URL not set in production build")
+        return "http://localhost:8080/"  // Will fail to connect — surfaces as auth error
     }
     private var redirectURI: String {
         return "\(urlScheme)://auth/callback"
@@ -79,13 +85,14 @@ class AuthService {
     private let kAuthTokenExpiry = "auth_tokenExpiry"
     private let kAuthTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
 
-    // Firebase Web API key (read from bundled GoogleService-Info.plist)
     // Firebase Web API key from FIREBASE_API_KEY env var (set in .env).
+    // Returns empty string if missing — callers surface auth errors to user.
     private var firebaseApiKey: String {
         if let apiKey = ProcessInfo.processInfo.environment["FIREBASE_API_KEY"], !apiKey.isEmpty {
             return apiKey
         }
-        fatalError("FIREBASE_API_KEY environment variable not set — cannot authenticate")
+        NSLog("OMI AUTH ERROR: FIREBASE_API_KEY environment variable not set — auth will fail")
+        return ""
     }
 
     // MARK: - User Name Properties

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -45,16 +45,18 @@ class AuthService {
 
     // API Configuration
     // Auth backend URL from AUTH_BACKEND_URL env var (use getenv to pick up setenv from .env loading).
-    // Dev builds fall back to localhost; prod builds log error.
+    // Points to Python backend (api.omi.me) in prod, localhost in dev.
+    // Dev builds fall back to localhost; prod builds return empty string (auth will fail visibly).
     private var apiBaseURL: String {
         if let cString = getenv("AUTH_BACKEND_URL"), let url = String(validatingUTF8: cString), !url.isEmpty {
             return url.hasSuffix("/") ? url : url + "/"
         }
         let isDev = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
-        if !isDev {
-            NSLog("OMI AUTH ERROR: AUTH_BACKEND_URL not set in production build")
+        if isDev {
+            return "http://localhost:8080/"
         }
-        return "http://localhost:8080/"
+        NSLog("OMI AUTH ERROR: AUTH_BACKEND_URL not set in production build — auth will not work")
+        return ""
     }
     private var redirectURI: String {
         return "\(urlScheme)://auth/callback"

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -43,12 +43,9 @@ class AuthService {
     private var appleSignInDelegate: AppleSignInDelegate?
 
     // API Configuration
-    // Auth backend URL: read from GoogleService-Info.plist AUTH_BACKEND_URL key,
-    // falls back to local dev backend. Prod URL injected at CI via plist.
+    // Auth backend URL from AUTH_BACKEND_URL env var, falls back to localhost for dev.
     private var apiBaseURL: String {
-        if let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
-           let plistDict = NSDictionary(contentsOfFile: plistPath),
-           let url = plistDict["AUTH_BACKEND_URL"] as? String {
+        if let url = ProcessInfo.processInfo.environment["AUTH_BACKEND_URL"], !url.isEmpty {
             return url.hasSuffix("/") ? url : url + "/"
         }
         return "http://localhost:8080/"
@@ -83,13 +80,12 @@ class AuthService {
     private let kAuthTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
 
     // Firebase Web API key (read from bundled GoogleService-Info.plist)
+    // Firebase Web API key from FIREBASE_API_KEY env var (set in .env).
     private var firebaseApiKey: String {
-        if let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
-           let plistDict = NSDictionary(contentsOfFile: plistPath),
-           let apiKey = plistDict["API_KEY"] as? String {
+        if let apiKey = ProcessInfo.processInfo.environment["FIREBASE_API_KEY"], !apiKey.isEmpty {
             return apiKey
         }
-        fatalError("GoogleService-Info.plist missing or has no API_KEY — cannot authenticate")
+        fatalError("FIREBASE_API_KEY environment variable not set — cannot authenticate")
     }
 
     // MARK: - User Name Properties
@@ -401,12 +397,13 @@ class AuthService {
             }
             NSLog("OMI AUTH: Received valid authorization code")
 
-            // Step 6: Exchange code for tokens (backend returns OAuth tokens, client does Firebase signInWithIdp)
-            NSLog("OMI AUTH: Exchanging code for tokens...")
+            // Step 6: Exchange code for custom token and user info
+            NSLog("OMI AUTH: Exchanging code for Firebase token...")
             let tokenResult = try await exchangeCodeForToken(code: code)
-            NSLog("OMI AUTH: Got Firebase tokens via client-side signInWithIdp")
+            NSLog("OMI AUTH: Got Firebase custom token")
 
-            // Save user info from OAuth response
+            // Save user info from OAuth response immediately (before Firebase sign-in)
+            // This ensures we have the name even if Firebase session doesn't persist
             if let extractedGivenName = tokenResult.givenName, !extractedGivenName.isEmpty {
                 givenName = extractedGivenName
                 familyName = tokenResult.familyName ?? ""
@@ -416,13 +413,28 @@ class AuthService {
                 AuthState.shared.userEmail = extractedEmail
             }
 
-            // Store Firebase tokens for API calls
-            let userId = tokenResult.firebaseUid
-            saveTokens(idToken: tokenResult.firebaseIdToken, refreshToken: tokenResult.refreshToken, expiresIn: 3600, userId: userId)
+            // Step 7: Exchange custom token for ID token via REST API
+            // This bypasses keychain issues with Firebase SDK on dev builds
+            NSLog("OMI AUTH: Exchanging custom token for ID token via REST API...")
+            let firebaseTokens = try await exchangeCustomTokenForIdToken(customToken: tokenResult.customToken)
+            NSLog("OMI AUTH: Got Firebase ID token via REST API")
+
+            // Store tokens for API calls (include userId to validate token ownership on retrieval)
+            saveTokens(idToken: firebaseTokens.idToken, refreshToken: firebaseTokens.refreshToken, expiresIn: firebaseTokens.expiresIn, userId: firebaseTokens.localId)
+
+            // Also try Firebase SDK sign-in (best effort for other Firebase features)
+            do {
+                let authResult = try await Auth.auth().signIn(withCustomToken: tokenResult.customToken)
+                NSLog("OMI AUTH: Firebase SDK sign-in SUCCESS - uid: %@", authResult.user.uid)
+            } catch let firebaseError as NSError {
+                // Keychain errors are expected on dev builds - we have REST API tokens as fallback
+                NSLog("OMI AUTH: Firebase SDK sign-in failed (using REST API tokens): %@", firebaseError.localizedDescription)
+            }
 
             isSignedIn = true
 
             // Save auth state immediately
+            let userId = firebaseTokens.localId
             saveAuthState(isSignedIn: true, email: tokenResult.email, userId: userId)
             await RewindDatabase.shared.configure(userId: userId)
 
@@ -537,11 +549,9 @@ class AuthService {
 
     // MARK: - Token Exchange
 
-    /// Response from token exchange — backend returns OAuth tokens, client does Firebase signInWithIdp
+    /// Response from token exchange containing custom token and user info
     struct TokenExchangeResult {
-        let firebaseIdToken: String
-        let refreshToken: String
-        let firebaseUid: String
+        let customToken: String
         let givenName: String?
         let familyName: String?
         let email: String?
@@ -559,7 +569,8 @@ class AuthService {
         let bodyParams = [
             "grant_type": "authorization_code",
             "code": code,
-            "redirect_uri": redirectURI
+            "redirect_uri": redirectURI,
+            "use_custom_token": "true"
         ]
 
         let bodyString = bodyParams
@@ -583,125 +594,47 @@ class AuthService {
             throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
         }
 
-        // Parse response — backend returns OAuth tokens (id_token, access_token, provider_id)
+        // Parse response
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw AuthError.invalidResponse
         }
 
-        guard let providerIdToken = json["id_token"] as? String,
-              let providerId = json["provider_id"] as? String else {
-            NSLog("OMI AUTH: Missing OAuth tokens in response")
-            throw AuthError.invalidResponse
+        // Get custom token
+        guard let customToken = json["custom_token"] as? String else {
+            NSLog("OMI AUTH: No custom_token in response")
+            throw AuthError.missingCustomToken
         }
 
-        let accessToken = json["access_token"] as? String
-
-        // Extract user info from provider id_token (JWT)
+        // Extract user info from id_token (JWT)
         var extractedGivenName: String?
         var extractedFamilyName: String?
         var extractedEmail: String?
 
-        if let userInfo = decodeJWT(providerIdToken) {
-            extractedGivenName = userInfo["given_name"] as? String
-            extractedFamilyName = userInfo["family_name"] as? String
-            extractedEmail = userInfo["email"] as? String
+        if let idToken = json["id_token"] as? String {
+            if let userInfo = decodeJWT(idToken) {
+                extractedGivenName = userInfo["given_name"] as? String
+                extractedFamilyName = userInfo["family_name"] as? String
+                extractedEmail = userInfo["email"] as? String
 
-            if extractedGivenName == nil, let fullName = userInfo["name"] as? String {
-                let parts = fullName.split(separator: " ", maxSplits: 1)
-                extractedGivenName = parts.first.map(String.init)
-                extractedFamilyName = parts.count > 1 ? String(parts[1]) : nil
+                // Fall back to "name" field if given_name not available
+                if extractedGivenName == nil, let fullName = userInfo["name"] as? String {
+                    let parts = fullName.split(separator: " ", maxSplits: 1)
+                    extractedGivenName = parts.first.map(String.init)
+                    extractedFamilyName = parts.count > 1 ? String(parts[1]) : nil
+                }
+
+                NSLog("OMI AUTH: Extracted from id_token - name: %@ %@, email: %@",
+                      extractedGivenName ?? "(none)",
+                      extractedFamilyName ?? "",
+                      extractedEmail ?? "(none)")
             }
-
-            NSLog("OMI AUTH: Extracted from id_token - name: %@ %@, email: %@",
-                  extractedGivenName ?? "(none)",
-                  extractedFamilyName ?? "",
-                  extractedEmail ?? "(none)")
         }
 
-        // Client-side Firebase signInWithIdp using FIREBASE_API_KEY from plist
-        NSLog("OMI AUTH: Calling Firebase signInWithIdp client-side...")
-        let firebaseResult = try await signInWithOAuthToken(
-            idToken: providerIdToken,
-            accessToken: accessToken,
-            providerId: providerId
-        )
-
         return TokenExchangeResult(
-            firebaseIdToken: firebaseResult.idToken,
-            refreshToken: firebaseResult.refreshToken,
-            firebaseUid: firebaseResult.localId,
+            customToken: customToken,
             givenName: extractedGivenName,
             familyName: extractedFamilyName,
             email: extractedEmail
-        )
-    }
-
-    /// Sign in with Firebase using OAuth tokens via signInWithIdp REST API.
-    /// Uses FIREBASE_API_KEY from GoogleService-Info.plist.
-    private func signInWithOAuthToken(idToken: String, accessToken: String?, providerId: String) async throws -> FirebaseTokenResult {
-        let url = URL(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=\(firebaseApiKey)")!
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-
-        var postBody = "id_token=\(idToken)&providerId=\(providerId)"
-        if let accessToken = accessToken {
-            postBody += "&access_token=\(accessToken)"
-        }
-
-        let body: [String: Any] = [
-            "postBody": postBody,
-            "requestUri": "http://localhost",
-            "returnIdpCredential": true,
-            "returnSecureToken": true
-        ]
-
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw AuthError.invalidResponse
-        }
-
-        guard httpResponse.statusCode == 200 else {
-            let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
-            NSLog("OMI AUTH: Firebase signInWithIdp error: %@", errorBody)
-            throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
-        }
-
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let firebaseIdToken = json["idToken"] as? String,
-              let refreshToken = json["refreshToken"] as? String else {
-            NSLog("OMI AUTH: Failed to parse Firebase signInWithIdp response")
-            throw AuthError.invalidResponse
-        }
-
-        let expiresIn: Int
-        if let expiresInStr = json["expiresIn"] as? String {
-            expiresIn = Int(expiresInStr) ?? 3600
-        } else if let expiresInInt = json["expiresIn"] as? Int {
-            expiresIn = expiresInInt
-        } else {
-            expiresIn = 3600
-        }
-
-        var localId = json["localId"] as? String ?? ""
-        if localId.isEmpty {
-            if let payload = decodeJWT(firebaseIdToken),
-               let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
-                localId = userId
-            }
-        }
-
-        NSLog("OMI AUTH: Firebase signInWithIdp successful, UID: %@", localId)
-
-        return FirebaseTokenResult(
-            idToken: firebaseIdToken,
-            refreshToken: refreshToken,
-            expiresIn: expiresIn,
-            localId: localId
         )
     }
 
@@ -861,6 +794,66 @@ class AuthService {
         let refreshToken: String
         let expiresIn: Int
         let localId: String
+    }
+
+    /// Exchange custom token for ID token using Firebase REST API
+    private func exchangeCustomTokenForIdToken(customToken: String) async throws -> FirebaseTokenResult {
+        let url = URL(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=\(firebaseApiKey)")!
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: [
+            "token": customToken,
+            "returnSecureToken": true
+        ])
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AuthError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
+            NSLog("OMI AUTH: Firebase REST API error: %@", errorBody)
+            throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let idToken = json["idToken"] as? String,
+              let refreshToken = json["refreshToken"] as? String else {
+            NSLog("OMI AUTH: Failed to parse Firebase response: %@", String(data: data, encoding: .utf8) ?? "nil")
+            throw AuthError.invalidResponse
+        }
+
+        // expiresIn can be String or Int
+        let expiresIn: Int
+        if let expiresInStr = json["expiresIn"] as? String {
+            expiresIn = Int(expiresInStr) ?? 3600
+        } else if let expiresInInt = json["expiresIn"] as? Int {
+            expiresIn = expiresInInt
+        } else {
+            expiresIn = 3600
+        }
+
+        // localId might be missing from REST API response - extract from JWT if needed
+        var localId = json["localId"] as? String ?? ""
+        if localId.isEmpty {
+            // Extract user_id from the JWT token payload
+            if let payload = decodeJWT(idToken),
+               let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
+                localId = userId
+                NSLog("OMI AUTH: Extracted user_id from JWT: %@", localId)
+            }
+        }
+
+        return FirebaseTokenResult(
+            idToken: idToken,
+            refreshToken: refreshToken,
+            expiresIn: expiresIn,
+            localId: localId
+        )
     }
 
     /// Refresh the ID token using the refresh token
@@ -1268,6 +1261,7 @@ enum AuthError: LocalizedError {
     case missingCodeOrState
     case invalidResponse
     case tokenExchangeFailed(Int)
+    case missingCustomToken
 
     var errorDescription: String? {
         switch self {
@@ -1295,6 +1289,8 @@ enum AuthError: LocalizedError {
             return "Invalid server response"
         case .tokenExchangeFailed(let code):
             return "Token exchange failed with status \(code)"
+        case .missingCustomToken:
+            return "Server did not return authentication token"
         }
     }
 }

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -401,13 +401,12 @@ class AuthService {
             }
             NSLog("OMI AUTH: Received valid authorization code")
 
-            // Step 6: Exchange code for custom token and user info
-            NSLog("OMI AUTH: Exchanging code for Firebase token...")
+            // Step 6: Exchange code for Firebase tokens (backend handles signInWithIdp)
+            NSLog("OMI AUTH: Exchanging code for Firebase tokens...")
             let tokenResult = try await exchangeCodeForToken(code: code)
-            NSLog("OMI AUTH: Got Firebase custom token")
+            NSLog("OMI AUTH: Got Firebase tokens directly from backend")
 
-            // Save user info from OAuth response immediately (before Firebase sign-in)
-            // This ensures we have the name even if Firebase session doesn't persist
+            // Save user info from OAuth response
             if let extractedGivenName = tokenResult.givenName, !extractedGivenName.isEmpty {
                 givenName = extractedGivenName
                 familyName = tokenResult.familyName ?? ""
@@ -417,28 +416,13 @@ class AuthService {
                 AuthState.shared.userEmail = extractedEmail
             }
 
-            // Step 7: Exchange custom token for ID token via REST API
-            // This bypasses keychain issues with Firebase SDK on dev builds
-            NSLog("OMI AUTH: Exchanging custom token for ID token via REST API...")
-            let firebaseTokens = try await exchangeCustomTokenForIdToken(customToken: tokenResult.customToken)
-            NSLog("OMI AUTH: Got Firebase ID token via REST API")
-
-            // Store tokens for API calls (include userId to validate token ownership on retrieval)
-            saveTokens(idToken: firebaseTokens.idToken, refreshToken: firebaseTokens.refreshToken, expiresIn: firebaseTokens.expiresIn, userId: firebaseTokens.localId)
-
-            // Also try Firebase SDK sign-in (best effort for other Firebase features)
-            do {
-                let authResult = try await Auth.auth().signIn(withCustomToken: tokenResult.customToken)
-                NSLog("OMI AUTH: Firebase SDK sign-in SUCCESS - uid: %@", authResult.user.uid)
-            } catch let firebaseError as NSError {
-                // Keychain errors are expected on dev builds - we have REST API tokens as fallback
-                NSLog("OMI AUTH: Firebase SDK sign-in failed (using REST API tokens): %@", firebaseError.localizedDescription)
-            }
+            // Store Firebase tokens for API calls (returned directly by backend, no extra exchange needed)
+            let userId = tokenResult.firebaseUid
+            saveTokens(idToken: tokenResult.firebaseIdToken, refreshToken: tokenResult.refreshToken, expiresIn: 3600, userId: userId)
 
             isSignedIn = true
 
             // Save auth state immediately
-            let userId = firebaseTokens.localId
             saveAuthState(isSignedIn: true, email: tokenResult.email, userId: userId)
             await RewindDatabase.shared.configure(userId: userId)
 
@@ -553,9 +537,11 @@ class AuthService {
 
     // MARK: - Token Exchange
 
-    /// Response from token exchange containing custom token and user info
+    /// Response from token exchange — backend returns Firebase tokens directly
     struct TokenExchangeResult {
-        let customToken: String
+        let firebaseIdToken: String
+        let refreshToken: String
+        let firebaseUid: String
         let givenName: String?
         let familyName: String?
         let email: String?
@@ -573,8 +559,7 @@ class AuthService {
         let bodyParams = [
             "grant_type": "authorization_code",
             "code": code,
-            "redirect_uri": redirectURI,
-            "use_custom_token": "true"
+            "redirect_uri": redirectURI
         ]
 
         let bodyString = bodyParams
@@ -598,18 +583,19 @@ class AuthService {
             throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
         }
 
-        // Parse response
+        // Parse response — backend returns Firebase tokens directly
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw AuthError.invalidResponse
         }
 
-        // Get custom token
-        guard let customToken = json["custom_token"] as? String else {
-            NSLog("OMI AUTH: No custom_token in response")
-            throw AuthError.missingCustomToken
+        guard let firebaseIdToken = json["firebase_id_token"] as? String,
+              let refreshToken = json["refresh_token"] as? String,
+              let firebaseUid = json["firebase_uid"] as? String else {
+            NSLog("OMI AUTH: Missing firebase tokens in response")
+            throw AuthError.invalidResponse
         }
 
-        // Extract user info from id_token (JWT)
+        // Extract user info from provider id_token (JWT)
         var extractedGivenName: String?
         var extractedFamilyName: String?
         var extractedEmail: String?
@@ -620,7 +606,6 @@ class AuthService {
                 extractedFamilyName = userInfo["family_name"] as? String
                 extractedEmail = userInfo["email"] as? String
 
-                // Fall back to "name" field if given_name not available
                 if extractedGivenName == nil, let fullName = userInfo["name"] as? String {
                     let parts = fullName.split(separator: " ", maxSplits: 1)
                     extractedGivenName = parts.first.map(String.init)
@@ -635,7 +620,9 @@ class AuthService {
         }
 
         return TokenExchangeResult(
-            customToken: customToken,
+            firebaseIdToken: firebaseIdToken,
+            refreshToken: refreshToken,
+            firebaseUid: firebaseUid,
             givenName: extractedGivenName,
             familyName: extractedFamilyName,
             email: extractedEmail
@@ -798,66 +785,6 @@ class AuthService {
         let refreshToken: String
         let expiresIn: Int
         let localId: String
-    }
-
-    /// Exchange custom token for ID token using Firebase REST API
-    private func exchangeCustomTokenForIdToken(customToken: String) async throws -> FirebaseTokenResult {
-        let url = URL(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=\(firebaseApiKey)")!
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try JSONSerialization.data(withJSONObject: [
-            "token": customToken,
-            "returnSecureToken": true
-        ])
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw AuthError.invalidResponse
-        }
-
-        guard httpResponse.statusCode == 200 else {
-            let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
-            NSLog("OMI AUTH: Firebase REST API error: %@", errorBody)
-            throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
-        }
-
-        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let idToken = json["idToken"] as? String,
-              let refreshToken = json["refreshToken"] as? String else {
-            NSLog("OMI AUTH: Failed to parse Firebase response: %@", String(data: data, encoding: .utf8) ?? "nil")
-            throw AuthError.invalidResponse
-        }
-
-        // expiresIn can be String or Int
-        let expiresIn: Int
-        if let expiresInStr = json["expiresIn"] as? String {
-            expiresIn = Int(expiresInStr) ?? 3600
-        } else if let expiresInInt = json["expiresIn"] as? Int {
-            expiresIn = expiresInInt
-        } else {
-            expiresIn = 3600
-        }
-
-        // localId might be missing from REST API response - extract from JWT if needed
-        var localId = json["localId"] as? String ?? ""
-        if localId.isEmpty {
-            // Extract user_id from the JWT token payload
-            if let payload = decodeJWT(idToken),
-               let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
-                localId = userId
-                NSLog("OMI AUTH: Extracted user_id from JWT: %@", localId)
-            }
-        }
-
-        return FirebaseTokenResult(
-            idToken: idToken,
-            refreshToken: refreshToken,
-            expiresIn: expiresIn,
-            localId: localId
-        )
     }
 
     /// Refresh the ID token using the refresh token
@@ -1265,7 +1192,6 @@ enum AuthError: LocalizedError {
     case missingCodeOrState
     case invalidResponse
     case tokenExchangeFailed(Int)
-    case missingCustomToken
 
     var errorDescription: String? {
         switch self {
@@ -1293,8 +1219,6 @@ enum AuthError: LocalizedError {
             return "Invalid server response"
         case .tokenExchangeFailed(let code):
             return "Token exchange failed with status \(code)"
-        case .missingCustomToken:
-            return "Server did not return authentication token"
         }
     }
 }

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -401,10 +401,10 @@ class AuthService {
             }
             NSLog("OMI AUTH: Received valid authorization code")
 
-            // Step 6: Exchange code for Firebase tokens (backend handles signInWithIdp)
-            NSLog("OMI AUTH: Exchanging code for Firebase tokens...")
+            // Step 6: Exchange code for tokens (backend returns OAuth tokens, client does Firebase signInWithIdp)
+            NSLog("OMI AUTH: Exchanging code for tokens...")
             let tokenResult = try await exchangeCodeForToken(code: code)
-            NSLog("OMI AUTH: Got Firebase tokens directly from backend")
+            NSLog("OMI AUTH: Got Firebase tokens via client-side signInWithIdp")
 
             // Save user info from OAuth response
             if let extractedGivenName = tokenResult.givenName, !extractedGivenName.isEmpty {
@@ -416,7 +416,7 @@ class AuthService {
                 AuthState.shared.userEmail = extractedEmail
             }
 
-            // Store Firebase tokens for API calls (returned directly by backend, no extra exchange needed)
+            // Store Firebase tokens for API calls
             let userId = tokenResult.firebaseUid
             saveTokens(idToken: tokenResult.firebaseIdToken, refreshToken: tokenResult.refreshToken, expiresIn: 3600, userId: userId)
 
@@ -537,7 +537,7 @@ class AuthService {
 
     // MARK: - Token Exchange
 
-    /// Response from token exchange — backend returns Firebase tokens directly
+    /// Response from token exchange — backend returns OAuth tokens, client does Firebase signInWithIdp
     struct TokenExchangeResult {
         let firebaseIdToken: String
         let refreshToken: String
@@ -583,49 +583,125 @@ class AuthService {
             throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
         }
 
-        // Parse response — backend returns Firebase tokens directly
+        // Parse response — backend returns OAuth tokens (id_token, access_token, provider_id)
         guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
             throw AuthError.invalidResponse
         }
 
-        guard let firebaseIdToken = json["firebase_id_token"] as? String,
-              let refreshToken = json["refresh_token"] as? String,
-              let firebaseUid = json["firebase_uid"] as? String else {
-            NSLog("OMI AUTH: Missing firebase tokens in response")
+        guard let providerIdToken = json["id_token"] as? String,
+              let providerId = json["provider_id"] as? String else {
+            NSLog("OMI AUTH: Missing OAuth tokens in response")
             throw AuthError.invalidResponse
         }
+
+        let accessToken = json["access_token"] as? String
 
         // Extract user info from provider id_token (JWT)
         var extractedGivenName: String?
         var extractedFamilyName: String?
         var extractedEmail: String?
 
-        if let idToken = json["id_token"] as? String {
-            if let userInfo = decodeJWT(idToken) {
-                extractedGivenName = userInfo["given_name"] as? String
-                extractedFamilyName = userInfo["family_name"] as? String
-                extractedEmail = userInfo["email"] as? String
+        if let userInfo = decodeJWT(providerIdToken) {
+            extractedGivenName = userInfo["given_name"] as? String
+            extractedFamilyName = userInfo["family_name"] as? String
+            extractedEmail = userInfo["email"] as? String
 
-                if extractedGivenName == nil, let fullName = userInfo["name"] as? String {
-                    let parts = fullName.split(separator: " ", maxSplits: 1)
-                    extractedGivenName = parts.first.map(String.init)
-                    extractedFamilyName = parts.count > 1 ? String(parts[1]) : nil
-                }
-
-                NSLog("OMI AUTH: Extracted from id_token - name: %@ %@, email: %@",
-                      extractedGivenName ?? "(none)",
-                      extractedFamilyName ?? "",
-                      extractedEmail ?? "(none)")
+            if extractedGivenName == nil, let fullName = userInfo["name"] as? String {
+                let parts = fullName.split(separator: " ", maxSplits: 1)
+                extractedGivenName = parts.first.map(String.init)
+                extractedFamilyName = parts.count > 1 ? String(parts[1]) : nil
             }
+
+            NSLog("OMI AUTH: Extracted from id_token - name: %@ %@, email: %@",
+                  extractedGivenName ?? "(none)",
+                  extractedFamilyName ?? "",
+                  extractedEmail ?? "(none)")
         }
 
+        // Client-side Firebase signInWithIdp using FIREBASE_API_KEY from plist
+        NSLog("OMI AUTH: Calling Firebase signInWithIdp client-side...")
+        let firebaseResult = try await signInWithOAuthToken(
+            idToken: providerIdToken,
+            accessToken: accessToken,
+            providerId: providerId
+        )
+
         return TokenExchangeResult(
-            firebaseIdToken: firebaseIdToken,
-            refreshToken: refreshToken,
-            firebaseUid: firebaseUid,
+            firebaseIdToken: firebaseResult.idToken,
+            refreshToken: firebaseResult.refreshToken,
+            firebaseUid: firebaseResult.localId,
             givenName: extractedGivenName,
             familyName: extractedFamilyName,
             email: extractedEmail
+        )
+    }
+
+    /// Sign in with Firebase using OAuth tokens via signInWithIdp REST API.
+    /// Uses FIREBASE_API_KEY from GoogleService-Info.plist.
+    private func signInWithOAuthToken(idToken: String, accessToken: String?, providerId: String) async throws -> FirebaseTokenResult {
+        let url = URL(string: "https://identitytoolkit.googleapis.com/v1/accounts:signInWithIdp?key=\(firebaseApiKey)")!
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        var postBody = "id_token=\(idToken)&providerId=\(providerId)"
+        if let accessToken = accessToken {
+            postBody += "&access_token=\(accessToken)"
+        }
+
+        let body: [String: Any] = [
+            "postBody": postBody,
+            "requestUri": "http://localhost",
+            "returnIdpCredential": true,
+            "returnSecureToken": true
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw AuthError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            let errorBody = String(data: data, encoding: .utf8) ?? "unknown"
+            NSLog("OMI AUTH: Firebase signInWithIdp error: %@", errorBody)
+            throw AuthError.tokenExchangeFailed(httpResponse.statusCode)
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let firebaseIdToken = json["idToken"] as? String,
+              let refreshToken = json["refreshToken"] as? String else {
+            NSLog("OMI AUTH: Failed to parse Firebase signInWithIdp response")
+            throw AuthError.invalidResponse
+        }
+
+        let expiresIn: Int
+        if let expiresInStr = json["expiresIn"] as? String {
+            expiresIn = Int(expiresInStr) ?? 3600
+        } else if let expiresInInt = json["expiresIn"] as? Int {
+            expiresIn = expiresInInt
+        } else {
+            expiresIn = 3600
+        }
+
+        var localId = json["localId"] as? String ?? ""
+        if localId.isEmpty {
+            if let payload = decodeJWT(firebaseIdToken),
+               let userId = payload["user_id"] as? String ?? payload["sub"] as? String {
+                localId = userId
+            }
+        }
+
+        NSLog("OMI AUTH: Firebase signInWithIdp successful, UID: %@", localId)
+
+        return FirebaseTokenResult(
+            idToken: firebaseIdToken,
+            refreshToken: refreshToken,
+            expiresIn: expiresIn,
+            localId: localId
         )
     }
 

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -74,8 +74,15 @@ class AuthService {
     private let kAuthTokenExpiry = "auth_tokenExpiry"
     private let kAuthTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
 
-    // Firebase Web API key (from GoogleService-Info.plist)
-    private let firebaseApiKey = "AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"
+    // Firebase Web API key (read from bundled GoogleService-Info.plist, falls back to prod)
+    private var firebaseApiKey: String {
+        if let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist"),
+           let plistDict = NSDictionary(contentsOfFile: plistPath),
+           let apiKey = plistDict["API_KEY"] as? String {
+            return apiKey
+        }
+        return "AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8"
+    }
 
     // MARK: - User Name Properties
 

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -43,18 +43,17 @@ class AuthService {
     private var appleSignInDelegate: AppleSignInDelegate?
 
     // API Configuration
-    // Auth backend URL from AUTH_BACKEND_URL env var.
-    // Dev builds fall back to localhost; prod builds log error and disable auth.
+    // Auth backend URL from AUTH_BACKEND_URL env var (use getenv to pick up setenv from .env loading).
+    // Dev builds fall back to localhost; prod builds log error.
     private var apiBaseURL: String {
-        if let url = ProcessInfo.processInfo.environment["AUTH_BACKEND_URL"], !url.isEmpty {
+        if let cString = getenv("AUTH_BACKEND_URL"), let url = String(validatingUTF8: cString), !url.isEmpty {
             return url.hasSuffix("/") ? url : url + "/"
         }
         let isDev = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
-        if isDev {
-            return "http://localhost:8080/"
+        if !isDev {
+            NSLog("OMI AUTH ERROR: AUTH_BACKEND_URL not set in production build")
         }
-        NSLog("OMI AUTH ERROR: AUTH_BACKEND_URL not set in production build")
-        return "http://localhost:8080/"  // Will fail to connect — surfaces as auth error
+        return "http://localhost:8080/"
     }
     private var redirectURI: String {
         return "\(urlScheme)://auth/callback"
@@ -85,10 +84,10 @@ class AuthService {
     private let kAuthTokenExpiry = "auth_tokenExpiry"
     private let kAuthTokenUserId = "auth_tokenUserId"  // User ID that owns the stored token
 
-    // Firebase Web API key from FIREBASE_API_KEY env var (set in .env).
+    // Firebase Web API key from FIREBASE_API_KEY env var (use getenv to pick up setenv from .env loading).
     // Returns empty string if missing — callers surface auth errors to user.
     private var firebaseApiKey: String {
-        if let apiKey = ProcessInfo.processInfo.environment["FIREBASE_API_KEY"], !apiKey.isEmpty {
+        if let cString = getenv("FIREBASE_API_KEY"), let apiKey = String(validatingUTF8: cString), !apiKey.isEmpty {
             return apiKey
         }
         NSLog("OMI AUTH ERROR: FIREBASE_API_KEY environment variable not set — auth will fail")

--- a/desktop/Desktop/Sources/GoogleService-Info-Dev.plist
+++ b/desktop/Desktop/Sources/GoogleService-Info-Dev.plist
@@ -3,23 +3,23 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>208440318997-68pb7d72igtvl7jgr1ep6d3m6qn4pnbo.apps.googleusercontent.com</string>
+	<string>1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.208440318997-68pb7d72igtvl7jgr1ep6d3m6qn4pnbo</string>
+	<string>com.googleusercontent.apps.1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde</string>
 	<key>ANDROID_CLIENT_ID</key>
-	<string>208440318997-1ek8tj5oa9ljmnh8tgehk27nqpivivbf.apps.googleusercontent.com</string>
+	<string>1031333818730-1cgqp3jc5p8n2rk467pl4t56qc4lnnbr.apps.googleusercontent.com</string>
 	<key>API_KEY</key>
-	<string>AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8</string>
+	<string>AIzaSyBK-G7KmEoC72mR10gmQyb2NFBbZyDvcqM</string>
 	<key>GCM_SENDER_ID</key>
-	<string>208440318997</string>
+	<string>1031333818730</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
 	<string>com.omi.desktop-dev</string>
 	<key>PROJECT_ID</key>
-	<string>based-hardware</string>
+	<string>based-hardware-dev</string>
 	<key>STORAGE_BUCKET</key>
-	<string>based-hardware.firebasestorage.app</string>
+	<string>based-hardware-dev.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -31,6 +31,8 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:208440318997:ios:a1906bb92fe244810e421c</string>
+	<string>1:1031333818730:ios:3bea63d8e4f41dbfafb513</string>
+	<key>AUTH_BACKEND_URL</key>
+	<string>http://localhost:8080</string>
 </dict>
 </plist>

--- a/desktop/Desktop/Sources/GoogleService-Info-Dev.plist
+++ b/desktop/Desktop/Sources/GoogleService-Info-Dev.plist
@@ -32,7 +32,5 @@
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
 	<string>1:1031333818730:ios:3bea63d8e4f41dbfafb513</string>
-	<key>AUTH_BACKEND_URL</key>
-	<string>http://localhost:8080</string>
 </dict>
 </plist>

--- a/desktop/Desktop/Sources/GoogleService-Info.plist
+++ b/desktop/Desktop/Sources/GoogleService-Info.plist
@@ -32,5 +32,7 @@
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
 	<string>1:1031333818730:ios:3bea63d8e4f41dbfafb513</string>
+	<key>AUTH_BACKEND_URL</key>
+	<string>http://localhost:8080</string>
 </dict>
 </plist>

--- a/desktop/Desktop/Sources/GoogleService-Info.plist
+++ b/desktop/Desktop/Sources/GoogleService-Info.plist
@@ -3,23 +3,23 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>208440318997-suqloh00q5r3ovgoqikvsrf9aqn1t54e.apps.googleusercontent.com</string>
+	<string>1031333818730-placeholder.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.208440318997-suqloh00q5r3ovgoqikvsrf9aqn1t54e</string>
+	<string>com.googleusercontent.apps.1031333818730-placeholder</string>
 	<key>ANDROID_CLIENT_ID</key>
-	<string>208440318997-1ek8tj5oa9ljmnh8tgehk27nqpivivbf.apps.googleusercontent.com</string>
+	<string>1031333818730-placeholder.apps.googleusercontent.com</string>
 	<key>API_KEY</key>
-	<string>AIzaSyD9dzBdglc7IO9pPDIOvqnCoTis_xKkkC8</string>
+	<string>AIzaSyBK-G7KmEoC72mR10gmQyb2NFBbZyDvcqM</string>
 	<key>GCM_SENDER_ID</key>
-	<string>208440318997</string>
+	<string>1031333818730</string>
 	<key>PLIST_VERSION</key>
 	<string>1</string>
 	<key>BUNDLE_ID</key>
 	<string>com.omi.computer-macos</string>
 	<key>PROJECT_ID</key>
-	<string>based-hardware</string>
+	<string>based-hardware-dev</string>
 	<key>STORAGE_BUCKET</key>
-	<string>based-hardware.firebasestorage.app</string>
+	<string>based-hardware-dev.firebasestorage.app</string>
 	<key>IS_ADS_ENABLED</key>
 	<false></false>
 	<key>IS_ANALYTICS_ENABLED</key>
@@ -31,6 +31,6 @@
 	<key>IS_SIGNIN_ENABLED</key>
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
-	<string>1:208440318997:ios:5a9bb6d5a555e8d90e421c</string>
+	<string>1:1031333818730:ios:3bea63d8e4f41dbfafb513</string>
 </dict>
 </plist>

--- a/desktop/Desktop/Sources/GoogleService-Info.plist
+++ b/desktop/Desktop/Sources/GoogleService-Info.plist
@@ -32,7 +32,5 @@
 	<true></true>
 	<key>GOOGLE_APP_ID</key>
 	<string>1:1031333818730:ios:3bea63d8e4f41dbfafb513</string>
-	<key>AUTH_BACKEND_URL</key>
-	<string>http://localhost:8080</string>
 </dict>
 </plist>

--- a/desktop/Desktop/Sources/GoogleService-Info.plist
+++ b/desktop/Desktop/Sources/GoogleService-Info.plist
@@ -3,11 +3,11 @@
 <plist version="1.0">
 <dict>
 	<key>CLIENT_ID</key>
-	<string>1031333818730-placeholder.apps.googleusercontent.com</string>
+	<string>1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde.apps.googleusercontent.com</string>
 	<key>REVERSED_CLIENT_ID</key>
-	<string>com.googleusercontent.apps.1031333818730-placeholder</string>
+	<string>com.googleusercontent.apps.1031333818730-dusn243nct6i5rgfpfkj5mchuj1qnmde</string>
 	<key>ANDROID_CLIENT_ID</key>
-	<string>1031333818730-placeholder.apps.googleusercontent.com</string>
+	<string>1031333818730-1cgqp3jc5p8n2rk467pl4t56qc4lnnbr.apps.googleusercontent.com</string>
 	<key>API_KEY</key>
 	<string>AIzaSyBK-G7KmEoC72mR10gmQyb2NFBbZyDvcqM</string>
 	<key>GCM_SENDER_ID</key>

--- a/desktop/build.sh
+++ b/desktop/build.sh
@@ -84,8 +84,14 @@ cp Desktop/Info.plist "$APP_BUNDLE/Contents/Info.plist"
 # Copy app icon
 cp omi_icon.icns "$APP_BUNDLE/Contents/Resources/OmiIcon.icns"
 
-# Copy Firebase config for desktop auth
-cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+# Copy Firebase config (prod plist injected from CI secret, dev fallback in git)
+if [ -n "$MACOS_GOOGLE_SERVICE_INFO_PLIST" ]; then
+    echo "$MACOS_GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+    echo "Injected prod GoogleService-Info.plist from CI secret"
+else
+    cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+    echo "WARNING: Using dev GoogleService-Info.plist (MACOS_GOOGLE_SERVICE_INFO_PLIST not set)"
+fi
 
 # Update Info.plist with actual values
 /usr/libexec/PlistBuddy -c "Set :CFBundleExecutable $BINARY_NAME" "$APP_BUNDLE/Contents/Info.plist"

--- a/desktop/build.sh
+++ b/desktop/build.sh
@@ -87,6 +87,7 @@ cp omi_icon.icns "$APP_BUNDLE/Contents/Resources/OmiIcon.icns"
 # Copy Firebase config (prod plist injected from CI secret, dev fallback in git)
 if [ -n "$MACOS_GOOGLE_SERVICE_INFO_PLIST" ]; then
     echo "$MACOS_GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+    plutil -lint "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist" || { echo "ERROR: Decoded GoogleService-Info.plist is invalid"; exit 1; }
     echo "Injected prod GoogleService-Info.plist from CI secret"
 else
     cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"

--- a/desktop/dev.sh
+++ b/desktop/dev.sh
@@ -97,7 +97,7 @@ if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
 else
     echo "OMI_API_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
-# Ensure AUTH_BACKEND_URL points to the local Rust desktop backend
+# Ensure AUTH_BACKEND_URL is set (prod: api.omi.me, local dev: same Rust backend)
 if grep -q "^AUTH_BACKEND_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
     sed -i '' "s|^AUTH_BACKEND_URL=.*|AUTH_BACKEND_URL=$BACKEND_URL|" "$APP_BUNDLE/Contents/Resources/.env"
 else

--- a/desktop/dev.sh
+++ b/desktop/dev.sh
@@ -97,10 +97,10 @@ if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
 else
     echo "OMI_API_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
-# Ensure AUTH_BACKEND_URL is set (prod: api.omi.me, local dev: same Rust backend)
-if grep -q "^AUTH_BACKEND_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
-    sed -i '' "s|^AUTH_BACKEND_URL=.*|AUTH_BACKEND_URL=$BACKEND_URL|" "$APP_BUNDLE/Contents/Resources/.env"
-else
+# AUTH_BACKEND_URL: only set a default if not already in .env.app
+# Do NOT force localhost — local Rust backend cannot produce custom tokens.
+# Set AUTH_BACKEND_URL in .env.app to point to api.omi.me or a local Python backend.
+if ! grep -q "^AUTH_BACKEND_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
     echo "AUTH_BACKEND_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
 

--- a/desktop/dev.sh
+++ b/desktop/dev.sh
@@ -8,15 +8,10 @@ BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 BACKEND_DIR="$(dirname "$0")/Backend"
 BACKEND_PID=""
-TUNNEL_PID=""
-TUNNEL_URL="https://omi-dev.m13v.com"
+BACKEND_URL="http://localhost:8080"
 
-# Cleanup function to stop backend and tunnel on exit
+# Cleanup function to stop backend on exit
 cleanup() {
-    if [ -n "$TUNNEL_PID" ] && kill -0 "$TUNNEL_PID" 2>/dev/null; then
-        echo "Stopping tunnel (PID: $TUNNEL_PID)..."
-        kill "$TUNNEL_PID" 2>/dev/null || true
-    fi
     if [ -n "$BACKEND_PID" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
         echo "Stopping backend (PID: $BACKEND_PID)..."
         kill "$BACKEND_PID" 2>/dev/null || true
@@ -26,14 +21,7 @@ trap cleanup EXIT
 
 # Kill existing instances
 pkill "$BINARY_NAME" 2>/dev/null || true
-pkill -f "cloudflared.*omi-computer-dev" 2>/dev/null || true
 lsof -ti:8080 | xargs kill -9 2>/dev/null || true
-
-# Start Cloudflare tunnel
-echo "Starting Cloudflare tunnel..."
-cloudflared tunnel run omi-computer-dev &
-TUNNEL_PID=$!
-sleep 2
 
 # Start backend
 echo "Starting backend..."
@@ -97,19 +85,24 @@ else
     echo "Warning: Resource bundle not found at $SWIFT_BUILD_DIR/Omi Computer_Omi Computer.bundle"
 fi
 
-# Copy .env.app (app runtime secrets only) and add API URL
+# Copy .env.app (app runtime secrets only) and set backend URLs
 if [ -f ".env.app" ]; then
     cp .env.app "$APP_BUNDLE/Contents/Resources/.env"
 else
     touch "$APP_BUNDLE/Contents/Resources/.env"
 fi
-# Set API URL to tunnel for development (overrides production default)
+# Ensure OMI_API_URL points to the local Rust desktop backend
 if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
-    sed -i '' "s|^OMI_API_URL=.*|OMI_API_URL=$TUNNEL_URL|" "$APP_BUNDLE/Contents/Resources/.env"
+    sed -i '' "s|^OMI_API_URL=.*|OMI_API_URL=$BACKEND_URL|" "$APP_BUNDLE/Contents/Resources/.env"
 else
-    echo "OMI_API_URL=$TUNNEL_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+    echo "OMI_API_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
-echo "Using backend: $TUNNEL_URL"
+# Ensure AUTH_BACKEND_URL points to the local Rust desktop backend
+if grep -q "^AUTH_BACKEND_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
+    sed -i '' "s|^AUTH_BACKEND_URL=.*|AUTH_BACKEND_URL=$BACKEND_URL|" "$APP_BUNDLE/Contents/Resources/.env"
+else
+    echo "AUTH_BACKEND_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+fi
 
 # Copy app icon
 cp -f omi_icon.icns "$APP_BUNDLE/Contents/Resources/OmiIcon.icns"
@@ -143,8 +136,7 @@ fi
 echo "Dev build complete: $APP_BUNDLE"
 echo ""
 echo "=== Services Running ==="
-echo "Backend:  http://localhost:8080 (PID: $BACKEND_PID)"
-echo "Tunnel:   $TUNNEL_URL (PID: $TUNNEL_PID)"
+echo "Backend:  $BACKEND_URL (PID: $BACKEND_PID)"
 echo "========================"
 echo ""
 open "$APP_BUNDLE"

--- a/desktop/release.sh
+++ b/desktop/release.sh
@@ -427,6 +427,7 @@ fi
 # Copy Firebase config (prod plist injected from CI secret, dev fallback in git)
 if [ -n "$MACOS_GOOGLE_SERVICE_INFO_PLIST" ]; then
     echo "$MACOS_GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+    plutil -lint "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist" || { echo "ERROR: Decoded GoogleService-Info.plist is invalid"; exit 1; }
     echo "Injected prod GoogleService-Info.plist from CI secret"
 else
     echo "ERROR: MACOS_GOOGLE_SERVICE_INFO_PLIST not set — refusing release build without prod Firebase config"

--- a/desktop/release.sh
+++ b/desktop/release.sh
@@ -429,8 +429,8 @@ if [ -n "$MACOS_GOOGLE_SERVICE_INFO_PLIST" ]; then
     echo "$MACOS_GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
     echo "Injected prod GoogleService-Info.plist from CI secret"
 else
-    cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
-    echo "WARNING: Using dev GoogleService-Info.plist (MACOS_GOOGLE_SERVICE_INFO_PLIST not set)"
+    echo "ERROR: MACOS_GOOGLE_SERVICE_INFO_PLIST not set — refusing release build without prod Firebase config"
+    exit 1
 fi
 
 # Copy resource bundle (contains app assets like permissions.gif, herologo.png, etc.)

--- a/desktop/release.sh
+++ b/desktop/release.sh
@@ -424,8 +424,14 @@ if [ -f "omi_icon.icns" ]; then
     cp omi_icon.icns "$APP_BUNDLE/Contents/Resources/OmiIcon.icns"
 fi
 
-# Copy GoogleService-Info.plist for Firebase
-cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
+# Copy Firebase config (prod plist injected from CI secret, dev fallback in git)
+if [ -n "$MACOS_GOOGLE_SERVICE_INFO_PLIST" ]; then
+    echo "$MACOS_GOOGLE_SERVICE_INFO_PLIST" | base64 --decode > "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
+    echo "Injected prod GoogleService-Info.plist from CI secret"
+else
+    cp Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
+    echo "WARNING: Using dev GoogleService-Info.plist (MACOS_GOOGLE_SERVICE_INFO_PLIST not set)"
+fi
 
 # Copy resource bundle (contains app assets like permissions.gif, herologo.png, etc.)
 # Note: Bundle goes in Contents/Resources/ - our custom BundleExtension.swift looks for it there

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -37,18 +37,13 @@ APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_PATH="/Applications/$APP_NAME.app"
 SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
 
-# Backend configuration (Rust)
+# Backend configuration (Rust desktop backend on localhost)
 BACKEND_DIR="$(dirname "$0")/Backend-Rust"
 BACKEND_PID=""
-TUNNEL_PID=""
-TUNNEL_URL="https://omi-dev.m13v.com"
+BACKEND_URL="http://localhost:8080"
 
-# Cleanup function to stop backend and tunnel on exit
+# Cleanup function to stop backend on exit
 cleanup() {
-    if [ -n "$TUNNEL_PID" ] && kill -0 "$TUNNEL_PID" 2>/dev/null; then
-        echo "Stopping tunnel (PID: $TUNNEL_PID)..."
-        kill "$TUNNEL_PID" 2>/dev/null || true
-    fi
     if [ -n "$BACKEND_PID" ] && kill -0 "$BACKEND_PID" 2>/dev/null; then
         echo "Stopping backend (PID: $BACKEND_PID)..."
         kill "$BACKEND_PID" 2>/dev/null || true
@@ -66,7 +61,6 @@ auth_debug "BEFORE pkill: auth_isSignedIn=$(defaults read "$BUNDLE_ID" auth_isSi
 auth_debug "BEFORE pkill: ALL_KEYS=$(defaults read "$BUNDLE_ID" 2>&1 | grep -E 'auth_|hasCompleted|hasLaunched|currentTier|userShow' || true)"
 # Only kill the dev app — never touch Omi Beta (production)
 pkill -f "$APP_NAME.app" 2>/dev/null || true
-pkill -f "cloudflared.*omi-computer-dev" 2>/dev/null || true
 # Kill only the Rust backend on port 8080 (not other apps that might use it)
 lsof -ti:8080 -sTCP:LISTEN 2>/dev/null | while read pid; do
     if ps -p "$pid" -o command= 2>/dev/null | grep -q "omi-backend\|Backend-Rust\|target/"; then
@@ -105,12 +99,7 @@ find "$HOME" -maxdepth 4 -name "Omi Dev.app" -type d -not -path "$APP_BUNDLE" -n
     rm -rf "$stale"
 done
 
-step "Starting Cloudflare tunnel..."
-cloudflared tunnel run omi-computer-dev &
-TUNNEL_PID=$!
-sleep 2
-
-step "Starting Rust backend..."
+step "Starting Rust desktop backend..."
 cd "$BACKEND_DIR"
 
 # Copy .env if not present
@@ -267,10 +256,17 @@ elif [ -f ".env.app" ]; then
 else
     touch "$APP_BUNDLE/Contents/Resources/.env"
 fi
+# Ensure OMI_API_URL points to the local Rust desktop backend
 if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
-    sed -i '' "s|^OMI_API_URL=.*|OMI_API_URL=$TUNNEL_URL|" "$APP_BUNDLE/Contents/Resources/.env"
+    sed -i '' "s|^OMI_API_URL=.*|OMI_API_URL=$BACKEND_URL|" "$APP_BUNDLE/Contents/Resources/.env"
 else
-    echo "OMI_API_URL=$TUNNEL_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+    echo "OMI_API_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
+fi
+# Ensure AUTH_BACKEND_URL points to the local Rust desktop backend
+if grep -q "^AUTH_BACKEND_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
+    sed -i '' "s|^AUTH_BACKEND_URL=.*|AUTH_BACKEND_URL=$BACKEND_URL|" "$APP_BUNDLE/Contents/Resources/.env"
+else
+    echo "AUTH_BACKEND_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
 
 substep "Copying app icon"
@@ -395,10 +391,8 @@ TOTAL_TIME=$(echo "$NOW - $SCRIPT_START_TIME" | bc)
 printf "  └─ done (%.2fs)\n" "$(echo "$NOW - $STEP_START_TIME" | bc)"
 echo ""
 echo "=== Services Running (total: ${TOTAL_TIME%.*}s) ==="
-echo "Backend:  http://localhost:8080 (PID: $BACKEND_PID)"
-echo "Tunnel:   $TUNNEL_URL (PID: $TUNNEL_PID)"
+echo "Backend:  $BACKEND_URL (PID: $BACKEND_PID)"
 echo "App:      $APP_PATH (installed from $APP_BUNDLE)"
-echo "Using backend: $TUNNEL_URL"
 echo "========================================"
 echo ""
 

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -262,10 +262,11 @@ if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
 else
     echo "OMI_API_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
-# Ensure AUTH_BACKEND_URL is set (prod: api.omi.me, local dev: same Rust backend)
-if grep -q "^AUTH_BACKEND_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
-    sed -i '' "s|^AUTH_BACKEND_URL=.*|AUTH_BACKEND_URL=$BACKEND_URL|" "$APP_BUNDLE/Contents/Resources/.env"
-else
+# AUTH_BACKEND_URL: only set a default if not already in .env.app
+# In prod this points to api.omi.me (Python backend). For local dev, set it in
+# .env.app to wherever auth is running (e.g. api.omi.me or a local Python backend).
+# We do NOT force localhost here because the local Rust backend cannot produce custom tokens.
+if ! grep -q "^AUTH_BACKEND_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
     echo "AUTH_BACKEND_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
 

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -262,7 +262,7 @@ if grep -q "^OMI_API_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
 else
     echo "OMI_API_URL=$BACKEND_URL" >> "$APP_BUNDLE/Contents/Resources/.env"
 fi
-# Ensure AUTH_BACKEND_URL points to the local Rust desktop backend
+# Ensure AUTH_BACKEND_URL is set (prod: api.omi.me, local dev: same Rust backend)
 if grep -q "^AUTH_BACKEND_URL=" "$APP_BUNDLE/Contents/Resources/.env"; then
     sed -i '' "s|^AUTH_BACKEND_URL=.*|AUTH_BACKEND_URL=$BACKEND_URL|" "$APP_BUNDLE/Contents/Resources/.env"
 else

--- a/desktop/tests/test_plist_injection.sh
+++ b/desktop/tests/test_plist_injection.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Tests for Firebase plist CI injection logic in build.sh and release.sh
+# Validates: valid base64 plist, invalid plist, missing env var, fail-closed behavior
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+pass() { PASS=$((PASS + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); echo "  FAIL: $1"; }
+
+echo "=== Plist injection tests ==="
+
+# --- Test 1: Valid base64 plist decodes correctly ---
+echo ""
+echo "Test 1: Valid base64 plist decodes correctly"
+VALID_PLIST='<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PROJECT_ID</key>
+	<string>based-hardware</string>
+	<key>API_KEY</key>
+	<string>test-key</string>
+</dict>
+</plist>'
+ENCODED=$(echo "$VALID_PLIST" | base64)
+echo "$ENCODED" | base64 --decode > "$TMPDIR/valid.plist" 2>/dev/null
+if [ -f "$TMPDIR/valid.plist" ]; then
+    pass "base64 decode produced a file"
+else
+    fail "base64 decode did not produce a file"
+fi
+
+# Validate plist structure (plutil only available on macOS)
+if command -v plutil &>/dev/null; then
+    if plutil -lint "$TMPDIR/valid.plist" &>/dev/null; then
+        pass "plutil validates decoded plist"
+    else
+        fail "plutil rejected decoded plist"
+    fi
+else
+    echo "  SKIP: plutil not available (not macOS)"
+fi
+
+# --- Test 2: Invalid base64 data should fail plutil ---
+echo ""
+echo "Test 2: Invalid plist content fails validation"
+INVALID_PLIST="this is not a valid plist"
+echo "$INVALID_PLIST" | base64 | base64 --decode > "$TMPDIR/invalid.plist" 2>/dev/null
+if command -v plutil &>/dev/null; then
+    if plutil -lint "$TMPDIR/invalid.plist" &>/dev/null; then
+        fail "plutil should reject invalid plist"
+    else
+        pass "plutil correctly rejects invalid plist"
+    fi
+else
+    echo "  SKIP: plutil not available (not macOS)"
+fi
+
+# --- Test 3: release.sh fails when MACOS_GOOGLE_SERVICE_INFO_PLIST is missing ---
+echo ""
+echo "Test 3: release.sh injection is fail-closed"
+# Extract and test the injection logic from release.sh
+INJECT_SCRIPT='
+if [ -n "${MACOS_GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
+    echo "INJECT"
+else
+    echo "FAIL_CLOSED"
+    exit 1
+fi
+'
+unset MACOS_GOOGLE_SERVICE_INFO_PLIST 2>/dev/null || true
+OUTPUT=$(bash -c "$INJECT_SCRIPT" 2>&1) && RC=$? || RC=$?
+if [ "$RC" -ne 0 ]; then
+    pass "release injection exits non-zero when env var missing"
+else
+    fail "release injection should exit non-zero when env var missing"
+fi
+
+# --- Test 4: build.sh falls back to dev plist when env var missing ---
+echo ""
+echo "Test 4: build.sh injection falls back to dev plist"
+BUILD_INJECT='
+if [ -n "${MACOS_GOOGLE_SERVICE_INFO_PLIST:-}" ]; then
+    echo "INJECT_PROD"
+else
+    echo "FALLBACK_DEV"
+fi
+'
+unset MACOS_GOOGLE_SERVICE_INFO_PLIST 2>/dev/null || true
+OUTPUT=$(bash -c "$BUILD_INJECT" 2>&1)
+if echo "$OUTPUT" | grep -q "FALLBACK_DEV"; then
+    pass "build injection falls back to dev plist"
+else
+    fail "build injection should fall back to dev plist"
+fi
+
+# --- Test 5: Env var set triggers prod injection ---
+echo ""
+echo "Test 5: Env var set triggers prod injection path"
+export MACOS_GOOGLE_SERVICE_INFO_PLIST="$ENCODED"
+OUTPUT=$(bash -c "$BUILD_INJECT" 2>&1)
+if echo "$OUTPUT" | grep -q "INJECT_PROD"; then
+    pass "prod injection path triggered with env var set"
+else
+    fail "prod injection path should be triggered"
+fi
+unset MACOS_GOOGLE_SERVICE_INFO_PLIST
+
+# --- Test 6: Dev plist contains only dev project values ---
+echo ""
+echo "Test 6: Dev plist has dev-only values"
+DEV_PLIST="$(dirname "$0")/../Desktop/Sources/GoogleService-Info.plist"
+if [ -f "$DEV_PLIST" ]; then
+    if grep -q "based-hardware-dev" "$DEV_PLIST"; then
+        pass "dev plist contains based-hardware-dev project"
+    else
+        fail "dev plist should contain based-hardware-dev"
+    fi
+    if grep -q "based-hardware-prod" "$DEV_PLIST"; then
+        fail "dev plist should NOT contain prod project ID"
+    else
+        pass "dev plist does not contain prod project ID"
+    fi
+else
+    echo "  SKIP: dev plist not found at $DEV_PLIST"
+fi
+
+# --- Summary ---
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Remove prod credentials from desktop app, inject at CI time
- Cherry-pick auth changes from PR #5374: Python backend handles desktop OAuth (redirect_uri validation, Admin SDK fallback, `omi-computer://` scheme support)
- `AUTH_BACKEND_URL` → Python backend (`api.omi.me` in prod) for OAuth
- `OMI_API_URL` → Rust desktop-backend for data APIs (unchanged)
- Firebase API key derived from GoogleService-Info.plist (no env var needed)
- Remove Matt-specific Cloudflare tunnel from run.sh/dev.sh, use localhost
- Prod builds fail visibly when AUTH_BACKEND_URL missing (empty string, not localhost fallback)
- run.sh/dev.sh don't force AUTH_BACKEND_URL — let .env.app control it

## Architecture (after this PR)

```
Desktop Swift App
  ├── AUTH_BACKEND_URL (api.omi.me) ──► Python backend: /v1/auth/*
  ├── OMI_API_URL (desktop-backend)  ──► Rust backend: conversations, memories, etc.
  └── GoogleService-Info.plist        ──► Firebase project + API key
```

## Environment Variables (Swift app .env)
| Variable | Local dev | Production |
|----------|-----------|------------|
| `OMI_API_URL` | `http://localhost:8080` (forced by run.sh) | Rust desktop-backend Cloud Run URL |
| `AUTH_BACKEND_URL` | Set in .env.app (e.g. api.omi.me) | `https://api.omi.me` |
| `DEEPGRAM_API_KEY` | from .env.app | from OMI_DESKTOP_APP_ENV secret |
| `GEMINI_API_KEY` | optional | optional |

## CI Secrets (new)
| Secret | Purpose |
|--------|---------|
| `MACOS_GOOGLE_SERVICE_INFO_PLIST` | Base64-encoded prod Firebase plist |
| `AUTH_BACKEND_URL` in `OMI_DESKTOP_APP_ENV` | Must be set to `https://api.omi.me` |

## Files Changed (17 files, +476/-137)
**Desktop Swift:**
- `AuthService.swift` — env var reads via getenv(), Firebase API key from plist, prod fail-visible
- `GoogleService-Info.plist` / `GoogleService-Info-Dev.plist` — dev values only
- `run.sh` / `dev.sh` — removed Cloudflare tunnel, don't force AUTH_BACKEND_URL
- `.env.example` — documents all env vars with prod values

**Desktop Rust backend:**
- `config.rs` — dev defaults + 5 unit tests
- `main.rs` / `users.rs` — dev defaults

**Python backend (cherry-picked from #5374):**
- `auth.py` — redirect_uri validation, Admin SDK fallback for custom token generation
- `auth_callback.html` — dynamic redirect_uri with scheme validation

**CI:**
- `codemagic.yaml` / `build.sh` / `release.sh` — prod plist injection
- `tests/test_plist_injection.sh` — 6 shell tests

## Test Coverage
- 5 Rust config tests (dev defaults, env var precedence, no-prod-defaults)
- 6 shell injection tests (plist decode, fail-closed, dev fallback)
- Mac Mini e2e (Google OAuth flow verified on physical hardware)

## Review Cycle
- 3 reviewer rounds: localhost fallback fix, prod fail-visible, AUTH_BACKEND_URL not forced
- Tester: TESTS_APPROVED
- Live test: Mac Mini e2e PASSED

Closes #5540

_by AI for @beastoin_