### PR TITLE
Strip formatting chars from phone numbers before E.164 validation

### DIFF
--- a/app/lib/pages/phone_calls/phone_calls_page.dart
+++ b/app/lib/pages/phone_calls/phone_calls_page.dart
@@ -88,8 +88,8 @@ class _PhoneCallsPageState extends State<PhoneCallsPage> with SingleTickerProvid
   }
 
   Future<void> _makeCall(String phoneNumber, {String? contactName}) async {
-    // Strip spaces, dashes, parens — contacts often have formatted numbers
-    phoneNumber = phoneNumber.replaceAll(RegExp(r'[\s\-\(\)]+'), '');
+    // Strip spaces, dashes, parens, dots — contacts often have formatted numbers
+    phoneNumber = phoneNumber.replaceAll(RegExp(r'[\s\-\(\).]+'), '');
 
     var provider = context.read<PhoneCallProvider>();
 

--- a/backend/routers/phone_calls.py
+++ b/backend/routers/phone_calls.py
@@ -265,9 +265,9 @@ async def twiml_voice_webhook(request: Request):
         response.say('No verified caller ID found. Please verify a phone number first.')
         return Response(content=str(response), media_type='text/xml')
 
-    # Ensure clean E.164 format (remove all whitespace, dashes, parens)
-    caller_number = re.sub(r'[\s\-\(\)]+', '', caller_number)
-    to_number = re.sub(r'[\s\-\(\)]+', '', to_number)
+    # Ensure clean E.164 format (remove all whitespace, dashes, parens, dots)
+    caller_number = re.sub(r'[\s\-\(\).]+', '', caller_number)
+    to_number = re.sub(r'[\s\-\(\).]+', '', to_number)
 
     # Validate destination number format
     if not E164_PATTERN.match(to_number):


### PR DESCRIPTION
## Summary
- Phone numbers from contacts often contain spaces, dashes, and parens (e.g. `+91 90329 85387`)
- The TwiML webhook's E.164 regex rejected these with "Invalid destination number format"
- Now strips all whitespace, dashes, and parens from both `to_number` and `caller_number` in the backend webhook
- Also strips formatting on the client side in `_makeCall` before sending to Twilio SDK

## Test plan
- [ ] Call a contact whose number has spaces/dashes — should connect instead of returning "Invalid destination number format"
- [ ] Call via keypad (already clean digits) — still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)