### PR TITLE
Fix onboarding reset isolation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,6 +128,12 @@ Always format code after making changes. The pre-commit hook handles this automa
 - **Python (backend/)**: `black --line-length 120 --skip-string-normalization <files>`
 - **C/C++ (firmware: omi/, omiGlass/)**: `clang-format -i <files>`
 
+## Git
+
+- Never push directly to `main`.
+- Never merge directly from a local branch. Land changes through a PR only.
+- When a change should go remote, create or use a feature branch, commit there, open/update a PR, and merge via the PR.
+
 ## Documentation Maintenance
 
 - Update this file and `CLAUDE.md` in the same commit when rules change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,6 +201,9 @@ clang-format -i <files>
 
 ### Rules
 - Always commit to the current branch — never switch branches.
+- Never push directly to `main`.
+- Never merge directly from a local branch. Land changes through a PR only.
+- When a change should go remote, create or use a feature branch, commit there, open/update a PR, and merge via the PR.
 - Never squash merge PRs — use regular merge.
 - Make individual commits per file, not bulk commits.
 - The pre-commit hook auto-formats staged code — no need to format manually before committing.

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -2461,12 +2461,10 @@ class AppState: ObservableObject {
         }
     }
 
-    /// Reset onboarding state and all TCC permissions, then restart the app
-    /// This clears UserDefaults onboarding keys and resets permissions so the user
-    /// can go through onboarding again with fresh permission prompts.
-    /// Performs thorough cleanup matching reset-and-run.sh behavior.
+    /// Reset onboarding state for the current app only, then restart.
+    /// This clears onboarding state without touching production data or system permissions.
     nonisolated func resetOnboardingAndRestart() {
-        log("Resetting onboarding (full cleanup)...")
+        log("Resetting onboarding state for current app...")
 
         // Clear onboarding-related UserDefaults keys (thread-safe, do first)
         let onboardingKeys = [
@@ -2503,92 +2501,10 @@ class AppState: ObservableObject {
             }
         }
 
-        // Clear all local user data: database, screenshots, videos, knowledge graph, etc.
-        let dataKeys = [
-            "omi.focus.sessions",
-            "omi.advice.history",
-            "TasksSavedFilterViews",
-        ]
-        for key in dataKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
-        log("Cleared local data UserDefaults keys")
-
-        // Close database and delete entire user data directory
-        Task {
-            await RewindDatabase.shared.close()
-            await RewindStorage.shared.reset()
-            await KnowledgeGraphStorage.shared.invalidateCache()
-
-            let fileManager = FileManager.default
-            let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
-            let userId = UserDefaults.standard.string(forKey: "auth_userId") ?? "anonymous"
-            let userDir = appSupport
-                .appendingPathComponent("Omi", isDirectory: true)
-                .appendingPathComponent("users", isDirectory: true)
-                .appendingPathComponent(userId, isDirectory: true)
-
-            if fileManager.fileExists(atPath: userDir.path) {
-                do {
-                    try fileManager.removeItem(at: userDir)
-                    log("Deleted user data directory: \(userDir.path)")
-                } catch {
-                    log("Failed to delete user data directory: \(error)")
-                }
-            }
-        }
-
-        // Also clear UserDefaults for both bundle IDs
-        let allKeys = onboardingKeys + dataKeys
-        if let prodDefaults = UserDefaults(suiteName: "com.omi.computer-macos") {
-            for key in allKeys {
-                prodDefaults.removeObject(forKey: key)
-            }
-        }
-        if let devDefaults = UserDefaults(suiteName: "com.omi.desktop-dev") {
-            for key in allKeys {
-                devDefaults.removeObject(forKey: key)
-            }
-        }
-
-        // Run all blocking Process calls on a background thread
+        // Restart off the main thread to avoid blocking the menu action path.
         DispatchQueue.global(qos: .utility).async { [self] in
-            // 1. Clean conflicting app bundles from Trash, DerivedData, DMG staging
-            cleanConflictingAppBundles()
-
-            // 2. Eject any mounted Omi DMG volumes
-            ejectMountedDMGVolumes()
-
-            // 3. Reset Launch Services database to clear stale registrations
-            resetLaunchServicesDatabase()
-
-            // 4. Ensure this app is the authoritative version in Launch Services
-            ScreenCaptureService.ensureLaunchServicesRegistration()
-
-            // 5. Reset ALL TCC permissions using tccutil for BOTH bundle IDs
-            let bundleIds = [
-                "com.omi.computer-macos",       // Production
-                "com.omi.desktop-dev"           // Development
-            ]
-
-            for id in bundleIds {
-                let process = Process()
-                process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
-                process.arguments = ["reset", "All", id]
-
-                do {
-                    try process.run()
-                    process.waitUntilExit()
-                    log("tccutil reset All for \(id) completed with exit code: \(process.terminationStatus)")
-                } catch {
-                    log("Failed to run tccutil for \(id): \(error)")
-                }
-            }
-
-            // 6. Also clean user TCC database directly via sqlite3
-            self.cleanUserTCCDatabase()
-
-            // 7. Restart the app
+            // Keep onboarding reset scoped to the current app instance.
+            // It must not mutate production defaults, shared local data, or TCC permissions.
             self.restartApp()
         }
     }


### PR DESCRIPTION
## Summary
- scope Reset Onboarding to the current app only
- stop it from resetting prod defaults, shared local data, and macOS permissions
- document the repo rule that remote changes must go through a PR

## Testing
- xcrun swift build -c debug --package-path desktop/Desktop