### PR TITLE
Add desktop onboarding audio shortcut verification step

### DIFF
--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -9,13 +9,14 @@ struct OnboardingView: View {
     var onComplete: (() -> Void)? = nil
     @AppStorage("onboardingStep") private var currentStep = 0
     @AppStorage("onboardingVideoStepMigrationDone") private var hasMigratedOnboardingSteps = false
+    @AppStorage("onboardingVoiceShortcutStepMigrationDone") private var hasInsertedVoiceShortcutStep = false
     @StateObject private var graphViewModel = MemoryGraphViewModel()
     @State private var graphHasData = false
     @State private var showTrustPreview = true
     @State private var showGraphHints = false
     @State private var hintsHovered = false
 
-    let steps = ["Chat", "Notifications", "FloatingBar", "VoiceInput", "Tasks"]
+    let steps = ["Chat", "Notifications", "FloatingBar", "VoiceShortcut", "VoiceInput", "Tasks"]
 
     var body: some View {
         ZStack {
@@ -54,9 +55,18 @@ struct OnboardingView: View {
                 hasMigratedOnboardingSteps = true
             }
 
-            // If currentStep is beyond the 5-step flow (0-4), clamp to last step.
-            if currentStep > 4 {
-                currentStep = 4
+            // Inserted a new voice-shortcut verification step before voice input.
+            // Existing users already at voice input or later should be shifted forward once.
+            if !hasInsertedVoiceShortcutStep {
+                if currentStep >= 3 {
+                    currentStep += 1
+                }
+                hasInsertedVoiceShortcutStep = true
+            }
+
+            // If currentStep is beyond the 6-step flow (0-5), clamp to last step.
+            if currentStep > 5 {
+                currentStep = 5
             }
         }
         .task {
@@ -184,24 +194,38 @@ struct OnboardingView: View {
                     }
                 )
             } else if currentStep == 3 {
-                // Step 3: Voice Input Demo
+                // Step 3: Verify Push-to-Talk Shortcut
+                OnboardingVoiceShortcutStepView(
+                    appState: appState,
+                    chatProvider: chatProvider,
+                    onComplete: {
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "VoiceShortcut")
+                        currentStep = 4
+                    },
+                    onSkip: {
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "VoiceShortcut_Skipped")
+                        currentStep = 4
+                    }
+                )
+            } else if currentStep == 4 {
+                // Step 4: Voice Input Demo
                 OnboardingVoiceInputDemoView(
                     appState: appState,
                     chatProvider: chatProvider,
                     onComplete: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "VoiceInput")
-                        currentStep = 4
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "VoiceInput")
+                        currentStep = 5
                     },
                     onSkip: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "VoiceInput_Skipped")
-                        currentStep = 4
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "VoiceInput_Skipped")
+                        currentStep = 5
                     }
                 )
             } else {
-                // Step 4: Tasks
+                // Step 5: Tasks
                 OnboardingTasksStepView(
                     onComplete: {
-                        AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "Tasks")
+                        AnalyticsManager.shared.onboardingStepCompleted(step: 5, stepName: "Tasks")
                         handleOnboardingComplete()
                     }
                 )

--- a/desktop/Desktop/Sources/OnboardingVoiceInputDemoView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceInputDemoView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import AppKit
 
