### PR TITLE
fix: guard llm_mini cost with goal check, dedup, and rate limiting

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -882,3 +882,20 @@ def check_credits_invalidation(uid: str) -> bool:
     """
     result = r.get(f'credits_invalidated:{uid}')
     return result is not None
+
+
+# ******************************************************
+# *************** GOAL RATE LIMITING *******************
+# ******************************************************
+
+
+def try_acquire_goal_extraction_lock(uid: str, ttl: int = 300) -> bool:
+    """Per-user rate limit for goal extraction. Returns True if acquired (not rate limited)."""
+    result = r.set(f'users:{uid}:goal_extraction_lock', '1', ex=ttl, nx=True)
+    return result is not None
+
+
+def try_acquire_conversation_goal_lock(uid: str, conversation_id: str, ttl: int = 3600) -> bool:
+    """Idempotency lock: one goal extraction per conversation. Returns True if acquired."""
+    result = r.set(f'users:{uid}:conv_goal_lock:{conversation_id}', '1', ex=ttl, nx=True)
+    return result is not None

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -35,6 +35,7 @@ from utils.chat import (
 from utils.llm.persona import initial_persona_chat_message
 from utils.llm.chat import initial_chat_message
 from utils.llm.goals import extract_and_update_goal_progress
+from database.redis_db import try_acquire_goal_extraction_lock
 from utils.other import endpoints as auth, storage
 from utils.other.chat_file import FileChatTool
 from utils.retrieval.graph import execute_graph_chat, execute_graph_chat_stream, execute_persona_chat_stream
@@ -113,8 +114,9 @@ def send_message(
 
     chat_db.add_message(uid, message.dict())
 
-    # Check for goal progress (background)
-    threading.Thread(target=extract_and_update_goal_progress, args=(uid, data.text)).start()
+    # Check for goal progress (background) — rate-limited to one call per user per 5 min
+    if try_acquire_goal_extraction_lock(uid):
+        threading.Thread(target=extract_and_update_goal_progress, args=(uid, data.text)).start()
 
     app = get_available_app_by_id(compat_app_id, uid)
     app = App(**app) if app else None

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -361,6 +361,11 @@ def _trigger_apps(
 def _update_goal_progress(uid: str, conversation: Conversation):
     """Extract and update goal progress from conversation text."""
     try:
+        # Idempotency: skip if this conversation was already processed for goals
+        if not redis_db.try_acquire_conversation_goal_lock(uid, conversation.id):
+            logger.info(f"[GOAL] Skipping already-processed conversation {conversation.id}")
+            return
+
         # Get conversation text
         text = ""
         if conversation.structured and conversation.structured.overview:

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -144,9 +144,7 @@ def retrieve_is_an_omi_question(question: str) -> bool:
     {question}
     
     Is this asking about the Omi/Friend app product itself?
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     with_parser = llm_mini.with_structured_output(IsAnOmiQuestion)
     response: IsAnOmiQuestion = with_parser.invoke(prompt)
     try:
@@ -197,9 +195,7 @@ def retrieve_context_dates_by_question(question: str, tz: str) -> List[datetime]
     {question}
     </question>
 
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
 
     # print(prompt)
     # print(llm_mini.invoke(prompt).content)
@@ -254,9 +250,7 @@ def _get_answer_simple_message_prompt(uid: str, messages: List[Message], app: Op
     {conversation_history}
 
     Answer:
-    """.replace(
-        '    ', ''
-    ).strip()
+    """.replace('    ', '').strip()
 
 
 def answer_simple_message(uid: str, messages: List[Message], plugin: Optional[App] = None) -> str:
@@ -287,9 +281,7 @@ def _get_answer_omi_question_prompt(messages: List[Message], context: str) -> st
     {conversation_history}
 
     Answer:
-    """.replace(
-        '    ', ''
-    ).strip()
+    """.replace('    ', '').strip()
 
 
 def answer_omi_question(messages: List[Message], context: str) -> str:
@@ -329,8 +321,7 @@ def _get_qa_rag_prompt(
       - Avoid citing irrelevant memories.
     """
 
