### PR TITLE
fix: prevent infinite TCC reset loop with dev signing

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -792,11 +792,7 @@ class AppState: ObservableObject {
             if !realPermission && !isScreenRecordingStale {
                 log("Screen capture: stale TCC entry detected (developer signing changed)")
                 isScreenRecordingStale = true
-                // Try tccutil reset in case it works (it may not on macOS 15+ for system TCC)
-                Task.detached {
-                    ScreenCaptureService.ensureLaunchServicesRegistrationSync()
-                    _ = ScreenCaptureService.resetScreenCapturePermission()
-                }
+                log("Screen capture: please toggle Screen Recording OFF then ON for this app in System Settings → Privacy & Security → Screen Recording")
             } else if realPermission {
                 // Permission recovered (user toggled off/on in System Settings)
                 isScreenRecordingStale = false


### PR DESCRIPTION
## Summary
Removes automatic `tccutil reset ScreenCapture` call when stale TCC is detected, preventing an infinite permission wipe loop on dev-signed builds.

## Changes
- **Removed** `Task.detached` block that auto-called `resetScreenCapturePermission()` on stale TCC detection
- **Added** log message guiding user to toggle Screen Recording permission manually in System Settings

## Root Cause
With dev signing, CDHash changes every rebuild. `tccutil reset` wipes the grant → next check detects no permission → triggers reset again → infinite loop.

Fixes #5552