### PR TITLE
fix: pass user_name to all transcript callers

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -348,6 +348,7 @@ class Conversation(BaseModel):
         use_transcript: bool = False,
         include_timestamps: bool = False,
         people: List[Person] = None,
+        user_name: str = None,
     ) -> str:
         result = []
         people_map = {p.id: p for p in people} if people else {}
@@ -403,7 +404,7 @@ class Conversation(BaseModel):
                     conversation_str += f"- {event.title} ({event.start} - {event.duration} minutes)\n"
 
             if use_transcript:
-                conversation_str += f"\nTranscript:\n{conversation.get_transcript(include_timestamps=include_timestamps, people=people)}\n"
+                conversation_str += f"\nTranscript:\n{conversation.get_transcript(include_timestamps=include_timestamps, people=people, user_name=user_name)}\n"
                 # photos
                 photo_descriptions = conversation.get_photos_descriptions(include_timestamps=include_timestamps)
                 if photo_descriptions != 'None':
@@ -413,10 +414,10 @@ class Conversation(BaseModel):
 
         return "\n\n---------------------\n\n".join(result).strip()
 
-    def get_transcript(self, include_timestamps: bool, people: List[Person] = None) -> str:
+    def get_transcript(self, include_timestamps: bool, people: List[Person] = None, user_name: str = None) -> str:
         # Warn: missing transcript for workflow source, external integration source
         return TranscriptSegment.segments_as_string(
-            self.transcript_segments, include_timestamps=include_timestamps, people=people
+            self.transcript_segments, include_timestamps=include_timestamps, user_name=user_name, people=people
         )
 
     def get_photos_descriptions(self, include_timestamps: bool = False) -> str:
@@ -459,9 +460,9 @@ class CreateConversation(BaseModel):
     processing_conversation_id: Optional[str] = None
     calendar_meeting_context: Optional[CalendarMeetingContext] = None
 
-    def get_transcript(self, include_timestamps: bool, people: List[Person] = None) -> str:
+    def get_transcript(self, include_timestamps: bool, people: List[Person] = None, user_name: str = None) -> str:
         return TranscriptSegment.segments_as_string(
-            self.transcript_segments, include_timestamps=include_timestamps, people=people
+            self.transcript_segments, include_timestamps=include_timestamps, user_name=user_name, people=people
         )
 
     def get_person_ids(self) -> List[str]:

--- a/backend/scripts/rag/app.py
+++ b/backend/scripts/rag/app.py
@@ -18,6 +18,7 @@ if project_root not in sys.path:
 
 from current import *
 from _shared import *
+from database.auth import get_user_name
 from models.chat import Message
 from models.conversation import Conversation
 from models.transcript_segment import TranscriptSegment
@@ -216,9 +217,9 @@ for message in get_messages():
                     col1, col2 = st.columns(2)
                     with col1:
                         st.markdown("**Raw Transcript Segments**")
-                        transcript = TranscriptSegment.segments_as_string(memory.transcript_segments).replace(
-                            '\n\n', '\n'
-                        )
+                        transcript = TranscriptSegment.segments_as_string(
+                            memory.transcript_segments, user_name=get_user_name(uid, use_default=False)
+                        ).replace('\n\n', '\n')
                         lines = transcript.count('\n')
                         ten_lines = transcript.split('\n')[:10]
                         st.text('\n'.join(ten_lines))

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -144,9 +144,7 @@ def retrieve_is_an_omi_question(question: str) -> bool:
     {question}
     
     Is this asking about the Omi/Friend app product itself?
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     with_parser = llm_mini.with_structured_output(IsAnOmiQuestion)
     response: IsAnOmiQuestion = with_parser.invoke(prompt)
     try:
@@ -197,9 +195,7 @@ def retrieve_context_dates_by_question(question: str, tz: str) -> List[datetime]
     {question}
     </question>
 
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
 
     # print(prompt)
     # print(llm_mini.invoke(prompt).content)
@@ -212,8 +208,10 @@ class SummaryOutput(BaseModel):
     summary: str = Field(description="The extracted content, maximum 500 words.")
 
 
