### PR TITLE
Fix desktop onboarding reset scoping

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -2466,6 +2466,12 @@ class AppState: ObservableObject {
     nonisolated func resetOnboardingAndRestart() {
         log("Resetting onboarding state for current app...")
 
+        // Update live @AppStorage state in the current app instance before touching
+        // raw UserDefaults so SwiftUI doesn't write stale onboarding values back.
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .resetOnboardingRequested, object: nil)
+        }
+
         // Clear onboarding-related UserDefaults keys (thread-safe, do first)
         let onboardingKeys = [
             "hasCompletedOnboarding",
@@ -2503,6 +2509,7 @@ class AppState: ObservableObject {
 
         // Restart off the main thread to avoid blocking the menu action path.
         DispatchQueue.global(qos: .utility).async { [self] in
+            Thread.sleep(forTimeInterval: 0.15)
             // Keep onboarding reset scoped to the current app instance.
             // It must not mutate production defaults, shared local data, or TCC permissions.
             self.restartApp()
@@ -2773,6 +2780,8 @@ class AppState: ObservableObject {
 // MARK: - System Event Notification Names
 
 extension Notification.Name {
+    /// Posted when the current app instance should fully clear its own onboarding state.
+    static let resetOnboardingRequested = Notification.Name("resetOnboardingRequested")
     /// Posted when the system wakes from sleep
     static let systemDidWake = Notification.Name("systemDidWake")
     /// Posted when the screen is locked

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -22,6 +22,8 @@ struct DesktopHomeView: View {
     }()
     @State private var isSidebarCollapsed: Bool = false
     @AppStorage("currentTierLevel") private var currentTierLevel = 0
+    @AppStorage("onboardingStep") private var onboardingStep = 0
+    @AppStorage("onboardingJustCompleted") private var onboardingJustCompleted = false
 
     // Settings sidebar state
     @State private var selectedSettingsSection: SettingsContentView.SettingsSection = .general
@@ -199,6 +201,13 @@ struct DesktopHomeView: View {
                         .onReceive(NotificationCenter.default.publisher(for: .userDidSignOut)) { _ in
                             log("DesktopHomeView: userDidSignOut — resetting hasCompletedOnboarding and stopping transcription")
                             appState.hasCompletedOnboarding = false
+                            appState.stopTranscription()
+                        }
+                        .onReceive(NotificationCenter.default.publisher(for: .resetOnboardingRequested)) { _ in
+                            log("DesktopHomeView: resetOnboardingRequested — clearing live onboarding state for current app")
+                            appState.hasCompletedOnboarding = false
+                            onboardingStep = 0
+                            onboardingJustCompleted = false
                             appState.stopTranscription()
                         }
                         // Handle transcription toggle from menu bar

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -3801,7 +3801,7 @@ struct SettingsContentView: View {
                             .scaledFont(size: 16, weight: .semibold)
                             .foregroundColor(OmiColors.textPrimary)
 
-                        Text("Restart setup wizard and reset permissions")
+                        Text("Restart setup wizard for this app build only")
                             .scaledFont(size: 13)
                             .foregroundColor(OmiColors.textTertiary)
                     }
@@ -3828,7 +3828,7 @@ struct SettingsContentView: View {
                     appState.resetOnboardingAndRestart()
                 }
             } message: {
-                Text("This will reset all permissions, clear chat history, and restart the app. You'll need to grant permissions again during setup.")
+                Text("This will reset onboarding for this app build only, clear onboarding chat history, and restart the app without affecting the other installed build.")
             }
         }
     }

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -63,6 +63,10 @@ struct OnboardingView: View {
             // Pre-warm the ACP bridge before the chat step starts.
             await chatProvider.warmupBridge()
         }
+        .onReceive(NotificationCenter.default.publisher(for: .resetOnboardingRequested)) { _ in
+            log("OnboardingView: resetOnboardingRequested — returning to chat step for current app")
+            currentStep = 0
+        }
     }
 
     private var onboardingContent: some View {


### PR DESCRIPTION
## Summary
- reset onboarding through a live in-process notification before restart
- clear current-build onboarding app storage state in desktop home and onboarding views
- clarify settings copy that reset is scoped to the current app build only

## Testing
- xcrun swift build -c debug --package-path Desktop *(currently fails in repo due existing macOS deployment target mismatch: omi-lib 10.13 vs AudioKit 11.0)*