### PR TITLE
Add experimental Windows desktop client

### DIFF
--- a/desktop/Backend-Rust/src/routes/auth.rs
+++ b/desktop/Backend-Rust/src/routes/auth.rs
@@ -652,14 +652,50 @@ async fn generate_custom_token(
 
     tracing::info!("Firebase sign-in successful, UID: {}", firebase_uid);
 
-    // For custom token generation, we need Firebase Admin SDK
-    // In Rust, we'd need to use the service account to create a custom token
-    // For now, return an error indicating this needs server-side implementation
-    // The Python version uses firebase_admin.auth.create_custom_token()
+    // Generate Firebase custom token using service account credentials from GOOGLE_APPLICATION_CREDENTIALS
+    let sa_path = state
+        .config
+        .google_application_credentials
+        .as_ref()
+        .ok_or("GOOGLE_APPLICATION_CREDENTIALS not configured")?;
 
-    // TODO: Implement custom token generation using service account
-    // This requires signing a JWT with the service account private key
-    Err("Custom token generation requires Firebase Admin SDK - not yet implemented in Rust".into())
+    #[derive(Deserialize)]
+    struct ServiceAccount {
+        client_email: String,
+        private_key: String,
+        project_id: String,
+    }
+
+    let sa_json = tokio::fs::read_to_string(sa_path).await?;
+    let sa: ServiceAccount = serde_json::from_str(&sa_json)?;
+
+    #[derive(Serialize)]
+    struct FirebaseCustomTokenClaims<'a> {
+        iss: &'a str,
+        sub: &'a str,
+        aud: &'a str,
+        uid: &'a str,
+        iat: i64,
+        exp: i64,
+    }
+
+    let now = Utc::now().timestamp();
+    let claims = FirebaseCustomTokenClaims {
+        iss: &sa.client_email,
+        sub: &sa.client_email,
+        aud: "https://identitytoolkit.googleapis.com/google.identity.identitytoolkit.v1.IdentityToolkit",
+        uid: &firebase_uid,
+        iat: now,
+        exp: now + 3600,
+    };
+
+    let mut header = Header::new(Algorithm::RS256);
+    header.kid = None;
+
+    let key = EncodingKey::from_rsa_pem(sa.private_key.as_bytes())?;
+    let token = encode(&header, &claims, &key)?;
+
+    Ok(token)
 }
 
 fn render_auth_callback(code: &str, state: &str, redirect_uri: &str, error: Option<&str>) -> String {

--- a/windows/App/App.xaml
+++ b/windows/App/App.xaml
@@ -1,0 +1,9 @@
+﻿<Application x:Class="Omi.Windows.App.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:local="clr-namespace:Omi.Windows.App"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+         
+    </Application.Resources>
+</Application>

--- a/windows/App/App.xaml.cs
+++ b/windows/App/App.xaml.cs
@@ -1,0 +1,13 @@
+﻿using System.Configuration;
+using System.Data;
+using System.Windows;
+
+namespace Omi.Windows.App;
+
+/// <summary>
+/// Interaction logic for App.xaml
+/// </summary>
+public partial class App : Application
+{
+}
+

--- a/windows/App/AssemblyInfo.cs
+++ b/windows/App/AssemblyInfo.cs
@@ -1,0 +1,10 @@
+using System.Windows;
+
+[assembly:ThemeInfo(
+    ResourceDictionaryLocation.None,            //where theme specific resource dictionaries are located
+                                                //(used if a resource is not found in the page,
+                                                // or application resource dictionaries)
+    ResourceDictionaryLocation.SourceAssembly   //where the generic resource dictionary is located
+                                                //(used if a resource is not found in the page,
+                                                // app, or any theme specific resource dictionaries)
+)]

--- a/windows/App/FloatingBar/FloatingBarWindow.xaml
+++ b/windows/App/FloatingBar/FloatingBarWindow.xaml
@@ -1,0 +1,31 @@
+<Window x:Class="Omi.Windows.App.FloatingBar.FloatingBarWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Omi Floating Bar"
+        Width="400"
+        Height="80"
+        Topmost="True"
+        WindowStyle="None"
+        ResizeMode="CanResizeWithGrip"
+        AllowsTransparency="True"
+        Background="#AA202020"
+        ShowInTaskbar="False">
+    <Border CornerRadius="8" Background="#DD202020" Padding="8">
+        <DockPanel>
+            <Button Content="🎙"
+                    Width="32"
+                    Height="32"
+                    Margin="0,0,8,0"
+                    DockPanel.Dock="Left"
+                    ToolTip="Push-to-talk (Ctrl+Alt+O)" />
+            <TextBox x:Name="QueryTextBox"
+                     VerticalContentAlignment="Center"
+                     Background="#FF303030"
+                     Foreground="White"
+                     BorderThickness="0"
+                     Padding="4"
+                     Text="Posez une question à Omi..." />
+        </DockPanel>
+    </Border>
+</Window>
+

--- a/windows/App/FloatingBar/FloatingBarWindow.xaml.cs
+++ b/windows/App/FloatingBar/FloatingBarWindow.xaml.cs
@@ -1,0 +1,12 @@
+using System.Windows;
+
+namespace Omi.Windows.App.FloatingBar;
+
+public partial class FloatingBarWindow : Window
+{
+    public FloatingBarWindow()
+    {
+        InitializeComponent();
+    }
+}
+

--- a/windows/App/Infrastructure/EnvConfig.cs
+++ b/windows/App/Infrastructure/EnvConfig.cs
@@ -1,0 +1,31 @@
+using System;
+
+namespace Omi.Windows.App.Infrastructure;
+
+public static class EnvConfig
+{
+    // Point par défaut vers la prod, surchargeable via variable d'env
+    private const string DefaultApiBaseUrl = "https://api.omi.me/";
+    private const string DefaultFirebaseApiKey = "";
+
+    public static string ApiBaseUrl
+    {
+        get
+        {
+            var fromEnv = Environment.GetEnvironmentVariable("OMI_API_BASE_URL");
+            if (string.IsNullOrWhiteSpace(fromEnv))
+            {
+                return DefaultApiBaseUrl;
+            }
+
+            fromEnv = fromEnv.TrimEnd('/') + "/";
+            return fromEnv;
+        }
+    }
+
+    public static string FirebaseApiKey =>
+        Environment.GetEnvironmentVariable("OMI_FIREBASE_API_KEY")
+        ?? Environment.GetEnvironmentVariable("FIREBASE_API_KEY")
+        ?? DefaultFirebaseApiKey;
+}
+

--- a/windows/App/MainWindow.xaml
+++ b/windows/App/MainWindow.xaml
@@ -1,0 +1,31 @@
+<Window x:Class="Omi.Windows.App.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:Omi.Windows.App"
+        mc:Ignorable="d"
+        Title="Omi for Windows (Phase 1)" Height="450" Width="800">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <StackPanel Orientation="Horizontal" Margin="0,0,0,8">
+            <Button Content="Démarrer l'enregistrement"
+                    Width="200"
+                    Margin="0,0,8,0"
+                    Click="OnStartRecordingClick" />
+            <Button Content="Arrêter"
+                    Width="100"
+                    Click="OnStopRecordingClick" />
+        </StackPanel>
+
+        <TextBox Grid.Row="1"
+                 Text="{Binding LastTranscript, Mode=OneWay}"
+                 TextWrapping="Wrap"
+                 VerticalScrollBarVisibility="Auto"
+                 IsReadOnly="True" />
+    </Grid>
+</Window>

--- a/windows/App/MainWindow.xaml.cs
+++ b/windows/App/MainWindow.xaml.cs
@@ -1,0 +1,89 @@
+using System;
+using System.Windows;
+using System.Windows.Interop;
+using Omi.Windows.App.Services.Audio;
+using Omi.Windows.App.Services.Auth;
+using Omi.Windows.App.Services.Hotkeys;
+using Omi.Windows.App.Services.Notifications;
+using Omi.Windows.App.Services.Transcription;
+using Omi.Windows.App.ViewModels;
+using Omi.Windows.App.FloatingBar;
+
+namespace Omi.Windows.App;
+
+public partial class MainWindow : Window
+{
+    private readonly CaptureViewModel _captureViewModel;
+    private readonly GlobalHotkeyManager _hotkeyManager;
+    private readonly WindowsNotificationService _notificationService = new();
+    private FloatingBarWindow? _floatingBar;
+
+    public MainWindow()
+    {
+        InitializeComponent();
+
+        // Wiring minimal manuel pour la phase 1
+        var authService = new AuthService(new System.Net.Http.HttpClient());
+        var sttClient = new SttWebSocketClient(authService);
+        var audioService = new AudioCaptureService();
+        _captureViewModel = new CaptureViewModel(audioService, sttClient);
+
+        DataContext = _captureViewModel;
+
+        if (!authService.IsAuthenticated)
+        {
+            var tokenWindow = new TokenInputWindow(authService);
+            tokenWindow.ShowDialog();
+        }
+
+        Loaded += OnLoaded;
+        Closed += OnClosed;
+
+        _hotkeyManager = new GlobalHotkeyManager(ToggleFloatingBar);
+    }
+
+    private void OnLoaded(object sender, RoutedEventArgs e)
+    {
+        var source = (HwndSource)PresentationSource.FromVisual(this)!;
+        _hotkeyManager.Register(source);
+
+        _notificationService.ShowInfo("Omi pour Windows", "App démarrée. Raccourci barre flottante : Ctrl+Alt+O.");
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        _hotkeyManager.Dispose();
+        _floatingBar?.Close();
+    }
+
+    private void ToggleFloatingBar()
+    {
+        if (_floatingBar is { IsVisible: true })
+        {
+            _floatingBar.Hide();
+            return;
+        }
+
+        if (_floatingBar is null)
+        {
+            _floatingBar = new FloatingBarWindow
+            {
+                Left = SystemParameters.WorkArea.Right - 420,
+                Top = SystemParameters.WorkArea.Bottom - 120
+            };
+        }
+
+        _floatingBar.Show();
+        _floatingBar.Activate();
+    }
+
+    private async void OnStartRecordingClick(object sender, RoutedEventArgs e)
+    {
+        await _captureViewModel.StartAsync();
+    }
+
+    private async void OnStopRecordingClick(object sender, RoutedEventArgs e)
+    {
+        await _captureViewModel.StopAsync();
+    }
+}

--- a/windows/App/Omi.Windows.App.csproj
+++ b/windows/App/Omi.Windows.App.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net9.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Toolkit.Uwp.Notifications" Version="7.1.3" />
+    <PackageReference Include="NAudio" Version="2.2.1" />
+    <PackageReference Include="System.Net.WebSockets.Client" Version="4.3.2" />
+  </ItemGroup>
+
+</Project>

--- a/windows/App/Services/Api/HttpApiClient.cs
+++ b/windows/App/Services/Api/HttpApiClient.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Omi.Windows.App.Infrastructure;
+
+namespace Omi.Windows.App.Services.Api;
+
+public class HttpApiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly IAuthTokenProvider _authTokenProvider;
+
+    public HttpApiClient(HttpClient httpClient, IAuthTokenProvider authTokenProvider)
+    {
+        _httpClient = httpClient;
+        _authTokenProvider = authTokenProvider;
+        _httpClient.BaseAddress ??= new Uri(EnvConfig.ApiBaseUrl);
+    }
+
+    public async Task<T?> GetAsync<T>(string path, bool requireAuth = true, CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, path);
+        await EnrichHeadersAsync(request, requireAuth, ct).ConfigureAwait(false);
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        return await response.Content.ReadFromJsonAsync<T>(cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    public async Task<TResponse?> PostJsonAsync<TRequest, TResponse>(
+        string path,
+        TRequest body,
+        bool requireAuth = true,
+        CancellationToken ct = default)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Post, path)
+        {
+            Content = JsonContent.Create(body)
+        };
+
+        await EnrichHeadersAsync(request, requireAuth, ct).ConfigureAwait(false);
+        using var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+            .ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+        if (response.Content.Headers.ContentLength is 0)
+        {
+            return default;
+        }
+        return await response.Content.ReadFromJsonAsync<TResponse>(cancellationToken: ct).ConfigureAwait(false);
+    }
+
+    private async Task EnrichHeadersAsync(HttpRequestMessage request, bool requireAuth, CancellationToken ct)
+    {
+        request.Headers.Add("X-App-Platform", "windows");
+        request.Headers.Add("X-App-Version", "0.1.0");
+        request.Headers.Add("X-Request-Start-Time", (DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() / 1000.0).ToString("F3"));
+
+        if (!requireAuth)
+        {
+            return;
+        }
+
+        var token = await _authTokenProvider.GetIdTokenAsync(ct).ConfigureAwait(false);
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            request.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+        }
+    }
+}
+

