### PR TITLE
Publish static beta redirect artifacts

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -1874,6 +1874,7 @@ workflows:
         GCP_REGION: "us-central1"
         CLOUD_RUN_SERVICE: "desktop-backend"
         BACKEND_IMAGE: "gcr.io/based-hardware/desktop-backend"
+        GCS_DESKTOP_UPDATES_BUCKET: "gs://omi_macos_updates"
       xcode: 16.4
     triggering:
       events:
@@ -2418,6 +2419,66 @@ workflows:
             "$DMG_PATH"
 
           echo "GitHub release created: $CM_TAG"
+
+      - name: Publish static beta redirect artifacts
+        script: |
+          set -e
+
+          echo "$GCP_SERVICE_ACCOUNT_KEY" | base64 --decode > /tmp/gcp_key.json
+          gcloud auth activate-service-account --key-file=/tmp/gcp_key.json --quiet
+          gcloud config set project "$GCP_PROJECT" --quiet
+          rm /tmp/gcp_key.json
+
+          export BETA_DMG_URL="https://github.com/$GITHUB_REPO/releases/download/$CM_TAG/omi.dmg"
+          export RELEASED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          cat > /tmp/macos-beta-index.html <<EOF
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url=${BETA_DMG_URL}">
+            <meta name="robots" content="noindex">
+            <title>Redirecting to latest Omi Beta download…</title>
+          </head>
+          <body>
+            <p>Redirecting to the latest Omi Beta download.</p>
+            <p><a href="${BETA_DMG_URL}">If you are not redirected, click here.</a></p>
+            <script>window.location.replace(${BETA_DMG_URL@Q});</script>
+          </body>
+          </html>
+          EOF
+
+          python3 - <<'PY' > /tmp/macos-beta-redirect.json
+          import json, os
+          print(json.dumps({
+              "channel": "beta",
+              "version": os.environ["VERSION"],
+              "build_number": int(os.environ["BUILD_NUMBER"]),
+              "tag": os.environ["CM_TAG"],
+              "download_url": os.environ["BETA_DMG_URL"],
+              "published_at": os.environ["RELEASED_AT"],
+          }, indent=2))
+          PY
+
+          echo "$BETA_DMG_URL" > /tmp/macos-beta-latest-url.txt
+
+          gcloud storage cp \
+            --cache-control="no-store,max-age=0" \
+            /tmp/macos-beta-index.html \
+            "$GCS_DESKTOP_UPDATES_BUCKET/beta/index.html"
+
+          gcloud storage cp \
+            --cache-control="no-store,max-age=0" \
+            /tmp/macos-beta-redirect.json \
+            "$GCS_DESKTOP_UPDATES_BUCKET/beta/redirect.json"
+
+          gcloud storage cp \
+            --cache-control="no-store,max-age=0" \
+            /tmp/macos-beta-latest-url.txt \
+            "$GCS_DESKTOP_UPDATES_BUCKET/beta/latest-url.txt"
+
+          echo "Static beta redirect artifacts published to $GCS_DESKTOP_UPDATES_BUCKET/beta/"
 
       - name: Bridge release to Firestore for old clients
         script: |


### PR DESCRIPTION
## Summary
- publish static beta redirect files to the macOS updates GCS bucket during desktop release
- write beta/index.html, beta/latest-url.txt, and beta/redirect.json
- prepare macos.omi.me/beta for a static cutover off the backend

## Notes
- this does not change the live domain routing by itself; infra still needs to point /beta at the static artifact path