### PR TITLE
fix: replace fixed 15s WebSocket reconnect with exponential backoff + jitter

### DIFF
--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1356,7 +1356,7 @@ class CaptureProvider extends ChangeNotifier
   }
 
   Duration _getReconnectDelay() {
-    final cap = min(pow(2, _reconnectAttempt).toInt(), _maxBackoffSeconds);
+    final cap = min(pow(2, _reconnectAttempt), _maxBackoffSeconds).toInt();
     final jitterMs = cap > 0 ? Random().nextInt(cap * 1000) : 1000;
     return Duration(milliseconds: jitterMs);
   }


### PR DESCRIPTION
## Summary
Replaces the fixed 15-second WebSocket reconnection timer with exponential backoff and full jitter to prevent synchronized reconnect storms.

## Changes
- Added `_reconnectAttempt` counter and `_maxBackoffSeconds = 120`
- Added `_getReconnectDelay()` — exponential backoff (1s→2s→4s→...→120s cap) with full jitter
- Replaced `Timer.periodic(Duration(seconds: 15))` with single-shot `Timer` using computed delay
- Reset `_reconnectAttempt = 0` on successful connection in `onConnected()`

**Note:** The diff includes some auto-formatting changes alongside the substantive logic changes.

Fixes #5527