### PR TITLE
chore: update Codemagic signing profiles from v4 to v7

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -12,10 +12,10 @@ workflows:
     environment:
       ios_signing:
         provisioning_profiles:
-          - codemagic_v4
-          - codemagic_watchos_v4
+          - codemagic_v7
+          - codemagic_watchos_v7
         certificates:
-          - codemagic_v4
+          - codemagic_v7
       groups:
         - app_env
         - firebase
@@ -361,10 +361,10 @@ workflows:
     environment:
       ios_signing:
         provisioning_profiles:
-          - codemagic_v4
-          - codemagic_watchos_v4
+          - codemagic_v7
+          - codemagic_watchos_v7
         certificates:
-          - codemagic_v4
+          - codemagic_v7
       groups:
         - app_env
         - firebase
@@ -912,10 +912,10 @@ workflows:
     environment:
       ios_signing:
         provisioning_profiles:
-          - codemagic_v4
-          - codemagic_watchos_v4
+          - codemagic_v7
+          - codemagic_watchos_v7
         certificates:
-          - codemagic_v4
+          - codemagic_v7
       groups:
         - app_env
         - firebase


### PR DESCRIPTION
## Summary
- Update all iOS signing provisioning profiles from `codemagic_v4` to `codemagic_v7`
- Update all iOS signing certificates from `codemagic_v4` to `codemagic_v7`
- Applies to prod, staging, and TestFlight workflows

## Test plan
- [ ] Trigger a TestFlight build to verify signing works with v7 profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)