-/// Onboarding step: prompts user to hold the PTT key (Option by default)
+/// Onboarding step: prompts user to hold the selected push-to-talk key
 /// to ask a question using voice via the real floating bar.
 struct OnboardingVoiceInputDemoView: View {
     @ObservedObject var appState: AppState
@@ -10,6 +10,7 @@ struct OnboardingVoiceInputDemoView: View {
     var onSkip: () -> Void
 
     @ObservedObject private var pttManager = PushToTalkManager.shared
+    @ObservedObject private var shortcutSettings = ShortcutSettings.shared
     @State private var hasTried = false
     @State private var showContinue = false
     @State private var pulseAnimation = false
@@ -67,7 +68,7 @@ struct OnboardingVoiceInputDemoView: View {
                         .font(.system(size: 24, weight: .bold))
                         .foregroundColor(OmiColors.textPrimary)
 
-                    Text("Hold the Option key and speak your question.\nRelease to send it.")
+                    Text("Hold \(shortcutSettings.pttKey.rawValue) and speak your question.\nRelease to send it.")
                         .font(.system(size: 14))
                         .foregroundColor(OmiColors.textSecondary)
                         .multilineTextAlignment(.center)
@@ -81,7 +82,7 @@ struct OnboardingVoiceInputDemoView: View {
                                 .font(.system(size: 13))
                                 .foregroundColor(OmiColors.textTertiary)
 
-                            keyCap("⌥")
+                            keyCap(shortcutSettings.pttKey.symbol)
                         }
 
                         Text("Try asking: \"What's the weather in my city?\"")

--- a/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
@@ -1,0 +1,259 @@
+import SwiftUI
+
+/// Onboarding step: verify the push-to-talk shortcut is detected before asking
+/// the user to try a real voice query in the next step.
+struct OnboardingVoiceShortcutStepView: View {
+    @ObservedObject var appState: AppState
+    @ObservedObject var chatProvider: ChatProvider
+    var onComplete: () -> Void
+    var onSkip: () -> Void
+
+    @ObservedObject private var pttManager = PushToTalkManager.shared
+    @ObservedObject private var shortcutSettings = ShortcutSettings.shared
+
+    @State private var observedShortcutPress = false
+
+    var body: some View {
+        HStack(spacing: 0) {
+            leftPane
+
+            Divider()
+                .background(OmiColors.backgroundTertiary)
+
+            rightPane
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(OmiColors.backgroundPrimary)
+        .onAppear {
+            FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
+            if !FloatingControlBarManager.shared.isVisible {
+                FloatingControlBarManager.shared.show()
+            }
+
+            if let barState = FloatingControlBarManager.shared.barState {
+                PushToTalkManager.shared.setup(barState: barState)
+            }
+        }
+        .onChange(of: pttManager.state) { _, newState in
+            if newState != .idle {
+                observedShortcutPress = true
+            }
+        }
+    }
+
+    private var leftPane: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack {
+                Button(action: onSkip) {
+                    Text("Skip")
+                        .font(.system(size: 13))
+                        .foregroundColor(OmiColors.textTertiary)
+                }
+                .buttonStyle(.plain)
+
+                Spacer()
+            }
+            .padding(.horizontal, 28)
+            .padding(.top, 18)
+
+            Spacer()
+
+            VStack(alignment: .leading, spacing: 18) {
+                Text("Press the shortcut\nto test audio")
+                    .font(.system(size: 40, weight: .bold))
+                    .foregroundColor(OmiColors.textPrimary)
+                    .lineSpacing(2)
+
+                Text("Press the key you want to use for voice questions. If it lights up on the right, you're good to go. If not, switch to another key.")
+                    .font(.system(size: 16))
+                    .foregroundColor(OmiColors.textSecondary)
+                    .lineSpacing(4)
+                    .frame(maxWidth: 420, alignment: .leading)
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.horizontal, 50)
+    }
+
+    private var rightPane: some View {
+        ZStack {
+            LinearGradient(
+                colors: [
+                    Color(red: 0.17, green: 0.16, blue: 0.08).opacity(0.12),
+                    Color(red: 0.57, green: 0.48, blue: 0.08).opacity(0.08),
+                    Color.clear
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+            .ignoresSafeArea()
+
+            VStack(spacing: 28) {
+                VStack(alignment: .leading, spacing: 18) {
+                    Text("Does the button turn purple while pressing it?")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(Color.black.opacity(0.86))
+                        .frame(maxWidth: .infinity, alignment: .leading)
+
+                    RoundedRectangle(cornerRadius: 16, style: .continuous)
+                        .fill(Color(red: 0.95, green: 0.94, blue: 0.92))
+                        .frame(height: 128)
+                        .overlay {
+                            shortcutKeyPreview
+                        }
+
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Try another key if it doesn't react:")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(Color.black.opacity(0.68))
+
+                        HStack(spacing: 10) {
+                            ForEach(ShortcutSettings.PTTKey.allCases, id: \.self) { key in
+                                shortcutChoiceButton(key)
+                            }
+                        }
+                    }
+                }
+                .padding(32)
+                .background(
+                    RoundedRectangle(cornerRadius: 24, style: .continuous)
+                        .fill(Color.white.opacity(0.97))
+                        .shadow(color: .black.opacity(0.08), radius: 26, x: 0, y: 14)
+                )
+                .frame(maxWidth: 520)
+
+                HStack(spacing: 14) {
+                    Button(action: cycleShortcut) {
+                        Text("No, change shortcut")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(Color.black.opacity(0.72))
+                            .padding(.horizontal, 18)
+                            .padding(.vertical, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(Color.white.opacity(0.82))
+                            )
+                    }
+                    .buttonStyle(.plain)
+
+                    Button(action: onComplete) {
+                        Text("Yes")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 28)
+                            .padding(.vertical, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(observedShortcutPress ? OmiColors.purplePrimary : Color(red: 0.85, green: 0.82, blue: 0.78))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!observedShortcutPress)
+                    .opacity(observedShortcutPress ? 1 : 0.7)
+                }
+            }
+            .padding(.horizontal, 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var shortcutKeyPreview: some View {
+        VStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(isShortcutActive ? OmiColors.purplePrimary : Color.white)
+                .frame(width: 64, height: 64)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .stroke(isShortcutActive ? OmiColors.purplePrimary : Color.black.opacity(0.12), lineWidth: 2)
+                )
+                .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 6)
+                .overlay {
+                    VStack(spacing: 6) {
+                        Text(shortcutLabelTop)
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(isShortcutActive ? .white : Color.black.opacity(0.7))
+
+                        Text(shortcutLabelBottom)
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(isShortcutActive ? .white.opacity(0.95) : Color.black.opacity(0.65))
+                    }
+                }
+
+            Text(isShortcutActive ? "Shortcut detected" : "Press and hold to test")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(Color.black.opacity(0.55))
+        }
+    }
+
+    private func shortcutChoiceButton(_ key: ShortcutSettings.PTTKey) -> some View {
+        let isSelected = shortcutSettings.pttKey == key
+        return Button {
+            shortcutSettings.pttKey = key
+            observedShortcutPress = false
+        } label: {
+            HStack(spacing: 6) {
+                Text(key.symbol)
+                    .font(.system(size: 14, weight: .medium))
+                Text(pttChoiceTitle(for: key))
+                    .font(.system(size: 13, weight: .semibold))
+            }
+            .foregroundColor(isSelected ? .white : Color.black.opacity(0.7))
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isSelected ? OmiColors.purplePrimary : Color.white)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(isSelected ? OmiColors.purplePrimary : Color.black.opacity(0.08), lineWidth: 1)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var isShortcutActive: Bool {
+        switch pttManager.state {
+        case .idle:
+            return false
+        case .listening, .lockedListening, .finalizing:
+            return true
+        }
+    }
+
+    private var shortcutLabelTop: String {
+        switch shortcutSettings.pttKey {
+        case .option:
+            return "option"
+        case .rightCommand:
+            return "right cmd"
+        case .fn:
+            return "fn"
+        }
+    }
+
+    private var shortcutLabelBottom: String {
+        shortcutSettings.pttKey.symbol
+    }
+
+    private func pttChoiceTitle(for key: ShortcutSettings.PTTKey) -> String {
+        switch key {
+        case .option:
+            return "Option"
+        case .rightCommand:
+            return "Right Cmd"
+        case .fn:
+            return "Fn"
+        }
+    }
+
+    private func cycleShortcut() {
+        let allKeys = ShortcutSettings.PTTKey.allCases
+        guard let currentIndex = allKeys.firstIndex(of: shortcutSettings.pttKey) else { return }
+        let nextIndex = allKeys.index(after: currentIndex)
+        shortcutSettings.pttKey = nextIndex == allKeys.endIndex ? allKeys[allKeys.startIndex] : allKeys[nextIndex]
+        observedShortcutPress = false
+    }
+}


### PR DESCRIPTION
## Summary
- insert a dedicated onboarding step to verify the push-to-talk audio shortcut before the voice-input demo
- let the screen reflect the selected audio shortcut and enable continue after a real shortcut press is detected
- update the following voice-input onboarding step to show the currently selected push-to-talk key

## Testing
- xcrun swift build -c debug --package-path Desktop
- launched isolated app bundle `/Applications/Omi Audio Shortcut.app` (`com.omi.desktop-audio-shortcut-test`)
- verified through UI that the new step renders before voice input
- verified a real Option key press enables the `Yes` button on the new step
- verified the following voice-input screen shows `Hold Option (⌥)`
