### PR TITLE
Fix requestPerPod metric for scaling backend-listen

### DIFF
--- a/backend/charts/monitoring/prometheus-adapter/dev_omi_prometheus_adapter.yaml
+++ b/backend/charts/monitoring/prometheus-adapter/dev_omi_prometheus_adapter.yaml
@@ -13,7 +13,7 @@ rules:
     - name:
         as: "backend_listen_requests_per_pod"
       seriesQuery: 'stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="dev-backend-listen"}'
-      metricsQuery: '(sum(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="dev-backend-listen"})/sum(kube_deployment_status_replicas{deployment="dev-omi-backend-listen"}))'
+      metricsQuery: '(sum(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="dev-backend-listen",response_code="101"})/sum(kube_deployment_status_replicas{deployment="dev-omi-backend-listen"}))'
       resources:
         overrides:
           namespace: { resource: "namespace" }

--- a/backend/charts/monitoring/prometheus-adapter/prod_omi_prometheus_adapter.yaml
+++ b/backend/charts/monitoring/prometheus-adapter/prod_omi_prometheus_adapter.yaml
@@ -13,7 +13,7 @@ rules:
     - name:
         as: "backend_listen_requests_per_pod"
       seriesQuery: 'stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be"}'
-      metricsQuery: 'avg_over_time((sum(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be"})/sum(kube_deployment_status_replicas{deployment="prod-omi-backend-listen"}))[5m:])'
+      metricsQuery: 'avg_over_time((sum(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be",response_code="101"})/sum(kube_deployment_status_replicas{deployment="prod-omi-backend-listen"}))[5m:])'
       resources:
         overrides:
           namespace: { resource: "namespace" }


### PR DESCRIPTION
Change:
- Fix requestPerPod metric for scaling backend-listen: only count response code 101 to prevent the noise from another response codes