-    return (
-        f"""
+    return f"""
     <assistant_role>
         You are an assistant for question-answering tasks.
     </assistant_role>
@@ -389,12 +380,7 @@ def _get_qa_rag_prompt(
     </question_timezone>
 
     <answer>
-    """.replace(
-            '    ', ''
-        )
-        .replace('\n\n\n', '\n\n')
-        .strip()
-    )
+    """.replace('    ', '').replace('\n\n\n', '\n\n').strip()
 
 
 def _get_agentic_qa_prompt(
@@ -874,9 +860,7 @@ def retrieve_memory_context_params(uid: str, memory: Conversation) -> List[str]:
 
     Conversation:
     {transcript}
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
 
     try:
         with_parser = llm_mini.with_structured_output(TopicsContext)
@@ -918,9 +902,7 @@ def obtain_emotional_message(uid: str, memory: Conversation, context: str, emoti
     ```
     {context}
     ```
-    """.replace(
-        '    ', ''
-    ).strip()
+    """.replace('    ', '').strip()
     return llm_mini.invoke(prompt).content
 
 
@@ -1024,7 +1006,7 @@ def extract_question_from_conversation(messages: List[Message]) -> str:
     </user_last_messages>
 
     <previous_messages>
-    {Message.get_messages_as_xml(messages)}
+    {Message.get_messages_as_xml(messages[:user_message_idx])}
     </previous_messages>
 
     <date_in_term>
@@ -1035,9 +1017,7 @@ def extract_question_from_conversation(messages: List[Message]) -> str:
     - this day
     - etc.
     </date_in_term>
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     # print(prompt)
     question = llm_mini.with_structured_output(OutputQuestion).invoke(prompt).question
     # print(question)
@@ -1084,9 +1064,7 @@ def retrieve_metadata_fields_from_transcript(
     ```
     {full_context}
     ```
-    '''.replace(
-        '    ', ''
-    )
+    '''.replace('    ', '')
     try:
         result: ExtractedInformation = llm_mini.with_structured_output(ExtractedInformation).invoke(prompt)
     except Exception as e:
@@ -1169,9 +1147,7 @@ def retrieve_metadata_from_message(
     ```
     {message_text}
     ```
-    '''.replace(
-        '    ', ''
-    )
+    '''.replace('    ', '')
 
     return _process_extracted_metadata(uid, prompt)
 
@@ -1205,9 +1181,7 @@ def retrieve_metadata_from_text(
     ```
     {text}
     ```
-    '''.replace(
-        '    ', ''
-    )
+    '''.replace('    ', '')
 
     return _process_extracted_metadata(uid, prompt)
 
@@ -1280,9 +1254,7 @@ def select_structured_filters(question: str, filters_available: dict) -> dict:
     ```
 
     Question: {question}
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     # print(prompt)
     with_parser = llm_mini.with_structured_output(FiltersToUse)
     try:
@@ -1330,9 +1302,7 @@ def extract_question_from_transcript(uid: str, segments: List[TranscriptSegment]
     ```
     {TranscriptSegment.segments_as_string(segments, people=people)}
     ```
-    '''.replace(
-        '    ', ''
-    ).strip()
+    '''.replace('    ', '').strip()
     return llm_mini.with_structured_output(OutputQuestion).invoke(prompt).question
 
 
@@ -1381,7 +1351,5 @@ def provide_advice_message(uid: str, segments: List[TranscriptSegment], context:
     ```
     {context}
     ```
-    """.replace(
-        '    ', ''
-    ).strip()
+    """.replace('    ', '').strip()
     return llm_mini.with_structured_output(OutputMessage).invoke(prompt).message


### PR DESCRIPTION
## Summary
Adds structural guards to prevent the LLM cost spike that occurred on Mar 9 (~5x OpenAI spend).

## Changes
- `backend/database/redis_db.py` — Added two Redis guard functions:
  - `try_acquire_goal_extraction_lock(uid)` — per-user rate limit (5 min cooldown) for chat-triggered goal extraction
  - `try_acquire_conversation_goal_lock(uid, conversation_id)` — idempotency gate preventing duplicate goal extraction for the same conversation
- `backend/routers/chat.py` — Goal extraction now gated behind rate limit check; only fires once per 5 min per user instead of every message
- `backend/utils/llm/chat.py` — Fixed `extract_question_from_conversation` sending the full message history twice; `previous_messages` now excludes already-included `user_last_messages`

Fixes #5530