### PR TITLE
Keep Ask Omi from surfacing the main window

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2,8 +2,11 @@ import Cocoa
 import Combine
 import SwiftUI
 
-/// NSWindow subclass for the floating control bar.
-class FloatingControlBarWindow: NSWindow, NSWindowDelegate {
+/// NSPanel subclass for the floating control bar.
+///
+/// Using a non-activating panel lets the Ask Omi shortcut focus the floating bar
+/// without surfacing the main Omi window when the app is already running.
+class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private static let positionKey = "FloatingControlBarPosition"
     private static let sizeKey = "FloatingControlBarSize"
     private static let defaultSize = NSSize(width: 40, height: 10)
@@ -56,7 +59,7 @@ class FloatingControlBarWindow: NSWindow, NSWindowDelegate {
 
         super.init(
             contentRect: initialRect,
-            styleMask: [.borderless],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: backingStoreType,
             defer: flag
         )
@@ -90,7 +93,7 @@ class FloatingControlBarWindow: NSWindow, NSWindowDelegate {
     }
 
     override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { true }
+    override var canBecomeMain: Bool { false }
 
     override func keyDown(with event: NSEvent) {
         // Esc closes the AI conversation only — never hides the entire bar
@@ -937,9 +940,8 @@ class FloatingControlBarManager {
     func openAIInput() {
         guard let window = window else { return }
 
-        // Activate only the app process so the floating bar can accept keyboard input
-        // without pulling the main Omi window in front of the current app.
-        NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
+        // The bar is a non-activating panel, so it can become key for text input
+        // without surfacing the main Omi window.
 
         // If a conversation is already showing, just focus the follow-up input
         if window.state.showingAIConversation && window.state.showingAIResponse {


### PR DESCRIPTION
## Summary
- make the floating bar a non-activating panel instead of a regular window
- keep Ask Omi focus on the floating bar without surfacing the main Omi window
- preserve text-input focus behavior for the floating bar shortcut flow

## Testing
- xcrun swift build -c debug --package-path desktop/Desktop
- launched isolated app bundle `/Applications/Omi Shortcut Focus Test.app`
- verified through full-screen UI screenshots that after `⌘ Enter`, the foreground app stayed visible and only the floating bar appeared on top
- evidence: `/tmp/omi-shortcut-full-before.png` and `/tmp/omi-shortcut-full-after.png`
