### PR TITLE
fix scrollDown crash Bad state No element

### DIFF
--- a/app/lib/pages/onboarding/speech_profile_widget.dart
+++ b/app/lib/pages/onboarding/speech_profile_widget.dart
@@ -74,14 +74,14 @@ class _SpeechProfileWidgetState extends State<SpeechProfileWidget> with TickerPr
   final ScrollController _scrollController = ScrollController();
 
   void scrollDown() async {
-    if (_scrollController.hasClients) {
-      await Future.delayed(const Duration(milliseconds: 250));
-      _scrollController.animateTo(
-        _scrollController.position.maxScrollExtent,
-        duration: const Duration(milliseconds: 200),
-        curve: Curves.easeOut,
-      );
-    }
+    if (!_scrollController.hasClients) return;
+    await Future.delayed(const Duration(milliseconds: 250));
+    if (!mounted || !_scrollController.hasClients) return;
+    _scrollController.animateTo(
+      _scrollController.position.maxScrollExtent,
+      duration: const Duration(milliseconds: 200),
+      curve: Curves.easeOut,
+    );
   }
 
   String _getLoadingText(BuildContext context, SpeechProfileLoadingState state) {


### PR DESCRIPTION
## Crash

**`_SpeechProfileWidgetState.scrollDown`**
`io.flutter.plugins.firebase.crashlytics.FlutterError - Bad state: No element`
`package:omi/pages/onboarding/speech_profile_widget.dart:74`

https://console.firebase.google.com/u/0/project/based-hardware/crashlytics/app/android:com.friend.ios/issues/169df273e42f6fc20706e58f4d7c1e2f?time=7d&types=crash&sessionEventKey=69B2BB2E0331000125D46BFA80806735_2194801920813340392

```
Fatal Exception: io.flutter.plugins.firebase.crashlytics.FlutterError: Bad state: No element
   at List.single(dart:core)
   at ScrollController.position(scroll_controller.dart:173)
   at _SpeechProfileWidgetState.scrollDown(speech_profile_widget.dart:80)
```

## How we fixed it

`scrollDown()` is an `async` method that checks `hasClients`, then waits 250ms before accessing `_scrollController.position`. During that 250ms delay the widget can be disposed (e.g. BLE disconnect triggers navigation away from onboarding). After disposal `_scrollController.positions` is empty, so `.position` — which internally calls `List.single` — throws **"Bad state: No element"**.

The fix re-checks both `mounted` and `hasClients` after the delay before accessing `.position`. If either guard fails, the scroll is silently skipped instead of crashing.

```dart
// Before
void scrollDown() async {
  if (_scrollController.hasClients) {
    await Future.delayed(const Duration(milliseconds: 250));
    _scrollController.animateTo(             // 💥 crash if disposed during delay
      _scrollController.position.maxScrollExtent,
      ...
    );
  }
}

// After
void scrollDown() async {
  if (!_scrollController.hasClients) return;
  await Future.delayed(const Duration(milliseconds: 250));
  if (!mounted || !_scrollController.hasClients) return;  // ← guard after delay
  _scrollController.animateTo(
    _scrollController.position.maxScrollExtent,
    ...
  );
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)