### PR TITLE
fix folder deletion not reflected in UI

### DIFF
--- a/web/app/src/app/api/proxy/[...path]/route.ts
+++ b/web/app/src/app/api/proxy/[...path]/route.ts
@@ -142,9 +142,6 @@ async function handleRequest(
       ) {
         // Static reference data - cache for 1 hour
         cacheHeaders['Cache-Control'] = 'public, max-age=3600, stale-while-revalidate=86400';
-      } else if (path.includes('folders') && request.method === 'GET') {
-        // User folders - cache briefly with revalidation
-        cacheHeaders['Cache-Control'] = 'private, max-age=60, stale-while-revalidate=300';
       }
 
       return NextResponse.json(data, {


### PR DESCRIPTION
The proxy was setting `Cache-Control: max-age=60, stale-while-revalidate=300` on folder GET responses. After deletion, the browser served the cached list — making the deleted folder reappear. Removed the HTTP cache since the app already manages its own JS-level cache.

## Demo

https://github.com/user-attachments/assets/aa7450c0-c41c-4a9e-b7cb-54d67e3531d0