### PR TITLE
Use backend-listen active WS connections for autoscaling

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -353,22 +353,23 @@ autoscaling:
         periodSeconds: 300
       - type: Pods
         value: 1
-        periodSeconds: 60
+        periodSeconds: 120
       selectPolicy: Min
     scaleUp:
-      stabilizationWindowSeconds: 30
+      stabilizationWindowSeconds: 120
       policies:
       - type: Percent
-        value: 100
-        periodSeconds: 1
+        value: 30
+        periodSeconds: 60
       - type: Pods
-        value: 10
-        periodSeconds: 1
+        value: 5
+        periodSeconds: 60
       selectPolicy: Max
   # targetCPUUtilizationPercentage: 70
   # targetMemoryUtilizationPercentage: 70
-  requestsPerPod: 10
+  # requestsPerPod: 10
   # failedResponseCode: 10
+  activeConnectionsPerPod: 20
 
 podDisruptionBudget:
   minAvailable: "80%"

--- a/backend/charts/backend-listen/templates/hpa.yaml
+++ b/backend/charts/backend-listen/templates/hpa.yaml
@@ -51,4 +51,13 @@ spec:
           type: Value
           value: {{ .Values.autoscaling.failedResponseCode }}
     {{- end }}
+    {{- if .Values.autoscaling.activeConnectionsPerPod }}
+    - type: External
+      external:
+        metric:
+          name: backend_listen_active_ws_connections_per_pod
+        target:
+          type: Value
+          value: {{ .Values.autoscaling.activeConnectionsPerPod }}
+    {{- end }}
 {{- end }}

--- a/backend/charts/monitoring/prometheus-adapter/dev_omi_prometheus_adapter.yaml
+++ b/backend/charts/monitoring/prometheus-adapter/dev_omi_prometheus_adapter.yaml
@@ -4,6 +4,13 @@ rules:
   default: false
   external:
     - name:
+        as: "backend_listen_active_ws_connections_per_pod"
+      seriesQuery: 'backend_listen_active_ws_connections'
+      metricsQuery: 'avg(backend_listen_active_ws_connections)'
+      resources:
+        overrides:
+          namespace: { resource: "namespace" }
+    - name:
         as: "backend_listen_response_code_500"
       seriesQuery: 'stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="dev-backend-listen"}'
       metricsQuery: 'avg(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{response_code="500", backend_target_name="dev-backend-listen"}) or vector(0)'

--- a/backend/charts/monitoring/prometheus-adapter/prod_omi_prometheus_adapter.yaml
+++ b/backend/charts/monitoring/prometheus-adapter/prod_omi_prometheus_adapter.yaml
@@ -4,6 +4,13 @@ rules:
   default: false
   external:
     - name:
+        as: "backend_listen_active_ws_connections_per_pod"
+      seriesQuery: 'backend_listen_active_ws_connections'
+      metricsQuery: 'avg(backend_listen_active_ws_connections)'
+      resources:
+        overrides:
+          namespace: { resource: "namespace" }
+    - name:
         as: "backend_listen_response_code_500"
       seriesQuery: 'stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be"}'
       metricsQuery: 'avg(stackdriver_https_lb_rule_loadbalancing_googleapis_com_https_backend_request_count{response_code="500", backend_target_name="custom-domains-api-omi-me-backend-listen-49a4-be"}) or vector(0)'


### PR DESCRIPTION
Changes:
- Use **backend_listen_active_ws_connections_per_pod** for autoscaling
- Modify scaleUp and scaleDown behaviors to be compatible the new autoscaling factor