### PR TITLE
fix: use local timezone for Today journey day boundary and timestamps

### DIFF
--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -937,24 +937,20 @@ def test_daily_summary(request: TestDailySummaryRequest = None, uid: str = Depen
                 start_of_day = user_tz.localize(datetime.combine(target_date, time.min))
                 end_of_day = user_tz.localize(datetime.combine(target_date, time.max))
             else:
-                # Use past 24 hours
+                # Use local day boundaries (midnight-to-midnight)
                 now_in_user_tz = datetime.now(user_tz)
-                end_date_utc = now_in_user_tz.astimezone(pytz.utc)
-                start_date_utc = (now_in_user_tz - timedelta(hours=24)).astimezone(pytz.utc)
 
-                # Determine display date based on current hour
+                # Determine which calendar day to summarize
                 if now_in_user_tz.hour < 12:
                     display_date = now_in_user_tz.date() - timedelta(days=1)
                 else:
                     display_date = now_in_user_tz.date()
                 date_str = display_date.strftime('%Y-%m-%d')
-                # Skip the conversion below since we already have UTC times
-                start_of_day = None
-                end_of_day = None
+                start_of_day = user_tz.localize(datetime.combine(display_date, time.min))
+                end_of_day = user_tz.localize(datetime.combine(display_date, time.max))
 
-            if start_of_day and end_of_day:
-                start_date_utc = start_of_day.astimezone(pytz.utc)
-                end_date_utc = end_of_day.astimezone(pytz.utc)
+            start_date_utc = start_of_day.astimezone(pytz.utc)
+            end_date_utc = end_of_day.astimezone(pytz.utc)
         except Exception as e:
             raise HTTPException(status_code=500, detail=f'Timezone error: {str(e)}')
     else:
@@ -964,16 +960,14 @@ def test_daily_summary(request: TestDailySummaryRequest = None, uid: str = Depen
             start_date_utc = datetime.combine(target_date, time.min).replace(tzinfo=pytz.utc)
             end_date_utc = datetime.combine(target_date, time.max).replace(tzinfo=pytz.utc)
         else:
-            # Use past 24 hours
-            end_date_utc = now_utc
-            start_date_utc = now_utc - timedelta(hours=24)
-
-            # Determine display date based on current hour
+            # Use UTC day boundaries
             if now_utc.hour < 12:
                 display_date = now_utc.date() - timedelta(days=1)
             else:
                 display_date = now_utc.date()
             date_str = display_date.strftime('%Y-%m-%d')
+            start_date_utc = datetime.combine(display_date, time.min).replace(tzinfo=pytz.utc)
+            end_date_utc = datetime.combine(display_date, time.max).replace(tzinfo=pytz.utc)
 
     # Get conversations for the date
     conversations_data = conversations_db.get_conversations(uid, start_date=start_date_utc, end_date=end_date_utc)

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -77,7 +77,7 @@ def _send_summary_notification(user_data: tuple):
     uid = user_data[0]
     user_tz_name = user_data[2] if len(user_data) > 2 else None
 
-    # Calculate past 24 hours for conversation fetching
+    # Calculate local day boundaries for conversation fetching
     # date_str is set based on current hour:
     #   - Before 12 PM (noon): use previous day's date
     #   - 12 PM or after: use current day's date
@@ -89,17 +89,19 @@ def _send_summary_notification(user_data: tuple):
             user_tz = pytz.timezone(user_tz_name)
             now_in_user_tz = datetime.now(user_tz)
 
-            # Use past 24 hours for conversation range
-            end_date_utc = now_in_user_tz.astimezone(pytz.utc)
-            start_date_utc = (now_in_user_tz - timedelta(hours=24)).astimezone(pytz.utc)
-
-            # Determine display date based on current hour
+            # Determine which calendar day to summarize
             if now_in_user_tz.hour < 12:
-                # Before noon: show previous day
+                # Before noon: summarize previous day
                 display_date = now_in_user_tz.date() - timedelta(days=1)
             else:
-                # Noon or after: show current day
+                # Noon or after: summarize current day
                 display_date = now_in_user_tz.date()
+
+            # Use local day boundaries (midnight-to-midnight) converted to UTC
+            start_of_day = user_tz.localize(datetime.combine(display_date, time.min))
+            end_of_day = user_tz.localize(datetime.combine(display_date, time.max))
+            start_date_utc = start_of_day.astimezone(pytz.utc)
+            end_date_utc = end_of_day.astimezone(pytz.utc)
             date_str = display_date.strftime('%Y-%m-%d')
         except Exception as e:
             logger.error(e)
@@ -108,15 +110,15 @@ def _send_summary_notification(user_data: tuple):
     if not start_date_utc or not end_date_utc:
         now_utc = datetime.now(pytz.utc)
 
-        # Use past 24 hours for conversation range
-        end_date_utc = now_utc
-        start_date_utc = now_utc - timedelta(hours=24)
-
-        # Determine display date based on current hour
+        # Determine which calendar day to summarize
         if now_utc.hour < 12:
             display_date = now_utc.date() - timedelta(days=1)
         else:
             display_date = now_utc.date()
+
+        # Use UTC day boundaries
+        start_date_utc = datetime.combine(display_date, time.min).replace(tzinfo=pytz.utc)
+        end_date_utc = datetime.combine(display_date, time.max).replace(tzinfo=pytz.utc)
         date_str = display_date.strftime('%Y-%m-%d')
 
     # Atomically acquire lock BEFORE expensive LLM work to prevent race condition


### PR DESCRIPTION
## Summary
Fixes the 'Today's journey' showing entries from previous days and future-dated timestamps by using local calendar day boundaries instead of a 24-hour sliding UTC window.

## Changes
- `backend/utils/other/notifications.py` — Replaced 24h sliding window with user's local calendar day boundaries (midnight-to-midnight in user TZ, converted to UTC for DB query)
- `backend/routers/users.py` — Same fix for test/manual trigger endpoint; unified both branches to use localized `start_of_day`/`end_of_day`

The location timestamp formatting (UTC → local HH:MM) in `external_integrations.py` was already correct — the bug was in which conversations were included.

Fixes #5553