--- a/windows/App/Services/Api/IAuthTokenProvider.cs
+++ b/windows/App/Services/Api/IAuthTokenProvider.cs
@@ -1,0 +1,10 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Omi.Windows.App.Services.Api;
+
+public interface IAuthTokenProvider
+{
+    Task<string?> GetIdTokenAsync(CancellationToken ct = default);
+}
+

--- a/windows/App/Services/Audio/AudioCaptureService.cs
+++ b/windows/App/Services/Audio/AudioCaptureService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using NAudio.Wave;
+
+namespace Omi.Windows.App.Services.Audio;
+
+public sealed class AudioCaptureService : IAsyncDisposable
+{
+    private const int TargetSampleRate = 16000;
+    private const int Channels = 1;
+
+    private WaveInEvent? _waveIn;
+    private WaveFormat? _inputFormat;
+    private readonly object _sync = new();
+    private Func<byte[], Task>? _onAudioFrame;
+
+    public bool IsCapturing { get; private set; }
+
+    public void Configure(Func<byte[], Task> onAudioFrame)
+    {
+        _onAudioFrame = onAudioFrame;
+    }
+
+    public Task<bool> StartAsync(CancellationToken ct = default)
+    {
+        lock (_sync)
+        {
+            if (IsCapturing)
+            {
+                return Task.FromResult(true);
+            }
+
+            _waveIn = new WaveInEvent
+            {
+                WaveFormat = new WaveFormat(TargetSampleRate, 16, Channels),
+                BufferMilliseconds = 100
+            };
+
+            _inputFormat = _waveIn.WaveFormat;
+            _waveIn.DataAvailable += OnDataAvailable;
+            _waveIn.RecordingStopped += OnRecordingStopped;
+            _waveIn.StartRecording();
+            IsCapturing = true;
+        }
+
+        return Task.FromResult(true);
+    }
+
+    public Task StopAsync()
+    {
+        lock (_sync)
+        {
+            if (!IsCapturing || _waveIn is null)
+            {
+                return Task.CompletedTask;
+            }
+
+            _waveIn.StopRecording();
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void OnDataAvailable(object? sender, WaveInEventArgs e)
+    {
+        var handler = _onAudioFrame;
+        if (handler is null || e.BytesRecorded == 0)
+        {
+            return;
+        }
+
+        // e.Buffer est déjà en PCM16 mono à 16 kHz, on peut envoyer tel quel
+        var buffer = new byte[e.BytesRecorded];
+        Array.Copy(e.Buffer, buffer, e.BytesRecorded);
+
+        _ = handler(buffer);
+    }
+
+    private void OnRecordingStopped(object? sender, StoppedEventArgs e)
+    {
+        lock (_sync)
+        {
+            if (_waveIn is not null)
+            {
+                _waveIn.DataAvailable -= OnDataAvailable;
+                _waveIn.RecordingStopped -= OnRecordingStopped;
+                _waveIn.Dispose();
+                _waveIn = null;
+            }
+
+            IsCapturing = false;
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync().ConfigureAwait(false);
+    }
+}
+

--- a/windows/App/Services/Auth/AuthService.cs
+++ b/windows/App/Services/Auth/AuthService.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Win32;
+using Omi.Windows.App.Infrastructure;
+using Omi.Windows.App.Services.Api;
+
+namespace Omi.Windows.App.Services.Auth;
+
+public class AuthService : IAuthTokenProvider
+{
+    private const string RegistryKeyPath = @"Software\Omi\WindowsApp";
+    private const string TokenValueName = "IdToken";
+    private const string DefaultRedirectUri = "omi://auth/callback";
+
+    private readonly HttpClient _httpClient;
+
+    private string? _cachedToken;
+
+    public AuthService(HttpClient httpClient)
+    {
+        _httpClient = httpClient;
+        _httpClient.BaseAddress ??= new Uri(EnvConfig.ApiBaseUrl);
+        _cachedToken = LoadTokenFromRegistry();
+    }
+
+    public bool IsAuthenticated => !string.IsNullOrWhiteSpace(_cachedToken);
+
+    /// <summary>
+    /// Ouvre la page de connexion Omi dans le navigateur.
+    /// </summary>
+    public void OpenAuthPage(string provider = "apple", string? redirectUri = null)
+    {
+        var redirect = string.IsNullOrWhiteSpace(redirectUri) ? DefaultRedirectUri : redirectUri!;
+        var baseUrl = EnvConfig.ApiBaseUrl.TrimEnd('/');
+        var url = $"{baseUrl}/v1/auth/authorize?provider={provider}&redirect_uri={Uri.EscapeDataString(redirect)}";
+
+        try
+        {
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true,
+            });
+        }
+        catch
+        {
+            // Ignorer les erreurs d’ouverture de navigateur, l’utilisateur pourra copier l’URL manuellement si besoin.
+        }
+    }
+
+    /// <summary>
+    /// Mode développement / debug : accepte un token déjà prêt (Firebase ID token).
+    /// </summary>
+    public async Task<bool> SignInWithPastedTokenAsync(string rawToken, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(rawToken))
+        {
+            return false;
+        }
+
+        _cachedToken = rawToken.Trim();
+        SaveTokenToRegistry(_cachedToken);
+        return true;
+    }
+
+    /// <summary>
+    /// Échange un auth_code Omi contre un Firebase ID token en utilisant
+    /// /v1/auth/token (backend Python) puis Firebase Identity Toolkit.
+    /// </summary>
+    public async Task<bool> SignInWithAuthCodeAsync(string authCode, string? redirectUri = null, CancellationToken ct = default)
+    {
+        if (string.IsNullOrWhiteSpace(authCode))
+        {
+            return false;
+        }
+
+        var redirect = string.IsNullOrWhiteSpace(redirectUri) ? DefaultRedirectUri : redirectUri!;
+
+        // 1) Échanger le code contre un custom_token via /v1/auth/token
+        using var form = new FormUrlEncodedContent(new[]
+        {
+            new KeyValuePair<string?, string?>("grant_type", "authorization_code"),
+            new KeyValuePair<string?, string?>("code", authCode.Trim()),
+            new KeyValuePair<string?, string?>("redirect_uri", redirect),
+            new KeyValuePair<string?, string?>("use_custom_token", "true"),
+        });
+
+        using var tokenResponse = await _httpClient.PostAsync("v1/auth/token", form, ct).ConfigureAwait(false);
+        if (!tokenResponse.IsSuccessStatusCode)
+        {
+            return false;
+        }
+
+        var tokenPayload = await tokenResponse.Content.ReadFromJsonAsync<AuthTokenResponse>(cancellationToken: ct)
+            .ConfigureAwait(false);
+        if (tokenPayload is null || string.IsNullOrWhiteSpace(tokenPayload.CustomToken))
+        {
+            return false;
+        }
+
+        // 2) Échanger custom_token contre Firebase ID token via Identity Toolkit
+        if (string.IsNullOrWhiteSpace(EnvConfig.FirebaseApiKey))
+        {
+            // Sans clé Firebase côté client, on ne peut pas obtenir d’ID token
+            return false;
+        }
+
+        var firebaseUrl =
+            $"https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key={EnvConfig.FirebaseApiKey}";
+
+        var firebaseBody = new FirebaseSignInWithCustomTokenRequest
+        {
+            Token = tokenPayload.CustomToken,
+            ReturnSecureToken = true,
+        };
+
+        using var firebaseResponse =
+            await _httpClient.PostAsJsonAsync(firebaseUrl, firebaseBody, ct).ConfigureAwait(false);
+        if (!firebaseResponse.IsSuccessStatusCode)
+        {
+            return false;
+        }
+
+        var firebasePayload =
+            await firebaseResponse.Content.ReadFromJsonAsync<FirebaseSignInWithCustomTokenResponse>(
+                cancellationToken: ct).ConfigureAwait(false);
+        if (firebasePayload is null || string.IsNullOrWhiteSpace(firebasePayload.IdToken))
+        {
+            return false;
+        }
+
+        _cachedToken = firebasePayload.IdToken;
+        SaveTokenToRegistry(_cachedToken);
+        return true;
+    }
+
+    public Task SignOutAsync()
+    {
+        _cachedToken = null;
+        try
+        {
+            using var key = Registry.CurrentUser.CreateSubKey(RegistryKeyPath);
+            key?.DeleteValue(TokenValueName, false);
+        }
+        catch
+        {
+            // Ignorer les erreurs de nettoyage
+        }
+
+        return Task.CompletedTask;
+    }
+
+    public Task<string?> GetIdTokenAsync(CancellationToken ct = default)
+    {
+        return Task.FromResult(_cachedToken);
+    }
+
+    private sealed class AuthTokenResponse
+    {
+        public string? Provider { get; set; }
+        public string? IdToken { get; set; }
+        public string? AccessToken { get; set; }
+        public string? ProviderId { get; set; }
+        public string? TokenType { get; set; }
+        public int ExpiresIn { get; set; }
+        public string? CustomToken { get; set; }
+    }
+
+    private sealed class FirebaseSignInWithCustomTokenRequest
+    {
+        public string Token { get; set; } = string.Empty;
+        public bool ReturnSecureToken { get; set; }
+    }
+
+    private sealed class FirebaseSignInWithCustomTokenResponse
+    {
+        public string? IdToken { get; set; }
+        public string? RefreshToken { get; set; }
+        public string? LocalId { get; set; }
+        public string? ExpiresIn { get; set; }
+    }
+
+    private static string? LoadTokenFromRegistry()
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.OpenSubKey(RegistryKeyPath);
+            return key?.GetValue(TokenValueName) as string;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static void SaveTokenToRegistry(string token)
+    {
+        try
+        {
+            using var key = Registry.CurrentUser.CreateSubKey(RegistryKeyPath);
+            key?.SetValue(TokenValueName, token);
+        }
+        catch
+        {
+            // Ignorer les erreurs de persistance ; l’app restera fonctionnelle pour la session courante
+        }
+    }
+}
+