-def chunk_extraction(segments: List[TranscriptSegment], topics: List[str], people: List[Person] = None) -> str:
-    content = TranscriptSegment.segments_as_string(segments, people=people)
+def chunk_extraction(
+    segments: List[TranscriptSegment], topics: List[str], people: List[Person] = None, user_name: str = None
+) -> str:
+    content = TranscriptSegment.segments_as_string(segments, people=people, user_name=user_name)
     prompt = f'''
     You are an experienced detective, your task is to extract the key points of the conversation related to the topics you were provided.
     You will be given a conversation transcript of a low quality recording, and a list of topics.
@@ -254,9 +252,7 @@ def _get_answer_simple_message_prompt(uid: str, messages: List[Message], app: Op
     {conversation_history}
 
     Answer:
-    """.replace(
-        '    ', ''
-    ).strip()
+    """.replace('    ', '').strip()
 
 
 def answer_simple_message(uid: str, messages: List[Message], plugin: Optional[App] = None) -> str:
@@ -287,9 +283,7 @@ def _get_answer_omi_question_prompt(messages: List[Message], context: str) -> st
     {conversation_history}
 
     Answer:
-    """.replace(
-        '    ', ''
-    ).strip()
+    """.replace('    ', '').strip()
 
 
 def answer_omi_question(messages: List[Message], context: str) -> str:
@@ -329,8 +323,7 @@ def _get_qa_rag_prompt(
       - Avoid citing irrelevant memories.
     """
 
-    return (
-        f"""
+    return f"""
     <assistant_role>
         You are an assistant for question-answering tasks.
     </assistant_role>
@@ -389,12 +382,7 @@ def _get_qa_rag_prompt(
     </question_timezone>
 
     <answer>
-    """.replace(
-            '    ', ''
-        )
-        .replace('\n\n\n', '\n\n')
-        .strip()
-    )
+    """.replace('    ', '').replace('\n\n\n', '\n\n').strip()
 
 
 def _get_agentic_qa_prompt(
@@ -862,7 +850,8 @@ def retrieve_memory_context_params(uid: str, memory: Conversation) -> List[str]:
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))
         people = [Person(**p) for p in people_data]
 
-    transcript = memory.get_transcript(False, people=people)
+    user_name = get_user_name(uid, use_default=False)
+    transcript = memory.get_transcript(False, people=people, user_name=user_name)
     if len(transcript) == 0:
         return []
 
@@ -874,9 +863,7 @@ def retrieve_memory_context_params(uid: str, memory: Conversation) -> List[str]:
 
     Conversation:
     {transcript}
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
 
     try:
         with_parser = llm_mini.with_structured_output(TopicsContext)
@@ -896,7 +883,7 @@ def obtain_emotional_message(uid: str, memory: Conversation, context: str, emoti
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))
         people = [Person(**p) for p in people_data]
 
-    transcript = memory.get_transcript(False, people=people)
+    transcript = memory.get_transcript(False, people=people, user_name=user_name)
     prompt = f"""
     You are a thoughtful and encouraging Friend.
     Your best friend is {user_name}, {memories_str}
@@ -918,9 +905,7 @@ def obtain_emotional_message(uid: str, memory: Conversation, context: str, emoti
     ```
     {context}
     ```
-    """.replace(
-        '    ', ''
-    ).strip()
+    """.replace('    ', '').strip()
     return llm_mini.invoke(prompt).content
 
 
@@ -1035,9 +1020,7 @@ def extract_question_from_conversation(messages: List[Message]) -> str:
     - this day
     - etc.
     </date_in_term>
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     # print(prompt)
     question = llm_mini.with_structured_output(OutputQuestion).invoke(prompt).question
     # print(question)
@@ -1084,9 +1067,7 @@ def retrieve_metadata_fields_from_transcript(
     ```
     {full_context}
     ```
-    '''.replace(
-        '    ', ''
-    )
+    '''.replace('    ', '')
     try:
         result: ExtractedInformation = llm_mini.with_structured_output(ExtractedInformation).invoke(prompt)
     except Exception as e:
@@ -1169,9 +1150,7 @@ def retrieve_metadata_from_message(
     ```
     {message_text}
     ```
-    '''.replace(
-        '    ', ''
-    )
+    '''.replace('    ', '')
 
     return _process_extracted_metadata(uid, prompt)
 
@@ -1205,9 +1184,7 @@ def retrieve_metadata_from_text(
     ```
     {text}
     ```
-    '''.replace(
-        '    ', ''
-    )
+    '''.replace('    ', '')
 
     return _process_extracted_metadata(uid, prompt)
 
@@ -1280,9 +1257,7 @@ def select_structured_filters(question: str, filters_available: dict) -> dict:
     ```
 
     Question: {question}
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     # print(prompt)
     with_parser = llm_mini.with_structured_output(FiltersToUse)
     try:
@@ -1328,11 +1303,9 @@ def extract_question_from_transcript(uid: str, segments: List[TranscriptSegment]
 
     Conversation:
     ```
-    {TranscriptSegment.segments_as_string(segments, people=people)}
+    {TranscriptSegment.segments_as_string(segments, people=people, user_name=user_name)}
     ```
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     return llm_mini.with_structured_output(OutputQuestion).invoke(prompt).question
 
 
@@ -1349,7 +1322,7 @@ def provide_advice_message(uid: str, segments: List[TranscriptSegment], context:
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))
         people = [Person(**p) for p in people_data]
 
-    transcript = TranscriptSegment.segments_as_string(segments, people=people)
+    transcript = TranscriptSegment.segments_as_string(segments, people=people, user_name=user_name)
     # TODO: tweak with different type of requests, like this, or roast, or praise or emotional, etc.
 
     prompt = f"""
@@ -1381,7 +1354,5 @@ def provide_advice_message(uid: str, segments: List[TranscriptSegment], context:
     ```
     {context}
     ```
-    """.replace(
-        '    ', ''
-    ).strip()
+    """.replace('    ', '').strip()
     return llm_mini.with_structured_output(OutputMessage).invoke(prompt).message

--- a/backend/utils/llm/followup.py
+++ b/backend/utils/llm/followup.py
@@ -5,8 +5,12 @@ from models.transcript_segment import TranscriptSegment
 from utils.llm.clients import llm_mini
 
 
-def followup_question_prompt(segments: List[TranscriptSegment], people: Optional[List[Person]] = None):
-    transcript_str = TranscriptSegment.segments_as_string(segments, include_timestamps=False, people=people)
+def followup_question_prompt(
+    segments: List[TranscriptSegment], people: Optional[List[Person]] = None, user_name: str = None
+):
+    transcript_str = TranscriptSegment.segments_as_string(
+        segments, include_timestamps=False, people=people, user_name=user_name
+    )
     words = transcript_str.split()
     w_count = len(words)
     if w_count < 10:
@@ -24,7 +28,5 @@ def followup_question_prompt(segments: List[TranscriptSegment], people: Optional
 
         Output your response in plain text, without markdown.
         Output only the question, without context, be concise and straight to the point.
-        """.replace(
-        '    ', ''
-    ).strip()
+        """.replace('    ', '').strip()
     return llm_mini.invoke(prompt).content

--- a/backend/utils/llm/trends.py
+++ b/backend/utils/llm/trends.py
@@ -2,6 +2,7 @@ from typing import List
 from pydantic import BaseModel, Field
 
 import database.users as users_db
+from database.auth import get_user_name
 from models.conversation import Conversation
 from models.other import Person
 from models.trend import (
@@ -36,7 +37,8 @@ def trends_extractor(uid: str, memory: Conversation) -> List[Item]:
         people_data = users_db.get_people_by_ids(uid, list(set(person_ids)))
         people = [Person(**p) for p in people_data]
 
-    transcript = memory.get_transcript(False, people=people)
+    user_name = get_user_name(uid, use_default=False)
+    transcript = memory.get_transcript(False, people=people, user_name=user_name)
     if len(transcript) == 0:
         return []
 
@@ -60,9 +62,7 @@ def trends_extractor(uid: str, memory: Conversation) -> List[Item]:
 
     Conversation:
     {transcript}
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     try:
         with_parser = llm_mini.with_structured_output(ExpectedOutput)
         response: ExpectedOutput = with_parser.invoke(prompt)

--- a/backend/utils/retrieval/rag.py
+++ b/backend/utils/retrieval/rag.py
@@ -3,6 +3,7 @@ from collections import Counter, defaultdict
 from typing import List, Tuple
 
 import database.users as users_db
+from database.auth import get_user_name
 from database.conversations import get_conversations_by_id
 from database.vector_db import query_vectors
 from models.conversation import Conversation
@@ -51,15 +52,15 @@ def retrieve_memories_for_topics(uid: str, topics: List[str], dates_range: List)
 
 
 def get_better_conversation_chunk(
-    memory: Conversation, topics: List[str], context_data: dict, people: List[Person] = None
+    memory: Conversation, topics: List[str], context_data: dict, people: List[Person] = None, user_name: str = None
 ) -> str:
     logger.info(f'get_better_memory_chunk {memory.id} {topics}')
     conversation = TranscriptSegment.segments_as_string(
-        memory.transcript_segments, include_timestamps=True, people=people
+        memory.transcript_segments, include_timestamps=True, people=people, user_name=user_name
     )
     if num_tokens_from_string(conversation) < 250:
-        return Conversation.conversations_to_string([memory], people=people)
-    chunk = chunk_extraction(memory.transcript_segments, topics, people=people)
+        return Conversation.conversations_to_string([memory], people=people, user_name=user_name)
+    chunk = chunk_extraction(memory.transcript_segments, topics, people=people, user_name=user_name)
     if not chunk or len(chunk) < 10:
         return
     context_data[memory.id] = chunk
@@ -93,18 +94,22 @@ def retrieve_rag_conversation_context(uid: str, memory: Conversation) -> Tuple[s
         people_data = users_db.get_people_by_ids(uid, list(set(all_person_ids)))
         people = [Person(**p) for p in people_data]
 
+    user_name = get_user_name(uid, use_default=False)
+
     if memories_id_to_topics:
         # TODO: restore sorthing here
         context_data = {}
         threads = []
         for memory in memories:
             topics = memories_id_to_topics.get(memory.id, [])
-            t = threading.Thread(target=get_better_conversation_chunk, args=(memory, topics, context_data, people))
+            t = threading.Thread(
+                target=get_better_conversation_chunk, args=(memory, topics, context_data, people, user_name)
+            )
             threads.append(t)
         [t.start() for t in threads]
         [t.join() for t in threads]
         context_str = '\n'.join(context_data.values()).strip()
     else:
-        context_str = Conversation.conversations_to_string(memories, people=people)
+        context_str = Conversation.conversations_to_string(memories, people=people, user_name=user_name)
 
     return context_str, (memories if context_str else [])


### PR DESCRIPTION
## Summary
Threads `user_name` parameter through all `get_transcript()` and `segments_as_string()` callers so transcripts show the actual user name instead of generic 'User' label.

## Changes
- `backend/models/conversation.py` — Added `user_name` param to `get_transcript()` and `conversations_to_string()`
- `backend/utils/llm/trends.py` — Pass `user_name` via `get_user_name(uid)`
- `backend/utils/llm/chat.py` — Thread `user_name` through RAG context, emotional message, chunk extraction, question generation
- `backend/utils/llm/followup.py` — Added `user_name` parameter
- `backend/utils/retrieval/rag.py` — Thread `user_name` through RAG retrieval
- `backend/scripts/rag/app.py` — Pass `user_name` to `segments_as_string()`
- `backend/routers/users.py` — Pass `user_name` to followup prompt

## Testing
All affected callers now use the same `get_user_name(uid, use_default=False)` pattern established in PR #5369.

Fixes #5532