### PR TITLE
chore: add widget provisioning profile to Codemagic

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -14,6 +14,7 @@ workflows:
         provisioning_profiles:
           - codemagic_v7
           - codemagic_watchos_v7
+          - codemagic_widget_v7
         certificates:
           - codemagic_v7
       groups:
@@ -363,6 +364,7 @@ workflows:
         provisioning_profiles:
           - codemagic_v7
           - codemagic_watchos_v7
+          - codemagic_widget_v7
         certificates:
           - codemagic_v7
       groups:
@@ -914,6 +916,7 @@ workflows:
         provisioning_profiles:
           - codemagic_v7
           - codemagic_watchos_v7
+          - codemagic_widget_v7
         certificates:
           - codemagic_v7
       groups:


### PR DESCRIPTION
## Summary
- Add `codemagic_widget_v7` provisioning profile to all iOS workflows
- Required for the new BatteryWidget lock screen extension (`com.friend-app-with-wearable.ios12.widget`)

## Test plan
- [ ] Trigger a build to verify the widget extension signs correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)