### PR TITLE
Update CHANGELOG.json for v0.11.93 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -2,6 +2,13 @@
   "unreleased": [],
   "releases": [
     {
+      "version": "0.11.93",
+      "date": "2026-03-13",
+      "changes": [
+        "Bug fixes and improvements"
+      ]
+    },
+    {
       "version": "0.11.92",
       "date": "2026-03-12",
       "changes": [


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.93 and clears the unreleased array.