--- a/windows/App/Services/Hotkeys/GlobalHotkeyManager.cs
+++ b/windows/App/Services/Hotkeys/GlobalHotkeyManager.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Runtime.InteropServices;
+using System.Windows.Interop;
+
+namespace Omi.Windows.App.Services.Hotkeys;
+
+public sealed class GlobalHotkeyManager : IDisposable
+{
+    private const int HotkeyId = 1;
+    private const int WmHotkey = 0x0312;
+
+    [DllImport("user32.dll")]
+    private static extern bool RegisterHotKey(IntPtr hWnd, int id, uint fsModifiers, uint vk);
+
+    [DllImport("user32.dll")]
+    private static extern bool UnregisterHotKey(IntPtr hWnd, int id);
+
+    private readonly Action _onToggleFloatingBar;
+    private HwndSource? _source;
+
+    public GlobalHotkeyManager(Action onToggleFloatingBar)
+    {
+        _onToggleFloatingBar = onToggleFloatingBar;
+    }
+
+    public void Register(HwndSource source)
+    {
+        _source = source;
+        _source.AddHook(WndProc);
+
+        const uint modifiers = 0x0002 | 0x0004; // CTRL + ALT
+        const uint vkO = 0x4F; // O
+
+        RegisterHotKey(_source.Handle, HotkeyId, modifiers, vkO);
+    }
+
+    private IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+    {
+        if (msg == WmHotkey && wParam.ToInt32() == HotkeyId)
+        {
+            _onToggleFloatingBar();
+            handled = true;
+        }
+
+        return IntPtr.Zero;
+    }
+
+    public void Dispose()
+    {
+        if (_source != null)
+        {
+            UnregisterHotKey(_source.Handle, HotkeyId);
+            _source.RemoveHook(WndProc);
+            _source = null;
+        }
+    }
+}
+

