### PR TITLE
Fix Twilio signature validation behind reverse proxy

### DIFF
--- a/backend/routers/phone_calls.py
+++ b/backend/routers/phone_calls.py
@@ -228,7 +228,7 @@ async def twiml_voice_webhook(request: Request):
     signature = request.headers.get('X-Twilio-Signature', '')
     base_api_url = os.getenv('BASE_API_URL', '').rstrip('/')
     if base_api_url:
-        url = f"{base_api_url}/v1/phone/twiml"
+        url = f"{base_api_url}{request.url.path}"
     else:
         url = str(request.url)
     form_data = await request.form()


### PR DESCRIPTION
## Summary
- Twilio webhook `/v1/phone/twiml` was returning 403 "Invalid Twilio signature" on every call
- Root cause: `request.url` returns the internal pod/proxy URL (e.g. `http://pod-ip:8080/...`), but Twilio signs requests using the public URL configured in the TwiML App (`https://api.omi.me/v1/phone/twiml`)
- Fix: reconstruct the canonical URL from `BASE_API_URL` env var (already available) so the signature matches

## Test plan
- [ ] Deploy to dev and verify phone calls connect (no more 403 on TwiML webhook)
- [ ] Verify existing non-phone-call endpoints are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)