### PR TITLE
feat: parse timestamp markers and fix WAL timing in SD card sync (app)

### DIFF
--- a/app/lib/services/wals/sdcard_wal_sync.dart
+++ b/app/lib/services/wals/sdcard_wal_sync.dart
@@ -447,7 +447,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
 
     List<List<int>> bytesData = [];
     var bytesLeft = 0;
-    var chunkSize = sdcardChunkSizeSecs * 2 * wal.codec.getFramesPerSecond();
+    var chunkSize = sdcardChunkSizeSecs * wal.codec.getFramesPerSecond();
     List<MapEntry<int, int>> timestampMarkers = [];
     await _storageStream?.cancel();
     final completer = Completer<bool>();
@@ -1179,7 +1179,7 @@ class SDCardWalSyncImpl implements SDCardWalSync {
       List<List<int>> bytesData = [];
       var bytesLeft = 0;
       final bool useMarkers = _supportsTimestampMarkers();
-      var chunkSize = useMarkers ? sdcardChunkSizeSecs * 2 * wal.codec.getFramesPerSecond() : sdcardChunkSizeSecs * 100;
+      var chunkSize = useMarkers ? sdcardChunkSizeSecs * wal.codec.getFramesPerSecond() : sdcardChunkSizeSecs * 100;
       var timerStart = wal.timerStart;
       List<MapEntry<int, int>> timestampMarkers = [];
 


### PR DESCRIPTION
## Summary

- Parses inline `0xFF` timestamp markers from the offline audio data stream so each recording segment has an exact UTC start time
- Fixes WAL timing bugs: chunk size now uses actual codec FPS, and WAL duration derives from real frame count instead of a hardcoded 60-second assumption
- Splits audio into correctly-timed WAL segments based on timestamp markers

Split from #4851 — app changes only. See #5571 for the firmware counterpart.

### App changes
- **sdcard_wal_sync.dart**: Gates all timestamp marker logic on firmware version `>= 3.0.16` using `_supportsTimestampMarkers()`. Old firmware uses the original legacy parsing path unchanged. New firmware uses marker-aware parsing in both BLE and WiFi sync paths, splitting audio into correctly-timed WAL segments. Also fixes chunk size from `sdcardChunkSizeSecs * 100` to `sdcardChunkSizeSecs * codec.getFramesPerSecond()` (new firmware path only).

### Firmware version gating
- **Old firmware (< 3.0.16)**: Takes the `_readStorageBytesToFileLegacy()` path — identical to current `main` branch behavior. No marker detection, no new chunking logic.
- **New firmware (>= 3.0.16)**: Takes the `_readStorageBytesToFileWithMarkers()` path — parses `0xFF` markers, splits segments by timestamp boundaries, uses device-provided recording start time.

## Test plan

- [ ] Connect with old firmware (< 3.0.16) → verify BLE sync works identically to current behavior
- [ ] Connect with new firmware (>= 3.0.16) → disconnect BLE → record ~1 min offline → reconnect → sync
- [ ] Verify app shows WAL segments with correct timestamps from device-provided epochs
- [ ] Test WiFi sync path with both old and new firmware

🤖 Generated with [Claude Code](https://claude.com/claude-code)