--- a/windows/App/Services/Notifications/WindowsNotificationService.cs
+++ b/windows/App/Services/Notifications/WindowsNotificationService.cs
@@ -1,0 +1,13 @@
+using System.Windows;
+
+namespace Omi.Windows.App.Services.Notifications;
+
+public class WindowsNotificationService
+{
+    public void ShowInfo(string title, string message)
+    {
+        // Phase 2 : fallback simple en attendant une intégration Toast complète
+        MessageBox.Show(message, title, MessageBoxButton.OK, MessageBoxImage.Information);
+    }
+}
+

--- a/windows/App/Services/Transcription/SttWebSocketClient.cs
+++ b/windows/App/Services/Transcription/SttWebSocketClient.cs
@@ -1,0 +1,111 @@
+using System;
+using System.Net.WebSockets;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Omi.Windows.App.Infrastructure;
+using Omi.Windows.App.Services.Api;
+
+namespace Omi.Windows.App.Services.Transcription;
+
+public sealed class SttWebSocketClient : IAsyncDisposable
+{
+    private readonly IAuthTokenProvider _authTokenProvider;
+    private ClientWebSocket? _socket;
+
+    public event Func<string, Task>? OnTranscriptJson;
+
+    public SttWebSocketClient(IAuthTokenProvider authTokenProvider)
+    {
+        _authTokenProvider = authTokenProvider;
+    }
+
+    public async Task<bool> ConnectAsync(string language = "multi", CancellationToken ct = default)
+    {
+        if (_socket is { State: WebSocketState.Open })
+        {
+            return true;
+        }
+
+        var token = await _authTokenProvider.GetIdTokenAsync(ct).ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(token))
+        {
+            return false;
+        }
+
+        var apiUri = new Uri(EnvConfig.ApiBaseUrl);
+        var wsScheme = apiUri.Scheme == "https" ? "wss" : "ws";
+        var builder = new UriBuilder(apiUri)
+        {
+            Scheme = wsScheme,
+            Path = "v4/listen",
+            Query = $"language={language}&sample_rate=16000&codec=pcm16&channels=1&source=windows"
+        };
+
+        try
+        {
+            _socket?.Dispose();
+            _socket = new ClientWebSocket();
+            _socket.Options.SetRequestHeader("Authorization", $"Bearer {token}");
+
+            await _socket.ConnectAsync(builder.Uri, ct).ConfigureAwait(false);
+
+            _ = Task.Run(() => ReceiveLoopAsync(_socket, ct), ct);
+
+            return _socket.State == WebSocketState.Open;
+        }
+        catch (Exception ex)
+        {
+            if (OnTranscriptJson is not null)
+            {
+                await OnTranscriptJson.Invoke($"{{\"type\":\"error\",\"message\":\"WebSocket connect failed: {ex.Message}\"}}")
+                    .ConfigureAwait(false);
+            }
+            _socket?.Dispose();
+            _socket = null;
+            return false;
+        }
+    }
+
+    public async Task SendAudioAsync(byte[] buffer, CancellationToken ct = default)
+    {
+        if (_socket is not { State: WebSocketState.Open })
+        {
+            return;
+        }
+
+        await _socket.SendAsync(buffer, WebSocketMessageType.Binary, true, ct).ConfigureAwait(false);
+    }
+
+    private async Task ReceiveLoopAsync(ClientWebSocket socket, CancellationToken ct)
+    {
+        var buffer = new byte[64 * 1024];
+        while (!ct.IsCancellationRequested && socket.State == WebSocketState.Open)
+        {
+            var result = await socket.ReceiveAsync(buffer, ct).ConfigureAwait(false);
+            if (result.MessageType == WebSocketMessageType.Close)
+            {
+                break;
+            }
+
+            var json = System.Text.Encoding.UTF8.GetString(buffer, 0, result.Count);
+            if (OnTranscriptJson is not null)
+            {
+                await OnTranscriptJson.Invoke(json).ConfigureAwait(false);
+            }
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_socket is { State: WebSocketState.Open } s)
+        {
+            await s.CloseAsync(WebSocketCloseStatus.NormalClosure, "Disposing", CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+
+        _socket?.Dispose();
+        _socket = null;
+    }
+}
+

--- a/windows/App/TokenInputWindow.xaml
+++ b/windows/App/TokenInputWindow.xaml
@@ -1,0 +1,47 @@
+<Window x:Class="Omi.Windows.App.TokenInputWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="Connexion Omi" Height="260" Width="520" WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <TextBlock Text="1. Clique sur « Ouvrir la page de connexion » pour te connecter avec Apple (ou Google)."
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,4" />
+        <TextBlock Grid.Row="1"
+                   Text="2. Après la connexion, copie le paramètre 'code' de l’URL de callback (omi://auth/callback?code=...)."
+                   TextWrapping="Wrap"
+                   Margin="0,0,0,8" />
+
+        <TextBox x:Name="TokenTextBox"
+                 Grid.Row="2"
+                 AcceptsReturn="True"
+                 VerticalScrollBarVisibility="Auto"
+                 TextWrapping="Wrap" />
+
+        <StackPanel Grid.Row="3"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Margin="0,8,0,0">
+            <Button Content="Ouvrir la page de connexion"
+                    Width="200"
+                    Margin="0,0,8,0"
+                    Click="OnOpenAuthPageClick" />
+            <Button Content="Annuler"
+                    Width="80"
+                    Margin="0,0,8,0"
+                    IsCancel="True" />
+            <Button Content="Valider"
+                    Width="80"
+                    IsDefault="True"
+                    Click="OnValidateClick" />
+        </StackPanel>
+    </Grid>
+</Window>
+

--- a/windows/App/TokenInputWindow.xaml.cs
+++ b/windows/App/TokenInputWindow.xaml.cs
@@ -1,0 +1,38 @@
+using System.Windows;
+using Omi.Windows.App.Services.Auth;
+
+namespace Omi.Windows.App;
+
+public partial class TokenInputWindow : Window
+{
+    private readonly AuthService _authService;
+
+    public TokenInputWindow(AuthService authService)
+    {
+        _authService = authService;
+        InitializeComponent();
+    }
+
+    private async void OnValidateClick(object sender, RoutedEventArgs e)
+    {
+        var code = TokenTextBox.Text;
+        // Pour l’instant on suppose que le redirect_uri utilisé pour /v1/auth/authorize est omi://auth/callback
+        var ok = await _authService.SignInWithAuthCodeAsync(code, null);
+        if (!ok)
+        {
+            MessageBox.Show(this, "Impossible d’échanger le code contre un jeton Omi.\nVérifie que tu utilises le même redirect_uri et que le code n’a pas expiré.", "Erreur", MessageBoxButton.OK,
+                MessageBoxImage.Error);
+            return;
+        }
+
+        DialogResult = true;
+        Close();
+    }
+
+    private void OnOpenAuthPageClick(object sender, RoutedEventArgs e)
+    {
+        // Ouvre le flux d’authentification standard sur le backend existant
+        _authService.OpenAuthPage("apple", null);
+    }
+}
+

--- a/windows/App/ViewModels/CaptureViewModel.cs
+++ b/windows/App/ViewModels/CaptureViewModel.cs
@@ -1,0 +1,107 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Omi.Windows.App.Services.Audio;
+using Omi.Windows.App.Services.Transcription;
+
+namespace Omi.Windows.App.ViewModels;
+
+public sealed class CaptureViewModel : INotifyPropertyChanged
+{
+    private readonly AudioCaptureService _audioCaptureService;
+    private readonly SttWebSocketClient _sttClient;
+    private readonly CancellationTokenSource _cts = new();
+
+    private bool _isRecording;
+    private string _lastTranscript = string.Empty;
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    public bool IsRecording
+    {
+        get => _isRecording;
+        private set
+        {
+            if (value == _isRecording) return;
+            _isRecording = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public string LastTranscript
+    {
+        get => _lastTranscript;
+        private set
+        {
+            if (value == _lastTranscript) return;
+            _lastTranscript = value;
+            OnPropertyChanged();
+        }
+    }
+
+    public CaptureViewModel(AudioCaptureService audioCaptureService, SttWebSocketClient sttClient)
+    {
+        _audioCaptureService = audioCaptureService;
+        _sttClient = sttClient;
+
+        _audioCaptureService.Configure(async bytes =>
+        {
+            await _sttClient.SendAudioAsync(bytes, _cts.Token).ConfigureAwait(false);
+        });
+
+        _sttClient.OnTranscriptJson += HandleTranscriptJsonAsync;
+    }
+
+    public async Task StartAsync()
+    {
+        if (IsRecording)
+        {
+            return;
+        }
+
+        if (!await _sttClient.ConnectAsync(ct: _cts.Token).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        var ok = await _audioCaptureService.StartAsync(_cts.Token).ConfigureAwait(false);
+        if (ok)
+        {
+            IsRecording = true;
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        if (!IsRecording)
+        {
+            return;
+        }
+
+        await _audioCaptureService.StopAsync().ConfigureAwait(false);
+        IsRecording = false;
+    }
+
+    private Task HandleTranscriptJsonAsync(string json)
+    {
+        // Phase 1 : on stocke simplement le dernier message JSON reçu
+        try
+        {
+            using var doc = JsonDocument.Parse(json);
+            LastTranscript = doc.RootElement.ToString();
+        }
+        catch
+        {
+            LastTranscript = json;
+        }
+
+        return Task.CompletedTask;
+    }
+
+    private void OnPropertyChanged([CallerMemberName] string? propertyName = null) =>
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+}
+

--- a/windows/Omi.Windows.sln
+++ b/windows/Omi.Windows.sln
@@ -1,0 +1,39 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "App", "App", "{F95F473B-E98A-ACD6-1986-755F447BE36F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Omi.Windows.App", "App\Omi.Windows.App.csproj", "{1580F655-778A-4D00-B9FB-FC5429883782}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Debug|x64.Build.0 = Debug|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Debug|x86.Build.0 = Debug|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Release|x64.ActiveCfg = Release|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Release|x64.Build.0 = Release|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Release|x86.ActiveCfg = Release|Any CPU
+		{1580F655-778A-4D00-B9FB-FC5429883782}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{1580F655-778A-4D00-B9FB-FC5429883782} = {F95F473B-E98A-ACD6-1986-755F447BE36F}
+	EndGlobalSection
+EndGlobal

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,124 @@
+## Omi Windows – Guide contributeur
+
+### 1. Objectif
+
+Ce dossier contient une première implémentation d’un client Windows natif (WPF) pour Omi, qui se branche sur les **endpoints publics existants** :
+
+- Backend principal : `https://api.omi.me`
+- Authentification : `/v1/auth/authorize`, `/v1/auth/callback/*`, `/v1/auth/token`
+- WebSocket STT temps réel : `/v4/listen`
+
+L’app Windows suit le même modèle que les autres clients : tout passe par **Firebase Auth** (ID token), vérifié côté serveur.
+
+---
+
+### 2. Pré-requis
+
+- Windows 11
+- .NET 9 SDK (`dotnet --version` ≈ 9.x)
+
+Variables d’environnement recommandées :
+
+- `OMI_API_BASE_URL` (optionnel) : URL de base de l’API, défaut : `https://api.omi.me/`.
+- `OMI_FIREBASE_API_KEY` **ou** `FIREBASE_API_KEY` : clé Web Firebase utilisée par le frontend Omi (publique, pas un secret serveur).
+
+---
+
+### 3. Lancer l’app Windows en local
+
+Dans la racine du mono-repo :
+
+```powershell
+cd D:\omi
+dotnet run --project windows/App/Omi.Windows.App.csproj
+```
+
+Une fenêtre “Connexion Omi” apparaît au premier lancement.
+
+---
+
+### 4. Flux d’authentification (Apple/Google)
+
+L’app ne gère **pas** directement le flux OAuth : elle délègue entièrement au backend Python existant (`backend/routers/auth.py`).
+
+#### Étapes côté utilisateur (mode manuel actuel)
+
+1. Dans la fenêtre “Connexion Omi”, clique sur **“Ouvrir la page de connexion”**.  
+   Cela ouvre dans ton navigateur :
+
+   ```text
+   https://api.omi.me/v1/auth/authorize?provider=apple&redirect_uri=omi://auth/callback
+   ```
+
+2. Connecte‑toi avec Apple (ou Google une fois supporté côté UI), comme tu le fais déjà dans les autres apps Omi.
+
+3. À la fin, tu es redirigé vers une URL de callback du type :
+
+   ```text
+   omi://auth/callback?code=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+   ```
+
+   Copie **la valeur du paramètre `code`**.
+
+4. Colle ce `code` dans la zone de texte de la fenêtre “Connexion Omi”, puis clique sur **“Valider”**.
+
+#### Ce qui se passe côté app Windows
+
+La méthode `AuthService.SignInWithAuthCodeAsync` :
+
+1. Appelle `POST /v1/auth/token` sur l’API Omi existante :
+
+   - Body `x-www-form-urlencoded` :
+
+     - `grant_type=authorization_code`
+     - `code=<code_collé>`
+     - `redirect_uri=omi://auth/callback`
+     - `use_custom_token=true`
+
+   - Le backend retourne :
+
+     - `provider` (apple/google),
+     - `id_token` + `access_token` du provider,
+     - `provider_id`,
+     - `custom_token` (Firebase custom token) si `use_custom_token=true`.
+
+2. Échange `custom_token` contre un **Firebase ID token** via l’API publique Firebase Identity Toolkit :
+
+   ```text
+   POST https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=<FIREBASE_API_KEY>
+   {
+     "token": "<custom_token>",
+     "returnSecureToken": true
+   }
+   ```
+
+   → Réponse : `idToken`, `refreshToken`, `localId`, etc.
+
+3. Stocke `idToken` en local (registre Windows, clé `HKCU\Software\Omi\WindowsApp\IdToken`) et l’utilise comme **token d’authentification** pour :
+
+   - les requêtes HTTP sécurisées (via `HttpApiClient`),
+   - le WebSocket `/v4/listen` (via `SttWebSocketClient`).
+
+Le backend `/v4/listen` voit donc un **Firebase ID token** standard et le valide exactement comme pour les clients mobile/macOS.
+
+---
+
+### 5. Tester la capture audio + STT
+
+Une fois connecté (fenêtre de login fermée) :
+
+1. Clique sur **“Démarrer l’enregistrement”**.
+2. Parle quelques secondes dans ton micro.
+3. Clique sur **“Arrêter”**.
+4. Observe la grande zone de texte :
+   - en cas de succès, tu verras les messages JSON renvoyés par `/v4/listen` (segments, events, etc.),
+   - en cas d’erreur (ex. token invalide, 403), tu verras un JSON d’erreur explicite sans que l’app ne se ferme.
+
+---
+
+### 6. Notes pour contributions futures
+
+- **Schéma de callback** : pour une meilleure UX, on pourra enregistrer un schéma `omi://auth/callback-windows` via l’installer Windows, pour éviter le copier/coller manuel du `code`.
+- **Provider Google** : le flux `/v1/auth/authorize?provider=google` est déjà supporté côté backend ; il suffira d’ajouter une option dans l’UI Windows pour le sélectionner.
+- **Sécurité** : la clé `FIREBASE_API_KEY` est une clé web publique (comme sur les autres clients). Les secrets sensibles (service account, etc.) restent sur le backend Python/Firebase Admin, jamais embarqués dans l’app Windows.
+


### PR DESCRIPTION
**Summary**  
This PR adds an experimental Windows desktop client (WPF / .NET 9) that integrates with the existing Omi backend and Firebase-based auth, without modifying the existing mobile or macOS flows.

- New `windows/` directory with a WPF app (`Omi.Windows.App`) and a contributor‑oriented `windows/README.md`.  
- The Windows client authenticates via the existing `/v1/auth` endpoints (Python backend) and uses `use_custom_token=true` on `/v1/auth/token` to obtain a Firebase custom token.  
- It then exchanges that custom token for a Firebase ID token using the public Identity Toolkit API, and uses that ID token for all secured HTTP and WebSocket calls, including `/v4/listen`.

**Auth flow (Windows)**  
1. The app opens `GET /v1/auth/authorize?provider=apple&redirect_uri=omi://auth/callback` in the system browser.  
2. After the user signs in with Apple (or Google in the future), the Python backend handles the provider callback and renders `auth_callback.html`, which redirects to the app using `omi://auth/callback?code=...`.  
3. The user pastes the `code` into the Windows app (current UX), which calls:
   - `POST /v1/auth/token` with `grant_type=authorization_code`, `code`, `redirect_uri`, and `use_custom_token=true`.  
   - This returns a `custom_token` generated via `firebase_admin.auth.create_custom_token` on the server.  
4. The app calls:
   ```text
   https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=<FIREBASE_API_KEY>
   ```  
   to obtain a standard Firebase `idToken`.  
5. The Windows client uses that `idToken` as `Authorization: Bearer <idToken>` for:
   - HTTP endpoints like `/v1/users/profile`, `/v1/conversations/*`  
   - WebSocket `/v4/listen` (real-time transcription), which uses `verify_id_token` server‑side.

This mirrors the trust model of the existing mobile/desktop clients: the backend still verifies a real Firebase ID token, and the client does not need any privileged service account credentials (only the public Web API key).

**Windows client behavior**  
- “Connect to Omi” dialog:
  - Button to open the `/v1/auth/authorize` URL in the browser.  
  - Textbox to paste the `code` from the `omi://auth/callback?...` URL.  
- Main window:
  - “Start recording” / “Stop” wired to a WASAPI/NAudio-based microphone capture.  
  - Textbox showing raw JSON messages from `/v4/listen` (segments, events, or errors) for debugging and verification.  
- Hotkey + floating bar:
  - Global hotkey (Ctrl+Alt+O) toggles a simple floating bar window, similar in spirit to the macOS floating control bar but intentionally minimal for now.

**Configuration**  
- The Windows client reads:
  - `OMI_API_BASE_URL` (default `https://api.omi.me/`).  
  - `OMI_FIREBASE_API_KEY` or `FIREBASE_API_KEY` (the public Firebase Web API key for the `based-hardware` Firebase project).  
- No secrets or service account JSON are embedded in the client. All privileged operations (provider token exchange, custom token generation, ID token verification) remain on the backend.

**Known limitations / open questions**  
- On `https://api.omi.me` today, `/v4/listen` is currently returning HTTP 403 for this flow, even though the client presents a Firebase ID token obtained via `signInWithCustomToken`. This suggests a configuration/deployment detail on the backend or Firebase side, rather than a client‑side issue.  
- The `omi://auth/callback` scheme is handled manually by asking the user to copy the `code` from the URL. A future iteration should register a proper Windows URI handler and parse the `code` automatically.  
- Only Apple is wired in the UI; Google is supported by the backend and can be exposed similarly.

**Why this is safe**  
- The Windows client only ever uses:
  - The existing public HTTP/WS endpoints (`/v1/auth/*`, `/v4/listen`, `/v1/conversations`, etc.).  
  - The public Firebase Web API key (already used by the web frontend).  
- All privileged operations (OAuth token exchange, Firebase custom token generation, ID token verification) are done entirely on the server.  
- No secrets or service account credentials are stored in the repo or shipped in the client.