### PR TITLE
Fix Codemagic desktop release DMG step

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2307,6 +2307,7 @@ workflows:
             --hide-extension "$APP_NAME.app" \
             --app-drop-link 155 175 \
             --no-internet-enable \
+            --skip-jenkins \
             $BG_ARGS \
             "$DMG_PATH" \
             "$STAGING_DIR/$APP_NAME.app"


### PR DESCRIPTION
## Summary\n- restore  for Not enough arguments. Run 'create-dmg --help' for help. in \n- fixes CI/headless DMG creation failure at step "Create DMG installer" (exit 64)\n\n## Context\nRecent desktop auto-release tags were created, but Codemagic failed before publishing GitHub Releases due to DMG creation failing in CI.\n\n## Validation\n- static diff-only CI config fix\n