### PR TITLE
Add local desktop automation bridge and managed Sparkle updates

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -1,2838 +1,2979 @@
-import SwiftUI
-import Combine
-import UserNotifications
 import AVFoundation
+import Combine
 @preconcurrency import ObjectiveC
+import SwiftUI
+import UserNotifications
 
 /// Speaker segment for diarized transcription
 struct SpeakerSegment: Identifiable {
-    /// Stable identity derived from speaker + start time (unique per segment)
-    var id: String { "\(speaker)-\(start)" }
-    var speaker: Int
-    var text: String
-    var start: Double
-    var end: Double
+  /// Stable identity derived from speaker + start time (unique per segment)
+  var id: String { "\(speaker)-\(start)" }
+  var speaker: Int
+  var text: String
+  var start: Double
+  var end: Double
 }
 
 /// Result of finalizing a conversation
 enum FinishConversationResult {
-    case saved
-    case discarded
-    case error(String)
+  case saved
+  case discarded
+  case error(String)
 }
 
 @MainActor
 class AppState: ObservableObject {
-    @AppStorage("hasCompletedOnboarding") var hasCompletedOnboarding = false
+  @AppStorage("hasCompletedOnboarding") var hasCompletedOnboarding = false
 
-    // Transcription state
-    @Published var isTranscribing = false
-    @Published var isSavingConversation = false
-    // currentTranscript is internal-only (not observed by views), so no @Published needed
-    private var currentTranscript: String = ""
-    @Published var hasMicrophonePermission = false
-    @Published var hasSystemAudioPermission = false
-    @Published var isSystemAudioSupported = false
+  // Transcription state
+  @Published var isTranscribing = false
+  @Published var isSavingConversation = false
+  // currentTranscript is internal-only (not observed by views), so no @Published needed
+  private var currentTranscript: String = ""
+  @Published var hasMicrophonePermission = false
+  @Published var hasSystemAudioPermission = false
+  @Published var isSystemAudioSupported = false
 
-    // Audio source (microphone or BLE device)
-    @Published var audioSource: AudioSource = .microphone
-    /// Tracks the source for the current recording (for API tagging)
-    private var currentConversationSource: ConversationSource = .desktop
+  // Audio source (microphone or BLE device)
+  @Published var audioSource: AudioSource = .microphone
+  /// Tracks the source for the current recording (for API tagging)
+  private var currentConversationSource: ConversationSource = .desktop
 
-    // Audio levels moved to AudioLevelMonitor to avoid triggering global re-renders
-    // Access via AudioLevelMonitor.shared.microphoneLevel / .systemLevel
-    var microphoneAudioLevel: Float { AudioLevelMonitor.shared.microphoneLevel }
-    var systemAudioLevel: Float { AudioLevelMonitor.shared.systemLevel }
+  // Audio levels moved to AudioLevelMonitor to avoid triggering global re-renders
+  // Access via AudioLevelMonitor.shared.microphoneLevel / .systemLevel
+  var microphoneAudioLevel: Float { AudioLevelMonitor.shared.microphoneLevel }
+  var systemAudioLevel: Float { AudioLevelMonitor.shared.systemLevel }
 
-    // Recording timer moved to RecordingTimer to avoid triggering global re-renders
-    // Access via RecordingTimer.shared.duration
-    var recordingDuration: TimeInterval { RecordingTimer.shared.duration }
+  // Recording timer moved to RecordingTimer to avoid triggering global re-renders
+  // Access via RecordingTimer.shared.duration
+  var recordingDuration: TimeInterval { RecordingTimer.shared.duration }
 
-    // Live speaker segments moved to LiveTranscriptMonitor to avoid triggering global re-renders
-    // Access via LiveTranscriptMonitor.shared.segments
-    var liveSpeakerSegments: [SpeakerSegment] { LiveTranscriptMonitor.shared.segments }
+  // Live speaker segments moved to LiveTranscriptMonitor to avoid triggering global re-renders
+  // Access via LiveTranscriptMonitor.shared.segments
+  var liveSpeakerSegments: [SpeakerSegment] { LiveTranscriptMonitor.shared.segments }
 
-    // Conversation state
-    @Published var conversations: [ServerConversation] = []
-    @Published var isLoadingConversations: Bool = false
-    @Published var conversationsError: String? = nil
-    @Published var totalConversationsCount: Int? = nil  // Total count (fetched separately)
+  // Conversation state
+  @Published var conversations: [ServerConversation] = []
+  @Published var isLoadingConversations: Bool = false
+  @Published var conversationsError: String? = nil
+  @Published var totalConversationsCount: Int? = nil  // Total count (fetched separately)
 
-    // Conversation filters
-    @Published var showStarredOnly: Bool = false
-    @Published var selectedDateFilter: Date? = nil
-    @Published var selectedFolderId: String? = nil
+  // Conversation filters
+  @Published var showStarredOnly: Bool = false
+  @Published var selectedDateFilter: Date? = nil
+  @Published var selectedFolderId: String? = nil
 
-    // Folders
-    @Published var folders: [Folder] = []
-    @Published var isLoadingFolders: Bool = false
+  // Folders
+  @Published var folders: [Folder] = []
+  @Published var isLoadingFolders: Bool = false
 
-    // People (speaker voice profiles)
-    @Published var people: [Person] = []
-    var peopleById: [String: Person] {
-        Dictionary(uniqueKeysWithValues: people.map { ($0.id, $0) })
+  // People (speaker voice profiles)
+  @Published var people: [Person] = []
+  var peopleById: [String: Person] {
+    Dictionary(uniqueKeysWithValues: people.map { ($0.id, $0) })
+  }
+
+  /// Maps live speaker IDs to person IDs during recording (cleared on finalize)
+  @Published var liveSpeakerPersonMap: [Int: String] = [:]
+
+  // Permission states for onboarding
+  @Published var hasNotificationPermission = false
+  @Published var notificationAlertStyle: UNAlertStyle = .none  // .none, .banner, or .alert
+  @Published var hasScreenRecordingPermission = false
+  @Published var hasBluetoothPermission = false
+
+  // Track last notification settings for change detection (avoid duplicate analytics)
+  private var lastNotificationAuthStatus: String?
+  private var lastNotificationAlertStyle: String?
+  private var lastNotificationSoundEnabled: Bool?
+  private var lastNotificationBadgeEnabled: Bool?
+  @Published var isScreenCaptureKitBroken = false  // TCC says yes but ScreenCaptureKit says no
+  @Published var isScreenRecordingStale = false  // TCC says yes but capture fails (developer signing changed)
+  var screenRecordingGrantAttempts = 0  // Track how many times user clicked Grant without success
+  @Published var hasAutomationPermission = false
+  @Published var automationPermissionError: OSStatus = 0  // Non-zero when check fails unexpectedly (e.g. -600 procNotFound)
+  private var isCheckingAutomationPermission = false  // Prevent concurrent checks (retry path has a 1s sleep)
+  @Published var hasAccessibilityPermission = false
+  @Published var isAccessibilityBroken = false  // TCC says yes but AX calls actually fail (common after macOS updates/app re-signs)
+
+  /// True if notifications are enabled but won't show visual banners
+  var isNotificationBannerDisabled: Bool {
+    hasNotificationPermission && notificationAlertStyle == .none
+  }
+
+  /// Returns list of missing permissions that are required for full functionality
+  var missingPermissions: [String] {
+    var missing: [String] = []
+    if !hasMicrophonePermission { missing.append("Microphone") }
+    if !hasScreenRecordingPermission || isScreenCaptureKitBroken || isScreenRecordingStale {
+      missing.append("Screen Recording")
+    }
+    if !hasNotificationPermission {
+      missing.append("Notifications")
+    } else if isNotificationBannerDisabled {
+      missing.append("Notification Banners")
+    }
+    if !hasAccessibilityPermission || isAccessibilityBroken { missing.append("Accessibility") }
+    return missing
+  }
+
+  /// Check if notification permission was explicitly denied
+  func isNotificationPermissionDenied() -> Bool {
+    // We need to check synchronously, so use a semaphore pattern
+    // This is cached from checkNotificationPermission() calls
+    return hasCompletedOnboarding && !hasNotificationPermission
+  }
+
+  /// Open notification preferences in System Settings (directly to Omi's settings)
+  func openNotificationPreferences() {
+    let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
+    if let url = URL(
+      string: "x-apple.systempreferences:com.apple.preference.notifications?id=\(bundleId)")
+    {
+      NSWorkspace.shared.open(url)
+    }
+  }
+
+  /// True if any required permissions are missing
+  var hasMissingPermissions: Bool {
+    !missingPermissions.isEmpty
+  }
+
+  // Transcription services
+  private var audioCaptureService: AudioCaptureService?
+  private var transcriptionService: TranscriptionService?
+  private var systemAudioCaptureService: Any?  // SystemAudioCaptureService (macOS 14.4+)
+  private var audioMixer: AudioMixer?
+  private var vadGateService: VADGateService?
+
+  // Batch transcription mode
+  private var useBatchTranscription: Bool = false
+  private var recordingStartCATime: Double = 0  // CACurrentMediaTime at recording start
+
+  // Speaker segments for diarized transcription (sliding window — older segments are in SQLite)
+  private var speakerSegments: [SpeakerSegment] = []
+  private let maxInMemorySegments = 200
+  private var totalSegmentCount = 0  // Total segments created this session (including trimmed)
+  private var totalWordCount = 0  // Running word count for analytics
+
+  // Conversation tracking for auto-save
+  private var recordingStartTime: Date?
+  private var recordingInputDeviceName: String?  // Microphone name used for this recording
+  private var maxRecordingTimer: Timer?
+  private let maxRecordingDuration: TimeInterval = 4 * 60 * 60  // 4 hours
+
+  // Periodic notification health check timer
+  private var notificationHealthTimer: Timer?
+
+  // Crash-safe transcription storage
+  private var currentSessionId: Int64?
+
+  // Observers for app lifecycle
+  private var willTerminateObserver: NSObjectProtocol?
+  private var willSleepObserver: NSObjectProtocol?
+  private var didWakeObserver: NSObjectProtocol?
+  private var screenLockedObserver: NSObjectProtocol?
+  private var screenUnlockedObserver: NSObjectProtocol?
+  private var screenCapturePermissionLostObserver: NSObjectProtocol?
+  private var screenCaptureKitBrokenObserver: NSObjectProtocol?
+
+  // Track transcription state across sleep/wake cycles
+  private var wasTranscribingBeforeSleep = false
+
+  // Debounce timestamps to prevent duplicate system notifications
+  private var lastScreenLockTime: Date?
+  private var lastScreenUnlockTime: Date?
+
+  // BLE device button handling
+  private var buttonStreamTask: Task<Void, Never>?
+
+  // Combine subscriptions
+  private var bluetoothStateCancellable: AnyCancellable?
+
+  init() {
+    // Load API key from environment or .env file
+    loadEnvironment()
+
+    // Setup lifecycle observers for saving conversations
+    setupLifecycleObservers()
+
+    // Wire up memory pressure callback so ResourceMonitor can trim transcript state
+    ResourceMonitor.shared.onMemoryPressureTrimTranscript = { [weak self] in
+      self?.trimTranscriptStateForMemoryPressure()
     }
 
-    /// Maps live speaker IDs to person IDs during recording (cleared on finalize)
-    @Published var liveSpeakerPersonMap: [Int: String] = [:]
-
-    // Permission states for onboarding
-    @Published var hasNotificationPermission = false
-    @Published var notificationAlertStyle: UNAlertStyle = .none  // .none, .banner, or .alert
-    @Published var hasScreenRecordingPermission = false
-    @Published var hasBluetoothPermission = false
-
-    // Track last notification settings for change detection (avoid duplicate analytics)
-    private var lastNotificationAuthStatus: String?
-    private var lastNotificationAlertStyle: String?
-    private var lastNotificationSoundEnabled: Bool?
-    private var lastNotificationBadgeEnabled: Bool?
-    @Published var isScreenCaptureKitBroken = false  // TCC says yes but ScreenCaptureKit says no
-    @Published var isScreenRecordingStale = false  // TCC says yes but capture fails (developer signing changed)
-    var screenRecordingGrantAttempts = 0  // Track how many times user clicked Grant without success
-    @Published var hasAutomationPermission = false
-    @Published var automationPermissionError: OSStatus = 0  // Non-zero when check fails unexpectedly (e.g. -600 procNotFound)
-    private var isCheckingAutomationPermission = false  // Prevent concurrent checks (retry path has a 1s sleep)
-    @Published var hasAccessibilityPermission = false
-    @Published var isAccessibilityBroken = false  // TCC says yes but AX calls actually fail (common after macOS updates/app re-signs)
-
-    /// True if notifications are enabled but won't show visual banners
-    var isNotificationBannerDisabled: Bool {
-        hasNotificationPermission && notificationAlertStyle == .none
+    // Listen for screen capture permission loss notifications
+    screenCapturePermissionLostObserver = NotificationCenter.default.addObserver(
+      forName: .screenCapturePermissionLost,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        self?.hasScreenRecordingPermission = false
+        self?.isScreenCaptureKitBroken = false  // Not broken, just lost
+        log("AppState: Screen recording permission lost")
+      }
     }
 
-
-    /// Returns list of missing permissions that are required for full functionality
-    var missingPermissions: [String] {
-        var missing: [String] = []
-        if !hasMicrophonePermission { missing.append("Microphone") }
-        if !hasScreenRecordingPermission || isScreenCaptureKitBroken || isScreenRecordingStale { missing.append("Screen Recording") }
-        if !hasNotificationPermission { missing.append("Notifications") }
-        else if isNotificationBannerDisabled { missing.append("Notification Banners") }
-        if !hasAccessibilityPermission || isAccessibilityBroken { missing.append("Accessibility") }
-        return missing
+    // Listen for ScreenCaptureKit broken notifications (TCC granted but SCK declined)
+    screenCaptureKitBrokenObserver = NotificationCenter.default.addObserver(
+      forName: .screenCaptureKitBroken,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        self?.hasScreenRecordingPermission = false
+        self?.isScreenCaptureKitBroken = true  // Needs reset
+        log("AppState: ScreenCaptureKit broken - needs reset")
+      }
     }
 
-    /// Check if notification permission was explicitly denied
-    func isNotificationPermissionDenied() -> Bool {
-        // We need to check synchronously, so use a semaphore pattern
-        // This is cached from checkNotificationPermission() calls
-        return hasCompletedOnboarding && !hasNotificationPermission
+    // Check if system audio capture is supported (macOS 14.4+)
+    // Note: hasSystemAudioPermission stays false until actually tested during onboarding
+    if #available(macOS 14.4, *) {
+      isSystemAudioSupported = true
     }
 
-    /// Open notification preferences in System Settings (directly to Omi's settings)
-    func openNotificationPreferences() {
-        let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications?id=\(bundleId)") {
-            NSWorkspace.shared.open(url)
-        }
+    // Note: Bluetooth subscription is initialized lazily via initializeBluetoothIfNeeded()
+    // to avoid triggering the permission dialog before the user reaches the Bluetooth step
+
+    // Start periodic notification health check (every 30 min)
+    // Detects when macOS silently revokes notification authorization and auto-repairs
+    notificationHealthTimer = Timer.scheduledTimer(withTimeInterval: 30 * 60, repeats: true) {
+      [weak self] _ in
+      DispatchQueue.main.async {
+        self?.checkNotificationPermission()
+      }
+    }
+  }
+
+  /// Initialize Bluetooth manager and subscribe to state changes
+  /// Call this only when the user reaches the Bluetooth onboarding step
+  func initializeBluetoothIfNeeded() {
+    guard bluetoothStateCancellable == nil else {
+      log("Bluetooth already initialized, skipping")
+      return
     }
 
-    /// True if any required permissions are missing
-    var hasMissingPermissions: Bool {
-        !missingPermissions.isEmpty
-    }
+    log("Initializing Bluetooth manager...")
 
-    // Transcription services
-    private var audioCaptureService: AudioCaptureService?
-    private var transcriptionService: TranscriptionService?
-    private var systemAudioCaptureService: Any?  // SystemAudioCaptureService (macOS 14.4+)
-    private var audioMixer: AudioMixer?
-    private var vadGateService: VADGateService?
+    // Also initialize DeviceProvider's Bluetooth bindings
+    DeviceProvider.shared.initializeBluetoothBindingsIfNeeded()
 
-    // Batch transcription mode
-    private var useBatchTranscription: Bool = false
-    private var recordingStartCATime: Double = 0  // CACurrentMediaTime at recording start
-
-    // Speaker segments for diarized transcription (sliding window — older segments are in SQLite)
-    private var speakerSegments: [SpeakerSegment] = []
-    private let maxInMemorySegments = 200
-    private var totalSegmentCount = 0  // Total segments created this session (including trimmed)
-    private var totalWordCount = 0     // Running word count for analytics
-
-    // Conversation tracking for auto-save
-    private var recordingStartTime: Date?
-    private var recordingInputDeviceName: String?  // Microphone name used for this recording
-    private var maxRecordingTimer: Timer?
-    private let maxRecordingDuration: TimeInterval = 4 * 60 * 60  // 4 hours
-
-    // Periodic notification health check timer
-    private var notificationHealthTimer: Timer?
-
-    // Crash-safe transcription storage
-    private var currentSessionId: Int64?
-
-    // Observers for app lifecycle
-    private var willTerminateObserver: NSObjectProtocol?
-    private var willSleepObserver: NSObjectProtocol?
-    private var didWakeObserver: NSObjectProtocol?
-    private var screenLockedObserver: NSObjectProtocol?
-    private var screenUnlockedObserver: NSObjectProtocol?
-    private var screenCapturePermissionLostObserver: NSObjectProtocol?
-    private var screenCaptureKitBrokenObserver: NSObjectProtocol?
-
-    // Track transcription state across sleep/wake cycles
-    private var wasTranscribingBeforeSleep = false
-
-    // Debounce timestamps to prevent duplicate system notifications
-    private var lastScreenLockTime: Date?
-    private var lastScreenUnlockTime: Date?
-
-    // BLE device button handling
-    private var buttonStreamTask: Task<Void, Never>?
-
-    // Combine subscriptions
-    private var bluetoothStateCancellable: AnyCancellable?
-
-    init() {
-        // Load API key from environment or .env file
-        loadEnvironment()
-
-        // Setup lifecycle observers for saving conversations
-        setupLifecycleObservers()
-
-        // Wire up memory pressure callback so ResourceMonitor can trim transcript state
-        ResourceMonitor.shared.onMemoryPressureTrimTranscript = { [weak self] in
-            self?.trimTranscriptStateForMemoryPressure()
-        }
-
-        // Listen for screen capture permission loss notifications
-        screenCapturePermissionLostObserver = NotificationCenter.default.addObserver(
-            forName: .screenCapturePermissionLost,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.hasScreenRecordingPermission = false
-                self?.isScreenCaptureKitBroken = false  // Not broken, just lost
-                log("AppState: Screen recording permission lost")
-            }
-        }
-
-        // Listen for ScreenCaptureKit broken notifications (TCC granted but SCK declined)
-        screenCaptureKitBrokenObserver = NotificationCenter.default.addObserver(
-            forName: .screenCaptureKitBroken,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.hasScreenRecordingPermission = false
-                self?.isScreenCaptureKitBroken = true  // Needs reset
-                log("AppState: ScreenCaptureKit broken - needs reset")
-            }
-        }
-
-        // Check if system audio capture is supported (macOS 14.4+)
-        // Note: hasSystemAudioPermission stays false until actually tested during onboarding
-        if #available(macOS 14.4, *) {
-            isSystemAudioSupported = true
-        }
-
-        // Note: Bluetooth subscription is initialized lazily via initializeBluetoothIfNeeded()
-        // to avoid triggering the permission dialog before the user reaches the Bluetooth step
-
-        // Start periodic notification health check (every 30 min)
-        // Detects when macOS silently revokes notification authorization and auto-repairs
-        notificationHealthTimer = Timer.scheduledTimer(withTimeInterval: 30 * 60, repeats: true) { [weak self] _ in
-            DispatchQueue.main.async {
-                self?.checkNotificationPermission()
-            }
-        }
-    }
-
-    /// Initialize Bluetooth manager and subscribe to state changes
-    /// Call this only when the user reaches the Bluetooth onboarding step
-    func initializeBluetoothIfNeeded() {
-        guard bluetoothStateCancellable == nil else {
-            log("Bluetooth already initialized, skipping")
-            return
-        }
-
-        log("Initializing Bluetooth manager...")
-
-        // Also initialize DeviceProvider's Bluetooth bindings
-        DeviceProvider.shared.initializeBluetoothBindingsIfNeeded()
-
-        // Subscribe to Bluetooth state changes for reactive permission updates
-        bluetoothStateCancellable = BluetoothManager.shared.$bluetoothState
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] state in
-                guard let self = self else { return }
-                let oldValue = self.hasBluetoothPermission
-                // poweredOn = ready to use, poweredOff = allowed but BT is off
-                let newValue = state == .poweredOn || state == .poweredOff
-                log("BLUETOOTH_SUBSCRIPTION: state=\(BluetoothManager.shared.bluetoothStateDescription), stateRaw=\(state.rawValue), auth=\(BluetoothManager.shared.authorizationDescription), granted=\(newValue)")
-                if newValue != oldValue {
-                    log("Bluetooth permission changed via subscription: \(oldValue) -> \(newValue), state=\(BluetoothManager.shared.bluetoothStateDescription)")
-                    self.hasBluetoothPermission = newValue
-                }
-            }
-    }
-
-    /// Setup observers for app quit and system sleep to finalize conversations
-    private func setupLifecycleObservers() {
-        // App is about to quit
-        willTerminateObserver = NotificationCenter.default.addObserver(
-            forName: NSApplication.willTerminateNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            guard let self = self else { return }
-            Task { @MainActor in
-                if self.isTranscribing {
-                    log("App terminating - finalizing conversation")
-                    _ = await self.finalizeConversation()
-                    self.clearTranscriptionState()
-                }
-            }
-        }
-
-        // Computer is about to sleep
-        willSleepObserver = NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.willSleepNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            guard let self = self else { return }
-            Task { @MainActor in
-                self.wasTranscribingBeforeSleep = self.isTranscribing
-                if self.isTranscribing {
-                    log("Computer sleeping - finalizing conversation (will restart on wake)")
-                    _ = await self.finalizeConversation()
-                    self.stopAudioCapture()
-                    self.clearTranscriptionState()
-                }
-                // Flush final sync changes before sleep
-                await AgentSyncService.shared.stop()
-            }
-        }
-
-        // Computer woke from sleep
-        didWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
-            forName: NSWorkspace.didWakeNotification,
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            log("System woke from sleep")
-            NotificationCenter.default.post(name: .systemDidWake, object: nil)
-
-            // Restart transcription if it was active before sleep
-            Task { @MainActor in
-                guard let self = self else { return }
-                if self.wasTranscribingBeforeSleep && AssistantSettings.shared.transcriptionEnabled {
-                    log("System wake: Restarting transcription (was active before sleep)")
-                    // Brief delay to let audio subsystem settle after wake
-                    try? await Task.sleep(for: .seconds(2))
-                    if !self.isTranscribing {
-                        self.startTranscription()
-                    }
-                }
-                self.wasTranscribingBeforeSleep = false
-            }
-        }
-
-        // Screen locked (debounced - macOS sometimes fires multiple times)
-        screenLockedObserver = DistributedNotificationCenter.default().addObserver(
-            forName: NSNotification.Name("com.apple.screenIsLocked"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                let now = Date()
-                if let lastTime = self?.lastScreenLockTime, now.timeIntervalSince(lastTime) < 1.0 {
-                    return // Ignore duplicate within 1 second
-                }
-                self?.lastScreenLockTime = now
-                log("Screen locked")
-                NotificationCenter.default.post(name: .screenDidLock, object: nil)
-            }
-        }
-
-        // Screen unlocked (debounced - macOS sometimes fires multiple times)
-        screenUnlockedObserver = DistributedNotificationCenter.default().addObserver(
-            forName: NSNotification.Name("com.apple.screenIsUnlocked"),
-            object: nil,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                let now = Date()
-                if let lastTime = self?.lastScreenUnlockTime, now.timeIntervalSince(lastTime) < 1.0 {
-                    return // Ignore duplicate within 1 second
-                }
-                self?.lastScreenUnlockTime = now
-                log("Screen unlocked")
-                NotificationCenter.default.post(name: .screenDidUnlock, object: nil)
-            }
-        }
-    }
-
-    deinit {
-        if let observer = willTerminateObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        if let observer = willSleepObserver {
-            NSWorkspace.shared.notificationCenter.removeObserver(observer)
-        }
-        if let observer = didWakeObserver {
-            NSWorkspace.shared.notificationCenter.removeObserver(observer)
-        }
-        if let observer = screenLockedObserver {
-            DistributedNotificationCenter.default().removeObserver(observer)
-        }
-        if let observer = screenUnlockedObserver {
-            DistributedNotificationCenter.default().removeObserver(observer)
-        }
-        if let observer = screenCapturePermissionLostObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        if let observer = screenCaptureKitBrokenObserver {
-            NotificationCenter.default.removeObserver(observer)
-        }
-    }
-
-    private func loadEnvironment() {
-        let bundledEnvPath = Bundle.main.path(forResource: ".env", ofType: nil)
-
-        // Try to load from .env file in various locations
-        let envPaths = [
-            bundledEnvPath,
-            FileManager.default.currentDirectoryPath + "/.env",
-            NSHomeDirectory() + "/.hartford.env",
-            NSHomeDirectory() + "/.omi.env",
-            // Explicit paths for development
-            "/Users/matthewdi/omi-computer-swift/.env",
-            "/Users/matthewdi/omi/backend/.env"
-        ].compactMap { $0 }
-
-        for path in envPaths {
-            if let contents = try? String(contentsOfFile: path, encoding: .utf8) {
-                log("Loading environment from: \(path)")
-                for line in contents.components(separatedBy: .newlines) {
-                    let parts = line.split(separator: "=", maxSplits: 1)
-                    if parts.count == 2 {
-                        let key = String(parts[0]).trimmingCharacters(in: .whitespaces)
-                        // Skip comments
-                        guard !key.hasPrefix("#") else { continue }
-                        if shouldSkipBundledAnthropicKey(key: key, sourcePath: path, bundledEnvPath: bundledEnvPath) {
-                            log("  Skipped ANTHROPIC_API_KEY from bundled .env (prod safety)")
-                            continue
-                        }
-                        let value = String(parts[1]).trimmingCharacters(in: .whitespaces)
-                            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                        setenv(key, value, 1)
-                        // Log key names (not values for security)
-                        if key.contains("API_KEY") || key.contains("KEY") {
-                            log("  Set \(key)=***")
-                        }
-                    }
-                }
-                // Don't break - load all .env files to merge keys
-            }
-        }
-
-        // Log final state of important keys
-        if getenv("DEEPGRAM_API_KEY") != nil {
-            log("DEEPGRAM_API_KEY is set")
-        } else {
-            log("WARNING: DEEPGRAM_API_KEY is NOT set")
-        }
-    }
-
-    private func shouldSkipBundledAnthropicKey(key: String, sourcePath: String, bundledEnvPath: String?) -> Bool {
-        guard key == "ANTHROPIC_API_KEY" else { return false }
-        guard let bundledEnvPath, sourcePath == bundledEnvPath else { return false }
-        let bundleId = Bundle.main.bundleIdentifier ?? ""
-        let isProductionBundle = bundleId == "com.omi.computer-macos"
-        return isProductionBundle
-    }
-
-    func openScreenRecordingPreferences() {
-        ScreenCaptureService.openScreenRecordingPreferences()
-    }
-
-    func openAutomationPreferences() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
-    func requestNotificationPermission() {
-        // First check current authorization status
-        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
-            DispatchQueue.main.async {
-                guard let self = self else { return }
-
-                if settings.authorizationStatus == .notDetermined {
-                    // First time - show the system prompt
-                    NSApp.activate(ignoringOtherApps: true)
-                    UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge]) { [weak self] granted, error in
-                        if let error = error {
-                            let nsError = error as NSError
-                            log("Notification permission error: \(error) (domain=\(nsError.domain) code=\(nsError.code))")
-
-                            // UNErrorDomain code 1 = notificationsNotAllowed
-                            // This happens when LaunchServices has the app marked as launch-disabled,
-                            // which prevents the notification center from registering the app.
-                            // Fix: unregister from LaunchServices and re-register to clear the flag, then retry.
-                            if nsError.domain == "UNErrorDomain" && nsError.code == 1 {
-                                DispatchQueue.main.async {
-                                    AnalyticsManager.shared.notificationRepairTriggered(
-                                        reason: "launch_disabled_error",
-                                        previousStatus: "notDetermined",
-                                        currentStatus: "error_code_1"
-                                    )
-                                    self?.repairNotificationRegistrationAndRetry()
-                                }
-                                return
-                            }
-                        }
-                        DispatchQueue.main.async {
-                            self?.checkNotificationPermission()
-                        }
-                    }
-                } else if settings.authorizationStatus == .denied {
-                    // Previously denied - open System Settings so user can enable manually
-                    self.openNotificationPreferences()
-                }
-                // If already authorized, checkNotificationPermission() will handle it
-            }
-        }
-    }
-
-    /// Repair LaunchServices registration when notification authorization fails.
-    /// The "launch-disabled" flag in LaunchServices prevents the notification center
-    /// from registering the app. This unregisters and re-registers to clear the flag.
-    private func repairNotificationRegistrationAndRetry() {
-        // Use the shared repair utility (also used by ProactiveAssistantsPlugin)
-        ProactiveAssistantsPlugin.repairNotificationRegistration()
-
-        // After the repair + retry, update our permission state and open System Settings as fallback
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
-            UNUserNotificationCenter.current().getNotificationSettings { settings in
-                DispatchQueue.main.async {
-                    let isNowGranted = settings.authorizationStatus == .authorized
-                    self?.hasNotificationPermission = isNowGranted
-                    if !isNowGranted {
-                        log("Notification permission still not granted after repair. Opening System Settings.")
-                        self?.openNotificationPreferences()
-                    }
-                }
-            }
-        }
-    }
-
-    /// Repair notification registration via lsregister, then fall back to System Settings if still broken.
-    /// Called from sidebar and settings "Fix" buttons when auth is not authorized.
-    func repairNotificationAndFallback() {
-        log("Fix button tapped — running lsregister repair for notifications")
-        ProactiveAssistantsPlugin.repairNotificationRegistration()
-
-        // Wait for repair + re-authorization, then check if it worked
-        DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) { [weak self] in
-            UNUserNotificationCenter.current().getNotificationSettings { settings in
-                DispatchQueue.main.async {
-                    let isNowGranted = settings.authorizationStatus == .authorized
-                    self?.hasNotificationPermission = isNowGranted
-                    self?.notificationAlertStyle = settings.alertStyle
-                    if isNowGranted {
-                        log("Notification repair succeeded — auth is now authorized")
-                    } else {
-                        log("Notification repair didn't restore auth (status=\(settings.authorizationStatus.rawValue)) — opening System Settings")
-                        self?.openNotificationPreferences()
-                    }
-                }
-            }
-        }
-    }
-
-    /// Trigger screen recording permission prompt
-    func triggerScreenRecordingPermission() {
-        // Request both traditional TCC and ScreenCaptureKit permissions
-        ScreenCaptureService.requestAllScreenCapturePermissions()
-    }
-
-    /// Trigger automation permission by attempting to use Apple Events
-    nonisolated func triggerAutomationPermission() {
-        // Run a simple AppleScript to trigger the permission prompt
-        // This must be done on a background thread since it's nonisolated
-        Task.detached {
-            // First, ensure System Events is running — without it, the TCC prompt won't appear
-            // and checkAutomationPermission returns -600 (procNotFound)
-            let launchScript = NSAppleScript(source: """
-                launch application "System Events"
-            """)
-            var launchError: NSDictionary?
-            launchScript?.executeAndReturnError(&launchError)
-            if let launchError = launchError {
-                log("AUTOMATION_TRIGGER: Failed to launch System Events: \(launchError)")
-            } else {
-                log("AUTOMATION_TRIGGER: System Events launched successfully")
-            }
-
-            // Small delay to let System Events initialize
-            try? await Task.sleep(nanoseconds: 500_000_000)
-
-            // Now trigger the actual TCC prompt
-            let script = NSAppleScript(source: """
-                tell application "System Events"
-                    return name of first process whose frontmost is true
-                end tell
-            """)
-            var error: NSDictionary?
-            script?.executeAndReturnError(&error)
-
-            if let error = error {
-                let errorNum = error[NSAppleScript.errorNumber] as? Int ?? 0
-                let errorMsg = error[NSAppleScript.errorMessage] as? String ?? "unknown"
-                log("AUTOMATION_TRIGGER: AppleScript failed: \(errorNum) - \(errorMsg)")
-            } else {
-                log("AUTOMATION_TRIGGER: AppleScript succeeded, permission may have been granted")
-            }
-
-            // Re-check permission status before opening settings
-            await MainActor.run { [weak self] in
-                self?.checkAutomationPermission()
-            }
-
-            // Small delay to let the check complete
-            try? await Task.sleep(nanoseconds: 300_000_000)
-
-            // Open settings so user can toggle if needed
-            await MainActor.run {
-                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation") {
-                    NSWorkspace.shared.open(url)
-                }
-            }
-        }
-    }
-
-    // MARK: - Permission Status Checks
-
-    /// Check and update all permission states
-    func checkAllPermissions() {
-        checkNotificationPermission()
-        checkScreenRecordingPermission()
-        checkAutomationPermission()
-        checkMicrophonePermission()
-        checkSystemAudioPermission()
-        checkAccessibilityPermission()
-        // One-time startup diagnostic for accessibility
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
-        log("ACCESSIBILITY_STARTUP: bundleId=\(bundleId), macOS=\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion), TCC=\(hasAccessibilityPermission), broken=\(isAccessibilityBroken), onboarded=\(hasCompletedOnboarding)")
-        // Only check Bluetooth if already initialized (to avoid triggering permission prompt early)
-        if bluetoothStateCancellable != nil {
-            checkBluetoothPermission()
-        }
-    }
-
-    /// Check Bluetooth permission status
-    /// Bluetooth is considered "granted" if state is poweredOn or poweredOff (allowed but BT off)
-    /// IMPORTANT: Only call this after initializeBluetoothIfNeeded() has been called
-    func checkBluetoothPermission() {
-        // Guard: Only check if Bluetooth has been initialized (to avoid triggering permission prompt early)
-        guard bluetoothStateCancellable != nil else {
-            log("BLUETOOTH_CHECK: Skipping - Bluetooth not initialized yet")
-            return
-        }
-        let state = BluetoothManager.shared.bluetoothState
-        let oldValue = hasBluetoothPermission
+    // Subscribe to Bluetooth state changes for reactive permission updates
+    bluetoothStateCancellable = BluetoothManager.shared.$bluetoothState
+      .receive(on: DispatchQueue.main)
+      .sink { [weak self] state in
+        guard let self = self else { return }
+        let oldValue = self.hasBluetoothPermission
         // poweredOn = ready to use, poweredOff = allowed but BT is off
-        // unauthorized = denied
         let newValue = state == .poweredOn || state == .poweredOff
-        log("BLUETOOTH_CHECK: state=\(BluetoothManager.shared.bluetoothStateDescription), stateRaw=\(state.rawValue), auth=\(BluetoothManager.shared.authorizationDescription), granted=\(newValue)")
+        log(
+          "BLUETOOTH_SUBSCRIPTION: state=\(BluetoothManager.shared.bluetoothStateDescription), stateRaw=\(state.rawValue), auth=\(BluetoothManager.shared.authorizationDescription), granted=\(newValue)"
+        )
         if newValue != oldValue {
-            log("Bluetooth permission changed: \(oldValue) -> \(newValue), state=\(BluetoothManager.shared.bluetoothStateDescription)")
+          log(
+            "Bluetooth permission changed via subscription: \(oldValue) -> \(newValue), state=\(BluetoothManager.shared.bluetoothStateDescription)"
+          )
+          self.hasBluetoothPermission = newValue
         }
-        hasBluetoothPermission = newValue
+      }
+  }
+
+  /// Setup observers for app quit and system sleep to finalize conversations
+  private func setupLifecycleObservers() {
+    // App is about to quit
+    willTerminateObserver = NotificationCenter.default.addObserver(
+      forName: NSApplication.willTerminateNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      guard let self = self else { return }
+      Task { @MainActor in
+        if self.isTranscribing {
+          log("App terminating - finalizing conversation")
+          _ = await self.finalizeConversation()
+          self.clearTranscriptionState()
+        }
+      }
     }
 
-    /// Trigger Bluetooth permission by attempting to scan
-    /// On macOS, the permission dialog only appears when actually using Bluetooth
-    func triggerBluetoothPermission() {
-        // Ensure Bluetooth is initialized first (this is expected to be called from the Bluetooth onboarding step)
-        initializeBluetoothIfNeeded()
-
-        log("triggerBluetoothPermission: Starting, state=\(BluetoothManager.shared.bluetoothStateDescription), auth=\(BluetoothManager.shared.authorizationDescription)")
-        // Trigger the permission prompt by attempting to scan
-        // This bypasses state checks because we specifically want the system dialog
-        BluetoothManager.shared.triggerPermissionPrompt()
-        // Check permission state after a delay to allow user to respond
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            log("triggerBluetoothPermission: After 1s delay, state=\(BluetoothManager.shared.bluetoothStateDescription), auth=\(BluetoothManager.shared.authorizationDescription)")
-            self.checkBluetoothPermission()
+    // Computer is about to sleep
+    willSleepObserver = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.willSleepNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      guard let self = self else { return }
+      Task { @MainActor in
+        self.wasTranscribingBeforeSleep = self.isTranscribing
+        if self.isTranscribing {
+          log("Computer sleeping - finalizing conversation (will restart on wake)")
+          _ = await self.finalizeConversation()
+          self.stopAudioCapture()
+          self.clearTranscriptionState()
         }
-        // Also check again after 3 seconds in case state updates slowly
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-            log("triggerBluetoothPermission: After 3s delay, state=\(BluetoothManager.shared.bluetoothStateDescription), auth=\(BluetoothManager.shared.authorizationDescription)")
-            self.checkBluetoothPermission()
-        }
+        // Flush final sync changes before sleep
+        await AgentSyncService.shared.stop()
+      }
     }
 
-    /// Check if Bluetooth permission was explicitly denied
-    /// Returns false if Bluetooth hasn't been initialized yet (to avoid triggering permission prompt)
-    func isBluetoothPermissionDenied() -> Bool {
-        // Guard: Only check if Bluetooth has been initialized
-        guard bluetoothStateCancellable != nil else {
-            return false
+    // Computer woke from sleep
+    didWakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+      forName: NSWorkspace.didWakeNotification,
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      log("System woke from sleep")
+      NotificationCenter.default.post(name: .systemDidWake, object: nil)
+
+      // Restart transcription if it was active before sleep
+      Task { @MainActor in
+        guard let self = self else { return }
+        if self.wasTranscribingBeforeSleep && AssistantSettings.shared.transcriptionEnabled {
+          log("System wake: Restarting transcription (was active before sleep)")
+          // Brief delay to let audio subsystem settle after wake
+          try? await Task.sleep(for: .seconds(2))
+          if !self.isTranscribing {
+            self.startTranscription()
+          }
         }
-        return BluetoothManager.shared.bluetoothState == .unauthorized
+        self.wasTranscribingBeforeSleep = false
+      }
     }
 
-    /// Check if Bluetooth is reported as unsupported (may be macOS version issue)
-    /// Returns false if Bluetooth hasn't been initialized yet (to avoid triggering permission prompt)
-    func isBluetoothUnsupported() -> Bool {
-        // Guard: Only check if Bluetooth has been initialized
-        guard bluetoothStateCancellable != nil else {
-            return false
+    // Screen locked (debounced - macOS sometimes fires multiple times)
+    screenLockedObserver = DistributedNotificationCenter.default().addObserver(
+      forName: NSNotification.Name("com.apple.screenIsLocked"),
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        let now = Date()
+        if let lastTime = self?.lastScreenLockTime, now.timeIntervalSince(lastTime) < 1.0 {
+          return  // Ignore duplicate within 1 second
         }
-        return BluetoothManager.shared.bluetoothState == .unsupported
+        self?.lastScreenLockTime = now
+        log("Screen locked")
+        NotificationCenter.default.post(name: .screenDidLock, object: nil)
+      }
     }
 
-    /// Open Bluetooth preferences in System Settings
-    func openBluetoothPreferences() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Bluetooth") {
-            NSWorkspace.shared.open(url)
+    // Screen unlocked (debounced - macOS sometimes fires multiple times)
+    screenUnlockedObserver = DistributedNotificationCenter.default().addObserver(
+      forName: NSNotification.Name("com.apple.screenIsUnlocked"),
+      object: nil,
+      queue: .main
+    ) { [weak self] _ in
+      Task { @MainActor in
+        let now = Date()
+        if let lastTime = self?.lastScreenUnlockTime, now.timeIntervalSince(lastTime) < 1.0 {
+          return  // Ignore duplicate within 1 second
         }
+        self?.lastScreenUnlockTime = now
+        log("Screen unlocked")
+        NotificationCenter.default.post(name: .screenDidUnlock, object: nil)
+      }
     }
+  }
 
-    /// Check notification permission status and alert style
-    func checkNotificationPermission() {
-        UNUserNotificationCenter.current().getNotificationSettings { settings in
-            DispatchQueue.main.async {
-                let isNowGranted = settings.authorizationStatus == .authorized
-                self.hasNotificationPermission = isNowGranted
-                self.notificationAlertStyle = settings.alertStyle
+  deinit {
+    if let observer = willTerminateObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    if let observer = willSleepObserver {
+      NSWorkspace.shared.notificationCenter.removeObserver(observer)
+    }
+    if let observer = didWakeObserver {
+      NSWorkspace.shared.notificationCenter.removeObserver(observer)
+    }
+    if let observer = screenLockedObserver {
+      DistributedNotificationCenter.default().removeObserver(observer)
+    }
+    if let observer = screenUnlockedObserver {
+      DistributedNotificationCenter.default().removeObserver(observer)
+    }
+    if let observer = screenCapturePermissionLostObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    if let observer = screenCaptureKitBrokenObserver {
+      NotificationCenter.default.removeObserver(observer)
+    }
+  }
 
-                // Log the current notification settings
-                let authStatus = switch settings.authorizationStatus {
-                    case .notDetermined: "notDetermined"
-                    case .denied: "denied"
-                    case .authorized: "authorized"
-                    case .provisional: "provisional"
-                    case .ephemeral: "ephemeral"
-                    @unknown default: "unknown"
-                }
-                let alertStyleName = switch settings.alertStyle {
-                    case .none: "NONE (no banners)"
-                    case .banner: "BANNER"
-                    case .alert: "ALERT"
-                    @unknown default: "unknown"
-                }
-                log("Notification settings: auth=\(authStatus), alertStyle=\(alertStyleName), sound=\(settings.soundSetting.rawValue), badge=\(settings.badgeSetting.rawValue)")
+  private func loadEnvironment() {
+    let bundledEnvPath = Bundle.main.path(forResource: ".env", ofType: nil)
 
-                // Track notification settings in analytics only when they change
-                let soundEnabled = settings.soundSetting == .enabled
-                let badgeEnabled = settings.badgeSetting == .enabled
-                let settingsChanged = authStatus != self.lastNotificationAuthStatus ||
-                                      alertStyleName != self.lastNotificationAlertStyle ||
-                                      soundEnabled != self.lastNotificationSoundEnabled ||
-                                      badgeEnabled != self.lastNotificationBadgeEnabled
+    // Try to load from .env file in various locations
+    let envPaths = [
+      bundledEnvPath,
+      FileManager.default.currentDirectoryPath + "/.env",
+      NSHomeDirectory() + "/.hartford.env",
+      NSHomeDirectory() + "/.omi.env",
+      // Explicit paths for development
+      "/Users/matthewdi/omi-computer-swift/.env",
+      "/Users/matthewdi/omi/backend/.env",
+    ].compactMap { $0 }
 
-                if settingsChanged {
-                    AnalyticsManager.shared.notificationSettingsChecked(
-                        authStatus: authStatus,
-                        alertStyle: alertStyleName,
-                        soundEnabled: soundEnabled,
-                        badgeEnabled: badgeEnabled,
-                        bannersDisabled: settings.alertStyle == .none
-                    )
-
-                    // Detect regression: was authorized, now reverted to notDetermined
-                    // This happens on macOS 26+ where the OS silently revokes notification permission
-                    if self.lastNotificationAuthStatus == "authorized" && authStatus == "notDetermined" {
-                        log("Notification permission REGRESSED from authorized to notDetermined — triggering auto-repair")
-                        AnalyticsManager.shared.notificationRepairTriggered(
-                            reason: "auth_regression",
-                            previousStatus: "authorized",
-                            currentStatus: "notDetermined"
-                        )
-                        self.repairNotificationRegistrationAndRetry()
-                    }
-
-                    // Update last known state
-                    self.lastNotificationAuthStatus = authStatus
-                    self.lastNotificationAlertStyle = alertStyleName
-                    self.lastNotificationSoundEnabled = soundEnabled
-                    self.lastNotificationBadgeEnabled = badgeEnabled
-                }
-
+    for path in envPaths {
+      if let contents = try? String(contentsOfFile: path, encoding: .utf8) {
+        log("Loading environment from: \(path)")
+        for line in contents.components(separatedBy: .newlines) {
+          let parts = line.split(separator: "=", maxSplits: 1)
+          if parts.count == 2 {
+            let key = String(parts[0]).trimmingCharacters(in: .whitespaces)
+            // Skip comments
+            guard !key.hasPrefix("#") else { continue }
+            if shouldSkipBundledAnthropicKey(
+              key: key, sourcePath: path, bundledEnvPath: bundledEnvPath)
+            {
+              log("  Skipped ANTHROPIC_API_KEY from bundled .env (prod safety)")
+              continue
             }
+            let value = String(parts[1]).trimmingCharacters(in: .whitespaces)
+              .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            setenv(key, value, 1)
+            // Log key names (not values for security)
+            if key.contains("API_KEY") || key.contains("KEY") {
+              log("  Set \(key)=***")
+            }
+          }
         }
+        // Don't break - load all .env files to merge keys
+      }
     }
 
-    /// Check screen recording permission status
-    func checkScreenRecordingPermission() {
-        let tccGranted = CGPreflightScreenCaptureAccess()
-
-        if !tccGranted {
-            hasScreenRecordingPermission = false
-            isScreenCaptureKitBroken = false
-            // If user already tried Grant once and permission is still not granted,
-            // the TCC entry is likely corrupted (e.g. after developer account change
-            // + tccutil reset). Show stale UI with toggle off/on instructions.
-            if screenRecordingGrantAttempts > 0 && !isScreenRecordingStale {
-                log("Screen capture: Grant attempted but permission still denied — showing recovery instructions")
-                isScreenRecordingStale = true
-            }
-            return
-        }
-
-        // TCC says granted. If the permission alert is currently showing (permission was
-        // previously false or broken or stale), do a real capture test to verify the stale TCC case
-        // (e.g. after developer account change). This avoids spawning a screencapture process
-        // on every didBecomeActive when everything is fine.
-        if !hasScreenRecordingPermission || isScreenCaptureKitBroken || isScreenRecordingStale {
-            let realPermission = ScreenCaptureService.checkPermission()
-            hasScreenRecordingPermission = realPermission
-
-            // Stale TCC entry from old developer signing: CGPreflight says granted but
-            // actual capture fails. The user must toggle OFF then ON in System Settings
-            // to update the code signing requirement (csreq) stored in the TCC database.
-            if !realPermission && !isScreenRecordingStale {
-                log("Screen capture: stale TCC entry detected (developer signing changed)")
-                isScreenRecordingStale = true
-                // Try tccutil reset in case it works (it may not on macOS 15+ for system TCC)
-                Task.detached {
-                    ScreenCaptureService.ensureLaunchServicesRegistrationSync()
-                    _ = ScreenCaptureService.resetScreenCapturePermission()
-                }
-            } else if realPermission {
-                // Permission recovered (user toggled off/on in System Settings)
-                isScreenRecordingStale = false
-                screenRecordingGrantAttempts = 0
-            }
-
-            if isScreenCaptureKitBroken {
-                // Re-check if SCK has recovered (user toggled permission in System Settings)
-                if #available(macOS 14.0, *) {
-                    Task {
-                        let sckWorks = await ScreenCaptureService.testScreenCaptureKitPermission()
-                        if sckWorks {
-                            log("AppState: ScreenCaptureKit recovered — clearing broken flag")
-                            self.isScreenCaptureKitBroken = false
-                            self.hasScreenRecordingPermission = true
-                        }
-                    }
-                }
-            }
-        } else {
-            hasScreenRecordingPermission = true
-        }
+    // Log final state of important keys
+    if getenv("DEEPGRAM_API_KEY") != nil {
+      log("DEEPGRAM_API_KEY is set")
+    } else {
+      log("WARNING: DEEPGRAM_API_KEY is NOT set")
     }
+  }
 
-    /// Check automation permission without triggering a prompt
-    /// Uses AEDeterminePermissionToAutomateTarget to query TCC status for System Events
-    func checkAutomationPermission() {
-        guard !isCheckingAutomationPermission else { return }
-        isCheckingAutomationPermission = true
-        Task.detached {
-            defer { Task { @MainActor in self.isCheckingAutomationPermission = false } }
-            let status = Self.queryAutomationPermissionStatus()
+  private func shouldSkipBundledAnthropicKey(
+    key: String, sourcePath: String, bundledEnvPath: String?
+  ) -> Bool {
+    guard key == "ANTHROPIC_API_KEY" else { return false }
+    guard let bundledEnvPath, sourcePath == bundledEnvPath else { return false }
+    let bundleId = Bundle.main.bundleIdentifier ?? ""
+    let isProductionBundle = bundleId == "com.omi.computer-macos"
+    return isProductionBundle
+  }
 
-            // noErr (0) = granted, errAEEventNotPermitted (-1743) = denied, -1744 = not determined
-            // -600 (procNotFound) = System Events not running — try to launch it and retry
-            if status == -600 {
-                log("AUTOMATION_CHECK: status=-600 (procNotFound), launching System Events and retrying...")
-                let launchScript = NSAppleScript(source: "launch application \"System Events\"")
-                var launchError: NSDictionary?
-                launchScript?.executeAndReturnError(&launchError)
+  func openScreenRecordingPreferences() {
+    ScreenCaptureService.openScreenRecordingPreferences()
+  }
 
-                // Wait for System Events to initialize
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-
-                let retryStatus = Self.queryAutomationPermissionStatus()
-                let hasPermission = retryStatus == noErr
-                log("AUTOMATION_CHECK: retry status=\(retryStatus), hasPermission=\(hasPermission)")
-
-                await MainActor.run {
-                    self.hasAutomationPermission = hasPermission
-                    self.automationPermissionError = hasPermission ? 0 : retryStatus
-                }
-            } else {
-                let hasPermission = status == noErr
-                let previousValue = await MainActor.run { self.hasAutomationPermission }
-                if hasPermission != previousValue {
-                    log("AUTOMATION_CHECK: status=\(status), hasPermission=\(hasPermission)")
-                }
-
-                await MainActor.run {
-                    self.hasAutomationPermission = hasPermission
-                    // Track unexpected errors (not denied/not-determined, which are normal states)
-                    self.automationPermissionError = (status == noErr || status == -1743 || status == -1744) ? 0 : status
-                }
-            }
-        }
+  func openAutomationPreferences() {
+    if let url = URL(
+      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
+    {
+      NSWorkspace.shared.open(url)
     }
-
-    /// Query the TCC automation permission status for System Events without triggering a prompt
-    nonisolated private static func queryAutomationPermissionStatus() -> OSStatus {
-        let bundleIDString = "com.apple.systemevents"
-        var addressDesc = AEAddressDesc()
-
-        let status: OSStatus = bundleIDString.withCString { cString in
-            AECreateDesc(typeApplicationBundleID, cString, strlen(cString), &addressDesc)
-            let result = AEDeterminePermissionToAutomateTarget(
-                &addressDesc,
-                typeWildCard,
-                typeWildCard,
-                false // askUserIfNeeded = false → never shows dialog
-            )
-            AEDisposeDesc(&addressDesc)
-            return result
-        }
-
-        return status
-    }
-
-    /// Check accessibility permission status
-    /// AXIsProcessTrusted() can return stale data after macOS updates or app re-signs,
-    /// so we also do a functional AX test to detect the "broken" state.
-    func checkAccessibilityPermission() {
-        let tccGranted = AXIsProcessTrusted()
-        let previouslyGranted = hasAccessibilityPermission
-
-        if tccGranted {
-            hasAccessibilityPermission = true
-
-            // Log transitions
-            if !previouslyGranted {
-                let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
-                log("ACCESSIBILITY_CHECK: Permission granted (bundleId=\(bundleId))")
-            }
-
-            // TCC says yes — verify with an actual AX call
-            let broken = !testAccessibilityPermission()
-            if broken != isAccessibilityBroken {
-                isAccessibilityBroken = broken
-                if broken {
-                    log("ACCESSIBILITY_CHECK: TCC says granted but AX calls fail — stuck/broken state detected")
-                } else {
-                    log("ACCESSIBILITY_CHECK: AX calls working normally")
-                }
-            }
-        } else {
-            // AXIsProcessTrusted() says not granted — but on macOS 26 this may be stale.
-            // Probe via event tap which checks the live TCC database.
-            if probeAccessibilityViaEventTap() {
-                if !previouslyGranted {
-                    log("ACCESSIBILITY_CHECK: AXIsProcessTrusted() returned false but event tap succeeded — stale cache detected")
-                }
-                let axWorks = testAccessibilityPermission()
-                hasAccessibilityPermission = true
-                if !axWorks {
-                    if !isAccessibilityBroken {
-                        log("ACCESSIBILITY_CHECK: Event tap OK but AX calls fail — marking as broken")
-                    }
-                    isAccessibilityBroken = true
-                } else {
-                    if isAccessibilityBroken {
-                        log("ACCESSIBILITY_CHECK: Permission confirmed via event tap probe, AX calls working")
-                    }
-                    isAccessibilityBroken = false
-                }
-            } else {
-                // Event tap also failed — permission genuinely not granted
-                if previouslyGranted {
-                    let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
-                    log("ACCESSIBILITY_CHECK: Permission revoked (bundleId=\(bundleId))")
-                }
-                hasAccessibilityPermission = false
-                isAccessibilityBroken = false
-            }
-        }
-    }
-
-    /// Test if Accessibility API actually works by attempting a real AX call.
-    /// Returns true if AX calls succeed, false if permission is stuck/broken.
-    private func testAccessibilityPermission() -> Bool {
-        guard let frontApp = NSWorkspace.shared.frontmostApplication else {
-            // No frontmost app to test against — can't determine, assume OK
-            return true
-        }
-
-        let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
-        var focusedWindow: CFTypeRef?
-        let result = AXUIElementCopyAttributeValue(appElement, kAXFocusedWindowAttribute as CFString, &focusedWindow)
-
-        // .success or .noValue (app has no windows) both mean AX is working
-        switch result {
-        case .success, .noValue, .notImplemented, .attributeUnsupported:
-            return true
-        case .apiDisabled:
-            // System-wide AX is disabled — unambiguous, no confirmation needed
-            log("ACCESSIBILITY_CHECK: AXError.apiDisabled — permission stuck (tested against pid \(frontApp.processIdentifier), app: \(frontApp.localizedName ?? "unknown"))")
-            return false
-        case .cannotComplete:
-            // cannotComplete is ambiguous: it can mean our permission is broken, OR that the
-            // frontmost app doesn't implement AX (e.g. Qt, OpenGL, Python-based apps like PyMOL).
-            // Confirm against Finder before concluding the permission is truly broken.
-            return confirmAccessibilityBrokenViaFinder(suspectApp: frontApp.localizedName ?? "unknown")
-        default:
-            log("ACCESSIBILITY_CHECK: AXError code \(result.rawValue) from app \(frontApp.localizedName ?? "unknown") — not permission-related, treating as OK")
-            return true
-        }
-    }
-
-    /// Secondary AX check against Finder to disambiguate cannotComplete errors.
-    /// If Finder (a known AX-compliant app) also fails, the permission is truly broken.
-    /// If Finder succeeds, the original failure was app-specific, not a permission issue.
-    private func confirmAccessibilityBrokenViaFinder(suspectApp: String) -> Bool {
-        if let finder = NSRunningApplication.runningApplications(withBundleIdentifier: "com.apple.finder").first {
-            let finderElement = AXUIElementCreateApplication(finder.processIdentifier)
-            var finderWindow: CFTypeRef?
-            let finderResult = AXUIElementCopyAttributeValue(finderElement, kAXFocusedWindowAttribute as CFString, &finderWindow)
-            if finderResult == .cannotComplete || finderResult == .apiDisabled {
-                log("ACCESSIBILITY_CHECK: AXError.cannotComplete confirmed by Finder — permission is truly stuck (original app: \(suspectApp))")
-                return false
-            } else {
-                log("ACCESSIBILITY_CHECK: AXError.cannotComplete from \(suspectApp) but Finder OK — app-specific AX incompatibility, permission is fine")
-                return true
-            }
-        } else {
-            // Finder not running — fall back to event tap probe as tie-breaker
-            log("ACCESSIBILITY_CHECK: AXError.cannotComplete from \(suspectApp), Finder not running — using event tap probe")
-            return probeAccessibilityViaEventTap()
-        }
-    }
-
-    /// Probe accessibility permission by attempting to create a CGEvent tap.
-    /// Unlike AXIsProcessTrusted(), event tap creation checks the live TCC database,
-    /// bypassing the per-process cache that can go stale on macOS 26 (Tahoe).
-    private func probeAccessibilityViaEventTap() -> Bool {
-        let tap = CGEvent.tapCreate(
-            tap: .cgSessionEventTap,
-            place: .tailAppendEventTap,
-            options: .listenOnly,
-            eventsOfInterest: CGEventMask(1 << CGEventType.mouseMoved.rawValue),
-            callback: { _, _, event, _ in Unmanaged.passRetained(event) },
-            userInfo: nil
-        )
-        if let tap = tap {
-            CFMachPortInvalidate(tap)
-            return true
-        }
-        return false
-    }
-
-    /// Check if accessibility permission was explicitly denied
-    func isAccessibilityPermissionDenied() -> Bool {
-        return hasCompletedOnboarding && (!hasAccessibilityPermission || isAccessibilityBroken)
-    }
-
-    /// Trigger accessibility permission prompt
-    func triggerAccessibilityPermission() {
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
-        log("ACCESSIBILITY_TRIGGER: User clicked Grant Access — bundleId=\(bundleId), macOS \(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)")
-
-        // This will prompt the user if not already trusted
-        let options = [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
-        let trusted = AXIsProcessTrustedWithOptions(options)
-        if trusted {
-            hasAccessibilityPermission = true
-        }
-        // Don't set hasAccessibilityPermission = false here — the API may return
-        // stale data on macOS 26. Let checkAccessibilityPermission() handle detection
-        // via the event tap probe on the next poll cycle.
-        log("ACCESSIBILITY_TRIGGER: AXIsProcessTrustedWithOptions returned \(trusted)")
-
-        // On macOS Sequoia+, AXIsProcessTrustedWithOptions no longer shows a visible dialog,
-        // so explicitly open System Settings to the Accessibility pane
-        if !trusted {
-            log("ACCESSIBILITY_TRIGGER: Not trusted, opening System Settings Accessibility pane")
-            openAccessibilityPreferences()
-        }
-    }
-
-    /// Open Accessibility preferences in System Settings
-    func openAccessibilityPreferences() {
-        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility") {
-            NSWorkspace.shared.open(url)
-        }
-    }
-
-    /// Reset accessibility permission (requires terminal command)
-    nonisolated func resetAccessibilityPermissionDirect(shouldRestart: Bool = false) -> Bool {
-        let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
-        log("Resetting accessibility permission for \(bundleId) via tccutil...")
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
-        process.arguments = ["reset", "Accessibility", bundleId]
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-            let success = process.terminationStatus == 0
-            log("tccutil reset completed with exit code: \(process.terminationStatus)")
-
-            if success && shouldRestart {
-                restartApp()
-            }
-
-            return success
-        } catch {
-            log("Failed to run tccutil: \(error)")
-            return false
-        }
-    }
-
-    /// Reset accessibility permission via tccutil and restart the app.
-    /// Mirrors ScreenCaptureService.resetScreenCapturePermissionAndRestart().
-    func resetAccessibilityPermissionAndRestart() {
-        if UpdaterViewModel.isUpdateInProgress {
-            log("Sparkle update in progress, skipping accessibility reset restart")
-            return
-        }
-
-        Task.detached { [weak self] in
-            guard let self = self else { return }
-            let success = self.resetAccessibilityPermissionDirect(shouldRestart: false)
-
-            await MainActor.run {
-                if success {
-                    log("Accessibility permission reset, restarting app...")
-                    self.restartApp()
-                } else {
-                    log("Accessibility permission reset failed")
-                }
-            }
-        }
-    }
-
-    private func showPermissionAlert() {
-        let alert = NSAlert()
-        alert.messageText = "Permission Required"
-        alert.informativeText = "Screen Recording permission is needed.\n\nClick 'Grant Screen Permission' in the menu, then add this app and restart."
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "OK")
-        alert.runModal()
-    }
-
-    private func showAlert(title: String, message: String) {
-        let alert = NSAlert()
-        alert.messageText = title
-        alert.informativeText = message
-        alert.alertStyle = .warning
-        alert.addButton(withTitle: "OK")
-        alert.runModal()
-    }
-
-    // MARK: - Transcription
-
-    /// Toggle transcription on/off
-    func toggleTranscription() {
-        if isTranscribing {
-            stopTranscription()
-        } else {
-            startTranscription()
-        }
-    }
-
-    /// Start real-time transcription
-    /// - Parameter source: Audio source to use (defaults to current audioSource setting)
-    func startTranscription(source: AudioSource? = nil) {
-        guard !isTranscribing else { return }
-
-        // Use provided source or fall back to current setting
-        let effectiveSource = source ?? audioSource
-
-        // For BLE device, check if device is connected
-        if effectiveSource == .bleDevice {
-            guard DeviceProvider.shared.isConnected else {
-                showAlert(title: "Device Not Connected", message: "Please connect a wearable device first.")
-                return
-            }
-        } else {
-            // For microphone, check permission
-            guard AudioCaptureService.checkPermission() else {
-                requestMicrophonePermission()
-                return
-            }
-        }
-
-        do {
-            // Get effective language from settings (handles auto-detect vs single language)
-            let effectiveLanguage = AssistantSettings.shared.effectiveTranscriptionLanguage
-            let vocabulary = AssistantSettings.shared.effectiveVocabulary
-            log("Transcription: Using language=\(effectiveLanguage) (autoDetect=\(AssistantSettings.shared.transcriptionAutoDetect), selected=\(AssistantSettings.shared.transcriptionLanguage))")
-            log("Transcription: Custom vocabulary: \(vocabulary.joined(separator: ", "))")
-
-            // Determine transcription mode
-            useBatchTranscription = AssistantSettings.shared.batchTranscriptionEnabled && effectiveSource == .microphone
-
-            if !useBatchTranscription {
-                // Streaming mode: initialize WebSocket transcription service
-                transcriptionService = try TranscriptionService(language: effectiveLanguage, vocabulary: vocabulary)
-            } else {
-                log("Transcription: Batch mode enabled — skipping WebSocket")
-            }
-
-            // Set conversation source based on audio source
-            if effectiveSource == .bleDevice, let device = DeviceProvider.shared.connectedDevice {
-                currentConversationSource = ConversationSource.from(deviceType: device.type)
-                recordingInputDeviceName = device.displayName
-            } else {
-                currentConversationSource = .desktop
-                recordingInputDeviceName = AudioCaptureService.getCurrentMicrophoneName()
-            }
-
-            // Initialize audio services based on source
-            if effectiveSource == .microphone {
-                // Initialize audio capture service
-                audioCaptureService = AudioCaptureService()
-
-                // Initialize audio mixer for combining mic and system audio
-                audioMixer = AudioMixer()
-
-                // VAD gate is always needed for batch mode (chunk boundaries),
-                // and optional for streaming mode (silence gating)
-                if useBatchTranscription || AssistantSettings.shared.vadGateEnabled {
-                    let gate = VADGateService()
-                    if useBatchTranscription && !gate.modelAvailable {
-                        // Batch mode requires working VAD — fall back to streaming
-                        log("Transcription: VAD models unavailable, falling back from batch to streaming mode")
-                        useBatchTranscription = false
-                        vadGateService = nil
-                        transcriptionService = try TranscriptionService(language: effectiveLanguage, vocabulary: vocabulary)
-                    } else {
-                        vadGateService = gate
-                        log("Transcription: VAD gate enabled\(useBatchTranscription ? " (batch mode)" : "")")
-                    }
-                } else {
-                    vadGateService = nil
-                }
-
-                // Initialize system audio capture if supported (macOS 14.4+)
-                // Can be disabled via: defaults write com.omi.desktop-dev disableSystemAudioCapture -bool true
-                //                  or: defaults write com.omi.computer-macos disableSystemAudioCapture -bool true
-                let systemAudioDisabled = UserDefaults.standard.bool(forKey: "disableSystemAudioCapture")
-                if systemAudioDisabled {
-                    log("Transcription: System audio capture DISABLED by user preference (disableSystemAudioCapture)")
-                } else if #available(macOS 14.4, *) {
-                    systemAudioCaptureService = SystemAudioCaptureService()
-                    log("Transcription: System audio capture initialized (macOS 14.4+)")
-                } else {
-                    log("Transcription: System audio capture not available (requires macOS 14.4+)")
-                }
-            }
-            // For BLE device, BleAudioService will be used in startAudioCapture
-
-            if useBatchTranscription {
-                // Batch mode: start audio capture directly (no WebSocket to wait for)
-                recordingStartCATime = CACurrentMediaTime()
-                Task { @MainActor [weak self] in
-                    await self?.startAudioCapture(source: effectiveSource)
-                }
-            } else {
-                // Streaming mode: start transcription service first, then audio on connect
-                transcriptionService?.start(
-                    onTranscript: { [weak self] segment in
-                        Task { @MainActor in
-                            self?.handleTranscriptSegment(segment)
-                        }
-                    },
-                    onError: { [weak self] error in
-                        Task { @MainActor in
-                            logError("Transcription error", error: error)
-                            AnalyticsManager.shared.recordingError(error: error.localizedDescription)
-                            self?.stopTranscription()
-                        }
-                    },
-                    onConnected: { [weak self] in
-                        Task { @MainActor in
-                            log("Transcription: Connected to DeepGram")
-                            // Start audio capture once connected
-                            await self?.startAudioCapture(source: effectiveSource)
-                        }
-                    },
-                    onDisconnected: {
-                        log("Transcription: Disconnected from DeepGram")
-                    }
-                )
-            }
-
-            isTranscribing = true
-            AssistantSettings.shared.transcriptionEnabled = true
-            audioSource = effectiveSource
-            currentTranscript = ""
-            speakerSegments = []
-            totalSegmentCount = 0
-            totalWordCount = 0
-            liveSpeakerPersonMap = [:]
-            LiveTranscriptMonitor.shared.clear()
-            recordingStartTime = Date()
-            AudioLevelMonitor.shared.reset()
-            RecordingTimer.shared.start()
-
-            log("Transcription: Using source: \(effectiveSource.rawValue), device: \(recordingInputDeviceName ?? "Unknown")")
-
-            // Create crash-safe DB session for persistence
-            Task {
-                do {
-                    let sessionId = try await TranscriptionStorage.shared.startSession(
-                        source: currentConversationSource.rawValue,
-                        language: effectiveLanguage,
-                        timezone: TimeZone.current.identifier,
-                        inputDeviceName: recordingInputDeviceName
-                    )
-                    await MainActor.run {
-                        self.currentSessionId = sessionId
-                        // Start live notes session
-                        LiveNotesMonitor.shared.startSession(sessionId: sessionId)
-                    }
-                    log("Transcription: Created DB session \(sessionId)")
-                } catch {
-                    logError("Transcription: Failed to create DB session", error: error)
-                    // Non-fatal - continue recording even if DB fails
-                }
-            }
-
-            // Start 4-hour max recording timer
-            maxRecordingTimer = Timer.scheduledTimer(withTimeInterval: maxRecordingDuration, repeats: false) { [weak self] _ in
-                Task { @MainActor in
-                    guard let self = self, self.isTranscribing else { return }
-                    log("Transcription: 4-hour limit reached - finalizing conversation")
-                    _ = await self.finalizeConversation()
-                    // Start a new recording session automatically
-                    self.stopAudioCapture()
-                    self.clearTranscriptionState()
-                    self.startTranscription()
-                }
-            }
-
-            // Track transcription started
-            AnalyticsManager.shared.transcriptionStarted()
-
-            log("Transcription: Starting...")
-
-        } catch {
-            AnalyticsManager.shared.recordingError(error: error.localizedDescription)
-            showAlert(title: "Transcription Error", message: error.localizedDescription)
-        }
-    }
-
-    /// Start audio capture and pipe to transcription service
-    /// - Parameter source: Audio source to capture from
-    private func startAudioCapture(source: AudioSource = .microphone) async {
-        if source == .bleDevice {
-            // Use BLE device audio
-            await startBleAudioCapture()
-        } else {
-            // Use microphone (+ optional system audio)
-            await startMicrophoneAudioCapture()
-        }
-    }
-
-    /// Start microphone audio capture (original implementation)
-    private func startMicrophoneAudioCapture() async {
-        guard let audioCaptureService = audioCaptureService,
-              let audioMixer = audioMixer else { return }
-
-        // Start the audio mixer - it will send stereo audio to transcription service
-        // Branch on batch vs streaming mode
-        audioMixer.start { [weak self] stereoData in
-            guard let self = self else { return }
-            if self.useBatchTranscription {
-                // Batch mode: accumulate audio in VAD gate, transcribe on silence
-                guard let gate = self.vadGateService else { return }
-                let output = gate.processAudioBatch(stereoData)
-                if output.isComplete, let audioBuffer = output.audioBuffer {
-                    let wallStartTime = output.speechStartWallTime
-                    Task { @MainActor [weak self] in
-                        await self?.batchTranscribeChunk(audioBuffer: audioBuffer, wallStartTime: wallStartTime)
-                    }
-                }
-            } else if let gate = self.vadGateService {
-                // Streaming mode with VAD gate
-                let output = gate.processAudio(stereoData)
-                if !output.audioToSend.isEmpty {
-                    self.transcriptionService?.sendAudio(output.audioToSend)
-                } else if gate.needsKeepalive() {
-                    self.transcriptionService?.sendKeepalivePublic()
-                }
-                if output.shouldFinalize {
-                    self.transcriptionService?.sendFinalize()
-                }
-            } else {
-                // Streaming mode without VAD gate
-                self.transcriptionService?.sendAudio(stereoData)
-            }
-        }
-
-        do {
-            // Start microphone capture - sends to mixer channel 0 (left/user)
-            try await audioCaptureService.startCapture(
-                onAudioChunk: { [weak self] audioData in
-                    self?.audioMixer?.setMicAudio(audioData)
-                },
-                onAudioLevel: { level in
-                    // Use dedicated monitor to avoid triggering AppState re-renders
-                    AudioLevelMonitor.shared.updateMicrophoneLevel(level)
-                }
-            )
-            log("Transcription: Microphone capture started")
-
-            // Start system audio capture if available (macOS 14.4+)
-            if #available(macOS 14.4, *) {
-                if let systemService = systemAudioCaptureService as? SystemAudioCaptureService {
-                    do {
-                        try await systemService.startCapture(
-                            onAudioChunk: { [weak self] audioData in
-                                self?.audioMixer?.setSystemAudio(audioData)
-                            },
-                            onAudioLevel: { level in
-                                // Use dedicated monitor to avoid triggering AppState re-renders
-                                AudioLevelMonitor.shared.updateSystemLevel(level)
-                            }
-                        )
-                        log("Transcription: System audio capture started")
-                    } catch {
-                        // System audio is optional - continue with mic only
-                        logError("Transcription: System audio capture failed (continuing with mic only)", error: error)
-                    }
-                }
-            }
-
-            log("Transcription: Audio capture started (multichannel)")
-        } catch {
-            logError("Transcription: Failed to start audio capture", error: error)
-            stopTranscription()
-        }
-    }
-
-    /// Start BLE device audio capture
-    private func startBleAudioCapture() async {
-        guard let connection = DeviceProvider.shared.activeConnection,
-              let transcriptionService = transcriptionService else {
-            logError("Transcription: No device connection or transcription service", error: nil)
-            stopTranscription()
-            return
-        }
-
-        // Start BLE audio processing and pipe directly to transcription
-        await BleAudioService.shared.startProcessing(
-            from: connection,
-            transcriptionService: transcriptionService,
-            audioDataHandler: { _ in
-                // Audio level is updated by BleAudioService
-                Task { @MainActor in
-                    AudioLevelMonitor.shared.updateMicrophoneLevel(BleAudioService.shared.audioLevel)
-                }
-            }
-        )
-
-        // Start listening for button events
-        startButtonEventListener()
-
-        log("Transcription: BLE audio capture started (device: \(connection.device.displayName))")
-    }
-
-    /// Start listening for button events from BLE device
-    private func startButtonEventListener() {
-        guard let buttonStream = DeviceProvider.shared.getButtonStream() else {
-            log("Transcription: Device does not support button events")
-            return
-        }
-
-        buttonStreamTask?.cancel()
-        buttonStreamTask = Task { [weak self] in
-            do {
-                for try await buttonState in buttonStream {
-                    self?.handleButtonEvent(buttonState)
-                }
-            } catch {
-                log("Transcription: Button stream ended: \(error.localizedDescription)")
-            }
-        }
-    }
-
-    /// Handle button events from BLE device
-    private func handleButtonEvent(_ buttonState: [UInt8]) {
-        guard !buttonState.isEmpty else { return }
-
-        let state = buttonState[0]
-        log("Transcription: Device button event: \(state)")
-
-        switch state {
-        case 1:
-            // Single tap - could be used for voice command mode (future feature)
-            log("Transcription: Single tap - no action configured")
-
-        case 2:
-            // Double tap - finalize conversation and continue recording
-            log("Transcription: Double tap - finalizing conversation")
-            Task {
-                _ = await finalizeConversation()
-                clearTranscriptionState()
-                // Restart with same source
-                startTranscription(source: audioSource)
-            }
-
-        case 3:
-            // Long press - stop transcription completely
-            log("Transcription: Long press - stopping transcription")
-            stopTranscription()
-
-        default:
-            log("Transcription: Unknown button state: \(state)")
-        }
-    }
-
-    /// Stop button event listener
-    private func stopButtonEventListener() {
-        buttonStreamTask?.cancel()
-        buttonStreamTask = nil
-    }
-
-    /// Stop real-time transcription and finalize the conversation
-    func stopTranscription() {
-        // Immediately stop audio capture but show saving state
-        stopAudioCapture()
-        isSavingConversation = true
-
-        Task {
-            _ = await finalizeConversation()
-            isSavingConversation = false
-            clearTranscriptionState()
-
-            // Refresh conversations after stopping
-            await loadConversations()
-        }
-    }
-
-    /// Finish the current conversation and keep recording for a new one
-    func finishConversation() async -> FinishConversationResult {
-        guard totalSegmentCount > 0 || !speakerSegments.isEmpty else {
-            log("Transcription: No segments to finish")
-            return .discarded
-        }
-
-        log("Transcription: Finishing conversation, keeping recording active")
-
-        let result = await finalizeConversation()
-
-        // Clear segments for the next conversation but keep recording
-        speakerSegments = []
-        totalSegmentCount = 0
-        totalWordCount = 0
-        liveSpeakerPersonMap = [:]
-        LiveTranscriptMonitor.shared.clear()
-        LiveNotesMonitor.shared.endSession()
-        LiveNotesMonitor.shared.clear()
-
-        // Reset the recording start time for the next conversation
-        recordingStartTime = Date()
-        RecordingTimer.shared.restart()
-
-        // Restart the 4-hour max recording timer
-        maxRecordingTimer?.invalidate()
-        maxRecordingTimer = Timer.scheduledTimer(withTimeInterval: maxRecordingDuration, repeats: false) { [weak self] _ in
-            Task { @MainActor in
-                guard let self = self, self.isTranscribing else { return }
-                log("Transcription: 4-hour limit reached - finalizing conversation")
-                _ = await self.finalizeConversation()
-                self.stopAudioCapture()
-                self.clearTranscriptionState()
-                self.startTranscription()
-            }
-        }
-
-        // Start a new DB session for the next conversation
-        let lang = AssistantSettings.shared.effectiveTranscriptionLanguage
-        Task {
-            do {
-                let sessionId = try await TranscriptionStorage.shared.startSession(
-                    source: currentConversationSource.rawValue,
-                    language: lang,
-                    timezone: TimeZone.current.identifier,
-                    inputDeviceName: recordingInputDeviceName
-                )
-                await MainActor.run {
-                    self.currentSessionId = sessionId
-                    LiveNotesMonitor.shared.startSession(sessionId: sessionId)
-                }
-                log("Transcription: Created new DB session \(sessionId) for next conversation")
-            } catch {
-                logError("Transcription: Failed to create DB session for next conversation", error: error)
-            }
-        }
-
-        // Refresh the conversations list to show the new conversation
-        await loadConversations()
-
-        log("Transcription: Ready for next conversation")
-        return result
-    }
-
-    /// Stop audio capture services (but keep transcript data for saving)
-    private func stopAudioCapture() {
-        // Cancel timers
-        maxRecordingTimer?.invalidate()
-        maxRecordingTimer = nil
-        RecordingTimer.shared.stop()
-
-        // Reset audio levels
-        AudioLevelMonitor.shared.reset()
-
-        // Stop BLE audio if active
-        if audioSource == .bleDevice {
-            BleAudioService.shared.stopProcessing()
-            stopButtonEventListener()
-        }
-
-        // Stop system audio capture first (if available)
-        if #available(macOS 14.4, *) {
-            if let systemService = systemAudioCaptureService as? SystemAudioCaptureService {
-                systemService.stopCapture()
-            }
-        }
-        systemAudioCaptureService = nil
-
-        // Stop microphone capture
-        audioCaptureService?.stopCapture()
-        audioCaptureService = nil
-
-        // Stop audio mixer
-        audioMixer?.stop()
-        audioMixer = nil
-
-        // Flush batch buffer before clearing VAD gate
-        if useBatchTranscription, let gate = vadGateService, let output = gate.flushBatchBuffer() {
-            if let audioBuffer = output.audioBuffer {
-                let wallStartTime = output.speechStartWallTime
-                Task { @MainActor [weak self] in
-                    await self?.batchTranscribeChunk(audioBuffer: audioBuffer, wallStartTime: wallStartTime)
-                }
-            }
-        }
-
-        // Clear VAD gate
-        vadGateService = nil
-
-        // Stop transcription service
-        transcriptionService?.stop()
-        transcriptionService = nil
-
-        isTranscribing = false
-    }
-
-    /// Clear transcription state after saving
-    private func clearTranscriptionState() {
-        log("Transcription: Final segments count: \(totalSegmentCount) (in-memory: \(speakerSegments.count)), words: \(totalWordCount)")
-
-        // End live notes session
-        LiveNotesMonitor.shared.endSession()
-
-        // Clear segments after finalization
-        speakerSegments = []
-        liveSpeakerPersonMap = [:]
-        LiveTranscriptMonitor.shared.clear()
-        LiveNotesMonitor.shared.clear()
-        recordingStartTime = nil
-        currentSessionId = nil
-
-        // Track transcription stopped
-        AnalyticsManager.shared.transcriptionStopped(wordCount: totalWordCount)
-        totalSegmentCount = 0
-        totalWordCount = 0
-        currentTranscript = ""
-
-        log("Transcription: Stopped")
-    }
-
-    /// Aggressively trim transcript state to free memory (called by ResourceMonitor during critical memory pressure).
-    /// Segments are already persisted in SQLite, so trimming in-memory state is safe.
-    func trimTranscriptStateForMemoryPressure() {
-        let beforeCount = speakerSegments.count
-        if speakerSegments.count > 50 {
-            speakerSegments = Array(speakerSegments.suffix(50))
-        }
-        currentTranscript = ""
-        LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
-        log("ResourceMonitor: Trimmed transcript state \(beforeCount) -> \(speakerSegments.count) segments")
-    }
-
-    // MARK: - Conversations
-
-    /// Load conversations - first from local cache (instant), then from API (background refresh)
-    func loadConversations() async {
-        guard !isLoadingConversations else { return }
-
-        isLoadingConversations = true
-        conversationsError = nil
-
-        // Step 1: Load from local cache first (instant display)
-        // Use timeout to avoid blocking UI if database is initializing (e.g. recovery)
-        do {
-            let cachedConversations = try await withThrowingTaskGroup(of: [ServerConversation].self) { group in
-                group.addTask {
-                    try await TranscriptionStorage.shared.getLocalConversations(
-                        limit: 50,
-                        starredOnly: self.showStarredOnly,
-                        folderId: self.selectedFolderId
-                    )
-                }
-                group.addTask {
-                    try await Task.sleep(nanoseconds: 3_000_000_000) // 3 second timeout
-                    throw CancellationError()
-                }
-                let result = try await group.next()!
-                group.cancelAll()
-                return result
-            }
-
-            if !cachedConversations.isEmpty {
-                conversations = cachedConversations
-                log("Conversations: Loaded \(cachedConversations.count) from local cache (instant)")
-
-                // Get local count
-                let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(starredOnly: showStarredOnly)
-                totalConversationsCount = localCount
-
-                // Stop loading state so UI shows cached data immediately
-                isLoadingConversations = false
-                // Notify sidebar immediately so loading indicator clears with cached data
-                NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
-            }
-        } catch {
-            log("Conversations: Local cache unavailable, falling back to API")
-            // Continue to API fetch even if local fails
-        }
-
-        // Step 2: Fetch from API in background to get fresh data
-        // Calculate date range if date filter is set
-        let startDate: Date?
-        let endDate: Date?
-        if let filterDate = selectedDateFilter {
-            let calendar = Calendar.current
-            startDate = calendar.startOfDay(for: filterDate)
-            endDate = calendar.date(byAdding: .day, value: 1, to: startDate!)
-        } else {
-            startDate = nil
-            endDate = nil
-        }
-
-        // Fetch conversations and count in parallel
-        async let conversationsTask = APIClient.shared.getConversations(
-            limit: 50,
-            offset: 0,
-            statuses: [.completed, .processing],
-            includeDiscarded: false,
-            startDate: startDate,
-            endDate: endDate,
-            folderId: selectedFolderId,
-            starred: showStarredOnly ? true : nil
-        )
-        async let countTask = APIClient.shared.getConversationsCount(includeDiscarded: false)
-
-        do {
-            let fetchedConversations = try await conversationsTask
-            conversations = fetchedConversations
-            log("Conversations: Refreshed \(fetchedConversations.count) from API (starred=\(showStarredOnly), date=\(selectedDateFilter?.description ?? "nil"))")
-
-            // DEBUG: Log any conversations with empty titles
-            for conv in fetchedConversations where conv.structured.title.isEmpty {
-                log("DEBUG: Conversation \(conv.id) has EMPTY title! overview=\(conv.structured.overview.prefix(50))...")
-            }
-
-            // Sync conversations to local database in background
-            Task.detached(priority: .background) {
-                var syncedCount = 0
-                for conversation in fetchedConversations {
-                    do {
-                        try await TranscriptionStorage.shared.syncServerConversation(conversation)
-                        syncedCount += 1
-                    } catch {
-                        log("Conversations: Failed to sync \(conversation.id) to local DB: \(error.localizedDescription)")
-                    }
-                }
-                log("Conversations: Synced \(syncedCount)/\(fetchedConversations.count) to local database")
-            }
-        } catch {
-            logError("Conversations: API fetch failed", error: error)
-            // Only set error if we don't have cached data
-            if conversations.isEmpty {
-                conversationsError = error.localizedDescription
-            } else {
-                log("Conversations: Using cached data after API failure")
-            }
-        }
-
-        // Update total count from API (more accurate than local)
-        do {
-            let count = try await countTask
-            totalConversationsCount = count
-            log("Conversations: Total count from API = \(count)")
-        } catch {
-            logError("Conversations: Failed to get count from API", error: error)
-            // Keep local count if API fails
-        }
-
-        isLoadingConversations = false
-        NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
-    }
-
-    /// Refresh conversations silently (for auto-refresh timer and app-activate).
-    /// Fetches from API only, merges in-place, and only triggers @Published if data actually changed.
-    func refreshConversations() async {
-        // Skip if user is signed out (tokens are cleared)
-        guard AuthState.shared.isSignedIn else { return }
-        // Skip if currently doing a full load
-        guard !isLoadingConversations else { return }
-
-        // Calculate date range if date filter is set
-        let startDate: Date?
-        let endDate: Date?
-        if let filterDate = selectedDateFilter {
-            let calendar = Calendar.current
-            startDate = calendar.startOfDay(for: filterDate)
-            endDate = calendar.date(byAdding: .day, value: 1, to: startDate!)
-        } else {
-            startDate = nil
-            endDate = nil
-        }
-
-        do {
-            let fetchedConversations = try await APIClient.shared.getConversations(
-                limit: 50,
-                offset: 0,
-                statuses: [.completed, .processing],
-                includeDiscarded: false,
-                startDate: startDate,
-                endDate: endDate,
-                folderId: selectedFolderId,
-                starred: showStarredOnly ? true : nil
-            )
-
-            // Merge in-place: update existing, add new, remove gone
-            let merged = mergeConversations(source: fetchedConversations, current: conversations)
-            if merged != conversations {
-                conversations = merged
-                log("Conversations: Auto-refresh updated (\(merged.count) items)")
-            }
-
-            // Sync to local database in background
-            Task.detached(priority: .background) {
-                for conversation in fetchedConversations {
-                    _ = try? await TranscriptionStorage.shared.syncServerConversation(conversation)
-                }
-            }
-        } catch {
-            // Silently ignore errors during auto-refresh — cached data stays visible.
-            // Auth errors (notSignedIn) are transient: token refresh may fail momentarily
-            // while the user is still signed in. Don't send these to Sentry.
-            if case AuthError.notSignedIn = error {
-                log("Conversations: Auto-refresh skipped (auth token temporarily unavailable)")
-            } else {
-                logError("Conversations: Auto-refresh failed", error: error)
-            }
-        }
-
-        // Update total count
-        do {
-            let count = try await APIClient.shared.getConversationsCount(includeDiscarded: false)
-            if totalConversationsCount != count {
-                totalConversationsCount = count
-            }
-        } catch {
-            // Keep existing count
-        }
-    }
-
-    /// Merge fetched conversations into the current list in-place.
-    /// Updates changed items, adds new ones, removes ones no longer in source.
-    private func mergeConversations(source: [ServerConversation], current: [ServerConversation]) -> [ServerConversation] {
-        let sourceById = Dictionary(uniqueKeysWithValues: source.map { ($0.id, $0) })
-        let sourceIds = Set(source.map { $0.id })
-        let currentIds = Set(current.map { $0.id })
-
-        var result = current
-
-        // Update existing items in-place
-        for i in result.indices {
-            if let updated = sourceById[result[i].id], updated != result[i] {
-                result[i] = updated
-            }
-        }
-
-        // Remove items no longer in source
-        result.removeAll { !sourceIds.contains($0.id) }
-
-        // Add new items from source that aren't in current
-        let newIds = sourceIds.subtracting(currentIds)
-        if !newIds.isEmpty {
-            let newItems = source.filter { newIds.contains($0.id) }
-            result.append(contentsOf: newItems)
-            // Re-sort by createdAt descending (newest first) to maintain order
-            result.sort { $0.createdAt > $1.createdAt }
-        }
-
-        return result
-    }
-
-    /// Update the starred status of a conversation locally
-    func setConversationStarred(_ conversationId: String, starred: Bool) {
-        if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
-            conversations[index].starred = starred
-        }
-    }
-
-    /// Toggle starred filter and reload conversations
-    func toggleStarredFilter() async {
-        showStarredOnly.toggle()
-        await loadConversations()
-    }
-
-    /// Set date filter and reload conversations
-    func setDateFilter(_ date: Date?) async {
-        selectedDateFilter = date
-        await loadConversations()
-    }
-
-    /// Clear all filters and reload conversations
-    func clearFilters() async {
-        showStarredOnly = false
-        selectedDateFilter = nil
-        selectedFolderId = nil
-        await loadConversations()
-    }
-
-    /// Set folder filter and reload conversations
-    func setFolderFilter(_ folderId: String?) async {
-        selectedFolderId = folderId
-        await loadConversations()
-    }
-
-    // MARK: - Folder Management
-
-    /// Load folders from API
-    func loadFolders() async {
-        guard !isLoadingFolders else { return }
-
-        isLoadingFolders = true
-
-        do {
-            let fetchedFolders = try await APIClient.shared.getFolders()
-            folders = fetchedFolders
-            log("Folders: Loaded \(fetchedFolders.count) folders")
-        } catch {
-            logError("Folders: Failed to load", error: error)
-        }
-
-        isLoadingFolders = false
-    }
-
-    /// Create a new folder
-    func createFolder(name: String, description: String? = nil, color: String? = nil) async -> Folder? {
-        do {
-            let folder = try await APIClient.shared.createFolder(name: name, description: description, color: color)
-            folders.append(folder)
-            log("Folders: Created folder '\(name)'")
-            return folder
-        } catch {
-            logError("Folders: Failed to create folder", error: error)
-            return nil
-        }
-    }
-
-    /// Delete a folder
-    func deleteFolder(_ folderId: String, moveToFolderId: String? = nil) async {
-        do {
-            try await APIClient.shared.deleteFolder(id: folderId, moveToFolderId: moveToFolderId)
-            folders.removeAll { $0.id == folderId }
-            if selectedFolderId == folderId {
-                selectedFolderId = nil
-            }
-            log("Folders: Deleted folder \(folderId)")
-        } catch {
-            logError("Folders: Failed to delete folder", error: error)
-        }
-    }
-
-    /// Update a folder
-    func updateFolder(_ folderId: String, name: String?, description: String?, color: String?) async {
-        do {
-            let updated = try await APIClient.shared.updateFolder(id: folderId, name: name, description: description, color: color)
-            if let index = folders.firstIndex(where: { $0.id == folderId }) {
-                folders[index] = updated
-            }
-            log("Folders: Updated folder \(folderId)")
-        } catch {
-            logError("Folders: Failed to update folder", error: error)
-        }
-    }
-
-    /// Move a conversation to a folder
-    func moveConversationToFolder(_ conversationId: String, folderId: String?) async {
-        do {
-            try await APIClient.shared.moveConversationToFolder(conversationId: conversationId, folderId: folderId)
-
-            // Sync to local SQLite cache so reload doesn't revert the change
-            try await TranscriptionStorage.shared.updateFolderByBackendId(conversationId, folderId: folderId)
-
-            // Update local state
-            if conversations.contains(where: { $0.id == conversationId }) {
-                // Reload to get updated conversation
-                await loadConversations()
-            }
-            log("Folders: Moved conversation \(conversationId) to folder \(folderId ?? "none")")
-        } catch {
-            logError("Folders: Failed to move conversation to folder", error: error)
-        }
-    }
-
-    /// Delete a conversation locally (after successful API call)
-    func deleteConversationLocally(_ conversationId: String) {
-        withAnimation {
-            conversations.removeAll { $0.id == conversationId }
-        }
-    }
-
-    /// Update a conversation title locally (after successful API call)
-    func updateConversationTitle(_ conversationId: String, title: String) {
-        if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
-            conversations[index].structured.title = title
-        }
-    }
-
-    // MARK: - People (Speaker Profiles)
-
-    /// Fetches all people from the OMI API
-    func fetchPeople() async {
-        do {
-            let fetchedPeople = try await APIClient.shared.getPeople()
-            people = fetchedPeople
-            log("People: Loaded \(fetchedPeople.count) people")
-        } catch {
-            logError("People: Failed to load", error: error)
-        }
-    }
-
-    /// Creates a new person and adds to local cache
-    func createPerson(name: String) async -> Person? {
-        do {
-            let person = try await APIClient.shared.createPerson(name: name)
-            people.append(person)
-            log("People: Created person '\(name)' with id \(person.id)")
-            return person
-        } catch {
-            logError("People: Failed to create person", error: error)
-            return nil
-        }
-    }
-
-    /// Assigns segments to a person or user via bulk API
-    func assignSpeakerToSegments(
-        conversationId: String,
-        segmentIds: [Int],
-        personId: String?,
-        isUser: Bool
-    ) async -> Bool {
-        do {
-            try await APIClient.shared.assignSegmentsBulk(
-                conversationId: conversationId,
-                segmentIds: segmentIds.map(String.init),
-                isUser: isUser,
-                personId: personId
-            )
-            log("People: Assigned \(segmentIds.count) segments in conversation \(conversationId)")
-            return true
-        } catch {
-            logError("People: Failed to assign segments", error: error)
-            return false
-        }
-    }
-
-    /// Finalize and save the current conversation to the backend
-    /// Uses DB as source of truth for crash safety
-    private func finalizeConversation() async -> FinishConversationResult {
-        guard let startTime = recordingStartTime else {
-            log("Transcription: No recording start time")
-            return .discarded
-        }
-
-        let endTime = Date()
-        let sessionId = currentSessionId
-
-        // Try to load segments from DB if we have a session, fall back to in-memory
-        var segmentsToUpload: [SpeakerSegment] = speakerSegments
-
-        if let sessionId = sessionId {
-            do {
-                // Mark session as finished in DB first
-                try await TranscriptionStorage.shared.finishSession(id: sessionId)
-
-                // Load segments from DB (source of truth for crash recovery)
-                let dbSegments = try await TranscriptionStorage.shared.getSegments(sessionId: sessionId)
-                if !dbSegments.isEmpty {
-                    // Convert DB segments to SpeakerSegment format
-                    segmentsToUpload = dbSegments.map { dbSeg in
-                        SpeakerSegment(
-                            speaker: dbSeg.speaker,
-                            text: dbSeg.text,
-                            start: dbSeg.startTime,
-                            end: dbSeg.endTime
-                        )
-                    }
-                    log("Transcription: Loaded \(segmentsToUpload.count) segments from DB")
-                }
-            } catch {
-                logError("Transcription: Failed to load segments from DB, using in-memory", error: error)
-                // Fall through to use in-memory segments
-            }
-        }
-
-        guard !segmentsToUpload.isEmpty else {
-            log("Transcription: No segments to save")
-            // Clean up empty session
-            if let sessionId = sessionId {
-                try? await TranscriptionStorage.shared.deleteSession(id: sessionId)
-            }
-            return .discarded
-        }
-
-        log("Transcription: Finalizing conversation with \(segmentsToUpload.count) segments")
-
-        // Convert SpeakerSegment to API request format (include person_id from live naming)
-        let speakerPersonMap = liveSpeakerPersonMap
-        let apiSegments = segmentsToUpload.map { segment in
-            APIClient.TranscriptSegmentRequest(
-                text: segment.text,
-                speaker: "SPEAKER_\(String(format: "%02d", segment.speaker))",
-                speakerId: segment.speaker,
-                isUser: segment.speaker == 0,  // Assume speaker 0 is the user
-                personId: speakerPersonMap[segment.speaker],
-                start: segment.start,
-                end: segment.end
-            )
-        }
-
-        // Mark session as uploading
-        if let sessionId = sessionId {
-            try? await TranscriptionStorage.shared.markSessionUploading(id: sessionId)
-        }
-
-        do {
-            let response = try await APIClient.shared.createConversationFromSegments(
-                segments: apiSegments,
-                startedAt: startTime,
-                finishedAt: endTime,
-                source: currentConversationSource,
-                inputDeviceName: recordingInputDeviceName
-            )
-            log("Transcription: Conversation saved - id=\(response.id), status=\(response.status), discarded=\(response.discarded), source=\(currentConversationSource.rawValue), device=\(recordingInputDeviceName ?? "Unknown")")
-
-            // Mark session as completed in DB
-            if let sessionId = sessionId {
-                do {
-                    try await TranscriptionStorage.shared.markSessionCompleted(id: sessionId, backendId: response.id)
-                } catch {
-                    logError("Transcription: Failed to mark session \(sessionId) as completed (backendId: \(response.id))", error: error)
-                    // Session is stuck in 'uploading' state — mark as failed so retry service can recover it
-                    try? await TranscriptionStorage.shared.markSessionFailed(id: sessionId, error: "markSessionCompleted failed: \(error.localizedDescription)")
-                }
-            }
-
-            if response.discarded {
-                return .discarded
-            }
-
-            // Track successful conversation creation in analytics (Mixpanel + PostHog)
-            let durationSeconds = Int(endTime.timeIntervalSince(startTime))
-            AnalyticsManager.shared.conversationCreated(
-                conversationId: response.id,
-                source: currentConversationSource.rawValue,
-                durationSeconds: durationSeconds
-            )
-
-            // Fire-and-forget: extract goal progress from conversation transcript
-            let transcriptText = segmentsToUpload.map { $0.text }.joined(separator: " ")
-            if transcriptText.count >= 10 {
-                Task.detached(priority: .background) {
-                    await GoalsAIService.shared.extractProgressFromAllGoals(text: transcriptText)
-                }
-            }
-
-            // Check daily goal generation
-            Task { @MainActor in
-                GoalGenerationService.shared.onConversationCreated()
-            }
-
-            return .saved
-        } catch {
-            logError("Transcription: Failed to save conversation", error: error)
-            // Error event deferred to TranscriptionRetryService after all retries are exhausted
-
-            // Mark session as failed in DB for later retry
-            if let sessionId = sessionId {
-                try? await TranscriptionStorage.shared.markSessionFailed(id: sessionId, error: error.localizedDescription)
-            }
-
-            return .error(error.localizedDescription)
-        }
-    }
-
-    // MARK: - Batch Transcription
-
-    /// Transcribe a completed speech chunk from VAD batch mode.
-    /// Offsets word timestamps to session-relative time, then feeds through handleTranscriptSegment.
-    private func batchTranscribeChunk(audioBuffer: Data, wallStartTime: Double) async {
-        let offsetSec = wallStartTime - recordingStartCATime
-        let effectiveLanguage = AssistantSettings.shared.effectiveTranscriptionLanguage
-        let vocabulary = AssistantSettings.shared.effectiveVocabulary
-
-        do {
-            let segments = try await TranscriptionService.batchTranscribeFull(
-                audioData: audioBuffer,
-                language: effectiveLanguage,
-                vocabulary: vocabulary
-            )
-
-            for segment in segments {
-                // Offset all word timestamps by the chunk's start time relative to recording start
-                let offsetWords = segment.words.map { word in
-                    TranscriptionService.TranscriptSegment.Word(
-                        word: word.word,
-                        start: word.start + offsetSec,
-                        end: word.end + offsetSec,
-                        confidence: word.confidence,
-                        speaker: word.speaker,
-                        punctuatedWord: word.punctuatedWord
-                    )
-                }
-
-                let offsetSegment = TranscriptionService.TranscriptSegment(
-                    text: segment.text,
-                    isFinal: true,
-                    speechFinal: true,
-                    confidence: segment.confidence,
-                    words: offsetWords,
-                    channelIndex: segment.channelIndex
-                )
-
-                handleTranscriptSegment(offsetSegment)
-            }
-        } catch {
-            logError("Transcription: Batch transcribe chunk failed", error: error)
-        }
-    }
-
-    /// Handle incoming transcript segment with speaker diarization
-    /// Uses channel index for primary speaker attribution:
-    ///   - Channel 0 = microphone = user (speaker 0)
-    ///   - Channel 1 = system audio = others (speaker 1+)
-    private func handleTranscriptSegment(_ segment: TranscriptionService.TranscriptSegment) {
-        // Only process final segments (speechFinal or isFinal)
-        guard segment.speechFinal || segment.isFinal else { return }
-
-        // Determine speaker based on channel index
-        // Channel 0 = mic = user (speaker 0)
-        // Channel 1 = system audio = others (speaker 1+)
-        let channelBasedSpeaker = segment.channelIndex == 0 ? 0 : 1
-
-        // Process words and merge by speaker
-        // If VAD gate is active (streaming mode only), remap Deepgram timestamps to wall-clock time
-        // In batch mode, timestamps are already session-relative after offsetting in batchTranscribeChunk
-        let words: [TranscriptionService.TranscriptSegment.Word]
-        if !useBatchTranscription, let gate = vadGateService {
-            words = segment.words.map { word in
-                let (remappedStart, remappedEnd) = gate.remapTimestamp(start: word.start, end: word.end)
-                return TranscriptionService.TranscriptSegment.Word(
-                    word: word.word,
-                    start: remappedStart,
-                    end: remappedEnd,
-                    confidence: word.confidence,
-                    speaker: word.speaker,
-                    punctuatedWord: word.punctuatedWord
-                )
-            }
-        } else {
-            words = segment.words
-        }
-        guard !words.isEmpty else {
-            // Fallback: no words, just append text with channel-based speaker
-            if segment.speechFinal && !segment.text.isEmpty {
-                appendToTranscript(segment.text)
-                log("Transcript [FINAL no words] Ch\(segment.channelIndex) Speaker \(channelBasedSpeaker): \(segment.text)")
-            }
-            return
-        }
-
-        // Word-to-segment aggregation: merge consecutive words from same speaker
-        // For channel 1 (system audio), use diarization speaker ID + 1 to distinguish multiple remote speakers
-        var newSegments: [SpeakerSegment] = []
-        for word in words {
-            // Speaker assignment:
-            // - Channel 0 (mic): Always speaker 0 (user)
-            // - Channel 1 (system): Use diarization speaker + 1, or default to 1
-            let speaker: Int
-            if segment.channelIndex == 0 {
-                speaker = 0  // Mic is always user
-            } else {
-                // System audio: offset diarization speakers by 1
-                // This allows distinguishing multiple remote speakers (1, 2, 3, etc.)
-                speaker = (word.speaker ?? 0) + 1
-            }
-
-            if let last = newSegments.last, last.speaker == speaker {
-                // Same speaker - append word to existing segment
-                newSegments[newSegments.count - 1].text += " " + word.punctuatedWord
-                newSegments[newSegments.count - 1].end = word.end
-            } else {
-                // Different speaker - create new segment
-                newSegments.append(SpeakerSegment(
-                    speaker: speaker,
-                    text: word.punctuatedWord,
-                    start: word.start,
-                    end: word.end
-                ))
-            }
-        }
-
-        // Log new segments from this chunk
-        for seg in newSegments {
-            let channelLabel = segment.channelIndex == 0 ? "mic" : "sys"
-            log("Transcript [NEW] Ch\(segment.channelIndex)(\(channelLabel)) Speaker \(seg.speaker) [\(String(format: "%.1f", seg.start))s-\(String(format: "%.1f", seg.end))s]: \(seg.text)")
-        }
-
-        // Gap-based merging: combine with existing segments if same speaker and gap < 3 seconds
-        for newSeg in newSegments {
-            // Track word count incrementally
-            totalWordCount += newSeg.text.split(separator: " ").count
-
-            if let lastIdx = speakerSegments.indices.last,
-               speakerSegments[lastIdx].speaker == newSeg.speaker,
-               newSeg.start - speakerSegments[lastIdx].end < 3.0 {
-                // Same speaker and gap < 3s - merge
-                let gap = newSeg.start - speakerSegments[lastIdx].end
-                log("Transcript [MERGE] Speaker \(newSeg.speaker) gap=\(String(format: "%.2f", gap))s: merging into existing segment")
-                speakerSegments[lastIdx].text += " " + newSeg.text
-                speakerSegments[lastIdx].end = newSeg.end
-            } else {
-                // Different speaker or gap >= 3s - add as new segment
-                if let lastIdx = speakerSegments.indices.last {
-                    let gap = newSeg.start - speakerSegments[lastIdx].end
-                    log("Transcript [ADD] Speaker \(newSeg.speaker) gap=\(String(format: "%.2f", gap))s: new segment (different speaker or gap >= 3s)")
-                } else {
-                    log("Transcript [ADD] Speaker \(newSeg.speaker): first segment")
-                }
-                speakerSegments.append(newSeg)
-                totalSegmentCount += 1
-            }
-        }
-
-        // Sliding window: trim old segments from memory (they're already persisted in SQLite)
-        if speakerSegments.count > maxInMemorySegments {
-            let excess = speakerSegments.count - maxInMemorySegments
-            speakerSegments.removeFirst(excess)
-        }
-
-        // Log current segments summary (only last 5 segments when count > 20 to avoid log spam)
-        log("Transcript [SEGMENTS] Total: \(totalSegmentCount) segments (in-memory: \(speakerSegments.count))")
-        let logSegments = speakerSegments.count > 20
-            ? Array(speakerSegments.suffix(5))
-            : speakerSegments
-        let startIdx = speakerSegments.count > 20 ? speakerSegments.count - 5 : 0
-        if speakerSegments.count > 20 {
-            log("  ... (\(speakerSegments.count - 5) earlier segments omitted)")
-        }
-        for (offset, seg) in logSegments.enumerated() {
-            let i = startIdx + offset
-            let speakerLabel = seg.speaker == 0 ? "user" : "other"
-            log("  [\(i)] Speaker \(seg.speaker)(\(speakerLabel)) [\(String(format: "%.1f", seg.start))s-\(String(format: "%.1f", seg.end))s]: \(seg.text)")
-        }
-
-        // Update published segments for UI (via isolated monitor)
-        LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
-
-        // Update display transcript
-        updateTranscriptDisplay()
-
-        // Persist new segments to DB for crash safety
-        if let sessionId = currentSessionId {
-            Task {
-                for newSeg in newSegments {
-                    do {
-                        try await TranscriptionStorage.shared.appendSegment(
-                            sessionId: sessionId,
-                            speaker: newSeg.speaker,
-                            text: newSeg.text,
-                            startTime: newSeg.start,
-                            endTime: newSeg.end
-                        )
-                    } catch {
-                        logError("Transcription: Failed to persist segment to DB", error: error)
-                        await RewindDatabase.shared.reportQueryError(error)
-                        // Non-fatal - continue recording
-                    }
-                }
-            }
-        }
-    }
-
-    /// Update the display transcript — no-op since word count is tracked incrementally
-    /// and views use LiveTranscriptMonitor.segments directly
-    private func updateTranscriptDisplay() {
-        // Previously rebuilt currentTranscript from all speakerSegments on every incoming segment,
-        // causing O(N^2) string allocations. Word count is now tracked via totalWordCount.
-    }
-
-    /// Append text to transcript (fallback when no word-level data)
-    private func appendToTranscript(_ text: String) {
-        if !currentTranscript.isEmpty {
-            currentTranscript += "\n"
-        }
-        currentTranscript += text
-    }
-
-    /// Request microphone permission
-    func requestMicrophonePermission() {
-        // Activate app to ensure permission dialog appears
-        NSApp.activate(ignoringOtherApps: true)
-
-        log("Requesting microphone permission, current status: \(AudioCaptureService.authorizationStatus().rawValue)")
-
-        Task {
-            let granted = await AudioCaptureService.requestPermission()
-            await MainActor.run {
-                self.hasMicrophonePermission = granted
-                log("Microphone permission request completed, granted: \(granted)")
-                if granted {
-                    log("Microphone permission granted")
-                    // Only start transcription if onboarding is complete
-                    // During onboarding, we just update the permission state
-                    if self.hasCompletedOnboarding {
-                        self.startTranscription()
-                    }
-                } else {
-                    log("Microphone permission denied")
-                    // UI will show the denied state with reset options inline
-                }
-            }
-        }
-    }
-
-    /// Check microphone permission status
-    func checkMicrophonePermission() {
-        hasMicrophonePermission = AudioCaptureService.checkPermission()
-    }
-
-    /// Check if microphone permission was explicitly denied
-    func isMicrophonePermissionDenied() -> Bool {
-        return AudioCaptureService.isPermissionDenied()
-    }
-
-    /// Check if screen recording permission is denied (onboarding complete but permission not granted)
-    func isScreenRecordingPermissionDenied() -> Bool {
-        return hasCompletedOnboarding && !CGPreflightScreenCaptureAccess()
-    }
-
-    /// Restart the app by launching a new instance and terminating the current one
-    nonisolated func restartApp() {
-        if UpdaterViewModel.isUpdateInProgress {
-            log("Sparkle update in progress, skipping independent restart (Sparkle will handle relaunch)")
-            return
-        }
-
-        log("Restarting app...")
-
-        guard let bundleURL = Bundle.main.bundleURL as URL? else {
-            log("Failed to get bundle URL for restart")
-            return
-        }
-
-        // Use a shell script to wait briefly, then relaunch the app
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/bin/sh")
-        task.arguments = ["-c", "sleep 0.5 && open \"\(bundleURL.path)\""]
-
-        do {
-            try task.run()
-            log("Restart scheduled, terminating current instance...")
-
-            // Terminate the current app
-            DispatchQueue.main.async {
-                NSApplication.shared.terminate(nil)
-            }
-        } catch {
-            log("Failed to schedule restart: \(error)")
-        }
-    }
-
-    /// Reset onboarding state for the current app only, then restart.
-    /// This clears onboarding state without touching production data or system permissions.
-    nonisolated func resetOnboardingAndRestart() {
-        log("Resetting onboarding state for current app...")
-
-        // Update live @AppStorage state in the current app instance before touching
-        // raw UserDefaults so SwiftUI doesn't write stale onboarding values back.
-        DispatchQueue.main.async {
-            NotificationCenter.default.post(name: .resetOnboardingRequested, object: nil)
-        }
-
-        // Clear onboarding-related UserDefaults keys (thread-safe, do first)
-        let onboardingKeys = [
-            "hasCompletedOnboarding",
-            "onboardingStep",
-            "hasSeenRewindIntro",
-            "hasTriggeredNotification",
-            "hasTriggeredAutomation",
-            "hasTriggeredScreenRecording",
-            "hasTriggeredMicrophone",
-            "hasTriggeredSystemAudio",
-            "hasTriggeredAccessibility",
-            "hasTriggeredBluetooth",
-            "onboardingJustCompleted"
-        ]
-        for key in onboardingKeys {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
-        UserDefaults.standard.synchronize()
-        log("Cleared onboarding UserDefaults keys")
-
-        // Clear onboarding chat persistence and messages
-        OnboardingChatPersistence.clear()
-        log("Cleared onboarding chat persistence")
-
-        // Clear persisted backend chat messages so onboarding does not resume old history.
-        // Onboarding currently uses the default chat message stream.
-        Task {
-            do {
-                _ = try await APIClient.shared.deleteMessages()
-                log("Cleared backend chat messages")
-            } catch {
-                logError("Failed to clear backend chat messages during onboarding reset", error: error)
-            }
-        }
-
-        // Restart off the main thread to avoid blocking the menu action path.
-        DispatchQueue.global(qos: .utility).async { [self] in
-            Thread.sleep(forTimeInterval: 0.15)
-            // Keep onboarding reset scoped to the current app instance.
-            // It must not mutate production defaults, shared local data, or TCC permissions.
-            self.restartApp()
-        }
-    }
-
-    /// Clean conflicting app bundles from Trash, DerivedData, and DMG staging directories
-    private nonisolated func cleanConflictingAppBundles() {
-        let fileManager = FileManager.default
-        let homeDir = fileManager.homeDirectoryForCurrentUser.path
-
-        // Clean Omi apps from Trash (they still pollute Launch Services!)
-        let trashPath = "\(homeDir)/.Trash"
-        if let contents = try? fileManager.contentsOfDirectory(atPath: trashPath) {
-            for item in contents where item.lowercased().contains("omi") {
-                let itemPath = "\(trashPath)/\(item)"
-                do {
-                    try fileManager.removeItem(atPath: itemPath)
-                    log("Cleaned from Trash: \(item)")
-                } catch {
-                    log("Failed to clean from Trash: \(item) - \(error.localizedDescription)")
-                }
-            }
-        }
-
-        // Clean DMG staging directories
-        let tmpDir = "/private/tmp"
-        if let contents = try? fileManager.contentsOfDirectory(atPath: tmpDir) {
-            for item in contents where item.hasPrefix("omi-dmg-staging") || item.hasPrefix("omi-dmg-test") {
-                let itemPath = "\(tmpDir)/\(item)"
-                do {
-                    try fileManager.removeItem(atPath: itemPath)
-                    log("Cleaned DMG staging: \(item)")
-                } catch {
-                    log("Failed to clean DMG staging: \(item) - \(error.localizedDescription)")
-                }
-            }
-        }
-
-        // Clean Xcode DerivedData Omi builds
-        let derivedDataPath = "\(homeDir)/Library/Developer/Xcode/DerivedData"
-        if let contents = try? fileManager.contentsOfDirectory(atPath: derivedDataPath) {
-            for item in contents where item.lowercased().contains("omi") {
-                let buildProductsPath = "\(derivedDataPath)/\(item)/Build/Products"
-                if let buildDirs = try? fileManager.contentsOfDirectory(atPath: buildProductsPath) {
-                    for buildDir in buildDirs {
-                        let appPath = "\(buildProductsPath)/\(buildDir)/Omi.app"
-                        let appPath2 = "\(buildProductsPath)/\(buildDir)/Omi Computer.app"
-                        let appPath3 = "\(buildProductsPath)/\(buildDir)/omi.app"
-                        let appPath4 = "\(buildProductsPath)/\(buildDir)/Omi Dev.app"
-                        for path in [appPath, appPath2, appPath3, appPath4] {
-                            if fileManager.fileExists(atPath: path) {
-                                do {
-                                    try fileManager.removeItem(atPath: path)
-                                    log("Cleaned DerivedData: \(path)")
-                                } catch {
-                                    log("Failed to clean DerivedData: \(path) - \(error.localizedDescription)")
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    /// Eject any mounted Omi DMG volumes
-    private nonisolated func ejectMountedDMGVolumes() {
-        let fileManager = FileManager.default
-        let volumesPath = "/Volumes"
-
-        guard let contents = try? fileManager.contentsOfDirectory(atPath: volumesPath) else { return }
-
-        for volume in contents where volume.lowercased().contains("omi") || volume.hasPrefix("dmg.") {
-            let volumePath = "\(volumesPath)/\(volume)"
-
-            // Try diskutil eject first
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
-            process.arguments = ["eject", volumePath]
-            process.standardOutput = FileHandle.nullDevice
-            process.standardError = FileHandle.nullDevice
-
-            do {
-                try process.run()
-                process.waitUntilExit()
-                if process.terminationStatus == 0 {
-                    log("Ejected volume: \(volume)")
-                } else {
-                    // Try hdiutil detach as fallback
-                    let detachProcess = Process()
-                    detachProcess.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
-                    detachProcess.arguments = ["detach", volumePath]
-                    detachProcess.standardOutput = FileHandle.nullDevice
-                    detachProcess.standardError = FileHandle.nullDevice
-                    try? detachProcess.run()
-                    detachProcess.waitUntilExit()
-                }
-            } catch {
-                log("Failed to eject volume: \(volume) - \(error.localizedDescription)")
-            }
-        }
-    }
-
-    /// Reset Launch Services database to clear stale app registrations
-    private nonisolated func resetLaunchServicesDatabase() {
-        let lsregisterPath = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: lsregisterPath)
-        process.arguments = ["-kill", "-r", "-domain", "local", "-domain", "user"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-            log("Launch Services database reset (exit code: \(process.terminationStatus))")
-        } catch {
-            log("Failed to reset Launch Services: \(error.localizedDescription)")
-        }
-    }
-
-    /// Clean user TCC database entries for Omi apps
-    private nonisolated func cleanUserTCCDatabase() {
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
-        let tccDbPath = "\(homeDir)/Library/Application Support/com.apple.TCC/TCC.db"
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
-        process.arguments = [tccDbPath, "DELETE FROM access WHERE client LIKE '%com.omi.computer-macos%';"]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-            log("User TCC database cleaned (exit code: \(process.terminationStatus))")
-        } catch {
-            log("Failed to clean user TCC database: \(error.localizedDescription)")
-        }
-
-        // Also clean entries for new dev bundle ID pattern (com.omi.desktop-dev)
-        let process2 = Process()
-        process2.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
-        process2.arguments = [tccDbPath, "DELETE FROM access WHERE client LIKE '%com.omi.desktop%';"]
-        process2.standardOutput = FileHandle.nullDevice
-        process2.standardError = FileHandle.nullDevice
-
-        do {
-            try process2.run()
-            process2.waitUntilExit()
-            log("User TCC database cleaned for desktop-dev (exit code: \(process2.terminationStatus))")
-        } catch {
-            log("Failed to clean user TCC database for desktop-dev: \(error.localizedDescription)")
-        }
-    }
-
-    /// Reset microphone permission using tccutil (Option 1: Direct)
-    /// Returns true if the reset command was executed successfully
-    /// If shouldRestart is true, the app will restart after reset
-    nonisolated func resetMicrophonePermissionDirect(shouldRestart: Bool = false) -> Bool {
-        let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
-        log("Resetting microphone permission for \(bundleId) via tccutil...")
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
-        process.arguments = ["reset", "Microphone", bundleId]
-
-        do {
-            try process.run()
-            process.waitUntilExit()
-            let success = process.terminationStatus == 0
-            log("tccutil reset completed with exit code: \(process.terminationStatus)")
-
-            if success && shouldRestart {
-                restartApp()
-            }
-
-            return success
-        } catch {
-            log("Failed to run tccutil: \(error)")
-            return false
-        }
-    }
-
-    /// Reset microphone permission via Terminal (Option 2: Visible to user)
-    /// If shouldRestart is true, the app will restart after the terminal command
-    func resetMicrophonePermissionViaTerminal(shouldRestart: Bool = false) {
-        let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
-        let appPath = Bundle.main.bundleURL.path
-        log("Opening Terminal to reset microphone permission for \(bundleId)...")
-
-        // Build the shell command - escape single quotes in path for shell
-        let escapedPath = appPath.replacingOccurrences(of: "'", with: "'\\''")
-        let restartCommand = shouldRestart ? " && open '\(escapedPath)'" : ""
-        let shellCommand = "tccutil reset Microphone \(bundleId) && echo 'Done! Permission reset.'\(restartCommand)"
-
-        // AppleScript to open Terminal and run the command
-        let script = "tell application \"Terminal\"\nactivate\ndo script \"\(shellCommand)\"\nend tell"
-
-        var error: NSDictionary?
-        if let appleScript = NSAppleScript(source: script) {
-            appleScript.executeAndReturnError(&error)
+  }
+
+  func requestNotificationPermission() {
+    // First check current authorization status
+    UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+      DispatchQueue.main.async {
+        guard let self = self else { return }
+
+        if settings.authorizationStatus == .notDetermined {
+          // First time - show the system prompt
+          NSApp.activate(ignoringOtherApps: true)
+          UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound, .badge])
+          { [weak self] granted, error in
             if let error = error {
-                log("AppleScript error: \(error)")
-            } else if shouldRestart {
-                // Terminate current app after terminal script is running
-                DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-                    NSApplication.shared.terminate(nil)
+              let nsError = error as NSError
+              log(
+                "Notification permission error: \(error) (domain=\(nsError.domain) code=\(nsError.code))"
+              )
+
+              // UNErrorDomain code 1 = notificationsNotAllowed
+              // This happens when LaunchServices has the app marked as launch-disabled,
+              // which prevents the notification center from registering the app.
+              // Fix: unregister from LaunchServices and re-register to clear the flag, then retry.
+              if nsError.domain == "UNErrorDomain" && nsError.code == 1 {
+                DispatchQueue.main.async {
+                  AnalyticsManager.shared.notificationRepairTriggered(
+                    reason: "launch_disabled_error",
+                    previousStatus: "notDetermined",
+                    currentStatus: "error_code_1"
+                  )
+                  self?.repairNotificationRegistrationAndRetry()
                 }
+                return
+              }
             }
-        }
-    }
-
-    /// Check system audio permission status
-    /// This checks if the test capture was successful (set by triggerSystemAudioPermission)
-    func checkSystemAudioPermission() {
-        // Permission is set by triggerSystemAudioPermission after successful test
-        // No-op here - we rely on the test result
-    }
-
-    /// Trigger system audio permission by actually testing capture
-    /// This verifies system audio works by briefly starting and stopping capture
-    func triggerSystemAudioPermission() {
-        guard #available(macOS 14.4, *) else {
-            log("System audio not supported on this macOS version")
-            hasSystemAudioPermission = false
-            return
-        }
-
-        log("System audio: Testing capture...")
-
-        // Create a test capture service
-        let testService = SystemAudioCaptureService()
-
-        Task {
-            do {
-                // Try to start capture - this will fail if permission is not granted
-                try await testService.startCapture { _ in
-                    // We don't need the audio data, just testing if it works
-                }
-
-                // If we get here, capture started successfully
-                log("System audio: Test capture started successfully")
-
-                // Stop the test capture
-                testService.stopCapture()
-                log("System audio: Test capture stopped")
-
-                // Mark permission as granted
-                hasSystemAudioPermission = true
-                log("System audio: Permission verified")
-
-            } catch {
-                logError("System audio: Test capture failed", error: error)
-                hasSystemAudioPermission = false
-
-                // Open System Settings to Screen Recording section
-                if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
-                    NSWorkspace.shared.open(url)
-                }
+            DispatchQueue.main.async {
+              self?.checkNotificationPermission()
             }
+          }
+        } else if settings.authorizationStatus == .denied {
+          // Previously denied - open System Settings so user can enable manually
+          self.openNotificationPreferences()
         }
+        // If already authorized, checkNotificationPermission() will handle it
+      }
     }
+  }
+
+  /// Repair LaunchServices registration when notification authorization fails.
+  /// The "launch-disabled" flag in LaunchServices prevents the notification center
+  /// from registering the app. This unregisters and re-registers to clear the flag.
+  private func repairNotificationRegistrationAndRetry() {
+    // Use the shared repair utility (also used by ProactiveAssistantsPlugin)
+    ProactiveAssistantsPlugin.repairNotificationRegistration()
+
+    // After the repair + retry, update our permission state and open System Settings as fallback
+    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+      UNUserNotificationCenter.current().getNotificationSettings { settings in
+        DispatchQueue.main.async {
+          let isNowGranted = settings.authorizationStatus == .authorized
+          self?.hasNotificationPermission = isNowGranted
+          if !isNowGranted {
+            log("Notification permission still not granted after repair. Opening System Settings.")
+            self?.openNotificationPreferences()
+          }
+        }
+      }
+    }
+  }
+
+  /// Repair notification registration via lsregister, then fall back to System Settings if still broken.
+  /// Called from sidebar and settings "Fix" buttons when auth is not authorized.
+  func repairNotificationAndFallback() {
+    log("Fix button tapped — running lsregister repair for notifications")
+    ProactiveAssistantsPlugin.repairNotificationRegistration()
+
+    // Wait for repair + re-authorization, then check if it worked
+    DispatchQueue.main.asyncAfter(deadline: .now() + 4.0) { [weak self] in
+      UNUserNotificationCenter.current().getNotificationSettings { settings in
+        DispatchQueue.main.async {
+          let isNowGranted = settings.authorizationStatus == .authorized
+          self?.hasNotificationPermission = isNowGranted
+          self?.notificationAlertStyle = settings.alertStyle
+          if isNowGranted {
+            log("Notification repair succeeded — auth is now authorized")
+          } else {
+            log(
+              "Notification repair didn't restore auth (status=\(settings.authorizationStatus.rawValue)) — opening System Settings"
+            )
+            self?.openNotificationPreferences()
+          }
+        }
+      }
+    }
+  }
+
+  /// Trigger screen recording permission prompt
+  func triggerScreenRecordingPermission() {
+    // Request both traditional TCC and ScreenCaptureKit permissions
+    ScreenCaptureService.requestAllScreenCapturePermissions()
+  }
+
+  /// Trigger automation permission by attempting to use Apple Events
+  nonisolated func triggerAutomationPermission() {
+    // Run a simple AppleScript to trigger the permission prompt
+    // This must be done on a background thread since it's nonisolated
+    Task.detached {
+      // First, ensure System Events is running — without it, the TCC prompt won't appear
+      // and checkAutomationPermission returns -600 (procNotFound)
+      let launchScript = NSAppleScript(
+        source: """
+              launch application "System Events"
+          """)
+      var launchError: NSDictionary?
+      launchScript?.executeAndReturnError(&launchError)
+      if let launchError = launchError {
+        log("AUTOMATION_TRIGGER: Failed to launch System Events: \(launchError)")
+      } else {
+        log("AUTOMATION_TRIGGER: System Events launched successfully")
+      }
+
+      // Small delay to let System Events initialize
+      try? await Task.sleep(nanoseconds: 500_000_000)
+
+      // Now trigger the actual TCC prompt
+      let script = NSAppleScript(
+        source: """
+              tell application "System Events"
+                  return name of first process whose frontmost is true
+              end tell
+          """)
+      var error: NSDictionary?
+      script?.executeAndReturnError(&error)
+
+      if let error = error {
+        let errorNum = error[NSAppleScript.errorNumber] as? Int ?? 0
+        let errorMsg = error[NSAppleScript.errorMessage] as? String ?? "unknown"
+        log("AUTOMATION_TRIGGER: AppleScript failed: \(errorNum) - \(errorMsg)")
+      } else {
+        log("AUTOMATION_TRIGGER: AppleScript succeeded, permission may have been granted")
+      }
+
+      // Re-check permission status before opening settings
+      await MainActor.run { [weak self] in
+        self?.checkAutomationPermission()
+      }
+
+      // Small delay to let the check complete
+      try? await Task.sleep(nanoseconds: 300_000_000)
+
+      // Open settings so user can toggle if needed
+      await MainActor.run {
+        if let url = URL(
+          string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation")
+        {
+          NSWorkspace.shared.open(url)
+        }
+      }
+    }
+  }
+
+  // MARK: - Permission Status Checks
+
+  /// Check and update all permission states
+  func checkAllPermissions() {
+    checkNotificationPermission()
+    checkScreenRecordingPermission()
+    checkAutomationPermission()
+    checkMicrophonePermission()
+    checkSystemAudioPermission()
+    checkAccessibilityPermission()
+    // One-time startup diagnostic for accessibility
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+    let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
+    log(
+      "ACCESSIBILITY_STARTUP: bundleId=\(bundleId), macOS=\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion), TCC=\(hasAccessibilityPermission), broken=\(isAccessibilityBroken), onboarded=\(hasCompletedOnboarding)"
+    )
+    // Only check Bluetooth if already initialized (to avoid triggering permission prompt early)
+    if bluetoothStateCancellable != nil {
+      checkBluetoothPermission()
+    }
+  }
+
+  /// Check Bluetooth permission status
+  /// Bluetooth is considered "granted" if state is poweredOn or poweredOff (allowed but BT off)
+  /// IMPORTANT: Only call this after initializeBluetoothIfNeeded() has been called
+  func checkBluetoothPermission() {
+    // Guard: Only check if Bluetooth has been initialized (to avoid triggering permission prompt early)
+    guard bluetoothStateCancellable != nil else {
+      log("BLUETOOTH_CHECK: Skipping - Bluetooth not initialized yet")
+      return
+    }
+    let state = BluetoothManager.shared.bluetoothState
+    let oldValue = hasBluetoothPermission
+    // poweredOn = ready to use, poweredOff = allowed but BT is off
+    // unauthorized = denied
+    let newValue = state == .poweredOn || state == .poweredOff
+    log(
+      "BLUETOOTH_CHECK: state=\(BluetoothManager.shared.bluetoothStateDescription), stateRaw=\(state.rawValue), auth=\(BluetoothManager.shared.authorizationDescription), granted=\(newValue)"
+    )
+    if newValue != oldValue {
+      log(
+        "Bluetooth permission changed: \(oldValue) -> \(newValue), state=\(BluetoothManager.shared.bluetoothStateDescription)"
+      )
+    }
+    hasBluetoothPermission = newValue
+  }
+
+  /// Trigger Bluetooth permission by attempting to scan
+  /// On macOS, the permission dialog only appears when actually using Bluetooth
+  func triggerBluetoothPermission() {
+    // Ensure Bluetooth is initialized first (this is expected to be called from the Bluetooth onboarding step)
+    initializeBluetoothIfNeeded()
+
+    log(
+      "triggerBluetoothPermission: Starting, state=\(BluetoothManager.shared.bluetoothStateDescription), auth=\(BluetoothManager.shared.authorizationDescription)"
+    )
+    // Trigger the permission prompt by attempting to scan
+    // This bypasses state checks because we specifically want the system dialog
+    BluetoothManager.shared.triggerPermissionPrompt()
+    // Check permission state after a delay to allow user to respond
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+      log(
+        "triggerBluetoothPermission: After 1s delay, state=\(BluetoothManager.shared.bluetoothStateDescription), auth=\(BluetoothManager.shared.authorizationDescription)"
+      )
+      self.checkBluetoothPermission()
+    }
+    // Also check again after 3 seconds in case state updates slowly
+    DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+      log(
+        "triggerBluetoothPermission: After 3s delay, state=\(BluetoothManager.shared.bluetoothStateDescription), auth=\(BluetoothManager.shared.authorizationDescription)"
+      )
+      self.checkBluetoothPermission()
+    }
+  }
+
+  /// Check if Bluetooth permission was explicitly denied
+  /// Returns false if Bluetooth hasn't been initialized yet (to avoid triggering permission prompt)
+  func isBluetoothPermissionDenied() -> Bool {
+    // Guard: Only check if Bluetooth has been initialized
+    guard bluetoothStateCancellable != nil else {
+      return false
+    }
+    return BluetoothManager.shared.bluetoothState == .unauthorized
+  }
+
+  /// Check if Bluetooth is reported as unsupported (may be macOS version issue)
+  /// Returns false if Bluetooth hasn't been initialized yet (to avoid triggering permission prompt)
+  func isBluetoothUnsupported() -> Bool {
+    // Guard: Only check if Bluetooth has been initialized
+    guard bluetoothStateCancellable != nil else {
+      return false
+    }
+    return BluetoothManager.shared.bluetoothState == .unsupported
+  }
+
+  /// Open Bluetooth preferences in System Settings
+  func openBluetoothPreferences() {
+    if let url = URL(
+      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Bluetooth")
+    {
+      NSWorkspace.shared.open(url)
+    }
+  }
+
+  /// Check notification permission status and alert style
+  func checkNotificationPermission() {
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+      DispatchQueue.main.async {
+        let isNowGranted = settings.authorizationStatus == .authorized
+        self.hasNotificationPermission = isNowGranted
+        self.notificationAlertStyle = settings.alertStyle
+
+        // Log the current notification settings
+        let authStatus =
+          switch settings.authorizationStatus {
+          case .notDetermined: "notDetermined"
+          case .denied: "denied"
+          case .authorized: "authorized"
+          case .provisional: "provisional"
+          case .ephemeral: "ephemeral"
+          @unknown default: "unknown"
+          }
+        let alertStyleName =
+          switch settings.alertStyle {
+          case .none: "NONE (no banners)"
+          case .banner: "BANNER"
+          case .alert: "ALERT"
+          @unknown default: "unknown"
+          }
+        log(
+          "Notification settings: auth=\(authStatus), alertStyle=\(alertStyleName), sound=\(settings.soundSetting.rawValue), badge=\(settings.badgeSetting.rawValue)"
+        )
+
+        // Track notification settings in analytics only when they change
+        let soundEnabled = settings.soundSetting == .enabled
+        let badgeEnabled = settings.badgeSetting == .enabled
+        let settingsChanged =
+          authStatus != self.lastNotificationAuthStatus
+          || alertStyleName != self.lastNotificationAlertStyle
+          || soundEnabled != self.lastNotificationSoundEnabled
+          || badgeEnabled != self.lastNotificationBadgeEnabled
+
+        if settingsChanged {
+          AnalyticsManager.shared.notificationSettingsChecked(
+            authStatus: authStatus,
+            alertStyle: alertStyleName,
+            soundEnabled: soundEnabled,
+            badgeEnabled: badgeEnabled,
+            bannersDisabled: settings.alertStyle == .none
+          )
+
+          // Detect regression: was authorized, now reverted to notDetermined
+          // This happens on macOS 26+ where the OS silently revokes notification permission
+          if self.lastNotificationAuthStatus == "authorized" && authStatus == "notDetermined" {
+            log(
+              "Notification permission REGRESSED from authorized to notDetermined — triggering auto-repair"
+            )
+            AnalyticsManager.shared.notificationRepairTriggered(
+              reason: "auth_regression",
+              previousStatus: "authorized",
+              currentStatus: "notDetermined"
+            )
+            self.repairNotificationRegistrationAndRetry()
+          }
+
+          // Update last known state
+          self.lastNotificationAuthStatus = authStatus
+          self.lastNotificationAlertStyle = alertStyleName
+          self.lastNotificationSoundEnabled = soundEnabled
+          self.lastNotificationBadgeEnabled = badgeEnabled
+        }
+
+      }
+    }
+  }
+
+  /// Check screen recording permission status
+  func checkScreenRecordingPermission() {
+    let tccGranted = CGPreflightScreenCaptureAccess()
+
+    if !tccGranted {
+      hasScreenRecordingPermission = false
+      isScreenCaptureKitBroken = false
+      // If user already tried Grant once and permission is still not granted,
+      // the TCC entry is likely corrupted (e.g. after developer account change
+      // + tccutil reset). Show stale UI with toggle off/on instructions.
+      if screenRecordingGrantAttempts > 0 && !isScreenRecordingStale {
+        log(
+          "Screen capture: Grant attempted but permission still denied — showing recovery instructions"
+        )
+        isScreenRecordingStale = true
+      }
+      return
+    }
+
+    // TCC says granted. If the permission alert is currently showing (permission was
+    // previously false or broken or stale), do a real capture test to verify the stale TCC case
+    // (e.g. after developer account change). This avoids spawning a screencapture process
+    // on every didBecomeActive when everything is fine.
+    if !hasScreenRecordingPermission || isScreenCaptureKitBroken || isScreenRecordingStale {
+      let realPermission = ScreenCaptureService.checkPermission()
+      hasScreenRecordingPermission = realPermission
+
+      // Stale TCC entry from old developer signing: CGPreflight says granted but
+      // actual capture fails. The user must toggle OFF then ON in System Settings
+      // to update the code signing requirement (csreq) stored in the TCC database.
+      if !realPermission && !isScreenRecordingStale {
+        log("Screen capture: stale TCC entry detected (developer signing changed)")
+        isScreenRecordingStale = true
+        // Try tccutil reset in case it works (it may not on macOS 15+ for system TCC)
+        Task.detached {
+          ScreenCaptureService.ensureLaunchServicesRegistrationSync()
+          _ = ScreenCaptureService.resetScreenCapturePermission()
+        }
+      } else if realPermission {
+        // Permission recovered (user toggled off/on in System Settings)
+        isScreenRecordingStale = false
+        screenRecordingGrantAttempts = 0
+      }
+
+      if isScreenCaptureKitBroken {
+        // Re-check if SCK has recovered (user toggled permission in System Settings)
+        if #available(macOS 14.0, *) {
+          Task {
+            let sckWorks = await ScreenCaptureService.testScreenCaptureKitPermission()
+            if sckWorks {
+              log("AppState: ScreenCaptureKit recovered — clearing broken flag")
+              self.isScreenCaptureKitBroken = false
+              self.hasScreenRecordingPermission = true
+            }
+          }
+        }
+      }
+    } else {
+      hasScreenRecordingPermission = true
+    }
+  }
+
+  /// Check automation permission without triggering a prompt
+  /// Uses AEDeterminePermissionToAutomateTarget to query TCC status for System Events
+  func checkAutomationPermission() {
+    guard !isCheckingAutomationPermission else { return }
+    isCheckingAutomationPermission = true
+    Task.detached {
+      defer { Task { @MainActor in self.isCheckingAutomationPermission = false } }
+      let status = Self.queryAutomationPermissionStatus()
+
+      // noErr (0) = granted, errAEEventNotPermitted (-1743) = denied, -1744 = not determined
+      // -600 (procNotFound) = System Events not running — try to launch it and retry
+      if status == -600 {
+        log("AUTOMATION_CHECK: status=-600 (procNotFound), launching System Events and retrying...")
+        let launchScript = NSAppleScript(source: "launch application \"System Events\"")
+        var launchError: NSDictionary?
+        launchScript?.executeAndReturnError(&launchError)
+
+        // Wait for System Events to initialize
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+
+        let retryStatus = Self.queryAutomationPermissionStatus()
+        let hasPermission = retryStatus == noErr
+        log("AUTOMATION_CHECK: retry status=\(retryStatus), hasPermission=\(hasPermission)")
+
+        await MainActor.run {
+          self.hasAutomationPermission = hasPermission
+          self.automationPermissionError = hasPermission ? 0 : retryStatus
+        }
+      } else {
+        let hasPermission = status == noErr
+        let previousValue = await MainActor.run { self.hasAutomationPermission }
+        if hasPermission != previousValue {
+          log("AUTOMATION_CHECK: status=\(status), hasPermission=\(hasPermission)")
+        }
+
+        await MainActor.run {
+          self.hasAutomationPermission = hasPermission
+          // Track unexpected errors (not denied/not-determined, which are normal states)
+          self.automationPermissionError =
+            (status == noErr || status == -1743 || status == -1744) ? 0 : status
+        }
+      }
+    }
+  }
+
+  /// Query the TCC automation permission status for System Events without triggering a prompt
+  nonisolated private static func queryAutomationPermissionStatus() -> OSStatus {
+    let bundleIDString = "com.apple.systemevents"
+    var addressDesc = AEAddressDesc()
+
+    let status: OSStatus = bundleIDString.withCString { cString in
+      AECreateDesc(typeApplicationBundleID, cString, strlen(cString), &addressDesc)
+      let result = AEDeterminePermissionToAutomateTarget(
+        &addressDesc,
+        typeWildCard,
+        typeWildCard,
+        false  // askUserIfNeeded = false → never shows dialog
+      )
+      AEDisposeDesc(&addressDesc)
+      return result
+    }
+
+    return status
+  }
+
+  /// Check accessibility permission status
+  /// AXIsProcessTrusted() can return stale data after macOS updates or app re-signs,
+  /// so we also do a functional AX test to detect the "broken" state.
+  func checkAccessibilityPermission() {
+    let tccGranted = AXIsProcessTrusted()
+    let previouslyGranted = hasAccessibilityPermission
+
+    if tccGranted {
+      hasAccessibilityPermission = true
+
+      // Log transitions
+      if !previouslyGranted {
+        let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
+        log("ACCESSIBILITY_CHECK: Permission granted (bundleId=\(bundleId))")
+      }
+
+      // TCC says yes — verify with an actual AX call
+      let broken = !testAccessibilityPermission()
+      if broken != isAccessibilityBroken {
+        isAccessibilityBroken = broken
+        if broken {
+          log(
+            "ACCESSIBILITY_CHECK: TCC says granted but AX calls fail — stuck/broken state detected")
+        } else {
+          log("ACCESSIBILITY_CHECK: AX calls working normally")
+        }
+      }
+    } else {
+      // AXIsProcessTrusted() says not granted — but on macOS 26 this may be stale.
+      // Probe via event tap which checks the live TCC database.
+      if probeAccessibilityViaEventTap() {
+        if !previouslyGranted {
+          log(
+            "ACCESSIBILITY_CHECK: AXIsProcessTrusted() returned false but event tap succeeded — stale cache detected"
+          )
+        }
+        let axWorks = testAccessibilityPermission()
+        hasAccessibilityPermission = true
+        if !axWorks {
+          if !isAccessibilityBroken {
+            log("ACCESSIBILITY_CHECK: Event tap OK but AX calls fail — marking as broken")
+          }
+          isAccessibilityBroken = true
+        } else {
+          if isAccessibilityBroken {
+            log("ACCESSIBILITY_CHECK: Permission confirmed via event tap probe, AX calls working")
+          }
+          isAccessibilityBroken = false
+        }
+      } else {
+        // Event tap also failed — permission genuinely not granted
+        if previouslyGranted {
+          let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
+          log("ACCESSIBILITY_CHECK: Permission revoked (bundleId=\(bundleId))")
+        }
+        hasAccessibilityPermission = false
+        isAccessibilityBroken = false
+      }
+    }
+  }
+
+  /// Test if Accessibility API actually works by attempting a real AX call.
+  /// Returns true if AX calls succeed, false if permission is stuck/broken.
+  private func testAccessibilityPermission() -> Bool {
+    guard let frontApp = NSWorkspace.shared.frontmostApplication else {
+      // No frontmost app to test against — can't determine, assume OK
+      return true
+    }
+
+    let appElement = AXUIElementCreateApplication(frontApp.processIdentifier)
+    var focusedWindow: CFTypeRef?
+    let result = AXUIElementCopyAttributeValue(
+      appElement, kAXFocusedWindowAttribute as CFString, &focusedWindow)
+
+    // .success or .noValue (app has no windows) both mean AX is working
+    switch result {
+    case .success, .noValue, .notImplemented, .attributeUnsupported:
+      return true
+    case .apiDisabled:
+      // System-wide AX is disabled — unambiguous, no confirmation needed
+      log(
+        "ACCESSIBILITY_CHECK: AXError.apiDisabled — permission stuck (tested against pid \(frontApp.processIdentifier), app: \(frontApp.localizedName ?? "unknown"))"
+      )
+      return false
+    case .cannotComplete:
+      // cannotComplete is ambiguous: it can mean our permission is broken, OR that the
+      // frontmost app doesn't implement AX (e.g. Qt, OpenGL, Python-based apps like PyMOL).
+      // Confirm against Finder before concluding the permission is truly broken.
+      return confirmAccessibilityBrokenViaFinder(suspectApp: frontApp.localizedName ?? "unknown")
+    default:
+      log(
+        "ACCESSIBILITY_CHECK: AXError code \(result.rawValue) from app \(frontApp.localizedName ?? "unknown") — not permission-related, treating as OK"
+      )
+      return true
+    }
+  }
+
+  /// Secondary AX check against Finder to disambiguate cannotComplete errors.
+  /// If Finder (a known AX-compliant app) also fails, the permission is truly broken.
+  /// If Finder succeeds, the original failure was app-specific, not a permission issue.
+  private func confirmAccessibilityBrokenViaFinder(suspectApp: String) -> Bool {
+    if let finder = NSRunningApplication.runningApplications(
+      withBundleIdentifier: "com.apple.finder"
+    ).first {
+      let finderElement = AXUIElementCreateApplication(finder.processIdentifier)
+      var finderWindow: CFTypeRef?
+      let finderResult = AXUIElementCopyAttributeValue(
+        finderElement, kAXFocusedWindowAttribute as CFString, &finderWindow)
+      if finderResult == .cannotComplete || finderResult == .apiDisabled {
+        log(
+          "ACCESSIBILITY_CHECK: AXError.cannotComplete confirmed by Finder — permission is truly stuck (original app: \(suspectApp))"
+        )
+        return false
+      } else {
+        log(
+          "ACCESSIBILITY_CHECK: AXError.cannotComplete from \(suspectApp) but Finder OK — app-specific AX incompatibility, permission is fine"
+        )
+        return true
+      }
+    } else {
+      // Finder not running — fall back to event tap probe as tie-breaker
+      log(
+        "ACCESSIBILITY_CHECK: AXError.cannotComplete from \(suspectApp), Finder not running — using event tap probe"
+      )
+      return probeAccessibilityViaEventTap()
+    }
+  }
+
+  /// Probe accessibility permission by attempting to create a CGEvent tap.
+  /// Unlike AXIsProcessTrusted(), event tap creation checks the live TCC database,
+  /// bypassing the per-process cache that can go stale on macOS 26 (Tahoe).
+  private func probeAccessibilityViaEventTap() -> Bool {
+    let tap = CGEvent.tapCreate(
+      tap: .cgSessionEventTap,
+      place: .tailAppendEventTap,
+      options: .listenOnly,
+      eventsOfInterest: CGEventMask(1 << CGEventType.mouseMoved.rawValue),
+      callback: { _, _, event, _ in Unmanaged.passRetained(event) },
+      userInfo: nil
+    )
+    if let tap = tap {
+      CFMachPortInvalidate(tap)
+      return true
+    }
+    return false
+  }
+
+  /// Check if accessibility permission was explicitly denied
+  func isAccessibilityPermissionDenied() -> Bool {
+    return hasCompletedOnboarding && (!hasAccessibilityPermission || isAccessibilityBroken)
+  }
+
+  /// Trigger accessibility permission prompt
+  func triggerAccessibilityPermission() {
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+    let bundleId = Bundle.main.bundleIdentifier ?? "unknown"
+    log(
+      "ACCESSIBILITY_TRIGGER: User clicked Grant Access — bundleId=\(bundleId), macOS \(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+    )
+
+    // This will prompt the user if not already trusted
+    let options =
+      [kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true] as CFDictionary
+    let trusted = AXIsProcessTrustedWithOptions(options)
+    if trusted {
+      hasAccessibilityPermission = true
+    }
+    // Don't set hasAccessibilityPermission = false here — the API may return
+    // stale data on macOS 26. Let checkAccessibilityPermission() handle detection
+    // via the event tap probe on the next poll cycle.
+    log("ACCESSIBILITY_TRIGGER: AXIsProcessTrustedWithOptions returned \(trusted)")
+
+    // On macOS Sequoia+, AXIsProcessTrustedWithOptions no longer shows a visible dialog,
+    // so explicitly open System Settings to the Accessibility pane
+    if !trusted {
+      log("ACCESSIBILITY_TRIGGER: Not trusted, opening System Settings Accessibility pane")
+      openAccessibilityPreferences()
+    }
+  }
+
+  /// Open Accessibility preferences in System Settings
+  func openAccessibilityPreferences() {
+    if let url = URL(
+      string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+    {
+      NSWorkspace.shared.open(url)
+    }
+  }
+
+  /// Reset accessibility permission (requires terminal command)
+  nonisolated func resetAccessibilityPermissionDirect(shouldRestart: Bool = false) -> Bool {
+    let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
+    log("Resetting accessibility permission for \(bundleId) via tccutil...")
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
+    process.arguments = ["reset", "Accessibility", bundleId]
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+      let success = process.terminationStatus == 0
+      log("tccutil reset completed with exit code: \(process.terminationStatus)")
+
+      if success && shouldRestart {
+        restartApp()
+      }
+
+      return success
+    } catch {
+      log("Failed to run tccutil: \(error)")
+      return false
+    }
+  }
+
+  /// Reset accessibility permission via tccutil and restart the app.
+  /// Mirrors ScreenCaptureService.resetScreenCapturePermissionAndRestart().
+  func resetAccessibilityPermissionAndRestart() {
+    if UpdaterViewModel.isUpdateInProgress {
+      log("Sparkle update in progress, skipping accessibility reset restart")
+      return
+    }
+
+    Task.detached { [weak self] in
+      guard let self = self else { return }
+      let success = self.resetAccessibilityPermissionDirect(shouldRestart: false)
+
+      await MainActor.run {
+        if success {
+          log("Accessibility permission reset, restarting app...")
+          self.restartApp()
+        } else {
+          log("Accessibility permission reset failed")
+        }
+      }
+    }
+  }
+
+  private func showPermissionAlert() {
+    let alert = NSAlert()
+    alert.messageText = "Permission Required"
+    alert.informativeText =
+      "Screen Recording permission is needed.\n\nClick 'Grant Screen Permission' in the menu, then add this app and restart."
+    alert.alertStyle = .warning
+    alert.addButton(withTitle: "OK")
+    alert.runModal()
+  }
+
+  private func showAlert(title: String, message: String) {
+    let alert = NSAlert()
+    alert.messageText = title
+    alert.informativeText = message
+    alert.alertStyle = .warning
+    alert.addButton(withTitle: "OK")
+    alert.runModal()
+  }
+
+  // MARK: - Transcription
+
+  /// Toggle transcription on/off
+  func toggleTranscription() {
+    if isTranscribing {
+      stopTranscription()
+    } else {
+      startTranscription()
+    }
+  }
+
+  /// Start real-time transcription
+  /// - Parameter source: Audio source to use (defaults to current audioSource setting)
+  func startTranscription(source: AudioSource? = nil) {
+    guard !isTranscribing else { return }
+
+    // Use provided source or fall back to current setting
+    let effectiveSource = source ?? audioSource
+
+    // For BLE device, check if device is connected
+    if effectiveSource == .bleDevice {
+      guard DeviceProvider.shared.isConnected else {
+        showAlert(title: "Device Not Connected", message: "Please connect a wearable device first.")
+        return
+      }
+    } else {
+      // For microphone, check permission
+      guard AudioCaptureService.checkPermission() else {
+        requestMicrophonePermission()
+        return
+      }
+    }
+
+    do {
+      // Get effective language from settings (handles auto-detect vs single language)
+      let effectiveLanguage = AssistantSettings.shared.effectiveTranscriptionLanguage
+      let vocabulary = AssistantSettings.shared.effectiveVocabulary
+      log(
+        "Transcription: Using language=\(effectiveLanguage) (autoDetect=\(AssistantSettings.shared.transcriptionAutoDetect), selected=\(AssistantSettings.shared.transcriptionLanguage))"
+      )
+      log("Transcription: Custom vocabulary: \(vocabulary.joined(separator: ", "))")
+
+      // Determine transcription mode
+      useBatchTranscription =
+        AssistantSettings.shared.batchTranscriptionEnabled && effectiveSource == .microphone
+
+      if !useBatchTranscription {
+        // Streaming mode: initialize WebSocket transcription service
+        transcriptionService = try TranscriptionService(
+          language: effectiveLanguage, vocabulary: vocabulary)
+      } else {
+        log("Transcription: Batch mode enabled — skipping WebSocket")
+      }
+
+      // Set conversation source based on audio source
+      if effectiveSource == .bleDevice, let device = DeviceProvider.shared.connectedDevice {
+        currentConversationSource = ConversationSource.from(deviceType: device.type)
+        recordingInputDeviceName = device.displayName
+      } else {
+        currentConversationSource = .desktop
+        recordingInputDeviceName = AudioCaptureService.getCurrentMicrophoneName()
+      }
+
+      // Initialize audio services based on source
+      if effectiveSource == .microphone {
+        // Initialize audio capture service
+        audioCaptureService = AudioCaptureService()
+
+        // Initialize audio mixer for combining mic and system audio
+        audioMixer = AudioMixer()
+
+        // VAD gate is always needed for batch mode (chunk boundaries),
+        // and optional for streaming mode (silence gating)
+        if useBatchTranscription || AssistantSettings.shared.vadGateEnabled {
+          let gate = VADGateService()
+          if useBatchTranscription && !gate.modelAvailable {
+            // Batch mode requires working VAD — fall back to streaming
+            log("Transcription: VAD models unavailable, falling back from batch to streaming mode")
+            useBatchTranscription = false
+            vadGateService = nil
+            transcriptionService = try TranscriptionService(
+              language: effectiveLanguage, vocabulary: vocabulary)
+          } else {
+            vadGateService = gate
+            log("Transcription: VAD gate enabled\(useBatchTranscription ? " (batch mode)" : "")")
+          }
+        } else {
+          vadGateService = nil
+        }
+
+        // Initialize system audio capture if supported (macOS 14.4+)
+        // Can be disabled via: defaults write com.omi.desktop-dev disableSystemAudioCapture -bool true
+        //                  or: defaults write com.omi.computer-macos disableSystemAudioCapture -bool true
+        let systemAudioDisabled = UserDefaults.standard.bool(forKey: "disableSystemAudioCapture")
+        if systemAudioDisabled {
+          log(
+            "Transcription: System audio capture DISABLED by user preference (disableSystemAudioCapture)"
+          )
+        } else if #available(macOS 14.4, *) {
+          systemAudioCaptureService = SystemAudioCaptureService()
+          log("Transcription: System audio capture initialized (macOS 14.4+)")
+        } else {
+          log("Transcription: System audio capture not available (requires macOS 14.4+)")
+        }
+      }
+      // For BLE device, BleAudioService will be used in startAudioCapture
+
+      if useBatchTranscription {
+        // Batch mode: start audio capture directly (no WebSocket to wait for)
+        recordingStartCATime = CACurrentMediaTime()
+        Task { @MainActor [weak self] in
+          await self?.startAudioCapture(source: effectiveSource)
+        }
+      } else {
+        // Streaming mode: start transcription service first, then audio on connect
+        transcriptionService?.start(
+          onTranscript: { [weak self] segment in
+            Task { @MainActor in
+              self?.handleTranscriptSegment(segment)
+            }
+          },
+          onError: { [weak self] error in
+            Task { @MainActor in
+              logError("Transcription error", error: error)
+              AnalyticsManager.shared.recordingError(error: error.localizedDescription)
+              self?.stopTranscription()
+            }
+          },
+          onConnected: { [weak self] in
+            Task { @MainActor in
+              log("Transcription: Connected to DeepGram")
+              // Start audio capture once connected
+              await self?.startAudioCapture(source: effectiveSource)
+            }
+          },
+          onDisconnected: {
+            log("Transcription: Disconnected from DeepGram")
+          }
+        )
+      }
+
+      isTranscribing = true
+      AssistantSettings.shared.transcriptionEnabled = true
+      audioSource = effectiveSource
+      currentTranscript = ""
+      speakerSegments = []
+      totalSegmentCount = 0
+      totalWordCount = 0
+      liveSpeakerPersonMap = [:]
+      LiveTranscriptMonitor.shared.clear()
+      recordingStartTime = Date()
+      AudioLevelMonitor.shared.reset()
+      RecordingTimer.shared.start()
+
+      log(
+        "Transcription: Using source: \(effectiveSource.rawValue), device: \(recordingInputDeviceName ?? "Unknown")"
+      )
+
+      // Create crash-safe DB session for persistence
+      Task {
+        do {
+          let sessionId = try await TranscriptionStorage.shared.startSession(
+            source: currentConversationSource.rawValue,
+            language: effectiveLanguage,
+            timezone: TimeZone.current.identifier,
+            inputDeviceName: recordingInputDeviceName
+          )
+          await MainActor.run {
+            self.currentSessionId = sessionId
+            // Start live notes session
+            LiveNotesMonitor.shared.startSession(sessionId: sessionId)
+          }
+          log("Transcription: Created DB session \(sessionId)")
+        } catch {
+          logError("Transcription: Failed to create DB session", error: error)
+          // Non-fatal - continue recording even if DB fails
+        }
+      }
+
+      // Start 4-hour max recording timer
+      maxRecordingTimer = Timer.scheduledTimer(
+        withTimeInterval: maxRecordingDuration, repeats: false
+      ) { [weak self] _ in
+        Task { @MainActor in
+          guard let self = self, self.isTranscribing else { return }
+          log("Transcription: 4-hour limit reached - finalizing conversation")
+          _ = await self.finalizeConversation()
+          // Start a new recording session automatically
+          self.stopAudioCapture()
+          self.clearTranscriptionState()
+          self.startTranscription()
+        }
+      }
+
+      // Track transcription started
+      AnalyticsManager.shared.transcriptionStarted()
+
+      log("Transcription: Starting...")
+
+    } catch {
+      AnalyticsManager.shared.recordingError(error: error.localizedDescription)
+      showAlert(title: "Transcription Error", message: error.localizedDescription)
+    }
+  }
+
+  /// Start audio capture and pipe to transcription service
+  /// - Parameter source: Audio source to capture from
+  private func startAudioCapture(source: AudioSource = .microphone) async {
+    if source == .bleDevice {
+      // Use BLE device audio
+      await startBleAudioCapture()
+    } else {
+      // Use microphone (+ optional system audio)
+      await startMicrophoneAudioCapture()
+    }
+  }
+
+  /// Start microphone audio capture (original implementation)
+  private func startMicrophoneAudioCapture() async {
+    guard let audioCaptureService = audioCaptureService,
+      let audioMixer = audioMixer
+    else { return }
+
+    // Start the audio mixer - it will send stereo audio to transcription service
+    // Branch on batch vs streaming mode
+    audioMixer.start { [weak self] stereoData in
+      guard let self = self else { return }
+      if self.useBatchTranscription {
+        // Batch mode: accumulate audio in VAD gate, transcribe on silence
+        guard let gate = self.vadGateService else { return }
+        let output = gate.processAudioBatch(stereoData)
+        if output.isComplete, let audioBuffer = output.audioBuffer {
+          let wallStartTime = output.speechStartWallTime
+          Task { @MainActor [weak self] in
+            await self?.batchTranscribeChunk(audioBuffer: audioBuffer, wallStartTime: wallStartTime)
+          }
+        }
+      } else if let gate = self.vadGateService {
+        // Streaming mode with VAD gate
+        let output = gate.processAudio(stereoData)
+        if !output.audioToSend.isEmpty {
+          self.transcriptionService?.sendAudio(output.audioToSend)
+        } else if gate.needsKeepalive() {
+          self.transcriptionService?.sendKeepalivePublic()
+        }
+        if output.shouldFinalize {
+          self.transcriptionService?.sendFinalize()
+        }
+      } else {
+        // Streaming mode without VAD gate
+        self.transcriptionService?.sendAudio(stereoData)
+      }
+    }
+
+    do {
+      // Start microphone capture - sends to mixer channel 0 (left/user)
+      try await audioCaptureService.startCapture(
+        onAudioChunk: { [weak self] audioData in
+          self?.audioMixer?.setMicAudio(audioData)
+        },
+        onAudioLevel: { level in
+          // Use dedicated monitor to avoid triggering AppState re-renders
+          AudioLevelMonitor.shared.updateMicrophoneLevel(level)
+        }
+      )
+      log("Transcription: Microphone capture started")
+
+      // Start system audio capture if available (macOS 14.4+)
+      if #available(macOS 14.4, *) {
+        if let systemService = systemAudioCaptureService as? SystemAudioCaptureService {
+          do {
+            try await systemService.startCapture(
+              onAudioChunk: { [weak self] audioData in
+                self?.audioMixer?.setSystemAudio(audioData)
+              },
+              onAudioLevel: { level in
+                // Use dedicated monitor to avoid triggering AppState re-renders
+                AudioLevelMonitor.shared.updateSystemLevel(level)
+              }
+            )
+            log("Transcription: System audio capture started")
+          } catch {
+            // System audio is optional - continue with mic only
+            logError(
+              "Transcription: System audio capture failed (continuing with mic only)", error: error)
+          }
+        }
+      }
+
+      log("Transcription: Audio capture started (multichannel)")
+    } catch {
+      logError("Transcription: Failed to start audio capture", error: error)
+      stopTranscription()
+    }
+  }
+
+  /// Start BLE device audio capture
+  private func startBleAudioCapture() async {
+    guard let connection = DeviceProvider.shared.activeConnection,
+      let transcriptionService = transcriptionService
+    else {
+      logError("Transcription: No device connection or transcription service", error: nil)
+      stopTranscription()
+      return
+    }
+
+    // Start BLE audio processing and pipe directly to transcription
+    await BleAudioService.shared.startProcessing(
+      from: connection,
+      transcriptionService: transcriptionService,
+      audioDataHandler: { _ in
+        // Audio level is updated by BleAudioService
+        Task { @MainActor in
+          AudioLevelMonitor.shared.updateMicrophoneLevel(BleAudioService.shared.audioLevel)
+        }
+      }
+    )
+
+    // Start listening for button events
+    startButtonEventListener()
+
+    log("Transcription: BLE audio capture started (device: \(connection.device.displayName))")
+  }
+
+  /// Start listening for button events from BLE device
+  private func startButtonEventListener() {
+    guard let buttonStream = DeviceProvider.shared.getButtonStream() else {
+      log("Transcription: Device does not support button events")
+      return
+    }
+
+    buttonStreamTask?.cancel()
+    buttonStreamTask = Task { [weak self] in
+      do {
+        for try await buttonState in buttonStream {
+          self?.handleButtonEvent(buttonState)
+        }
+      } catch {
+        log("Transcription: Button stream ended: \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Handle button events from BLE device
+  private func handleButtonEvent(_ buttonState: [UInt8]) {
+    guard !buttonState.isEmpty else { return }
+
+    let state = buttonState[0]
+    log("Transcription: Device button event: \(state)")
+
+    switch state {
+    case 1:
+      // Single tap - could be used for voice command mode (future feature)
+      log("Transcription: Single tap - no action configured")
+
+    case 2:
+      // Double tap - finalize conversation and continue recording
+      log("Transcription: Double tap - finalizing conversation")
+      Task {
+        _ = await finalizeConversation()
+        clearTranscriptionState()
+        // Restart with same source
+        startTranscription(source: audioSource)
+      }
+
+    case 3:
+      // Long press - stop transcription completely
+      log("Transcription: Long press - stopping transcription")
+      stopTranscription()
+
+    default:
+      log("Transcription: Unknown button state: \(state)")
+    }
+  }
+
+  /// Stop button event listener
+  private func stopButtonEventListener() {
+    buttonStreamTask?.cancel()
+    buttonStreamTask = nil
+  }
+
+  /// Stop real-time transcription and finalize the conversation
+  func stopTranscription() {
+    // Immediately stop audio capture but show saving state
+    stopAudioCapture()
+    isSavingConversation = true
+
+    Task {
+      _ = await finalizeConversation()
+      isSavingConversation = false
+      clearTranscriptionState()
+
+      // Refresh conversations after stopping
+      await loadConversations()
+    }
+  }
+
+  /// Finish the current conversation and keep recording for a new one
+  func finishConversation() async -> FinishConversationResult {
+    guard totalSegmentCount > 0 || !speakerSegments.isEmpty else {
+      log("Transcription: No segments to finish")
+      return .discarded
+    }
+
+    log("Transcription: Finishing conversation, keeping recording active")
+
+    let result = await finalizeConversation()
+
+    // Clear segments for the next conversation but keep recording
+    speakerSegments = []
+    totalSegmentCount = 0
+    totalWordCount = 0
+    liveSpeakerPersonMap = [:]
+    LiveTranscriptMonitor.shared.clear()
+    LiveNotesMonitor.shared.endSession()
+    LiveNotesMonitor.shared.clear()
+
+    // Reset the recording start time for the next conversation
+    recordingStartTime = Date()
+    RecordingTimer.shared.restart()
+
+    // Restart the 4-hour max recording timer
+    maxRecordingTimer?.invalidate()
+    maxRecordingTimer = Timer.scheduledTimer(withTimeInterval: maxRecordingDuration, repeats: false)
+    { [weak self] _ in
+      Task { @MainActor in
+        guard let self = self, self.isTranscribing else { return }
+        log("Transcription: 4-hour limit reached - finalizing conversation")
+        _ = await self.finalizeConversation()
+        self.stopAudioCapture()
+        self.clearTranscriptionState()
+        self.startTranscription()
+      }
+    }
+
+    // Start a new DB session for the next conversation
+    let lang = AssistantSettings.shared.effectiveTranscriptionLanguage
+    Task {
+      do {
+        let sessionId = try await TranscriptionStorage.shared.startSession(
+          source: currentConversationSource.rawValue,
+          language: lang,
+          timezone: TimeZone.current.identifier,
+          inputDeviceName: recordingInputDeviceName
+        )
+        await MainActor.run {
+          self.currentSessionId = sessionId
+          LiveNotesMonitor.shared.startSession(sessionId: sessionId)
+        }
+        log("Transcription: Created new DB session \(sessionId) for next conversation")
+      } catch {
+        logError("Transcription: Failed to create DB session for next conversation", error: error)
+      }
+    }
+
+    // Refresh the conversations list to show the new conversation
+    await loadConversations()
+
+    log("Transcription: Ready for next conversation")
+    return result
+  }
+
+  /// Stop audio capture services (but keep transcript data for saving)
+  private func stopAudioCapture() {
+    // Cancel timers
+    maxRecordingTimer?.invalidate()
+    maxRecordingTimer = nil
+    RecordingTimer.shared.stop()
+
+    // Reset audio levels
+    AudioLevelMonitor.shared.reset()
+
+    // Stop BLE audio if active
+    if audioSource == .bleDevice {
+      BleAudioService.shared.stopProcessing()
+      stopButtonEventListener()
+    }
+
+    // Stop system audio capture first (if available)
+    if #available(macOS 14.4, *) {
+      if let systemService = systemAudioCaptureService as? SystemAudioCaptureService {
+        systemService.stopCapture()
+      }
+    }
+    systemAudioCaptureService = nil
+
+    // Stop microphone capture
+    audioCaptureService?.stopCapture()
+    audioCaptureService = nil
+
+    // Stop audio mixer
+    audioMixer?.stop()
+    audioMixer = nil
+
+    // Flush batch buffer before clearing VAD gate
+    if useBatchTranscription, let gate = vadGateService, let output = gate.flushBatchBuffer() {
+      if let audioBuffer = output.audioBuffer {
+        let wallStartTime = output.speechStartWallTime
+        Task { @MainActor [weak self] in
+          await self?.batchTranscribeChunk(audioBuffer: audioBuffer, wallStartTime: wallStartTime)
+        }
+      }
+    }
+
+    // Clear VAD gate
+    vadGateService = nil
+
+    // Stop transcription service
+    transcriptionService?.stop()
+    transcriptionService = nil
+
+    isTranscribing = false
+  }
+
+  /// Clear transcription state after saving
+  private func clearTranscriptionState() {
+    log(
+      "Transcription: Final segments count: \(totalSegmentCount) (in-memory: \(speakerSegments.count)), words: \(totalWordCount)"
+    )
+
+    // End live notes session
+    LiveNotesMonitor.shared.endSession()
+
+    // Clear segments after finalization
+    speakerSegments = []
+    liveSpeakerPersonMap = [:]
+    LiveTranscriptMonitor.shared.clear()
+    LiveNotesMonitor.shared.clear()
+    recordingStartTime = nil
+    currentSessionId = nil
+
+    // Track transcription stopped
+    AnalyticsManager.shared.transcriptionStopped(wordCount: totalWordCount)
+    totalSegmentCount = 0
+    totalWordCount = 0
+    currentTranscript = ""
+
+    log("Transcription: Stopped")
+  }
+
+  /// Aggressively trim transcript state to free memory (called by ResourceMonitor during critical memory pressure).
+  /// Segments are already persisted in SQLite, so trimming in-memory state is safe.
+  func trimTranscriptStateForMemoryPressure() {
+    let beforeCount = speakerSegments.count
+    if speakerSegments.count > 50 {
+      speakerSegments = Array(speakerSegments.suffix(50))
+    }
+    currentTranscript = ""
+    LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
+    log(
+      "ResourceMonitor: Trimmed transcript state \(beforeCount) -> \(speakerSegments.count) segments"
+    )
+  }
+
+  // MARK: - Conversations
+
+  /// Load conversations - first from local cache (instant), then from API (background refresh)
+  func loadConversations() async {
+    guard !isLoadingConversations else { return }
+
+    isLoadingConversations = true
+    conversationsError = nil
+
+    // Step 1: Load from local cache first (instant display)
+    // Use timeout to avoid blocking UI if database is initializing (e.g. recovery)
+    do {
+      let cachedConversations = try await withThrowingTaskGroup(of: [ServerConversation].self) {
+        group in
+        group.addTask {
+          try await TranscriptionStorage.shared.getLocalConversations(
+            limit: 50,
+            starredOnly: self.showStarredOnly,
+            folderId: self.selectedFolderId
+          )
+        }
+        group.addTask {
+          try await Task.sleep(nanoseconds: 3_000_000_000)  // 3 second timeout
+          throw CancellationError()
+        }
+        let result = try await group.next()!
+        group.cancelAll()
+        return result
+      }
+
+      if !cachedConversations.isEmpty {
+        conversations = cachedConversations
+        log("Conversations: Loaded \(cachedConversations.count) from local cache (instant)")
+
+        // Get local count
+        let localCount = try await TranscriptionStorage.shared.getLocalConversationsCount(
+          starredOnly: showStarredOnly)
+        totalConversationsCount = localCount
+
+        // Stop loading state so UI shows cached data immediately
+        isLoadingConversations = false
+        // Notify sidebar immediately so loading indicator clears with cached data
+        NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
+      }
+    } catch {
+      log("Conversations: Local cache unavailable, falling back to API")
+      // Continue to API fetch even if local fails
+    }
+
+    // Step 2: Fetch from API in background to get fresh data
+    // Calculate date range if date filter is set
+    let startDate: Date?
+    let endDate: Date?
+    if let filterDate = selectedDateFilter {
+      let calendar = Calendar.current
+      startDate = calendar.startOfDay(for: filterDate)
+      endDate = calendar.date(byAdding: .day, value: 1, to: startDate!)
+    } else {
+      startDate = nil
+      endDate = nil
+    }
+
+    // Fetch conversations and count in parallel
+    async let conversationsTask = APIClient.shared.getConversations(
+      limit: 50,
+      offset: 0,
+      statuses: [.completed, .processing],
+      includeDiscarded: false,
+      startDate: startDate,
+      endDate: endDate,
+      folderId: selectedFolderId,
+      starred: showStarredOnly ? true : nil
+    )
+    async let countTask = APIClient.shared.getConversationsCount(includeDiscarded: false)
+
+    do {
+      let fetchedConversations = try await conversationsTask
+      conversations = fetchedConversations
+      log(
+        "Conversations: Refreshed \(fetchedConversations.count) from API (starred=\(showStarredOnly), date=\(selectedDateFilter?.description ?? "nil"))"
+      )
+
+      // DEBUG: Log any conversations with empty titles
+      for conv in fetchedConversations where conv.structured.title.isEmpty {
+        log(
+          "DEBUG: Conversation \(conv.id) has EMPTY title! overview=\(conv.structured.overview.prefix(50))..."
+        )
+      }
+
+      // Sync conversations to local database in background
+      Task.detached(priority: .background) {
+        var syncedCount = 0
+        for conversation in fetchedConversations {
+          do {
+            try await TranscriptionStorage.shared.syncServerConversation(conversation)
+            syncedCount += 1
+          } catch {
+            log(
+              "Conversations: Failed to sync \(conversation.id) to local DB: \(error.localizedDescription)"
+            )
+          }
+        }
+        log("Conversations: Synced \(syncedCount)/\(fetchedConversations.count) to local database")
+      }
+    } catch {
+      logError("Conversations: API fetch failed", error: error)
+      // Only set error if we don't have cached data
+      if conversations.isEmpty {
+        conversationsError = error.localizedDescription
+      } else {
+        log("Conversations: Using cached data after API failure")
+      }
+    }
+
+    // Update total count from API (more accurate than local)
+    do {
+      let count = try await countTask
+      totalConversationsCount = count
+      log("Conversations: Total count from API = \(count)")
+    } catch {
+      logError("Conversations: Failed to get count from API", error: error)
+      // Keep local count if API fails
+    }
+
+    isLoadingConversations = false
+    NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
+  }
+
+  /// Refresh conversations silently (for auto-refresh timer and app-activate).
+  /// Fetches from API only, merges in-place, and only triggers @Published if data actually changed.
+  func refreshConversations() async {
+    // Skip if user is signed out (tokens are cleared)
+    guard AuthState.shared.isSignedIn else { return }
+    // Skip if currently doing a full load
+    guard !isLoadingConversations else { return }
+
+    // Calculate date range if date filter is set
+    let startDate: Date?
+    let endDate: Date?
+    if let filterDate = selectedDateFilter {
+      let calendar = Calendar.current
+      startDate = calendar.startOfDay(for: filterDate)
+      endDate = calendar.date(byAdding: .day, value: 1, to: startDate!)
+    } else {
+      startDate = nil
+      endDate = nil
+    }
+
+    do {
+      let fetchedConversations = try await APIClient.shared.getConversations(
+        limit: 50,
+        offset: 0,
+        statuses: [.completed, .processing],
+        includeDiscarded: false,
+        startDate: startDate,
+        endDate: endDate,
+        folderId: selectedFolderId,
+        starred: showStarredOnly ? true : nil
+      )
+
+      // Merge in-place: update existing, add new, remove gone
+      let merged = mergeConversations(source: fetchedConversations, current: conversations)
+      if merged != conversations {
+        conversations = merged
+        log("Conversations: Auto-refresh updated (\(merged.count) items)")
+      }
+
+      // Sync to local database in background
+      Task.detached(priority: .background) {
+        for conversation in fetchedConversations {
+          _ = try? await TranscriptionStorage.shared.syncServerConversation(conversation)
+        }
+      }
+    } catch {
+      // Silently ignore errors during auto-refresh — cached data stays visible.
+      // Auth errors (notSignedIn) are transient: token refresh may fail momentarily
+      // while the user is still signed in. Don't send these to Sentry.
+      if case AuthError.notSignedIn = error {
+        log("Conversations: Auto-refresh skipped (auth token temporarily unavailable)")
+      } else {
+        logError("Conversations: Auto-refresh failed", error: error)
+      }
+    }
+
+    // Update total count
+    do {
+      let count = try await APIClient.shared.getConversationsCount(includeDiscarded: false)
+      if totalConversationsCount != count {
+        totalConversationsCount = count
+      }
+    } catch {
+      // Keep existing count
+    }
+  }
+
+  /// Merge fetched conversations into the current list in-place.
+  /// Updates changed items, adds new ones, removes ones no longer in source.
+  private func mergeConversations(source: [ServerConversation], current: [ServerConversation])
+    -> [ServerConversation]
+  {
+    let sourceById = Dictionary(uniqueKeysWithValues: source.map { ($0.id, $0) })
+    let sourceIds = Set(source.map { $0.id })
+    let currentIds = Set(current.map { $0.id })
+
+    var result = current
+
+    // Update existing items in-place
+    for i in result.indices {
+      if let updated = sourceById[result[i].id], updated != result[i] {
+        result[i] = updated
+      }
+    }
+
+    // Remove items no longer in source
+    result.removeAll { !sourceIds.contains($0.id) }
+
+    // Add new items from source that aren't in current
+    let newIds = sourceIds.subtracting(currentIds)
+    if !newIds.isEmpty {
+      let newItems = source.filter { newIds.contains($0.id) }
+      result.append(contentsOf: newItems)
+      // Re-sort by createdAt descending (newest first) to maintain order
+      result.sort { $0.createdAt > $1.createdAt }
+    }
+
+    return result
+  }
+
+  /// Update the starred status of a conversation locally
+  func setConversationStarred(_ conversationId: String, starred: Bool) {
+    if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
+      conversations[index].starred = starred
+    }
+  }
+
+  /// Toggle starred filter and reload conversations
+  func toggleStarredFilter() async {
+    showStarredOnly.toggle()
+    await loadConversations()
+  }
+
+  /// Set date filter and reload conversations
+  func setDateFilter(_ date: Date?) async {
+    selectedDateFilter = date
+    await loadConversations()
+  }
+
+  /// Clear all filters and reload conversations
+  func clearFilters() async {
+    showStarredOnly = false
+    selectedDateFilter = nil
+    selectedFolderId = nil
+    await loadConversations()
+  }
+
+  /// Set folder filter and reload conversations
+  func setFolderFilter(_ folderId: String?) async {
+    selectedFolderId = folderId
+    await loadConversations()
+  }
+
+  // MARK: - Folder Management
+
+  /// Load folders from API
+  func loadFolders() async {
+    guard !isLoadingFolders else { return }
+
+    isLoadingFolders = true
+
+    do {
+      let fetchedFolders = try await APIClient.shared.getFolders()
+      folders = fetchedFolders
+      log("Folders: Loaded \(fetchedFolders.count) folders")
+    } catch {
+      logError("Folders: Failed to load", error: error)
+    }
+
+    isLoadingFolders = false
+  }
+
+  /// Create a new folder
+  func createFolder(name: String, description: String? = nil, color: String? = nil) async -> Folder?
+  {
+    do {
+      let folder = try await APIClient.shared.createFolder(
+        name: name, description: description, color: color)
+      folders.append(folder)
+      log("Folders: Created folder '\(name)'")
+      return folder
+    } catch {
+      logError("Folders: Failed to create folder", error: error)
+      return nil
+    }
+  }
+
+  /// Delete a folder
+  func deleteFolder(_ folderId: String, moveToFolderId: String? = nil) async {
+    do {
+      try await APIClient.shared.deleteFolder(id: folderId, moveToFolderId: moveToFolderId)
+      folders.removeAll { $0.id == folderId }
+      if selectedFolderId == folderId {
+        selectedFolderId = nil
+      }
+      log("Folders: Deleted folder \(folderId)")
+    } catch {
+      logError("Folders: Failed to delete folder", error: error)
+    }
+  }
+
+  /// Update a folder
+  func updateFolder(_ folderId: String, name: String?, description: String?, color: String?) async {
+    do {
+      let updated = try await APIClient.shared.updateFolder(
+        id: folderId, name: name, description: description, color: color)
+      if let index = folders.firstIndex(where: { $0.id == folderId }) {
+        folders[index] = updated
+      }
+      log("Folders: Updated folder \(folderId)")
+    } catch {
+      logError("Folders: Failed to update folder", error: error)
+    }
+  }
+
+  /// Move a conversation to a folder
+  func moveConversationToFolder(_ conversationId: String, folderId: String?) async {
+    do {
+      try await APIClient.shared.moveConversationToFolder(
+        conversationId: conversationId, folderId: folderId)
+
+      // Sync to local SQLite cache so reload doesn't revert the change
+      try await TranscriptionStorage.shared.updateFolderByBackendId(
+        conversationId, folderId: folderId)
+
+      // Update local state
+      if conversations.contains(where: { $0.id == conversationId }) {
+        // Reload to get updated conversation
+        await loadConversations()
+      }
+      log("Folders: Moved conversation \(conversationId) to folder \(folderId ?? "none")")
+    } catch {
+      logError("Folders: Failed to move conversation to folder", error: error)
+    }
+  }
+
+  /// Delete a conversation locally (after successful API call)
+  func deleteConversationLocally(_ conversationId: String) {
+    withAnimation {
+      conversations.removeAll { $0.id == conversationId }
+    }
+  }
+
+  /// Update a conversation title locally (after successful API call)
+  func updateConversationTitle(_ conversationId: String, title: String) {
+    if let index = conversations.firstIndex(where: { $0.id == conversationId }) {
+      conversations[index].structured.title = title
+    }
+  }
+
+  // MARK: - People (Speaker Profiles)
+
+  /// Fetches all people from the OMI API
+  func fetchPeople() async {
+    do {
+      let fetchedPeople = try await APIClient.shared.getPeople()
+      people = fetchedPeople
+      log("People: Loaded \(fetchedPeople.count) people")
+    } catch {
+      logError("People: Failed to load", error: error)
+    }
+  }
+
+  /// Creates a new person and adds to local cache
+  func createPerson(name: String) async -> Person? {
+    do {
+      let person = try await APIClient.shared.createPerson(name: name)
+      people.append(person)
+      log("People: Created person '\(name)' with id \(person.id)")
+      return person
+    } catch {
+      logError("People: Failed to create person", error: error)
+      return nil
+    }
+  }
+
+  /// Assigns segments to a person or user via bulk API
+  func assignSpeakerToSegments(
+    conversationId: String,
+    segmentIds: [Int],
+    personId: String?,
+    isUser: Bool
+  ) async -> Bool {
+    do {
+      try await APIClient.shared.assignSegmentsBulk(
+        conversationId: conversationId,
+        segmentIds: segmentIds.map(String.init),
+        isUser: isUser,
+        personId: personId
+      )
+      log("People: Assigned \(segmentIds.count) segments in conversation \(conversationId)")
+      return true
+    } catch {
+      logError("People: Failed to assign segments", error: error)
+      return false
+    }
+  }
+
+  /// Finalize and save the current conversation to the backend
+  /// Uses DB as source of truth for crash safety
+  private func finalizeConversation() async -> FinishConversationResult {
+    guard let startTime = recordingStartTime else {
+      log("Transcription: No recording start time")
+      return .discarded
+    }
+
+    let endTime = Date()
+    let sessionId = currentSessionId
+
+    // Try to load segments from DB if we have a session, fall back to in-memory
+    var segmentsToUpload: [SpeakerSegment] = speakerSegments
+
+    if let sessionId = sessionId {
+      do {
+        // Mark session as finished in DB first
+        try await TranscriptionStorage.shared.finishSession(id: sessionId)
+
+        // Load segments from DB (source of truth for crash recovery)
+        let dbSegments = try await TranscriptionStorage.shared.getSegments(sessionId: sessionId)
+        if !dbSegments.isEmpty {
+          // Convert DB segments to SpeakerSegment format
+          segmentsToUpload = dbSegments.map { dbSeg in
+            SpeakerSegment(
+              speaker: dbSeg.speaker,
+              text: dbSeg.text,
+              start: dbSeg.startTime,
+              end: dbSeg.endTime
+            )
+          }
+          log("Transcription: Loaded \(segmentsToUpload.count) segments from DB")
+        }
+      } catch {
+        logError("Transcription: Failed to load segments from DB, using in-memory", error: error)
+        // Fall through to use in-memory segments
+      }
+    }
+
+    guard !segmentsToUpload.isEmpty else {
+      log("Transcription: No segments to save")
+      // Clean up empty session
+      if let sessionId = sessionId {
+        try? await TranscriptionStorage.shared.deleteSession(id: sessionId)
+      }
+      return .discarded
+    }
+
+    log("Transcription: Finalizing conversation with \(segmentsToUpload.count) segments")
+
+    // Convert SpeakerSegment to API request format (include person_id from live naming)
+    let speakerPersonMap = liveSpeakerPersonMap
+    let apiSegments = segmentsToUpload.map { segment in
+      APIClient.TranscriptSegmentRequest(
+        text: segment.text,
+        speaker: "SPEAKER_\(String(format: "%02d", segment.speaker))",
+        speakerId: segment.speaker,
+        isUser: segment.speaker == 0,  // Assume speaker 0 is the user
+        personId: speakerPersonMap[segment.speaker],
+        start: segment.start,
+        end: segment.end
+      )
+    }
+
+    // Mark session as uploading
+    if let sessionId = sessionId {
+      try? await TranscriptionStorage.shared.markSessionUploading(id: sessionId)
+    }
+
+    do {
+      let response = try await APIClient.shared.createConversationFromSegments(
+        segments: apiSegments,
+        startedAt: startTime,
+        finishedAt: endTime,
+        source: currentConversationSource,
+        inputDeviceName: recordingInputDeviceName
+      )
+      log(
+        "Transcription: Conversation saved - id=\(response.id), status=\(response.status), discarded=\(response.discarded), source=\(currentConversationSource.rawValue), device=\(recordingInputDeviceName ?? "Unknown")"
+      )
+
+      // Mark session as completed in DB
+      if let sessionId = sessionId {
+        do {
+          try await TranscriptionStorage.shared.markSessionCompleted(
+            id: sessionId, backendId: response.id)
+        } catch {
+          logError(
+            "Transcription: Failed to mark session \(sessionId) as completed (backendId: \(response.id))",
+            error: error)
+          // Session is stuck in 'uploading' state — mark as failed so retry service can recover it
+          try? await TranscriptionStorage.shared.markSessionFailed(
+            id: sessionId, error: "markSessionCompleted failed: \(error.localizedDescription)")
+        }
+      }
+
+      if response.discarded {
+        return .discarded
+      }
+
+      // Track successful conversation creation in analytics (Mixpanel + PostHog)
+      let durationSeconds = Int(endTime.timeIntervalSince(startTime))
+      AnalyticsManager.shared.conversationCreated(
+        conversationId: response.id,
+        source: currentConversationSource.rawValue,
+        durationSeconds: durationSeconds
+      )
+
+      // Fire-and-forget: extract goal progress from conversation transcript
+      let transcriptText = segmentsToUpload.map { $0.text }.joined(separator: " ")
+      if transcriptText.count >= 10 {
+        Task.detached(priority: .background) {
+          await GoalsAIService.shared.extractProgressFromAllGoals(text: transcriptText)
+        }
+      }
+
+      // Check daily goal generation
+      Task { @MainActor in
+        GoalGenerationService.shared.onConversationCreated()
+      }
+
+      return .saved
+    } catch {
+      logError("Transcription: Failed to save conversation", error: error)
+      // Error event deferred to TranscriptionRetryService after all retries are exhausted
+
+      // Mark session as failed in DB for later retry
+      if let sessionId = sessionId {
+        try? await TranscriptionStorage.shared.markSessionFailed(
+          id: sessionId, error: error.localizedDescription)
+      }
+
+      return .error(error.localizedDescription)
+    }
+  }
+
+  // MARK: - Batch Transcription
+
+  /// Transcribe a completed speech chunk from VAD batch mode.
+  /// Offsets word timestamps to session-relative time, then feeds through handleTranscriptSegment.
+  private func batchTranscribeChunk(audioBuffer: Data, wallStartTime: Double) async {
+    let offsetSec = wallStartTime - recordingStartCATime
+    let effectiveLanguage = AssistantSettings.shared.effectiveTranscriptionLanguage
+    let vocabulary = AssistantSettings.shared.effectiveVocabulary
+
+    do {
+      let segments = try await TranscriptionService.batchTranscribeFull(
+        audioData: audioBuffer,
+        language: effectiveLanguage,
+        vocabulary: vocabulary
+      )
+
+      for segment in segments {
+        // Offset all word timestamps by the chunk's start time relative to recording start
+        let offsetWords = segment.words.map { word in
+          TranscriptionService.TranscriptSegment.Word(
+            word: word.word,
+            start: word.start + offsetSec,
+            end: word.end + offsetSec,
+            confidence: word.confidence,
+            speaker: word.speaker,
+            punctuatedWord: word.punctuatedWord
+          )
+        }
+
+        let offsetSegment = TranscriptionService.TranscriptSegment(
+          text: segment.text,
+          isFinal: true,
+          speechFinal: true,
+          confidence: segment.confidence,
+          words: offsetWords,
+          channelIndex: segment.channelIndex
+        )
+
+        handleTranscriptSegment(offsetSegment)
+      }
+    } catch {
+      logError("Transcription: Batch transcribe chunk failed", error: error)
+    }
+  }
+
+  /// Handle incoming transcript segment with speaker diarization
+  /// Uses channel index for primary speaker attribution:
+  ///   - Channel 0 = microphone = user (speaker 0)
+  ///   - Channel 1 = system audio = others (speaker 1+)
+  private func handleTranscriptSegment(_ segment: TranscriptionService.TranscriptSegment) {
+    // Only process final segments (speechFinal or isFinal)
+    guard segment.speechFinal || segment.isFinal else { return }
+
+    // Determine speaker based on channel index
+    // Channel 0 = mic = user (speaker 0)
+    // Channel 1 = system audio = others (speaker 1+)
+    let channelBasedSpeaker = segment.channelIndex == 0 ? 0 : 1
+
+    // Process words and merge by speaker
+    // If VAD gate is active (streaming mode only), remap Deepgram timestamps to wall-clock time
+    // In batch mode, timestamps are already session-relative after offsetting in batchTranscribeChunk
+    let words: [TranscriptionService.TranscriptSegment.Word]
+    if !useBatchTranscription, let gate = vadGateService {
+      words = segment.words.map { word in
+        let (remappedStart, remappedEnd) = gate.remapTimestamp(start: word.start, end: word.end)
+        return TranscriptionService.TranscriptSegment.Word(
+          word: word.word,
+          start: remappedStart,
+          end: remappedEnd,
+          confidence: word.confidence,
+          speaker: word.speaker,
+          punctuatedWord: word.punctuatedWord
+        )
+      }
+    } else {
+      words = segment.words
+    }
+    guard !words.isEmpty else {
+      // Fallback: no words, just append text with channel-based speaker
+      if segment.speechFinal && !segment.text.isEmpty {
+        appendToTranscript(segment.text)
+        log(
+          "Transcript [FINAL no words] Ch\(segment.channelIndex) Speaker \(channelBasedSpeaker): \(segment.text)"
+        )
+      }
+      return
+    }
+
+    // Word-to-segment aggregation: merge consecutive words from same speaker
+    // For channel 1 (system audio), use diarization speaker ID + 1 to distinguish multiple remote speakers
+    var newSegments: [SpeakerSegment] = []
+    for word in words {
+      // Speaker assignment:
+      // - Channel 0 (mic): Always speaker 0 (user)
+      // - Channel 1 (system): Use diarization speaker + 1, or default to 1
+      let speaker: Int
+      if segment.channelIndex == 0 {
+        speaker = 0  // Mic is always user
+      } else {
+        // System audio: offset diarization speakers by 1
+        // This allows distinguishing multiple remote speakers (1, 2, 3, etc.)
+        speaker = (word.speaker ?? 0) + 1
+      }
+
+      if let last = newSegments.last, last.speaker == speaker {
+        // Same speaker - append word to existing segment
+        newSegments[newSegments.count - 1].text += " " + word.punctuatedWord
+        newSegments[newSegments.count - 1].end = word.end
+      } else {
+        // Different speaker - create new segment
+        newSegments.append(
+          SpeakerSegment(
+            speaker: speaker,
+            text: word.punctuatedWord,
+            start: word.start,
+            end: word.end
+          ))
+      }
+    }
+
+    // Log new segments from this chunk
+    for seg in newSegments {
+      let channelLabel = segment.channelIndex == 0 ? "mic" : "sys"
+      log(
+        "Transcript [NEW] Ch\(segment.channelIndex)(\(channelLabel)) Speaker \(seg.speaker) [\(String(format: "%.1f", seg.start))s-\(String(format: "%.1f", seg.end))s]: \(seg.text)"
+      )
+    }
+
+    // Gap-based merging: combine with existing segments if same speaker and gap < 3 seconds
+    for newSeg in newSegments {
+      // Track word count incrementally
+      totalWordCount += newSeg.text.split(separator: " ").count
+
+      if let lastIdx = speakerSegments.indices.last,
+        speakerSegments[lastIdx].speaker == newSeg.speaker,
+        newSeg.start - speakerSegments[lastIdx].end < 3.0
+      {
+        // Same speaker and gap < 3s - merge
+        let gap = newSeg.start - speakerSegments[lastIdx].end
+        log(
+          "Transcript [MERGE] Speaker \(newSeg.speaker) gap=\(String(format: "%.2f", gap))s: merging into existing segment"
+        )
+        speakerSegments[lastIdx].text += " " + newSeg.text
+        speakerSegments[lastIdx].end = newSeg.end
+      } else {
+        // Different speaker or gap >= 3s - add as new segment
+        if let lastIdx = speakerSegments.indices.last {
+          let gap = newSeg.start - speakerSegments[lastIdx].end
+          log(
+            "Transcript [ADD] Speaker \(newSeg.speaker) gap=\(String(format: "%.2f", gap))s: new segment (different speaker or gap >= 3s)"
+          )
+        } else {
+          log("Transcript [ADD] Speaker \(newSeg.speaker): first segment")
+        }
+        speakerSegments.append(newSeg)
+        totalSegmentCount += 1
+      }
+    }
+
+    // Sliding window: trim old segments from memory (they're already persisted in SQLite)
+    if speakerSegments.count > maxInMemorySegments {
+      let excess = speakerSegments.count - maxInMemorySegments
+      speakerSegments.removeFirst(excess)
+    }
+
+    // Log current segments summary (only last 5 segments when count > 20 to avoid log spam)
+    log(
+      "Transcript [SEGMENTS] Total: \(totalSegmentCount) segments (in-memory: \(speakerSegments.count))"
+    )
+    let logSegments =
+      speakerSegments.count > 20
+      ? Array(speakerSegments.suffix(5))
+      : speakerSegments
+    let startIdx = speakerSegments.count > 20 ? speakerSegments.count - 5 : 0
+    if speakerSegments.count > 20 {
+      log("  ... (\(speakerSegments.count - 5) earlier segments omitted)")
+    }
+    for (offset, seg) in logSegments.enumerated() {
+      let i = startIdx + offset
+      let speakerLabel = seg.speaker == 0 ? "user" : "other"
+      log(
+        "  [\(i)] Speaker \(seg.speaker)(\(speakerLabel)) [\(String(format: "%.1f", seg.start))s-\(String(format: "%.1f", seg.end))s]: \(seg.text)"
+      )
+    }
+
+    // Update published segments for UI (via isolated monitor)
+    LiveTranscriptMonitor.shared.updateSegments(speakerSegments)
+
+    // Update display transcript
+    updateTranscriptDisplay()
+
+    // Persist new segments to DB for crash safety
+    if let sessionId = currentSessionId {
+      Task {
+        for newSeg in newSegments {
+          do {
+            try await TranscriptionStorage.shared.appendSegment(
+              sessionId: sessionId,
+              speaker: newSeg.speaker,
+              text: newSeg.text,
+              startTime: newSeg.start,
+              endTime: newSeg.end
+            )
+          } catch {
+            logError("Transcription: Failed to persist segment to DB", error: error)
+            await RewindDatabase.shared.reportQueryError(error)
+            // Non-fatal - continue recording
+          }
+        }
+      }
+    }
+  }
+
+  /// Update the display transcript — no-op since word count is tracked incrementally
+  /// and views use LiveTranscriptMonitor.segments directly
+  private func updateTranscriptDisplay() {
+    // Previously rebuilt currentTranscript from all speakerSegments on every incoming segment,
+    // causing O(N^2) string allocations. Word count is now tracked via totalWordCount.
+  }
+
+  /// Append text to transcript (fallback when no word-level data)
+  private func appendToTranscript(_ text: String) {
+    if !currentTranscript.isEmpty {
+      currentTranscript += "\n"
+    }
+    currentTranscript += text
+  }
+
+  /// Request microphone permission
+  func requestMicrophonePermission() {
+    // Activate app to ensure permission dialog appears
+    NSApp.activate(ignoringOtherApps: true)
+
+    log(
+      "Requesting microphone permission, current status: \(AudioCaptureService.authorizationStatus().rawValue)"
+    )
+
+    Task {
+      let granted = await AudioCaptureService.requestPermission()
+      await MainActor.run {
+        self.hasMicrophonePermission = granted
+        log("Microphone permission request completed, granted: \(granted)")
+        if granted {
+          log("Microphone permission granted")
+          // Only start transcription if onboarding is complete
+          // During onboarding, we just update the permission state
+          if self.hasCompletedOnboarding {
+            self.startTranscription()
+          }
+        } else {
+          log("Microphone permission denied")
+          // UI will show the denied state with reset options inline
+        }
+      }
+    }
+  }
+
+  /// Check microphone permission status
+  func checkMicrophonePermission() {
+    hasMicrophonePermission = AudioCaptureService.checkPermission()
+  }
+
+  /// Check if microphone permission was explicitly denied
+  func isMicrophonePermissionDenied() -> Bool {
+    return AudioCaptureService.isPermissionDenied()
+  }
+
+  /// Check if screen recording permission is denied (onboarding complete but permission not granted)
+  func isScreenRecordingPermissionDenied() -> Bool {
+    return hasCompletedOnboarding && !CGPreflightScreenCaptureAccess()
+  }
+
+  /// Restart the app by launching a new instance and terminating the current one
+  nonisolated func restartApp() {
+    if UpdaterViewModel.isUpdateInProgress {
+      log("Sparkle update in progress, skipping independent restart (Sparkle will handle relaunch)")
+      return
+    }
+
+    log("Restarting app...")
+
+    guard let bundleURL = Bundle.main.bundleURL as URL? else {
+      log("Failed to get bundle URL for restart")
+      return
+    }
+
+    // Use a shell script to wait briefly, then relaunch the app
+    let task = Process()
+    task.executableURL = URL(fileURLWithPath: "/bin/sh")
+    task.arguments = ["-c", "sleep 0.5 && open \"\(bundleURL.path)\""]
+
+    do {
+      try task.run()
+      log("Restart scheduled, terminating current instance...")
+
+      // Terminate the current app
+      DispatchQueue.main.async {
+        NSApplication.shared.terminate(nil)
+      }
+    } catch {
+      log("Failed to schedule restart: \(error)")
+    }
+  }
+
+  /// Reset onboarding state for the current app only, then restart.
+  /// This clears onboarding state without touching production data or system permissions.
+  nonisolated func resetOnboardingAndRestart() {
+    log("Resetting onboarding state for current app...")
+
+    // Update live @AppStorage state in the current app instance before touching
+    // raw UserDefaults so SwiftUI doesn't write stale onboarding values back.
+    DispatchQueue.main.async {
+      NotificationCenter.default.post(name: .resetOnboardingRequested, object: nil)
+    }
+
+    // Clear onboarding-related UserDefaults keys (thread-safe, do first)
+    let onboardingKeys = [
+      "hasCompletedOnboarding",
+      "onboardingStep",
+      "hasSeenRewindIntro",
+      "hasTriggeredNotification",
+      "hasTriggeredAutomation",
+      "hasTriggeredScreenRecording",
+      "hasTriggeredMicrophone",
+      "hasTriggeredSystemAudio",
+      "hasTriggeredAccessibility",
+      "hasTriggeredBluetooth",
+      "onboardingJustCompleted",
+    ]
+    for key in onboardingKeys {
+      UserDefaults.standard.removeObject(forKey: key)
+    }
+    UserDefaults.standard.synchronize()
+    log("Cleared onboarding UserDefaults keys")
+
+    // Clear onboarding chat persistence and messages
+    OnboardingChatPersistence.clear()
+    log("Cleared onboarding chat persistence")
+
+    // Clear persisted backend chat messages so onboarding does not resume old history.
+    // Onboarding currently uses the default chat message stream.
+    Task {
+      do {
+        _ = try await APIClient.shared.deleteMessages()
+        log("Cleared backend chat messages")
+      } catch {
+        logError("Failed to clear backend chat messages during onboarding reset", error: error)
+      }
+    }
+
+    // Restart off the main thread to avoid blocking the menu action path.
+    DispatchQueue.global(qos: .utility).async { [self] in
+      Thread.sleep(forTimeInterval: 0.15)
+      // Keep onboarding reset scoped to the current app instance.
+      // It must not mutate production defaults, shared local data, or TCC permissions.
+      self.restartApp()
+    }
+  }
+
+  /// Clean conflicting app bundles from Trash, DerivedData, and DMG staging directories
+  private nonisolated func cleanConflictingAppBundles() {
+    let fileManager = FileManager.default
+    let homeDir = fileManager.homeDirectoryForCurrentUser.path
+
+    // Clean Omi apps from Trash (they still pollute Launch Services!)
+    let trashPath = "\(homeDir)/.Trash"
+    if let contents = try? fileManager.contentsOfDirectory(atPath: trashPath) {
+      for item in contents where item.lowercased().contains("omi") {
+        let itemPath = "\(trashPath)/\(item)"
+        do {
+          try fileManager.removeItem(atPath: itemPath)
+          log("Cleaned from Trash: \(item)")
+        } catch {
+          log("Failed to clean from Trash: \(item) - \(error.localizedDescription)")
+        }
+      }
+    }
+
+    // Clean DMG staging directories
+    let tmpDir = "/private/tmp"
+    if let contents = try? fileManager.contentsOfDirectory(atPath: tmpDir) {
+      for item in contents where item.hasPrefix("omi-dmg-staging") || item.hasPrefix("omi-dmg-test")
+      {
+        let itemPath = "\(tmpDir)/\(item)"
+        do {
+          try fileManager.removeItem(atPath: itemPath)
+          log("Cleaned DMG staging: \(item)")
+        } catch {
+          log("Failed to clean DMG staging: \(item) - \(error.localizedDescription)")
+        }
+      }
+    }
+
+    // Clean Xcode DerivedData Omi builds
+    let derivedDataPath = "\(homeDir)/Library/Developer/Xcode/DerivedData"
+    if let contents = try? fileManager.contentsOfDirectory(atPath: derivedDataPath) {
+      for item in contents where item.lowercased().contains("omi") {
+        let buildProductsPath = "\(derivedDataPath)/\(item)/Build/Products"
+        if let buildDirs = try? fileManager.contentsOfDirectory(atPath: buildProductsPath) {
+          for buildDir in buildDirs {
+            let appPath = "\(buildProductsPath)/\(buildDir)/Omi.app"
+            let appPath2 = "\(buildProductsPath)/\(buildDir)/Omi Computer.app"
+            let appPath3 = "\(buildProductsPath)/\(buildDir)/omi.app"
+            let appPath4 = "\(buildProductsPath)/\(buildDir)/Omi Dev.app"
+            for path in [appPath, appPath2, appPath3, appPath4] {
+              if fileManager.fileExists(atPath: path) {
+                do {
+                  try fileManager.removeItem(atPath: path)
+                  log("Cleaned DerivedData: \(path)")
+                } catch {
+                  log("Failed to clean DerivedData: \(path) - \(error.localizedDescription)")
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /// Eject any mounted Omi DMG volumes
+  private nonisolated func ejectMountedDMGVolumes() {
+    let fileManager = FileManager.default
+    let volumesPath = "/Volumes"
+
+    guard let contents = try? fileManager.contentsOfDirectory(atPath: volumesPath) else { return }
+
+    for volume in contents where volume.lowercased().contains("omi") || volume.hasPrefix("dmg.") {
+      let volumePath = "\(volumesPath)/\(volume)"
+
+      // Try diskutil eject first
+      let process = Process()
+      process.executableURL = URL(fileURLWithPath: "/usr/sbin/diskutil")
+      process.arguments = ["eject", volumePath]
+      process.standardOutput = FileHandle.nullDevice
+      process.standardError = FileHandle.nullDevice
+
+      do {
+        try process.run()
+        process.waitUntilExit()
+        if process.terminationStatus == 0 {
+          log("Ejected volume: \(volume)")
+        } else {
+          // Try hdiutil detach as fallback
+          let detachProcess = Process()
+          detachProcess.executableURL = URL(fileURLWithPath: "/usr/bin/hdiutil")
+          detachProcess.arguments = ["detach", volumePath]
+          detachProcess.standardOutput = FileHandle.nullDevice
+          detachProcess.standardError = FileHandle.nullDevice
+          try? detachProcess.run()
+          detachProcess.waitUntilExit()
+        }
+      } catch {
+        log("Failed to eject volume: \(volume) - \(error.localizedDescription)")
+      }
+    }
+  }
+
+  /// Reset Launch Services database to clear stale app registrations
+  private nonisolated func resetLaunchServicesDatabase() {
+    let lsregisterPath =
+      "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: lsregisterPath)
+    process.arguments = ["-kill", "-r", "-domain", "local", "-domain", "user"]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+      log("Launch Services database reset (exit code: \(process.terminationStatus))")
+    } catch {
+      log("Failed to reset Launch Services: \(error.localizedDescription)")
+    }
+  }
+
+  /// Clean user TCC database entries for Omi apps
+  private nonisolated func cleanUserTCCDatabase() {
+    let homeDir = FileManager.default.homeDirectoryForCurrentUser.path
+    let tccDbPath = "\(homeDir)/Library/Application Support/com.apple.TCC/TCC.db"
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+    process.arguments = [
+      tccDbPath, "DELETE FROM access WHERE client LIKE '%com.omi.computer-macos%';",
+    ]
+    process.standardOutput = FileHandle.nullDevice
+    process.standardError = FileHandle.nullDevice
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+      log("User TCC database cleaned (exit code: \(process.terminationStatus))")
+    } catch {
+      log("Failed to clean user TCC database: \(error.localizedDescription)")
+    }
+
+    // Also clean entries for new dev bundle ID pattern (com.omi.desktop-dev)
+    let process2 = Process()
+    process2.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
+    process2.arguments = [tccDbPath, "DELETE FROM access WHERE client LIKE '%com.omi.desktop%';"]
+    process2.standardOutput = FileHandle.nullDevice
+    process2.standardError = FileHandle.nullDevice
+
+    do {
+      try process2.run()
+      process2.waitUntilExit()
+      log("User TCC database cleaned for desktop-dev (exit code: \(process2.terminationStatus))")
+    } catch {
+      log("Failed to clean user TCC database for desktop-dev: \(error.localizedDescription)")
+    }
+  }
+
+  /// Reset microphone permission using tccutil (Option 1: Direct)
+  /// Returns true if the reset command was executed successfully
+  /// If shouldRestart is true, the app will restart after reset
+  nonisolated func resetMicrophonePermissionDirect(shouldRestart: Bool = false) -> Bool {
+    let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
+    log("Resetting microphone permission for \(bundleId) via tccutil...")
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: "/usr/bin/tccutil")
+    process.arguments = ["reset", "Microphone", bundleId]
+
+    do {
+      try process.run()
+      process.waitUntilExit()
+      let success = process.terminationStatus == 0
+      log("tccutil reset completed with exit code: \(process.terminationStatus)")
+
+      if success && shouldRestart {
+        restartApp()
+      }
+
+      return success
+    } catch {
+      log("Failed to run tccutil: \(error)")
+      return false
+    }
+  }
+
+  /// Reset microphone permission via Terminal (Option 2: Visible to user)
+  /// If shouldRestart is true, the app will restart after the terminal command
+  func resetMicrophonePermissionViaTerminal(shouldRestart: Bool = false) {
+    let bundleId = Bundle.main.bundleIdentifier ?? "com.omi.computer-macos"
+    let appPath = Bundle.main.bundleURL.path
+    log("Opening Terminal to reset microphone permission for \(bundleId)...")
+
+    // Build the shell command - escape single quotes in path for shell
+    let escapedPath = appPath.replacingOccurrences(of: "'", with: "'\\''")
+    let restartCommand = shouldRestart ? " && open '\(escapedPath)'" : ""
+    let shellCommand =
+      "tccutil reset Microphone \(bundleId) && echo 'Done! Permission reset.'\(restartCommand)"
+
+    // AppleScript to open Terminal and run the command
+    let script = "tell application \"Terminal\"\nactivate\ndo script \"\(shellCommand)\"\nend tell"
+
+    var error: NSDictionary?
+    if let appleScript = NSAppleScript(source: script) {
+      appleScript.executeAndReturnError(&error)
+      if let error = error {
+        log("AppleScript error: \(error)")
+      } else if shouldRestart {
+        // Terminate current app after terminal script is running
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+          NSApplication.shared.terminate(nil)
+        }
+      }
+    }
+  }
+
+  /// Check system audio permission status
+  /// This checks if the test capture was successful (set by triggerSystemAudioPermission)
+  func checkSystemAudioPermission() {
+    // Permission is set by triggerSystemAudioPermission after successful test
+    // No-op here - we rely on the test result
+  }
+
+  /// Trigger system audio permission by actually testing capture
+  /// This verifies system audio works by briefly starting and stopping capture
+  func triggerSystemAudioPermission() {
+    guard #available(macOS 14.4, *) else {
+      log("System audio not supported on this macOS version")
+      hasSystemAudioPermission = false
+      return
+    }
+
+    log("System audio: Testing capture...")
+
+    // Create a test capture service
+    let testService = SystemAudioCaptureService()
+
+    Task {
+      do {
+        // Try to start capture - this will fail if permission is not granted
+        try await testService.startCapture { _ in
+          // We don't need the audio data, just testing if it works
+        }
+
+        // If we get here, capture started successfully
+        log("System audio: Test capture started successfully")
+
+        // Stop the test capture
+        testService.stopCapture()
+        log("System audio: Test capture stopped")
+
+        // Mark permission as granted
+        hasSystemAudioPermission = true
+        log("System audio: Permission verified")
+
+      } catch {
+        logError("System audio: Test capture failed", error: error)
+        hasSystemAudioPermission = false
+
+        // Open System Settings to Screen Recording section
+        if let url = URL(
+          string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
+        {
+          NSWorkspace.shared.open(url)
+        }
+      }
+    }
+  }
 }
 
 // MARK: - System Event Notification Names
 
 extension Notification.Name {
-    /// Posted when the current app instance should fully clear its own onboarding state.
-    static let resetOnboardingRequested = Notification.Name("resetOnboardingRequested")
-    /// Posted when the system wakes from sleep
-    static let systemDidWake = Notification.Name("systemDidWake")
-    /// Posted when the screen is locked
-    static let screenDidLock = Notification.Name("screenDidLock")
-    /// Posted when the screen is unlocked
-    static let screenDidUnlock = Notification.Name("screenDidUnlock")
-    /// Posted when screen capture permission is detected as lost
-    static let screenCapturePermissionLost = Notification.Name("screenCapturePermissionLost")
-    /// Posted when ScreenCaptureKit is broken (TCC granted but SCK declined)
-    static let screenCaptureKitBroken = Notification.Name("screenCaptureKitBroken")
-    /// Posted to navigate to Rewind settings
-    static let navigateToRewindSettings = Notification.Name("navigateToRewindSettings")
-    /// Posted to navigate to Rewind page (global hotkey: Cmd+Option+R)
-    static let navigateToRewind = Notification.Name("navigateToRewind")
-    /// Posted to navigate to Rewind page with notes panel expanded
-    static let navigateToRewindNotes = Notification.Name("navigateToRewindNotes")
-    /// Posted to expand the transcript/notes panel on the Rewind page
-    static let expandRewindTranscript = Notification.Name("expandRewindTranscript")
-    /// Posted to navigate to Device settings
-    static let navigateToDeviceSettings = Notification.Name("navigateToDeviceSettings")
-    /// Posted to navigate to Task Assistant settings (Developer Settings)
-    static let navigateToTaskSettings = Notification.Name("navigateToTaskSettings")
-    /// Posted to navigate to Ask Omi Floating Bar settings
-    static let navigateToFloatingBarSettings = Notification.Name("navigateToFloatingBarSettings")
-    /// Posted to navigate to AI Chat settings
-    static let navigateToAIChatSettings = Notification.Name("navigateToAIChatSettings")
-    /// Posted when a new Rewind frame is captured (for live frame count updates)
-    static let rewindFrameCaptured = Notification.Name("rewindFrameCaptured")
-    /// Posted when Rewind page finishes loading initial data
-    static let rewindPageDidLoad = Notification.Name("rewindPageDidLoad")
-    /// Posted when Conversations page finishes loading initial data
-    static let conversationsPageDidLoad = Notification.Name("conversationsPageDidLoad")
-    /// Posted when Tasks page finishes loading initial data
-    static let tasksPageDidLoad = Notification.Name("tasksPageDidLoad")
-    /// Posted when Focus page finishes loading initial data
-    static let focusPageDidLoad = Notification.Name("focusPageDidLoad")
-    /// Posted when Advice page finishes loading initial data
-    static let advicePageDidLoad = Notification.Name("advicePageDidLoad")
-    /// Posted when Apps page finishes loading initial data
-    static let appsPageDidLoad = Notification.Name("appsPageDidLoad")
-    /// Posted when a goal is auto-created by GoalGenerationService
-    static let goalAutoCreated = Notification.Name("goalAutoCreated")
-    /// Posted when a goal is completed (current_value >= target_value)
-    static let goalCompleted = Notification.Name("goalCompleted")
-    /// Posted to navigate to AI Chat page
-    static let navigateToChat = Notification.Name("navigateToChat")
-    static let navigateToTasks = Notification.Name("navigateToTasks")
-    /// Posted when file indexing completes (userInfo: ["totalFiles": Int])
-    static let fileIndexingComplete = Notification.Name("fileIndexingComplete")
-    /// Posted from Settings to trigger the file indexing sheet
-    static let triggerFileIndexing = Notification.Name("triggerFileIndexing")
-    /// Posted from menu bar to toggle transcription (userInfo: ["enabled": Bool])
-    static let toggleTranscriptionRequested = Notification.Name("toggleTranscriptionRequested")
+  /// Posted when the current app instance should fully clear its own onboarding state.
+  static let resetOnboardingRequested = Notification.Name("resetOnboardingRequested")
+  /// Posted when the system wakes from sleep
+  static let systemDidWake = Notification.Name("systemDidWake")
+  /// Posted when the screen is locked
+  static let screenDidLock = Notification.Name("screenDidLock")
+  /// Posted when the screen is unlocked
+  static let screenDidUnlock = Notification.Name("screenDidUnlock")
+  /// Posted when screen capture permission is detected as lost
+  static let screenCapturePermissionLost = Notification.Name("screenCapturePermissionLost")
+  /// Posted when ScreenCaptureKit is broken (TCC granted but SCK declined)
+  static let screenCaptureKitBroken = Notification.Name("screenCaptureKitBroken")
+  /// Posted to navigate to Rewind settings
+  static let navigateToRewindSettings = Notification.Name("navigateToRewindSettings")
+  /// Posted to navigate to Rewind page (global hotkey: Cmd+Option+R)
+  static let navigateToRewind = Notification.Name("navigateToRewind")
+  /// Posted to navigate to Rewind page with notes panel expanded
+  static let navigateToRewindNotes = Notification.Name("navigateToRewindNotes")
+  /// Posted to expand the transcript/notes panel on the Rewind page
+  static let expandRewindTranscript = Notification.Name("expandRewindTranscript")
+  /// Posted to navigate to Device settings
+  static let navigateToDeviceSettings = Notification.Name("navigateToDeviceSettings")
+  /// Posted to navigate to Task Assistant settings (Developer Settings)
+  static let navigateToTaskSettings = Notification.Name("navigateToTaskSettings")
+  /// Posted to navigate to Ask Omi Floating Bar settings
+  static let navigateToFloatingBarSettings = Notification.Name("navigateToFloatingBarSettings")
+  /// Posted to navigate to AI Chat settings
+  static let navigateToAIChatSettings = Notification.Name("navigateToAIChatSettings")
+  /// Posted when a new Rewind frame is captured (for live frame count updates)
+  static let rewindFrameCaptured = Notification.Name("rewindFrameCaptured")
+  /// Posted when Rewind page finishes loading initial data
+  static let rewindPageDidLoad = Notification.Name("rewindPageDidLoad")
+  /// Posted when Conversations page finishes loading initial data
+  static let conversationsPageDidLoad = Notification.Name("conversationsPageDidLoad")
+  /// Posted when Tasks page finishes loading initial data
+  static let tasksPageDidLoad = Notification.Name("tasksPageDidLoad")
+  /// Posted when Focus page finishes loading initial data
+  static let focusPageDidLoad = Notification.Name("focusPageDidLoad")
+  /// Posted when Advice page finishes loading initial data
+  static let advicePageDidLoad = Notification.Name("advicePageDidLoad")
+  /// Posted when Apps page finishes loading initial data
+  static let appsPageDidLoad = Notification.Name("appsPageDidLoad")
+  /// Posted when a goal is auto-created by GoalGenerationService
+  static let goalAutoCreated = Notification.Name("goalAutoCreated")
+  /// Posted when a goal is completed (current_value >= target_value)
+  static let goalCompleted = Notification.Name("goalCompleted")
+  /// Posted to navigate to AI Chat page
+  static let navigateToChat = Notification.Name("navigateToChat")
+  static let navigateToTasks = Notification.Name("navigateToTasks")
+  /// Posted by the local desktop automation bridge to request semantic navigation.
+  static let desktopAutomationNavigateRequested = Notification.Name(
+    "desktopAutomationNavigateRequested")
+  /// Posted when file indexing completes (userInfo: ["totalFiles": Int])
+  static let fileIndexingComplete = Notification.Name("fileIndexingComplete")
+  /// Posted from Settings to trigger the file indexing sheet
+  static let triggerFileIndexing = Notification.Name("triggerFileIndexing")
+  /// Posted from menu bar to toggle transcription (userInfo: ["enabled": Bool])
+  static let toggleTranscriptionRequested = Notification.Name("toggleTranscriptionRequested")
 }

--- a/desktop/Desktop/Sources/DesktopAutomationBridge.swift
+++ b/desktop/Desktop/Sources/DesktopAutomationBridge.swift
@@ -1,0 +1,332 @@
+import AppKit
+import Foundation
+import Network
+
+enum DesktopAutomationLaunchOptions {
+  static let enableFlag = "--automation-bridge"
+  static let portPrefix = "--automation-port="
+  static let defaultPort: UInt16 = 47777
+
+  static var isEnabled: Bool {
+    CommandLine.arguments.contains(enableFlag)
+      || ProcessInfo.processInfo.environment["OMI_ENABLE_LOCAL_AUTOMATION"] == "1"
+  }
+
+  static var port: UInt16 {
+    for argument in CommandLine.arguments {
+      guard argument.hasPrefix(portPrefix) else { continue }
+      let rawValue = String(argument.dropFirst(portPrefix.count))
+      if let parsed = UInt16(rawValue) {
+        return parsed
+      }
+    }
+
+    if let rawValue = ProcessInfo.processInfo.environment["OMI_AUTOMATION_PORT"],
+      let parsed = UInt16(rawValue)
+    {
+      return parsed
+    }
+
+    return defaultPort
+  }
+}
+
+struct DesktopAutomationSnapshot: Codable {
+  var bridgeEnabled: Bool
+  var bridgePort: UInt16
+  var bundleIdentifier: String
+  var appState: String
+  var selectedTab: String?
+  var selectedTabIndex: Int?
+  var selectedSettingsSection: String?
+  var highlightedSettingId: String?
+  var hasCompletedOnboarding: Bool
+  var isSignedIn: Bool
+  var isRestoringAuth: Bool
+  var isAppActive: Bool
+  var mainWindowTitle: String?
+  var updatedAt: String
+}
+
+struct DesktopAutomationNavigationRequest: Codable {
+  let target: String
+  let settingsSection: String?
+  let highlightedSettingId: String?
+  let activateApp: Bool?
+}
+
+private struct DesktopAutomationResponse<T: Codable>: Codable {
+  let ok: Bool
+  let result: T?
+  let error: String?
+}
+
+actor DesktopAutomationStateStore {
+  static let shared = DesktopAutomationStateStore()
+
+  private var snapshot = DesktopAutomationSnapshot(
+    bridgeEnabled: DesktopAutomationLaunchOptions.isEnabled,
+    bridgePort: DesktopAutomationLaunchOptions.port,
+    bundleIdentifier: Bundle.main.bundleIdentifier ?? "unknown",
+    appState: "launching",
+    selectedTab: nil,
+    selectedTabIndex: nil,
+    selectedSettingsSection: nil,
+    highlightedSettingId: nil,
+    hasCompletedOnboarding: false,
+    isSignedIn: false,
+    isRestoringAuth: true,
+    isAppActive: false,
+    mainWindowTitle: nil,
+    updatedAt: ISO8601DateFormatter().string(from: Date())
+  )
+
+  func update(_ snapshot: DesktopAutomationSnapshot) {
+    self.snapshot = snapshot
+  }
+
+  func current() -> DesktopAutomationSnapshot {
+    snapshot
+  }
+}
+
+final class DesktopAutomationBridge {
+  static let shared = DesktopAutomationBridge()
+
+  private let queue = DispatchQueue(label: "com.omi.desktop.automation-bridge")
+  private var listener: NWListener?
+
+  private init() {}
+
+  func startIfNeeded() {
+    guard DesktopAutomationLaunchOptions.isEnabled else { return }
+    guard listener == nil else { return }
+
+    do {
+      let parameters = NWParameters.tcp
+      parameters.allowLocalEndpointReuse = true
+      guard let port = NWEndpoint.Port(rawValue: DesktopAutomationLaunchOptions.port) else {
+        log("DesktopAutomationBridge: invalid port \(DesktopAutomationLaunchOptions.port)")
+        return
+      }
+      let listener = try NWListener(using: parameters, on: port)
+      listener.newConnectionHandler = { [weak self] connection in
+        self?.handleConnection(connection)
+      }
+      listener.stateUpdateHandler = { (state: NWListener.State) in
+        log("DesktopAutomationBridge: listener state changed to \(String(describing: state))")
+      }
+      listener.start(queue: queue)
+      self.listener = listener
+      log(
+        "DesktopAutomationBridge: listening on http://127.0.0.1:\(DesktopAutomationLaunchOptions.port)"
+      )
+    } catch {
+      logError("DesktopAutomationBridge: failed to start listener", error: error)
+    }
+  }
+
+  private func handleConnection(_ connection: NWConnection) {
+    connection.start(queue: queue)
+    receiveRequest(on: connection, buffer: Data())
+  }
+
+  private func receiveRequest(on connection: NWConnection, buffer: Data) {
+    connection.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) {
+      [weak self] data, _, isComplete, error in
+      guard let self else { return }
+
+      if let error {
+        self.sendError(
+          "receive_failed: \(error.localizedDescription)", statusCode: 500, on: connection)
+        return
+      }
+
+      var accumulated = buffer
+      if let data {
+        accumulated.append(data)
+      }
+
+      if let request = self.parseRequest(from: accumulated) {
+        Task {
+          let response = await self.route(request: request)
+          self.send(response, on: connection)
+        }
+        return
+      }
+
+      if isComplete {
+        self.sendError("incomplete_request", statusCode: 400, on: connection)
+        return
+      }
+
+      self.receiveRequest(on: connection, buffer: accumulated)
+    }
+  }
+
+  private func parseRequest(from data: Data) -> HTTPRequest? {
+    guard let headerRange = data.range(of: Data("\r\n\r\n".utf8)) else {
+      return nil
+    }
+
+    let headerData = data[..<headerRange.lowerBound]
+    guard let headerString = String(data: headerData, encoding: .utf8) else {
+      return nil
+    }
+
+    let lines = headerString.components(separatedBy: "\r\n")
+    guard let requestLine = lines.first else { return nil }
+    let requestParts = requestLine.split(separator: " ")
+    guard requestParts.count >= 2 else { return nil }
+
+    let method = String(requestParts[0])
+    let path = String(requestParts[1])
+
+    var contentLength = 0
+    for line in lines.dropFirst() {
+      let pieces = line.split(separator: ":", maxSplits: 1)
+      guard pieces.count == 2 else { continue }
+      if pieces[0].lowercased() == "content-length" {
+        contentLength = Int(pieces[1].trimmingCharacters(in: .whitespaces)) ?? 0
+      }
+    }
+
+    let bodyStart = headerRange.upperBound
+    let expectedLength = data.distance(from: data.startIndex, to: bodyStart) + contentLength
+    guard data.count >= expectedLength else {
+      return nil
+    }
+
+    let body = Data(data[bodyStart..<data.index(bodyStart, offsetBy: contentLength)])
+    return HTTPRequest(method: method, path: path, body: body)
+  }
+
+  private func route(request: HTTPRequest) async -> HTTPResponse {
+    switch (request.method, request.path) {
+    case ("GET", "/health"):
+      let snapshot = await DesktopAutomationStateStore.shared.current()
+      return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
+    case ("GET", "/state"):
+      let snapshot = await DesktopAutomationStateStore.shared.current()
+      return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
+    case ("POST", "/navigate"):
+      do {
+        let payload = try JSONDecoder().decode(
+          DesktopAutomationNavigationRequest.self, from: request.body)
+        try await dispatchNavigation(payload)
+        try await Task.sleep(for: .milliseconds(150))
+        let snapshot = await DesktopAutomationStateStore.shared.current()
+        return jsonResponse(DesktopAutomationResponse(ok: true, result: snapshot, error: nil))
+      } catch {
+        return jsonResponse(
+          DesktopAutomationResponse<DesktopAutomationSnapshot>(
+            ok: false,
+            result: nil,
+            error: error.localizedDescription
+          ),
+          statusCode: 400
+        )
+      }
+    default:
+      return jsonResponse(
+        DesktopAutomationResponse<DesktopAutomationSnapshot>(
+          ok: false,
+          result: nil,
+          error: "unsupported_route"
+        ),
+        statusCode: 404
+      )
+    }
+  }
+
+  private func dispatchNavigation(_ payload: DesktopAutomationNavigationRequest) async throws {
+    await MainActor.run {
+      NotificationCenter.default.post(
+        name: .desktopAutomationNavigateRequested,
+        object: nil,
+        userInfo: [
+          "target": payload.target,
+          "settingsSection": payload.settingsSection as Any,
+          "highlightedSettingId": payload.highlightedSettingId as Any,
+          "activateApp": payload.activateApp ?? true,
+        ]
+      )
+    }
+  }
+
+  private func jsonResponse<T: Codable>(_ payload: T, statusCode: Int = 200) -> HTTPResponse {
+    do {
+      let body = try JSONEncoder.pretty.encode(payload)
+      return HTTPResponse(
+        statusCode: statusCode,
+        headers: ["Content-Type": "application/json"],
+        body: body
+      )
+    } catch {
+      let fallback = Data("{\"ok\":false,\"error\":\"encode_failed\"}".utf8)
+      return HTTPResponse(
+        statusCode: 500,
+        headers: ["Content-Type": "application/json"],
+        body: fallback
+      )
+    }
+  }
+
+  private func sendError(_ message: String, statusCode: Int, on connection: NWConnection) {
+    let response = jsonResponse(
+      DesktopAutomationResponse<DesktopAutomationSnapshot>(ok: false, result: nil, error: message),
+      statusCode: statusCode
+    )
+    send(response, on: connection)
+  }
+
+  private func send(_ response: HTTPResponse, on connection: NWConnection) {
+    let statusText: String
+    switch response.statusCode {
+    case 200: statusText = "OK"
+    case 400: statusText = "Bad Request"
+    case 404: statusText = "Not Found"
+    default: statusText = "Internal Server Error"
+    }
+
+    var headerLines = [
+      "HTTP/1.1 \(response.statusCode) \(statusText)",
+      "Content-Length: \(response.body.count)",
+      "Connection: close",
+    ]
+    for (key, value) in response.headers {
+      headerLines.append("\(key): \(value)")
+    }
+    headerLines.append("")
+    headerLines.append("")
+
+    var data = Data(headerLines.joined(separator: "\r\n").utf8)
+    data.append(response.body)
+
+    connection.send(
+      content: data,
+      completion: .contentProcessed { _ in
+        connection.cancel()
+      })
+  }
+}
+
+private struct HTTPRequest {
+  let method: String
+  let path: String
+  let body: Data
+}
+
+private struct HTTPResponse {
+  let statusCode: Int
+  let headers: [String: String]
+  let body: Data
+}
+
+extension JSONEncoder {
+  fileprivate static var pretty: JSONEncoder {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+    return encoder
+  }
+}

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2,8 +2,11 @@ import Cocoa
 import Combine
 import SwiftUI
 
-/// NSWindow subclass for the floating control bar.
-class FloatingControlBarWindow: NSWindow, NSWindowDelegate {
+/// NSPanel subclass for the floating control bar.
+///
+/// Using a non-activating panel lets the Ask Omi shortcut focus the floating bar
+/// without surfacing the main Omi window when the app is already running.
+class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     private static let positionKey = "FloatingControlBarPosition"
     private static let sizeKey = "FloatingControlBarSize"
     private static let defaultSize = NSSize(width: 40, height: 10)
@@ -56,7 +59,7 @@ class FloatingControlBarWindow: NSWindow, NSWindowDelegate {
 
         super.init(
             contentRect: initialRect,
-            styleMask: [.borderless],
+            styleMask: [.borderless, .nonactivatingPanel],
             backing: backingStoreType,
             defer: flag
         )
@@ -90,7 +93,7 @@ class FloatingControlBarWindow: NSWindow, NSWindowDelegate {
     }
 
     override var canBecomeKey: Bool { true }
-    override var canBecomeMain: Bool { true }
+    override var canBecomeMain: Bool { false }
 
     override func keyDown(with event: NSEvent) {
         // Esc closes the AI conversation only — never hides the entire bar
@@ -937,9 +940,8 @@ class FloatingControlBarManager {
     func openAIInput() {
         guard let window = window else { return }
 
-        // Activate only the app process so the floating bar can accept keyboard input
-        // without pulling the main Omi window in front of the current app.
-        NSRunningApplication.current.activate(options: [.activateIgnoringOtherApps])
+        // The bar is a non-activating panel, so it can become key for text input
+        // without surfacing the main Omi window.
 
         // If a conversation is already showing, just focus the follow-up input
         if window.state.showingAIConversation && window.state.showingAIResponse {

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -7,574 +7,735 @@ import SwiftUI
 /// This protocol + extension lets us access sizingOptions through existential dispatch.
 @MainActor
 private protocol HostingSizingConfigurable: AnyObject {
-    var sizingOptions: NSHostingSizingOptions { get set }
+  var sizingOptions: NSHostingSizingOptions { get set }
 }
 extension NSHostingView: HostingSizingConfigurable {}
 
 struct DesktopHomeView: View {
-    @StateObject private var appState = AppState()
-    @StateObject private var viewModelContainer = ViewModelContainer()
-    @ObservedObject private var authState = AuthState.shared
-    @State private var selectedIndex: Int = {
-        if OMIApp.launchMode == .rewind { return SidebarNavItem.rewind.rawValue }
-        let tier = UserDefaults.standard.integer(forKey: "currentTierLevel")
-        return SidebarNavItem.dashboard.rawValue
-    }()
-    @State private var isSidebarCollapsed: Bool = false
-    @AppStorage("currentTierLevel") private var currentTierLevel = 0
-    @AppStorage("onboardingStep") private var onboardingStep = 0
-    @AppStorage("onboardingJustCompleted") private var onboardingJustCompleted = false
+  @StateObject private var appState = AppState()
+  @StateObject private var viewModelContainer = ViewModelContainer()
+  @ObservedObject private var authState = AuthState.shared
+  @State private var selectedIndex: Int = {
+    if OMIApp.launchMode == .rewind { return SidebarNavItem.rewind.rawValue }
+    let tier = UserDefaults.standard.integer(forKey: "currentTierLevel")
+    return SidebarNavItem.dashboard.rawValue
+  }()
+  @State private var isSidebarCollapsed: Bool = false
+  @AppStorage("currentTierLevel") private var currentTierLevel = 0
+  @AppStorage("onboardingStep") private var onboardingStep = 0
+  @AppStorage("onboardingJustCompleted") private var onboardingJustCompleted = false
 
-    // Settings sidebar state
-    @State private var selectedSettingsSection: SettingsContentView.SettingsSection = .general
-    @State private var highlightedSettingId: String? = nil
-    @State private var previousIndexBeforeSettings: Int = 0
-    @State private var logoPulse = false
+  // Settings sidebar state
+  @State private var selectedSettingsSection: SettingsContentView.SettingsSection = .general
+  @State private var highlightedSettingId: String? = nil
+  @State private var previousIndexBeforeSettings: Int = 0
+  @State private var logoPulse = false
 
-    // Pre-loaded hero logo to avoid NSImage init crashes during SwiftUI body evaluation
-    private static let heroLogoImage: NSImage? = {
-        guard let url = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
-              let data = try? Data(contentsOf: url) else { return nil }
-        return NSImage(data: data)
-    }()
+  // Pre-loaded hero logo to avoid NSImage init crashes during SwiftUI body evaluation
+  private static let heroLogoImage: NSImage? = {
+    guard let url = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
+      let data = try? Data(contentsOf: url)
+    else { return nil }
+    return NSImage(data: data)
+  }()
 
+  /// Whether we're currently viewing the settings page
+  private var isInSettings: Bool {
+    selectedIndex == SidebarNavItem.settings.rawValue
+  }
 
-    /// Whether we're currently viewing the settings page
-    private var isInSettings: Bool {
-        selectedIndex == SidebarNavItem.settings.rawValue
-    }
-
-    var body: some View {
-        Group {
-            if authState.isRestoringAuth {
-                // State 0: Restoring auth session - show loading
-                VStack(spacing: 16) {
-                    if let nsImage = Self.heroLogoImage {
-                        Image(nsImage: nsImage)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 64, height: 64)
-                    }
-                    ProgressView()
-                        .scaleEffect(0.8)
-                        .tint(.white.opacity(0.6))
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .onAppear {
-                    log("DesktopHomeView: Showing auth loading splash")
-                }
-            } else if !authState.isSignedIn {
-                // State 1: Not signed in - show sign in
-                SignInView(authState: authState)
-                    .onAppear {
-                        log("DesktopHomeView: Showing SignInView (not signed in)")
-                    }
-            } else if !appState.hasCompletedOnboarding {
-                // State 2: Signed in but onboarding not complete
-                if shouldSkipOnboarding() {
-                    Color.clear.onAppear {
-                        log("DesktopHomeView: --skip-onboarding flag detected, skipping onboarding")
-                        appState.hasCompletedOnboarding = true
-                    }
-                } else {
-                    OnboardingView(appState: appState, chatProvider: viewModelContainer.chatProvider, onComplete: nil)
-                        .onAppear {
-                            log("DesktopHomeView: Showing OnboardingView (signed in, not onboarded)")
-                        }
-                }
-            } else {
-                // State 3: Signed in and onboarded - show main content
-                ZStack {
-                    // After onboarding completes, navigate to Tasks page
-                    Color.clear
-                        .frame(width: 0, height: 0)
-                        .onAppear {
-                            if UserDefaults.standard.bool(forKey: "onboardingJustCompleted") {
-                                UserDefaults.standard.removeObject(forKey: "onboardingJustCompleted")
-                                log("DesktopHomeView: Onboarding just completed — navigating to Tasks page")
-                                selectedIndex = SidebarNavItem.tasks.rawValue
-                            }
-                        }
-                    mainContent
-                        .opacity(viewModelContainer.isInitialLoadComplete ? 1 : 0)
-                        .onAppear {
-                            log("DesktopHomeView: Showing mainContent (signed in and onboarded)")
-                            // Check all permissions on launch
-                            appState.checkAllPermissions()
-
-                            // For existing users who haven't indexed files yet, run a background scan
-                            if !UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing") {
-                                UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
-                                Task {
-                                    log("DesktopHomeView: Running background file scan for existing user")
-                                    await FileIndexerService.shared.backgroundRescan()
-                                }
-                            }
-
-                            let settings = AssistantSettings.shared
-
-                            // Auto-start transcription if enabled in settings
-                            if settings.transcriptionEnabled && !appState.isTranscribing {
-                                log("DesktopHomeView: Auto-starting transcription")
-                                appState.startTranscription()
-                            } else if !settings.transcriptionEnabled {
-                                log("DesktopHomeView: Transcription disabled in settings, skipping auto-start")
-                            }
-
-                            // Migration: one-time reset for users whose screenAnalysisEnabled
-                            // was incorrectly set to false by a bug in syncMonitoringState() that
-                            // persisted false whenever monitoring stopped for any reason.
-                            // v2: re-run because the root cause (syncMonitoringState disabling the
-                            // setting) was only fixed in this release, so v1 users got re-broken.
-                            let migrationKey = "screenAnalysisAutoStartFixed_v2"
-                            if !UserDefaults.standard.bool(forKey: migrationKey) {
-                                UserDefaults.standard.set(true, forKey: "screenAnalysisEnabled")
-                                AssistantSettings.shared.screenAnalysisEnabled = true
-                                UserDefaults.standard.set(true, forKey: migrationKey)
-                                log("DesktopHomeView: Applied screenAnalysisAutoStart v2 migration — reset to enabled")
-                                // Push true to server so syncFromServer() doesn't revert it
-                                Task { await SettingsSyncManager.shared.syncToServer() }
-                            }
-
-                            // Start proactive assistants monitoring if enabled in settings
-                            if settings.screenAnalysisEnabled {
-                                ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
-                                    if success {
-                                        log("DesktopHomeView: Screen analysis started")
-                                    } else {
-                                        log("DesktopHomeView: Screen analysis failed to start: \(error ?? "unknown") — setting remains enabled for next launch")
-                                    }
-                                }
-                            } else {
-                                log("DesktopHomeView: Screen analysis disabled in settings, skipping auto-start")
-                            }
-
-                            // Start Crisp chat in background for notifications
-                            CrispManager.shared.start()
-
-                            // Set up floating control bar (only show if user hasn't disabled it)
-                            FloatingControlBarManager.shared.setup(appState: appState, chatProvider: viewModelContainer.chatProvider)
-                            if FloatingControlBarManager.shared.isEnabled {
-                                FloatingControlBarManager.shared.show()
-                            }
-
-                            // Set up push-to-talk voice input
-                            if let barState = FloatingControlBarManager.shared.barState {
-                                PushToTalkManager.shared.setup(barState: barState)
-                            }
-                        }
-                        .task {
-                            // Trigger eager data loading when main content appears
-                            // Load conversations/folders in parallel with other data
-                            async let vmLoad: Void = viewModelContainer.loadAllData()
-                            async let conversations: Void = appState.loadConversations()
-                            async let folders: Void = appState.loadFolders()
-                            _ = await (vmLoad, conversations, folders)
-
-                            // Backend-based check: ensure user has a cloud agent VM
-                            await AgentVMService.shared.ensureProvisioned()
-                        }
-                        // Refresh conversations when app becomes active (e.g. switching back from another app)
-                        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-                            Task { await appState.refreshConversations() }
-                            // Auto-start monitoring when returning to app if screen analysis is enabled
-                            // but monitoring is not running. Handles the case where the user granted
-                            // screen recording permission in System Settings and switched back.
-                            let plugin = ProactiveAssistantsPlugin.shared
-                            if AssistantSettings.shared.screenAnalysisEnabled && !plugin.isMonitoring {
-                                plugin.refreshScreenRecordingPermission()
-                                if plugin.hasScreenRecordingPermission {
-                                    log("DesktopHomeView: Permission available on app active — starting monitoring")
-                                    plugin.startMonitoring { _, _ in }
-                                }
-                            }
-                        }
-                        // Periodic refresh every 30s to pick up conversations from other devices (e.g. Omi Glass)
-                        .onReceive(Timer.publish(every: 30, on: .main, in: .common).autoconnect()) { _ in
-                            Task { await appState.refreshConversations() }
-                        }
-                        // On sign-out: reset @AppStorage-backed onboarding flag and stop transcription.
-                        // hasCompletedOnboarding must be set here (in a View) because @AppStorage
-                        // on ObservableObject caches internally and ignores UserDefaults.removeObject().
-                        // Stopping transcription here prevents FOREIGN KEY errors from an old
-                        // transcription session writing to a new user's database.
-                        .onReceive(NotificationCenter.default.publisher(for: .userDidSignOut)) { _ in
-                            log("DesktopHomeView: userDidSignOut — resetting hasCompletedOnboarding and stopping transcription")
-                            appState.hasCompletedOnboarding = false
-                            appState.stopTranscription()
-                        }
-                        .onReceive(NotificationCenter.default.publisher(for: .resetOnboardingRequested)) { _ in
-                            log("DesktopHomeView: resetOnboardingRequested — clearing live onboarding state for current app")
-                            appState.hasCompletedOnboarding = false
-                            onboardingStep = 0
-                            onboardingJustCompleted = false
-                            appState.stopTranscription()
-                        }
-                        // Handle transcription toggle from menu bar
-                        .onReceive(NotificationCenter.default.publisher(for: .toggleTranscriptionRequested)) { notification in
-                            if let enabled = notification.userInfo?["enabled"] as? Bool {
-                                log("DesktopHomeView: Menu bar toggled transcription: \(enabled)")
-                                if enabled {
-                                    appState.startTranscription()
-                                } else {
-                                    appState.stopTranscription()
-                                }
-                            }
-                        }
-                        // Periodic file re-scan (every 3 hours)
-                        .task {
-                            while !Task.isCancelled {
-                                try? await Task.sleep(for: .seconds(3 * 60 * 60))
-                                guard !Task.isCancelled else { break }
-                                guard UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing") else { continue }
-                                log("DesktopHomeView: Triggering background file rescan")
-                                await FileIndexerService.shared.backgroundRescan()
-                            }
-                        }
-                        .onReceive(NotificationCenter.default.publisher(for: .triggerFileIndexing)) { _ in
-                            // Background rescan — no loading screen needed
-                            Task {
-                                log("DesktopHomeView: File indexing triggered from settings, running background rescan")
-                                await FileIndexerService.shared.backgroundRescan()
-                            }
-                        }
-
-                    if !viewModelContainer.isInitialLoadComplete {
-                        VStack(spacing: 24) {
-                            if let nsImage = Self.heroLogoImage {
-                                Image(nsImage: nsImage)
-                                    .resizable()
-                                    .scaledToFit()
-                                    .frame(width: 72, height: 72)
-                                    .scaleEffect(logoPulse ? 1.08 : 1.0)
-                                    .opacity(logoPulse ? 1.0 : 0.7)
-                                    .animation(
-                                        .easeInOut(duration: 1.2).repeatForever(autoreverses: true),
-                                        value: logoPulse
-                                    )
-                                    .onAppear { logoPulse = true }
-                            }
-
-                            Text(viewModelContainer.initStatusMessage)
-                                .scaledFont(size: 14, weight: .medium)
-                                .foregroundColor(OmiColors.textTertiary)
-
-                            ProgressView()
-                                .scaleEffect(0.8)
-                                .tint(OmiColors.purplePrimary.opacity(0.6))
-                        }
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        .background(OmiColors.backgroundPrimary)
-                        .transition(.opacity.animation(.easeOut(duration: 0.3)))
-                    }
-                }
-            }
+  var body: some View {
+    Group {
+      if authState.isRestoringAuth {
+        // State 0: Restoring auth session - show loading
+        VStack(spacing: 16) {
+          if let nsImage = Self.heroLogoImage {
+            Image(nsImage: nsImage)
+              .resizable()
+              .scaledToFit()
+              .frame(width: 64, height: 64)
+          }
+          ProgressView()
+            .scaleEffect(0.8)
+            .tint(.white.opacity(0.6))
         }
-        .background(OmiColors.backgroundPrimary)
-        .frame(minWidth: 900, minHeight: 600)
-        .preferredColorScheme(.dark)
-        .tint(OmiColors.purplePrimary)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear {
-            log("DesktopHomeView: View appeared - isSignedIn=\(authState.isSignedIn), hasCompletedOnboarding=\(appState.hasCompletedOnboarding)")
-            // Force dark appearance and disable minSize computation on NSHostingView.
-            // By default, every @Published change triggers
-            // updateWindowContentSizeExtremaIfNecessary() → minSize() → sizeThatFits()
-            // which traverses the ENTIRE view tree (~200 samples per window per trigger).
-            // Removing .minSize from sizingOptions prevents this full-tree traversal.
-            // The window's min size is enforced at the AppKit level instead.
-            DispatchQueue.main.async {
-                for window in NSApp.windows {
-                    if window.title.lowercased().hasPrefix("omi") {
-                        window.appearance = NSAppearance(named: .darkAqua)
-                        window.minSize = NSSize(width: 900, height: 600)
-                        // Remove .minSize from hosting view's sizingOptions.
-                        // Search contentView itself + all descendants.
-                        Self.disableMinSizeComputation(in: window)
-                    }
-                }
-            }
-            // Redirect if current page isn't visible at current tier
-            redirectIfPageHidden()
+          log("DesktopHomeView: Showing auth loading splash")
         }
-        .onChange(of: currentTierLevel) { _, _ in
-            redirectIfPageHidden()
+      } else if !authState.isSignedIn {
+        // State 1: Not signed in - show sign in
+        SignInView(authState: authState)
+          .onAppear {
+            log("DesktopHomeView: Showing SignInView (not signed in)")
+          }
+      } else if !appState.hasCompletedOnboarding {
+        // State 2: Signed in but onboarding not complete
+        if shouldSkipOnboarding() {
+          Color.clear.onAppear {
+            log("DesktopHomeView: --skip-onboarding flag detected, skipping onboarding")
+            appState.hasCompletedOnboarding = true
+          }
+        } else {
+          OnboardingView(
+            appState: appState, chatProvider: viewModelContainer.chatProvider, onComplete: nil
+          )
+          .onAppear {
+            log("DesktopHomeView: Showing OnboardingView (signed in, not onboarded)")
+          }
         }
-    }
-
-    /// Recursively find all NSHostingViews in a window and set sizingOptions to [],
-    /// disabling ALL size computations to prevent full-tree sizeThatFits() traversals.
-    /// Window min/max sizes are enforced at the AppKit level via NSWindow.minSize instead.
-    /// NOTE: ClickThroughHostingView is excluded because it wraps the sidebar and needs
-    /// intrinsicContentSize for SwiftUI's .fixedSize() layout to compute the correct width.
-    private static func disableMinSizeComputation(in window: NSWindow) {
-        func visit(_ view: NSView) {
-            if let hosting = view as? any HostingSizingConfigurable {
-                // Skip ClickThroughHostingView — it's an NSViewRepresentable boundary
-                // that needs intrinsicContentSize for the sidebar's .fixedSize() to work.
-                let typeName = String(describing: type(of: view))
-                guard !typeName.contains("ClickThroughHostingView") else {
-                    log("DesktopHomeView: Skipping sizingOptions on \(typeName) (needs intrinsic size)")
-                    // Still visit children
-                    for subview in view.subviews { visit(subview) }
-                    return
-                }
-                let before = hosting.sizingOptions
-                hosting.sizingOptions = []
-                log("DesktopHomeView: Set sizingOptions on \(type(of: view)): \(before) → []")
-            }
-            for subview in view.subviews {
-                visit(subview)
-            }
-        }
-        if let contentView = window.contentView {
-            visit(contentView)
-        }
-    }
-
-    /// Redirect to conversations if current page isn't visible at the current tier level
-    private func redirectIfPageHidden() {
-        // Tier 0 or tier 6+ shows everything — no redirect needed
-        guard currentTierLevel > 0 && currentTierLevel < 6 else { return }
-        // Don't redirect from settings/permissions/device/help pages
-        let nonMainPages: Set<Int> = [SidebarNavItem.settings.rawValue, SidebarNavItem.permissions.rawValue, SidebarNavItem.device.rawValue, SidebarNavItem.help.rawValue]
-        guard !nonMainPages.contains(selectedIndex) else { return }
-
-        var visibleRawValues: Set<Int> = [SidebarNavItem.dashboard.rawValue, SidebarNavItem.rewind.rawValue]
-        if currentTierLevel >= 2 { visibleRawValues.insert(SidebarNavItem.memories.rawValue) }
-        if currentTierLevel >= 3 { visibleRawValues.insert(SidebarNavItem.tasks.rawValue) }
-        if currentTierLevel >= 4 { visibleRawValues.insert(SidebarNavItem.chat.rawValue) }
-
-        if !visibleRawValues.contains(selectedIndex) {
-            selectedIndex = SidebarNavItem.dashboard.rawValue
-        }
-    }
-
-    /// Whether to hide the sidebar (rewind mode)
-    private var hideSidebar: Bool {
-        OMIApp.launchMode == .rewind
-    }
-
-    /// Update store auto-refresh based on which page is visible
-    /// On launch, if the user quit with the task chat panel open, macOS restores the
-    /// expanded window frame but the chat panel itself is not shown. Shrink the window
-    /// back to its pre-chat width so the layout isn't unexpectedly wide.
-    private func restorePreChatWindowWidth() {
-        let key = "tasksPreChatWindowWidth"
-        let saved = UserDefaults.standard.double(forKey: key)
-        guard saved > 0 else { return }
-        // Reset the persisted value immediately so TasksPage won't double-shrink
-        UserDefaults.standard.set(Double(0), forKey: key)
-        // Delay slightly so the window is fully visible
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            guard let window = NSApp.windows.first(where: { $0.title.hasPrefix("Omi") && $0.isVisible }) else { return }
-            var frame = window.frame
-            frame.size.width = saved
-            window.setFrame(frame, display: true)
-        }
-    }
-
-    private func updateStoreActivity(for index: Int) {
-        viewModelContainer.tasksStore.isActive =
-            index == SidebarNavItem.dashboard.rawValue || index == SidebarNavItem.tasks.rawValue
-        viewModelContainer.memoriesViewModel.isActive =
-            index == SidebarNavItem.memories.rawValue
-    }
-
-    private var mainContent: some View {
-        HStack(spacing: 0) {
-            // Sidebar slot: settings sidebar overlays main sidebar
-            // IMPORTANT: SidebarView is kept alive (but hidden) when in settings to prevent
-            // EXC_BAD_ACCESS crash in SwiftUI's tooltip system. When the view is conditionally
-            // removed, its .help() tooltip graph nodes get invalidated, but the macOS tooltip
-            // tracking system still tries to evaluate them during window key state changes.
-            ZStack {
-                if !hideSidebar {
-                    SidebarView(
-                        selectedIndex: $selectedIndex,
-                        isCollapsed: $isSidebarCollapsed,
-                        appState: appState
-                    )
-                    .clickThrough(enabled: !isInSettings)
-                    .opacity(isInSettings ? 0 : 1)
-                    .allowsHitTesting(!isInSettings)
-                }
-
-                if isInSettings {
-                    SettingsSidebar(
-                        selectedSection: $selectedSettingsSection,
-                        highlightedSettingId: $highlightedSettingId,
-                        onBack: {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                selectedIndex = previousIndexBeforeSettings
-                            }
-                        }
-                    )
-                }
-            }
-            .fixedSize(horizontal: true, vertical: false)
-            .clipped()
-
-            // Main content area with rounded container
-            ZStack {
-                // Content container background
-                RoundedRectangle(cornerRadius: 16)
-                    .fill(OmiColors.backgroundSecondary.opacity(0.4))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 16)
-                            .stroke(OmiColors.backgroundTertiary.opacity(0.3), lineWidth: 1)
-                    )
-                    .shadow(color: .black.opacity(0.05), radius: 20, x: 0, y: 4)
-
-                // Page content - switch recreates views on tab change
-                // Extracted into a separate struct so that pages like TasksPage
-                // are not re-rendered when AppState publishes unrelated changes.
-                PageContentView(
-                    selectedIndex: selectedIndex,
-                    appState: appState,
-                    viewModelContainer: viewModelContainer,
-                    selectedSettingsSection: $selectedSettingsSection,
-                    highlightedSettingId: $highlightedSettingId,
-                    selectedTabIndex: $selectedIndex
-                )
-                .id(selectedIndex)
-                .transition(.opacity.combined(with: .move(edge: .trailing)))
-                .animation(.easeInOut(duration: 0.2), value: selectedIndex)
-                .clipShape(RoundedRectangle(cornerRadius: 16))
-            }
-            .padding(12)
-        }
-        .overlay {
-            // Goal completion celebration overlay
-            GoalCelebrationView()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindSettings)) { _ in
-            // Set the section directly and navigate to settings
-            selectedSettingsSection = .rewind
-            withAnimation(.easeInOut(duration: 0.2)) {
-                selectedIndex = SidebarNavItem.settings.rawValue
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToDeviceSettings)) { _ in
-            // Set the section directly and navigate to settings
-            withAnimation(.easeInOut(duration: 0.2)) {
-                selectedIndex = SidebarNavItem.settings.rawValue
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in
-            // Navigate to settings > advanced > task assistant subsection
-            selectedSettingsSection = .advanced
-            withAnimation(.easeInOut(duration: 0.2)) {
-                selectedIndex = SidebarNavItem.settings.rawValue
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToFloatingBarSettings)) { _ in
-            selectedSettingsSection = .advanced
-            withAnimation(.easeInOut(duration: 0.2)) {
-                selectedIndex = SidebarNavItem.settings.rawValue
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToAIChatSettings)) { _ in
-            selectedSettingsSection = .aiChat
-            withAnimation(.easeInOut(duration: 0.2)) {
-                selectedIndex = SidebarNavItem.settings.rawValue
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToRewind)) { _ in
-            // Navigate to Rewind page (index 6) - triggered by global hotkey Cmd+Option+R
-            log("DesktopHomeView: Received navigateToRewind notification, navigating to Rewind (index \(SidebarNavItem.rewind.rawValue))")
-            withAnimation(.easeInOut(duration: 0.2)) {
-                selectedIndex = SidebarNavItem.rewind.rawValue
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindNotes)) { _ in
-            withAnimation(.easeInOut(duration: 0.2)) {
-                selectedIndex = SidebarNavItem.rewind.rawValue
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-                NotificationCenter.default.post(name: .expandRewindTranscript, object: nil)
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToChat)) { _ in
-            withAnimation(.easeInOut(duration: 0.2)) {
-                selectedIndex = SidebarNavItem.chat.rawValue
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToTasks)) { _ in
-            withAnimation(.easeInOut(duration: 0.2)) {
+      } else {
+        // State 3: Signed in and onboarded - show main content
+        ZStack {
+          // After onboarding completes, navigate to Tasks page
+          Color.clear
+            .frame(width: 0, height: 0)
+            .onAppear {
+              if UserDefaults.standard.bool(forKey: "onboardingJustCompleted") {
+                UserDefaults.standard.removeObject(forKey: "onboardingJustCompleted")
+                log("DesktopHomeView: Onboarding just completed — navigating to Tasks page")
                 selectedIndex = SidebarNavItem.tasks.rawValue
+              }
             }
-        }
-        .onChange(of: selectedIndex) { oldValue, newValue in
-            // Track the previous index when navigating to settings
-            if newValue == SidebarNavItem.settings.rawValue && oldValue != SidebarNavItem.settings.rawValue {
-                previousIndexBeforeSettings = oldValue
+          mainContent
+            .opacity(viewModelContainer.isInitialLoadComplete ? 1 : 0)
+            .onAppear {
+              log("DesktopHomeView: Showing mainContent (signed in and onboarded)")
+              // Check all permissions on launch
+              appState.checkAllPermissions()
+
+              // For existing users who haven't indexed files yet, run a background scan
+              if !UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing") {
+                UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
+                Task {
+                  log("DesktopHomeView: Running background file scan for existing user")
+                  await FileIndexerService.shared.backgroundRescan()
+                }
+              }
+
+              let settings = AssistantSettings.shared
+
+              // Auto-start transcription if enabled in settings
+              if settings.transcriptionEnabled && !appState.isTranscribing {
+                log("DesktopHomeView: Auto-starting transcription")
+                appState.startTranscription()
+              } else if !settings.transcriptionEnabled {
+                log("DesktopHomeView: Transcription disabled in settings, skipping auto-start")
+              }
+
+              // Migration: one-time reset for users whose screenAnalysisEnabled
+              // was incorrectly set to false by a bug in syncMonitoringState() that
+              // persisted false whenever monitoring stopped for any reason.
+              // v2: re-run because the root cause (syncMonitoringState disabling the
+              // setting) was only fixed in this release, so v1 users got re-broken.
+              let migrationKey = "screenAnalysisAutoStartFixed_v2"
+              if !UserDefaults.standard.bool(forKey: migrationKey) {
+                UserDefaults.standard.set(true, forKey: "screenAnalysisEnabled")
+                AssistantSettings.shared.screenAnalysisEnabled = true
+                UserDefaults.standard.set(true, forKey: migrationKey)
+                log(
+                  "DesktopHomeView: Applied screenAnalysisAutoStart v2 migration — reset to enabled"
+                )
+                // Push true to server so syncFromServer() doesn't revert it
+                Task { await SettingsSyncManager.shared.syncToServer() }
+              }
+
+              // Start proactive assistants monitoring if enabled in settings
+              if settings.screenAnalysisEnabled {
+                ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
+                  if success {
+                    log("DesktopHomeView: Screen analysis started")
+                  } else {
+                    log(
+                      "DesktopHomeView: Screen analysis failed to start: \(error ?? "unknown") — setting remains enabled for next launch"
+                    )
+                  }
+                }
+              } else {
+                log("DesktopHomeView: Screen analysis disabled in settings, skipping auto-start")
+              }
+
+              // Start Crisp chat in background for notifications
+              CrispManager.shared.start()
+
+              // Set up floating control bar (only show if user hasn't disabled it)
+              FloatingControlBarManager.shared.setup(
+                appState: appState, chatProvider: viewModelContainer.chatProvider)
+              if FloatingControlBarManager.shared.isEnabled {
+                FloatingControlBarManager.shared.show()
+              }
+
+              // Set up push-to-talk voice input
+              if let barState = FloatingControlBarManager.shared.barState {
+                PushToTalkManager.shared.setup(barState: barState)
+              }
             }
-            // Only auto-refresh stores when their pages are visible
-            updateStoreActivity(for: newValue)
+            .task {
+              // Trigger eager data loading when main content appears
+              // Load conversations/folders in parallel with other data
+              async let vmLoad: Void = viewModelContainer.loadAllData()
+              async let conversations: Void = appState.loadConversations()
+              async let folders: Void = appState.loadFolders()
+              _ = await (vmLoad, conversations, folders)
+
+              // Backend-based check: ensure user has a cloud agent VM
+              await AgentVMService.shared.ensureProvisioned()
+            }
+            // Refresh conversations when app becomes active (e.g. switching back from another app)
+            .onReceive(
+              NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+            ) { _ in
+              Task { await appState.refreshConversations() }
+              // Auto-start monitoring when returning to app if screen analysis is enabled
+              // but monitoring is not running. Handles the case where the user granted
+              // screen recording permission in System Settings and switched back.
+              let plugin = ProactiveAssistantsPlugin.shared
+              if AssistantSettings.shared.screenAnalysisEnabled && !plugin.isMonitoring {
+                plugin.refreshScreenRecordingPermission()
+                if plugin.hasScreenRecordingPermission {
+                  log("DesktopHomeView: Permission available on app active — starting monitoring")
+                  plugin.startMonitoring { _, _ in }
+                }
+              }
+            }
+            // Periodic refresh every 30s to pick up conversations from other devices (e.g. Omi Glass)
+            .onReceive(Timer.publish(every: 30, on: .main, in: .common).autoconnect()) { _ in
+              Task { await appState.refreshConversations() }
+            }
+            // On sign-out: reset @AppStorage-backed onboarding flag and stop transcription.
+            // hasCompletedOnboarding must be set here (in a View) because @AppStorage
+            // on ObservableObject caches internally and ignores UserDefaults.removeObject().
+            // Stopping transcription here prevents FOREIGN KEY errors from an old
+            // transcription session writing to a new user's database.
+            .onReceive(NotificationCenter.default.publisher(for: .userDidSignOut)) { _ in
+              log(
+                "DesktopHomeView: userDidSignOut — resetting hasCompletedOnboarding and stopping transcription"
+              )
+              appState.hasCompletedOnboarding = false
+              appState.stopTranscription()
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .resetOnboardingRequested)) { _ in
+              log(
+                "DesktopHomeView: resetOnboardingRequested — clearing live onboarding state for current app"
+              )
+              appState.hasCompletedOnboarding = false
+              onboardingStep = 0
+              onboardingJustCompleted = false
+              appState.stopTranscription()
+            }
+            // Handle transcription toggle from menu bar
+            .onReceive(NotificationCenter.default.publisher(for: .toggleTranscriptionRequested)) {
+              notification in
+              if let enabled = notification.userInfo?["enabled"] as? Bool {
+                log("DesktopHomeView: Menu bar toggled transcription: \(enabled)")
+                if enabled {
+                  appState.startTranscription()
+                } else {
+                  appState.stopTranscription()
+                }
+              }
+            }
+            // Periodic file re-scan (every 3 hours)
+            .task {
+              while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(3 * 60 * 60))
+                guard !Task.isCancelled else { break }
+                guard UserDefaults.standard.bool(forKey: "hasCompletedFileIndexing") else {
+                  continue
+                }
+                log("DesktopHomeView: Triggering background file rescan")
+                await FileIndexerService.shared.backgroundRescan()
+              }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .triggerFileIndexing)) { _ in
+              // Background rescan — no loading screen needed
+              Task {
+                log(
+                  "DesktopHomeView: File indexing triggered from settings, running background rescan"
+                )
+                await FileIndexerService.shared.backgroundRescan()
+              }
+            }
+
+          if !viewModelContainer.isInitialLoadComplete {
+            VStack(spacing: 24) {
+              if let nsImage = Self.heroLogoImage {
+                Image(nsImage: nsImage)
+                  .resizable()
+                  .scaledToFit()
+                  .frame(width: 72, height: 72)
+                  .scaleEffect(logoPulse ? 1.08 : 1.0)
+                  .opacity(logoPulse ? 1.0 : 0.7)
+                  .animation(
+                    .easeInOut(duration: 1.2).repeatForever(autoreverses: true),
+                    value: logoPulse
+                  )
+                  .onAppear { logoPulse = true }
+              }
+
+              Text(viewModelContainer.initStatusMessage)
+                .scaledFont(size: 14, weight: .medium)
+                .foregroundColor(OmiColors.textTertiary)
+
+              ProgressView()
+                .scaleEffect(0.8)
+                .tint(OmiColors.purplePrimary.opacity(0.6))
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(OmiColors.backgroundPrimary)
+            .transition(.opacity.animation(.easeOut(duration: 0.3)))
+          }
         }
-        .onAppear {
-            updateStoreActivity(for: selectedIndex)
-            // Restore window width if the user quit with task chat panel open.
-            // The chat panel is never open on startup (showChatPanel defaults to false),
-            // but macOS restores the expanded window frame from the previous session.
-            restorePreChatWindowWidth()
-        }
+      }
     }
+    .background(OmiColors.backgroundPrimary)
+    .frame(minWidth: 900, minHeight: 600)
+    .preferredColorScheme(.dark)
+    .tint(OmiColors.purplePrimary)
+    .onAppear {
+      log(
+        "DesktopHomeView: View appeared - isSignedIn=\(authState.isSignedIn), hasCompletedOnboarding=\(appState.hasCompletedOnboarding)"
+      )
+      // Force dark appearance and disable minSize computation on NSHostingView.
+      // By default, every @Published change triggers
+      // updateWindowContentSizeExtremaIfNecessary() → minSize() → sizeThatFits()
+      // which traverses the ENTIRE view tree (~200 samples per window per trigger).
+      // Removing .minSize from sizingOptions prevents this full-tree traversal.
+      // The window's min size is enforced at the AppKit level instead.
+      DispatchQueue.main.async {
+        for window in NSApp.windows {
+          if window.title.lowercased().hasPrefix("omi") {
+            window.appearance = NSAppearance(named: .darkAqua)
+            window.minSize = NSSize(width: 900, height: 600)
+            // Remove .minSize from hosting view's sizingOptions.
+            // Search contentView itself + all descendants.
+            Self.disableMinSizeComputation(in: window)
+          }
+        }
+      }
+      // Redirect if current page isn't visible at current tier
+      redirectIfPageHidden()
+      reportAutomationState()
+    }
+    .onChange(of: currentTierLevel) { _, _ in
+      redirectIfPageHidden()
+      reportAutomationState()
+    }
+    .onChange(of: selectedIndex) { _, _ in reportAutomationState() }
+    .onChange(of: selectedSettingsSection) { _, _ in reportAutomationState() }
+    .onChange(of: highlightedSettingId) { _, _ in reportAutomationState() }
+    .onChange(of: authState.isSignedIn) { _, _ in reportAutomationState() }
+    .onChange(of: authState.isRestoringAuth) { _, _ in reportAutomationState() }
+    .onChange(of: appState.hasCompletedOnboarding) { _, _ in reportAutomationState() }
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
+    { _ in
+      reportAutomationState()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didResignActiveNotification))
+    { _ in
+      reportAutomationState()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .desktopAutomationNavigateRequested)) {
+      notification in
+      handleAutomationNavigation(notification)
+    }
+  }
+
+  /// Recursively find all NSHostingViews in a window and set sizingOptions to [],
+  /// disabling ALL size computations to prevent full-tree sizeThatFits() traversals.
+  /// Window min/max sizes are enforced at the AppKit level via NSWindow.minSize instead.
+  /// NOTE: ClickThroughHostingView is excluded because it wraps the sidebar and needs
+  /// intrinsicContentSize for SwiftUI's .fixedSize() layout to compute the correct width.
+  private static func disableMinSizeComputation(in window: NSWindow) {
+    func visit(_ view: NSView) {
+      if let hosting = view as? any HostingSizingConfigurable {
+        // Skip ClickThroughHostingView — it's an NSViewRepresentable boundary
+        // that needs intrinsicContentSize for the sidebar's .fixedSize() to work.
+        let typeName = String(describing: type(of: view))
+        guard !typeName.contains("ClickThroughHostingView") else {
+          log("DesktopHomeView: Skipping sizingOptions on \(typeName) (needs intrinsic size)")
+          // Still visit children
+          for subview in view.subviews { visit(subview) }
+          return
+        }
+        let before = hosting.sizingOptions
+        hosting.sizingOptions = []
+        log("DesktopHomeView: Set sizingOptions on \(type(of: view)): \(before) → []")
+      }
+      for subview in view.subviews {
+        visit(subview)
+      }
+    }
+    if let contentView = window.contentView {
+      visit(contentView)
+    }
+  }
+
+  /// Redirect to conversations if current page isn't visible at the current tier level
+  private func redirectIfPageHidden() {
+    // Tier 0 or tier 6+ shows everything — no redirect needed
+    guard currentTierLevel > 0 && currentTierLevel < 6 else { return }
+    // Don't redirect from settings/permissions/device/help pages
+    let nonMainPages: Set<Int> = [
+      SidebarNavItem.settings.rawValue, SidebarNavItem.permissions.rawValue,
+      SidebarNavItem.device.rawValue, SidebarNavItem.help.rawValue,
+    ]
+    guard !nonMainPages.contains(selectedIndex) else { return }
+
+    var visibleRawValues: Set<Int> = [
+      SidebarNavItem.dashboard.rawValue, SidebarNavItem.rewind.rawValue,
+    ]
+    if currentTierLevel >= 2 { visibleRawValues.insert(SidebarNavItem.memories.rawValue) }
+    if currentTierLevel >= 3 { visibleRawValues.insert(SidebarNavItem.tasks.rawValue) }
+    if currentTierLevel >= 4 { visibleRawValues.insert(SidebarNavItem.chat.rawValue) }
+
+    if !visibleRawValues.contains(selectedIndex) {
+      selectedIndex = SidebarNavItem.dashboard.rawValue
+    }
+  }
+
+  /// Whether to hide the sidebar (rewind mode)
+  private var hideSidebar: Bool {
+    OMIApp.launchMode == .rewind
+  }
+
+  private var currentAppStateLabel: String {
+    if authState.isRestoringAuth { return "restoring_auth" }
+    if !authState.isSignedIn { return "signed_out" }
+    if !appState.hasCompletedOnboarding { return "onboarding" }
+    return "main"
+  }
+
+  private func reportAutomationState() {
+    guard DesktopAutomationLaunchOptions.isEnabled else { return }
+
+    let currentWindow = NSApp.windows.first(where: {
+      $0.title.lowercased().hasPrefix("omi") && $0.isVisible
+    })
+    let snapshot = DesktopAutomationSnapshot(
+      bridgeEnabled: true,
+      bridgePort: DesktopAutomationLaunchOptions.port,
+      bundleIdentifier: Bundle.main.bundleIdentifier ?? "unknown",
+      appState: currentAppStateLabel,
+      selectedTab: SidebarNavItem(rawValue: selectedIndex)?.title,
+      selectedTabIndex: selectedIndex,
+      selectedSettingsSection: isInSettings ? selectedSettingsSection.rawValue : nil,
+      highlightedSettingId: highlightedSettingId,
+      hasCompletedOnboarding: appState.hasCompletedOnboarding,
+      isSignedIn: authState.isSignedIn,
+      isRestoringAuth: authState.isRestoringAuth,
+      isAppActive: NSApp.isActive,
+      mainWindowTitle: currentWindow?.title,
+      updatedAt: ISO8601DateFormatter().string(from: Date())
+    )
+
+    Task {
+      await DesktopAutomationStateStore.shared.update(snapshot)
+    }
+  }
+
+  private func handleAutomationNavigation(_ notification: Notification) {
+    guard DesktopAutomationLaunchOptions.isEnabled else { return }
+    guard let target = notification.userInfo?["target"] as? String else { return }
+
+    let settingsSectionRaw = notification.userInfo?["settingsSection"] as? String
+    let settingId = notification.userInfo?["highlightedSettingId"] as? String
+    let activateApp = notification.userInfo?["activateApp"] as? Bool ?? true
+
+    if activateApp {
+      NSApp.activate(ignoringOtherApps: true)
+      if let window = NSApp.windows.first(where: { $0.title.lowercased().hasPrefix("omi") }) {
+        window.makeKeyAndOrderFront(nil)
+      }
+    }
+
+    if let sectionRaw = settingsSectionRaw,
+      let section = SettingsContentView.SettingsSection(rawValue: sectionRaw)
+    {
+      selectedSettingsSection = section
+    }
+    highlightedSettingId = settingId
+
+    if let item = resolvedAutomationTarget(target) {
+      withAnimation(.easeInOut(duration: 0.15)) {
+        selectedIndex = item.rawValue
+      }
+    }
+
+    reportAutomationState()
+  }
+
+  private func resolvedAutomationTarget(_ target: String) -> SidebarNavItem? {
+    let normalized = target.lowercased().replacingOccurrences(of: "-", with: "_")
+    switch normalized {
+    case "dashboard", "home":
+      return .dashboard
+    case "conversations":
+      return .conversations
+    case "chat":
+      return .chat
+    case "memories":
+      return .memories
+    case "tasks":
+      return .tasks
+    case "focus":
+      return .focus
+    case "advice":
+      return .advice
+    case "rewind":
+      return .rewind
+    case "apps", "integrations":
+      return .apps
+    case "settings":
+      return .settings
+    case "permissions":
+      return .permissions
+    case "device":
+      return .device
+    case "help":
+      return .help
+    default:
+      return nil
+    }
+  }
+
+  /// Update store auto-refresh based on which page is visible
+  /// On launch, if the user quit with the task chat panel open, macOS restores the
+  /// expanded window frame but the chat panel itself is not shown. Shrink the window
+  /// back to its pre-chat width so the layout isn't unexpectedly wide.
+  private func restorePreChatWindowWidth() {
+    let key = "tasksPreChatWindowWidth"
+    let saved = UserDefaults.standard.double(forKey: key)
+    guard saved > 0 else { return }
+    // Reset the persisted value immediately so TasksPage won't double-shrink
+    UserDefaults.standard.set(Double(0), forKey: key)
+    // Delay slightly so the window is fully visible
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+      guard let window = NSApp.windows.first(where: { $0.title.hasPrefix("Omi") && $0.isVisible })
+      else { return }
+      var frame = window.frame
+      frame.size.width = saved
+      window.setFrame(frame, display: true)
+    }
+  }
+
+  private func updateStoreActivity(for index: Int) {
+    viewModelContainer.tasksStore.isActive =
+      index == SidebarNavItem.dashboard.rawValue || index == SidebarNavItem.tasks.rawValue
+    viewModelContainer.memoriesViewModel.isActive =
+      index == SidebarNavItem.memories.rawValue
+  }
+
+  private var mainContent: some View {
+    HStack(spacing: 0) {
+      // Sidebar slot: settings sidebar overlays main sidebar
+      // IMPORTANT: SidebarView is kept alive (but hidden) when in settings to prevent
+      // EXC_BAD_ACCESS crash in SwiftUI's tooltip system. When the view is conditionally
+      // removed, its .help() tooltip graph nodes get invalidated, but the macOS tooltip
+      // tracking system still tries to evaluate them during window key state changes.
+      ZStack {
+        if !hideSidebar {
+          SidebarView(
+            selectedIndex: $selectedIndex,
+            isCollapsed: $isSidebarCollapsed,
+            appState: appState
+          )
+          .clickThrough(enabled: !isInSettings)
+          .opacity(isInSettings ? 0 : 1)
+          .allowsHitTesting(!isInSettings)
+        }
+
+        if isInSettings {
+          SettingsSidebar(
+            selectedSection: $selectedSettingsSection,
+            highlightedSettingId: $highlightedSettingId,
+            onBack: {
+              withAnimation(.easeInOut(duration: 0.2)) {
+                selectedIndex = previousIndexBeforeSettings
+              }
+            }
+          )
+        }
+      }
+      .fixedSize(horizontal: true, vertical: false)
+      .clipped()
+
+      // Main content area with rounded container
+      ZStack {
+        // Content container background
+        RoundedRectangle(cornerRadius: 16)
+          .fill(OmiColors.backgroundSecondary.opacity(0.4))
+          .overlay(
+            RoundedRectangle(cornerRadius: 16)
+              .stroke(OmiColors.backgroundTertiary.opacity(0.3), lineWidth: 1)
+          )
+          .shadow(color: .black.opacity(0.05), radius: 20, x: 0, y: 4)
+
+        // Page content - switch recreates views on tab change
+        // Extracted into a separate struct so that pages like TasksPage
+        // are not re-rendered when AppState publishes unrelated changes.
+        PageContentView(
+          selectedIndex: selectedIndex,
+          appState: appState,
+          viewModelContainer: viewModelContainer,
+          selectedSettingsSection: $selectedSettingsSection,
+          highlightedSettingId: $highlightedSettingId,
+          selectedTabIndex: $selectedIndex
+        )
+        .id(selectedIndex)
+        .transition(.opacity.combined(with: .move(edge: .trailing)))
+        .animation(.easeInOut(duration: 0.2), value: selectedIndex)
+        .clipShape(RoundedRectangle(cornerRadius: 16))
+      }
+      .padding(12)
+    }
+    .overlay {
+      // Goal completion celebration overlay
+      GoalCelebrationView()
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindSettings)) { _ in
+      // Set the section directly and navigate to settings
+      selectedSettingsSection = .rewind
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.settings.rawValue
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToDeviceSettings)) { _ in
+      // Set the section directly and navigate to settings
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.settings.rawValue
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in
+      // Navigate to settings > advanced > task assistant subsection
+      selectedSettingsSection = .advanced
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.settings.rawValue
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToFloatingBarSettings)) { _ in
+      selectedSettingsSection = .advanced
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.settings.rawValue
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToAIChatSettings)) { _ in
+      selectedSettingsSection = .aiChat
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.settings.rawValue
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToRewind)) { _ in
+      // Navigate to Rewind page (index 6) - triggered by global hotkey Cmd+Option+R
+      log(
+        "DesktopHomeView: Received navigateToRewind notification, navigating to Rewind (index \(SidebarNavItem.rewind.rawValue))"
+      )
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.rewind.rawValue
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToRewindNotes)) { _ in
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.rewind.rawValue
+      }
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        NotificationCenter.default.post(name: .expandRewindTranscript, object: nil)
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToChat)) { _ in
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.chat.rawValue
+      }
+    }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToTasks)) { _ in
+      withAnimation(.easeInOut(duration: 0.2)) {
+        selectedIndex = SidebarNavItem.tasks.rawValue
+      }
+    }
+    .onChange(of: selectedIndex) { oldValue, newValue in
+      // Track the previous index when navigating to settings
+      if newValue == SidebarNavItem.settings.rawValue
+        && oldValue != SidebarNavItem.settings.rawValue
+      {
+        previousIndexBeforeSettings = oldValue
+      }
+      // Only auto-refresh stores when their pages are visible
+      updateStoreActivity(for: newValue)
+    }
+    .onAppear {
+      updateStoreActivity(for: selectedIndex)
+      // Restore window width if the user quit with task chat panel open.
+      // The chat panel is never open on startup (showChatPanel defaults to false),
+      // but macOS restores the expanded window frame from the previous session.
+      restorePreChatWindowWidth()
+    }
+  }
 }
 
 /// Isolated page content switch — does NOT observe AppState or ViewModelContainer
 /// as @ObservedObject, so pages like TasksPage won't re-render when unrelated
 /// AppState properties (conversations, permissions, etc.) change.
 private struct PageContentView: View {
-    let selectedIndex: Int
-    let appState: AppState
-    let viewModelContainer: ViewModelContainer
-    @Binding var selectedSettingsSection: SettingsContentView.SettingsSection
-    @Binding var highlightedSettingId: String?
-    @Binding var selectedTabIndex: Int
+  let selectedIndex: Int
+  let appState: AppState
+  let viewModelContainer: ViewModelContainer
+  @Binding var selectedSettingsSection: SettingsContentView.SettingsSection
+  @Binding var highlightedSettingId: String?
+  @Binding var selectedTabIndex: Int
 
-    var body: some View {
-        let _ = log("RENDER: PageContentView body evaluated (index=\(selectedIndex))")
-        Group {
-            switch selectedIndex {
-            case 0:
-                DashboardPage(viewModel: viewModelContainer.dashboardViewModel, appState: appState, selectedIndex: $selectedTabIndex)
-            case 1:
-                DashboardPage(viewModel: viewModelContainer.dashboardViewModel, appState: appState, selectedIndex: $selectedTabIndex)
-            case 2:
-                ChatPage(appProvider: viewModelContainer.appProvider, chatProvider: viewModelContainer.chatProvider)
-            case 3:
-                MemoriesPage(viewModel: viewModelContainer.memoriesViewModel)
-            case 4:
-                TasksPage(viewModel: viewModelContainer.tasksViewModel, chatCoordinator: viewModelContainer.taskChatCoordinator, chatProvider: viewModelContainer.chatProvider)
-            case 5:
-                FocusPage()
-            case 6:
-                AdvicePage()
-            case 7:
-                RewindPage(appState: appState)
-            case 8:
-                AppsPage(appProvider: viewModelContainer.appProvider)
-            case 9:
-                SettingsPage(
-                    appState: appState,
-                    selectedSection: $selectedSettingsSection,
-                    highlightedSettingId: $highlightedSettingId,
-                    chatProvider: viewModelContainer.chatProvider
-                )
-            case 10:
-                PermissionsPage(appState: appState)
-            case 11:
-                DeviceSettingsPage()
-            case 12:
-                HelpPage()
-            default:
-                DashboardPage(viewModel: viewModelContainer.dashboardViewModel, appState: appState, selectedIndex: $selectedTabIndex)
-            }
-        }
+  var body: some View {
+    let _ = log("RENDER: PageContentView body evaluated (index=\(selectedIndex))")
+    Group {
+      switch selectedIndex {
+      case 0:
+        DashboardPage(
+          viewModel: viewModelContainer.dashboardViewModel, appState: appState,
+          selectedIndex: $selectedTabIndex)
+      case 1:
+        DashboardPage(
+          viewModel: viewModelContainer.dashboardViewModel, appState: appState,
+          selectedIndex: $selectedTabIndex)
+      case 2:
+        ChatPage(
+          appProvider: viewModelContainer.appProvider, chatProvider: viewModelContainer.chatProvider
+        )
+      case 3:
+        MemoriesPage(viewModel: viewModelContainer.memoriesViewModel)
+      case 4:
+        TasksPage(
+          viewModel: viewModelContainer.tasksViewModel,
+          chatCoordinator: viewModelContainer.taskChatCoordinator,
+          chatProvider: viewModelContainer.chatProvider)
+      case 5:
+        FocusPage()
+      case 6:
+        AdvicePage()
+      case 7:
+        RewindPage(appState: appState)
+      case 8:
+        AppsPage(appProvider: viewModelContainer.appProvider)
+      case 9:
+        SettingsPage(
+          appState: appState,
+          selectedSection: $selectedSettingsSection,
+          highlightedSettingId: $highlightedSettingId,
+          chatProvider: viewModelContainer.chatProvider
+        )
+      case 10:
+        PermissionsPage(appState: appState)
+      case 11:
+        DeviceSettingsPage()
+      case 12:
+        HelpPage()
+      default:
+        DashboardPage(
+          viewModel: viewModelContainer.dashboardViewModel, appState: appState,
+          selectedIndex: $selectedTabIndex)
+      }
     }
+  }
 }
 
 #Preview {
-    DesktopHomeView()
+  DesktopHomeView()
 }

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -1,5015 +1,5274 @@
-import SwiftUI
 import Sparkle
+import SwiftUI
 import UniformTypeIdentifiers
 
 /// Settings page that wraps SettingsView with proper dark theme styling for the main window
 struct SettingsPage: View {
-    @ObservedObject var appState: AppState
-    @Binding var selectedSection: SettingsContentView.SettingsSection
-    @Binding var highlightedSettingId: String?
-    var chatProvider: ChatProvider? = nil
+  @ObservedObject var appState: AppState
+  @Binding var selectedSection: SettingsContentView.SettingsSection
+  @Binding var highlightedSettingId: String?
+  var chatProvider: ChatProvider? = nil
 
-    var body: some View {
-        ScrollViewReader { proxy in
-            ScrollView {
-                VStack(spacing: 0) {
-                    // Section header
-                    HStack {
-                        Text(selectedSection.rawValue)
-                            .scaledFont(size: 28, weight: .bold)
-                            .foregroundColor(OmiColors.textPrimary)
-                            .id(selectedSection)
-                            .transition(.opacity)
-                            .animation(.easeInOut(duration: 0.15), value: selectedSection)
+  var body: some View {
+    ScrollViewReader { proxy in
+      ScrollView {
+        VStack(spacing: 0) {
+          // Section header
+          HStack {
+            Text(selectedSection.rawValue)
+              .scaledFont(size: 28, weight: .bold)
+              .foregroundColor(OmiColors.textPrimary)
+              .id(selectedSection)
+              .transition(.opacity)
+              .animation(.easeInOut(duration: 0.15), value: selectedSection)
 
-                        Spacer()
-                    }
-                    .padding(.horizontal, 32)
-                    .padding(.top, 32)
-                    .padding(.bottom, 24)
+            Spacer()
+          }
+          .padding(.horizontal, 32)
+          .padding(.top, 32)
+          .padding(.bottom, 24)
 
-                    // Settings content - embedded SettingsView with dark theme override
-                    SettingsContentView(
-                        appState: appState,
-                        selectedSection: $selectedSection,
-                        highlightedSettingId: $highlightedSettingId,
-                        chatProvider: chatProvider
-                    )
-                    .padding(.horizontal, 32)
+          // Settings content - embedded SettingsView with dark theme override
+          SettingsContentView(
+            appState: appState,
+            selectedSection: $selectedSection,
+            highlightedSettingId: $highlightedSettingId,
+            chatProvider: chatProvider
+          )
+          .padding(.horizontal, 32)
 
-                    Spacer()
-                }
-            }
-            .onChange(of: highlightedSettingId) { _, newId in
-                guard let newId = newId else { return }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-                    withAnimation(.easeInOut(duration: 0.3)) {
-                        proxy.scrollTo(newId, anchor: .center)
-                    }
-                }
-            }
+          Spacer()
         }
-        .background(OmiColors.backgroundSecondary.opacity(0.3))
-        .onAppear {
-            AnalyticsManager.shared.settingsPageOpened()
+      }
+      .onChange(of: highlightedSettingId) { _, newId in
+        guard let newId = newId else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+          withAnimation(.easeInOut(duration: 0.3)) {
+            proxy.scrollTo(newId, anchor: .center)
+          }
         }
+      }
     }
+    .background(OmiColors.backgroundSecondary.opacity(0.3))
+    .onAppear {
+      AnalyticsManager.shared.settingsPageOpened()
+    }
+  }
 }
 
 /// Dark-themed settings content matching the main window style
 struct SettingsContentView: View {
-    // AppState for transcription control
-    @ObservedObject var appState: AppState
+  // AppState for transcription control
+  @ObservedObject var appState: AppState
 
-    // ChatProvider for browser extension setup
-    var chatProvider: ChatProvider? = nil
+  // ChatProvider for browser extension setup
+  var chatProvider: ChatProvider? = nil
 
-    // Updater view model
-    @ObservedObject private var updaterViewModel = UpdaterViewModel.shared
+  // Updater view model
+  @ObservedObject private var updaterViewModel = UpdaterViewModel.shared
 
-    // Master monitoring state (screen analysis)
-    @State private var isMonitoring: Bool
-    @State private var isToggling: Bool = false
-    @State private var permissionError: String?
+  // Master monitoring state (screen analysis)
+  @State private var isMonitoring: Bool
+  @State private var isToggling: Bool = false
+  @State private var permissionError: String?
 
-    // Ask Omi floating bar state
-    @State private var showAskOmiBar: Bool = false
+  // Ask Omi floating bar state
+  @State private var showAskOmiBar: Bool = false
 
-    // Transcription state
-    @State private var isTranscribing: Bool
-    @State private var isTogglingTranscription: Bool = false
-    @State private var transcriptionError: String?
+  // Transcription state
+  @State private var isTranscribing: Bool
+  @State private var isTogglingTranscription: Bool = false
+  @State private var transcriptionError: String?
 
-    // Log export state
+  // Log export state
 
-    // Focus Assistant states
-    @State private var focusEnabled: Bool
-    @State private var cooldownInterval: Int
-    @State private var glowOverlayEnabled: Bool
-    @State private var analysisDelay: Int
-    @State private var focusNotificationsEnabled: Bool
-    @State private var focusExcludedApps: Set<String>
+  // Focus Assistant states
+  @State private var focusEnabled: Bool
+  @State private var cooldownInterval: Int
+  @State private var glowOverlayEnabled: Bool
+  @State private var analysisDelay: Int
+  @State private var focusNotificationsEnabled: Bool
+  @State private var focusExcludedApps: Set<String>
 
-    // Task Assistant states
-    @State private var taskEnabled: Bool
-    @State private var taskChatAgentEnabled: Bool
-    @State private var taskAgentWorkingDirectory: String
-    @State private var taskExtractionInterval: Double
-    @State private var taskMinConfidence: Double
-    @State private var taskNotificationsEnabled: Bool
-    @State private var taskAllowedApps: Set<String>
-    @State private var taskBrowserKeywords: [String]
-    @State private var isRescoringTasks = false
+  // Task Assistant states
+  @State private var taskEnabled: Bool
+  @State private var taskChatAgentEnabled: Bool
+  @State private var taskAgentWorkingDirectory: String
+  @State private var taskExtractionInterval: Double
+  @State private var taskMinConfidence: Double
+  @State private var taskNotificationsEnabled: Bool
+  @State private var taskAllowedApps: Set<String>
+  @State private var taskBrowserKeywords: [String]
+  @State private var isRescoringTasks = false
 
-    // Advice Assistant states
-    @State private var adviceEnabled: Bool
-    @State private var adviceExtractionInterval: Double
-    @State private var adviceMinConfidence: Double
-    @State private var adviceNotificationsEnabled: Bool
-    @State private var adviceExcludedApps: Set<String>
+  // Advice Assistant states
+  @State private var adviceEnabled: Bool
+  @State private var adviceExtractionInterval: Double
+  @State private var adviceMinConfidence: Double
+  @State private var adviceNotificationsEnabled: Bool
+  @State private var adviceExcludedApps: Set<String>
 
-    // Memory Assistant states
-    @State private var memoryEnabled: Bool
-    @State private var memoryExtractionInterval: Double
-    @State private var memoryMinConfidence: Double
-    @State private var memoryNotificationsEnabled: Bool
-    @State private var memoryExcludedApps: Set<String>
+  // Memory Assistant states
+  @State private var memoryEnabled: Bool
+  @State private var memoryExtractionInterval: Double
+  @State private var memoryMinConfidence: Double
+  @State private var memoryNotificationsEnabled: Bool
+  @State private var memoryExcludedApps: Set<String>
 
-    // Goals states
-    @State private var goalsAutoGenerateEnabled: Bool = GoalGenerationService.shared.isAutoGenerationEnabled
+  // Goals states
+  @State private var goalsAutoGenerateEnabled: Bool = GoalGenerationService.shared
+    .isAutoGenerationEnabled
 
-    // Glow preview state
-    @State private var isPreviewRunning: Bool = false
+  // Glow preview state
+  @State private var isPreviewRunning: Bool = false
 
-    // Downgrade confirmation alert
-    @State private var showDowngradeAlert = false
+  // Downgrade confirmation alert
+  @State private var showDowngradeAlert = false
 
-    // Tier gating (0 = show all, 1-6 = sequential tiers)
-    @AppStorage("currentTierLevel") private var currentTierLevel = 0
+  // Tier gating (0 = show all, 1-6 = sequential tiers)
+  @AppStorage("currentTierLevel") private var currentTierLevel = 0
 
-    // Advanced stats
-    @State private var advancedStats: UserStats?
-    @State private var isLoadingStats = false
-    @State private var chatMessageCount: Int?
-    @State private var isLoadingChatMessages = false
+  // Advanced stats
+  @State private var advancedStats: UserStats?
+  @State private var isLoadingStats = false
+  @State private var chatMessageCount: Int?
+  @State private var isLoadingChatMessages = false
 
-    // AI User Profile
-    @State private var aiProfileId: Int64?
-    @State private var aiProfileText: String?
-    @State private var aiProfileGeneratedAt: Date?
-    @State private var aiProfileDataSourcesUsed: Int = 0
-    @State private var isGeneratingAIProfile = false
-    @State private var isEditingAIProfile = false
-    @State private var aiProfileEditText: String = ""
+  // AI User Profile
+  @State private var aiProfileId: Int64?
+  @State private var aiProfileText: String?
+  @State private var aiProfileGeneratedAt: Date?
+  @State private var aiProfileDataSourcesUsed: Int = 0
+  @State private var isGeneratingAIProfile = false
+  @State private var isEditingAIProfile = false
+  @State private var aiProfileEditText: String = ""
 
-    // Selected section (passed in from parent)
-    @Binding var selectedSection: SettingsSection
-    @Binding var highlightedSettingId: String?
+  // Selected section (passed in from parent)
+  @Binding var selectedSection: SettingsSection
+  @Binding var highlightedSettingId: String?
 
-    // Notification settings (from backend)
-    @State private var dailySummaryEnabled: Bool = true
-    @State private var dailySummaryHour: Int = 22
-    @State private var notificationsEnabled: Bool = true
-    @State private var notificationFrequency: Int = 3
+  // Notification settings (from backend)
+  @State private var dailySummaryEnabled: Bool = true
+  @State private var dailySummaryHour: Int = 22
+  @State private var notificationsEnabled: Bool = true
+  @State private var notificationFrequency: Int = 3
 
-    // Privacy settings (from backend)
-    @State private var recordingPermissionEnabled: Bool = false
-    @State private var privateCloudSyncEnabled: Bool = true
-    @State private var isTrackingExpanded: Bool = false
+  // Privacy settings (from backend)
+  @State private var recordingPermissionEnabled: Bool = false
+  @State private var privateCloudSyncEnabled: Bool = true
+  @State private var isTrackingExpanded: Bool = false
 
-    // Transcription settings (from backend)
-    @State private var singleLanguageMode: Bool = false
-    @State private var newVocabularyWord: String = ""
-    @State private var vocabularyList: [String] = []
+  // Transcription settings (from backend)
+  @State private var singleLanguageMode: Bool = false
+  @State private var newVocabularyWord: String = ""
+  @State private var vocabularyList: [String] = []
 
-    // Language setting
-    @State private var userLanguage: String = "en"
+  // Language setting
+  @State private var userLanguage: String = "en"
 
-    // Loading states
-    @State private var isLoadingSettings: Bool = false
+  // Loading states
+  @State private var isLoadingSettings: Bool = false
 
-    private let cooldownOptions = [1, 2, 5, 10, 15, 30, 60]
-    private let analysisDelayOptions = [0, 10, 20, 30, 60, 300] // seconds: instant, 10s, 20s, 30s, 1 min, 5 min
-    private let extractionIntervalOptions: [Double] = [10.0, 600.0, 3600.0] // 10s, 10min, 1hr
-    private let hourOptions = Array(0...23)
-    private let frequencyOptions = [
-        (0, "Off"),
-        (1, "Minimal"),
-        (2, "Low"),
-        (3, "Balanced"),
-        (4, "High"),
-        (5, "Maximum")
-    ]
-    // Use the full language list from AssistantSettings
-    private var languageOptions: [(String, String)] {
-        AssistantSettings.supportedLanguages.map { ($0.code, $0.name) }
+  private let cooldownOptions = [1, 2, 5, 10, 15, 30, 60]
+  private let analysisDelayOptions = [0, 10, 20, 30, 60, 300]  // seconds: instant, 10s, 20s, 30s, 1 min, 5 min
+  private let extractionIntervalOptions: [Double] = [10.0, 600.0, 3600.0]  // 10s, 10min, 1hr
+  private let hourOptions = Array(0...23)
+  private let frequencyOptions = [
+    (0, "Off"),
+    (1, "Minimal"),
+    (2, "Low"),
+    (3, "Balanced"),
+    (4, "High"),
+    (5, "Maximum"),
+  ]
+  // Use the full language list from AssistantSettings
+  private var languageOptions: [(String, String)] {
+    AssistantSettings.supportedLanguages.map { ($0.code, $0.name) }
+  }
+
+  // Language auto-detect state (from local settings)
+  @State private var transcriptionAutoDetect: Bool = true
+  @State private var transcriptionLanguage: String = "en"
+  @State private var vadGateEnabled: Bool = false
+  @State private var batchTranscriptionEnabled: Bool = true
+
+  // Multi-chat mode setting
+  @AppStorage("multiChatEnabled") private var multiChatEnabled = false
+  @AppStorage("conversationsCompactView") private var conversationsCompactView = true
+
+  // AI Chat settings
+  @AppStorage("chatBridgeMode") private var chatBridgeMode: String = "agentSDK"
+  @AppStorage("askModeEnabled") private var askModeEnabled = false
+  @AppStorage("claudeMdEnabled") private var claudeMdEnabled = true
+  @AppStorage("projectClaudeMdEnabled") private var projectClaudeMdEnabled = true
+  @AppStorage("aiChatWorkingDirectory") private var aiChatWorkingDirectory: String = ""
+  @State private var aiChatClaudeMdContent: String?
+  @State private var aiChatClaudeMdPath: String?
+  @State private var aiChatProjectClaudeMdContent: String?
+  @State private var aiChatProjectClaudeMdPath: String?
+  @State private var aiChatDiscoveredSkills: [(name: String, description: String, path: String)] =
+    []
+  @State private var aiChatProjectDiscoveredSkills:
+    [(name: String, description: String, path: String)] = []
+  @State private var aiChatDisabledSkills: Set<String> = []
+  @State private var showFileViewer = false
+  @State private var fileViewerContent = ""
+  @State private var fileViewerTitle = ""
+  @State private var skillSearchQuery = ""
+
+  // Dev Mode setting
+  @AppStorage("devModeEnabled") private var devModeEnabled = false
+
+  // Browser Extension settings
+  @AppStorage("playwrightUseExtension") private var playwrightUseExtension = true
+  @State private var playwrightExtensionToken: String = ""
+  @State private var showBrowserSetup = false
+
+  // Launch at login manager
+  @ObservedObject private var launchAtLoginManager = LaunchAtLoginManager.shared
+
+  enum SettingsSection: String, CaseIterable {
+    case general = "General"
+    case rewind = "Rewind"
+    case transcription = "Transcription"
+    case notifications = "Notifications"
+    case privacy = "Privacy"
+    case account = "Account"
+    case aiChat = "AI Chat"
+    case advanced = "Advanced"
+    case about = "About"
+  }
+
+  enum AdvancedSubsection: String, CaseIterable {
+    case aiUserProfile = "AI User Profile"
+    case stats = "Your Stats"
+    case featureTiers = "Feature Tiers"
+    case focusAssistant = "Focus Assistant"
+    case taskAssistant = "Task Assistant"
+    case adviceAssistant = "Advice Assistant"
+    case memoryAssistant = "Memory Assistant"
+    case analysisThrottle = "Analysis Throttle"
+    case goals = "Goals"
+    case askOmiFloatingBar = "Ask omi Floating Bar"
+    case preferences = "Preferences"
+    case troubleshooting = "Troubleshooting"
+
+    var icon: String {
+      switch self {
+      case .aiUserProfile: return "brain"
+      case .stats: return "chart.bar"
+      case .featureTiers: return "lock.shield"
+      case .focusAssistant: return "eye.fill"
+      case .taskAssistant: return "checklist"
+      case .adviceAssistant: return "lightbulb.fill"
+      case .memoryAssistant: return "brain.head.profile"
+      case .analysisThrottle: return "clock.arrow.2.circlepath"
+      case .goals: return "target"
+      case .askOmiFloatingBar: return "sparkles"
+      case .preferences: return "slider.horizontal.3"
+      case .troubleshooting: return "wrench.and.screwdriver"
+      }
     }
+  }
 
-    // Language auto-detect state (from local settings)
-    @State private var transcriptionAutoDetect: Bool = true
-    @State private var transcriptionLanguage: String = "en"
-    @State private var vadGateEnabled: Bool = false
-    @State private var batchTranscriptionEnabled: Bool = true
+  @State private var showResetOnboardingAlert: Bool = false
+  @State private var showRescanFilesAlert: Bool = false
+  @State private var showDeleteAccountAlert: Bool = false
+  @State private var isDeletingAccount: Bool = false
+  @State private var deleteAccountError: String?
 
-    // Multi-chat mode setting
-    @AppStorage("multiChatEnabled") private var multiChatEnabled = false
-    @AppStorage("conversationsCompactView") private var conversationsCompactView = true
+  init(
+    appState: AppState,
+    selectedSection: Binding<SettingsSection>,
+    highlightedSettingId: Binding<String?> = .constant(nil),
+    chatProvider: ChatProvider? = nil
+  ) {
+    self.appState = appState
+    self._selectedSection = selectedSection
+    self._highlightedSettingId = highlightedSettingId
+    self.chatProvider = chatProvider
+    let settings = AssistantSettings.shared
+    _isMonitoring = State(initialValue: ProactiveAssistantsPlugin.shared.isMonitoring)
+    _isTranscribing = State(initialValue: appState.isTranscribing)
+    _focusEnabled = State(initialValue: FocusAssistantSettings.shared.isEnabled)
+    _cooldownInterval = State(initialValue: FocusAssistantSettings.shared.cooldownInterval)
+    _glowOverlayEnabled = State(initialValue: settings.glowOverlayEnabled)
+    _analysisDelay = State(initialValue: settings.analysisDelay)
+    _focusNotificationsEnabled = State(
+      initialValue: FocusAssistantSettings.shared.notificationsEnabled)
+    _focusExcludedApps = State(initialValue: FocusAssistantSettings.shared.excludedApps)
+    _taskEnabled = State(initialValue: TaskAssistantSettings.shared.isEnabled)
+    _taskChatAgentEnabled = State(initialValue: TaskAgentSettings.shared.isChatEnabled)
+    _taskAgentWorkingDirectory = State(initialValue: TaskAgentSettings.shared.workingDirectory)
+    _taskExtractionInterval = State(initialValue: TaskAssistantSettings.shared.extractionInterval)
+    _taskMinConfidence = State(initialValue: TaskAssistantSettings.shared.minConfidence)
+    _taskNotificationsEnabled = State(
+      initialValue: TaskAssistantSettings.shared.notificationsEnabled)
+    _taskAllowedApps = State(initialValue: TaskAssistantSettings.shared.allowedApps)
+    _taskBrowserKeywords = State(initialValue: TaskAssistantSettings.shared.browserKeywords)
+    _adviceEnabled = State(initialValue: AdviceAssistantSettings.shared.isEnabled)
+    _adviceExtractionInterval = State(
+      initialValue: AdviceAssistantSettings.shared.extractionInterval)
+    _adviceMinConfidence = State(initialValue: AdviceAssistantSettings.shared.minConfidence)
+    _adviceNotificationsEnabled = State(
+      initialValue: AdviceAssistantSettings.shared.notificationsEnabled)
+    _adviceExcludedApps = State(initialValue: AdviceAssistantSettings.shared.excludedApps)
+    _memoryEnabled = State(initialValue: MemoryAssistantSettings.shared.isEnabled)
+    _memoryExtractionInterval = State(
+      initialValue: MemoryAssistantSettings.shared.extractionInterval)
+    _memoryMinConfidence = State(initialValue: MemoryAssistantSettings.shared.minConfidence)
+    _memoryNotificationsEnabled = State(
+      initialValue: MemoryAssistantSettings.shared.notificationsEnabled)
+    _memoryExcludedApps = State(initialValue: MemoryAssistantSettings.shared.excludedApps)
+    _vadGateEnabled = State(initialValue: settings.vadGateEnabled)
+    _batchTranscriptionEnabled = State(initialValue: settings.batchTranscriptionEnabled)
+    _transcriptionLanguage = State(initialValue: settings.transcriptionLanguage)
+    _transcriptionAutoDetect = State(initialValue: settings.transcriptionAutoDetect)
+  }
 
-    // AI Chat settings
-    @AppStorage("chatBridgeMode") private var chatBridgeMode: String = "agentSDK"
-    @AppStorage("askModeEnabled") private var askModeEnabled = false
-    @AppStorage("claudeMdEnabled") private var claudeMdEnabled = true
-    @AppStorage("projectClaudeMdEnabled") private var projectClaudeMdEnabled = true
-    @AppStorage("aiChatWorkingDirectory") private var aiChatWorkingDirectory: String = ""
-    @State private var aiChatClaudeMdContent: String?
-    @State private var aiChatClaudeMdPath: String?
-    @State private var aiChatProjectClaudeMdContent: String?
-    @State private var aiChatProjectClaudeMdPath: String?
-    @State private var aiChatDiscoveredSkills: [(name: String, description: String, path: String)] = []
-    @State private var aiChatProjectDiscoveredSkills: [(name: String, description: String, path: String)] = []
-    @State private var aiChatDisabledSkills: Set<String> = []
-    @State private var showFileViewer = false
-    @State private var fileViewerContent = ""
-    @State private var fileViewerTitle = ""
-    @State private var skillSearchQuery = ""
-
-    // Dev Mode setting
-    @AppStorage("devModeEnabled") private var devModeEnabled = false
-
-    // Browser Extension settings
-    @AppStorage("playwrightUseExtension") private var playwrightUseExtension = true
-    @State private var playwrightExtensionToken: String = ""
-    @State private var showBrowserSetup = false
-
-    // Launch at login manager
-    @ObservedObject private var launchAtLoginManager = LaunchAtLoginManager.shared
-
-    enum SettingsSection: String, CaseIterable {
-        case general = "General"
-        case rewind = "Rewind"
-        case transcription = "Transcription"
-        case notifications = "Notifications"
-        case privacy = "Privacy"
-        case account = "Account"
-        case aiChat = "AI Chat"
-        case advanced = "Advanced"
-        case about = "About"
+  /// Computed status text for notifications
+  private var notificationStatusText: String {
+    if !appState.hasNotificationPermission {
+      return "Notifications are disabled"
+    } else if appState.isNotificationBannerDisabled {
+      return "Enabled but banners are off"
+    } else {
+      return "Proactive alerts enabled"
     }
+  }
 
-    enum AdvancedSubsection: String, CaseIterable {
-        case aiUserProfile = "AI User Profile"
-        case stats = "Your Stats"
-        case featureTiers = "Feature Tiers"
-        case focusAssistant = "Focus Assistant"
-        case taskAssistant = "Task Assistant"
-        case adviceAssistant = "Advice Assistant"
-        case memoryAssistant = "Memory Assistant"
-        case analysisThrottle = "Analysis Throttle"
-        case goals = "Goals"
-        case askOmiFloatingBar = "Ask omi Floating Bar"
-        case preferences = "Preferences"
-        case troubleshooting = "Troubleshooting"
-
-        var icon: String {
-            switch self {
-            case .aiUserProfile: return "brain"
-            case .stats: return "chart.bar"
-            case .featureTiers: return "lock.shield"
-            case .focusAssistant: return "eye.fill"
-            case .taskAssistant: return "checklist"
-            case .adviceAssistant: return "lightbulb.fill"
-            case .memoryAssistant: return "brain.head.profile"
-            case .analysisThrottle: return "clock.arrow.2.circlepath"
-            case .goals: return "target"
-            case .askOmiFloatingBar: return "sparkles"
-            case .preferences: return "slider.horizontal.3"
-            case .troubleshooting: return "wrench.and.screwdriver"
-            }
+  var body: some View {
+    VStack(spacing: 24) {
+      // Section content
+      Group {
+        switch selectedSection {
+        case .general:
+          generalSection
+        case .rewind:
+          rewindSection
+        case .transcription:
+          transcriptionSection
+        case .notifications:
+          notificationsSection
+        case .privacy:
+          privacySection
+        case .account:
+          accountSection
+        case .aiChat:
+          aiChatSection
+        case .advanced:
+          advancedSection
+        case .about:
+          aboutSection
         }
+      }
+      .id(selectedSection)
+      .transition(.opacity)
+      .animation(.easeInOut(duration: 0.15), value: selectedSection)
     }
-
-    @State private var showResetOnboardingAlert: Bool = false
-    @State private var showRescanFilesAlert: Bool = false
-    @State private var showDeleteAccountAlert: Bool = false
-    @State private var isDeletingAccount: Bool = false
-    @State private var deleteAccountError: String?
-
-    init(
-        appState: AppState,
-        selectedSection: Binding<SettingsSection>,
-        highlightedSettingId: Binding<String?> = .constant(nil),
-        chatProvider: ChatProvider? = nil
-    ) {
-        self.appState = appState
-        self._selectedSection = selectedSection
-        self._highlightedSettingId = highlightedSettingId
-        self.chatProvider = chatProvider
-        let settings = AssistantSettings.shared
-        _isMonitoring = State(initialValue: ProactiveAssistantsPlugin.shared.isMonitoring)
-        _isTranscribing = State(initialValue: appState.isTranscribing)
-        _focusEnabled = State(initialValue: FocusAssistantSettings.shared.isEnabled)
-        _cooldownInterval = State(initialValue: FocusAssistantSettings.shared.cooldownInterval)
-        _glowOverlayEnabled = State(initialValue: settings.glowOverlayEnabled)
-        _analysisDelay = State(initialValue: settings.analysisDelay)
-        _focusNotificationsEnabled = State(initialValue: FocusAssistantSettings.shared.notificationsEnabled)
-        _focusExcludedApps = State(initialValue: FocusAssistantSettings.shared.excludedApps)
-        _taskEnabled = State(initialValue: TaskAssistantSettings.shared.isEnabled)
-        _taskChatAgentEnabled = State(initialValue: TaskAgentSettings.shared.isChatEnabled)
-        _taskAgentWorkingDirectory = State(initialValue: TaskAgentSettings.shared.workingDirectory)
-        _taskExtractionInterval = State(initialValue: TaskAssistantSettings.shared.extractionInterval)
-        _taskMinConfidence = State(initialValue: TaskAssistantSettings.shared.minConfidence)
-        _taskNotificationsEnabled = State(initialValue: TaskAssistantSettings.shared.notificationsEnabled)
-        _taskAllowedApps = State(initialValue: TaskAssistantSettings.shared.allowedApps)
-        _taskBrowserKeywords = State(initialValue: TaskAssistantSettings.shared.browserKeywords)
-        _adviceEnabled = State(initialValue: AdviceAssistantSettings.shared.isEnabled)
-        _adviceExtractionInterval = State(initialValue: AdviceAssistantSettings.shared.extractionInterval)
-        _adviceMinConfidence = State(initialValue: AdviceAssistantSettings.shared.minConfidence)
-        _adviceNotificationsEnabled = State(initialValue: AdviceAssistantSettings.shared.notificationsEnabled)
-        _adviceExcludedApps = State(initialValue: AdviceAssistantSettings.shared.excludedApps)
-        _memoryEnabled = State(initialValue: MemoryAssistantSettings.shared.isEnabled)
-        _memoryExtractionInterval = State(initialValue: MemoryAssistantSettings.shared.extractionInterval)
-        _memoryMinConfidence = State(initialValue: MemoryAssistantSettings.shared.minConfidence)
-        _memoryNotificationsEnabled = State(initialValue: MemoryAssistantSettings.shared.notificationsEnabled)
-        _memoryExcludedApps = State(initialValue: MemoryAssistantSettings.shared.excludedApps)
-        _vadGateEnabled = State(initialValue: settings.vadGateEnabled)
-        _batchTranscriptionEnabled = State(initialValue: settings.batchTranscriptionEnabled)
-        _transcriptionLanguage = State(initialValue: settings.transcriptionLanguage)
-        _transcriptionAutoDetect = State(initialValue: settings.transcriptionAutoDetect)
+    .onAppear {
+      loadBackendSettings()
+      // Sync transcription state with appState
+      isTranscribing = appState.isTranscribing
+      // Sync floating bar state
+      showAskOmiBar = FloatingControlBarManager.shared.isVisible
+      // Refresh notification permission state
+      appState.checkNotificationPermission()
     }
-
-    /// Computed status text for notifications
-    private var notificationStatusText: String {
-        if !appState.hasNotificationPermission {
-            return "Notifications are disabled"
-        } else if appState.isNotificationBannerDisabled {
-            return "Enabled but banners are off"
-        } else {
-            return "Proactive alerts enabled"
-        }
+    .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) {
+      notification in
+      if let userInfo = notification.userInfo, let state = userInfo["isMonitoring"] as? Bool {
+        isMonitoring = state
+      }
     }
-
-    var body: some View {
-        VStack(spacing: 24) {
-            // Section content
-            Group {
-                switch selectedSection {
-                case .general:
-                    generalSection
-                case .rewind:
-                    rewindSection
-                case .transcription:
-                    transcriptionSection
-                case .notifications:
-                    notificationsSection
-                case .privacy:
-                    privacySection
-                case .account:
-                    accountSection
-                case .aiChat:
-                    aiChatSection
-                case .advanced:
-                    advancedSection
-                case .about:
-                    aboutSection
-                }
-            }
-            .id(selectedSection)
-            .transition(.opacity)
-            .animation(.easeInOut(duration: 0.15), value: selectedSection)
-        }
-        .onAppear {
-            loadBackendSettings()
-            // Sync transcription state with appState
-            isTranscribing = appState.isTranscribing
-            // Sync floating bar state
-            showAskOmiBar = FloatingControlBarManager.shared.isVisible
-            // Refresh notification permission state
-            appState.checkNotificationPermission()
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .assistantMonitoringStateDidChange)) { notification in
-            if let userInfo = notification.userInfo, let state = userInfo["isMonitoring"] as? Bool {
-                isMonitoring = state
-            }
-        }
-        .onChange(of: appState.isTranscribing) { _, newValue in
-            isTranscribing = newValue
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in
-            selectedSection = .advanced
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                highlightedSettingId = "advanced.taskassistant"
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: .navigateToFloatingBarSettings)) { _ in
-            selectedSection = .advanced
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                highlightedSettingId = "advanced.askomifloatingbar"
-            }
-        }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
-            // Refresh notification permission when app becomes active (user may have changed it in System Settings)
-            appState.checkNotificationPermission()
-        }
+    .onChange(of: appState.isTranscribing) { _, newValue in
+      isTranscribing = newValue
     }
-
-    // MARK: - General Section
-
-    private var generalSection: some View {
-        VStack(spacing: 20) {
-            // Screen Capture toggle
-            settingsCard(settingId: "general.screencapture") {
-                HStack(spacing: 16) {
-                    Circle()
-                        .fill(isMonitoring ? OmiColors.success : OmiColors.textTertiary.opacity(0.3))
-                        .frame(width: 12, height: 12)
-                        .shadow(color: isMonitoring ? OmiColors.success.opacity(0.5) : .clear, radius: 6)
-
-                    Image(systemName: "rectangle.dashed.badge.record")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.purplePrimary)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Screen Capture")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text(permissionError ?? (isMonitoring ? "Capturing screen content" : "Screen capture is paused"))
-                            .scaledFont(size: 13)
-                            .foregroundColor(permissionError != nil ? OmiColors.warning : OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    if isToggling {
-                        ProgressView()
-                            .scaleEffect(0.8)
-                    } else {
-                        Toggle("", isOn: Binding(
-                            get: { isMonitoring },
-                            set: { newValue in
-                                isMonitoring = newValue
-                                toggleMonitoring(enabled: newValue)
-                            }
-                        ))
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                    }
-                }
-            }
-
-            // Audio Recording toggle
-            settingsCard(settingId: "general.audiorecording") {
-                HStack(spacing: 16) {
-                    Circle()
-                        .fill(isTranscribing ? OmiColors.success : OmiColors.textTertiary.opacity(0.3))
-                        .frame(width: 12, height: 12)
-                        .shadow(color: isTranscribing ? OmiColors.success.opacity(0.5) : .clear, radius: 6)
-
-                    Image(systemName: "mic.fill")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.purplePrimary)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Audio Recording")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text(transcriptionError ?? (isTranscribing ? "Recording and transcribing audio" : "Audio recording is paused"))
-                            .scaledFont(size: 13)
-                            .foregroundColor(transcriptionError != nil ? OmiColors.warning : OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    if isTogglingTranscription {
-                        ProgressView()
-                            .scaleEffect(0.8)
-                    } else {
-                        Toggle("", isOn: Binding(
-                            get: { isTranscribing },
-                            set: { newValue in
-                                isTranscribing = newValue
-                                toggleTranscription(enabled: newValue)
-                            }
-                        ))
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                    }
-                }
-            }
-
-            // Notifications toggle
-            settingsCard(settingId: "general.notifications") {
-                VStack(spacing: 12) {
-                    HStack(spacing: 16) {
-                        Circle()
-                            .fill(appState.hasNotificationPermission && !appState.isNotificationBannerDisabled
-                                  ? OmiColors.success
-                                  : (appState.isNotificationBannerDisabled ? OmiColors.warning : OmiColors.textTertiary.opacity(0.3)))
-                            .frame(width: 12, height: 12)
-                            .shadow(color: appState.hasNotificationPermission && !appState.isNotificationBannerDisabled
-                                    ? OmiColors.success.opacity(0.5) : .clear, radius: 6)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Notifications")
-                                .scaledFont(size: 16, weight: .semibold)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Text(notificationStatusText)
-                                .scaledFont(size: 13)
-                                .foregroundColor(appState.isNotificationBannerDisabled ? OmiColors.warning : OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        if appState.hasNotificationPermission && !appState.isNotificationBannerDisabled {
-                            // Show enabled badge
-                            Text("Enabled")
-                                .scaledFont(size: 12, weight: .medium)
-                                .foregroundColor(.green)
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 4)
-                                .background(
-                                    Capsule()
-                                        .fill(Color.green.opacity(0.15))
-                                )
-                        } else {
-                            // Show button to enable or fix
-                            Button(action: {
-                                if appState.isNotificationBannerDisabled {
-                                    // Banners off — user needs to change style in System Settings
-                                    appState.openNotificationPreferences()
-                                } else {
-                                    // Auth not granted — try lsregister repair first
-                                    AnalyticsManager.shared.notificationRepairTriggered(
-                                        reason: "settings_fix_button",
-                                        previousStatus: "not_authorized",
-                                        currentStatus: "not_authorized"
-                                    )
-                                    appState.repairNotificationAndFallback()
-                                }
-                            }) {
-                                Text(appState.isNotificationBannerDisabled ? "Fix" : "Enable")
-                                    .scaledFont(size: 12, weight: .semibold)
-                                    .foregroundColor(.white)
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 6)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 6)
-                                            .fill(appState.isNotificationBannerDisabled ? OmiColors.warning : OmiColors.purplePrimary)
-                                    )
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-
-                    // Warning when banners are disabled
-                    if appState.isNotificationBannerDisabled {
-                        HStack(spacing: 8) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.warning)
-
-                            Text("Banners disabled - you won't see visual alerts. Set style to \"Banners\" in System Settings.")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.warning)
-
-                            Spacer()
-                        }
-                        .padding(10)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(OmiColors.warning.opacity(0.1))
-                        )
-                    }
-                }
-            }
-
-            // Ask Omi floating bar toggle
-            settingsCard(settingId: "general.askomi") {
-                HStack(spacing: 16) {
-                    Circle()
-                        .fill(showAskOmiBar ? OmiColors.success : OmiColors.textTertiary.opacity(0.3))
-                        .frame(width: 12, height: 12)
-                        .shadow(color: showAskOmiBar ? OmiColors.success.opacity(0.5) : .clear, radius: 6)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Ask omi")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text(showAskOmiBar ? "Floating bar is visible (⌘\\)" : "Floating bar is hidden (⌘\\)")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    Toggle("", isOn: $showAskOmiBar)
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                        .onChange(of: showAskOmiBar) { _, newValue in
-                            if newValue {
-                                FloatingControlBarManager.shared.show()
-                            } else {
-                                FloatingControlBarManager.shared.hide()
-                            }
-                        }
-                }
-            }
-
-            // Font Size
-            settingsCard(settingId: "general.fontsize") {
-                VStack(spacing: 12) {
-                    HStack(spacing: 16) {
-                        Image(systemName: "textformat.size")
-                            .scaledFont(size: 16, weight: .medium)
-                            .foregroundColor(OmiColors.purplePrimary)
-                            .frame(width: 12)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Font Size")
-                                .scaledFont(size: 16, weight: .semibold)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Text("Scale: \(Int(fontScaleSettings.scale * 100))%")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        if fontScaleSettings.scale != 1.0 {
-                            Button("Reset") {
-                                fontScaleSettings.resetToDefault()
-                            }
-                            .scaledFont(size: 12, weight: .medium)
-                            .foregroundColor(OmiColors.purplePrimary)
-                            .buttonStyle(.plain)
-                        }
-                    }
-
-                    HStack(spacing: 12) {
-                        Text("A")
-                            .scaledFont(size: 12, weight: .medium)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        Slider(value: $fontScaleSettings.scale, in: 0.5...2.0, step: 0.05)
-                            .tint(OmiColors.purplePrimary)
-
-                        Text("A")
-                            .scaledFont(size: 18, weight: .medium)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Text("The quick brown fox jumps over the lazy dog")
-                        .scaledFont(size: 14)
-                        .foregroundColor(OmiColors.textSecondary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.top, 4)
-
-                    // Keyboard shortcuts for font size
-                    VStack(spacing: 6) {
-                        fontShortcutRow(label: "Increase font size", keys: "\u{2318}+")
-                        fontShortcutRow(label: "Decrease font size", keys: "\u{2318}\u{2212}")
-                        fontShortcutRow(label: "Reset font size", keys: "\u{2318}0")
-                    }
-                    .padding(.top, 4)
-
-                    HStack {
-                        Spacer()
-                        Button(action: {
-                            resetWindowToDefaultSize()
-                        }) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "arrow.uturn.backward")
-                                    .scaledFont(size: 11)
-                                Text("Reset Window Size")
-                                    .scaledFont(size: 12, weight: .medium)
-                            }
-                            .foregroundColor(OmiColors.textSecondary)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 5)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .fill(OmiColors.backgroundTertiary)
-                            )
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-            }
-
-        }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToTaskSettings)) { _ in
+      selectedSection = .advanced
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+        highlightedSettingId = "advanced.taskassistant"
+      }
     }
-
-    // MARK: - Rewind Section
-
-    @ObservedObject private var fontScaleSettings = FontScaleSettings.shared
-    @ObservedObject private var rewindSettings = RewindSettings.shared
-
-    @State private var rewindStats: (total: Int, indexed: Int, storageSize: Int64)? = nil
-
-    private var rewindSection: some View {
-        VStack(spacing: 20) {
-            // Storage Stats
-            settingsCard(settingId: "rewind.storage") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "internaldrive.fill")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Storage")
-                                .scaledFont(size: 15, weight: .medium)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            if let stats = rewindStats {
-                                Text("\(stats.total) frames • \(RewindStorage.formatBytes(stats.storageSize))")
-                                    .scaledFont(size: 13)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            } else {
-                                Text("Loading...")
-                                    .scaledFont(size: 13)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-                        }
-
-                        Spacer()
-                    }
-                }
-            }
-            .task {
-                rewindStats = await RewindIndexer.shared.getStats()
-            }
-
-            // Excluded Apps
-            settingsCard(settingId: "rewind.excludedapps") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "eye.slash.fill")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Excluded Apps")
-                                .scaledFont(size: 15, weight: .medium)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Text("Screen capture is paused when these apps are active")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        Button("Reset to Defaults") {
-                            rewindSettings.resetToDefaults()
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // List of excluded apps
-                    if rewindSettings.excludedApps.isEmpty {
-                        HStack {
-                            Spacer()
-                            VStack(spacing: 8) {
-                                Image(systemName: "checkmark.shield")
-                                    .scaledFont(size: 24)
-                                    .foregroundColor(OmiColors.textTertiary)
-                                Text("No apps excluded")
-                                    .scaledFont(size: 13)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-                            .padding(.vertical, 16)
-                            Spacer()
-                        }
-                    } else {
-                        LazyVStack(spacing: 8) {
-                            ForEach(Array(rewindSettings.excludedApps).sorted(), id: \.self) { appName in
-                                ExcludedAppRow(
-                                    appName: appName,
-                                    onRemove: {
-                                        rewindSettings.includeApp(appName)
-                                    }
-                                )
-                            }
-                        }
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Add app section
-                    AddExcludedAppView(
-                        onAdd: { appName in
-                            rewindSettings.excludeApp(appName)
-                        },
-                        excludedApps: rewindSettings.excludedApps
-                    )
-                }
-            }
-
-            // Battery Settings
-            settingsCard(settingId: "rewind.battery") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "battery.75percent")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Battery Optimization")
-                                .scaledFont(size: 15, weight: .medium)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Text("Pause text recognition on battery to save energy. OCR runs automatically when plugged back in.")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        Toggle("", isOn: $rewindSettings.pauseOCROnBattery)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                    }
-                }
-            }
-
-            // Retention Settings
-            settingsCard(settingId: "rewind.retention") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "clock.fill")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Data Retention")
-                                .scaledFont(size: 15, weight: .medium)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Text("How long to keep screen recordings")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        Picker("", selection: $rewindSettings.retentionDays) {
-                            Text("3 days").tag(3)
-                            Text("7 days").tag(7)
-                            Text("14 days").tag(14)
-                            Text("30 days").tag(30)
-                        }
-                        .pickerStyle(.menu)
-                        .frame(width: 110)
-                    }
-                }
-            }
-        }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToFloatingBarSettings)) { _ in
+      selectedSection = .advanced
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+        highlightedSettingId = "advanced.askomifloatingbar"
+      }
     }
-
-    // MARK: - Transcription Section
-
-    private var transcriptionSection: some View {
-        VStack(spacing: 20) {
-            // Language Mode
-            settingsCard(settingId: "transcription.languagemode") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "globe")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Language Mode")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-                    }
-
-                    // Auto-Detect option
-                    Button(action: {
-                        transcriptionAutoDetect = true
-                        AssistantSettings.shared.transcriptionAutoDetect = true
-                        updateTranscriptionPreferences(singleLanguageMode: false)
-                        restartTranscriptionIfNeeded()
-                    }) {
-                        HStack(alignment: .top, spacing: 12) {
-                            Image(systemName: transcriptionAutoDetect ? "checkmark.circle.fill" : "circle")
-                                .scaledFont(size: 20)
-                                .foregroundColor(transcriptionAutoDetect ? OmiColors.purplePrimary : OmiColors.textTertiary)
-
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Auto-Detect (Multi-Language)")
-                                    .scaledFont(size: 14, weight: .medium)
-                                    .foregroundColor(OmiColors.textPrimary)
-
-                                Text("Automatically detects and transcribes:")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-
-                                // List of supported languages
-                                Text("English, Spanish, French, German, Hindi, Russian, Portuguese, Japanese, Italian, Dutch")
-                                    .scaledFont(size: 11)
-                                    .foregroundColor(OmiColors.textTertiary)
-                                    .fixedSize(horizontal: false, vertical: true)
-                            }
-
-                            Spacer()
-                        }
-                        .padding(12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(transcriptionAutoDetect ? OmiColors.purplePrimary.opacity(0.1) : Color.clear)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(transcriptionAutoDetect ? OmiColors.purplePrimary.opacity(0.3) : OmiColors.backgroundQuaternary, lineWidth: 1)
-                                )
-                        )
-                    }
-                    .buttonStyle(.plain)
-
-                    // Single Language option
-                    Button(action: {
-                        transcriptionAutoDetect = false
-                        AssistantSettings.shared.transcriptionAutoDetect = false
-                        updateTranscriptionPreferences(singleLanguageMode: true)
-                        restartTranscriptionIfNeeded()
-                    }) {
-                        HStack(alignment: .top, spacing: 12) {
-                            Image(systemName: !transcriptionAutoDetect ? "checkmark.circle.fill" : "circle")
-                                .scaledFont(size: 20)
-                                .foregroundColor(!transcriptionAutoDetect ? OmiColors.purplePrimary : OmiColors.textTertiary)
-
-                            VStack(alignment: .leading, spacing: 6) {
-                                Text("Single Language (Better Accuracy)")
-                                    .scaledFont(size: 14, weight: .medium)
-                                    .foregroundColor(OmiColors.textPrimary)
-
-                                Text("Best for speaking in one specific language")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-
-                                // Language picker (only shown when single language is selected)
-                                if !transcriptionAutoDetect {
-                                    HStack {
-                                        Text("Language:")
-                                            .scaledFont(size: 12)
-                                            .foregroundColor(OmiColors.textTertiary)
-
-                                        Picker("", selection: $transcriptionLanguage) {
-                                            ForEach(languageOptions, id: \.0) { option in
-                                                Text(option.1).tag(option.0)
-                                            }
-                                        }
-                                        .pickerStyle(.menu)
-                                        .frame(width: 180)
-                                        .onChange(of: transcriptionLanguage) { _, newValue in
-                                            AssistantSettings.shared.transcriptionLanguage = newValue
-                                            let supportsMulti = AssistantSettings.supportsAutoDetect(newValue)
-                                            transcriptionAutoDetect = supportsMulti
-                                            AssistantSettings.shared.transcriptionAutoDetect = supportsMulti
-                                            updateTranscriptionPreferences(singleLanguageMode: !supportsMulti)
-                                            updateLanguage(newValue)
-                                            restartTranscriptionIfNeeded()
-                                        }
-                                    }
-                                    .padding(.top, 4)
-                                }
-                            }
-
-                            Spacer()
-                        }
-                        .padding(12)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(!transcriptionAutoDetect ? OmiColors.purplePrimary.opacity(0.1) : Color.clear)
-                                .overlay(
-                                    RoundedRectangle(cornerRadius: 8)
-                                        .stroke(!transcriptionAutoDetect ? OmiColors.purplePrimary.opacity(0.3) : OmiColors.backgroundQuaternary, lineWidth: 1)
-                                )
-                        )
-                    }
-                    .buttonStyle(.plain)
-
-                    // Info about language support
-                    HStack(spacing: 8) {
-                        Image(systemName: "info.circle")
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        Text("Single language mode supports 42 languages including Ukrainian, Russian, and more.")
-                            .scaledFont(size: 11)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                }
-            }
-
-            // Custom Vocabulary
-            settingsCard(settingId: "transcription.vocabulary") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "text.book.closed")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Custom Vocabulary")
-                                .scaledFont(size: 15, weight: .medium)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Text("Improve recognition of names, brands, and technical terms")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        if !vocabularyList.isEmpty {
-                            Text("\(vocabularyList.count) terms")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-                    }
-
-                    // Current vocabulary display with removable tags
-                    if !vocabularyList.isEmpty {
-                        FlowLayout(spacing: 6) {
-                            ForEach(vocabularyList, id: \.self) { term in
-                                HStack(spacing: 4) {
-                                    Text(term)
-                                        .scaledFont(size: 12)
-                                        .foregroundColor(OmiColors.textSecondary)
-
-                                    Button(action: {
-                                        removeVocabularyWord(term)
-                                    }) {
-                                        Image(systemName: "xmark")
-                                            .scaledFont(size: 9, weight: .medium)
-                                            .foregroundColor(OmiColors.textTertiary)
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                                .padding(.horizontal, 10)
-                                .padding(.vertical, 6)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 6)
-                                        .fill(OmiColors.backgroundQuaternary)
-                                )
-                            }
-                        }
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Add new word input
-                    HStack(spacing: 8) {
-                        TextField("Add a word...", text: $newVocabularyWord)
-                            .textFieldStyle(.roundedBorder)
-                            .onSubmit {
-                                addVocabularyWord()
-                            }
-
-                        Button(action: {
-                            addVocabularyWord()
-                        }) {
-                            Image(systemName: "plus.circle.fill")
-                                .scaledFont(size: 20)
-                                .foregroundColor(newVocabularyWord.trimmingCharacters(in: .whitespaces).isEmpty ? OmiColors.textTertiary : OmiColors.purplePrimary)
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(newVocabularyWord.trimmingCharacters(in: .whitespaces).isEmpty)
-                    }
-
-                    Text("Press Enter or click + to add • Click × to remove")
-                        .scaledFont(size: 11)
-                        .foregroundColor(OmiColors.textTertiary)
-                }
-            }
-
-            // Local VAD Gate
-            settingsCard(settingId: "transcription.vadgate") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "waveform.badge.minus")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Local VAD Gate")
-                                .scaledFont(size: 15, weight: .medium)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Text("Uses on-device voice activity detection to skip silence, reducing Deepgram API usage. May save ~40% on transcription costs.")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-
-                        Spacer()
-
-                        Toggle("", isOn: $vadGateEnabled)
-                            .toggleStyle(.switch)
-                            .onChange(of: vadGateEnabled) { _, newValue in
-                                AssistantSettings.shared.vadGateEnabled = newValue
-                                restartTranscriptionIfNeeded()
-                            }
-                    }
-                }
-            }
-
-            // Batch Transcription
-            settingsCard(settingId: "transcription.batch") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "square.stack.3d.up")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Batch Transcription")
-                                .scaledFont(size: 15, weight: .medium)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Text("Transcribes audio in chunks at silence boundaries. Better accuracy, but transcript appears with a few seconds delay.")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                                .fixedSize(horizontal: false, vertical: true)
-                        }
-
-                        Spacer()
-
-                        Toggle("", isOn: $batchTranscriptionEnabled)
-                            .toggleStyle(.switch)
-                            .onChange(of: batchTranscriptionEnabled) { _, newValue in
-                                AssistantSettings.shared.batchTranscriptionEnabled = newValue
-                                restartTranscriptionIfNeeded()
-                            }
-                    }
-                }
-            }
-        }
+    .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification))
+    { _ in
+      // Refresh notification permission when app becomes active (user may have changed it in System Settings)
+      appState.checkNotificationPermission()
     }
-
-    /// Add a word to the vocabulary
-    private func addVocabularyWord() {
-        let word = newVocabularyWord.trimmingCharacters(in: .whitespaces)
-        guard !word.isEmpty else { return }
-
-        // Don't add duplicates (case-insensitive check)
-        guard !vocabularyList.contains(where: { $0.lowercased() == word.lowercased() }) else {
-            newVocabularyWord = ""
-            return
-        }
-
-        vocabularyList.append(word)
-        newVocabularyWord = ""
-        saveVocabulary()
-    }
-
-    /// Remove a word from the vocabulary
-    private func removeVocabularyWord(_ word: String) {
-        vocabularyList.removeAll { $0 == word }
-        saveVocabulary()
-    }
-
-    /// Save vocabulary to local settings and backend
-    private func saveVocabulary() {
-        // Save to local settings
-        AssistantSettings.shared.transcriptionVocabulary = vocabularyList
-
-        // Sync to backend
-        updateTranscriptionPreferences(vocabulary: vocabularyList.joined(separator: ", "))
-    }
-
-    /// Restart transcription if currently running to apply new settings
-    private func restartTranscriptionIfNeeded() {
-        guard appState.isTranscribing else { return }
-
-        // Stop and restart to apply new language settings
-        appState.stopTranscription()
-
-        // Wait a moment for cleanup, then restart
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
-            self.appState.startTranscription()
-        }
-    }
-
-    // MARK: - Notifications Section
-
-    private var notificationsSection: some View {
-        VStack(spacing: 20) {
-            // Notifications
-            settingsCard(settingId: "notifications.settings") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "bell.badge.fill")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Notifications")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $notificationsEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .onChange(of: notificationsEnabled) { _, newValue in
-                                updateNotificationSettings(enabled: newValue)
-                            }
-                    }
-
-                    Text("Control how often you receive notifications")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if notificationsEnabled {
-                        Divider()
-                            .background(OmiColors.backgroundQuaternary)
-
-                        settingRow(title: "Frequency", subtitle: "How often to receive notifications", settingId: "notifications.frequency") {
-                            Picker("", selection: $notificationFrequency) {
-                                ForEach(frequencyOptions, id: \.0) { option in
-                                    Text(option.1).tag(option.0)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                            .frame(width: 120)
-                            .onChange(of: notificationFrequency) { _, newValue in
-                                updateNotificationSettings(frequency: newValue)
-                            }
-                        }
-
-                        settingRow(title: "Focus Notifications", subtitle: "Show notification on focus changes", settingId: "notifications.focus") {
-                            Toggle("", isOn: $focusNotificationsEnabled)
-                                .toggleStyle(.switch)
-                                .labelsHidden()
-                                .onChange(of: focusNotificationsEnabled) { _, newValue in
-                                    FocusAssistantSettings.shared.notificationsEnabled = newValue
-                                    SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(focus: FocusSettingsResponse(notificationsEnabled: newValue)))
-                                }
-                        }
-
-                        settingRow(title: "Task Notifications", subtitle: "Show notification when a task is extracted", settingId: "notifications.task") {
-                            Toggle("", isOn: $taskNotificationsEnabled)
-                                .toggleStyle(.switch)
-                                .labelsHidden()
-                                .onChange(of: taskNotificationsEnabled) { _, newValue in
-                                    TaskAssistantSettings.shared.notificationsEnabled = newValue
-                                    SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(task: TaskSettingsResponse(notificationsEnabled: newValue)))
-                                }
-                        }
-
-                        settingRow(title: "Advice Notifications", subtitle: "Show notification when advice is generated", settingId: "notifications.advice") {
-                            Toggle("", isOn: $adviceNotificationsEnabled)
-                                .toggleStyle(.switch)
-                                .labelsHidden()
-                                .onChange(of: adviceNotificationsEnabled) { _, newValue in
-                                    AdviceAssistantSettings.shared.notificationsEnabled = newValue
-                                    SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(advice: AdviceSettingsResponse(notificationsEnabled: newValue)))
-                                }
-                        }
-
-                        settingRow(title: "Memory Notifications", subtitle: "Show notification when a memory is extracted", settingId: "notifications.memory") {
-                            Toggle("", isOn: $memoryNotificationsEnabled)
-                                .toggleStyle(.switch)
-                                .labelsHidden()
-                                .onChange(of: memoryNotificationsEnabled) { _, newValue in
-                                    MemoryAssistantSettings.shared.notificationsEnabled = newValue
-                                    SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(memory: MemorySettingsResponse(notificationsEnabled: newValue)))
-                                }
-                        }
-                    }
-                }
-            }
-
-            // Daily Summary
-            settingsCard(settingId: "notifications.dailysummary") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "text.badge.checkmark")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Daily Summary")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $dailySummaryEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .onChange(of: dailySummaryEnabled) { _, newValue in
-                                updateDailySummarySettings(enabled: newValue)
-                            }
-                    }
-
-                    Text("Receive a daily summary of your conversations and activities")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if dailySummaryEnabled {
-                        Divider()
-                            .background(OmiColors.backgroundQuaternary)
-
-                        settingRow(title: "Summary Time", subtitle: "When to send your daily summary", settingId: "notifications.summarytime") {
-                            Picker("", selection: $dailySummaryHour) {
-                                ForEach(hourOptions, id: \.self) { hour in
-                                    Text(formatHour(hour)).tag(hour)
-                                }
-                            }
-                            .pickerStyle(.menu)
-                            .frame(width: 100)
-                            .onChange(of: dailySummaryHour) { _, newValue in
-                                updateDailySummarySettings(hour: newValue)
-                            }
-                        }
-                    }
-                }
-            }
-
-        }
-    }
-
-    // MARK: - Privacy Section
-
-    private var privacySection: some View {
-        VStack(spacing: 16) {
-            // Data Controls
-            settingsCard(settingId: "privacy.storerecordings") {
-                VStack(alignment: .leading, spacing: 0) {
-                    HStack {
-                        Image(systemName: "mic.fill")
-                            .scaledFont(size: 14)
-                            .foregroundColor(OmiColors.purplePrimary)
-                            .frame(width: 20)
-
-                        Text("Store Recordings")
-                            .scaledFont(size: 14, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $recordingPermissionEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .controlSize(.small)
-                            .onChange(of: recordingPermissionEnabled) { _, newValue in
-                                updateRecordingPermission(newValue)
-                            }
-                    }
-                    .padding(.bottom, 4)
-
-                    Text("Allow omi to store audio recordings of your conversations")
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-                        .padding(.leading, 34)
-
-                    Divider()
-                        .padding(.vertical, 12)
-
-                    HStack {
-                        Image(systemName: "cloud.fill")
-                            .scaledFont(size: 14)
-                            .foregroundColor(OmiColors.purplePrimary)
-                            .frame(width: 20)
-
-                        Text("Private Cloud Sync")
-                            .scaledFont(size: 14, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $privateCloudSyncEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .controlSize(.small)
-                            .onChange(of: privateCloudSyncEnabled) { _, newValue in
-                                updatePrivateCloudSync(newValue)
-                            }
-                    }
-                    .padding(.bottom, 4)
-
-                    Text("Sync your data securely to your private cloud storage")
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-                        .padding(.leading, 34)
-                }
-            }
-
-            // Encryption
-            settingsCard(settingId: "privacy.encryption") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack(spacing: 10) {
-                        Image(systemName: "shield.lefthalf.filled")
-                            .scaledFont(size: 14)
-                            .foregroundColor(OmiColors.purplePrimary)
-                            .frame(width: 20)
-
-                        Text("Encryption")
-                            .scaledFont(size: 14, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-                    }
-
-                    HStack(spacing: 10) {
-                        Image(systemName: "checkmark.circle.fill")
-                            .scaledFont(size: 12)
-                            .foregroundColor(.green)
-                            .frame(width: 20)
-
-                        Text("Server-side encryption")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textSecondary)
-
-                        Text("Active")
-                            .scaledFont(size: 10, weight: .semibold)
-                            .foregroundColor(.green)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 1)
-                            .background(Color.green.opacity(0.15))
-                            .cornerRadius(3)
-                    }
-                    .padding(.leading, 14)
-
-                    Text("Your data is encrypted and stored securely with Google Cloud infrastructure.")
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-                        .padding(.leading, 34)
-                }
-            }
-
-            // What We Track
-            settingsCard(settingId: "privacy.tracking") {
-                VStack(alignment: .leading, spacing: 0) {
-                    Button(action: {
-                        withAnimation(.easeInOut(duration: 0.2)) {
-                            isTrackingExpanded.toggle()
-                        }
-                    }) {
-                        HStack(spacing: 10) {
-                            Image(systemName: "list.bullet")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.purplePrimary)
-                                .frame(width: 20)
-
-                            Text("What We Track")
-                                .scaledFont(size: 14, weight: .medium)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            Spacer()
-
-                            Image(systemName: "chevron.right")
-                                .scaledFont(size: 11, weight: .semibold)
-                                .foregroundColor(OmiColors.textTertiary)
-                                .rotationEffect(.degrees(isTrackingExpanded ? 90 : 0))
-                        }
-                    }
-                    .buttonStyle(.plain)
-
-                    if isTrackingExpanded {
-                        VStack(alignment: .leading, spacing: 6) {
-                            trackingItem("Onboarding steps completed")
-                            trackingItem("Settings changes")
-                            trackingItem("App installations and usage")
-                            trackingItem("Device connection status")
-                            trackingItem("Transcript processing events")
-                            trackingItem("Conversation creation and updates")
-                            trackingItem("Memory extraction events")
-                            trackingItem("Chat interactions")
-                            trackingItem("Speech profile creation")
-                            trackingItem("Focus session events")
-                            trackingItem("App open/close events")
-                        }
-                        .padding(.top, 10)
-                        .padding(.leading, 34)
-                        .transition(.opacity)
-                    }
-                }
-            }
-
-            // Privacy Guarantees
-            settingsCard(settingId: "privacy.privacy") {
-                VStack(alignment: .leading, spacing: 10) {
-                    HStack(spacing: 10) {
-                        Image(systemName: "hand.raised.fill")
-                            .scaledFont(size: 14)
-                            .foregroundColor(OmiColors.purplePrimary)
-                            .frame(width: 20)
-
-                        Text("Privacy Guarantees")
-                            .scaledFont(size: 14, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-                    }
-
-                    VStack(alignment: .leading, spacing: 6) {
-                        privacyBullet("Anonymous tracking with randomly generated IDs")
-                        privacyBullet("No personal info stored in analytics")
-                        privacyBullet("Data is never sold or shared with third parties")
-                        privacyBullet("Opt out of tracking at any time")
-                    }
-                    .padding(.leading, 34)
-                }
-            }
-        }
-    }
-
-    // MARK: - Account Section
-
-    private var accountSection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "account.account") {
-                VStack(alignment: .leading, spacing: 14) {
-                    HStack(spacing: 16) {
-                        Image(systemName: "person.circle.fill")
-                            .scaledFont(size: 40)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text(AuthService.shared.displayName.isEmpty ? "User" : AuthService.shared.displayName)
-                                .scaledFont(size: 16, weight: .semibold)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            if let email = AuthState.shared.userEmail {
-                                Text(email)
-                                    .scaledFont(size: 13)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-                        }
-
-                        Spacer()
-
-                        Button("Sign Out") {
-                            appState.stopTranscription()
-                            ProactiveAssistantsPlugin.shared.stopMonitoring()
-                            try? AuthService.shared.signOut()
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(isDeletingAccount)
-                    }
-
-                    Divider()
-                        .overlay(OmiColors.backgroundQuaternary)
-
-                    HStack(alignment: .center, spacing: 16) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Delete Account & Data")
-                                .scaledFont(size: 15, weight: .semibold)
-                                .foregroundColor(OmiColors.error)
-
-                            Text("Permanently deletes server data, clears local data for this account, resets onboarding, and signs you out.")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        Button(action: {
-                            AnalyticsManager.shared.deleteAccountClicked()
-                            showDeleteAccountAlert = true
-                        }) {
-                            if isDeletingAccount {
-                                ProgressView()
-                                    .controlSize(.small)
-                            } else {
-                                Text("Delete")
-                                    .scaledFont(size: 13, weight: .semibold)
-                            }
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .tint(OmiColors.error)
-                        .disabled(isDeletingAccount)
-                    }
-
-                    if let deleteAccountError {
-                        Text(deleteAccountError)
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.warning)
-                    }
-                }
-            }
-            .alert("Delete Account and Data?", isPresented: $showDeleteAccountAlert) {
-                Button("Cancel", role: .cancel) {
-                    AnalyticsManager.shared.deleteAccountCancelled()
-                }
-                Button("Delete Permanently", role: .destructive) {
-                    deleteAccountAndData()
-                }
-            } message: {
-                Text("This cannot be undone. Your account, chat history, and all server data will be permanently deleted. Local data for this account will be cleared and you'll return to onboarding.")
-            }
-
-//            settingsCard {
-//                HStack(spacing: 16) {
-//                    Image(systemName: "bolt.fill")
-//                        .scaledFont(size: 16)
-//                        .foregroundColor(.yellow)
-//
-//                    VStack(alignment: .leading, spacing: 4) {
-//                        Text("Upgrade to Pro")
-//                            .scaledFont(size: 15, weight: .medium)
-//                            .foregroundColor(OmiColors.textPrimary)
-//
-//                        Text("Unlock all features and unlimited usage")
-//                            .scaledFont(size: 13)
-//                            .foregroundColor(OmiColors.textTertiary)
-//                    }
-//
-//                    Spacer()
-//
-//                    Button("Upgrade") {
-//                        if let url = URL(string: "https://omi.me/pricing") {
-//                            NSWorkspace.shared.open(url)
-//                        }
-//                    }
-//                    .buttonStyle(.borderedProminent)
-//                    .tint(OmiColors.purplePrimary)
-//                }
-//            }
-        }
-    }
-
-    // MARK: - AI Chat Section
-
-    private var aiChatSection: some View {
-        VStack(spacing: 20) {
-            // AI Provider card
-            settingsCard(settingId: "aichat.provider") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "cpu")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        Text("AI Provider")
-                            .scaledFont(size: 15, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Picker("", selection: $chatBridgeMode) {
-                            Text("omi account").tag("agentSDK")
-                            Text("Your Claude Account").tag("claudeCode")
-                        }
-                        .pickerStyle(.menu)
-                        .frame(width: 200)
-                        .onChange(of: chatBridgeMode) { _, newMode in
-                            if let mode = ChatProvider.BridgeMode(rawValue: newMode) {
-                                Task {
-                                    await chatProvider?.switchBridgeMode(to: mode)
-                                }
-                            }
-                        }
-                    }
-
-                    Text(chatBridgeMode == "claudeCode"
-                         ? "Using your Claude Pro/Max subscription. You'll be prompted to sign in with your Claude account."
-                         : "Using your omi account.")
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if chatBridgeMode == "claudeCode" && chatProvider?.isClaudeConnected == true {
-                        Divider()
-
-                        HStack {
-                            Image(systemName: "checkmark.circle.fill")
-                                .foregroundColor(.green)
-                                .scaledFont(size: 12)
-                            Text("Connected to Claude")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textSecondary)
-
-                            Spacer()
-
-                            Button("Disconnect") {
-                                Task {
-                                    await chatProvider?.disconnectClaude()
-                                }
-                            }
-                            .buttonStyle(.plain)
-                            .scaledFont(size: 12, weight: .medium)
-                            .foregroundColor(.red)
-                        }
-                    }
-                }
-            }
-            .onAppear {
-                chatProvider?.checkClaudeConnectionStatus()
-            }
-
-            // Ask Mode card
-            settingsCard(settingId: "aichat.askmode") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "bubble.left.and.bubble.right")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        Text("Ask Mode")
-                            .scaledFont(size: 15, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $askModeEnabled)
-                            .toggleStyle(.switch)
-                            .controlSize(.small)
-                            .labelsHidden()
-                    }
-
-                    Text("When enabled, shows an Ask/Act toggle in the chat. Ask mode restricts the AI to read-only actions. When disabled, the AI always runs in Act mode.")
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-                }
-            }
-
-            // Workspace card
-            settingsCard(settingId: "aichat.workspace") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "folder")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        Text("Workspace")
-                            .scaledFont(size: 15, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Button("Browse...") {
-                            let panel = NSOpenPanel()
-                            panel.canChooseFiles = false
-                            panel.canChooseDirectories = true
-                            panel.allowsMultipleSelection = false
-                            panel.message = "Select a project directory"
-                            if panel.runModal() == .OK, let url = panel.url {
-                                aiChatWorkingDirectory = url.path
-                                refreshAIChatConfig()
-                                // Update ChatProvider
-                                chatProvider?.aiChatWorkingDirectory = url.path
-                                Task { await chatProvider?.discoverClaudeConfig() }
-                                if chatProvider?.workingDirectory == nil {
-                                    chatProvider?.workingDirectory = url.path
-                                }
-                            }
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-
-                        if !aiChatWorkingDirectory.isEmpty {
-                            Button("Clear") {
-                                aiChatWorkingDirectory = ""
-                                refreshAIChatConfig()
-                                chatProvider?.aiChatWorkingDirectory = ""
-                                Task { await chatProvider?.discoverClaudeConfig() }
-                                chatProvider?.workingDirectory = nil
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-                    }
-
-                    if !aiChatWorkingDirectory.isEmpty {
-                        Text(aiChatWorkingDirectory)
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textTertiary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-
-                        Text("Project-level CLAUDE.md and skills will be discovered from this directory")
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textTertiary)
-                    } else {
-                        Text("No workspace set. Set a project directory to discover project-level CLAUDE.md and skills.")
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                }
-            }
-
-            // CLAUDE.md card
-            settingsCard(settingId: "aichat.claudemd") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "doc.text")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        Text("CLAUDE.md")
-                            .scaledFont(size: 15, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-                    }
-
-                    // Global CLAUDE.md
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            Text("Global")
-                                .scaledFont(size: 11, weight: .medium)
-                                .foregroundColor(OmiColors.textTertiary)
-                                .padding(.horizontal, 6)
-                                .padding(.vertical, 2)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 4)
-                                        .fill(OmiColors.backgroundPrimary.opacity(0.5))
-                                )
-
-                            Spacer()
-
-                            if aiChatClaudeMdContent != nil {
-                                Button("View") {
-                                    fileViewerTitle = "Global CLAUDE.md"
-                                    fileViewerContent = aiChatClaudeMdContent ?? ""
-                                    showFileViewer = true
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-
-                                Toggle("", isOn: $claudeMdEnabled)
-                                    .toggleStyle(.switch)
-                                    .controlSize(.small)
-                                    .labelsHidden()
-                            }
-                        }
-
-                        if let path = aiChatClaudeMdPath, let content = aiChatClaudeMdContent {
-                            let sizeKB = Double(content.utf8.count) / 1024.0
-                            Text("\(path) (\(String(format: "%.1f", sizeKB)) KB)")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        } else {
-                            Text("No CLAUDE.md found at ~/.claude/CLAUDE.md")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-                    }
-
-                    // Project CLAUDE.md (only show if workspace is set)
-                    if !aiChatWorkingDirectory.isEmpty {
-                        Divider().opacity(0.3)
-
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack {
-                                Text("Project")
-                                    .scaledFont(size: 11, weight: .medium)
-                                    .foregroundColor(OmiColors.purplePrimary)
-                                    .padding(.horizontal, 6)
-                                    .padding(.vertical, 2)
-                                    .background(
-                                        RoundedRectangle(cornerRadius: 4)
-                                            .fill(OmiColors.purplePrimary.opacity(0.1))
-                                    )
-
-                                Spacer()
-
-                                if aiChatProjectClaudeMdContent != nil {
-                                    Button("View") {
-                                        fileViewerTitle = "Project CLAUDE.md"
-                                        fileViewerContent = aiChatProjectClaudeMdContent ?? ""
-                                        showFileViewer = true
-                                    }
-                                    .buttonStyle(.bordered)
-                                    .controlSize(.small)
-
-                                    Toggle("", isOn: $projectClaudeMdEnabled)
-                                        .toggleStyle(.switch)
-                                        .controlSize(.small)
-                                        .labelsHidden()
-                                }
-                            }
-
-                            if let path = aiChatProjectClaudeMdPath, let content = aiChatProjectClaudeMdContent {
-                                let sizeKB = Double(content.utf8.count) / 1024.0
-                                Text("\(path) (\(String(format: "%.1f", sizeKB)) KB)")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-                                    .lineLimit(1)
-                                    .truncationMode(.middle)
-                            } else {
-                                Text("No CLAUDE.md found at \(aiChatWorkingDirectory)/CLAUDE.md")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Skills card
-            settingsCard(settingId: "aichat.skills") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "sparkles")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        if aiChatProjectDiscoveredSkills.isEmpty {
-                            Text("Skills (\(aiChatDiscoveredSkills.count) discovered)")
-                                .scaledFont(size: 15, weight: .semibold)
-                                .foregroundColor(OmiColors.textPrimary)
-                        } else {
-                            Text("Skills (\(aiChatDiscoveredSkills.count) global + \(aiChatProjectDiscoveredSkills.count) project)")
-                                .scaledFont(size: 15, weight: .semibold)
-                                .foregroundColor(OmiColors.textPrimary)
-                        }
-
-                        Spacer()
-
-                        Button(action: { refreshAIChatConfig() }) {
-                            Image(systemName: "arrow.clockwise")
-                                .scaledFont(size: 13)
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    }
-
-                    let allSkills: [(skill: (name: String, description: String, path: String), origin: String)] =
-                        aiChatDiscoveredSkills.map { ($0, "Global") } +
-                        aiChatProjectDiscoveredSkills.map { ($0, "Project") }
-
-                    if allSkills.isEmpty {
-                        Text("No skills found in ~/.claude/skills/")
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textTertiary)
-                    } else {
-                        Text("Skill descriptions are included in the AI chat system prompt")
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        // Search field
-                        HStack(spacing: 8) {
-                            Image(systemName: "magnifyingglass")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-
-                            TextField("Search skills...", text: $skillSearchQuery)
-                                .textFieldStyle(.plain)
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textPrimary)
-
-                            if !skillSearchQuery.isEmpty {
-                                Button(action: { skillSearchQuery = "" }) {
-                                    Image(systemName: "xmark.circle.fill")
-                                        .scaledFont(size: 12)
-                                        .foregroundColor(OmiColors.textTertiary)
-                                }
-                                .buttonStyle(.plain)
-                            }
-                        }
-                        .padding(8)
-                        .background(
-                            RoundedRectangle(cornerRadius: 8)
-                                .fill(OmiColors.backgroundPrimary.opacity(0.5))
-                        )
-
-                        ScrollView {
-                            let filteredSkills = allSkills.enumerated().filter { _, item in
-                                skillSearchQuery.isEmpty ||
-                                item.skill.name.localizedCaseInsensitiveContains(skillSearchQuery) ||
-                                item.skill.description.localizedCaseInsensitiveContains(skillSearchQuery)
-                            }
-
-                            VStack(spacing: 0) {
-                                ForEach(Array(filteredSkills.enumerated()), id: \.offset) { filteredIndex, item in
-                                    let skill = item.element.skill
-                                    let origin = item.element.origin
-                                    HStack(spacing: 10) {
-                                        Toggle("", isOn: Binding(
-                                            get: { !aiChatDisabledSkills.contains(skill.name) },
-                                            set: { enabled in
-                                                if enabled {
-                                                    aiChatDisabledSkills.remove(skill.name)
-                                                } else {
-                                                    aiChatDisabledSkills.insert(skill.name)
-                                                }
-                                                saveDisabledSkills()
-                                            }
-                                        ))
-                                        .toggleStyle(.checkbox)
-                                        .labelsHidden()
-
-                                        VStack(alignment: .leading, spacing: 2) {
-                                            HStack(spacing: 6) {
-                                                Text(skill.name)
-                                                    .scaledFont(size: 13, weight: .medium)
-                                                    .foregroundColor(OmiColors.textPrimary)
-
-                                                Text(origin)
-                                                    .scaledFont(size: 9, weight: .medium)
-                                                    .foregroundColor(origin == "Project" ? OmiColors.purplePrimary : OmiColors.textTertiary)
-                                                    .padding(.horizontal, 4)
-                                                    .padding(.vertical, 1)
-                                                    .background(
-                                                        RoundedRectangle(cornerRadius: 3)
-                                                            .fill(origin == "Project" ? OmiColors.purplePrimary.opacity(0.1) : OmiColors.backgroundPrimary.opacity(0.5))
-                                                    )
-                                            }
-
-                                            if !skill.description.isEmpty {
-                                                Text(skill.description)
-                                                    .scaledFont(size: 11)
-                                                    .foregroundColor(OmiColors.textTertiary)
-                                                    .lineLimit(1)
-                                                    .truncationMode(.tail)
-                                            }
-                                        }
-
-                                        Spacer()
-
-                                        Button("View") {
-                                            fileViewerTitle = "\(skill.name)/SKILL.md"
-                                            fileViewerContent = (try? String(contentsOfFile: skill.path, encoding: .utf8)) ?? "Unable to read file"
-                                            showFileViewer = true
-                                        }
-                                        .buttonStyle(.bordered)
-                                        .controlSize(.mini)
-                                    }
-                                    .padding(.vertical, 6)
-                                    .padding(.horizontal, 4)
-
-                                    if filteredIndex < filteredSkills.count - 1 {
-                                        Divider()
-                                            .opacity(0.3)
-                                    }
-                                }
-                            }
-                        }
-                        .frame(maxHeight: 300)
-                    }
-                }
-            }
-
-            // Browser Extension card
-            settingsCard(settingId: "aichat.browserextension") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "globe")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        Text("Browser Extension")
-                            .scaledFont(size: 15, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        if !playwrightExtensionToken.isEmpty {
-                            HStack(spacing: 4) {
-                                Circle()
-                                    .fill(Color.green)
-                                    .frame(width: 6, height: 6)
-                                Text("Connected")
-                                    .scaledFont(size: 11)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-                        }
-
-                        Toggle("", isOn: $playwrightUseExtension)
-                            .toggleStyle(.switch)
-                            .controlSize(.small)
-                            .labelsHidden()
-                            .onChange(of: playwrightUseExtension) { _, _ in
-                            }
-                    }
-
-                    Text("Lets the AI use your Chrome browser with all your logged-in sessions.")
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if playwrightUseExtension {
-                        if playwrightExtensionToken.isEmpty {
-                            // No token — show "Set Up" button
-                            Button(action: {
-                                showBrowserSetup = true
-                            }) {
-                                HStack(spacing: 6) {
-                                    Image(systemName: "wrench.and.screwdriver")
-                                        .scaledFont(size: 12)
-                                    Text("Set Up")
-                                        .scaledFont(size: 13, weight: .medium)
-                                }
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .controlSize(.small)
-                        } else {
-                            // Token is set — show compact view
-                            HStack(spacing: 8) {
-                                Text("Token")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-
-                                Text(String(playwrightExtensionToken.prefix(8)) + "...")
-                                    .scaledFont(size: 12, weight: .medium)
-                                    .foregroundColor(OmiColors.textPrimary)
-                                    .font(.system(.body, design: .monospaced))
-
-                                Spacer()
-
-                                Button(action: {
-                                    showBrowserSetup = true
-                                }) {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "arrow.clockwise")
-                                            .scaledFont(size: 11)
-                                        Text("Reconfigure")
-                                            .scaledFont(size: 12)
-                                    }
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-
-                                Button(action: {
-                                    playwrightExtensionToken = ""
-                                    UserDefaults.standard.set("", forKey: "playwrightExtensionToken")
-                                }) {
-                                    HStack(spacing: 4) {
-                                        Image(systemName: "xmark")
-                                            .scaledFont(size: 11)
-                                        Text("Reset")
-                                            .scaledFont(size: 12)
-                                    }
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Dev Mode card
-            settingsCard(settingId: "aichat.devmode") {
-                VStack(alignment: .leading, spacing: 12) {
-                    HStack {
-                        Image(systemName: "hammer")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.textTertiary)
-
-                        Text("Dev Mode")
-                            .scaledFont(size: 15, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $devModeEnabled)
-                            .toggleStyle(.switch)
-                            .controlSize(.small)
-                            .labelsHidden()
-                            .onChange(of: devModeEnabled) { _, newValue in
-                                AnalyticsManager.shared.settingToggled(setting: "dev_mode", enabled: newValue)
-                            }
-                    }
-
-                    Text("Let the AI modify the app's source code, rebuild it, and add custom features.")
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if devModeEnabled {
-                        VStack(alignment: .leading, spacing: 8) {
-                            HStack(spacing: 6) {
-                                Image(systemName: "checkmark.circle.fill")
-                                    .foregroundColor(.green)
-                                    .scaledFont(size: 12)
-                                Text("AI can modify UI, add features, create custom SQLite tables")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textSecondary)
-                            }
-                            HStack(spacing: 6) {
-                                Image(systemName: "lock.fill")
-                                    .foregroundColor(.orange)
-                                    .scaledFont(size: 12)
-                                Text("Backend API, auth, and sync logic are read-only")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textSecondary)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        .onAppear {
-            refreshAIChatConfig()
-            playwrightExtensionToken = UserDefaults.standard.string(forKey: "playwrightExtensionToken") ?? ""
-        }
-        .sheet(isPresented: $showFileViewer) {
-            fileViewerSheet
-        }
-        .sheet(isPresented: $showBrowserSetup) {
-            BrowserExtensionSetup(
-                onComplete: {
-                    showBrowserSetup = false
-                    playwrightExtensionToken = UserDefaults.standard.string(forKey: "playwrightExtensionToken") ?? ""
-                },
-                onDismiss: {
-                    showBrowserSetup = false
-                    playwrightExtensionToken = UserDefaults.standard.string(forKey: "playwrightExtensionToken") ?? ""
-                },
-                chatProvider: chatProvider
+  }
+
+  // MARK: - General Section
+
+  private var generalSection: some View {
+    VStack(spacing: 20) {
+      // Screen Capture toggle
+      settingsCard(settingId: "general.screencapture") {
+        HStack(spacing: 16) {
+          Circle()
+            .fill(isMonitoring ? OmiColors.success : OmiColors.textTertiary.opacity(0.3))
+            .frame(width: 12, height: 12)
+            .shadow(color: isMonitoring ? OmiColors.success.opacity(0.5) : .clear, radius: 6)
+
+          Image(systemName: "rectangle.dashed.badge.record")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.purplePrimary)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Screen Capture")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text(
+              permissionError
+                ?? (isMonitoring ? "Capturing screen content" : "Screen capture is paused")
             )
-            .fixedSize()
-        }
-    }
+            .scaledFont(size: 13)
+            .foregroundColor(permissionError != nil ? OmiColors.warning : OmiColors.textTertiary)
+          }
 
-    private var fileViewerSheet: some View {
-        VStack(spacing: 0) {
-            // Header
-            HStack {
-                Text(fileViewerTitle)
-                    .scaledFont(size: 16, weight: .semibold)
-                    .foregroundColor(OmiColors.textPrimary)
+          Spacer()
 
-                Spacer()
-
-                Button(action: { showFileViewer = false }) {
-                    Image(systemName: "xmark.circle.fill")
-                        .scaledFont(size: 18)
-                        .foregroundColor(OmiColors.textTertiary)
-                }
-                .buttonStyle(.plain)
-            }
-            .padding(16)
-
-            Divider().opacity(0.3)
-
-            // Content
-            ScrollView {
-                Text(fileViewerContent)
-                    .font(.system(size: 12, design: .monospaced))
-                    .foregroundColor(OmiColors.textSecondary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(16)
-            }
-        }
-        .frame(width: 600, height: 500)
-        .background(OmiColors.backgroundSecondary)
-    }
-
-    private func refreshAIChatConfig() {
-        // Pull skill and CLAUDE.md data directly from ChatProvider (already discovered at startup).
-        // Fall back to reading from disk only when ChatProvider is unavailable.
-        if let provider = chatProvider {
-            aiChatClaudeMdContent = provider.claudeMdContent
-            aiChatClaudeMdPath = provider.claudeMdPath
-            aiChatDiscoveredSkills = provider.discoveredSkills
-            aiChatProjectClaudeMdContent = provider.projectClaudeMdContent
-            aiChatProjectClaudeMdPath = provider.projectClaudeMdPath
-            aiChatProjectDiscoveredSkills = provider.projectDiscoveredSkills
-            loadDisabledSkills()
-            return
-        }
-
-        // Fallback: read from disk (used when Settings is shown before ChatProvider initializes)
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let claudeDir = "\(home)/.claude"
-
-        let mdPath = "\(claudeDir)/CLAUDE.md"
-        if FileManager.default.fileExists(atPath: mdPath),
-           let content = try? String(contentsOfFile: mdPath, encoding: .utf8) {
-            aiChatClaudeMdContent = content
-            aiChatClaudeMdPath = mdPath
-        } else {
-            aiChatClaudeMdContent = nil
-            aiChatClaudeMdPath = nil
-        }
-
-        var skills: [(name: String, description: String, path: String)] = []
-        let skillsDir = "\(claudeDir)/skills"
-        if let skillDirs = try? FileManager.default.contentsOfDirectory(atPath: skillsDir) {
-            for dir in skillDirs.sorted() {
-                let skillPath = "\(skillsDir)/\(dir)/SKILL.md"
-                if FileManager.default.fileExists(atPath: skillPath),
-                   let content = try? String(contentsOfFile: skillPath, encoding: .utf8) {
-                    let desc = ChatProvider.extractSkillDescription(from: content)
-                    skills.append((name: dir, description: desc, path: skillPath))
-                }
-            }
-        }
-        aiChatDiscoveredSkills = skills
-
-        let workspace = aiChatWorkingDirectory
-        if !workspace.isEmpty, FileManager.default.fileExists(atPath: workspace) {
-            let projectMdPath = "\(workspace)/CLAUDE.md"
-            if FileManager.default.fileExists(atPath: projectMdPath),
-               let content = try? String(contentsOfFile: projectMdPath, encoding: .utf8) {
-                aiChatProjectClaudeMdContent = content
-                aiChatProjectClaudeMdPath = projectMdPath
-            } else {
-                aiChatProjectClaudeMdContent = nil
-                aiChatProjectClaudeMdPath = nil
-            }
-
-            var projectSkills: [(name: String, description: String, path: String)] = []
-            let projectSkillsDir = "\(workspace)/.claude/skills"
-            if let skillDirs = try? FileManager.default.contentsOfDirectory(atPath: projectSkillsDir) {
-                for dir in skillDirs.sorted() {
-                    let skillPath = "\(projectSkillsDir)/\(dir)/SKILL.md"
-                    if FileManager.default.fileExists(atPath: skillPath),
-                       let content = try? String(contentsOfFile: skillPath, encoding: .utf8) {
-                        let desc = ChatProvider.extractSkillDescription(from: content)
-                        projectSkills.append((name: dir, description: desc, path: skillPath))
-                    }
-                }
-            }
-            aiChatProjectDiscoveredSkills = projectSkills
-        } else {
-            aiChatProjectClaudeMdContent = nil
-            aiChatProjectClaudeMdPath = nil
-            aiChatProjectDiscoveredSkills = []
-        }
-
-        loadDisabledSkills()
-    }
-
-    private func loadDisabledSkills() {
-        let json = UserDefaults.standard.string(forKey: "disabledSkillsJSON") ?? ""
-        guard let data = json.data(using: .utf8),
-              let names = try? JSONDecoder().decode([String].self, from: data) else {
-            aiChatDisabledSkills = [] // Default: nothing disabled = all enabled
-            return
-        }
-        aiChatDisabledSkills = Set(names)
-    }
-
-    private func saveDisabledSkills() {
-        if let data = try? JSONEncoder().encode(Array(aiChatDisabledSkills)),
-           let json = String(data: data, encoding: .utf8) {
-            UserDefaults.standard.set(json, forKey: "disabledSkillsJSON")
-        }
-    }
-
-    // MARK: - About Section
-
-    // MARK: - Advanced Section
-
-    struct UserStats {
-        let conversations: Int
-        let appsInstalled: Int
-        let screenshotsTotal: Int
-        let focusSessions: Int
-        let tasksTodo: Int
-        let tasksDone: Int
-        let tasksDeleted: Int
-        let goalsCount: Int
-        let memoriesTotal: Int
-    }
-
-    private func advancedCategoryHeader(title: String, icon: String) -> some View {
-        HStack(spacing: 10) {
-            Image(systemName: icon)
-                .scaledFont(size: 16)
-                .foregroundColor(OmiColors.purplePrimary)
-            Text(title)
-                .scaledFont(size: 18, weight: .semibold)
-                .foregroundColor(OmiColors.textPrimary)
-            Spacer()
-        }
-        .padding(.top, 16)
-    }
-
-    private var advancedSection: some View {
-        VStack(spacing: 24) {
-            advancedCategoryHeader(title: "AI User Profile", icon: "brain")
-            aiUserProfileSubsection
-            advancedCategoryHeader(title: "Your Stats", icon: "chart.bar")
-            statsSubsection
-            advancedCategoryHeader(title: "Feature Tiers", icon: "lock.shield")
-            featureTiersSubsection
-            advancedCategoryHeader(title: "Focus Assistant", icon: "eye.fill")
-            focusAssistantSubsection
-            advancedCategoryHeader(title: "Task Assistant", icon: "checklist")
-            taskAssistantSubsection
-            advancedCategoryHeader(title: "Advice Assistant", icon: "lightbulb.fill")
-            adviceAssistantSubsection
-            advancedCategoryHeader(title: "Memory Assistant", icon: "brain.head.profile")
-            memoryAssistantSubsection
-            advancedCategoryHeader(title: "Analysis Throttle", icon: "clock.arrow.2.circlepath")
-            analysisThrottleSubsection
-            advancedCategoryHeader(title: "Goals", icon: "target")
-            goalsSubsection
-            advancedCategoryHeader(title: "Ask omi Floating Bar", icon: "sparkles")
-            askOmiFloatingBarSubsection
-            advancedCategoryHeader(title: "Preferences", icon: "slider.horizontal.3")
-            preferencesSubsection
-            advancedCategoryHeader(title: "Troubleshooting", icon: "wrench.and.screwdriver")
-            troubleshootingSubsection
-        }
-    }
-
-    // MARK: - Advanced Subsections
-
-    private var aiUserProfileSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.aiuserprofile") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack(spacing: 10) {
-                        Image(systemName: "brain")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("AI User Profile")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        if isGeneratingAIProfile {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else {
-                            Button(action: {
-                                regenerateAIProfile()
-                            }) {
-                                Text(aiProfileText == nil ? "Generate Now" : "Regenerate")
-                                    .scaledFont(size: 12)
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    if let text = aiProfileText {
-                        if isEditingAIProfile {
-                            TextEditor(text: $aiProfileEditText)
-                                .scaledFont(size: 13, design: .monospaced)
-                                .foregroundColor(OmiColors.textSecondary)
-                                .scrollContentBackground(.hidden)
-                                .frame(maxHeight: 200)
-
-                            HStack {
-                                Button("Cancel") {
-                                    isEditingAIProfile = false
-                                }
-                                .buttonStyle(.bordered)
-                                .controlSize(.small)
-
-                                Button("Save") {
-                                    if let id = aiProfileId {
-                                        Task {
-                                            let success = await AIUserProfileService.shared.updateProfileText(
-                                                id: id, newText: aiProfileEditText
-                                            )
-                                            if success {
-                                                aiProfileText = aiProfileEditText
-                                            }
-                                            isEditingAIProfile = false
-                                        }
-                                    }
-                                }
-                                .buttonStyle(.borderedProminent)
-                                .controlSize(.small)
-
-                                Spacer()
-                            }
-                        } else {
-                            ScrollView {
-                                Text(text)
-                                    .scaledFont(size: 13, design: .monospaced)
-                                    .foregroundColor(OmiColors.textSecondary)
-                                    .textSelection(.enabled)
-                                    .if_available_writingToolsNone()
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                            }
-                            .frame(maxHeight: 200)
-
-                            HStack {
-                                if let date = aiProfileGeneratedAt {
-                                    Text("Last updated: \(date.formatted(.relative(presentation: .named)))")
-                                        .scaledFont(size: 12)
-                                        .foregroundColor(OmiColors.textTertiary)
-                                }
-
-                                Spacer()
-
-                                if aiProfileDataSourcesUsed > 0 {
-                                    Text("Data sources: \(aiProfileDataSourcesUsed) items")
-                                        .scaledFont(size: 12)
-                                        .foregroundColor(OmiColors.textTertiary)
-                                }
-
-                                Button(action: {
-                                    aiProfileEditText = text
-                                    isEditingAIProfile = true
-                                }) {
-                                    Image(systemName: "pencil")
-                                        .scaledFont(size: 11)
-                                }
-                                .buttonStyle(.borderless)
-                                .help("Edit profile")
-
-                                Button(action: {
-                                    deleteCurrentAIProfile()
-                                }) {
-                                    Image(systemName: "trash")
-                                        .scaledFont(size: 11)
-                                        .foregroundColor(.red.opacity(0.7))
-                                }
-                                .buttonStyle(.borderless)
-                                .help("Delete this profile")
-                            }
-                        }
-                    } else if !isGeneratingAIProfile {
-                        Text("Your AI user profile will be generated automatically on next launch, or click \"Generate Now\" to create it now.")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    } else {
-                        HStack {
-                            Spacer()
-                            VStack(spacing: 8) {
-                                ProgressView()
-                                Text("Generating profile...")
-                                    .scaledFont(size: 13)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-                            Spacer()
-                        }
-                        .padding(.vertical, 20)
-                    }
-                }
-            }
-        }
-        .task {
-            // Try loading immediately (covers all restarts after first generation)
-            if let profile = await AIUserProfileService.shared.getLatestProfile() {
-                aiProfileId = profile.id
-                aiProfileText = profile.profileText
-                aiProfileGeneratedAt = profile.generatedAt
-                aiProfileDataSourcesUsed = profile.dataSourcesUsed
-                return
-            }
-            // No profile yet — first-ever generation may be in progress, poll briefly
-            for _ in 0..<6 {
-                try? await Task.sleep(nanoseconds: 5_000_000_000)
-                if let profile = await AIUserProfileService.shared.getLatestProfile() {
-                    aiProfileId = profile.id
-                    aiProfileText = profile.profileText
-                    aiProfileGeneratedAt = profile.generatedAt
-                    aiProfileDataSourcesUsed = profile.dataSourcesUsed
-                    return
-                }
-            }
-        }
-    }
-
-    private var statsSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.stats") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack(spacing: 10) {
-                        Image(systemName: "chart.bar")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Your Stats")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    if let stats = advancedStats {
-                        statRow(label: "Conversations", value: stats.conversations)
-                        statRow(label: "Apps Installed", value: stats.appsInstalled)
-                        if isLoadingChatMessages {
-                            HStack {
-                                Text("AI Chat Messages")
-                                    .scaledFont(size: 14)
-                                    .foregroundColor(OmiColors.textSecondary)
-                                Spacer()
-                                ProgressView()
-                                    .controlSize(.mini)
-                            }
-                        } else if let count = chatMessageCount {
-                            statRow(label: "AI Chat Messages", value: count)
-                        }
-                        statRow(label: "Screenshots", value: stats.screenshotsTotal)
-                        statRow(label: "Focus Sessions", value: stats.focusSessions)
-                        statRow(label: "Tasks (To Do)", value: stats.tasksTodo)
-                        statRow(label: "Tasks (Done)", value: stats.tasksDone)
-                        statRow(label: "Tasks (Removed)", value: stats.tasksDeleted)
-                        statRow(label: "Goals", value: stats.goalsCount)
-                        statRow(label: "Memories", value: stats.memoriesTotal)
-                    } else if isLoadingStats {
-                        statRowLoading(label: "Conversations")
-                        statRowLoading(label: "Apps Installed")
-                        statRowLoading(label: "AI Chat Messages")
-                        statRowLoading(label: "Screenshots")
-                        statRowLoading(label: "Focus Sessions")
-                        statRowLoading(label: "Tasks (To Do)")
-                        statRowLoading(label: "Tasks (Done)")
-                        statRowLoading(label: "Tasks (Removed)")
-                        statRowLoading(label: "Goals")
-                        statRowLoading(label: "Memories")
-                    } else {
-                        Text("Unable to load stats")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                }
-            }
-        }
-        .task {
-            await loadAdvancedStats()
-        }
-        .task {
-            await loadChatMessageCount()
-        }
-    }
-
-    private var featureTiersSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.featuretiers") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack(spacing: 10) {
-                        Image(systemName: "lock.shield")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Feature Tiers")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Tier picker — radio-style selector
-                    VStack(alignment: .leading, spacing: 6) {
-                        tierPickerRow(tier: 0, label: "Show All Features", subtitle: "Unlock everything")
-                        tierPickerRow(tier: 1, label: "Tier 1", subtitle: "Conversations + Rewind")
-                        tierPickerRow(tier: 2, label: "Tier 2", subtitle: "+ Memories (100 memories)")
-                        tierPickerRow(tier: 3, label: "Tier 3", subtitle: "+ Tasks (100 tasks)")
-                        tierPickerRow(tier: 4, label: "Tier 4", subtitle: "+ AI Chat (100 conversations)")
-                        tierPickerRow(tier: 5, label: "Tier 5", subtitle: "+ Dashboard (200 convos + 2K screenshots)")
-                        tierPickerRow(tier: 6, label: "Tier 6", subtitle: "+ Apps (300 conversations)")
-                    }
-
-                    if currentTierLevel > 0 {
-                        Divider()
-                            .background(OmiColors.backgroundQuaternary)
-
-                        Text("Progress")
-                            .scaledFont(size: 13, weight: .semibold)
-                            .foregroundColor(OmiColors.textSecondary)
-
-                        // Tier 1 — always unlocked
-                        tierFeatureRow(
-                            tier: 1, name: "Conversations + Rewind",
-                            requirement: "Always unlocked",
-                            progress: nil, unlocked: true
-                        )
-
-                        // Tier 2 — 100 memories
-                        tierFeatureRow(
-                            tier: 2, name: "Memories",
-                            requirement: "100 memories",
-                            progress: advancedStats.map { "\($0.memoriesTotal) / 100" },
-                            unlocked: currentTierLevel >= 2
-                        )
-
-                        // Tier 3 — 100 tasks
-                        tierFeatureRow(
-                            tier: 3, name: "Tasks",
-                            requirement: "100 tasks (todo + done)",
-                            progress: advancedStats.map { "\($0.tasksTodo + $0.tasksDone) / 100" },
-                            unlocked: currentTierLevel >= 3
-                        )
-
-                        // Tier 4 — 100 conversations
-                        tierFeatureRow(
-                            tier: 4, name: "AI Chat",
-                            requirement: "100 conversations",
-                            progress: advancedStats.map { "\($0.conversations) / 100" },
-                            unlocked: currentTierLevel >= 4
-                        )
-
-                        // Tier 5 — 200 conversations + 2,000 screenshots
-                        tierFeatureRow(
-                            tier: 5, name: "Dashboard",
-                            requirement: "200 conversations + 2K screenshots",
-                            progress: advancedStats.map { "\($0.conversations) / 200 convos, \($0.screenshotsTotal) / 2,000 screenshots" },
-                            unlocked: currentTierLevel >= 5
-                        )
-
-                        // Tier 6 — 300 conversations
-                        tierFeatureRow(
-                            tier: 6, name: "Apps",
-                            requirement: "300 conversations",
-                            progress: advancedStats.map { "\($0.conversations) / 300" },
-                            unlocked: currentTierLevel >= 6
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-    private var focusAssistantSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.focusassistant") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "eye.fill")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Focus Assistant")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $focusEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .onChange(of: focusEnabled) { _, newValue in
-                                FocusAssistantSettings.shared.isEnabled = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(focus: FocusSettingsResponse(enabled: newValue)))
-                            }
-                    }
-
-                    Text("Detect distractions and help you stay focused")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if focusEnabled {
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    settingRow(title: "Visual Glow Effect", subtitle: "Show colored border when focus changes", settingId: "advanced.focusassistant.glow") {
-                        Toggle("", isOn: $glowOverlayEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .disabled(isPreviewRunning)
-                            .onChange(of: glowOverlayEnabled) { _, newValue in
-                                AssistantSettings.shared.glowOverlayEnabled = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(shared: SharedAssistantSettingsResponse(glowOverlayEnabled: newValue)))
-                                if newValue {
-                                    startGlowPreview()
-                                }
-                            }
-                    }
-
-                    settingRow(title: "Focus Cooldown", subtitle: "Minimum time between distraction alerts", settingId: "advanced.focusassistant.cooldown") {
-                        Picker("", selection: $cooldownInterval) {
-                            ForEach(cooldownOptions, id: \.self) { minutes in
-                                Text(formatMinutes(minutes)).tag(minutes)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .frame(width: 120)
-                        .onChange(of: cooldownInterval) { _, newValue in
-                            FocusAssistantSettings.shared.cooldownInterval = newValue
-                            SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(focus: FocusSettingsResponse(cooldownInterval: newValue)))
-                        }
-                    }
-
-                    settingRow(title: "Focus Analysis Prompt", subtitle: "Customize AI instructions for focus analysis", settingId: "advanced.focusassistant.prompt") {
-                        HStack(spacing: 8) {
-                            Button(action: {
-                                FocusTestRunnerWindow.show()
-                            }) {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "play.circle")
-                                        .scaledFont(size: 11)
-                                    Text("Test Run")
-                                        .scaledFont(size: 12)
-                                }
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-
-                            Button(action: {
-                                PromptEditorWindow.show()
-                            }) {
-                                HStack(spacing: 4) {
-                                    Text("Edit")
-                                        .scaledFont(size: 12)
-                                    Image(systemName: "arrow.up.right.square")
-                                        .scaledFont(size: 11)
-                                }
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Excluded Apps for Focus Analysis
-                    VStack(alignment: .leading, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Excluded Apps")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Text("Focus coaching won't trigger for these apps")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        // Built-in system exclusions (non-removable)
-                        DisclosureGroup {
-                            LazyVStack(spacing: 4) {
-                                ForEach(Array(TaskAssistantSettings.builtInExcludedApps).sorted(), id: \.self) { appName in
-                                    HStack(spacing: 12) {
-                                        AppIconView(appName: appName, size: 20)
-
-                                        Text(appName)
-                                            .scaledFont(size: 13)
-                                            .foregroundColor(OmiColors.textTertiary)
-
-                                        Spacer()
-                                    }
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 4)
-                                }
-                            }
-                        } label: {
-                            Text("System apps always excluded (\(TaskAssistantSettings.builtInExcludedApps.count))")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-                        .tint(OmiColors.textTertiary)
-
-                        if !focusExcludedApps.isEmpty {
-                            LazyVStack(spacing: 8) {
-                                ForEach(Array(focusExcludedApps).sorted(), id: \.self) { appName in
-                                    ExcludedAppRow(
-                                        appName: appName,
-                                        onRemove: {
-                                            FocusAssistantSettings.shared.includeApp(appName)
-                                            focusExcludedApps = FocusAssistantSettings.shared.excludedApps
-                                        }
-                                    )
-                                }
-                            }
-                        }
-
-                        AddExcludedAppView(
-                            onAdd: { appName in
-                                FocusAssistantSettings.shared.excludeApp(appName)
-                                focusExcludedApps = FocusAssistantSettings.shared.excludedApps
-                            },
-                            excludedApps: focusExcludedApps
-                        )
-                    }
-                    } // end if focusEnabled
-                }
-            }
-        }
-    }
-
-    private var taskAssistantSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.taskassistant") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "checklist")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Task Assistant")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $taskEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .onChange(of: taskEnabled) { _, newValue in
-                                TaskAssistantSettings.shared.isEnabled = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(task: TaskSettingsResponse(enabled: newValue)))
-                            }
-                    }
-
-                    Text("Extract tasks and action items from your screen")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if taskEnabled {
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Task Agent (chat / investigate) toggle
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Task Agent")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Text("Investigate button and sidebar chat for tasks")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        Toggle("", isOn: $taskChatAgentEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .onChange(of: taskChatAgentEnabled) { _, newValue in
-                                TaskAgentSettings.shared.isChatEnabled = newValue
-                            }
-                    }
-
-                    // Working Directory (shared by chat agent and terminal agent)
-                    HStack(spacing: 8) {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Working Directory")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Text(taskAgentWorkingDirectory.isEmpty ? "Not set — chat agent defaults to ~" : taskAgentWorkingDirectory)
-                                .scaledFont(size: 11)
-                                .foregroundColor(OmiColors.textTertiary)
-                                .lineLimit(1)
-                                .truncationMode(.middle)
-                        }
-
-                        Spacer()
-
-                        Button("Browse...") {
-                            let panel = NSOpenPanel()
-                            panel.canChooseFiles = false
-                            panel.canChooseDirectories = true
-                            panel.allowsMultipleSelection = false
-                            panel.canCreateDirectories = true
-                            if !taskAgentWorkingDirectory.isEmpty {
-                                panel.directoryURL = URL(fileURLWithPath: taskAgentWorkingDirectory)
-                            }
-                            if panel.runModal() == .OK, let url = panel.url {
-                                taskAgentWorkingDirectory = url.path
-                                TaskAgentSettings.shared.workingDirectory = url.path
-                            }
-                        }
-                        .scaledFont(size: 13)
-
-                        if !taskAgentWorkingDirectory.isEmpty {
-                            Button("Clear") {
-                                taskAgentWorkingDirectory = ""
-                                TaskAgentSettings.shared.workingDirectory = ""
-                            }
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                        }
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Extraction Interval Slider
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Extraction Interval")
-                                    .scaledFont(size: 14)
-                                    .foregroundColor(OmiColors.textSecondary)
-                                Text("How often to scan for new tasks")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-
-                            Spacer()
-
-                            Text(formatExtractionInterval(taskExtractionInterval))
-                                .scaledFont(size: 13, weight: .medium)
-                                .foregroundColor(OmiColors.textSecondary)
-                                .frame(width: 80, alignment: .trailing)
-                        }
-
-                        Slider(value: Binding(
-                            get: { Double(taskIntervalSliderIndex) },
-                            set: { taskExtractionInterval = extractionIntervalOptions[Int($0)] }
-                        ), in: 0...Double(extractionIntervalOptions.count - 1), step: 1)
-                            .tint(OmiColors.purplePrimary)
-                            .onChange(of: taskExtractionInterval) { _, newValue in
-                                TaskAssistantSettings.shared.extractionInterval = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(task: TaskSettingsResponse(extractionInterval: newValue)))
-                            }
-                    }
-
-                    // Minimum Confidence Slider
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Minimum Confidence")
-                                    .scaledFont(size: 14)
-                                    .foregroundColor(OmiColors.textSecondary)
-                                Text("Only show tasks above this confidence level")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-
-                            Spacer()
-
-                            Text("\(Int(taskMinConfidence * 100))%")
-                                .scaledFont(size: 13, weight: .medium)
-                                .foregroundColor(OmiColors.textSecondary)
-                                .frame(width: 40, alignment: .trailing)
-                        }
-
-                        Slider(value: $taskMinConfidence, in: 0.3...0.9, step: 0.1)
-                            .tint(OmiColors.purplePrimary)
-                            .onChange(of: taskMinConfidence) { _, newValue in
-                                TaskAssistantSettings.shared.minConfidence = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(task: TaskSettingsResponse(minConfidence: newValue)))
-                            }
-                    }
-
-                    settingRow(title: "Task Extraction Prompt", subtitle: "Customize AI instructions for task extraction", settingId: "advanced.taskassistant.prompt") {
-                        HStack(spacing: 8) {
-                            Button(action: {
-                                TaskTestRunnerWindow.show()
-                            }) {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "play.circle")
-                                        .scaledFont(size: 11)
-                                    Text("Test Run")
-                                        .scaledFont(size: 12)
-                                }
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-
-                            Button(action: {
-                                TaskPromptEditorWindow.show()
-                            }) {
-                                HStack(spacing: 4) {
-                                    Text("Edit")
-                                        .scaledFont(size: 12)
-                                    Image(systemName: "arrow.up.right.square")
-                                        .scaledFont(size: 11)
-                                }
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Allowed Apps for Task Extraction (Whitelist)
-                    VStack(alignment: .leading, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Allowed Apps")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Text("Tasks will only be extracted from these apps. Browsers are also filtered by keywords below.")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        // Editable list of all allowed apps
-                        LazyVStack(spacing: 4) {
-                            ForEach(Array(taskAllowedApps).sorted(), id: \.self) { appName in
-                                HStack(spacing: 12) {
-                                    AppIconView(appName: appName, size: 20)
-
-                                    Text(appName)
-                                        .scaledFont(size: 13)
-                                        .foregroundColor(OmiColors.textPrimary)
-
-                                    if TaskAssistantSettings.isBrowser(appName) {
-                                        Text("browser")
-                                            .scaledFont(size: 10)
-                                            .foregroundColor(OmiColors.purplePrimary)
-                                            .padding(.horizontal, 6)
-                                            .padding(.vertical, 2)
-                                            .background(OmiColors.purplePrimary.opacity(0.15))
-                                            .cornerRadius(4)
-                                    }
-
-                                    Spacer()
-
-                                    Button {
-                                        TaskAssistantSettings.shared.disallowApp(appName)
-                                        taskAllowedApps = TaskAssistantSettings.shared.allowedApps
-                                    } label: {
-                                        Image(systemName: "xmark.circle.fill")
-                                            .scaledFont(size: 14)
-                                            .foregroundColor(OmiColors.textTertiary)
-                                    }
-                                    .buttonStyle(.plain)
-                                }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 4)
-                            }
-                        }
-
-                        AddAllowedAppView(
-                            onAdd: { appName in
-                                TaskAssistantSettings.shared.allowApp(appName)
-                                taskAllowedApps = TaskAssistantSettings.shared.allowedApps
-                            },
-                            allowedApps: taskAllowedApps
-                        )
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Browser Window Keywords
-                    VStack(alignment: .leading, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Browser Window Keywords")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Text("For browser apps, only analyze windows whose title contains one of these keywords.")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        // Keyword chips (filterable, deletable)
-                        BrowserKeywordListView(
-                            keywords: $taskBrowserKeywords,
-                            onAdd: { keyword in
-                                TaskAssistantSettings.shared.addBrowserKeyword(keyword)
-                                taskBrowserKeywords = TaskAssistantSettings.shared.browserKeywords
-                            },
-                            onRemove: { keyword in
-                                TaskAssistantSettings.shared.removeBrowserKeyword(keyword)
-                                taskBrowserKeywords = TaskAssistantSettings.shared.browserKeywords
-                            }
-                        )
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Task Prioritization Re-score
-                    settingRow(title: "Task Prioritization", subtitle: "Re-score all tasks by relevance to your profile and goals", settingId: "advanced.taskassistant.prioritization") {
-                        if isRescoringTasks {
-                            ProgressView()
-                                .controlSize(.small)
-                        } else {
-                            Button(action: {
-                                isRescoringTasks = true
-                                Task {
-                                    await TaskPrioritizationService.shared.forceFullRescore()
-                                    await MainActor.run { isRescoringTasks = false }
-                                }
-                            }) {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "arrow.trianglehead.counterclockwise")
-                                        .scaledFont(size: 11)
-                                    Text("Re-score")
-                                        .scaledFont(size: 12)
-                                }
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-                    }
-                    } // end if taskEnabled
-                }
-            }
-
-
-            // Task Agent Settings (merged into Task Assistant subsection)
-            settingsCard(settingId: "advanced.taskassistant.agent") {
-                TaskAgentSettingsView()
-            }
-        }
-    }
-
-    private var adviceAssistantSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.adviceassistant") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "lightbulb.fill")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Advice Assistant")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $adviceEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .onChange(of: adviceEnabled) { _, newValue in
-                                AdviceAssistantSettings.shared.isEnabled = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(advice: AdviceSettingsResponse(enabled: newValue)))
-                            }
-                    }
-
-                    Text("Get proactive tips and suggestions")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if adviceEnabled {
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Frequency Slider
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Frequency")
-                                    .scaledFont(size: 14)
-                                    .foregroundColor(OmiColors.textSecondary)
-                                Text("How often to check for advice opportunities")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-
-                            Spacer()
-
-                            Text(formatExtractionInterval(adviceExtractionInterval))
-                                .scaledFont(size: 13, weight: .medium)
-                                .foregroundColor(OmiColors.textSecondary)
-                                .frame(width: 80, alignment: .trailing)
-                        }
-
-                        Slider(value: Binding(
-                            get: { Double(adviceIntervalSliderIndex) },
-                            set: { adviceExtractionInterval = extractionIntervalOptions[Int($0)] }
-                        ), in: 0...Double(extractionIntervalOptions.count - 1), step: 1)
-                            .tint(OmiColors.purplePrimary)
-                            .onChange(of: adviceExtractionInterval) { _, newValue in
-                                AdviceAssistantSettings.shared.extractionInterval = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(advice: AdviceSettingsResponse(extractionInterval: newValue)))
-                            }
-                    }
-
-                    // Minimum Confidence Slider
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Minimum Confidence")
-                                    .scaledFont(size: 14)
-                                    .foregroundColor(OmiColors.textSecondary)
-                                Text("Only show advice above this confidence level")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-
-                            Spacer()
-
-                            Text("\(Int(adviceMinConfidence * 100))%")
-                                .scaledFont(size: 13, weight: .medium)
-                                .foregroundColor(OmiColors.textSecondary)
-                                .frame(width: 40, alignment: .trailing)
-                        }
-
-                        Slider(value: $adviceMinConfidence, in: 0.5...0.95, step: 0.05)
-                            .tint(OmiColors.purplePrimary)
-                            .onChange(of: adviceMinConfidence) { _, newValue in
-                                AdviceAssistantSettings.shared.minConfidence = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(advice: AdviceSettingsResponse(minConfidence: newValue)))
-                            }
-                    }
-
-                    settingRow(title: "Advice Prompt", subtitle: "Customize AI instructions for advice", settingId: "advanced.adviceassistant.prompt") {
-                        HStack(spacing: 8) {
-                            Button(action: {
-                                AdviceTestRunnerWindow.show()
-                            }) {
-                                HStack(spacing: 4) {
-                                    Image(systemName: "play.circle")
-                                        .scaledFont(size: 11)
-                                    Text("Test Run")
-                                        .scaledFont(size: 12)
-                                }
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-
-                            Button(action: {
-                                AdvicePromptEditorWindow.show()
-                            }) {
-                                HStack(spacing: 4) {
-                                    Text("Edit")
-                                        .scaledFont(size: 12)
-                                    Image(systemName: "arrow.up.right.square")
-                                        .scaledFont(size: 11)
-                                }
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Excluded Apps for Advice
-                    VStack(alignment: .leading, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Excluded Apps")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Text("Advice won't be generated from these apps")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        // Built-in system exclusions (non-removable, shared with Task Extractor)
-                        DisclosureGroup {
-                            LazyVStack(spacing: 4) {
-                                ForEach(Array(TaskAssistantSettings.builtInExcludedApps).sorted(), id: \.self) { appName in
-                                    HStack(spacing: 12) {
-                                        AppIconView(appName: appName, size: 20)
-
-                                        Text(appName)
-                                            .scaledFont(size: 13)
-                                            .foregroundColor(OmiColors.textTertiary)
-
-                                        Spacer()
-                                    }
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 4)
-                                }
-                            }
-                        } label: {
-                            Text("System apps always excluded (\(TaskAssistantSettings.builtInExcludedApps.count))")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-                        .tint(OmiColors.textTertiary)
-
-                        if !adviceExcludedApps.isEmpty {
-                            LazyVStack(spacing: 8) {
-                                ForEach(Array(adviceExcludedApps).sorted(), id: \.self) { appName in
-                                    ExcludedAppRow(
-                                        appName: appName,
-                                        onRemove: {
-                                            AdviceAssistantSettings.shared.includeApp(appName)
-                                            adviceExcludedApps = AdviceAssistantSettings.shared.excludedApps
-                                        }
-                                    )
-                                }
-                            }
-                        }
-
-                        AddExcludedAppView(
-                            onAdd: { appName in
-                                AdviceAssistantSettings.shared.excludeApp(appName)
-                                adviceExcludedApps = AdviceAssistantSettings.shared.excludedApps
-                            },
-                            excludedApps: adviceExcludedApps
-                        )
-                    }
-                    } // end if adviceEnabled
-                }
-            }
-        }
-    }
-
-    private var memoryAssistantSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.memoryassistant") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "brain.head.profile")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Memory Assistant")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Toggle("", isOn: $memoryEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .onChange(of: memoryEnabled) { _, newValue in
-                                MemoryAssistantSettings.shared.isEnabled = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(memory: MemorySettingsResponse(enabled: newValue)))
-                            }
-                    }
-
-                    Text("Extract facts and wisdom from your screen")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    if memoryEnabled {
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Extraction Interval Slider
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Extraction Interval")
-                                    .scaledFont(size: 14)
-                                    .foregroundColor(OmiColors.textSecondary)
-                                Text("How often to scan for new memories")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-
-                            Spacer()
-
-                            Text(formatExtractionInterval(memoryExtractionInterval))
-                                .scaledFont(size: 13, weight: .medium)
-                                .foregroundColor(OmiColors.textSecondary)
-                                .frame(width: 80, alignment: .trailing)
-                        }
-
-                        Slider(value: Binding(
-                            get: { Double(memoryIntervalSliderIndex) },
-                            set: { memoryExtractionInterval = extractionIntervalOptions[Int($0)] }
-                        ), in: 0...Double(extractionIntervalOptions.count - 1), step: 1)
-                            .tint(OmiColors.purplePrimary)
-                            .onChange(of: memoryExtractionInterval) { _, newValue in
-                                MemoryAssistantSettings.shared.extractionInterval = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(memory: MemorySettingsResponse(extractionInterval: newValue)))
-                            }
-                    }
-
-                    // Minimum Confidence Slider
-                    VStack(alignment: .leading, spacing: 8) {
-                        HStack {
-                            VStack(alignment: .leading, spacing: 2) {
-                                Text("Minimum Confidence")
-                                    .scaledFont(size: 14)
-                                    .foregroundColor(OmiColors.textSecondary)
-                                Text("Only save memories above this confidence level")
-                                    .scaledFont(size: 12)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-
-                            Spacer()
-
-                            Text("\(Int(memoryMinConfidence * 100))%")
-                                .scaledFont(size: 13, weight: .medium)
-                                .foregroundColor(OmiColors.textSecondary)
-                                .frame(width: 40, alignment: .trailing)
-                        }
-
-                        Slider(value: $memoryMinConfidence, in: 0.5...0.95, step: 0.05)
-                            .tint(OmiColors.purplePrimary)
-                            .onChange(of: memoryMinConfidence) { _, newValue in
-                                MemoryAssistantSettings.shared.minConfidence = newValue
-                                SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(memory: MemorySettingsResponse(minConfidence: newValue)))
-                            }
-                    }
-
-                    settingRow(title: "Memory Extraction Prompt", subtitle: "Customize AI instructions for memory extraction", settingId: "advanced.memoryassistant.prompt") {
-                        Button(action: {
-                            MemoryPromptEditorWindow.show()
-                        }) {
-                            HStack(spacing: 4) {
-                                Text("Edit")
-                                    .scaledFont(size: 12)
-                                Image(systemName: "arrow.up.right.square")
-                                    .scaledFont(size: 11)
-                            }
-                        }
-                        .buttonStyle(.bordered)
-                        .controlSize(.small)
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Excluded Apps for Memory Extraction
-                    VStack(alignment: .leading, spacing: 12) {
-                        VStack(alignment: .leading, spacing: 4) {
-                            Text("Excluded Apps")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Text("Memories won't be extracted from these apps")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        // Built-in system exclusions (non-removable, shared across assistants)
-                        DisclosureGroup {
-                            LazyVStack(spacing: 4) {
-                                ForEach(Array(TaskAssistantSettings.builtInExcludedApps).sorted(), id: \.self) { appName in
-                                    HStack(spacing: 12) {
-                                        AppIconView(appName: appName, size: 20)
-
-                                        Text(appName)
-                                            .scaledFont(size: 13)
-                                            .foregroundColor(OmiColors.textTertiary)
-
-                                        Spacer()
-                                    }
-                                    .padding(.horizontal, 12)
-                                    .padding(.vertical, 4)
-                                }
-                            }
-                        } label: {
-                            Text("System apps always excluded (\(TaskAssistantSettings.builtInExcludedApps.count))")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-                        .tint(OmiColors.textTertiary)
-
-                        if !memoryExcludedApps.isEmpty {
-                            LazyVStack(spacing: 8) {
-                                ForEach(Array(memoryExcludedApps).sorted(), id: \.self) { appName in
-                                    ExcludedAppRow(
-                                        appName: appName,
-                                        onRemove: {
-                                            MemoryAssistantSettings.shared.includeApp(appName)
-                                            memoryExcludedApps = MemoryAssistantSettings.shared.excludedApps
-                                        }
-                                    )
-                                }
-                            }
-                        }
-
-                        AddExcludedAppView(
-                            onAdd: { appName in
-                                MemoryAssistantSettings.shared.excludeApp(appName)
-                                memoryExcludedApps = MemoryAssistantSettings.shared.excludedApps
-                            },
-                            excludedApps: memoryExcludedApps
-                        )
-                    }
-                    } // end if memoryEnabled
-                }
-            }
-        }
-    }
-
-    private var analysisThrottleSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.analysisthrottle") {
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        VStack(alignment: .leading, spacing: 2) {
-                            Text("Analysis Throttle")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-                            Text("Wait before analyzing after switching apps")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-
-                        Spacer()
-
-                        Text(formatAnalysisDelay(analysisDelay))
-                            .scaledFont(size: 13, weight: .medium)
-                            .foregroundColor(OmiColors.textSecondary)
-                            .frame(width: 80, alignment: .trailing)
-                    }
-
-                    Slider(value: Binding(
-                        get: { Double(analysisDelaySliderIndex) },
-                        set: { analysisDelay = analysisDelayOptions[Int($0)] }
-                    ), in: 0...Double(analysisDelayOptions.count - 1), step: 1)
-                        .tint(OmiColors.purplePrimary)
-                        .onChange(of: analysisDelay) { _, newValue in
-                            AssistantSettings.shared.analysisDelay = newValue
-                            SettingsSyncManager.shared.pushPartialUpdate(AssistantSettingsResponse(shared: SharedAssistantSettingsResponse(analysisDelay: newValue)))
-                        }
-                }
-            }
-        }
-    }
-
-    private var goalsSubsection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "advanced.goals") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "target")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
-
-                        Text("Goals")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-                    }
-
-                    Text("Track personal goals with AI-powered progress detection from your conversations")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    settingRow(title: "Auto-Generate Goals", subtitle: "Automatically suggest new goals daily based on your conversations and tasks", settingId: "advanced.goals.autogenerate") {
-                        Toggle("", isOn: $goalsAutoGenerateEnabled)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                            .onChange(of: goalsAutoGenerateEnabled) { _, newValue in
-                                GoalGenerationService.shared.isAutoGenerationEnabled = newValue
-                            }
-                    }
-                }
-            }
-        }
-    }
-
-    private var askOmiFloatingBarSubsection: some View {
-        VStack(spacing: 20) {
-            ShortcutsSettingsSection(highlightedSettingId: $highlightedSettingId)
-        }
-    }
-
-    private var preferencesSubsection: some View {
-        VStack(spacing: 20) {
-            // Multiple Chat Sessions toggle
-            settingsCard(settingId: "advanced.preferences.multichat") {
-                HStack(spacing: 16) {
-                    Image(systemName: "bubble.left.and.bubble.right")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.textSecondary)
-                        .frame(width: 24, height: 24)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Multiple Chat Sessions")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text(multiChatEnabled
-                             ? "Create separate chat threads"
-                             : "Single chat synced with mobile app")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    Toggle("", isOn: $multiChatEnabled)
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                }
-            }
-
-            // Conversation View toggle
-            settingsCard(settingId: "advanced.preferences.compact") {
-                HStack(spacing: 16) {
-                    Image(systemName: conversationsCompactView ? "list.bullet" : "list.bullet.rectangle")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.textSecondary)
-                        .frame(width: 24, height: 24)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Compact Conversations")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text(conversationsCompactView
-                             ? "Showing compact conversation list"
-                             : "Showing expanded conversation list")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    Toggle("", isOn: $conversationsCompactView)
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                }
-            }
-
-            // Launch at Login toggle
-            settingsCard(settingId: "advanced.preferences.launchatlogin") {
-                HStack(spacing: 16) {
-                    Image(systemName: "power")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.textSecondary)
-                        .frame(width: 24, height: 24)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Launch at Login")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text(launchAtLoginManager.statusDescription)
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    Toggle("", isOn: Binding(
-                        get: { launchAtLoginManager.isEnabled },
-                        set: { newValue in
-                            if launchAtLoginManager.setEnabled(newValue) {
-                                AnalyticsManager.shared.launchAtLoginChanged(enabled: newValue, source: "user")
-                            }
-                        }
-                    ))
-                        .toggleStyle(.switch)
-                        .labelsHidden()
-                }
-            }
-        }
-    }
-
-    private var troubleshootingSubsection: some View {
-        VStack(spacing: 20) {
-            // Report Issue
-            settingsCard(settingId: "advanced.troubleshooting.reportissue") {
-                HStack(spacing: 16) {
-                    Image(systemName: "exclamationmark.bubble")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.textSecondary)
-                        .frame(width: 24, height: 24)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Report Issue")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text("Send app logs and report a problem")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    Button(action: {
-                        FeedbackWindow.show(userEmail: AuthState.shared.userEmail)
-                    }) {
-                        Text("Report")
-                            .scaledFont(size: 13, weight: .medium)
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 6)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .fill(OmiColors.purplePrimary)
-                            )
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-
-            // Rescan Files
-            settingsCard(settingId: "advanced.troubleshooting.rescanfiles") {
-                HStack(spacing: 16) {
-                    Image(systemName: "folder.badge.gearshape")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.textSecondary)
-                        .frame(width: 24, height: 24)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Rescan Files")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text("Re-index your files and update your AI profile")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    Button(action: { showRescanFilesAlert = true }) {
-                        Text("Rescan")
-                            .scaledFont(size: 13, weight: .medium)
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 6)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .fill(OmiColors.purplePrimary)
-                            )
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .alert("Rescan Files?", isPresented: $showRescanFilesAlert) {
-                Button("Cancel", role: .cancel) { }
-                Button("Rescan") {
-                    NotificationCenter.default.post(name: .triggerFileIndexing, object: nil)
-                }
-            } message: {
-                Text("This will re-scan your files and update your AI profile with the latest information about your projects and interests.")
-            }
-
-            // Reset Onboarding
-            settingsCard(settingId: "advanced.troubleshooting.resetonboarding") {
-                HStack(spacing: 16) {
-                    Image(systemName: "arrow.counterclockwise")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.textSecondary)
-                        .frame(width: 24, height: 24)
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Reset Onboarding")
-                            .scaledFont(size: 16, weight: .semibold)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Text("Restart setup wizard for this app build only")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Spacer()
-
-                    Button(action: { showResetOnboardingAlert = true }) {
-                        Text("Reset")
-                            .scaledFont(size: 13, weight: .medium)
-                            .foregroundColor(.black)
-                            .padding(.horizontal, 14)
-                            .padding(.vertical, 6)
-                            .background(
-                                RoundedRectangle(cornerRadius: 6)
-                                    .fill(.white)
-                            )
-                    }
-                    .buttonStyle(.plain)
-                }
-            }
-            .alert("Reset Onboarding?", isPresented: $showResetOnboardingAlert) {
-                Button("Cancel", role: .cancel) { }
-                Button("Reset & Restart", role: .destructive) {
-                    appState.resetOnboardingAndRestart()
-                }
-            } message: {
-                Text("This will reset onboarding for this app build only, clear onboarding chat history, and restart the app without affecting the other installed build.")
-            }
-        }
-    }
-
-    private func tierPickerRow(tier: Int, label: String, subtitle: String) -> some View {
-        let isSelected = currentTierLevel == tier
-        return Button(action: {
-            TierManager.shared.userDidSetTier(tier)
-        }) {
-            HStack(spacing: 10) {
-                Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
-                    .scaledFont(size: 16)
-                    .foregroundColor(isSelected ? OmiColors.purplePrimary : OmiColors.textTertiary)
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(label)
-                        .scaledFont(size: 14, weight: isSelected ? .medium : .regular)
-                        .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textSecondary)
-
-                    Text(subtitle)
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-                }
-
-                Spacer()
-            }
-            .padding(.vertical, 6)
-            .padding(.horizontal, 8)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(isSelected ? OmiColors.purplePrimary.opacity(0.1) : Color.clear)
-            )
-        }
-        .buttonStyle(.plain)
-    }
-
-    private func tierFeatureRow(tier: Int, name: String, requirement: String, progress: String?, unlocked: Bool) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack {
-                Text("Tier \(tier)")
-                    .scaledFont(size: 11, weight: .semibold)
-                    .foregroundColor(unlocked ? OmiColors.purplePrimary : OmiColors.textTertiary)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(unlocked ? OmiColors.purplePrimary.opacity(0.15) : OmiColors.backgroundTertiary)
-                    )
-
-                Text(name)
-                    .scaledFont(size: 14, weight: .medium)
-                    .foregroundColor(unlocked ? OmiColors.textPrimary : OmiColors.textTertiary)
-
-                Spacer()
-
-                if unlocked {
-                    Image(systemName: "checkmark.circle.fill")
-                        .scaledFont(size: 14)
-                        .foregroundColor(.green)
-                } else {
-                    Image(systemName: "lock.fill")
-                        .scaledFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary)
-                }
-            }
-
-            HStack(spacing: 8) {
-                Text(requirement)
-                    .scaledFont(size: 12)
-                    .foregroundColor(OmiColors.textTertiary)
-
-                if let progress = progress, !unlocked {
-                    Text("(\(progress))")
-                        .scaledMonospacedDigitFont(size: 12)
-                        .foregroundColor(OmiColors.textTertiary.opacity(0.7))
-                }
-            }
-        }
-        .padding(.vertical, 4)
-    }
-
-    private func statRow(label: String, value: Int) -> some View {
-        HStack {
-            Text(label)
-                .scaledFont(size: 14)
-                .foregroundColor(OmiColors.textSecondary)
-
-            Spacer()
-
-            Text(formatNumber(value))
-                .scaledMonospacedDigitFont(size: 14, weight: .medium)
-                .foregroundColor(OmiColors.textPrimary)
-        }
-    }
-
-    private func statRowLoading(label: String) -> some View {
-        HStack {
-            Text(label)
-                .scaledFont(size: 14)
-                .foregroundColor(OmiColors.textSecondary)
-
-            Spacer()
-
+          if isToggling {
             ProgressView()
-                .controlSize(.mini)
-        }
-    }
-
-    private func formatNumber(_ n: Int) -> String {
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .decimal
-        return formatter.string(from: NSNumber(value: n)) ?? "\(n)"
-    }
-
-    private func loadAdvancedStats() async {
-        isLoadingStats = true
-        defer { isLoadingStats = false }
-
-        do {
-            async let conversationsCount = APIClient.shared.getConversationsCount()
-            async let installedApps = APIClient.shared.searchApps(installedOnly: true)
-            async let focusCount = ProactiveStorage.shared.getTotalFocusSessionCount()
-            async let filterCounts = ActionItemStorage.shared.getFilterCounts()
-            async let goals = APIClient.shared.getGoals()
-            async let memoryStats = MemoryStorage.shared.getStats()
-
-            let cc = try await conversationsCount
-            let ia = try await installedApps
-            let fc = try await focusCount
-            let filters = try await filterCounts
-            let g = try await goals
-            let ms = try await memoryStats
-
-            let screenshotCount: Int
-            do {
-                screenshotCount = try await RewindDatabase.shared.getScreenshotCount()
-            } catch {
-                screenshotCount = 0
-            }
-
-            advancedStats = UserStats(
-                conversations: cc,
-                appsInstalled: ia.count,
-                screenshotsTotal: screenshotCount,
-                focusSessions: fc,
-                tasksTodo: filters.todo,
-                tasksDone: filters.done,
-                tasksDeleted: filters.deleted,
-                goalsCount: g.count,
-                memoriesTotal: ms.total
+              .scaleEffect(0.8)
+          } else {
+            Toggle(
+              "",
+              isOn: Binding(
+                get: { isMonitoring },
+                set: { newValue in
+                  isMonitoring = newValue
+                  toggleMonitoring(enabled: newValue)
+                }
+              )
             )
-        } catch {
-            print("SETTINGS: Failed to load advanced stats: \(error)")
+            .toggleStyle(.switch)
+            .labelsHidden()
+          }
         }
-    }
+      }
 
-    private func loadChatMessageCount() async {
-        isLoadingChatMessages = true
-        defer { isLoadingChatMessages = false }
+      // Audio Recording toggle
+      settingsCard(settingId: "general.audiorecording") {
+        HStack(spacing: 16) {
+          Circle()
+            .fill(isTranscribing ? OmiColors.success : OmiColors.textTertiary.opacity(0.3))
+            .frame(width: 12, height: 12)
+            .shadow(color: isTranscribing ? OmiColors.success.opacity(0.5) : .clear, radius: 6)
 
-        do {
-            chatMessageCount = try await APIClient.shared.getChatMessageCount()
-        } catch {
-            chatMessageCount = 0
+          Image(systemName: "mic.fill")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.purplePrimary)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Audio Recording")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text(
+              transcriptionError
+                ?? (isTranscribing
+                  ? "Recording and transcribing audio" : "Audio recording is paused")
+            )
+            .scaledFont(size: 13)
+            .foregroundColor(transcriptionError != nil ? OmiColors.warning : OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          if isTogglingTranscription {
+            ProgressView()
+              .scaleEffect(0.8)
+          } else {
+            Toggle(
+              "",
+              isOn: Binding(
+                get: { isTranscribing },
+                set: { newValue in
+                  isTranscribing = newValue
+                  toggleTranscription(enabled: newValue)
+                }
+              )
+            )
+            .toggleStyle(.switch)
+            .labelsHidden()
+          }
         }
-    }
+      }
 
-    // MARK: - About Section
+      // Notifications toggle
+      settingsCard(settingId: "general.notifications") {
+        VStack(spacing: 12) {
+          HStack(spacing: 16) {
+            Circle()
+              .fill(
+                appState.hasNotificationPermission && !appState.isNotificationBannerDisabled
+                  ? OmiColors.success
+                  : (appState.isNotificationBannerDisabled
+                    ? OmiColors.warning : OmiColors.textTertiary.opacity(0.3))
+              )
+              .frame(width: 12, height: 12)
+              .shadow(
+                color: appState.hasNotificationPermission && !appState.isNotificationBannerDisabled
+                  ? OmiColors.success.opacity(0.5) : .clear, radius: 6)
 
-    private var aboutSection: some View {
-        VStack(spacing: 20) {
-            settingsCard(settingId: "about.version") {
-                VStack(spacing: 16) {
-                    // App info
-                    HStack(spacing: 16) {
-                        if let logoImage = NSImage(contentsOf: Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png")!) {
-                            Image(nsImage: logoImage)
-                                .resizable()
-                                .aspectRatio(contentMode: .fit)
-                                .frame(width: 48, height: 48)
-                        }
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Notifications")
+                .scaledFont(size: 16, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
 
-                        VStack(alignment: .leading, spacing: 4) {
-                            HStack(spacing: 6) {
-                                Text("omi")
-                                    .scaledFont(size: 18, weight: .bold)
-                                    .foregroundColor(OmiColors.textPrimary)
-
-                                if !updaterViewModel.activeChannelLabel.isEmpty {
-                                    Text("(\(updaterViewModel.activeChannelLabel))")
-                                        .scaledFont(size: 13, weight: .medium)
-                                        .foregroundColor(OmiColors.purplePrimary)
-                                }
-                            }
-
-                            Text("Version \(updaterViewModel.currentVersion) (\(updaterViewModel.buildNumber))")
-                                .scaledFont(size: 13)
-                                .foregroundColor(OmiColors.textTertiary)
-                                .textSelection(.enabled)
-                        }
-
-                        Spacer()
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    // Links
-                    linkRow(title: "Visit Website", url: "https://omi.me")
-                    linkRow(title: "Help Center", url: "https://help.omi.me")
-                    Button(action: {
-                        selectedSection = .privacy
-                    }) {
-                        HStack {
-                            Text("Privacy Policy")
-                                .scaledFont(size: 14)
-                                .foregroundColor(OmiColors.textSecondary)
-
-                            Spacer()
-
-                            Image(systemName: "arrow.right")
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textTertiary)
-                        }
-                    }
-                    .buttonStyle(.plain)
-                    linkRow(title: "Terms of Service", url: "https://omi.me/terms")
-                }
+              Text(notificationStatusText)
+                .scaledFont(size: 13)
+                .foregroundColor(
+                  appState.isNotificationBannerDisabled ? OmiColors.warning : OmiColors.textTertiary
+                )
             }
 
-            // Software Updates
-            settingsCard(settingId: "about.updates") {
-                VStack(alignment: .leading, spacing: 16) {
-                    HStack {
-                        Image(systemName: "arrow.triangle.2.circlepath")
-                            .scaledFont(size: 16)
-                            .foregroundColor(OmiColors.purplePrimary)
+            Spacer()
 
-                        Text("Software Updates")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        Spacer()
-
-                        Button("Check Now") {
-                            updaterViewModel.checkForUpdates()
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(!updaterViewModel.canCheckForUpdates)
-                    }
-
-                    if let lastCheck = updaterViewModel.lastUpdateCheckDate {
-                        Text("Last checked: \(lastCheck, style: .relative) ago")
-                            .scaledFont(size: 12)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    settingRow(title: "Automatic Updates", subtitle: "Check for updates automatically in the background", settingId: "about.autoupdates") {
-                        Toggle("", isOn: $updaterViewModel.automaticallyChecksForUpdates)
-                            .toggleStyle(.switch)
-                            .labelsHidden()
-                    }
-
-                    if updaterViewModel.automaticallyChecksForUpdates {
-                        settingRow(title: "Auto-Install Updates", subtitle: "Automatically download and install updates when available", settingId: "about.autoinstall") {
-                            Toggle("", isOn: $updaterViewModel.automaticallyDownloadsUpdates)
-                                .toggleStyle(.switch)
-                                .labelsHidden()
-                        }
-                    }
-
-                    Divider()
-                        .background(OmiColors.backgroundQuaternary)
-
-                    settingRow(title: "Update Channel", subtitle: updaterViewModel.updateChannel.description, settingId: "about.channel") {
-                        Picker("", selection: Binding(
-                            get: { updaterViewModel.updateChannel },
-                            set: { newChannel in
-                                // Switching beta → stable with a newer build: confirm first
-                                if updaterViewModel.updateChannel == .beta && newChannel == .stable && updaterViewModel.isDowngradeToStable {
-                                    showDowngradeAlert = true
-                                } else {
-                                    updaterViewModel.updateChannel = newChannel
-                                }
-                            }
-                        )) {
-                            ForEach(UpdateChannel.allCases, id: \.self) { channel in
-                                Text(channel.displayName).tag(channel)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .labelsHidden()
-                        .frame(width: 100)
-                    }
+            if appState.hasNotificationPermission && !appState.isNotificationBannerDisabled {
+              // Show enabled badge
+              Text("Enabled")
+                .scaledFont(size: 12, weight: .medium)
+                .foregroundColor(.green)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(
+                  Capsule()
+                    .fill(Color.green.opacity(0.15))
+                )
+            } else {
+              // Show button to enable or fix
+              Button(action: {
+                if appState.isNotificationBannerDisabled {
+                  // Banners off — user needs to change style in System Settings
+                  appState.openNotificationPreferences()
+                } else {
+                  // Auth not granted — try lsregister repair first
+                  AnalyticsManager.shared.notificationRepairTriggered(
+                    reason: "settings_fix_button",
+                    previousStatus: "not_authorized",
+                    currentStatus: "not_authorized"
+                  )
+                  appState.repairNotificationAndFallback()
                 }
+              }) {
+                Text(appState.isNotificationBannerDisabled ? "Fix" : "Enable")
+                  .scaledFont(size: 12, weight: .semibold)
+                  .foregroundColor(.white)
+                  .padding(.horizontal, 12)
+                  .padding(.vertical, 6)
+                  .background(
+                    RoundedRectangle(cornerRadius: 6)
+                      .fill(
+                        appState.isNotificationBannerDisabled
+                          ? OmiColors.warning : OmiColors.purplePrimary)
+                  )
+              }
+              .buttonStyle(.plain)
             }
-            .alert("Switch to Stable Channel?", isPresented: $showDowngradeAlert) {
-                Button("Stay on Beta", role: .cancel) { }
-                Button("Switch to Stable") {
-                    updaterViewModel.updateChannel = .stable
-                    if let url = URL(string: "https://macos.omi.me") {
-                        NSWorkspace.shared.open(url)
-                    }
-                }
-            } message: {
-                let stableVersion = updaterViewModel.latestStableVersionString ?? "an older version"
-                Text("You're on a newer beta build (\(updaterViewModel.currentVersion)). The latest stable release is \(stableVersion).\n\nSwitching to Stable means you won't receive new updates until a stable release surpasses your current version. You can also download the stable version now.")
+          }
+
+          // Warning when banners are disabled
+          if appState.isNotificationBannerDisabled {
+            HStack(spacing: 8) {
+              Image(systemName: "exclamationmark.triangle.fill")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.warning)
+
+              Text(
+                "Banners disabled - you won't see visual alerts. Set style to \"Banners\" in System Settings."
+              )
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.warning)
+
+              Spacer()
             }
+            .padding(10)
+            .background(
+              RoundedRectangle(cornerRadius: 8)
+                .fill(OmiColors.warning.opacity(0.1))
+            )
+          }
+        }
+      }
 
-            settingsCard(settingId: "about.reportissue") {
-                HStack(spacing: 16) {
-                    Image(systemName: "exclamationmark.bubble.fill")
-                        .scaledFont(size: 16)
-                        .foregroundColor(OmiColors.purplePrimary)
+      // Ask Omi floating bar toggle
+      settingsCard(settingId: "general.askomi") {
+        HStack(spacing: 16) {
+          Circle()
+            .fill(showAskOmiBar ? OmiColors.success : OmiColors.textTertiary.opacity(0.3))
+            .frame(width: 12, height: 12)
+            .shadow(color: showAskOmiBar ? OmiColors.success.opacity(0.5) : .clear, radius: 6)
 
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Report an Issue")
-                            .scaledFont(size: 15, weight: .medium)
-                            .foregroundColor(OmiColors.textPrimary)
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Ask omi")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
 
-                        Text("Help us improve omi")
-                            .scaledFont(size: 13)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
+            Text(showAskOmiBar ? "Floating bar is visible (⌘\\)" : "Floating bar is hidden (⌘\\)")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+          }
 
-                    Spacer()
+          Spacer()
 
-                    Button("Report") {
-                        FeedbackWindow.show(userEmail: AuthState.shared.userEmail)
-                    }
-                    .buttonStyle(.bordered)
-                }
+          Toggle("", isOn: $showAskOmiBar)
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .onChange(of: showAskOmiBar) { _, newValue in
+              if newValue {
+                FloatingControlBarManager.shared.show()
+              } else {
+                FloatingControlBarManager.shared.hide()
+              }
             }
         }
-    }
+      }
 
-    // MARK: - Helper Views
+      // Font Size
+      settingsCard(settingId: "general.fontsize") {
+        VStack(spacing: 12) {
+          HStack(spacing: 16) {
+            Image(systemName: "textformat.size")
+              .scaledFont(size: 16, weight: .medium)
+              .foregroundColor(OmiColors.purplePrimary)
+              .frame(width: 12)
 
-    private func fontShortcutRow(label: String, keys: String) -> some View {
-        HStack {
-            Text(label)
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Font Size")
+                .scaledFont(size: 16, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text("Scale: \(Int(fontScaleSettings.scale * 100))%")
                 .scaledFont(size: 13)
                 .foregroundColor(OmiColors.textTertiary)
-            Spacer()
-            Text(keys)
-                .scaledMonospacedFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textSecondary)
-                .padding(.horizontal, 8)
-                .padding(.vertical, 3)
-                .background(OmiColors.backgroundTertiary.opacity(0.8))
-                .cornerRadius(5)
-        }
-    }
-
-    private func settingsCard<Content: View>(settingId: String? = nil, @ViewBuilder content: () -> Content) -> some View {
-        let card = content()
-            .padding(20)
-            .background(
-                RoundedRectangle(cornerRadius: 12)
-                    .fill(OmiColors.backgroundTertiary.opacity(0.5))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(OmiColors.backgroundQuaternary.opacity(0.3), lineWidth: 1)
-                    )
-            )
-        return Group {
-            if let settingId = settingId {
-                card.modifier(SettingHighlightModifier(settingId: settingId, highlightedSettingId: $highlightedSettingId))
-            } else {
-                card
-            }
-        }
-    }
-
-    private func settingRow<Content: View>(title: String, subtitle: String, settingId: String? = nil, @ViewBuilder control: () -> Content) -> some View {
-        let row = HStack {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(title)
-                    .scaledFont(size: 14)
-                    .foregroundColor(OmiColors.textSecondary)
-                Text(subtitle)
-                    .scaledFont(size: 12)
-                    .foregroundColor(OmiColors.textTertiary)
             }
 
             Spacer()
 
-            control()
-        }
-        return Group {
-            if let settingId = settingId {
-                row.modifier(SettingHighlightModifier(settingId: settingId, highlightedSettingId: $highlightedSettingId))
-            } else {
-                row
+            if fontScaleSettings.scale != 1.0 {
+              Button("Reset") {
+                fontScaleSettings.resetToDefault()
+              }
+              .scaledFont(size: 12, weight: .medium)
+              .foregroundColor(OmiColors.purplePrimary)
+              .buttonStyle(.plain)
             }
-        }
-    }
+          }
 
-    private func linkRow(title: String, url: String) -> some View {
-        Button(action: {
-            if let url = URL(string: url) {
-                NSWorkspace.shared.open(url)
+          HStack(spacing: 12) {
+            Text("A")
+              .scaledFont(size: 12, weight: .medium)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Slider(value: $fontScaleSettings.scale, in: 0.5...2.0, step: 0.05)
+              .tint(OmiColors.purplePrimary)
+
+            Text("A")
+              .scaledFont(size: 18, weight: .medium)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Text("The quick brown fox jumps over the lazy dog")
+            .scaledFont(size: 14)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.top, 4)
+
+          // Keyboard shortcuts for font size
+          VStack(spacing: 6) {
+            fontShortcutRow(label: "Increase font size", keys: "\u{2318}+")
+            fontShortcutRow(label: "Decrease font size", keys: "\u{2318}\u{2212}")
+            fontShortcutRow(label: "Reset font size", keys: "\u{2318}0")
+          }
+          .padding(.top, 4)
+
+          HStack {
+            Spacer()
+            Button(action: {
+              resetWindowToDefaultSize()
+            }) {
+              HStack(spacing: 6) {
+                Image(systemName: "arrow.uturn.backward")
+                  .scaledFont(size: 11)
+                Text("Reset Window Size")
+                  .scaledFont(size: 12, weight: .medium)
+              }
+              .foregroundColor(OmiColors.textSecondary)
+              .padding(.horizontal, 10)
+              .padding(.vertical, 5)
+              .background(
+                RoundedRectangle(cornerRadius: 6)
+                  .fill(OmiColors.backgroundTertiary)
+              )
             }
-        }) {
+            .buttonStyle(.plain)
+          }
+        }
+      }
+
+    }
+  }
+
+  // MARK: - Rewind Section
+
+  @ObservedObject private var fontScaleSettings = FontScaleSettings.shared
+  @ObservedObject private var rewindSettings = RewindSettings.shared
+
+  @State private var rewindStats: (total: Int, indexed: Int, storageSize: Int64)? = nil
+
+  private var rewindSection: some View {
+    VStack(spacing: 20) {
+      // Storage Stats
+      settingsCard(settingId: "rewind.storage") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "internaldrive.fill")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Storage")
+                .scaledFont(size: 15, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              if let stats = rewindStats {
+                Text("\(stats.total) frames • \(RewindStorage.formatBytes(stats.storageSize))")
+                  .scaledFont(size: 13)
+                  .foregroundColor(OmiColors.textTertiary)
+              } else {
+                Text("Loading...")
+                  .scaledFont(size: 13)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+            }
+
+            Spacer()
+          }
+        }
+      }
+      .task {
+        rewindStats = await RewindIndexer.shared.getStats()
+      }
+
+      // Excluded Apps
+      settingsCard(settingId: "rewind.excludedapps") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "eye.slash.fill")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Excluded Apps")
+                .scaledFont(size: 15, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text("Screen capture is paused when these apps are active")
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+
+            Spacer()
+
+            Button("Reset to Defaults") {
+              rewindSettings.resetToDefaults()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          // List of excluded apps
+          if rewindSettings.excludedApps.isEmpty {
             HStack {
-                Text(title)
-                    .scaledFont(size: 14)
+              Spacer()
+              VStack(spacing: 8) {
+                Image(systemName: "checkmark.shield")
+                  .scaledFont(size: 24)
+                  .foregroundColor(OmiColors.textTertiary)
+                Text("No apps excluded")
+                  .scaledFont(size: 13)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+              .padding(.vertical, 16)
+              Spacer()
+            }
+          } else {
+            LazyVStack(spacing: 8) {
+              ForEach(Array(rewindSettings.excludedApps).sorted(), id: \.self) { appName in
+                ExcludedAppRow(
+                  appName: appName,
+                  onRemove: {
+                    rewindSettings.includeApp(appName)
+                  }
+                )
+              }
+            }
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          // Add app section
+          AddExcludedAppView(
+            onAdd: { appName in
+              rewindSettings.excludeApp(appName)
+            },
+            excludedApps: rewindSettings.excludedApps
+          )
+        }
+      }
+
+      // Battery Settings
+      settingsCard(settingId: "rewind.battery") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "battery.75percent")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Battery Optimization")
+                .scaledFont(size: 15, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text(
+                "Pause text recognition on battery to save energy. OCR runs automatically when plugged back in."
+              )
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $rewindSettings.pauseOCROnBattery)
+              .toggleStyle(.switch)
+              .labelsHidden()
+          }
+        }
+      }
+
+      // Retention Settings
+      settingsCard(settingId: "rewind.retention") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "clock.fill")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Data Retention")
+                .scaledFont(size: 15, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text("How long to keep screen recordings")
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+
+            Spacer()
+
+            Picker("", selection: $rewindSettings.retentionDays) {
+              Text("3 days").tag(3)
+              Text("7 days").tag(7)
+              Text("14 days").tag(14)
+              Text("30 days").tag(30)
+            }
+            .pickerStyle(.menu)
+            .frame(width: 110)
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Transcription Section
+
+  private var transcriptionSection: some View {
+    VStack(spacing: 20) {
+      // Language Mode
+      settingsCard(settingId: "transcription.languagemode") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "globe")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Language Mode")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+          }
+
+          // Auto-Detect option
+          Button(action: {
+            transcriptionAutoDetect = true
+            AssistantSettings.shared.transcriptionAutoDetect = true
+            updateTranscriptionPreferences(singleLanguageMode: false)
+            restartTranscriptionIfNeeded()
+          }) {
+            HStack(alignment: .top, spacing: 12) {
+              Image(systemName: transcriptionAutoDetect ? "checkmark.circle.fill" : "circle")
+                .scaledFont(size: 20)
+                .foregroundColor(
+                  transcriptionAutoDetect ? OmiColors.purplePrimary : OmiColors.textTertiary)
+
+              VStack(alignment: .leading, spacing: 6) {
+                Text("Auto-Detect (Multi-Language)")
+                  .scaledFont(size: 14, weight: .medium)
+                  .foregroundColor(OmiColors.textPrimary)
+
+                Text("Automatically detects and transcribes:")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+
+                // List of supported languages
+                Text(
+                  "English, Spanish, French, German, Hindi, Russian, Portuguese, Japanese, Italian, Dutch"
+                )
+                .scaledFont(size: 11)
+                .foregroundColor(OmiColors.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+              }
+
+              Spacer()
+            }
+            .padding(12)
+            .background(
+              RoundedRectangle(cornerRadius: 8)
+                .fill(transcriptionAutoDetect ? OmiColors.purplePrimary.opacity(0.1) : Color.clear)
+                .overlay(
+                  RoundedRectangle(cornerRadius: 8)
+                    .stroke(
+                      transcriptionAutoDetect
+                        ? OmiColors.purplePrimary.opacity(0.3) : OmiColors.backgroundQuaternary,
+                      lineWidth: 1)
+                )
+            )
+          }
+          .buttonStyle(.plain)
+
+          // Single Language option
+          Button(action: {
+            transcriptionAutoDetect = false
+            AssistantSettings.shared.transcriptionAutoDetect = false
+            updateTranscriptionPreferences(singleLanguageMode: true)
+            restartTranscriptionIfNeeded()
+          }) {
+            HStack(alignment: .top, spacing: 12) {
+              Image(systemName: !transcriptionAutoDetect ? "checkmark.circle.fill" : "circle")
+                .scaledFont(size: 20)
+                .foregroundColor(
+                  !transcriptionAutoDetect ? OmiColors.purplePrimary : OmiColors.textTertiary)
+
+              VStack(alignment: .leading, spacing: 6) {
+                Text("Single Language (Better Accuracy)")
+                  .scaledFont(size: 14, weight: .medium)
+                  .foregroundColor(OmiColors.textPrimary)
+
+                Text("Best for speaking in one specific language")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+
+                // Language picker (only shown when single language is selected)
+                if !transcriptionAutoDetect {
+                  HStack {
+                    Text("Language:")
+                      .scaledFont(size: 12)
+                      .foregroundColor(OmiColors.textTertiary)
+
+                    Picker("", selection: $transcriptionLanguage) {
+                      ForEach(languageOptions, id: \.0) { option in
+                        Text(option.1).tag(option.0)
+                      }
+                    }
+                    .pickerStyle(.menu)
+                    .frame(width: 180)
+                    .onChange(of: transcriptionLanguage) { _, newValue in
+                      AssistantSettings.shared.transcriptionLanguage = newValue
+                      let supportsMulti = AssistantSettings.supportsAutoDetect(newValue)
+                      transcriptionAutoDetect = supportsMulti
+                      AssistantSettings.shared.transcriptionAutoDetect = supportsMulti
+                      updateTranscriptionPreferences(singleLanguageMode: !supportsMulti)
+                      updateLanguage(newValue)
+                      restartTranscriptionIfNeeded()
+                    }
+                  }
+                  .padding(.top, 4)
+                }
+              }
+
+              Spacer()
+            }
+            .padding(12)
+            .background(
+              RoundedRectangle(cornerRadius: 8)
+                .fill(!transcriptionAutoDetect ? OmiColors.purplePrimary.opacity(0.1) : Color.clear)
+                .overlay(
+                  RoundedRectangle(cornerRadius: 8)
+                    .stroke(
+                      !transcriptionAutoDetect
+                        ? OmiColors.purplePrimary.opacity(0.3) : OmiColors.backgroundQuaternary,
+                      lineWidth: 1)
+                )
+            )
+          }
+          .buttonStyle(.plain)
+
+          // Info about language support
+          HStack(spacing: 8) {
+            Image(systemName: "info.circle")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Text(
+              "Single language mode supports 42 languages including Ukrainian, Russian, and more."
+            )
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.textTertiary)
+          }
+        }
+      }
+
+      // Custom Vocabulary
+      settingsCard(settingId: "transcription.vocabulary") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "text.book.closed")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Custom Vocabulary")
+                .scaledFont(size: 15, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text("Improve recognition of names, brands, and technical terms")
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+
+            Spacer()
+
+            if !vocabularyList.isEmpty {
+              Text("\(vocabularyList.count) terms")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+          }
+
+          // Current vocabulary display with removable tags
+          if !vocabularyList.isEmpty {
+            FlowLayout(spacing: 6) {
+              ForEach(vocabularyList, id: \.self) { term in
+                HStack(spacing: 4) {
+                  Text(term)
+                    .scaledFont(size: 12)
                     .foregroundColor(OmiColors.textSecondary)
+
+                  Button(action: {
+                    removeVocabularyWord(term)
+                  }) {
+                    Image(systemName: "xmark")
+                      .scaledFont(size: 9, weight: .medium)
+                      .foregroundColor(OmiColors.textTertiary)
+                  }
+                  .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(
+                  RoundedRectangle(cornerRadius: 6)
+                    .fill(OmiColors.backgroundQuaternary)
+                )
+              }
+            }
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          // Add new word input
+          HStack(spacing: 8) {
+            TextField("Add a word...", text: $newVocabularyWord)
+              .textFieldStyle(.roundedBorder)
+              .onSubmit {
+                addVocabularyWord()
+              }
+
+            Button(action: {
+              addVocabularyWord()
+            }) {
+              Image(systemName: "plus.circle.fill")
+                .scaledFont(size: 20)
+                .foregroundColor(
+                  newVocabularyWord.trimmingCharacters(in: .whitespaces).isEmpty
+                    ? OmiColors.textTertiary : OmiColors.purplePrimary)
+            }
+            .buttonStyle(.plain)
+            .disabled(newVocabularyWord.trimmingCharacters(in: .whitespaces).isEmpty)
+          }
+
+          Text("Press Enter or click + to add • Click × to remove")
+            .scaledFont(size: 11)
+            .foregroundColor(OmiColors.textTertiary)
+        }
+      }
+
+      // Local VAD Gate
+      settingsCard(settingId: "transcription.vadgate") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "waveform.badge.minus")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Local VAD Gate")
+                .scaledFont(size: 15, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text(
+                "Uses on-device voice activity detection to skip silence, reducing Deepgram API usage. May save ~40% on transcription costs."
+              )
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+              .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $vadGateEnabled)
+              .toggleStyle(.switch)
+              .onChange(of: vadGateEnabled) { _, newValue in
+                AssistantSettings.shared.vadGateEnabled = newValue
+                restartTranscriptionIfNeeded()
+              }
+          }
+        }
+      }
+
+      // Batch Transcription
+      settingsCard(settingId: "transcription.batch") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "square.stack.3d.up")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Batch Transcription")
+                .scaledFont(size: 15, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text(
+                "Transcribes audio in chunks at silence boundaries. Better accuracy, but transcript appears with a few seconds delay."
+              )
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+              .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: $batchTranscriptionEnabled)
+              .toggleStyle(.switch)
+              .onChange(of: batchTranscriptionEnabled) { _, newValue in
+                AssistantSettings.shared.batchTranscriptionEnabled = newValue
+                restartTranscriptionIfNeeded()
+              }
+          }
+        }
+      }
+    }
+  }
+
+  /// Add a word to the vocabulary
+  private func addVocabularyWord() {
+    let word = newVocabularyWord.trimmingCharacters(in: .whitespaces)
+    guard !word.isEmpty else { return }
+
+    // Don't add duplicates (case-insensitive check)
+    guard !vocabularyList.contains(where: { $0.lowercased() == word.lowercased() }) else {
+      newVocabularyWord = ""
+      return
+    }
+
+    vocabularyList.append(word)
+    newVocabularyWord = ""
+    saveVocabulary()
+  }
+
+  /// Remove a word from the vocabulary
+  private func removeVocabularyWord(_ word: String) {
+    vocabularyList.removeAll { $0 == word }
+    saveVocabulary()
+  }
+
+  /// Save vocabulary to local settings and backend
+  private func saveVocabulary() {
+    // Save to local settings
+    AssistantSettings.shared.transcriptionVocabulary = vocabularyList
+
+    // Sync to backend
+    updateTranscriptionPreferences(vocabulary: vocabularyList.joined(separator: ", "))
+  }
+
+  /// Restart transcription if currently running to apply new settings
+  private func restartTranscriptionIfNeeded() {
+    guard appState.isTranscribing else { return }
+
+    // Stop and restart to apply new language settings
+    appState.stopTranscription()
+
+    // Wait a moment for cleanup, then restart
+    DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+      self.appState.startTranscription()
+    }
+  }
+
+  // MARK: - Notifications Section
+
+  private var notificationsSection: some View {
+    VStack(spacing: 20) {
+      // Notifications
+      settingsCard(settingId: "notifications.settings") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "bell.badge.fill")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Notifications")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $notificationsEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .onChange(of: notificationsEnabled) { _, newValue in
+                updateNotificationSettings(enabled: newValue)
+              }
+          }
+
+          Text("Control how often you receive notifications")
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+
+          if notificationsEnabled {
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            settingRow(
+              title: "Frequency", subtitle: "How often to receive notifications",
+              settingId: "notifications.frequency"
+            ) {
+              Picker("", selection: $notificationFrequency) {
+                ForEach(frequencyOptions, id: \.0) { option in
+                  Text(option.1).tag(option.0)
+                }
+              }
+              .pickerStyle(.menu)
+              .frame(width: 120)
+              .onChange(of: notificationFrequency) { _, newValue in
+                updateNotificationSettings(frequency: newValue)
+              }
+            }
+
+            settingRow(
+              title: "Focus Notifications", subtitle: "Show notification on focus changes",
+              settingId: "notifications.focus"
+            ) {
+              Toggle("", isOn: $focusNotificationsEnabled)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .onChange(of: focusNotificationsEnabled) { _, newValue in
+                  FocusAssistantSettings.shared.notificationsEnabled = newValue
+                  SettingsSyncManager.shared.pushPartialUpdate(
+                    AssistantSettingsResponse(
+                      focus: FocusSettingsResponse(notificationsEnabled: newValue)))
+                }
+            }
+
+            settingRow(
+              title: "Task Notifications", subtitle: "Show notification when a task is extracted",
+              settingId: "notifications.task"
+            ) {
+              Toggle("", isOn: $taskNotificationsEnabled)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .onChange(of: taskNotificationsEnabled) { _, newValue in
+                  TaskAssistantSettings.shared.notificationsEnabled = newValue
+                  SettingsSyncManager.shared.pushPartialUpdate(
+                    AssistantSettingsResponse(
+                      task: TaskSettingsResponse(notificationsEnabled: newValue)))
+                }
+            }
+
+            settingRow(
+              title: "Advice Notifications", subtitle: "Show notification when advice is generated",
+              settingId: "notifications.advice"
+            ) {
+              Toggle("", isOn: $adviceNotificationsEnabled)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .onChange(of: adviceNotificationsEnabled) { _, newValue in
+                  AdviceAssistantSettings.shared.notificationsEnabled = newValue
+                  SettingsSyncManager.shared.pushPartialUpdate(
+                    AssistantSettingsResponse(
+                      advice: AdviceSettingsResponse(notificationsEnabled: newValue)))
+                }
+            }
+
+            settingRow(
+              title: "Memory Notifications",
+              subtitle: "Show notification when a memory is extracted",
+              settingId: "notifications.memory"
+            ) {
+              Toggle("", isOn: $memoryNotificationsEnabled)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .onChange(of: memoryNotificationsEnabled) { _, newValue in
+                  MemoryAssistantSettings.shared.notificationsEnabled = newValue
+                  SettingsSyncManager.shared.pushPartialUpdate(
+                    AssistantSettingsResponse(
+                      memory: MemorySettingsResponse(notificationsEnabled: newValue)))
+                }
+            }
+          }
+        }
+      }
+
+      // Daily Summary
+      settingsCard(settingId: "notifications.dailysummary") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "text.badge.checkmark")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Daily Summary")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $dailySummaryEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .onChange(of: dailySummaryEnabled) { _, newValue in
+                updateDailySummarySettings(enabled: newValue)
+              }
+          }
+
+          Text("Receive a daily summary of your conversations and activities")
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+
+          if dailySummaryEnabled {
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            settingRow(
+              title: "Summary Time", subtitle: "When to send your daily summary",
+              settingId: "notifications.summarytime"
+            ) {
+              Picker("", selection: $dailySummaryHour) {
+                ForEach(hourOptions, id: \.self) { hour in
+                  Text(formatHour(hour)).tag(hour)
+                }
+              }
+              .pickerStyle(.menu)
+              .frame(width: 100)
+              .onChange(of: dailySummaryHour) { _, newValue in
+                updateDailySummarySettings(hour: newValue)
+              }
+            }
+          }
+        }
+      }
+
+    }
+  }
+
+  // MARK: - Privacy Section
+
+  private var privacySection: some View {
+    VStack(spacing: 16) {
+      // Data Controls
+      settingsCard(settingId: "privacy.storerecordings") {
+        VStack(alignment: .leading, spacing: 0) {
+          HStack {
+            Image(systemName: "mic.fill")
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.purplePrimary)
+              .frame(width: 20)
+
+            Text("Store Recordings")
+              .scaledFont(size: 14, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $recordingPermissionEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .controlSize(.small)
+              .onChange(of: recordingPermissionEnabled) { _, newValue in
+                updateRecordingPermission(newValue)
+              }
+          }
+          .padding(.bottom, 4)
+
+          Text("Allow omi to store audio recordings of your conversations")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+            .padding(.leading, 34)
+
+          Divider()
+            .padding(.vertical, 12)
+
+          HStack {
+            Image(systemName: "cloud.fill")
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.purplePrimary)
+              .frame(width: 20)
+
+            Text("Private Cloud Sync")
+              .scaledFont(size: 14, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $privateCloudSyncEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .controlSize(.small)
+              .onChange(of: privateCloudSyncEnabled) { _, newValue in
+                updatePrivateCloudSync(newValue)
+              }
+          }
+          .padding(.bottom, 4)
+
+          Text("Sync your data securely to your private cloud storage")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+            .padding(.leading, 34)
+        }
+      }
+
+      // Encryption
+      settingsCard(settingId: "privacy.encryption") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack(spacing: 10) {
+            Image(systemName: "shield.lefthalf.filled")
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.purplePrimary)
+              .frame(width: 20)
+
+            Text("Encryption")
+              .scaledFont(size: 14, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+          }
+
+          HStack(spacing: 10) {
+            Image(systemName: "checkmark.circle.fill")
+              .scaledFont(size: 12)
+              .foregroundColor(.green)
+              .frame(width: 20)
+
+            Text("Server-side encryption")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textSecondary)
+
+            Text("Active")
+              .scaledFont(size: 10, weight: .semibold)
+              .foregroundColor(.green)
+              .padding(.horizontal, 5)
+              .padding(.vertical, 1)
+              .background(Color.green.opacity(0.15))
+              .cornerRadius(3)
+          }
+          .padding(.leading, 14)
+
+          Text("Your data is encrypted and stored securely with Google Cloud infrastructure.")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+            .padding(.leading, 34)
+        }
+      }
+
+      // What We Track
+      settingsCard(settingId: "privacy.tracking") {
+        VStack(alignment: .leading, spacing: 0) {
+          Button(action: {
+            withAnimation(.easeInOut(duration: 0.2)) {
+              isTrackingExpanded.toggle()
+            }
+          }) {
+            HStack(spacing: 10) {
+              Image(systemName: "list.bullet")
+                .scaledFont(size: 14)
+                .foregroundColor(OmiColors.purplePrimary)
+                .frame(width: 20)
+
+              Text("What We Track")
+                .scaledFont(size: 14, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+
+              Spacer()
+
+              Image(systemName: "chevron.right")
+                .scaledFont(size: 11, weight: .semibold)
+                .foregroundColor(OmiColors.textTertiary)
+                .rotationEffect(.degrees(isTrackingExpanded ? 90 : 0))
+            }
+          }
+          .buttonStyle(.plain)
+
+          if isTrackingExpanded {
+            VStack(alignment: .leading, spacing: 6) {
+              trackingItem("Onboarding steps completed")
+              trackingItem("Settings changes")
+              trackingItem("App installations and usage")
+              trackingItem("Device connection status")
+              trackingItem("Transcript processing events")
+              trackingItem("Conversation creation and updates")
+              trackingItem("Memory extraction events")
+              trackingItem("Chat interactions")
+              trackingItem("Speech profile creation")
+              trackingItem("Focus session events")
+              trackingItem("App open/close events")
+            }
+            .padding(.top, 10)
+            .padding(.leading, 34)
+            .transition(.opacity)
+          }
+        }
+      }
+
+      // Privacy Guarantees
+      settingsCard(settingId: "privacy.privacy") {
+        VStack(alignment: .leading, spacing: 10) {
+          HStack(spacing: 10) {
+            Image(systemName: "hand.raised.fill")
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.purplePrimary)
+              .frame(width: 20)
+
+            Text("Privacy Guarantees")
+              .scaledFont(size: 14, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+          }
+
+          VStack(alignment: .leading, spacing: 6) {
+            privacyBullet("Anonymous tracking with randomly generated IDs")
+            privacyBullet("No personal info stored in analytics")
+            privacyBullet("Data is never sold or shared with third parties")
+            privacyBullet("Opt out of tracking at any time")
+          }
+          .padding(.leading, 34)
+        }
+      }
+    }
+  }
+
+  // MARK: - Account Section
+
+  private var accountSection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "account.account") {
+        VStack(alignment: .leading, spacing: 14) {
+          HStack(spacing: 16) {
+            Image(systemName: "person.circle.fill")
+              .scaledFont(size: 40)
+              .foregroundColor(OmiColors.textTertiary)
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text(AuthService.shared.displayName.isEmpty ? "User" : AuthService.shared.displayName)
+                .scaledFont(size: 16, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+
+              if let email = AuthState.shared.userEmail {
+                Text(email)
+                  .scaledFont(size: 13)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+            }
+
+            Spacer()
+
+            Button("Sign Out") {
+              appState.stopTranscription()
+              ProactiveAssistantsPlugin.shared.stopMonitoring()
+              try? AuthService.shared.signOut()
+            }
+            .buttonStyle(.bordered)
+            .disabled(isDeletingAccount)
+          }
+
+          Divider()
+            .overlay(OmiColors.backgroundQuaternary)
+
+          HStack(alignment: .center, spacing: 16) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text("Delete Account & Data")
+                .scaledFont(size: 15, weight: .semibold)
+                .foregroundColor(OmiColors.error)
+
+              Text(
+                "Permanently deletes server data, clears local data for this account, resets onboarding, and signs you out."
+              )
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+            }
+
+            Spacer()
+
+            Button(action: {
+              AnalyticsManager.shared.deleteAccountClicked()
+              showDeleteAccountAlert = true
+            }) {
+              if isDeletingAccount {
+                ProgressView()
+                  .controlSize(.small)
+              } else {
+                Text("Delete")
+                  .scaledFont(size: 13, weight: .semibold)
+              }
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(OmiColors.error)
+            .disabled(isDeletingAccount)
+          }
+
+          if let deleteAccountError {
+            Text(deleteAccountError)
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.warning)
+          }
+        }
+      }
+      .alert("Delete Account and Data?", isPresented: $showDeleteAccountAlert) {
+        Button("Cancel", role: .cancel) {
+          AnalyticsManager.shared.deleteAccountCancelled()
+        }
+        Button("Delete Permanently", role: .destructive) {
+          deleteAccountAndData()
+        }
+      } message: {
+        Text(
+          "This cannot be undone. Your account, chat history, and all server data will be permanently deleted. Local data for this account will be cleared and you'll return to onboarding."
+        )
+      }
+
+      //            settingsCard {
+      //                HStack(spacing: 16) {
+      //                    Image(systemName: "bolt.fill")
+      //                        .scaledFont(size: 16)
+      //                        .foregroundColor(.yellow)
+      //
+      //                    VStack(alignment: .leading, spacing: 4) {
+      //                        Text("Upgrade to Pro")
+      //                            .scaledFont(size: 15, weight: .medium)
+      //                            .foregroundColor(OmiColors.textPrimary)
+      //
+      //                        Text("Unlock all features and unlimited usage")
+      //                            .scaledFont(size: 13)
+      //                            .foregroundColor(OmiColors.textTertiary)
+      //                    }
+      //
+      //                    Spacer()
+      //
+      //                    Button("Upgrade") {
+      //                        if let url = URL(string: "https://omi.me/pricing") {
+      //                            NSWorkspace.shared.open(url)
+      //                        }
+      //                    }
+      //                    .buttonStyle(.borderedProminent)
+      //                    .tint(OmiColors.purplePrimary)
+      //                }
+      //            }
+    }
+  }
+
+  // MARK: - AI Chat Section
+
+  private var aiChatSection: some View {
+    VStack(spacing: 20) {
+      // AI Provider card
+      settingsCard(settingId: "aichat.provider") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "cpu")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Text("AI Provider")
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Picker("", selection: $chatBridgeMode) {
+              Text("omi account").tag("agentSDK")
+              Text("Your Claude Account").tag("claudeCode")
+            }
+            .pickerStyle(.menu)
+            .frame(width: 200)
+            .onChange(of: chatBridgeMode) { _, newMode in
+              if let mode = ChatProvider.BridgeMode(rawValue: newMode) {
+                Task {
+                  await chatProvider?.switchBridgeMode(to: mode)
+                }
+              }
+            }
+          }
+
+          Text(
+            chatBridgeMode == "claudeCode"
+              ? "Using your Claude Pro/Max subscription. You'll be prompted to sign in with your Claude account."
+              : "Using your omi account."
+          )
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+
+          if chatBridgeMode == "claudeCode" && chatProvider?.isClaudeConnected == true {
+            Divider()
+
+            HStack {
+              Image(systemName: "checkmark.circle.fill")
+                .foregroundColor(.green)
+                .scaledFont(size: 12)
+              Text("Connected to Claude")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textSecondary)
+
+              Spacer()
+
+              Button("Disconnect") {
+                Task {
+                  await chatProvider?.disconnectClaude()
+                }
+              }
+              .buttonStyle(.plain)
+              .scaledFont(size: 12, weight: .medium)
+              .foregroundColor(.red)
+            }
+          }
+        }
+      }
+      .onAppear {
+        chatProvider?.checkClaudeConnectionStatus()
+      }
+
+      // Ask Mode card
+      settingsCard(settingId: "aichat.askmode") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "bubble.left.and.bubble.right")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Text("Ask Mode")
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $askModeEnabled)
+              .toggleStyle(.switch)
+              .controlSize(.small)
+              .labelsHidden()
+          }
+
+          Text(
+            "When enabled, shows an Ask/Act toggle in the chat. Ask mode restricts the AI to read-only actions. When disabled, the AI always runs in Act mode."
+          )
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+        }
+      }
+
+      // Workspace card
+      settingsCard(settingId: "aichat.workspace") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "folder")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Text("Workspace")
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Button("Browse...") {
+              let panel = NSOpenPanel()
+              panel.canChooseFiles = false
+              panel.canChooseDirectories = true
+              panel.allowsMultipleSelection = false
+              panel.message = "Select a project directory"
+              if panel.runModal() == .OK, let url = panel.url {
+                aiChatWorkingDirectory = url.path
+                refreshAIChatConfig()
+                // Update ChatProvider
+                chatProvider?.aiChatWorkingDirectory = url.path
+                Task { await chatProvider?.discoverClaudeConfig() }
+                if chatProvider?.workingDirectory == nil {
+                  chatProvider?.workingDirectory = url.path
+                }
+              }
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+
+            if !aiChatWorkingDirectory.isEmpty {
+              Button("Clear") {
+                aiChatWorkingDirectory = ""
+                refreshAIChatConfig()
+                chatProvider?.aiChatWorkingDirectory = ""
+                Task { await chatProvider?.discoverClaudeConfig() }
+                chatProvider?.workingDirectory = nil
+              }
+              .buttonStyle(.bordered)
+              .controlSize(.small)
+            }
+          }
+
+          if !aiChatWorkingDirectory.isEmpty {
+            Text(aiChatWorkingDirectory)
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+              .lineLimit(1)
+              .truncationMode(.middle)
+
+            Text("Project-level CLAUDE.md and skills will be discovered from this directory")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+          } else {
+            Text(
+              "No workspace set. Set a project directory to discover project-level CLAUDE.md and skills."
+            )
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+          }
+        }
+      }
+
+      // CLAUDE.md card
+      settingsCard(settingId: "aichat.claudemd") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "doc.text")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Text("CLAUDE.md")
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+          }
+
+          // Global CLAUDE.md
+          VStack(alignment: .leading, spacing: 8) {
+            HStack {
+              Text("Global")
+                .scaledFont(size: 11, weight: .medium)
+                .foregroundColor(OmiColors.textTertiary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                  RoundedRectangle(cornerRadius: 4)
+                    .fill(OmiColors.backgroundPrimary.opacity(0.5))
+                )
+
+              Spacer()
+
+              if aiChatClaudeMdContent != nil {
+                Button("View") {
+                  fileViewerTitle = "Global CLAUDE.md"
+                  fileViewerContent = aiChatClaudeMdContent ?? ""
+                  showFileViewer = true
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Toggle("", isOn: $claudeMdEnabled)
+                  .toggleStyle(.switch)
+                  .controlSize(.small)
+                  .labelsHidden()
+              }
+            }
+
+            if let path = aiChatClaudeMdPath, let content = aiChatClaudeMdContent {
+              let sizeKB = Double(content.utf8.count) / 1024.0
+              Text("\(path) (\(String(format: "%.1f", sizeKB)) KB)")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+            } else {
+              Text("No CLAUDE.md found at ~/.claude/CLAUDE.md")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+          }
+
+          // Project CLAUDE.md (only show if workspace is set)
+          if !aiChatWorkingDirectory.isEmpty {
+            Divider().opacity(0.3)
+
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                Text("Project")
+                  .scaledFont(size: 11, weight: .medium)
+                  .foregroundColor(OmiColors.purplePrimary)
+                  .padding(.horizontal, 6)
+                  .padding(.vertical, 2)
+                  .background(
+                    RoundedRectangle(cornerRadius: 4)
+                      .fill(OmiColors.purplePrimary.opacity(0.1))
+                  )
 
                 Spacer()
 
-                Image(systemName: "arrow.up.right")
-                    .scaledFont(size: 12)
-                    .foregroundColor(OmiColors.textTertiary)
+                if aiChatProjectClaudeMdContent != nil {
+                  Button("View") {
+                    fileViewerTitle = "Project CLAUDE.md"
+                    fileViewerContent = aiChatProjectClaudeMdContent ?? ""
+                    showFileViewer = true
+                  }
+                  .buttonStyle(.bordered)
+                  .controlSize(.small)
+
+                  Toggle("", isOn: $projectClaudeMdEnabled)
+                    .toggleStyle(.switch)
+                    .controlSize(.small)
+                    .labelsHidden()
+                }
+              }
+
+              if let path = aiChatProjectClaudeMdPath, let content = aiChatProjectClaudeMdContent {
+                let sizeKB = Double(content.utf8.count) / 1024.0
+                Text("\(path) (\(String(format: "%.1f", sizeKB)) KB)")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+                  .lineLimit(1)
+                  .truncationMode(.middle)
+              } else {
+                Text("No CLAUDE.md found at \(aiChatWorkingDirectory)/CLAUDE.md")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
             }
+          }
         }
-        .buttonStyle(.plain)
-    }
+      }
 
-    private func trackingItem(_ text: String) -> some View {
-        HStack(spacing: 8) {
-            Circle()
-                .fill(OmiColors.textTertiary.opacity(0.5))
-                .frame(width: 4, height: 4)
+      // Skills card
+      settingsCard(settingId: "aichat.skills") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "sparkles")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.textTertiary)
 
-            Text(text)
+            if aiChatProjectDiscoveredSkills.isEmpty {
+              Text("Skills (\(aiChatDiscoveredSkills.count) discovered)")
+                .scaledFont(size: 15, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+            } else {
+              Text(
+                "Skills (\(aiChatDiscoveredSkills.count) global + \(aiChatProjectDiscoveredSkills.count) project)"
+              )
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+            }
+
+            Spacer()
+
+            Button(action: { refreshAIChatConfig() }) {
+              Image(systemName: "arrow.clockwise")
+                .scaledFont(size: 13)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+          }
+
+          let allSkills:
+            [(skill: (name: String, description: String, path: String), origin: String)] =
+              aiChatDiscoveredSkills.map { ($0, "Global") }
+              + aiChatProjectDiscoveredSkills.map { ($0, "Project") }
+
+          if allSkills.isEmpty {
+            Text("No skills found in ~/.claude/skills/")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+          } else {
+            Text("Skill descriptions are included in the AI chat system prompt")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+
+            // Search field
+            HStack(spacing: 8) {
+              Image(systemName: "magnifyingglass")
                 .scaledFont(size: 12)
                 .foregroundColor(OmiColors.textTertiary)
+
+              TextField("Search skills...", text: $skillSearchQuery)
+                .textFieldStyle(.plain)
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textPrimary)
+
+              if !skillSearchQuery.isEmpty {
+                Button(action: { skillSearchQuery = "" }) {
+                  Image(systemName: "xmark.circle.fill")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+                .buttonStyle(.plain)
+              }
+            }
+            .padding(8)
+            .background(
+              RoundedRectangle(cornerRadius: 8)
+                .fill(OmiColors.backgroundPrimary.opacity(0.5))
+            )
+
+            ScrollView {
+              let filteredSkills = allSkills.enumerated().filter { _, item in
+                skillSearchQuery.isEmpty
+                  || item.skill.name.localizedCaseInsensitiveContains(skillSearchQuery)
+                  || item.skill.description.localizedCaseInsensitiveContains(skillSearchQuery)
+              }
+
+              VStack(spacing: 0) {
+                ForEach(Array(filteredSkills.enumerated()), id: \.offset) { filteredIndex, item in
+                  let skill = item.element.skill
+                  let origin = item.element.origin
+                  HStack(spacing: 10) {
+                    Toggle(
+                      "",
+                      isOn: Binding(
+                        get: { !aiChatDisabledSkills.contains(skill.name) },
+                        set: { enabled in
+                          if enabled {
+                            aiChatDisabledSkills.remove(skill.name)
+                          } else {
+                            aiChatDisabledSkills.insert(skill.name)
+                          }
+                          saveDisabledSkills()
+                        }
+                      )
+                    )
+                    .toggleStyle(.checkbox)
+                    .labelsHidden()
+
+                    VStack(alignment: .leading, spacing: 2) {
+                      HStack(spacing: 6) {
+                        Text(skill.name)
+                          .scaledFont(size: 13, weight: .medium)
+                          .foregroundColor(OmiColors.textPrimary)
+
+                        Text(origin)
+                          .scaledFont(size: 9, weight: .medium)
+                          .foregroundColor(
+                            origin == "Project" ? OmiColors.purplePrimary : OmiColors.textTertiary
+                          )
+                          .padding(.horizontal, 4)
+                          .padding(.vertical, 1)
+                          .background(
+                            RoundedRectangle(cornerRadius: 3)
+                              .fill(
+                                origin == "Project"
+                                  ? OmiColors.purplePrimary.opacity(0.1)
+                                  : OmiColors.backgroundPrimary.opacity(0.5))
+                          )
+                      }
+
+                      if !skill.description.isEmpty {
+                        Text(skill.description)
+                          .scaledFont(size: 11)
+                          .foregroundColor(OmiColors.textTertiary)
+                          .lineLimit(1)
+                          .truncationMode(.tail)
+                      }
+                    }
+
+                    Spacer()
+
+                    Button("View") {
+                      fileViewerTitle = "\(skill.name)/SKILL.md"
+                      fileViewerContent =
+                        (try? String(contentsOfFile: skill.path, encoding: .utf8))
+                        ?? "Unable to read file"
+                      showFileViewer = true
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.mini)
+                  }
+                  .padding(.vertical, 6)
+                  .padding(.horizontal, 4)
+
+                  if filteredIndex < filteredSkills.count - 1 {
+                    Divider()
+                      .opacity(0.3)
+                  }
+                }
+              }
+            }
+            .frame(maxHeight: 300)
+          }
         }
+      }
+
+      // Browser Extension card
+      settingsCard(settingId: "aichat.browserextension") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "globe")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Text("Browser Extension")
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            if !playwrightExtensionToken.isEmpty {
+              HStack(spacing: 4) {
+                Circle()
+                  .fill(Color.green)
+                  .frame(width: 6, height: 6)
+                Text("Connected")
+                  .scaledFont(size: 11)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+            }
+
+            Toggle("", isOn: $playwrightUseExtension)
+              .toggleStyle(.switch)
+              .controlSize(.small)
+              .labelsHidden()
+              .onChange(of: playwrightUseExtension) { _, _ in
+              }
+          }
+
+          Text("Lets the AI use your Chrome browser with all your logged-in sessions.")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+
+          if playwrightUseExtension {
+            if playwrightExtensionToken.isEmpty {
+              // No token — show "Set Up" button
+              Button(action: {
+                showBrowserSetup = true
+              }) {
+                HStack(spacing: 6) {
+                  Image(systemName: "wrench.and.screwdriver")
+                    .scaledFont(size: 12)
+                  Text("Set Up")
+                    .scaledFont(size: 13, weight: .medium)
+                }
+              }
+              .buttonStyle(.borderedProminent)
+              .controlSize(.small)
+            } else {
+              // Token is set — show compact view
+              HStack(spacing: 8) {
+                Text("Token")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+
+                Text(String(playwrightExtensionToken.prefix(8)) + "...")
+                  .scaledFont(size: 12, weight: .medium)
+                  .foregroundColor(OmiColors.textPrimary)
+                  .font(.system(.body, design: .monospaced))
+
+                Spacer()
+
+                Button(action: {
+                  showBrowserSetup = true
+                }) {
+                  HStack(spacing: 4) {
+                    Image(systemName: "arrow.clockwise")
+                      .scaledFont(size: 11)
+                    Text("Reconfigure")
+                      .scaledFont(size: 12)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(action: {
+                  playwrightExtensionToken = ""
+                  UserDefaults.standard.set("", forKey: "playwrightExtensionToken")
+                }) {
+                  HStack(spacing: 4) {
+                    Image(systemName: "xmark")
+                      .scaledFont(size: 11)
+                    Text("Reset")
+                      .scaledFont(size: 12)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+              }
+            }
+          }
+        }
+      }
+
+      // Dev Mode card
+      settingsCard(settingId: "aichat.devmode") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Image(systemName: "hammer")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.textTertiary)
+
+            Text("Dev Mode")
+              .scaledFont(size: 15, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $devModeEnabled)
+              .toggleStyle(.switch)
+              .controlSize(.small)
+              .labelsHidden()
+              .onChange(of: devModeEnabled) { _, newValue in
+                AnalyticsManager.shared.settingToggled(setting: "dev_mode", enabled: newValue)
+              }
+          }
+
+          Text("Let the AI modify the app's source code, rebuild it, and add custom features.")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+
+          if devModeEnabled {
+            VStack(alignment: .leading, spacing: 8) {
+              HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle.fill")
+                  .foregroundColor(.green)
+                  .scaledFont(size: 12)
+                Text("AI can modify UI, add features, create custom SQLite tables")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textSecondary)
+              }
+              HStack(spacing: 6) {
+                Image(systemName: "lock.fill")
+                  .foregroundColor(.orange)
+                  .scaledFont(size: 12)
+                Text("Backend API, auth, and sync logic are read-only")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textSecondary)
+              }
+            }
+          }
+        }
+      }
+    }
+    .onAppear {
+      refreshAIChatConfig()
+      playwrightExtensionToken =
+        UserDefaults.standard.string(forKey: "playwrightExtensionToken") ?? ""
+    }
+    .sheet(isPresented: $showFileViewer) {
+      fileViewerSheet
+    }
+    .sheet(isPresented: $showBrowserSetup) {
+      BrowserExtensionSetup(
+        onComplete: {
+          showBrowserSetup = false
+          playwrightExtensionToken =
+            UserDefaults.standard.string(forKey: "playwrightExtensionToken") ?? ""
+        },
+        onDismiss: {
+          showBrowserSetup = false
+          playwrightExtensionToken =
+            UserDefaults.standard.string(forKey: "playwrightExtensionToken") ?? ""
+        },
+        chatProvider: chatProvider
+      )
+      .fixedSize()
+    }
+  }
+
+  private var fileViewerSheet: some View {
+    VStack(spacing: 0) {
+      // Header
+      HStack {
+        Text(fileViewerTitle)
+          .scaledFont(size: 16, weight: .semibold)
+          .foregroundColor(OmiColors.textPrimary)
+
+        Spacer()
+
+        Button(action: { showFileViewer = false }) {
+          Image(systemName: "xmark.circle.fill")
+            .scaledFont(size: 18)
+            .foregroundColor(OmiColors.textTertiary)
+        }
+        .buttonStyle(.plain)
+      }
+      .padding(16)
+
+      Divider().opacity(0.3)
+
+      // Content
+      ScrollView {
+        Text(fileViewerContent)
+          .font(.system(size: 12, design: .monospaced))
+          .foregroundColor(OmiColors.textSecondary)
+          .textSelection(.enabled)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(16)
+      }
+    }
+    .frame(width: 600, height: 500)
+    .background(OmiColors.backgroundSecondary)
+  }
+
+  private func refreshAIChatConfig() {
+    // Pull skill and CLAUDE.md data directly from ChatProvider (already discovered at startup).
+    // Fall back to reading from disk only when ChatProvider is unavailable.
+    if let provider = chatProvider {
+      aiChatClaudeMdContent = provider.claudeMdContent
+      aiChatClaudeMdPath = provider.claudeMdPath
+      aiChatDiscoveredSkills = provider.discoveredSkills
+      aiChatProjectClaudeMdContent = provider.projectClaudeMdContent
+      aiChatProjectClaudeMdPath = provider.projectClaudeMdPath
+      aiChatProjectDiscoveredSkills = provider.projectDiscoveredSkills
+      loadDisabledSkills()
+      return
     }
 
-    private func privacyBullet(_ text: String) -> some View {
-        HStack(spacing: 8) {
-            Image(systemName: "checkmark")
-                .scaledFont(size: 9, weight: .bold)
-                .foregroundColor(.green)
+    // Fallback: read from disk (used when Settings is shown before ChatProvider initializes)
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    let claudeDir = "\(home)/.claude"
 
-            Text(text)
-                .scaledFont(size: 12)
+    let mdPath = "\(claudeDir)/CLAUDE.md"
+    if FileManager.default.fileExists(atPath: mdPath),
+      let content = try? String(contentsOfFile: mdPath, encoding: .utf8)
+    {
+      aiChatClaudeMdContent = content
+      aiChatClaudeMdPath = mdPath
+    } else {
+      aiChatClaudeMdContent = nil
+      aiChatClaudeMdPath = nil
+    }
+
+    var skills: [(name: String, description: String, path: String)] = []
+    let skillsDir = "\(claudeDir)/skills"
+    if let skillDirs = try? FileManager.default.contentsOfDirectory(atPath: skillsDir) {
+      for dir in skillDirs.sorted() {
+        let skillPath = "\(skillsDir)/\(dir)/SKILL.md"
+        if FileManager.default.fileExists(atPath: skillPath),
+          let content = try? String(contentsOfFile: skillPath, encoding: .utf8)
+        {
+          let desc = ChatProvider.extractSkillDescription(from: content)
+          skills.append((name: dir, description: desc, path: skillPath))
+        }
+      }
+    }
+    aiChatDiscoveredSkills = skills
+
+    let workspace = aiChatWorkingDirectory
+    if !workspace.isEmpty, FileManager.default.fileExists(atPath: workspace) {
+      let projectMdPath = "\(workspace)/CLAUDE.md"
+      if FileManager.default.fileExists(atPath: projectMdPath),
+        let content = try? String(contentsOfFile: projectMdPath, encoding: .utf8)
+      {
+        aiChatProjectClaudeMdContent = content
+        aiChatProjectClaudeMdPath = projectMdPath
+      } else {
+        aiChatProjectClaudeMdContent = nil
+        aiChatProjectClaudeMdPath = nil
+      }
+
+      var projectSkills: [(name: String, description: String, path: String)] = []
+      let projectSkillsDir = "\(workspace)/.claude/skills"
+      if let skillDirs = try? FileManager.default.contentsOfDirectory(atPath: projectSkillsDir) {
+        for dir in skillDirs.sorted() {
+          let skillPath = "\(projectSkillsDir)/\(dir)/SKILL.md"
+          if FileManager.default.fileExists(atPath: skillPath),
+            let content = try? String(contentsOfFile: skillPath, encoding: .utf8)
+          {
+            let desc = ChatProvider.extractSkillDescription(from: content)
+            projectSkills.append((name: dir, description: desc, path: skillPath))
+          }
+        }
+      }
+      aiChatProjectDiscoveredSkills = projectSkills
+    } else {
+      aiChatProjectClaudeMdContent = nil
+      aiChatProjectClaudeMdPath = nil
+      aiChatProjectDiscoveredSkills = []
+    }
+
+    loadDisabledSkills()
+  }
+
+  private func loadDisabledSkills() {
+    let json = UserDefaults.standard.string(forKey: "disabledSkillsJSON") ?? ""
+    guard let data = json.data(using: .utf8),
+      let names = try? JSONDecoder().decode([String].self, from: data)
+    else {
+      aiChatDisabledSkills = []  // Default: nothing disabled = all enabled
+      return
+    }
+    aiChatDisabledSkills = Set(names)
+  }
+
+  private func saveDisabledSkills() {
+    if let data = try? JSONEncoder().encode(Array(aiChatDisabledSkills)),
+      let json = String(data: data, encoding: .utf8)
+    {
+      UserDefaults.standard.set(json, forKey: "disabledSkillsJSON")
+    }
+  }
+
+  // MARK: - About Section
+
+  // MARK: - Advanced Section
+
+  struct UserStats {
+    let conversations: Int
+    let appsInstalled: Int
+    let screenshotsTotal: Int
+    let focusSessions: Int
+    let tasksTodo: Int
+    let tasksDone: Int
+    let tasksDeleted: Int
+    let goalsCount: Int
+    let memoriesTotal: Int
+  }
+
+  private func advancedCategoryHeader(title: String, icon: String) -> some View {
+    HStack(spacing: 10) {
+      Image(systemName: icon)
+        .scaledFont(size: 16)
+        .foregroundColor(OmiColors.purplePrimary)
+      Text(title)
+        .scaledFont(size: 18, weight: .semibold)
+        .foregroundColor(OmiColors.textPrimary)
+      Spacer()
+    }
+    .padding(.top, 16)
+  }
+
+  private var advancedSection: some View {
+    VStack(spacing: 24) {
+      advancedCategoryHeader(title: "AI User Profile", icon: "brain")
+      aiUserProfileSubsection
+      advancedCategoryHeader(title: "Your Stats", icon: "chart.bar")
+      statsSubsection
+      advancedCategoryHeader(title: "Feature Tiers", icon: "lock.shield")
+      featureTiersSubsection
+      advancedCategoryHeader(title: "Focus Assistant", icon: "eye.fill")
+      focusAssistantSubsection
+      advancedCategoryHeader(title: "Task Assistant", icon: "checklist")
+      taskAssistantSubsection
+      advancedCategoryHeader(title: "Advice Assistant", icon: "lightbulb.fill")
+      adviceAssistantSubsection
+      advancedCategoryHeader(title: "Memory Assistant", icon: "brain.head.profile")
+      memoryAssistantSubsection
+      advancedCategoryHeader(title: "Analysis Throttle", icon: "clock.arrow.2.circlepath")
+      analysisThrottleSubsection
+      advancedCategoryHeader(title: "Goals", icon: "target")
+      goalsSubsection
+      advancedCategoryHeader(title: "Ask omi Floating Bar", icon: "sparkles")
+      askOmiFloatingBarSubsection
+      advancedCategoryHeader(title: "Preferences", icon: "slider.horizontal.3")
+      preferencesSubsection
+      advancedCategoryHeader(title: "Troubleshooting", icon: "wrench.and.screwdriver")
+      troubleshootingSubsection
+    }
+  }
+
+  // MARK: - Advanced Subsections
+
+  private var aiUserProfileSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.aiuserprofile") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack(spacing: 10) {
+            Image(systemName: "brain")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("AI User Profile")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            if isGeneratingAIProfile {
+              ProgressView()
+                .controlSize(.small)
+            } else {
+              Button(action: {
+                regenerateAIProfile()
+              }) {
+                Text(aiProfileText == nil ? "Generate Now" : "Regenerate")
+                  .scaledFont(size: 12)
+              }
+              .buttonStyle(.bordered)
+              .controlSize(.small)
+            }
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          if let text = aiProfileText {
+            if isEditingAIProfile {
+              TextEditor(text: $aiProfileEditText)
+                .scaledFont(size: 13, design: .monospaced)
                 .foregroundColor(OmiColors.textSecondary)
+                .scrollContentBackground(.hidden)
+                .frame(maxHeight: 200)
+
+              HStack {
+                Button("Cancel") {
+                  isEditingAIProfile = false
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button("Save") {
+                  if let id = aiProfileId {
+                    Task {
+                      let success = await AIUserProfileService.shared.updateProfileText(
+                        id: id, newText: aiProfileEditText
+                      )
+                      if success {
+                        aiProfileText = aiProfileEditText
+                      }
+                      isEditingAIProfile = false
+                    }
+                  }
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+
+                Spacer()
+              }
+            } else {
+              ScrollView {
+                Text(text)
+                  .scaledFont(size: 13, design: .monospaced)
+                  .foregroundColor(OmiColors.textSecondary)
+                  .textSelection(.enabled)
+                  .if_available_writingToolsNone()
+                  .frame(maxWidth: .infinity, alignment: .leading)
+              }
+              .frame(maxHeight: 200)
+
+              HStack {
+                if let date = aiProfileGeneratedAt {
+                  Text("Last updated: \(date.formatted(.relative(presentation: .named)))")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+
+                Spacer()
+
+                if aiProfileDataSourcesUsed > 0 {
+                  Text("Data sources: \(aiProfileDataSourcesUsed) items")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+
+                Button(action: {
+                  aiProfileEditText = text
+                  isEditingAIProfile = true
+                }) {
+                  Image(systemName: "pencil")
+                    .scaledFont(size: 11)
+                }
+                .buttonStyle(.borderless)
+                .help("Edit profile")
+
+                Button(action: {
+                  deleteCurrentAIProfile()
+                }) {
+                  Image(systemName: "trash")
+                    .scaledFont(size: 11)
+                    .foregroundColor(.red.opacity(0.7))
+                }
+                .buttonStyle(.borderless)
+                .help("Delete this profile")
+              }
+            }
+          } else if !isGeneratingAIProfile {
+            Text(
+              "Your AI user profile will be generated automatically on next launch, or click \"Generate Now\" to create it now."
+            )
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+          } else {
+            HStack {
+              Spacer()
+              VStack(spacing: 8) {
+                ProgressView()
+                Text("Generating profile...")
+                  .scaledFont(size: 13)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+              Spacer()
+            }
+            .padding(.vertical, 20)
+          }
         }
+      }
     }
-
-    // MARK: - Language Helpers
-
-    /// Whether the selected language supports auto-detect mode
-    private var autoDetectSupported: Bool {
-        AssistantSettings.supportsAutoDetect(transcriptionLanguage)
+    .task {
+      // Try loading immediately (covers all restarts after first generation)
+      if let profile = await AIUserProfileService.shared.getLatestProfile() {
+        aiProfileId = profile.id
+        aiProfileText = profile.profileText
+        aiProfileGeneratedAt = profile.generatedAt
+        aiProfileDataSourcesUsed = profile.dataSourcesUsed
+        return
+      }
+      // No profile yet — first-ever generation may be in progress, poll briefly
+      for _ in 0..<6 {
+        try? await Task.sleep(nanoseconds: 5_000_000_000)
+        if let profile = await AIUserProfileService.shared.getLatestProfile() {
+          aiProfileId = profile.id
+          aiProfileText = profile.profileText
+          aiProfileGeneratedAt = profile.generatedAt
+          aiProfileDataSourcesUsed = profile.dataSourcesUsed
+          return
+        }
+      }
     }
+  }
 
-    /// Subtitle text for auto-detect toggle
-    private var autoDetectSubtitle: String {
-        if autoDetectSupported {
-            return "Automatically detect spoken language"
+  private var statsSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.stats") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack(spacing: 10) {
+            Image(systemName: "chart.bar")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Your Stats")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          if let stats = advancedStats {
+            statRow(label: "Conversations", value: stats.conversations)
+            statRow(label: "Apps Installed", value: stats.appsInstalled)
+            if isLoadingChatMessages {
+              HStack {
+                Text("AI Chat Messages")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.textSecondary)
+                Spacer()
+                ProgressView()
+                  .controlSize(.mini)
+              }
+            } else if let count = chatMessageCount {
+              statRow(label: "AI Chat Messages", value: count)
+            }
+            statRow(label: "Screenshots", value: stats.screenshotsTotal)
+            statRow(label: "Focus Sessions", value: stats.focusSessions)
+            statRow(label: "Tasks (To Do)", value: stats.tasksTodo)
+            statRow(label: "Tasks (Done)", value: stats.tasksDone)
+            statRow(label: "Tasks (Removed)", value: stats.tasksDeleted)
+            statRow(label: "Goals", value: stats.goalsCount)
+            statRow(label: "Memories", value: stats.memoriesTotal)
+          } else if isLoadingStats {
+            statRowLoading(label: "Conversations")
+            statRowLoading(label: "Apps Installed")
+            statRowLoading(label: "AI Chat Messages")
+            statRowLoading(label: "Screenshots")
+            statRowLoading(label: "Focus Sessions")
+            statRowLoading(label: "Tasks (To Do)")
+            statRowLoading(label: "Tasks (Done)")
+            statRowLoading(label: "Tasks (Removed)")
+            statRowLoading(label: "Goals")
+            statRowLoading(label: "Memories")
+          } else {
+            Text("Unable to load stats")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+        }
+      }
+    }
+    .task {
+      await loadAdvancedStats()
+    }
+    .task {
+      await loadChatMessageCount()
+    }
+  }
+
+  private var featureTiersSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.featuretiers") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack(spacing: 10) {
+            Image(systemName: "lock.shield")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Feature Tiers")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          // Tier picker — radio-style selector
+          VStack(alignment: .leading, spacing: 6) {
+            tierPickerRow(tier: 0, label: "Show All Features", subtitle: "Unlock everything")
+            tierPickerRow(tier: 1, label: "Tier 1", subtitle: "Conversations + Rewind")
+            tierPickerRow(tier: 2, label: "Tier 2", subtitle: "+ Memories (100 memories)")
+            tierPickerRow(tier: 3, label: "Tier 3", subtitle: "+ Tasks (100 tasks)")
+            tierPickerRow(tier: 4, label: "Tier 4", subtitle: "+ AI Chat (100 conversations)")
+            tierPickerRow(
+              tier: 5, label: "Tier 5", subtitle: "+ Dashboard (200 convos + 2K screenshots)")
+            tierPickerRow(tier: 6, label: "Tier 6", subtitle: "+ Apps (300 conversations)")
+          }
+
+          if currentTierLevel > 0 {
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            Text("Progress")
+              .scaledFont(size: 13, weight: .semibold)
+              .foregroundColor(OmiColors.textSecondary)
+
+            // Tier 1 — always unlocked
+            tierFeatureRow(
+              tier: 1, name: "Conversations + Rewind",
+              requirement: "Always unlocked",
+              progress: nil, unlocked: true
+            )
+
+            // Tier 2 — 100 memories
+            tierFeatureRow(
+              tier: 2, name: "Memories",
+              requirement: "100 memories",
+              progress: advancedStats.map { "\($0.memoriesTotal) / 100" },
+              unlocked: currentTierLevel >= 2
+            )
+
+            // Tier 3 — 100 tasks
+            tierFeatureRow(
+              tier: 3, name: "Tasks",
+              requirement: "100 tasks (todo + done)",
+              progress: advancedStats.map { "\($0.tasksTodo + $0.tasksDone) / 100" },
+              unlocked: currentTierLevel >= 3
+            )
+
+            // Tier 4 — 100 conversations
+            tierFeatureRow(
+              tier: 4, name: "AI Chat",
+              requirement: "100 conversations",
+              progress: advancedStats.map { "\($0.conversations) / 100" },
+              unlocked: currentTierLevel >= 4
+            )
+
+            // Tier 5 — 200 conversations + 2,000 screenshots
+            tierFeatureRow(
+              tier: 5, name: "Dashboard",
+              requirement: "200 conversations + 2K screenshots",
+              progress: advancedStats.map {
+                "\($0.conversations) / 200 convos, \($0.screenshotsTotal) / 2,000 screenshots"
+              },
+              unlocked: currentTierLevel >= 5
+            )
+
+            // Tier 6 — 300 conversations
+            tierFeatureRow(
+              tier: 6, name: "Apps",
+              requirement: "300 conversations",
+              progress: advancedStats.map { "\($0.conversations) / 300" },
+              unlocked: currentTierLevel >= 6
+            )
+          }
+        }
+      }
+    }
+  }
+
+  private var focusAssistantSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.focusassistant") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "eye.fill")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Focus Assistant")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $focusEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .onChange(of: focusEnabled) { _, newValue in
+                FocusAssistantSettings.shared.isEnabled = newValue
+                SettingsSyncManager.shared.pushPartialUpdate(
+                  AssistantSettingsResponse(focus: FocusSettingsResponse(enabled: newValue)))
+              }
+          }
+
+          Text("Detect distractions and help you stay focused")
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+
+          if focusEnabled {
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            settingRow(
+              title: "Visual Glow Effect", subtitle: "Show colored border when focus changes",
+              settingId: "advanced.focusassistant.glow"
+            ) {
+              Toggle("", isOn: $glowOverlayEnabled)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .disabled(isPreviewRunning)
+                .onChange(of: glowOverlayEnabled) { _, newValue in
+                  AssistantSettings.shared.glowOverlayEnabled = newValue
+                  SettingsSyncManager.shared.pushPartialUpdate(
+                    AssistantSettingsResponse(
+                      shared: SharedAssistantSettingsResponse(glowOverlayEnabled: newValue)))
+                  if newValue {
+                    startGlowPreview()
+                  }
+                }
+            }
+
+            settingRow(
+              title: "Focus Cooldown", subtitle: "Minimum time between distraction alerts",
+              settingId: "advanced.focusassistant.cooldown"
+            ) {
+              Picker("", selection: $cooldownInterval) {
+                ForEach(cooldownOptions, id: \.self) { minutes in
+                  Text(formatMinutes(minutes)).tag(minutes)
+                }
+              }
+              .pickerStyle(.menu)
+              .frame(width: 120)
+              .onChange(of: cooldownInterval) { _, newValue in
+                FocusAssistantSettings.shared.cooldownInterval = newValue
+                SettingsSyncManager.shared.pushPartialUpdate(
+                  AssistantSettingsResponse(
+                    focus: FocusSettingsResponse(cooldownInterval: newValue)))
+              }
+            }
+
+            settingRow(
+              title: "Focus Analysis Prompt",
+              subtitle: "Customize AI instructions for focus analysis",
+              settingId: "advanced.focusassistant.prompt"
+            ) {
+              HStack(spacing: 8) {
+                Button(action: {
+                  FocusTestRunnerWindow.show()
+                }) {
+                  HStack(spacing: 4) {
+                    Image(systemName: "play.circle")
+                      .scaledFont(size: 11)
+                    Text("Test Run")
+                      .scaledFont(size: 12)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(action: {
+                  PromptEditorWindow.show()
+                }) {
+                  HStack(spacing: 4) {
+                    Text("Edit")
+                      .scaledFont(size: 12)
+                    Image(systemName: "arrow.up.right.square")
+                      .scaledFont(size: 11)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+              }
+            }
+
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Excluded Apps for Focus Analysis
+            VStack(alignment: .leading, spacing: 12) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Excluded Apps")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.textSecondary)
+                Text("Focus coaching won't trigger for these apps")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+
+              // Built-in system exclusions (non-removable)
+              DisclosureGroup {
+                LazyVStack(spacing: 4) {
+                  ForEach(Array(TaskAssistantSettings.builtInExcludedApps).sorted(), id: \.self) {
+                    appName in
+                    HStack(spacing: 12) {
+                      AppIconView(appName: appName, size: 20)
+
+                      Text(appName)
+                        .scaledFont(size: 13)
+                        .foregroundColor(OmiColors.textTertiary)
+
+                      Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 4)
+                  }
+                }
+              } label: {
+                Text(
+                  "System apps always excluded (\(TaskAssistantSettings.builtInExcludedApps.count))"
+                )
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+              }
+              .tint(OmiColors.textTertiary)
+
+              if !focusExcludedApps.isEmpty {
+                LazyVStack(spacing: 8) {
+                  ForEach(Array(focusExcludedApps).sorted(), id: \.self) { appName in
+                    ExcludedAppRow(
+                      appName: appName,
+                      onRemove: {
+                        FocusAssistantSettings.shared.includeApp(appName)
+                        focusExcludedApps = FocusAssistantSettings.shared.excludedApps
+                      }
+                    )
+                  }
+                }
+              }
+
+              AddExcludedAppView(
+                onAdd: { appName in
+                  FocusAssistantSettings.shared.excludeApp(appName)
+                  focusExcludedApps = FocusAssistantSettings.shared.excludedApps
+                },
+                excludedApps: focusExcludedApps
+              )
+            }
+          }  // end if focusEnabled
+        }
+      }
+    }
+  }
+
+  private var taskAssistantSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.taskassistant") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "checklist")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Task Assistant")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $taskEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .onChange(of: taskEnabled) { _, newValue in
+                TaskAssistantSettings.shared.isEnabled = newValue
+                SettingsSyncManager.shared.pushPartialUpdate(
+                  AssistantSettingsResponse(task: TaskSettingsResponse(enabled: newValue)))
+              }
+          }
+
+          Text("Extract tasks and action items from your screen")
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+
+          if taskEnabled {
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Task Agent (chat / investigate) toggle
+            HStack {
+              VStack(alignment: .leading, spacing: 2) {
+                Text("Task Agent")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.textSecondary)
+                Text("Investigate button and sidebar chat for tasks")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+
+              Spacer()
+
+              Toggle("", isOn: $taskChatAgentEnabled)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .onChange(of: taskChatAgentEnabled) { _, newValue in
+                  TaskAgentSettings.shared.isChatEnabled = newValue
+                }
+            }
+
+            // Working Directory (shared by chat agent and terminal agent)
+            HStack(spacing: 8) {
+              VStack(alignment: .leading, spacing: 2) {
+                Text("Working Directory")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.textSecondary)
+                Text(
+                  taskAgentWorkingDirectory.isEmpty
+                    ? "Not set — chat agent defaults to ~" : taskAgentWorkingDirectory
+                )
+                .scaledFont(size: 11)
+                .foregroundColor(OmiColors.textTertiary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+              }
+
+              Spacer()
+
+              Button("Browse...") {
+                let panel = NSOpenPanel()
+                panel.canChooseFiles = false
+                panel.canChooseDirectories = true
+                panel.allowsMultipleSelection = false
+                panel.canCreateDirectories = true
+                if !taskAgentWorkingDirectory.isEmpty {
+                  panel.directoryURL = URL(fileURLWithPath: taskAgentWorkingDirectory)
+                }
+                if panel.runModal() == .OK, let url = panel.url {
+                  taskAgentWorkingDirectory = url.path
+                  TaskAgentSettings.shared.workingDirectory = url.path
+                }
+              }
+              .scaledFont(size: 13)
+
+              if !taskAgentWorkingDirectory.isEmpty {
+                Button("Clear") {
+                  taskAgentWorkingDirectory = ""
+                  TaskAgentSettings.shared.workingDirectory = ""
+                }
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textTertiary)
+              }
+            }
+
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Extraction Interval Slider
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                  Text("Extraction Interval")
+                    .scaledFont(size: 14)
+                    .foregroundColor(OmiColors.textSecondary)
+                  Text("How often to scan for new tasks")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+
+                Spacer()
+
+                Text(formatExtractionInterval(taskExtractionInterval))
+                  .scaledFont(size: 13, weight: .medium)
+                  .foregroundColor(OmiColors.textSecondary)
+                  .frame(width: 80, alignment: .trailing)
+              }
+
+              Slider(
+                value: Binding(
+                  get: { Double(taskIntervalSliderIndex) },
+                  set: { taskExtractionInterval = extractionIntervalOptions[Int($0)] }
+                ), in: 0...Double(extractionIntervalOptions.count - 1), step: 1
+              )
+              .tint(OmiColors.purplePrimary)
+              .onChange(of: taskExtractionInterval) { _, newValue in
+                TaskAssistantSettings.shared.extractionInterval = newValue
+                SettingsSyncManager.shared.pushPartialUpdate(
+                  AssistantSettingsResponse(
+                    task: TaskSettingsResponse(extractionInterval: newValue)))
+              }
+            }
+
+            // Minimum Confidence Slider
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                  Text("Minimum Confidence")
+                    .scaledFont(size: 14)
+                    .foregroundColor(OmiColors.textSecondary)
+                  Text("Only show tasks above this confidence level")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+
+                Spacer()
+
+                Text("\(Int(taskMinConfidence * 100))%")
+                  .scaledFont(size: 13, weight: .medium)
+                  .foregroundColor(OmiColors.textSecondary)
+                  .frame(width: 40, alignment: .trailing)
+              }
+
+              Slider(value: $taskMinConfidence, in: 0.3...0.9, step: 0.1)
+                .tint(OmiColors.purplePrimary)
+                .onChange(of: taskMinConfidence) { _, newValue in
+                  TaskAssistantSettings.shared.minConfidence = newValue
+                  SettingsSyncManager.shared.pushPartialUpdate(
+                    AssistantSettingsResponse(task: TaskSettingsResponse(minConfidence: newValue)))
+                }
+            }
+
+            settingRow(
+              title: "Task Extraction Prompt",
+              subtitle: "Customize AI instructions for task extraction",
+              settingId: "advanced.taskassistant.prompt"
+            ) {
+              HStack(spacing: 8) {
+                Button(action: {
+                  TaskTestRunnerWindow.show()
+                }) {
+                  HStack(spacing: 4) {
+                    Image(systemName: "play.circle")
+                      .scaledFont(size: 11)
+                    Text("Test Run")
+                      .scaledFont(size: 12)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(action: {
+                  TaskPromptEditorWindow.show()
+                }) {
+                  HStack(spacing: 4) {
+                    Text("Edit")
+                      .scaledFont(size: 12)
+                    Image(systemName: "arrow.up.right.square")
+                      .scaledFont(size: 11)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+              }
+            }
+
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Allowed Apps for Task Extraction (Whitelist)
+            VStack(alignment: .leading, spacing: 12) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Allowed Apps")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.textSecondary)
+                Text(
+                  "Tasks will only be extracted from these apps. Browsers are also filtered by keywords below."
+                )
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+              }
+
+              // Editable list of all allowed apps
+              LazyVStack(spacing: 4) {
+                ForEach(Array(taskAllowedApps).sorted(), id: \.self) { appName in
+                  HStack(spacing: 12) {
+                    AppIconView(appName: appName, size: 20)
+
+                    Text(appName)
+                      .scaledFont(size: 13)
+                      .foregroundColor(OmiColors.textPrimary)
+
+                    if TaskAssistantSettings.isBrowser(appName) {
+                      Text("browser")
+                        .scaledFont(size: 10)
+                        .foregroundColor(OmiColors.purplePrimary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(OmiColors.purplePrimary.opacity(0.15))
+                        .cornerRadius(4)
+                    }
+
+                    Spacer()
+
+                    Button {
+                      TaskAssistantSettings.shared.disallowApp(appName)
+                      taskAllowedApps = TaskAssistantSettings.shared.allowedApps
+                    } label: {
+                      Image(systemName: "xmark.circle.fill")
+                        .scaledFont(size: 14)
+                        .foregroundColor(OmiColors.textTertiary)
+                    }
+                    .buttonStyle(.plain)
+                  }
+                  .padding(.horizontal, 12)
+                  .padding(.vertical, 4)
+                }
+              }
+
+              AddAllowedAppView(
+                onAdd: { appName in
+                  TaskAssistantSettings.shared.allowApp(appName)
+                  taskAllowedApps = TaskAssistantSettings.shared.allowedApps
+                },
+                allowedApps: taskAllowedApps
+              )
+            }
+
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Browser Window Keywords
+            VStack(alignment: .leading, spacing: 12) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Browser Window Keywords")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.textSecondary)
+                Text(
+                  "For browser apps, only analyze windows whose title contains one of these keywords."
+                )
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+              }
+
+              // Keyword chips (filterable, deletable)
+              BrowserKeywordListView(
+                keywords: $taskBrowserKeywords,
+                onAdd: { keyword in
+                  TaskAssistantSettings.shared.addBrowserKeyword(keyword)
+                  taskBrowserKeywords = TaskAssistantSettings.shared.browserKeywords
+                },
+                onRemove: { keyword in
+                  TaskAssistantSettings.shared.removeBrowserKeyword(keyword)
+                  taskBrowserKeywords = TaskAssistantSettings.shared.browserKeywords
+                }
+              )
+            }
+
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Task Prioritization Re-score
+            settingRow(
+              title: "Task Prioritization",
+              subtitle: "Re-score all tasks by relevance to your profile and goals",
+              settingId: "advanced.taskassistant.prioritization"
+            ) {
+              if isRescoringTasks {
+                ProgressView()
+                  .controlSize(.small)
+              } else {
+                Button(action: {
+                  isRescoringTasks = true
+                  Task {
+                    await TaskPrioritizationService.shared.forceFullRescore()
+                    await MainActor.run { isRescoringTasks = false }
+                  }
+                }) {
+                  HStack(spacing: 4) {
+                    Image(systemName: "arrow.trianglehead.counterclockwise")
+                      .scaledFont(size: 11)
+                    Text("Re-score")
+                      .scaledFont(size: 12)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+              }
+            }
+          }  // end if taskEnabled
+        }
+      }
+
+      // Task Agent Settings (merged into Task Assistant subsection)
+      settingsCard(settingId: "advanced.taskassistant.agent") {
+        TaskAgentSettingsView()
+      }
+    }
+  }
+
+  private var adviceAssistantSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.adviceassistant") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "lightbulb.fill")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Advice Assistant")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $adviceEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .onChange(of: adviceEnabled) { _, newValue in
+                AdviceAssistantSettings.shared.isEnabled = newValue
+                SettingsSyncManager.shared.pushPartialUpdate(
+                  AssistantSettingsResponse(advice: AdviceSettingsResponse(enabled: newValue)))
+              }
+          }
+
+          Text("Get proactive tips and suggestions")
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+
+          if adviceEnabled {
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Frequency Slider
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                  Text("Frequency")
+                    .scaledFont(size: 14)
+                    .foregroundColor(OmiColors.textSecondary)
+                  Text("How often to check for advice opportunities")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+
+                Spacer()
+
+                Text(formatExtractionInterval(adviceExtractionInterval))
+                  .scaledFont(size: 13, weight: .medium)
+                  .foregroundColor(OmiColors.textSecondary)
+                  .frame(width: 80, alignment: .trailing)
+              }
+
+              Slider(
+                value: Binding(
+                  get: { Double(adviceIntervalSliderIndex) },
+                  set: { adviceExtractionInterval = extractionIntervalOptions[Int($0)] }
+                ), in: 0...Double(extractionIntervalOptions.count - 1), step: 1
+              )
+              .tint(OmiColors.purplePrimary)
+              .onChange(of: adviceExtractionInterval) { _, newValue in
+                AdviceAssistantSettings.shared.extractionInterval = newValue
+                SettingsSyncManager.shared.pushPartialUpdate(
+                  AssistantSettingsResponse(
+                    advice: AdviceSettingsResponse(extractionInterval: newValue)))
+              }
+            }
+
+            // Minimum Confidence Slider
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                  Text("Minimum Confidence")
+                    .scaledFont(size: 14)
+                    .foregroundColor(OmiColors.textSecondary)
+                  Text("Only show advice above this confidence level")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+
+                Spacer()
+
+                Text("\(Int(adviceMinConfidence * 100))%")
+                  .scaledFont(size: 13, weight: .medium)
+                  .foregroundColor(OmiColors.textSecondary)
+                  .frame(width: 40, alignment: .trailing)
+              }
+
+              Slider(value: $adviceMinConfidence, in: 0.5...0.95, step: 0.05)
+                .tint(OmiColors.purplePrimary)
+                .onChange(of: adviceMinConfidence) { _, newValue in
+                  AdviceAssistantSettings.shared.minConfidence = newValue
+                  SettingsSyncManager.shared.pushPartialUpdate(
+                    AssistantSettingsResponse(
+                      advice: AdviceSettingsResponse(minConfidence: newValue)))
+                }
+            }
+
+            settingRow(
+              title: "Advice Prompt", subtitle: "Customize AI instructions for advice",
+              settingId: "advanced.adviceassistant.prompt"
+            ) {
+              HStack(spacing: 8) {
+                Button(action: {
+                  AdviceTestRunnerWindow.show()
+                }) {
+                  HStack(spacing: 4) {
+                    Image(systemName: "play.circle")
+                      .scaledFont(size: 11)
+                    Text("Test Run")
+                      .scaledFont(size: 12)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(action: {
+                  AdvicePromptEditorWindow.show()
+                }) {
+                  HStack(spacing: 4) {
+                    Text("Edit")
+                      .scaledFont(size: 12)
+                    Image(systemName: "arrow.up.right.square")
+                      .scaledFont(size: 11)
+                  }
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+              }
+            }
+
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Excluded Apps for Advice
+            VStack(alignment: .leading, spacing: 12) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Excluded Apps")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.textSecondary)
+                Text("Advice won't be generated from these apps")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+
+              // Built-in system exclusions (non-removable, shared with Task Extractor)
+              DisclosureGroup {
+                LazyVStack(spacing: 4) {
+                  ForEach(Array(TaskAssistantSettings.builtInExcludedApps).sorted(), id: \.self) {
+                    appName in
+                    HStack(spacing: 12) {
+                      AppIconView(appName: appName, size: 20)
+
+                      Text(appName)
+                        .scaledFont(size: 13)
+                        .foregroundColor(OmiColors.textTertiary)
+
+                      Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 4)
+                  }
+                }
+              } label: {
+                Text(
+                  "System apps always excluded (\(TaskAssistantSettings.builtInExcludedApps.count))"
+                )
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+              }
+              .tint(OmiColors.textTertiary)
+
+              if !adviceExcludedApps.isEmpty {
+                LazyVStack(spacing: 8) {
+                  ForEach(Array(adviceExcludedApps).sorted(), id: \.self) { appName in
+                    ExcludedAppRow(
+                      appName: appName,
+                      onRemove: {
+                        AdviceAssistantSettings.shared.includeApp(appName)
+                        adviceExcludedApps = AdviceAssistantSettings.shared.excludedApps
+                      }
+                    )
+                  }
+                }
+              }
+
+              AddExcludedAppView(
+                onAdd: { appName in
+                  AdviceAssistantSettings.shared.excludeApp(appName)
+                  adviceExcludedApps = AdviceAssistantSettings.shared.excludedApps
+                },
+                excludedApps: adviceExcludedApps
+              )
+            }
+          }  // end if adviceEnabled
+        }
+      }
+    }
+  }
+
+  private var memoryAssistantSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.memoryassistant") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "brain.head.profile")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Memory Assistant")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $memoryEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .onChange(of: memoryEnabled) { _, newValue in
+                MemoryAssistantSettings.shared.isEnabled = newValue
+                SettingsSyncManager.shared.pushPartialUpdate(
+                  AssistantSettingsResponse(memory: MemorySettingsResponse(enabled: newValue)))
+              }
+          }
+
+          Text("Extract facts and wisdom from your screen")
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+
+          if memoryEnabled {
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Extraction Interval Slider
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                  Text("Extraction Interval")
+                    .scaledFont(size: 14)
+                    .foregroundColor(OmiColors.textSecondary)
+                  Text("How often to scan for new memories")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+
+                Spacer()
+
+                Text(formatExtractionInterval(memoryExtractionInterval))
+                  .scaledFont(size: 13, weight: .medium)
+                  .foregroundColor(OmiColors.textSecondary)
+                  .frame(width: 80, alignment: .trailing)
+              }
+
+              Slider(
+                value: Binding(
+                  get: { Double(memoryIntervalSliderIndex) },
+                  set: { memoryExtractionInterval = extractionIntervalOptions[Int($0)] }
+                ), in: 0...Double(extractionIntervalOptions.count - 1), step: 1
+              )
+              .tint(OmiColors.purplePrimary)
+              .onChange(of: memoryExtractionInterval) { _, newValue in
+                MemoryAssistantSettings.shared.extractionInterval = newValue
+                SettingsSyncManager.shared.pushPartialUpdate(
+                  AssistantSettingsResponse(
+                    memory: MemorySettingsResponse(extractionInterval: newValue)))
+              }
+            }
+
+            // Minimum Confidence Slider
+            VStack(alignment: .leading, spacing: 8) {
+              HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                  Text("Minimum Confidence")
+                    .scaledFont(size: 14)
+                    .foregroundColor(OmiColors.textSecondary)
+                  Text("Only save memories above this confidence level")
+                    .scaledFont(size: 12)
+                    .foregroundColor(OmiColors.textTertiary)
+                }
+
+                Spacer()
+
+                Text("\(Int(memoryMinConfidence * 100))%")
+                  .scaledFont(size: 13, weight: .medium)
+                  .foregroundColor(OmiColors.textSecondary)
+                  .frame(width: 40, alignment: .trailing)
+              }
+
+              Slider(value: $memoryMinConfidence, in: 0.5...0.95, step: 0.05)
+                .tint(OmiColors.purplePrimary)
+                .onChange(of: memoryMinConfidence) { _, newValue in
+                  MemoryAssistantSettings.shared.minConfidence = newValue
+                  SettingsSyncManager.shared.pushPartialUpdate(
+                    AssistantSettingsResponse(
+                      memory: MemorySettingsResponse(minConfidence: newValue)))
+                }
+            }
+
+            settingRow(
+              title: "Memory Extraction Prompt",
+              subtitle: "Customize AI instructions for memory extraction",
+              settingId: "advanced.memoryassistant.prompt"
+            ) {
+              Button(action: {
+                MemoryPromptEditorWindow.show()
+              }) {
+                HStack(spacing: 4) {
+                  Text("Edit")
+                    .scaledFont(size: 12)
+                  Image(systemName: "arrow.up.right.square")
+                    .scaledFont(size: 11)
+                }
+              }
+              .buttonStyle(.bordered)
+              .controlSize(.small)
+            }
+
+            Divider()
+              .background(OmiColors.backgroundQuaternary)
+
+            // Excluded Apps for Memory Extraction
+            VStack(alignment: .leading, spacing: 12) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Excluded Apps")
+                  .scaledFont(size: 14)
+                  .foregroundColor(OmiColors.textSecondary)
+                Text("Memories won't be extracted from these apps")
+                  .scaledFont(size: 12)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+
+              // Built-in system exclusions (non-removable, shared across assistants)
+              DisclosureGroup {
+                LazyVStack(spacing: 4) {
+                  ForEach(Array(TaskAssistantSettings.builtInExcludedApps).sorted(), id: \.self) {
+                    appName in
+                    HStack(spacing: 12) {
+                      AppIconView(appName: appName, size: 20)
+
+                      Text(appName)
+                        .scaledFont(size: 13)
+                        .foregroundColor(OmiColors.textTertiary)
+
+                      Spacer()
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 4)
+                  }
+                }
+              } label: {
+                Text(
+                  "System apps always excluded (\(TaskAssistantSettings.builtInExcludedApps.count))"
+                )
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+              }
+              .tint(OmiColors.textTertiary)
+
+              if !memoryExcludedApps.isEmpty {
+                LazyVStack(spacing: 8) {
+                  ForEach(Array(memoryExcludedApps).sorted(), id: \.self) { appName in
+                    ExcludedAppRow(
+                      appName: appName,
+                      onRemove: {
+                        MemoryAssistantSettings.shared.includeApp(appName)
+                        memoryExcludedApps = MemoryAssistantSettings.shared.excludedApps
+                      }
+                    )
+                  }
+                }
+              }
+
+              AddExcludedAppView(
+                onAdd: { appName in
+                  MemoryAssistantSettings.shared.excludeApp(appName)
+                  memoryExcludedApps = MemoryAssistantSettings.shared.excludedApps
+                },
+                excludedApps: memoryExcludedApps
+              )
+            }
+          }  // end if memoryEnabled
+        }
+      }
+    }
+  }
+
+  private var analysisThrottleSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.analysisthrottle") {
+        VStack(alignment: .leading, spacing: 8) {
+          HStack {
+            VStack(alignment: .leading, spacing: 2) {
+              Text("Analysis Throttle")
+                .scaledFont(size: 14)
+                .foregroundColor(OmiColors.textSecondary)
+              Text("Wait before analyzing after switching apps")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+
+            Spacer()
+
+            Text(formatAnalysisDelay(analysisDelay))
+              .scaledFont(size: 13, weight: .medium)
+              .foregroundColor(OmiColors.textSecondary)
+              .frame(width: 80, alignment: .trailing)
+          }
+
+          Slider(
+            value: Binding(
+              get: { Double(analysisDelaySliderIndex) },
+              set: { analysisDelay = analysisDelayOptions[Int($0)] }
+            ), in: 0...Double(analysisDelayOptions.count - 1), step: 1
+          )
+          .tint(OmiColors.purplePrimary)
+          .onChange(of: analysisDelay) { _, newValue in
+            AssistantSettings.shared.analysisDelay = newValue
+            SettingsSyncManager.shared.pushPartialUpdate(
+              AssistantSettingsResponse(
+                shared: SharedAssistantSettingsResponse(analysisDelay: newValue)))
+          }
+        }
+      }
+    }
+  }
+
+  private var goalsSubsection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "advanced.goals") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "target")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Goals")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+          }
+
+          Text("Track personal goals with AI-powered progress detection from your conversations")
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          settingRow(
+            title: "Auto-Generate Goals",
+            subtitle: "Automatically suggest new goals daily based on your conversations and tasks",
+            settingId: "advanced.goals.autogenerate"
+          ) {
+            Toggle("", isOn: $goalsAutoGenerateEnabled)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .onChange(of: goalsAutoGenerateEnabled) { _, newValue in
+                GoalGenerationService.shared.isAutoGenerationEnabled = newValue
+              }
+          }
+        }
+      }
+    }
+  }
+
+  private var askOmiFloatingBarSubsection: some View {
+    VStack(spacing: 20) {
+      ShortcutsSettingsSection(highlightedSettingId: $highlightedSettingId)
+    }
+  }
+
+  private var preferencesSubsection: some View {
+    VStack(spacing: 20) {
+      // Multiple Chat Sessions toggle
+      settingsCard(settingId: "advanced.preferences.multichat") {
+        HStack(spacing: 16) {
+          Image(systemName: "bubble.left.and.bubble.right")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Multiple Chat Sessions")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text(
+              multiChatEnabled
+                ? "Create separate chat threads"
+                : "Single chat synced with mobile app"
+            )
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          Toggle("", isOn: $multiChatEnabled)
+            .toggleStyle(.switch)
+            .labelsHidden()
+        }
+      }
+
+      // Conversation View toggle
+      settingsCard(settingId: "advanced.preferences.compact") {
+        HStack(spacing: 16) {
+          Image(systemName: conversationsCompactView ? "list.bullet" : "list.bullet.rectangle")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Compact Conversations")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text(
+              conversationsCompactView
+                ? "Showing compact conversation list"
+                : "Showing expanded conversation list"
+            )
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          Toggle("", isOn: $conversationsCompactView)
+            .toggleStyle(.switch)
+            .labelsHidden()
+        }
+      }
+
+      // Launch at Login toggle
+      settingsCard(settingId: "advanced.preferences.launchatlogin") {
+        HStack(spacing: 16) {
+          Image(systemName: "power")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Launch at Login")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text(launchAtLoginManager.statusDescription)
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          Toggle(
+            "",
+            isOn: Binding(
+              get: { launchAtLoginManager.isEnabled },
+              set: { newValue in
+                if launchAtLoginManager.setEnabled(newValue) {
+                  AnalyticsManager.shared.launchAtLoginChanged(enabled: newValue, source: "user")
+                }
+              }
+            )
+          )
+          .toggleStyle(.switch)
+          .labelsHidden()
+        }
+      }
+    }
+  }
+
+  private var troubleshootingSubsection: some View {
+    VStack(spacing: 20) {
+      // Report Issue
+      settingsCard(settingId: "advanced.troubleshooting.reportissue") {
+        HStack(spacing: 16) {
+          Image(systemName: "exclamationmark.bubble")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Report Issue")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text("Send app logs and report a problem")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          Button(action: {
+            FeedbackWindow.show(userEmail: AuthState.shared.userEmail)
+          }) {
+            Text("Report")
+              .scaledFont(size: 13, weight: .medium)
+              .foregroundColor(.white)
+              .padding(.horizontal, 14)
+              .padding(.vertical, 6)
+              .background(
+                RoundedRectangle(cornerRadius: 6)
+                  .fill(OmiColors.purplePrimary)
+              )
+          }
+          .buttonStyle(.plain)
+        }
+      }
+
+      // Rescan Files
+      settingsCard(settingId: "advanced.troubleshooting.rescanfiles") {
+        HStack(spacing: 16) {
+          Image(systemName: "folder.badge.gearshape")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Rescan Files")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text("Re-index your files and update your AI profile")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          Button(action: { showRescanFilesAlert = true }) {
+            Text("Rescan")
+              .scaledFont(size: 13, weight: .medium)
+              .foregroundColor(.white)
+              .padding(.horizontal, 14)
+              .padding(.vertical, 6)
+              .background(
+                RoundedRectangle(cornerRadius: 6)
+                  .fill(OmiColors.purplePrimary)
+              )
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .alert("Rescan Files?", isPresented: $showRescanFilesAlert) {
+        Button("Cancel", role: .cancel) {}
+        Button("Rescan") {
+          NotificationCenter.default.post(name: .triggerFileIndexing, object: nil)
+        }
+      } message: {
+        Text(
+          "This will re-scan your files and update your AI profile with the latest information about your projects and interests."
+        )
+      }
+
+      // Reset Onboarding
+      settingsCard(settingId: "advanced.troubleshooting.resetonboarding") {
+        HStack(spacing: 16) {
+          Image(systemName: "arrow.counterclockwise")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 24, height: 24)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Reset Onboarding")
+              .scaledFont(size: 16, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text("Restart setup wizard for this app build only")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          Button(action: { showResetOnboardingAlert = true }) {
+            Text("Reset")
+              .scaledFont(size: 13, weight: .medium)
+              .foregroundColor(.black)
+              .padding(.horizontal, 14)
+              .padding(.vertical, 6)
+              .background(
+                RoundedRectangle(cornerRadius: 6)
+                  .fill(.white)
+              )
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .alert("Reset Onboarding?", isPresented: $showResetOnboardingAlert) {
+        Button("Cancel", role: .cancel) {}
+        Button("Reset & Restart", role: .destructive) {
+          appState.resetOnboardingAndRestart()
+        }
+      } message: {
+        Text(
+          "This will reset onboarding for this app build only, clear onboarding chat history, and restart the app without affecting the other installed build."
+        )
+      }
+    }
+  }
+
+  private func tierPickerRow(tier: Int, label: String, subtitle: String) -> some View {
+    let isSelected = currentTierLevel == tier
+    return Button(action: {
+      TierManager.shared.userDidSetTier(tier)
+    }) {
+      HStack(spacing: 10) {
+        Image(systemName: isSelected ? "largecircle.fill.circle" : "circle")
+          .scaledFont(size: 16)
+          .foregroundColor(isSelected ? OmiColors.purplePrimary : OmiColors.textTertiary)
+
+        VStack(alignment: .leading, spacing: 1) {
+          Text(label)
+            .scaledFont(size: 14, weight: isSelected ? .medium : .regular)
+            .foregroundColor(isSelected ? OmiColors.textPrimary : OmiColors.textSecondary)
+
+          Text(subtitle)
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+        }
+
+        Spacer()
+      }
+      .padding(.vertical, 6)
+      .padding(.horizontal, 8)
+      .background(
+        RoundedRectangle(cornerRadius: 8)
+          .fill(isSelected ? OmiColors.purplePrimary.opacity(0.1) : Color.clear)
+      )
+    }
+    .buttonStyle(.plain)
+  }
+
+  private func tierFeatureRow(
+    tier: Int, name: String, requirement: String, progress: String?, unlocked: Bool
+  ) -> some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack {
+        Text("Tier \(tier)")
+          .scaledFont(size: 11, weight: .semibold)
+          .foregroundColor(unlocked ? OmiColors.purplePrimary : OmiColors.textTertiary)
+          .padding(.horizontal, 6)
+          .padding(.vertical, 2)
+          .background(
+            RoundedRectangle(cornerRadius: 4)
+              .fill(unlocked ? OmiColors.purplePrimary.opacity(0.15) : OmiColors.backgroundTertiary)
+          )
+
+        Text(name)
+          .scaledFont(size: 14, weight: .medium)
+          .foregroundColor(unlocked ? OmiColors.textPrimary : OmiColors.textTertiary)
+
+        Spacer()
+
+        if unlocked {
+          Image(systemName: "checkmark.circle.fill")
+            .scaledFont(size: 14)
+            .foregroundColor(.green)
         } else {
-            return "Not available for \(languageName(for: transcriptionLanguage))"
+          Image(systemName: "lock.fill")
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
         }
+      }
+
+      HStack(spacing: 8) {
+        Text(requirement)
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+
+        if let progress = progress, !unlocked {
+          Text("(\(progress))")
+            .scaledMonospacedDigitFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary.opacity(0.7))
+        }
+      }
+    }
+    .padding(.vertical, 4)
+  }
+
+  private func statRow(label: String, value: Int) -> some View {
+    HStack {
+      Text(label)
+        .scaledFont(size: 14)
+        .foregroundColor(OmiColors.textSecondary)
+
+      Spacer()
+
+      Text(formatNumber(value))
+        .scaledMonospacedDigitFont(size: 14, weight: .medium)
+        .foregroundColor(OmiColors.textPrimary)
+    }
+  }
+
+  private func statRowLoading(label: String) -> some View {
+    HStack {
+      Text(label)
+        .scaledFont(size: 14)
+        .foregroundColor(OmiColors.textSecondary)
+
+      Spacer()
+
+      ProgressView()
+        .controlSize(.mini)
+    }
+  }
+
+  private func formatNumber(_ n: Int) -> String {
+    let formatter = NumberFormatter()
+    formatter.numberStyle = .decimal
+    return formatter.string(from: NSNumber(value: n)) ?? "\(n)"
+  }
+
+  private func loadAdvancedStats() async {
+    isLoadingStats = true
+    defer { isLoadingStats = false }
+
+    do {
+      async let conversationsCount = APIClient.shared.getConversationsCount()
+      async let installedApps = APIClient.shared.searchApps(installedOnly: true)
+      async let focusCount = ProactiveStorage.shared.getTotalFocusSessionCount()
+      async let filterCounts = ActionItemStorage.shared.getFilterCounts()
+      async let goals = APIClient.shared.getGoals()
+      async let memoryStats = MemoryStorage.shared.getStats()
+
+      let cc = try await conversationsCount
+      let ia = try await installedApps
+      let fc = try await focusCount
+      let filters = try await filterCounts
+      let g = try await goals
+      let ms = try await memoryStats
+
+      let screenshotCount: Int
+      do {
+        screenshotCount = try await RewindDatabase.shared.getScreenshotCount()
+      } catch {
+        screenshotCount = 0
+      }
+
+      advancedStats = UserStats(
+        conversations: cc,
+        appsInstalled: ia.count,
+        screenshotsTotal: screenshotCount,
+        focusSessions: fc,
+        tasksTodo: filters.todo,
+        tasksDone: filters.done,
+        tasksDeleted: filters.deleted,
+        goalsCount: g.count,
+        memoriesTotal: ms.total
+      )
+    } catch {
+      print("SETTINGS: Failed to load advanced stats: \(error)")
+    }
+  }
+
+  private func loadChatMessageCount() async {
+    isLoadingChatMessages = true
+    defer { isLoadingChatMessages = false }
+
+    do {
+      chatMessageCount = try await APIClient.shared.getChatMessageCount()
+    } catch {
+      chatMessageCount = 0
+    }
+  }
+
+  // MARK: - About Section
+
+  private var aboutSection: some View {
+    VStack(spacing: 20) {
+      settingsCard(settingId: "about.version") {
+        VStack(spacing: 16) {
+          // App info
+          HStack(spacing: 16) {
+            if let logoImage = NSImage(
+              contentsOf: Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png")!)
+            {
+              Image(nsImage: logoImage)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: 48, height: 48)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+              HStack(spacing: 6) {
+                Text("omi")
+                  .scaledFont(size: 18, weight: .bold)
+                  .foregroundColor(OmiColors.textPrimary)
+
+                if !updaterViewModel.activeChannelLabel.isEmpty {
+                  Text("(\(updaterViewModel.activeChannelLabel))")
+                    .scaledFont(size: 13, weight: .medium)
+                    .foregroundColor(OmiColors.purplePrimary)
+                }
+              }
+
+              Text("Version \(updaterViewModel.currentVersion) (\(updaterViewModel.buildNumber))")
+                .scaledFont(size: 13)
+                .foregroundColor(OmiColors.textTertiary)
+                .textSelection(.enabled)
+            }
+
+            Spacer()
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          // Links
+          linkRow(title: "Visit Website", url: "https://omi.me")
+          linkRow(title: "Help Center", url: "https://help.omi.me")
+          Button(action: {
+            selectedSection = .privacy
+          }) {
+            HStack {
+              Text("Privacy Policy")
+                .scaledFont(size: 14)
+                .foregroundColor(OmiColors.textSecondary)
+
+              Spacer()
+
+              Image(systemName: "arrow.right")
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+          }
+          .buttonStyle(.plain)
+          linkRow(title: "Terms of Service", url: "https://omi.me/terms")
+        }
+      }
+
+      // Software Updates
+      settingsCard(settingId: "about.updates") {
+        VStack(alignment: .leading, spacing: 16) {
+          HStack {
+            Image(systemName: "arrow.triangle.2.circlepath")
+              .scaledFont(size: 16)
+              .foregroundColor(OmiColors.purplePrimary)
+
+            Text("Software Updates")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Spacer()
+
+            Button("Check Now") {
+              updaterViewModel.checkForUpdates()
+            }
+            .buttonStyle(.bordered)
+            .disabled(!updaterViewModel.canCheckForUpdates)
+          }
+
+          if let lastCheck = updaterViewModel.lastUpdateCheckDate {
+            Text("Last checked: \(lastCheck, style: .relative) ago")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          settingRow(
+            title: "Automatic Updates",
+            subtitle: "Check for updates automatically in the background",
+            settingId: "about.autoupdates"
+          ) {
+            Toggle("", isOn: $updaterViewModel.automaticallyChecksForUpdates)
+              .toggleStyle(.switch)
+              .labelsHidden()
+              .disabled(updaterViewModel.usesManagedUpdatePolicy || AnalyticsManager.isDevBuild)
+          }
+
+          if updaterViewModel.automaticallyChecksForUpdates {
+            settingRow(
+              title: "Auto-Install Updates",
+              subtitle: "Automatically download and install updates when available",
+              settingId: "about.autoinstall"
+            ) {
+              Toggle("", isOn: $updaterViewModel.automaticallyDownloadsUpdates)
+                .toggleStyle(.switch)
+                .labelsHidden()
+                .disabled(updaterViewModel.usesManagedUpdatePolicy || AnalyticsManager.isDevBuild)
+            }
+          }
+
+          if updaterViewModel.usesManagedUpdatePolicy {
+            Text("Release builds always auto-check and auto-install updates in the background.")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+          } else {
+            Text(
+              "Development builds keep automatic installation disabled to avoid replacing the local app."
+            )
+            .scaledFont(size: 12)
+            .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Divider()
+            .background(OmiColors.backgroundQuaternary)
+
+          settingRow(
+            title: "Update Channel", subtitle: updaterViewModel.updateChannel.description,
+            settingId: "about.channel"
+          ) {
+            Picker(
+              "",
+              selection: Binding(
+                get: { updaterViewModel.updateChannel },
+                set: { newChannel in
+                  // Switching beta → stable with a newer build: confirm first
+                  if updaterViewModel.updateChannel == .beta && newChannel == .stable
+                    && updaterViewModel.isDowngradeToStable
+                  {
+                    showDowngradeAlert = true
+                  } else {
+                    updaterViewModel.updateChannel = newChannel
+                  }
+                }
+              )
+            ) {
+              ForEach(UpdateChannel.allCases, id: \.self) { channel in
+                Text(channel.displayName).tag(channel)
+              }
+            }
+            .pickerStyle(.menu)
+            .labelsHidden()
+            .frame(width: 100)
+          }
+        }
+      }
+      .alert("Switch to Stable Channel?", isPresented: $showDowngradeAlert) {
+        Button("Stay on Beta", role: .cancel) {}
+        Button("Switch to Stable") {
+          updaterViewModel.updateChannel = .stable
+          if let url = URL(string: "https://macos.omi.me") {
+            NSWorkspace.shared.open(url)
+          }
+        }
+      } message: {
+        let stableVersion = updaterViewModel.latestStableVersionString ?? "an older version"
+        Text(
+          "You're on a newer beta build (\(updaterViewModel.currentVersion)). The latest stable release is \(stableVersion).\n\nSwitching to Stable means you won't receive new updates until a stable release surpasses your current version. You can also download the stable version now."
+        )
+      }
+
+      settingsCard(settingId: "about.reportissue") {
+        HStack(spacing: 16) {
+          Image(systemName: "exclamationmark.bubble.fill")
+            .scaledFont(size: 16)
+            .foregroundColor(OmiColors.purplePrimary)
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Report an Issue")
+              .scaledFont(size: 15, weight: .medium)
+              .foregroundColor(OmiColors.textPrimary)
+
+            Text("Help us improve omi")
+              .scaledFont(size: 13)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          Spacer()
+
+          Button("Report") {
+            FeedbackWindow.show(userEmail: AuthState.shared.userEmail)
+          }
+          .buttonStyle(.bordered)
+        }
+      }
+    }
+  }
+
+  // MARK: - Helper Views
+
+  private func fontShortcutRow(label: String, keys: String) -> some View {
+    HStack {
+      Text(label)
+        .scaledFont(size: 13)
+        .foregroundColor(OmiColors.textTertiary)
+      Spacer()
+      Text(keys)
+        .scaledMonospacedFont(size: 13, weight: .medium)
+        .foregroundColor(OmiColors.textSecondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(OmiColors.backgroundTertiary.opacity(0.8))
+        .cornerRadius(5)
+    }
+  }
+
+  private func settingsCard<Content: View>(
+    settingId: String? = nil, @ViewBuilder content: () -> Content
+  ) -> some View {
+    let card = content()
+      .padding(20)
+      .background(
+        RoundedRectangle(cornerRadius: 12)
+          .fill(OmiColors.backgroundTertiary.opacity(0.5))
+          .overlay(
+            RoundedRectangle(cornerRadius: 12)
+              .stroke(OmiColors.backgroundQuaternary.opacity(0.3), lineWidth: 1)
+          )
+      )
+    return Group {
+      if let settingId = settingId {
+        card.modifier(
+          SettingHighlightModifier(
+            settingId: settingId, highlightedSettingId: $highlightedSettingId))
+      } else {
+        card
+      }
+    }
+  }
+
+  private func settingRow<Content: View>(
+    title: String, subtitle: String, settingId: String? = nil, @ViewBuilder control: () -> Content
+  ) -> some View {
+    let row = HStack {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .scaledFont(size: 14)
+          .foregroundColor(OmiColors.textSecondary)
+        Text(subtitle)
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+      }
+
+      Spacer()
+
+      control()
+    }
+    return Group {
+      if let settingId = settingId {
+        row.modifier(
+          SettingHighlightModifier(
+            settingId: settingId, highlightedSettingId: $highlightedSettingId))
+      } else {
+        row
+      }
+    }
+  }
+
+  private func linkRow(title: String, url: String) -> some View {
+    Button(action: {
+      if let url = URL(string: url) {
+        NSWorkspace.shared.open(url)
+      }
+    }) {
+      HStack {
+        Text(title)
+          .scaledFont(size: 14)
+          .foregroundColor(OmiColors.textSecondary)
+
+        Spacer()
+
+        Image(systemName: "arrow.up.right")
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textTertiary)
+      }
+    }
+    .buttonStyle(.plain)
+  }
+
+  private func trackingItem(_ text: String) -> some View {
+    HStack(spacing: 8) {
+      Circle()
+        .fill(OmiColors.textTertiary.opacity(0.5))
+        .frame(width: 4, height: 4)
+
+      Text(text)
+        .scaledFont(size: 12)
+        .foregroundColor(OmiColors.textTertiary)
+    }
+  }
+
+  private func privacyBullet(_ text: String) -> some View {
+    HStack(spacing: 8) {
+      Image(systemName: "checkmark")
+        .scaledFont(size: 9, weight: .bold)
+        .foregroundColor(.green)
+
+      Text(text)
+        .scaledFont(size: 12)
+        .foregroundColor(OmiColors.textSecondary)
+    }
+  }
+
+  // MARK: - Language Helpers
+
+  /// Whether the selected language supports auto-detect mode
+  private var autoDetectSupported: Bool {
+    AssistantSettings.supportsAutoDetect(transcriptionLanguage)
+  }
+
+  /// Subtitle text for auto-detect toggle
+  private var autoDetectSubtitle: String {
+    if autoDetectSupported {
+      return "Automatically detect spoken language"
+    } else {
+      return "Not available for \(languageName(for: transcriptionLanguage))"
+    }
+  }
+
+  /// Get display name for a language code
+  private func languageName(for code: String) -> String {
+    AssistantSettings.supportedLanguages.first { $0.code == code }?.name ?? code
+  }
+
+  // MARK: - Slider Index Helpers
+
+  private var analysisDelaySliderIndex: Int {
+    analysisDelayOptions.firstIndex(of: analysisDelay) ?? 0
+  }
+
+  private var taskIntervalSliderIndex: Int {
+    extractionIntervalOptions.firstIndex(of: taskExtractionInterval) ?? 0
+  }
+
+  private var adviceIntervalSliderIndex: Int {
+    extractionIntervalOptions.firstIndex(of: adviceExtractionInterval) ?? 0
+  }
+
+  private var memoryIntervalSliderIndex: Int {
+    extractionIntervalOptions.firstIndex(of: memoryExtractionInterval) ?? 0
+  }
+
+  // MARK: - Helpers
+
+  private func toggleMonitoring(enabled: Bool) {
+    if enabled && !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
+      permissionError = "Screen recording permission required"
+      isMonitoring = false
+      ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
+      return
     }
 
-    /// Get display name for a language code
-    private func languageName(for code: String) -> String {
-        AssistantSettings.supportedLanguages.first { $0.code == code }?.name ?? code
-    }
+    permissionError = nil
+    isToggling = true
 
-    // MARK: - Slider Index Helpers
+    // Track setting change
+    AnalyticsManager.shared.settingToggled(setting: "monitoring", enabled: enabled)
 
-    private var analysisDelaySliderIndex: Int {
-        analysisDelayOptions.firstIndex(of: analysisDelay) ?? 0
-    }
-
-    private var taskIntervalSliderIndex: Int {
-        extractionIntervalOptions.firstIndex(of: taskExtractionInterval) ?? 0
-    }
-
-    private var adviceIntervalSliderIndex: Int {
-        extractionIntervalOptions.firstIndex(of: adviceExtractionInterval) ?? 0
-    }
-
-    private var memoryIntervalSliderIndex: Int {
-        extractionIntervalOptions.firstIndex(of: memoryExtractionInterval) ?? 0
-    }
-
-    // MARK: - Helpers
-
-    private func toggleMonitoring(enabled: Bool) {
-        if enabled && !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
-            permissionError = "Screen recording permission required"
+    if enabled {
+      ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
+        DispatchQueue.main.async {
+          isToggling = false
+          if !success {
+            permissionError = error ?? "Failed to start monitoring"
             isMonitoring = false
-            ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
-            return
+          }
         }
+      }
+    } else {
+      ProactiveAssistantsPlugin.shared.stopMonitoring()
+      isToggling = false
+    }
 
-        permissionError = nil
-        isToggling = true
+    // Persist the setting
+    AssistantSettings.shared.screenAnalysisEnabled = enabled
+  }
 
-        // Track setting change
-        AnalyticsManager.shared.settingToggled(setting: "monitoring", enabled: enabled)
+  private func toggleTranscription(enabled: Bool) {
+    // Check microphone permission
+    if enabled && !appState.hasMicrophonePermission {
+      transcriptionError = "Microphone permission required"
+      isTranscribing = false
+      return
+    }
 
-        if enabled {
-            ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
-                DispatchQueue.main.async {
-                    isToggling = false
-                    if !success {
-                        permissionError = error ?? "Failed to start monitoring"
-                        isMonitoring = false
-                    }
-                }
-            }
+    transcriptionError = nil
+    isTogglingTranscription = true
+
+    // Track setting change
+    AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
+
+    if enabled {
+      appState.startTranscription()
+      isTogglingTranscription = false
+      isTranscribing = true
+    } else {
+      appState.stopTranscription()
+      isTogglingTranscription = false
+      isTranscribing = false
+    }
+
+    // Persist the setting
+    AssistantSettings.shared.transcriptionEnabled = enabled
+  }
+
+  private func startGlowPreview() {
+    isPreviewRunning = true
+
+    // Show the demo window and get its frame
+    let demoWindow = GlowDemoWindow.show()
+    let windowFrame = demoWindow.frame
+
+    // Phase 1: Show focused (green) glow after a small delay
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+      GlowDemoWindow.setPhase(.focused)
+      OverlayService.shared.showGlow(around: windowFrame, colorMode: .focused, isPreview: true)
+    }
+
+    // Phase 2: Show distracted (red) glow
+    DispatchQueue.main.asyncAfter(deadline: .now() + 3.3) {
+      GlowDemoWindow.setPhase(.distracted)
+      OverlayService.shared.showGlow(around: windowFrame, colorMode: .distracted, isPreview: true)
+    }
+
+    // End preview and close demo window
+    DispatchQueue.main.asyncAfter(deadline: .now() + 7.0) {
+      GlowDemoWindow.close()
+      isPreviewRunning = false
+    }
+  }
+
+  private func deleteCurrentAIProfile() {
+    guard let id = aiProfileId else { return }
+    Task {
+      let previous = await AIUserProfileService.shared.deleteProfile(id: id)
+      await MainActor.run {
+        if let previous {
+          aiProfileId = previous.id
+          aiProfileText = previous.profileText
+          aiProfileGeneratedAt = previous.generatedAt
+          aiProfileDataSourcesUsed = previous.dataSourcesUsed
         } else {
-            ProactiveAssistantsPlugin.shared.stopMonitoring()
-            isToggling = false
+          aiProfileId = nil
+          aiProfileText = nil
+          aiProfileGeneratedAt = nil
+          aiProfileDataSourcesUsed = 0
         }
-
-        // Persist the setting
-        AssistantSettings.shared.screenAnalysisEnabled = enabled
+      }
     }
+  }
 
-    private func toggleTranscription(enabled: Bool) {
-        // Check microphone permission
-        if enabled && !appState.hasMicrophonePermission {
-            transcriptionError = "Microphone permission required"
-            isTranscribing = false
-            return
+  private func regenerateAIProfile() {
+    isGeneratingAIProfile = true
+    Task {
+      do {
+        let result = try await AIUserProfileService.shared.generateProfile()
+        await MainActor.run {
+          aiProfileId = result.id
+          aiProfileText = result.profileText
+          aiProfileGeneratedAt = result.generatedAt
+          aiProfileDataSourcesUsed = result.dataSourcesUsed
+          isGeneratingAIProfile = false
         }
-
-        transcriptionError = nil
-        isTogglingTranscription = true
-
-        // Track setting change
-        AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
-
-        if enabled {
-            appState.startTranscription()
-            isTogglingTranscription = false
-            isTranscribing = true
-        } else {
-            appState.stopTranscription()
-            isTogglingTranscription = false
-            isTranscribing = false
+      } catch {
+        log("Settings: AI profile generation failed: \(error.localizedDescription)")
+        await MainActor.run {
+          isGeneratingAIProfile = false
         }
-
-        // Persist the setting
-        AssistantSettings.shared.transcriptionEnabled = enabled
+      }
     }
+  }
 
-
-    private func startGlowPreview() {
-        isPreviewRunning = true
-
-        // Show the demo window and get its frame
-        let demoWindow = GlowDemoWindow.show()
-        let windowFrame = demoWindow.frame
-
-        // Phase 1: Show focused (green) glow after a small delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            GlowDemoWindow.setPhase(.focused)
-            OverlayService.shared.showGlow(around: windowFrame, colorMode: .focused, isPreview: true)
-        }
-
-        // Phase 2: Show distracted (red) glow
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.3) {
-            GlowDemoWindow.setPhase(.distracted)
-            OverlayService.shared.showGlow(around: windowFrame, colorMode: .distracted, isPreview: true)
-        }
-
-        // End preview and close demo window
-        DispatchQueue.main.asyncAfter(deadline: .now() + 7.0) {
-            GlowDemoWindow.close()
-            isPreviewRunning = false
-        }
+  private func formatMinutes(_ minutes: Int) -> String {
+    if minutes == 1 {
+      return "1 minute"
+    } else if minutes < 60 {
+      return "\(minutes) minutes"
+    } else {
+      return "1 hour"
     }
+  }
 
-    private func deleteCurrentAIProfile() {
-        guard let id = aiProfileId else { return }
-        Task {
-            let previous = await AIUserProfileService.shared.deleteProfile(id: id)
-            await MainActor.run {
-                if let previous {
-                    aiProfileId = previous.id
-                    aiProfileText = previous.profileText
-                    aiProfileGeneratedAt = previous.generatedAt
-                    aiProfileDataSourcesUsed = previous.dataSourcesUsed
-                } else {
-                    aiProfileId = nil
-                    aiProfileText = nil
-                    aiProfileGeneratedAt = nil
-                    aiProfileDataSourcesUsed = 0
-                }
-            }
-        }
+  private func formatAnalysisDelay(_ seconds: Int) -> String {
+    if seconds == 0 {
+      return "Instant"
+    } else if seconds < 60 {
+      return "\(seconds) seconds"
+    } else if seconds == 60 {
+      return "1 minute"
+    } else {
+      return "\(seconds / 60) minutes"
     }
+  }
 
-    private func regenerateAIProfile() {
-        isGeneratingAIProfile = true
-        Task {
-            do {
-                let result = try await AIUserProfileService.shared.generateProfile()
-                await MainActor.run {
-                    aiProfileId = result.id
-                    aiProfileText = result.profileText
-                    aiProfileGeneratedAt = result.generatedAt
-                    aiProfileDataSourcesUsed = result.dataSourcesUsed
-                    isGeneratingAIProfile = false
-                }
-            } catch {
-                log("Settings: AI profile generation failed: \(error.localizedDescription)")
-                await MainActor.run {
-                    isGeneratingAIProfile = false
-                }
-            }
-        }
+  private func formatExtractionInterval(_ seconds: Double) -> String {
+    if seconds < 60 {
+      return "\(Int(seconds)) seconds"
+    } else if seconds < 3600 {
+      let minutes = Int(seconds / 60)
+      return minutes == 1 ? "1 minute" : "\(minutes) minutes"
+    } else {
+      let hours = Int(seconds / 3600)
+      return hours == 1 ? "1 hour" : "\(hours) hours"
     }
+  }
 
-    private func formatMinutes(_ minutes: Int) -> String {
-        if minutes == 1 {
-            return "1 minute"
-        } else if minutes < 60 {
-            return "\(minutes) minutes"
-        } else {
-            return "1 hour"
-        }
+  private func formatHour(_ hour: Int) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "h:00 a"
+    var components = DateComponents()
+    components.hour = hour
+    if let date = Calendar.current.date(from: components) {
+      return formatter.string(from: date)
     }
+    return "\(hour):00"
+  }
 
-    private func formatAnalysisDelay(_ seconds: Int) -> String {
-        if seconds == 0 {
-            return "Instant"
-        } else if seconds < 60 {
-            return "\(seconds) seconds"
-        } else if seconds == 60 {
-            return "1 minute"
-        } else {
-            return "\(seconds / 60) minutes"
+  // MARK: - Backend Settings
+
+  private func loadBackendSettings() {
+    guard !isLoadingSettings else { return }
+    isLoadingSettings = true
+
+    // Load local transcription settings first (these are used immediately)
+    transcriptionLanguage = AssistantSettings.shared.transcriptionLanguage
+    transcriptionAutoDetect = AssistantSettings.shared.transcriptionAutoDetect
+    vocabularyList = AssistantSettings.shared.transcriptionVocabulary
+    vadGateEnabled = AssistantSettings.shared.vadGateEnabled
+    batchTranscriptionEnabled = AssistantSettings.shared.batchTranscriptionEnabled
+
+    Task {
+      do {
+        // Load all settings in parallel
+        async let dailySummaryTask = APIClient.shared.getDailySummarySettings()
+        async let notificationsTask = APIClient.shared.getNotificationSettings()
+        async let languageTask = APIClient.shared.getUserLanguage()
+        async let recordingTask = APIClient.shared.getRecordingPermission()
+        async let cloudSyncTask = APIClient.shared.getPrivateCloudSync()
+        async let transcriptionTask = APIClient.shared.getTranscriptionPreferences()
+
+        // Sync assistant settings from server in parallel
+        async let assistantSyncTask: () = SettingsSyncManager.shared.syncFromServer()
+
+        let (dailySummary, notifications, language, recording, cloudSync, transcription, _) = try
+          await (
+            dailySummaryTask,
+            notificationsTask,
+            languageTask,
+            recordingTask,
+            cloudSyncTask,
+            transcriptionTask,
+            assistantSyncTask
+          )
+
+        await MainActor.run {
+          dailySummaryEnabled = dailySummary.enabled
+          dailySummaryHour = dailySummary.hour
+          notificationsEnabled = notifications.enabled
+          notificationFrequency = notifications.frequency
+          userLanguage = language.language
+          recordingPermissionEnabled = recording.enabled
+          privateCloudSyncEnabled = cloudSync.enabled
+          singleLanguageMode = transcription.singleLanguageMode
+          vocabularyList = transcription.vocabulary
+          // Sync backend vocabulary to local settings
+          AssistantSettings.shared.transcriptionVocabulary = transcription.vocabulary
+
+          // Sync backend language to local if different (backend is source of truth for language)
+          if !language.language.isEmpty && language.language != transcriptionLanguage {
+            transcriptionLanguage = language.language
+            AssistantSettings.shared.transcriptionLanguage = language.language
+          }
+
+          // Sync single language mode from backend (inverted to auto-detect)
+          // Only update if we got a valid response and it differs
+          let backendAutoDetect = !transcription.singleLanguageMode
+          if backendAutoDetect != transcriptionAutoDetect {
+            transcriptionAutoDetect = backendAutoDetect
+            AssistantSettings.shared.transcriptionAutoDetect = backendAutoDetect
+          }
+
+          isLoadingSettings = false
         }
-    }
 
-    private func formatExtractionInterval(_ seconds: Double) -> String {
-        if seconds < 60 {
-            return "\(Int(seconds)) seconds"
-        } else if seconds < 3600 {
-            let minutes = Int(seconds / 60)
-            return minutes == 1 ? "1 minute" : "\(minutes) minutes"
-        } else {
-            let hours = Int(seconds / 3600)
-            return hours == 1 ? "1 hour" : "\(hours) hours"
+      } catch {
+        logError("Failed to load backend settings", error: error)
+        await MainActor.run {
+          isLoadingSettings = false
         }
+      }
     }
+  }
 
-    private func formatHour(_ hour: Int) -> String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "h:00 a"
-        var components = DateComponents()
-        components.hour = hour
-        if let date = Calendar.current.date(from: components) {
-            return formatter.string(from: date)
+  private func updateDailySummarySettings(enabled: Bool? = nil, hour: Int? = nil) {
+    Task {
+      do {
+        let _ = try await APIClient.shared.updateDailySummarySettings(enabled: enabled, hour: hour)
+      } catch {
+        logError("Failed to update daily summary settings", error: error)
+      }
+    }
+  }
+
+  private func updateNotificationSettings(enabled: Bool? = nil, frequency: Int? = nil) {
+    Task {
+      do {
+        let _ = try await APIClient.shared.updateNotificationSettings(
+          enabled: enabled, frequency: frequency)
+      } catch {
+        logError("Failed to update notification settings", error: error)
+      }
+    }
+  }
+
+  private func updateLanguage(_ language: String) {
+    Task {
+      // Track language change
+      AnalyticsManager.shared.languageChanged(language: language)
+      do {
+        let _ = try await APIClient.shared.updateUserLanguage(language)
+      } catch {
+        logError("Failed to update language", error: error)
+      }
+    }
+  }
+
+  private func updateRecordingPermission(_ enabled: Bool) {
+    Task {
+      do {
+        try await APIClient.shared.setRecordingPermission(enabled: enabled)
+      } catch {
+        logError("Failed to update recording permission", error: error)
+      }
+    }
+  }
+
+  private func updatePrivateCloudSync(_ enabled: Bool) {
+    Task {
+      do {
+        try await APIClient.shared.setPrivateCloudSync(enabled: enabled)
+      } catch {
+        logError("Failed to update private cloud sync", error: error)
+      }
+    }
+  }
+
+  private func updateTranscriptionPreferences(
+    singleLanguageMode: Bool? = nil, vocabulary: String? = nil
+  ) {
+    Task {
+      do {
+        var vocabArray: [String]? = nil
+        if let vocab = vocabulary {
+          vocabArray = vocab.split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
         }
-        return "\(hour):00"
+        let _ = try await APIClient.shared.updateTranscriptionPreferences(
+          singleLanguageMode: singleLanguageMode,
+          vocabulary: vocabArray
+        )
+      } catch {
+        logError("Failed to update transcription preferences", error: error)
+      }
     }
+  }
 
-    // MARK: - Backend Settings
+  private func deleteAccountAndData() {
+    guard !isDeletingAccount else { return }
 
-    private func loadBackendSettings() {
-        guard !isLoadingSettings else { return }
-        isLoadingSettings = true
+    deleteAccountError = nil
+    isDeletingAccount = true
+    AnalyticsManager.shared.deleteAccountConfirmed()
 
-        // Load local transcription settings first (these are used immediately)
-        transcriptionLanguage = AssistantSettings.shared.transcriptionLanguage
-        transcriptionAutoDetect = AssistantSettings.shared.transcriptionAutoDetect
-        vocabularyList = AssistantSettings.shared.transcriptionVocabulary
-        vadGateEnabled = AssistantSettings.shared.vadGateEnabled
-        batchTranscriptionEnabled = AssistantSettings.shared.batchTranscriptionEnabled
-
-        Task {
-            do {
-                // Load all settings in parallel
-                async let dailySummaryTask = APIClient.shared.getDailySummarySettings()
-                async let notificationsTask = APIClient.shared.getNotificationSettings()
-                async let languageTask = APIClient.shared.getUserLanguage()
-                async let recordingTask = APIClient.shared.getRecordingPermission()
-                async let cloudSyncTask = APIClient.shared.getPrivateCloudSync()
-                async let transcriptionTask = APIClient.shared.getTranscriptionPreferences()
-
-                // Sync assistant settings from server in parallel
-                async let assistantSyncTask: () = SettingsSyncManager.shared.syncFromServer()
-
-                let (dailySummary, notifications, language, recording, cloudSync, transcription, _) = try await (
-                    dailySummaryTask,
-                    notificationsTask,
-                    languageTask,
-                    recordingTask,
-                    cloudSyncTask,
-                    transcriptionTask,
-                    assistantSyncTask
-                )
-
-                await MainActor.run {
-                    dailySummaryEnabled = dailySummary.enabled
-                    dailySummaryHour = dailySummary.hour
-                    notificationsEnabled = notifications.enabled
-                    notificationFrequency = notifications.frequency
-                    userLanguage = language.language
-                    recordingPermissionEnabled = recording.enabled
-                    privateCloudSyncEnabled = cloudSync.enabled
-                    singleLanguageMode = transcription.singleLanguageMode
-                    vocabularyList = transcription.vocabulary
-                    // Sync backend vocabulary to local settings
-                    AssistantSettings.shared.transcriptionVocabulary = transcription.vocabulary
-
-                    // Sync backend language to local if different (backend is source of truth for language)
-                    if !language.language.isEmpty && language.language != transcriptionLanguage {
-                        transcriptionLanguage = language.language
-                        AssistantSettings.shared.transcriptionLanguage = language.language
-                    }
-
-                    // Sync single language mode from backend (inverted to auto-detect)
-                    // Only update if we got a valid response and it differs
-                    let backendAutoDetect = !transcription.singleLanguageMode
-                    if backendAutoDetect != transcriptionAutoDetect {
-                        transcriptionAutoDetect = backendAutoDetect
-                        AssistantSettings.shared.transcriptionAutoDetect = backendAutoDetect
-                    }
-
-                    isLoadingSettings = false
-                }
-
-            } catch {
-                logError("Failed to load backend settings", error: error)
-                await MainActor.run {
-                    isLoadingSettings = false
-                }
-            }
+    Task {
+      do {
+        try await APIClient.shared.deleteAccount()
+        await MainActor.run {
+          appState.stopTranscription()
+          ProactiveAssistantsPlugin.shared.stopMonitoring()
+          do {
+            try AuthService.shared.signOut()
+            isDeletingAccount = false
+          } catch {
+            deleteAccountError =
+              "Account deleted, but sign out failed: \(error.localizedDescription)"
+            isDeletingAccount = false
+          }
         }
-    }
-
-    private func updateDailySummarySettings(enabled: Bool? = nil, hour: Int? = nil) {
-        Task {
-            do {
-                let _ = try await APIClient.shared.updateDailySummarySettings(enabled: enabled, hour: hour)
-            } catch {
-                logError("Failed to update daily summary settings", error: error)
-            }
+      } catch {
+        await MainActor.run {
+          deleteAccountError = "Failed to delete account: \(error.localizedDescription)"
+          isDeletingAccount = false
         }
+      }
     }
-
-    private func updateNotificationSettings(enabled: Bool? = nil, frequency: Int? = nil) {
-        Task {
-            do {
-                let _ = try await APIClient.shared.updateNotificationSettings(enabled: enabled, frequency: frequency)
-            } catch {
-                logError("Failed to update notification settings", error: error)
-            }
-        }
-    }
-
-    private func updateLanguage(_ language: String) {
-        Task {
-            // Track language change
-            AnalyticsManager.shared.languageChanged(language: language)
-            do {
-                let _ = try await APIClient.shared.updateUserLanguage(language)
-            } catch {
-                logError("Failed to update language", error: error)
-            }
-        }
-    }
-
-    private func updateRecordingPermission(_ enabled: Bool) {
-        Task {
-            do {
-                try await APIClient.shared.setRecordingPermission(enabled: enabled)
-            } catch {
-                logError("Failed to update recording permission", error: error)
-            }
-        }
-    }
-
-    private func updatePrivateCloudSync(_ enabled: Bool) {
-        Task {
-            do {
-                try await APIClient.shared.setPrivateCloudSync(enabled: enabled)
-            } catch {
-                logError("Failed to update private cloud sync", error: error)
-            }
-        }
-    }
-
-    private func updateTranscriptionPreferences(singleLanguageMode: Bool? = nil, vocabulary: String? = nil) {
-        Task {
-            do {
-                var vocabArray: [String]? = nil
-                if let vocab = vocabulary {
-                    vocabArray = vocab.split(separator: ",")
-                        .map { $0.trimmingCharacters(in: .whitespaces) }
-                        .filter { !$0.isEmpty }
-                }
-                let _ = try await APIClient.shared.updateTranscriptionPreferences(
-                    singleLanguageMode: singleLanguageMode,
-                    vocabulary: vocabArray
-                )
-            } catch {
-                logError("Failed to update transcription preferences", error: error)
-            }
-        }
-    }
-
-    private func deleteAccountAndData() {
-        guard !isDeletingAccount else { return }
-
-        deleteAccountError = nil
-        isDeletingAccount = true
-        AnalyticsManager.shared.deleteAccountConfirmed()
-
-        Task {
-            do {
-                try await APIClient.shared.deleteAccount()
-                await MainActor.run {
-                    appState.stopTranscription()
-                    ProactiveAssistantsPlugin.shared.stopMonitoring()
-                    do {
-                        try AuthService.shared.signOut()
-                        isDeletingAccount = false
-                    } catch {
-                        deleteAccountError = "Account deleted, but sign out failed: \(error.localizedDescription)"
-                        isDeletingAccount = false
-                    }
-                }
-            } catch {
-                await MainActor.run {
-                    deleteAccountError = "Failed to delete account: \(error.localizedDescription)"
-                    isDeletingAccount = false
-                }
-            }
-        }
-    }
+  }
 }
 
 // MARK: - Excluded App Row
 
 struct ExcludedAppRow: View {
-    let appName: String
-    let onRemove: () -> Void
+  let appName: String
+  let onRemove: () -> Void
 
-    @State private var isHovered = false
+  @State private var isHovered = false
 
-    var body: some View {
-        HStack(spacing: 12) {
-            AppIconView(appName: appName, size: 24)
+  var body: some View {
+    HStack(spacing: 12) {
+      AppIconView(appName: appName, size: 24)
 
-            Text(appName)
-                .scaledFont(size: 14)
-                .foregroundColor(OmiColors.textPrimary)
+      Text(appName)
+        .scaledFont(size: 14)
+        .foregroundColor(OmiColors.textPrimary)
 
-            Spacer()
+      Spacer()
 
-            Button(action: onRemove) {
-                Image(systemName: "xmark.circle.fill")
-                    .scaledFont(size: 16)
-                    .foregroundColor(isHovered ? OmiColors.error : OmiColors.textTertiary)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .background(
-            RoundedRectangle(cornerRadius: 8)
-                .fill(isHovered ? OmiColors.backgroundQuaternary.opacity(0.5) : Color.clear)
-        )
-        .onHover { hovering in
-            isHovered = hovering
-        }
+      Button(action: onRemove) {
+        Image(systemName: "xmark.circle.fill")
+          .scaledFont(size: 16)
+          .foregroundColor(isHovered ? OmiColors.error : OmiColors.textTertiary)
+      }
+      .buttonStyle(.plain)
     }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+    .background(
+      RoundedRectangle(cornerRadius: 8)
+        .fill(isHovered ? OmiColors.backgroundQuaternary.opacity(0.5) : Color.clear)
+    )
+    .onHover { hovering in
+      isHovered = hovering
+    }
+  }
 }
 
 // MARK: - Add Excluded App View
 
 struct AddExcludedAppView: View {
-    let onAdd: (String) -> Void
-    let excludedApps: Set<String>
+  let onAdd: (String) -> Void
+  let excludedApps: Set<String>
 
-    @State private var newAppName: String = ""
-    @State private var showingSuggestions = false
-    @State private var runningApps: [String] = []
+  @State private var newAppName: String = ""
+  @State private var showingSuggestions = false
+  @State private var runningApps: [String] = []
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Add App to Exclusion List")
-                .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textSecondary)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Add App to Exclusion List")
+        .scaledFont(size: 13, weight: .medium)
+        .foregroundColor(OmiColors.textSecondary)
 
-            HStack(spacing: 8) {
-                TextField("App name (e.g., Passwords)", text: $newAppName)
-                    .textFieldStyle(.roundedBorder)
-                    .onSubmit {
-                        addApp()
-                    }
+      HStack(spacing: 8) {
+        TextField("App name (e.g., Passwords)", text: $newAppName)
+          .textFieldStyle(.roundedBorder)
+          .onSubmit {
+            addApp()
+          }
 
-                Button("Add") {
-                    addApp()
-                }
-                .buttonStyle(.bordered)
-                .disabled(newAppName.trimmingCharacters(in: .whitespaces).isEmpty)
-            }
-
-            // Running apps suggestions
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("Currently Running Apps")
-                        .scaledFont(size: 12, weight: .medium)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    Spacer()
-
-                    Button {
-                        refreshRunningApps()
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                            .scaledFont(size: 11)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        ForEach(runningApps.filter { !excludedApps.contains($0) && !TaskAssistantSettings.builtInExcludedApps.contains($0) }, id: \.self) { appName in
-                            RunningAppChip(appName: appName) {
-                                onAdd(appName)
-                            }
-                        }
-                    }
-                }
-            }
-            .padding(.top, 4)
+        Button("Add") {
+          addApp()
         }
-        .onAppear {
+        .buttonStyle(.bordered)
+        .disabled(newAppName.trimmingCharacters(in: .whitespaces).isEmpty)
+      }
+
+      // Running apps suggestions
+      VStack(alignment: .leading, spacing: 8) {
+        HStack {
+          Text("Currently Running Apps")
+            .scaledFont(size: 12, weight: .medium)
+            .foregroundColor(OmiColors.textTertiary)
+
+          Spacer()
+
+          Button {
             refreshRunningApps()
+          } label: {
+            Image(systemName: "arrow.clockwise")
+              .scaledFont(size: 11)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+          .buttonStyle(.plain)
         }
-    }
 
-    private func addApp() {
-        let trimmed = newAppName.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        onAdd(trimmed)
-        newAppName = ""
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 8) {
+            ForEach(
+              runningApps.filter {
+                !excludedApps.contains($0)
+                  && !TaskAssistantSettings.builtInExcludedApps.contains($0)
+              }, id: \.self
+            ) { appName in
+              RunningAppChip(appName: appName) {
+                onAdd(appName)
+              }
+            }
+          }
+        }
+      }
+      .padding(.top, 4)
     }
-
-    private func refreshRunningApps() {
-        let apps = NSWorkspace.shared.runningApplications
-            .compactMap { $0.localizedName }
-            .filter { !$0.isEmpty }
-            .sorted()
-
-        // Remove duplicates while preserving order
-        var seen = Set<String>()
-        runningApps = apps.filter { seen.insert($0).inserted }
+    .onAppear {
+      refreshRunningApps()
     }
+  }
+
+  private func addApp() {
+    let trimmed = newAppName.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return }
+    onAdd(trimmed)
+    newAppName = ""
+  }
+
+  private func refreshRunningApps() {
+    let apps = NSWorkspace.shared.runningApplications
+      .compactMap { $0.localizedName }
+      .filter { !$0.isEmpty }
+      .sorted()
+
+    // Remove duplicates while preserving order
+    var seen = Set<String>()
+    runningApps = apps.filter { seen.insert($0).inserted }
+  }
 }
 
 // MARK: - Add Allowed App View (Whitelist)
 
 struct AddAllowedAppView: View {
-    let onAdd: (String) -> Void
-    let allowedApps: Set<String>
+  let onAdd: (String) -> Void
+  let allowedApps: Set<String>
 
-    @State private var newAppName: String = ""
-    @State private var runningApps: [String] = []
+  @State private var newAppName: String = ""
+  @State private var runningApps: [String] = []
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Add App to Allowed List")
-                .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textSecondary)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Text("Add App to Allowed List")
+        .scaledFont(size: 13, weight: .medium)
+        .foregroundColor(OmiColors.textSecondary)
 
-            HStack(spacing: 8) {
-                TextField("App name (e.g., Mail)", text: $newAppName)
-                    .textFieldStyle(.roundedBorder)
-                    .onSubmit {
-                        addApp()
-                    }
+      HStack(spacing: 8) {
+        TextField("App name (e.g., Mail)", text: $newAppName)
+          .textFieldStyle(.roundedBorder)
+          .onSubmit {
+            addApp()
+          }
 
-                Button("Add") {
-                    addApp()
-                }
-                .buttonStyle(.bordered)
-                .disabled(newAppName.trimmingCharacters(in: .whitespaces).isEmpty)
-            }
-
-            // Running apps suggestions
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("Currently Running Apps")
-                        .scaledFont(size: 12, weight: .medium)
-                        .foregroundColor(OmiColors.textTertiary)
-
-                    Spacer()
-
-                    Button {
-                        refreshRunningApps()
-                    } label: {
-                        Image(systemName: "arrow.clockwise")
-                            .scaledFont(size: 11)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                    .buttonStyle(.plain)
-                }
-
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        ForEach(runningApps.filter { !allowedApps.contains($0) && !TaskAssistantSettings.defaultAllowedApps.contains($0) }, id: \.self) { appName in
-                            RunningAppChip(appName: appName) {
-                                onAdd(appName)
-                            }
-                        }
-                    }
-                }
-            }
-            .padding(.top, 4)
+        Button("Add") {
+          addApp()
         }
-        .onAppear {
+        .buttonStyle(.bordered)
+        .disabled(newAppName.trimmingCharacters(in: .whitespaces).isEmpty)
+      }
+
+      // Running apps suggestions
+      VStack(alignment: .leading, spacing: 8) {
+        HStack {
+          Text("Currently Running Apps")
+            .scaledFont(size: 12, weight: .medium)
+            .foregroundColor(OmiColors.textTertiary)
+
+          Spacer()
+
+          Button {
             refreshRunningApps()
+          } label: {
+            Image(systemName: "arrow.clockwise")
+              .scaledFont(size: 11)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+          .buttonStyle(.plain)
         }
-    }
 
-    private func addApp() {
-        let trimmed = newAppName.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        onAdd(trimmed)
-        newAppName = ""
+        ScrollView(.horizontal, showsIndicators: false) {
+          HStack(spacing: 8) {
+            ForEach(
+              runningApps.filter {
+                !allowedApps.contains($0) && !TaskAssistantSettings.defaultAllowedApps.contains($0)
+              }, id: \.self
+            ) { appName in
+              RunningAppChip(appName: appName) {
+                onAdd(appName)
+              }
+            }
+          }
+        }
+      }
+      .padding(.top, 4)
     }
-
-    private func refreshRunningApps() {
-        let apps = NSWorkspace.shared.runningApplications
-            .compactMap { $0.localizedName }
-            .filter { !$0.isEmpty }
-            .sorted()
-
-        // Remove duplicates while preserving order
-        var seen = Set<String>()
-        runningApps = apps.filter { seen.insert($0).inserted }
+    .onAppear {
+      refreshRunningApps()
     }
+  }
+
+  private func addApp() {
+    let trimmed = newAppName.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return }
+    onAdd(trimmed)
+    newAppName = ""
+  }
+
+  private func refreshRunningApps() {
+    let apps = NSWorkspace.shared.runningApplications
+      .compactMap { $0.localizedName }
+      .filter { !$0.isEmpty }
+      .sorted()
+
+    // Remove duplicates while preserving order
+    var seen = Set<String>()
+    runningApps = apps.filter { seen.insert($0).inserted }
+  }
 }
 
 // MARK: - Browser Keyword List View
 
 struct BrowserKeywordListView: View {
-    @Binding var keywords: [String]
-    let onAdd: (String) -> Void
-    let onRemove: (String) -> Void
+  @Binding var keywords: [String]
+  let onAdd: (String) -> Void
+  let onRemove: (String) -> Void
 
-    @State private var newKeyword: String = ""
-    @State private var filterText: String = ""
+  @State private var newKeyword: String = ""
+  @State private var filterText: String = ""
 
-    private var filteredKeywords: [String] {
-        if filterText.isEmpty {
-            return keywords
-        }
-        return keywords.filter { $0.lowercased().contains(filterText.lowercased()) }
+  private var filteredKeywords: [String] {
+    if filterText.isEmpty {
+      return keywords
     }
+    return keywords.filter { $0.lowercased().contains(filterText.lowercased()) }
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            // Filter field
-            HStack(spacing: 8) {
-                Image(systemName: "line.3.horizontal.decrease")
-                    .scaledFont(size: 11)
-                    .foregroundColor(OmiColors.textTertiary)
-                TextField("Filter keywords...", text: $filterText)
-                    .textFieldStyle(.plain)
-                    .scaledFont(size: 12)
-                if !filterText.isEmpty {
-                    Button {
-                        filterText = ""
-                    } label: {
-                        Image(systemName: "xmark.circle.fill")
-                            .scaledFont(size: 11)
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                    .buttonStyle(.plain)
-                }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      // Filter field
+      HStack(spacing: 8) {
+        Image(systemName: "line.3.horizontal.decrease")
+          .scaledFont(size: 11)
+          .foregroundColor(OmiColors.textTertiary)
+        TextField("Filter keywords...", text: $filterText)
+          .textFieldStyle(.plain)
+          .scaledFont(size: 12)
+        if !filterText.isEmpty {
+          Button {
+            filterText = ""
+          } label: {
+            Image(systemName: "xmark.circle.fill")
+              .scaledFont(size: 11)
+              .foregroundColor(OmiColors.textTertiary)
+          }
+          .buttonStyle(.plain)
+        }
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 4)
+      .background(OmiColors.backgroundTertiary)
+      .cornerRadius(6)
+
+      // Keyword chips in a wrapping flow layout
+      ScrollView {
+        FlowLayout(spacing: 6) {
+          ForEach(filteredKeywords, id: \.self) { keyword in
+            HStack(spacing: 4) {
+              Text(keyword)
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textPrimary)
+              Button {
+                onRemove(keyword)
+              } label: {
+                Image(systemName: "xmark")
+                  .scaledFont(size: 8, weight: .bold)
+                  .foregroundColor(OmiColors.textTertiary)
+              }
+              .buttonStyle(.plain)
             }
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
             .background(OmiColors.backgroundTertiary)
             .cornerRadius(6)
-
-            // Keyword chips in a wrapping flow layout
-            ScrollView {
-                FlowLayout(spacing: 6) {
-                    ForEach(filteredKeywords, id: \.self) { keyword in
-                        HStack(spacing: 4) {
-                            Text(keyword)
-                                .scaledFont(size: 12)
-                                .foregroundColor(OmiColors.textPrimary)
-                            Button {
-                                onRemove(keyword)
-                            } label: {
-                                Image(systemName: "xmark")
-                                    .scaledFont(size: 8, weight: .bold)
-                                    .foregroundColor(OmiColors.textTertiary)
-                            }
-                            .buttonStyle(.plain)
-                        }
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 4)
-                        .background(OmiColors.backgroundTertiary)
-                        .cornerRadius(6)
-                    }
-                }
-                .padding(.vertical, 2)
-            }
-            .frame(maxHeight: 150)
-
-            // Add new keyword
-            HStack(spacing: 8) {
-                TextField("Add keyword...", text: $newKeyword)
-                    .textFieldStyle(.roundedBorder)
-                    .scaledFont(size: 12)
-                    .onSubmit { addKeyword() }
-
-                Button("Add") { addKeyword() }
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-                    .disabled(newKeyword.trimmingCharacters(in: .whitespaces).isEmpty)
-            }
-
-            Text("\(keywords.count) keywords")
-                .scaledFont(size: 11)
-                .foregroundColor(OmiColors.textTertiary)
+          }
         }
-    }
+        .padding(.vertical, 2)
+      }
+      .frame(maxHeight: 150)
 
-    private func addKeyword() {
-        let trimmed = newKeyword.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        onAdd(trimmed)
-        newKeyword = ""
+      // Add new keyword
+      HStack(spacing: 8) {
+        TextField("Add keyword...", text: $newKeyword)
+          .textFieldStyle(.roundedBorder)
+          .scaledFont(size: 12)
+          .onSubmit { addKeyword() }
+
+        Button("Add") { addKeyword() }
+          .buttonStyle(.bordered)
+          .controlSize(.small)
+          .disabled(newKeyword.trimmingCharacters(in: .whitespaces).isEmpty)
+      }
+
+      Text("\(keywords.count) keywords")
+        .scaledFont(size: 11)
+        .foregroundColor(OmiColors.textTertiary)
     }
+  }
+
+  private func addKeyword() {
+    let trimmed = newKeyword.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return }
+    onAdd(trimmed)
+    newKeyword = ""
+  }
 }
-
 
 // MARK: - Running App Chip
 
 struct RunningAppChip: View {
-    let appName: String
-    let onTap: () -> Void
+  let appName: String
+  let onTap: () -> Void
 
-    @State private var isHovered = false
+  @State private var isHovered = false
 
-    var body: some View {
-        Button(action: onTap) {
-            HStack(spacing: 6) {
-                AppIconView(appName: appName, size: 16)
+  var body: some View {
+    Button(action: onTap) {
+      HStack(spacing: 6) {
+        AppIconView(appName: appName, size: 16)
 
-                Text(appName)
-                    .scaledFont(size: 12)
-                    .foregroundColor(OmiColors.textSecondary)
+        Text(appName)
+          .scaledFont(size: 12)
+          .foregroundColor(OmiColors.textSecondary)
 
-                Image(systemName: "plus.circle.fill")
-                    .scaledFont(size: 12)
-                    .foregroundColor(isHovered ? OmiColors.purplePrimary : OmiColors.textTertiary)
-            }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(
-                RoundedRectangle(cornerRadius: 6)
-                    .fill(isHovered ? OmiColors.backgroundQuaternary : OmiColors.backgroundTertiary.opacity(0.5))
-            )
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            isHovered = hovering
-        }
+        Image(systemName: "plus.circle.fill")
+          .scaledFont(size: 12)
+          .foregroundColor(isHovered ? OmiColors.purplePrimary : OmiColors.textTertiary)
+      }
+      .padding(.horizontal, 10)
+      .padding(.vertical, 6)
+      .background(
+        RoundedRectangle(cornerRadius: 6)
+          .fill(
+            isHovered ? OmiColors.backgroundQuaternary : OmiColors.backgroundTertiary.opacity(0.5))
+      )
     }
+    .buttonStyle(.plain)
+    .onHover { hovering in
+      isHovered = hovering
+    }
+  }
 }
 
 #Preview {
-    SettingsPage(
-        appState: AppState(),
-        selectedSection: .constant(.advanced),
-        highlightedSettingId: .constant(nil)
-    )
+  SettingsPage(
+    appState: AppState(),
+    selectedSection: .constant(.advanced),
+    highlightedSettingId: .constant(nil)
+  )
 }

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -1,1060 +1,1118 @@
-import SwiftUI
-import FirebaseCore
 import FirebaseAuth
+import FirebaseCore
 import Mixpanel
 import Sentry
 import Sparkle
+import SwiftUI
 
 // MARK: - Launch Mode
 /// Determines which UI to show based on command-line arguments
 enum LaunchMode: String {
-    case full = "full"       // Normal app with full sidebar
-    case rewind = "rewind"   // Rewind-only mode (no sidebar)
+  case full = "full"  // Normal app with full sidebar
+  case rewind = "rewind"  // Rewind-only mode (no sidebar)
 
-    static func fromCommandLine() -> LaunchMode {
-        // Check for --mode=rewind argument
-        for arg in CommandLine.arguments {
-            if arg == "--mode=rewind" {
-                NSLog("OMI LaunchMode: Detected rewind mode from command line")
-                return .rewind
-            }
-        }
-        return .full
+  static func fromCommandLine() -> LaunchMode {
+    // Check for --mode=rewind argument
+    for arg in CommandLine.arguments {
+      if arg == "--mode=rewind" {
+        NSLog("OMI LaunchMode: Detected rewind mode from command line")
+        return .rewind
+      }
     }
+    return .full
+  }
 }
 
 // MARK: - Dev Flags
 /// Check for --skip-onboarding flag to bypass onboarding during development
 func shouldSkipOnboarding() -> Bool {
-    return CommandLine.arguments.contains("--skip-onboarding")
+  return CommandLine.arguments.contains("--skip-onboarding")
 }
 
 // Simple observable state without Firebase types
 @MainActor
 class AuthState: ObservableObject {
-    static let shared = AuthState()
+  static let shared = AuthState()
 
-    // UserDefaults keys (must match AuthService)
-    private static let kAuthIsSignedIn = "auth_isSignedIn"
-    private static let kAuthUserEmail = "auth_userEmail"
-    private static let kAuthUserId = "auth_userId"
+  // UserDefaults keys (must match AuthService)
+  private static let kAuthIsSignedIn = "auth_isSignedIn"
+  private static let kAuthUserEmail = "auth_userEmail"
+  private static let kAuthUserId = "auth_userId"
 
-    @Published var isSignedIn: Bool
-    @Published var isLoading: Bool = false
-    @Published var isRestoringAuth: Bool = true
-    @Published var error: String?
-    @Published var userEmail: String?
+  @Published var isSignedIn: Bool
+  @Published var isLoading: Bool = false
+  @Published var isRestoringAuth: Bool = true
+  @Published var error: String?
+  @Published var userEmail: String?
 
-    private init() {
-        // Restore auth state from UserDefaults immediately on init (before UI renders)
-        let savedSignedIn = UserDefaults.standard.bool(forKey: Self.kAuthIsSignedIn)
-        let savedEmail = UserDefaults.standard.string(forKey: Self.kAuthUserEmail)
-        self.isSignedIn = savedSignedIn
-        self.userEmail = savedEmail
-        // Show loading splash while Firebase restores session (only if user was previously signed in)
-        self.isRestoringAuth = savedSignedIn
-        NSLog("OMI AuthState: Initialized with savedSignedIn=%@, email=%@, isRestoringAuth=%@",
-              savedSignedIn ? "true" : "false", savedEmail ?? "nil", self.isRestoringAuth ? "true" : "false")
-    }
+  private init() {
+    // Restore auth state from UserDefaults immediately on init (before UI renders)
+    let savedSignedIn = UserDefaults.standard.bool(forKey: Self.kAuthIsSignedIn)
+    let savedEmail = UserDefaults.standard.string(forKey: Self.kAuthUserEmail)
+    self.isSignedIn = savedSignedIn
+    self.userEmail = savedEmail
+    // Show loading splash while Firebase restores session (only if user was previously signed in)
+    self.isRestoringAuth = savedSignedIn
+    NSLog(
+      "OMI AuthState: Initialized with savedSignedIn=%@, email=%@, isRestoringAuth=%@",
+      savedSignedIn ? "true" : "false", savedEmail ?? "nil", self.isRestoringAuth ? "true" : "false"
+    )
+  }
 
-    func update(isSignedIn: Bool, userEmail: String? = nil) {
-        self.isSignedIn = isSignedIn
-        self.userEmail = userEmail
-    }
+  func update(isSignedIn: Bool, userEmail: String? = nil) {
+    self.isSignedIn = isSignedIn
+    self.userEmail = userEmail
+  }
 
-    /// Get the user's Firebase UID from UserDefaults (fallback when Firebase SDK auth fails)
-    var userId: String? {
-        UserDefaults.standard.string(forKey: Self.kAuthUserId)
-    }
+  /// Get the user's Firebase UID from UserDefaults (fallback when Firebase SDK auth fails)
+  var userId: String? {
+    UserDefaults.standard.string(forKey: Self.kAuthUserId)
+  }
 }
 
 @main
 struct OMIApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @StateObject private var appState = AppState()
-    @StateObject private var authState = AuthState.shared
-    @Environment(\.openWindow) private var openWindow
+  @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+  @StateObject private var appState = AppState()
+  @StateObject private var authState = AuthState.shared
+  @Environment(\.openWindow) private var openWindow
 
-    /// Launch mode determined at startup from command-line arguments
-    static let launchMode = LaunchMode.fromCommandLine()
+  /// Launch mode determined at startup from command-line arguments
+  static let launchMode = LaunchMode.fromCommandLine()
 
-    /// Window title with version number (different for rewind mode)
-    private var windowTitle: String {
-        // Keep a distinct title in dev builds so users can visually distinguish
-        // dev and production windows during side-by-side testing.
-        if Bundle.main.bundleIdentifier == "com.omi.desktop-dev" {
-            return Self.launchMode == .rewind ? "Omi Rewind Dev" : "Omi Dev"
-        }
-
-        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
-        let baseName = Self.launchMode == .rewind ? "omi Rewind" : UpdateChannel.appDisplayName
-        return version.isEmpty ? baseName : "\(baseName) v\(version)"
+  /// Window title with version number (different for rewind mode)
+  private var windowTitle: String {
+    // Keep a distinct title in dev builds so users can visually distinguish
+    // dev and production windows during side-by-side testing.
+    if Bundle.main.bundleIdentifier == "com.omi.desktop-dev" {
+      return Self.launchMode == .rewind ? "Omi Rewind Dev" : "Omi Dev"
     }
 
-    /// Window size based on launch mode
-    private var defaultWindowSize: CGSize {
-        Self.launchMode == .rewind ? CGSize(width: 1000, height: 700) : CGSize(width: 1200, height: 800)
+    let version =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+    let baseName = Self.launchMode == .rewind ? "omi Rewind" : UpdateChannel.appDisplayName
+    return version.isEmpty ? baseName : "\(baseName) v\(version)"
+  }
+
+  /// Window size based on launch mode
+  private var defaultWindowSize: CGSize {
+    Self.launchMode == .rewind ? CGSize(width: 1000, height: 700) : CGSize(width: 1200, height: 800)
+  }
+
+  var body: some Scene {
+    // Main desktop window - same view for both modes, sidebar hidden in rewind mode
+    Window(windowTitle, id: "main") {
+      DesktopHomeView()
+        .withFontScaling()
+        .onAppear {
+          log("OmiApp: Main window content appeared (mode: \(Self.launchMode.rawValue))")
+        }
+    }
+    .windowStyle(.titleBar)
+    .defaultSize(width: defaultWindowSize.width, height: defaultWindowSize.height)
+    .commands {
+      CommandGroup(after: .textFormatting) {
+        Button("Increase Font Size") {
+          let s = FontScaleSettings.shared
+          s.scale = min(2.0, round((s.scale + 0.05) * 20) / 20)
+        }
+        .keyboardShortcut("+", modifiers: .command)
+
+        Button("Decrease Font Size") {
+          let s = FontScaleSettings.shared
+          s.scale = max(0.5, round((s.scale - 0.05) * 20) / 20)
+        }
+        .keyboardShortcut("-", modifiers: .command)
+
+        Button("Reset Font Size") {
+          FontScaleSettings.shared.resetToDefault()
+        }
+        .keyboardShortcut("0", modifiers: .command)
+
+        Divider()
+
+        Button("Reset Window Size") {
+          resetWindowToDefaultSize()
+        }
+      }
     }
 
-    var body: some Scene {
-        // Main desktop window - same view for both modes, sidebar hidden in rewind mode
-        Window(windowTitle, id: "main") {
-            DesktopHomeView()
-                .withFontScaling()
-                .onAppear {
-                    log("OmiApp: Main window content appeared (mode: \(Self.launchMode.rawValue))")
-                }
-        }
-        .windowStyle(.titleBar)
-        .defaultSize(width: defaultWindowSize.width, height: defaultWindowSize.height)
-        .commands {
-            CommandGroup(after: .textFormatting) {
-                Button("Increase Font Size") {
-                    let s = FontScaleSettings.shared
-                    s.scale = min(2.0, round((s.scale + 0.05) * 20) / 20)
-                }
-                .keyboardShortcut("+", modifiers: .command)
-
-                Button("Decrease Font Size") {
-                    let s = FontScaleSettings.shared
-                    s.scale = max(0.5, round((s.scale - 0.05) * 20) / 20)
-                }
-                .keyboardShortcut("-", modifiers: .command)
-
-                Button("Reset Font Size") {
-                    FontScaleSettings.shared.resetToDefault()
-                }
-                .keyboardShortcut("0", modifiers: .command)
-
-                Divider()
-
-                Button("Reset Window Size") {
-                    resetWindowToDefaultSize()
-                }
-            }
-        }
-
-        // Note: Menu bar is now handled by NSStatusBar in AppDelegate.setupMenuBar()
-        // for better reliability on macOS Sequoia (SwiftUI MenuBarExtra had rendering issues)
-    }
+    // Note: Menu bar is now handled by NSStatusBar in AppDelegate.setupMenuBar()
+    // for better reliability on macOS Sequoia (SwiftUI MenuBarExtra had rendering issues)
+  }
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
-    private var sentryHeartbeatTimer: Timer?
-    private var globalHotkeyMonitor: Any?
-    private var localHotkeyMonitor: Any?
-    private var windowObservers: [NSObjectProtocol] = []
-    private var statusBarItem: NSStatusItem?
-    private var screenCaptureSwitch: NSSwitch?
-    private var audioRecordingSwitch: NSSwitch?
+  private var sentryHeartbeatTimer: Timer?
+  private var globalHotkeyMonitor: Any?
+  private var localHotkeyMonitor: Any?
+  private var windowObservers: [NSObjectProtocol] = []
+  private var statusBarItem: NSStatusItem?
+  private var screenCaptureSwitch: NSSwitch?
+  private var audioRecordingSwitch: NSSwitch?
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
-        // Ignore SIGPIPE so broken-pipe writes return errors instead of crashing the app.
-        // Without this, writing to a dead FFmpeg stdin or agent-bridge pipe kills the process.
-        signal(SIGPIPE, SIG_IGN)
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    // Ignore SIGPIPE so broken-pipe writes return errors instead of crashing the app.
+    // Without this, writing to a dead FFmpeg stdin or agent-bridge pipe kills the process.
+    signal(SIGPIPE, SIG_IGN)
 
-        // Strip com.apple.provenance xattrs that macOS adds when Sparkle extracts updates.
-        // These break the code signature seal, causing the NEXT update to fail with
-        // "An error occurred while running the updater."
-        stripProvenanceXattrs()
+    DesktopAutomationBridge.shared.startIfNeeded()
 
-        log("AppDelegate: applicationDidFinishLaunching started (mode: \(OMIApp.launchMode.rawValue))")
-        log("AppDelegate: AuthState.isSignedIn=\(AuthState.shared.isSignedIn)")
+    // Strip com.apple.provenance xattrs that macOS adds when Sparkle extracts updates.
+    // These break the code signature seal, causing the NEXT update to fail with
+    // "An error occurred while running the updater."
+    stripProvenanceXattrs()
 
-        // Force macOS to use the correct app icon (bypasses icon cache).
-        // Apply squircle mask with proper margins because NSApp.applicationIconImage
-        // renders the raw image without macOS auto-masking.
-        // Do NOT call NSWorkspace.setIcon(forFile:) — it writes a resource fork onto
-        // the .app bundle, which breaks the code signature and prevents Sparkle
-        // auto-updates from working ("An error occurred while running the updater").
-        if let iconURL = Bundle.resourceBundle.url(forResource: "omi_app_icon", withExtension: "png"),
-           let icon = NSImage(contentsOf: iconURL) {
-            let size = icon.size
-            let maskedIcon = NSImage(size: size)
-            maskedIcon.lockFocus()
-            // Scale content to ~88% with 6% margin on each side (matches macOS Dock icon sizing)
-            let margin = size.width * 0.06
-            let contentRect = NSRect(x: margin, y: margin,
-                                     width: size.width - margin * 2,
-                                     height: size.height - margin * 2)
-            // Corner radius ≈ 22.37% of content size
-            let radius = contentRect.width * 0.2237
-            let path = NSBezierPath(roundedRect: contentRect, xRadius: radius, yRadius: radius)
-            path.addClip()
-            icon.draw(in: contentRect)
-            maskedIcon.unlockFocus()
-            NSApp.applicationIconImage = maskedIcon
-            if let cfURL = Bundle.main.bundleURL as CFURL? {
-                LSRegisterURL(cfURL, true)
-            }
-            log("AppDelegate: Set application icon with squircle mask")
-        }
+    log("AppDelegate: applicationDidFinishLaunching started (mode: \(OMIApp.launchMode.rawValue))")
+    log("AppDelegate: AuthState.isSignedIn=\(AuthState.shared.isSignedIn)")
 
-        // One-time icon cache reset: forces macOS to pick up the new squircle icon.
-        // Without this, users who had the old square icon see it cached indefinitely
-        // in the Dock, notifications, and Sparkle updater.
-        resetIconCacheIfNeeded()
+    // Force macOS to use the correct app icon (bypasses icon cache).
+    // Apply squircle mask with proper margins because NSApp.applicationIconImage
+    // renders the raw image without macOS auto-masking.
+    // Do NOT call NSWorkspace.setIcon(forFile:) — it writes a resource fork onto
+    // the .app bundle, which breaks the code signature and prevents Sparkle
+    // auto-updates from working ("An error occurred while running the updater").
+    if let iconURL = Bundle.resourceBundle.url(forResource: "omi_app_icon", withExtension: "png"),
+      let icon = NSImage(contentsOf: iconURL)
+    {
+      let size = icon.size
+      let maskedIcon = NSImage(size: size)
+      maskedIcon.lockFocus()
+      // Scale content to ~88% with 6% margin on each side (matches macOS Dock icon sizing)
+      let margin = size.width * 0.06
+      let contentRect = NSRect(
+        x: margin, y: margin,
+        width: size.width - margin * 2,
+        height: size.height - margin * 2)
+      // Corner radius ≈ 22.37% of content size
+      let radius = contentRect.width * 0.2237
+      let path = NSBezierPath(roundedRect: contentRect, xRadius: radius, yRadius: radius)
+      path.addClip()
+      icon.draw(in: contentRect)
+      maskedIcon.unlockFocus()
+      NSApp.applicationIconImage = maskedIcon
+      if let cfURL = Bundle.main.bundleURL as CFURL? {
+        LSRegisterURL(cfURL, true)
+      }
+      log("AppDelegate: Set application icon with squircle mask")
+    }
 
-        // Initialize NotificationService early to set up UNUserNotificationCenterDelegate
-        // This ensures notifications display properly when app is in foreground
-        _ = NotificationService.shared
+    // One-time icon cache reset: forces macOS to pick up the new squircle icon.
+    // Without this, users who had the old square icon see it cached indefinitely
+    // in the Dock, notifications, and Sparkle updater.
+    resetIconCacheIfNeeded()
+
+    // Initialize NotificationService early to set up UNUserNotificationCenterDelegate
+    // This ensures notifications display properly when app is in foreground
+    _ = NotificationService.shared
 
         // Initialize Sparkle auto-updater early so the 10-minute check timer starts at launch
         // Without this, the updater only starts when the user opens Settings or clicks "Check for Updates"
         _ = UpdaterViewModel.shared
+        UpdaterViewModel.shared.checkForUpdatesImmediatelyAfterLaunchIfNeeded()
 
-        // Initialize Sentry for crash reporting and error tracking (including dev builds)
-        let isDev = AnalyticsManager.isDevBuild
-        SentrySDK.start { options in
-            options.dsn = "https://8f700584deda57b26041ff015539c8c1@o4507617161314304.ingest.us.sentry.io/4510790686277632"
-            options.debug = false
-            options.enableAutoSessionTracking = true
-            options.environment = isDev ? "development" : "production"
-            // Disable automatic HTTP client error capture — the SDK creates noisy events
-            // for every 4xx/5xx response (e.g. Cloud Run 503 cold starts on /v1/crisp/unread).
-            // App code already handles HTTP errors and reports meaningful ones explicitly.
-            options.enableCaptureFailedRequests = false
-            options.maxBreadcrumbs = 100
-            options.beforeSend = { event in
-                // Allow user feedback through from all builds (dev + prod)
-                if event.message?.formatted.hasPrefix("User Report") == true { return event }
-                // Never send other events from dev builds — they pollute production Sentry data
-                if isDev { return nil }
-                // Filter out HTTP errors targeting the dev tunnel — noise when the tunnel is down
-                if let urlTag = event.tags?["url"], urlTag.contains("m13v.com") {
-                    return nil
-                }
-                // Filter out NSURLErrorCancelled (-999) — these are intentional cancellations
-                // (e.g. proactive assistants cancelling in-flight Gemini requests on context switch)
-                if let exceptions = event.exceptions, exceptions.contains(where: { exc in
-                    exc.type == "NSURLErrorDomain" && exc.value.contains("Code=-999") ||
-                    exc.type == "NSURLErrorDomain" && exc.value.contains("Code: -999")
-                }) {
-                    return nil
-                }
-                // Filter out AuthError.notSignedIn — this is thrown when token refresh transiently
-                // fails (network blip, expired token mid-refresh). The user is still signed in per
-                // UserDefaults; the 30s refresh timer will retry. Not actionable as a Sentry error.
-                if let exceptions = event.exceptions, exceptions.contains(where: { exc in
-                    exc.type == "Omi_Computer.AuthError" && exc.value.contains("notSignedIn")
-                }) {
-                    return nil
-                }
-                return event
-            }
+    // Initialize Sentry for crash reporting and error tracking (including dev builds)
+    let isDev = AnalyticsManager.isDevBuild
+    SentrySDK.start { options in
+      options.dsn =
+        "https://8f700584deda57b26041ff015539c8c1@o4507617161314304.ingest.us.sentry.io/4510790686277632"
+      options.debug = false
+      options.enableAutoSessionTracking = true
+      options.environment = isDev ? "development" : "production"
+      // Disable automatic HTTP client error capture — the SDK creates noisy events
+      // for every 4xx/5xx response (e.g. Cloud Run 503 cold starts on /v1/crisp/unread).
+      // App code already handles HTTP errors and reports meaningful ones explicitly.
+      options.enableCaptureFailedRequests = false
+      options.maxBreadcrumbs = 100
+      options.beforeSend = { event in
+        // Allow user feedback through from all builds (dev + prod)
+        if event.message?.formatted.hasPrefix("User Report") == true { return event }
+        // Never send other events from dev builds — they pollute production Sentry data
+        if isDev { return nil }
+        // Filter out HTTP errors targeting the dev tunnel — noise when the tunnel is down
+        if let urlTag = event.tags?["url"], urlTag.contains("m13v.com") {
+          return nil
         }
-        log("Sentry initialized (environment: \(isDev ? "development" : "production"))")
-
-        // Initialize Firebase
-        let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist")
-
-        if let path = plistPath,
-           let options = FirebaseOptions(contentsOfFile: path) {
-            FirebaseApp.configure(options: options)
-            AuthService.shared.configure()
+        // Filter out NSURLErrorCancelled (-999) — these are intentional cancellations
+        // (e.g. proactive assistants cancelling in-flight Gemini requests on context switch)
+        if let exceptions = event.exceptions,
+          exceptions.contains(where: { exc in
+            exc.type == "NSURLErrorDomain" && exc.value.contains("Code=-999")
+              || exc.type == "NSURLErrorDomain" && exc.value.contains("Code: -999")
+          })
+        {
+          return nil
         }
-
-        // Initialize analytics (MixPanel + PostHog)
-        AnalyticsManager.shared.initialize()
-        AnalyticsManager.shared.appLaunched()
-        AnalyticsManager.shared.trackDisplayInfo()
-
-        // Tier gating: migrate old boolean key to new 6-tier system
-        TierManager.migrateExistingUsersIfNeeded()
-
-        // All users get all features (tier 0 = show all)
-        // Note: hasLaunchedBefore is also set by trackFirstLaunchIfNeeded(), but that
-        // skips dev builds. Set it here too so tier doesn't reset on every dev launch.
-        if !UserDefaults.standard.bool(forKey: "hasLaunchedBefore") {
-            UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
-            UserDefaults.standard.set(0, forKey: "currentTierLevel")
-            UserDefaults.standard.set(0, forKey: "lastSeenTierLevel")
-            UserDefaults.standard.set(true, forKey: "userShowAllFeatures")
+        // Filter out AuthError.notSignedIn — this is thrown when token refresh transiently
+        // fails (network blip, expired token mid-refresh). The user is still signed in per
+        // UserDefaults; the 30s refresh timer will retry. Not actionable as a Sentry error.
+        if let exceptions = event.exceptions,
+          exceptions.contains(where: { exc in
+            exc.type == "Omi_Computer.AuthError" && exc.value.contains("notSignedIn")
+          })
+        {
+          return nil
         }
+        return event
+      }
+    }
+    log("Sentry initialized (environment: \(isDev ? "development" : "production"))")
 
-        AnalyticsManager.shared.trackFirstLaunchIfNeeded()
+    // Initialize Firebase
+    let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist")
 
-        // Set per-user database path before any async tasks can trigger DB initialization.
-        // This is synchronous and must happen before TierManager / TranscriptionRetryService.
-        let userId = UserDefaults.standard.string(forKey: "auth_userId")
-        RewindDatabase.currentUserId = (userId?.isEmpty == false) ? userId : "anonymous"
+    if let path = plistPath,
+      let options = FirebaseOptions(contentsOfFile: path)
+    {
+      FirebaseApp.configure(options: options)
+      AuthService.shared.configure()
+    }
 
-        // Start resource monitoring (memory, CPU, disk)
-        ResourceMonitor.shared.start()
+    // Initialize analytics (MixPanel + PostHog)
+    AnalyticsManager.shared.initialize()
+    AnalyticsManager.shared.appLaunched()
+    AnalyticsManager.shared.trackDisplayInfo()
 
-        // Recover any pending/failed transcription sessions from previous runs
-        Task {
-            await TranscriptionRetryService.shared.recoverPendingTranscriptions()
-            TranscriptionRetryService.shared.start()
+    // Tier gating: migrate old boolean key to new 6-tier system
+    TierManager.migrateExistingUsersIfNeeded()
+
+    // All users get all features (tier 0 = show all)
+    // Note: hasLaunchedBefore is also set by trackFirstLaunchIfNeeded(), but that
+    // skips dev builds. Set it here too so tier doesn't reset on every dev launch.
+    if !UserDefaults.standard.bool(forKey: "hasLaunchedBefore") {
+      UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
+      UserDefaults.standard.set(0, forKey: "currentTierLevel")
+      UserDefaults.standard.set(0, forKey: "lastSeenTierLevel")
+      UserDefaults.standard.set(true, forKey: "userShowAllFeatures")
+    }
+
+    AnalyticsManager.shared.trackFirstLaunchIfNeeded()
+
+    // Set per-user database path before any async tasks can trigger DB initialization.
+    // This is synchronous and must happen before TierManager / TranscriptionRetryService.
+    let userId = UserDefaults.standard.string(forKey: "auth_userId")
+    RewindDatabase.currentUserId = (userId?.isEmpty == false) ? userId : "anonymous"
+
+    // Start resource monitoring (memory, CPU, disk)
+    ResourceMonitor.shared.start()
+
+    // Recover any pending/failed transcription sessions from previous runs
+    Task {
+      await TranscriptionRetryService.shared.recoverPendingTranscriptions()
+      TranscriptionRetryService.shared.start()
+    }
+
+    // Start recurring task scheduler (checks every 60s for due tasks)
+    RecurringTaskScheduler.shared.start()
+
+    // Identify user if already signed in
+    if AuthState.shared.isSignedIn {
+      AnalyticsManager.shared.identify()
+      // Set Sentry user context (now enabled for dev builds too)
+      if let email = AuthState.shared.userEmail {
+        let sentryUser = Sentry.User()
+        sentryUser.email = email
+        sentryUser.username =
+          AuthService.shared.displayName.isEmpty ? nil : AuthService.shared.displayName
+        SentrySDK.setUser(sentryUser)
+      }
+      // Fetch conversations on startup
+      AuthService.shared.fetchConversations()
+
+      // Check tier eligibility (at most once per day)
+      Task {
+        await TierManager.shared.checkTierIfNeeded()
+      }
+
+      // Report comprehensive settings state (at most once per day)
+      AnalyticsManager.shared.reportAllSettingsIfNeeded()
+
+      // File indexing now runs through FileIndexingView UI (user consent required)
+      // No background scan — prevents race condition where scan finishes before UI listens
+    }
+
+    // One-time migration: Enable launch at login for existing users who haven't set it
+    migrateLaunchAtLoginDefault()
+
+    // One-time migration: Rename app bundle from legacy names to "omi.app"
+    migrateAppName()
+
+    // Track launch at login status once per app launch
+    Task { @MainActor in
+      let isEnabled = LaunchAtLoginManager.shared.isEnabled
+      AnalyticsManager.shared.launchAtLoginStatusChecked(enabled: isEnabled)
+    }
+
+    // Register for Apple Events to handle URL scheme
+    NSAppleEventManager.shared().setEventHandler(
+      self,
+      andSelector: #selector(handleGetURLEvent(_:withReplyEvent:)),
+      forEventClass: AEEventClass(kInternetEventClass),
+      andEventID: AEEventID(kAEGetURL)
+    )
+
+    // Register global hotkey for Rewind (Cmd+Shift+Space)
+    setupGlobalHotkeys()
+
+    // Register Carbon-based global shortcuts for floating control bar (Ask Omi)
+    GlobalShortcutManager.shared.registerShortcuts()
+
+    // Ensure app always shows in dock as a regular app
+    NSApp.setActivationPolicy(.regular)
+
+    // Set up menu bar icon with NSStatusBar (more reliable than SwiftUI MenuBarExtra)
+    // Called synchronously on main thread to ensure status item is created before app finishes launching
+    Task { @MainActor in
+      self.setupMenuBar()
+    }
+
+    // Periodic health check: verify menu bar icon is still visible every 30 seconds.
+    // Safety net for any edge case (macOS Sequoia bugs, activation policy races) that
+    // causes the status bar item to vanish while the process keeps running.
+    Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+      DispatchQueue.main.async {
+        guard let self = self else { return }
+        let item = self.statusBarItem
+        let button = item?.button
+        let isPhantom = button != nil && button!.frame.width == 0
+        if item?.isVisible != true || button == nil || isPhantom {
+          log(
+            "AppDelegate: [MENUBAR] Health check: icon missing or phantom (visible=\(item?.isVisible ?? false), button=\(button != nil), frame=\(button?.frame ?? .zero)), recreating"
+          )
+          self.setupMenuBar()
         }
+      }
+    }
 
-        // Start recurring task scheduler (checks every 60s for due tasks)
-        RecurringTaskScheduler.shared.start()
+    // Start Sentry heartbeat timer (every 5 minutes) to capture breadcrumbs periodically
+    startSentryHeartbeat()
 
-        // Identify user if already signed in
-        if AuthState.shared.isSignedIn {
-            AnalyticsManager.shared.identify()
-            // Set Sentry user context (now enabled for dev builds too)
-            if let email = AuthState.shared.userEmail {
-                let sentryUser = Sentry.User()
-                sentryUser.email = email
-                sentryUser.username = AuthService.shared.displayName.isEmpty ? nil : AuthService.shared.displayName
-                SentrySDK.setUser(sentryUser)
-            }
-            // Fetch conversations on startup
-            AuthService.shared.fetchConversations()
-
-            // Check tier eligibility (at most once per day)
-            Task {
-                await TierManager.shared.checkTierIfNeeded()
-            }
-
-            // Report comprehensive settings state (at most once per day)
-            AnalyticsManager.shared.reportAllSettingsIfNeeded()
-
-            // File indexing now runs through FileIndexingView UI (user consent required)
-            // No background scan — prevents race condition where scan finishes before UI listens
+    // Activate app and show main window after a brief delay
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+      log("AppDelegate: Checking windows after 0.2s delay, count=\(NSApp.windows.count)")
+      NSApp.activate(ignoringOtherApps: true)
+      var foundOmiWindow = false
+      for window in NSApp.windows {
+        log("AppDelegate: Window title='\(window.title)', isVisible=\(window.isVisible)")
+        if window.title.hasPrefix("Omi") {
+          foundOmiWindow = true
+          window.makeKeyAndOrderFront(nil)
+          window.appearance = NSAppearance(named: .darkAqua)
+          // Ensure fullscreen always creates a dedicated Space
+          window.collectionBehavior.insert(.fullScreenPrimary)
+          log("AppDelegate: Main window shown on launch")
         }
+      }
+      if !foundOmiWindow {
+        log("AppDelegate: WARNING - 'Omi' window not found!")
+      }
+    }
 
-        // One-time migration: Enable launch at login for existing users who haven't set it
-        migrateLaunchAtLoginDefault()
+    log("AppDelegate: applicationDidFinishLaunching completed")
+  }
 
-        // One-time migration: Rename app bundle from legacy names to "omi.app"
-        migrateAppName()
+  /// Start a timer that sends Sentry session snapshots every 5 minutes
+  /// This ensures we have breadcrumbs captured even without errors
+  private func startSentryHeartbeat() {
+    // Now runs in dev builds too since Sentry is always initialized
+    sentryHeartbeatTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
+      // Capture a session heartbeat event with current breadcrumbs
+      SentrySDK.capture(message: "Session Heartbeat") { scope in
+        scope.setLevel(.info)
+        scope.setTag(value: "heartbeat", key: "event_type")
+      }
+      log("Sentry: Session heartbeat captured")
+    }
+  }
 
-        // Track launch at login status once per app launch
-        Task { @MainActor in
-            let isEnabled = LaunchAtLoginManager.shared.isEnabled
-            AnalyticsManager.shared.launchAtLoginStatusChecked(enabled: isEnabled)
-        }
+  /// Strip com.apple.provenance extended attributes from our own bundle.
+  /// macOS adds these when Sparkle extracts the update ZIP, which breaks the code
+  /// signature seal and causes subsequent updates to fail.
+  private func stripProvenanceXattrs() {
+    let bundlePath = Bundle.main.bundlePath
+    DispatchQueue.global(qos: .utility).async {
+      let process = Process()
+      process.launchPath = "/usr/bin/xattr"
+      process.arguments = ["-cr", bundlePath]
+      process.standardOutput = nil
+      process.standardError = nil
+      try? process.run()
+      process.waitUntilExit()
+      if process.terminationStatus == 0 {
+        log("AppDelegate: Stripped provenance xattrs from bundle")
+      }
+    }
+  }
 
-        // Register for Apple Events to handle URL scheme
-        NSAppleEventManager.shared().setEventHandler(
-            self,
-            andSelector: #selector(handleGetURLEvent(_:withReplyEvent:)),
-            forEventClass: AEEventClass(kInternetEventClass),
-            andEventID: AEEventID(kAEGetURL)
+  /// One-time icon cache reset to force macOS to pick up the new squircle icon.
+  /// Runs lsregister unregister/register + kills iconservicesagent (auto-restarts).
+  /// Includes a safety net to restart the Dock if it crashes during the reset.
+  private func resetIconCacheIfNeeded() {
+    let key = "hasResetIconCache_v2"
+    guard !UserDefaults.standard.bool(forKey: key) else { return }
+    UserDefaults.standard.set(true, forKey: key)
+    log("AppDelegate: Running one-time icon cache reset")
+
+    let appPath = Bundle.main.bundlePath
+    let lsregister =
+      "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+
+    DispatchQueue.global(qos: .utility).async {
+      // Unregister to clear stale icon entries
+      let unregister = Process()
+      unregister.executableURL = URL(fileURLWithPath: lsregister)
+      unregister.arguments = ["-u", appPath]
+      unregister.standardOutput = FileHandle.nullDevice
+      unregister.standardError = FileHandle.nullDevice
+      try? unregister.run()
+      unregister.waitUntilExit()
+
+      // Force re-register with updated icon
+      let register = Process()
+      register.executableURL = URL(fileURLWithPath: lsregister)
+      register.arguments = ["-f", appPath]
+      register.standardOutput = FileHandle.nullDevice
+      register.standardError = FileHandle.nullDevice
+      try? register.run()
+      register.waitUntilExit()
+
+      // Kill iconservicesagent to flush the icon cache (auto-restarts in <1s)
+      let killIcons = Process()
+      killIcons.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+      killIcons.arguments = ["iconservicesagent"]
+      killIcons.standardOutput = FileHandle.nullDevice
+      killIcons.standardError = FileHandle.nullDevice
+      try? killIcons.run()
+      killIcons.waitUntilExit()
+
+      // Safety net: verify the Dock is still running after 2 seconds.
+      // iconservicesagent restart can occasionally crash the Dock.
+      Thread.sleep(forTimeInterval: 2.0)
+      let dockCheck = Process()
+      dockCheck.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+      dockCheck.arguments = ["-x", "Dock"]
+      dockCheck.standardOutput = FileHandle.nullDevice
+      dockCheck.standardError = FileHandle.nullDevice
+      try? dockCheck.run()
+      dockCheck.waitUntilExit()
+
+      if dockCheck.terminationStatus != 0 {
+        // Dock is not running — restart it
+        log("AppDelegate: Dock not running after icon cache reset, restarting")
+        let restartDock = Process()
+        restartDock.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        restartDock.arguments = ["-a", "Dock"]
+        restartDock.standardOutput = FileHandle.nullDevice
+        restartDock.standardError = FileHandle.nullDevice
+        try? restartDock.run()
+        restartDock.waitUntilExit()
+      }
+
+      log("AppDelegate: Icon cache reset complete")
+    }
+  }
+
+  /// Set up global keyboard shortcuts
+  private func setupGlobalHotkeys() {
+    // Handler for Ctrl+Option+R -> Open Rewind
+    let hotkeyHandler: (NSEvent) -> NSEvent? = { event in
+      let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+      let keyCode = event.keyCode
+
+      // Log modifier key presses for debugging
+      if modifiers.contains(.control) || modifiers.contains(.option) {
+        log(
+          "AppDelegate: [HOTKEY] keyCode=\(keyCode), modifiers=\(modifiers.rawValue) (ctrl=\(modifiers.contains(.control)), opt=\(modifiers.contains(.option)))"
         )
+      }
 
-        // Register global hotkey for Rewind (Cmd+Shift+Space)
-        setupGlobalHotkeys()
+      // Check for Ctrl+Option+R (less likely to conflict with system shortcuts)
+      let isCtrlOption = modifiers.contains(.control) && modifiers.contains(.option)
+      let isR = keyCode == 15  // R key
 
-        // Register Carbon-based global shortcuts for floating control bar (Ask Omi)
-        GlobalShortcutManager.shared.registerShortcuts()
-
-        // Ensure app always shows in dock as a regular app
-        NSApp.setActivationPolicy(.regular)
-
-        // Set up menu bar icon with NSStatusBar (more reliable than SwiftUI MenuBarExtra)
-        // Called synchronously on main thread to ensure status item is created before app finishes launching
-        Task { @MainActor in
-            self.setupMenuBar()
-        }
-
-        // Periodic health check: verify menu bar icon is still visible every 30 seconds.
-        // Safety net for any edge case (macOS Sequoia bugs, activation policy races) that
-        // causes the status bar item to vanish while the process keeps running.
-        Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
-            DispatchQueue.main.async {
-                guard let self = self else { return }
-                let item = self.statusBarItem
-                let button = item?.button
-                let isPhantom = button != nil && button!.frame.width == 0
-                if item?.isVisible != true || button == nil || isPhantom {
-                    log("AppDelegate: [MENUBAR] Health check: icon missing or phantom (visible=\(item?.isVisible ?? false), button=\(button != nil), frame=\(button?.frame ?? .zero)), recreating")
-                    self.setupMenuBar()
-                }
-            }
-        }
-
-        // Start Sentry heartbeat timer (every 5 minutes) to capture breadcrumbs periodically
-        startSentryHeartbeat()
-
-        // Activate app and show main window after a brief delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            log("AppDelegate: Checking windows after 0.2s delay, count=\(NSApp.windows.count)")
-            NSApp.activate(ignoringOtherApps: true)
-            var foundOmiWindow = false
-            for window in NSApp.windows {
-                log("AppDelegate: Window title='\(window.title)', isVisible=\(window.isVisible)")
-                if window.title.hasPrefix("Omi") {
-                    foundOmiWindow = true
-                    window.makeKeyAndOrderFront(nil)
-                    window.appearance = NSAppearance(named: .darkAqua)
-                    // Ensure fullscreen always creates a dedicated Space
-                    window.collectionBehavior.insert(.fullScreenPrimary)
-                    log("AppDelegate: Main window shown on launch")
-                }
-            }
-            if !foundOmiWindow {
-                log("AppDelegate: WARNING - 'Omi' window not found!")
-            }
-        }
-
-        log("AppDelegate: applicationDidFinishLaunching completed")
-    }
-
-    /// Start a timer that sends Sentry session snapshots every 5 minutes
-    /// This ensures we have breadcrumbs captured even without errors
-    private func startSentryHeartbeat() {
-        // Now runs in dev builds too since Sentry is always initialized
-        sentryHeartbeatTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
-            // Capture a session heartbeat event with current breadcrumbs
-            SentrySDK.capture(message: "Session Heartbeat") { scope in
-                scope.setLevel(.info)
-                scope.setTag(value: "heartbeat", key: "event_type")
-            }
-            log("Sentry: Session heartbeat captured")
-        }
-    }
-
-    /// Strip com.apple.provenance extended attributes from our own bundle.
-    /// macOS adds these when Sparkle extracts the update ZIP, which breaks the code
-    /// signature seal and causes subsequent updates to fail.
-    private func stripProvenanceXattrs() {
-        let bundlePath = Bundle.main.bundlePath
-        DispatchQueue.global(qos: .utility).async {
-            let process = Process()
-            process.launchPath = "/usr/bin/xattr"
-            process.arguments = ["-cr", bundlePath]
-            process.standardOutput = nil
-            process.standardError = nil
-            try? process.run()
-            process.waitUntilExit()
-            if process.terminationStatus == 0 {
-                log("AppDelegate: Stripped provenance xattrs from bundle")
-            }
-        }
-    }
-
-    /// One-time icon cache reset to force macOS to pick up the new squircle icon.
-    /// Runs lsregister unregister/register + kills iconservicesagent (auto-restarts).
-    /// Includes a safety net to restart the Dock if it crashes during the reset.
-    private func resetIconCacheIfNeeded() {
-        let key = "hasResetIconCache_v2"
-        guard !UserDefaults.standard.bool(forKey: key) else { return }
-        UserDefaults.standard.set(true, forKey: key)
-        log("AppDelegate: Running one-time icon cache reset")
-
-        let appPath = Bundle.main.bundlePath
-        let lsregister = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
-
-        DispatchQueue.global(qos: .utility).async {
-            // Unregister to clear stale icon entries
-            let unregister = Process()
-            unregister.executableURL = URL(fileURLWithPath: lsregister)
-            unregister.arguments = ["-u", appPath]
-            unregister.standardOutput = FileHandle.nullDevice
-            unregister.standardError = FileHandle.nullDevice
-            try? unregister.run()
-            unregister.waitUntilExit()
-
-            // Force re-register with updated icon
-            let register = Process()
-            register.executableURL = URL(fileURLWithPath: lsregister)
-            register.arguments = ["-f", appPath]
-            register.standardOutput = FileHandle.nullDevice
-            register.standardError = FileHandle.nullDevice
-            try? register.run()
-            register.waitUntilExit()
-
-            // Kill iconservicesagent to flush the icon cache (auto-restarts in <1s)
-            let killIcons = Process()
-            killIcons.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
-            killIcons.arguments = ["iconservicesagent"]
-            killIcons.standardOutput = FileHandle.nullDevice
-            killIcons.standardError = FileHandle.nullDevice
-            try? killIcons.run()
-            killIcons.waitUntilExit()
-
-            // Safety net: verify the Dock is still running after 2 seconds.
-            // iconservicesagent restart can occasionally crash the Dock.
-            Thread.sleep(forTimeInterval: 2.0)
-            let dockCheck = Process()
-            dockCheck.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-            dockCheck.arguments = ["-x", "Dock"]
-            dockCheck.standardOutput = FileHandle.nullDevice
-            dockCheck.standardError = FileHandle.nullDevice
-            try? dockCheck.run()
-            dockCheck.waitUntilExit()
-
-            if dockCheck.terminationStatus != 0 {
-                // Dock is not running — restart it
-                log("AppDelegate: Dock not running after icon cache reset, restarting")
-                let restartDock = Process()
-                restartDock.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-                restartDock.arguments = ["-a", "Dock"]
-                restartDock.standardOutput = FileHandle.nullDevice
-                restartDock.standardError = FileHandle.nullDevice
-                try? restartDock.run()
-                restartDock.waitUntilExit()
-            }
-
-            log("AppDelegate: Icon cache reset complete")
-        }
-    }
-
-    /// Set up global keyboard shortcuts
-    private func setupGlobalHotkeys() {
-        // Handler for Ctrl+Option+R -> Open Rewind
-        let hotkeyHandler: (NSEvent) -> NSEvent? = { event in
-            let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            let keyCode = event.keyCode
-
-            // Log modifier key presses for debugging
-            if modifiers.contains(.control) || modifiers.contains(.option) {
-                log("AppDelegate: [HOTKEY] keyCode=\(keyCode), modifiers=\(modifiers.rawValue) (ctrl=\(modifiers.contains(.control)), opt=\(modifiers.contains(.option)))")
-            }
-
-            // Check for Ctrl+Option+R (less likely to conflict with system shortcuts)
-            let isCtrlOption = modifiers.contains(.control) && modifiers.contains(.option)
-            let isR = keyCode == 15 // R key
-
-            if isCtrlOption && isR {
-                log("AppDelegate: [HOTKEY] Rewind hotkey MATCHED (Ctrl+Option+R)")
-                DispatchQueue.main.async {
-                    log("AppDelegate: [HOTKEY] Activating app and posting notification")
-                    // Bring app to front
-                    NSApp.activate(ignoringOtherApps: true)
-                    // Find and show main window
-                    for window in NSApp.windows {
-                        if window.title.hasPrefix("Omi") {
-                            window.makeKeyAndOrderFront(nil)
-                            break
-                        }
-                    }
-                    // Post notification to navigate to Rewind
-                    NotificationCenter.default.post(name: .navigateToRewind, object: nil)
-                    log("AppDelegate: [HOTKEY] Posted navigateToRewind notification")
-                }
-            }
-            return event
-        }
-
-        // Ask Omi shortcut is registered via Carbon RegisterEventHotKey in
-        // GlobalShortcutManager (works regardless of accessibility permission state).
-
-        // Global monitor - for when OTHER apps are focused (Ctrl+Option+R only)
-        globalHotkeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
-            _ = hotkeyHandler(event)
-        }
-
-        // Local monitor - for when THIS app is focused (Ctrl+Option+R only)
-        localHotkeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            return hotkeyHandler(event)
-        }
-
-        log("AppDelegate: Hotkey monitors registered - global=\(globalHotkeyMonitor != nil), local=\(localHotkeyMonitor != nil)")
-        log("AppDelegate: Hotkey is Ctrl+Option+R (⌃⌥R), Ask Omi via Carbon hotkeys")
-    }
-
-    // Dock icon is always visible — LSUIElement=false and activation policy stays .regular
-
-    /// Force-refresh the menu bar icon after activation policy changes.
-    /// Works around a macOS Sequoia bug where NSStatusBar items vanish
-    /// when switching to .accessory activation policy.
-    @MainActor private func refreshMenuBarIcon() {
-        guard let item = statusBarItem else {
-            // Status bar item was lost — recreate it
-            log("AppDelegate: [MENUBAR] refreshMenuBarIcon: statusBarItem is nil, recreating")
-            setupMenuBar()
-            return
-        }
-        // Re-assert visibility synchronously
-        item.isVisible = true
-        // Re-apply the icon to force the system to redraw
-        if let button = item.button {
-            if OMIApp.launchMode == .rewind {
-                if let icon = NSImage(systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: "omi Rewind") {
-                    icon.isTemplate = true
-                    button.image = icon
-                }
-            } else if let iconURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
-                      let icon = NSImage(contentsOf: iconURL) {
-                icon.isTemplate = true
-                let aspect = icon.size.width / icon.size.height
-                icon.size = NSSize(width: 16 * aspect, height: 16)
-                button.image = icon
-            }
-        }
-        // Safety net: verify again after a short delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            let button = self?.statusBarItem?.button
-            let isPhantom = button != nil && button!.frame.width == 0
-            if self?.statusBarItem?.isVisible != true || isPhantom {
-                log("AppDelegate: [MENUBAR] Icon still not visible/phantom after refresh (frame=\(button?.frame ?? .zero)), recreating")
-                self?.setupMenuBar()
-            }
-        }
-        log("AppDelegate: [MENUBAR] Refreshed status bar item after policy change")
-    }
-
-    /// Set up menu bar icon using NSStatusBar (more reliable than SwiftUI MenuBarExtra)
-    @MainActor private func setupMenuBar() {
-        log("AppDelegate: [MENUBAR] Setting up NSStatusBar menu (macOS \(ProcessInfo.processInfo.operatingSystemVersionString))")
-        log("AppDelegate: [MENUBAR] Thread: \(Thread.isMainThread ? "main" : "background"), statusBar items: \(NSStatusBar.system.thickness)")
-
-        // Explicitly remove old status item before creating a new one.
-        // Relying on ARC deallocation alone can leave "phantom" items that exist
-        // in memory but never render on screen.
-        if let old = statusBarItem {
-            NSStatusBar.system.removeStatusItem(old)
-            statusBarItem = nil
-            log("AppDelegate: [MENUBAR] Removed old status bar item before recreating")
-        }
-
-        statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-
-        guard let statusBarItem = statusBarItem else {
-            log("AppDelegate: [MENUBAR] ERROR - Failed to create status bar item")
-            SentrySDK.capture(message: "Failed to create NSStatusItem") { scope in
-                scope.setLevel(.error)
-                scope.setTag(value: "menu_bar", key: "component")
-            }
-            return
-        }
-
-        log("AppDelegate: [MENUBAR] NSStatusItem created successfully")
-
-        let displayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "omi"
-
-        // Set up the button with icon — use "omi" text logo (not a circle)
-        if let button = statusBarItem.button {
-            if OMIApp.launchMode == .rewind {
-                // Rewind mode uses SF Symbol
-                if let icon = NSImage(systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: "omi Rewind") {
-                    icon.isTemplate = true
-                    button.image = icon
-                    log("AppDelegate: [MENUBAR] Rewind icon set successfully")
-                }
-            } else if let iconURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
-                      let icon = NSImage(contentsOf: iconURL) {
-                icon.isTemplate = true
-                // Scale to menu bar height (16pt) with proportional width
-                let aspect = icon.size.width / icon.size.height
-                icon.size = NSSize(width: 16 * aspect, height: 16)
-                button.image = icon
-                button.imagePosition = .imageOnly
-                log("AppDelegate: [MENUBAR] Omi text logo set successfully (size: \(icon.size))")
-            } else {
-                // Fallback to SF Symbol
-                if let icon = NSImage(systemSymbolName: "waveform", accessibilityDescription: "omi") {
-                    icon.isTemplate = true
-                    button.image = icon
-                }
-                log("AppDelegate: [MENUBAR] WARNING - Failed to load omi_text_logo, using fallback")
-            }
-            button.toolTip = OMIApp.launchMode == .rewind ? "omi Rewind" : displayName
-        } else {
-            log("AppDelegate: [MENUBAR] WARNING - statusBarItem.button is nil")
-        }
-
-        // Create menu
-        let menu = NSMenu()
-
-        // Quick toggles for screen capture and audio recording
-        let screenCaptureItem = NSMenuItem()
-        let screenCaptureView = makeToggleItemView(
-            title: "Screen Capture",
-            iconName: "rectangle.dashed.badge.record",
-            isOn: AssistantSettings.shared.screenAnalysisEnabled && ProactiveAssistantsPlugin.shared.isMonitoring,
-            action: #selector(screenCaptureToggled(_:))
-        )
-        screenCaptureItem.view = screenCaptureView
-        menu.addItem(screenCaptureItem)
-
-        let audioRecordingItem = NSMenuItem()
-        let audioRecordingView = makeToggleItemView(
-            title: "Audio Recording",
-            iconName: "mic.fill",
-            isOn: AssistantSettings.shared.transcriptionEnabled,
-            action: #selector(audioRecordingToggled(_:))
-        )
-        audioRecordingItem.view = audioRecordingView
-        menu.addItem(audioRecordingItem)
-
-        menu.addItem(NSMenuItem.separator())
-
-        // Open app item
-        let openItem = NSMenuItem(title: "Open \(displayName)", action: #selector(openOmiFromMenu), keyEquivalent: "o")
-        openItem.target = self
-        menu.addItem(openItem)
-
-        menu.addItem(NSMenuItem.separator())
-
-        // Check for Updates
-        let updatesItem = NSMenuItem(title: "Check for Updates...", action: #selector(checkForUpdates), keyEquivalent: "")
-        updatesItem.target = self
-        menu.addItem(updatesItem)
-
-        menu.addItem(NSMenuItem.separator())
-
-        // Sign out / User info
-        if AuthState.shared.isSignedIn {
-            if let email = AuthState.shared.userEmail {
-                let emailItem = NSMenuItem(title: "Signed in as \(email)", action: nil, keyEquivalent: "")
-                emailItem.isEnabled = false
-                menu.addItem(emailItem)
-                menu.addItem(NSMenuItem.separator())
-            }
-
-            let resetItem = NSMenuItem(title: "Reset Onboarding...", action: #selector(resetOnboarding), keyEquivalent: "")
-            resetItem.target = self
-            menu.addItem(resetItem)
-
-            menu.addItem(NSMenuItem.separator())
-
-            let reportItem = NSMenuItem(title: "Report Issue...", action: #selector(reportIssue), keyEquivalent: "")
-            reportItem.target = self
-            menu.addItem(reportItem)
-
-            menu.addItem(NSMenuItem.separator())
-
-            let signOutItem = NSMenuItem(title: "Sign Out", action: #selector(signOut), keyEquivalent: "")
-            signOutItem.target = self
-            menu.addItem(signOutItem)
-        } else {
-            let notSignedInItem = NSMenuItem(title: "Not signed in", action: nil, keyEquivalent: "")
-            notSignedInItem.isEnabled = false
-            menu.addItem(notSignedInItem)
-        }
-
-        menu.addItem(NSMenuItem.separator())
-
-        // Quit item
-        let quitItem = NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q")
-        quitItem.target = self
-        menu.addItem(quitItem)
-
-        statusBarItem.menu = menu
-        menu.delegate = self
-        log("AppDelegate: [MENUBAR] Menu bar setup completed - icon visible in status bar")
-
-        // Verify the status item is valid
-        if let button = statusBarItem.button {
-            log("AppDelegate: [MENUBAR] VERIFY - button exists, frame: \(button.frame), isHidden: \(button.isHidden)")
-        } else {
-            log("AppDelegate: [MENUBAR] VERIFY - WARNING: button is nil after setup!")
-        }
-    }
-
-    @MainActor @objc private func openOmiFromMenu() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "open_omi")
-        NSApp.activate(ignoringOtherApps: true)
-        var foundWindow = false
-        for window in NSApp.windows {
+      if isCtrlOption && isR {
+        log("AppDelegate: [HOTKEY] Rewind hotkey MATCHED (Ctrl+Option+R)")
+        DispatchQueue.main.async {
+          log("AppDelegate: [HOTKEY] Activating app and posting notification")
+          // Bring app to front
+          NSApp.activate(ignoringOtherApps: true)
+          // Find and show main window
+          for window in NSApp.windows {
             if window.title.hasPrefix("Omi") {
-                foundWindow = true
-                window.makeKeyAndOrderFront(nil)
-                window.appearance = NSAppearance(named: .darkAqua)
+              window.makeKeyAndOrderFront(nil)
+              break
             }
+          }
+          // Post notification to navigate to Rewind
+          NotificationCenter.default.post(name: .navigateToRewind, object: nil)
+          log("AppDelegate: [HOTKEY] Posted navigateToRewind notification")
         }
-        // Dock icon is always visible; just activate the app
-        NSApp.activate(ignoringOtherApps: true)
-        if !foundWindow {
-            log("AppDelegate: [MENUBAR] WARNING - No Omi window found when opening from menu bar")
+      }
+      return event
+    }
+
+    // Ask Omi shortcut is registered via Carbon RegisterEventHotKey in
+    // GlobalShortcutManager (works regardless of accessibility permission state).
+
+    // Global monitor - for when OTHER apps are focused (Ctrl+Option+R only)
+    globalHotkeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+      _ = hotkeyHandler(event)
+    }
+
+    // Local monitor - for when THIS app is focused (Ctrl+Option+R only)
+    localHotkeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+      return hotkeyHandler(event)
+    }
+
+    log(
+      "AppDelegate: Hotkey monitors registered - global=\(globalHotkeyMonitor != nil), local=\(localHotkeyMonitor != nil)"
+    )
+    log("AppDelegate: Hotkey is Ctrl+Option+R (⌃⌥R), Ask Omi via Carbon hotkeys")
+  }
+
+  // Dock icon is always visible — LSUIElement=false and activation policy stays .regular
+
+  /// Force-refresh the menu bar icon after activation policy changes.
+  /// Works around a macOS Sequoia bug where NSStatusBar items vanish
+  /// when switching to .accessory activation policy.
+  @MainActor private func refreshMenuBarIcon() {
+    guard let item = statusBarItem else {
+      // Status bar item was lost — recreate it
+      log("AppDelegate: [MENUBAR] refreshMenuBarIcon: statusBarItem is nil, recreating")
+      setupMenuBar()
+      return
+    }
+    // Re-assert visibility synchronously
+    item.isVisible = true
+    // Re-apply the icon to force the system to redraw
+    if let button = item.button {
+      if OMIApp.launchMode == .rewind {
+        if let icon = NSImage(
+          systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: "omi Rewind")
+        {
+          icon.isTemplate = true
+          button.image = icon
         }
+      } else if let iconURL = Bundle.resourceBundle.url(
+        forResource: "omi_text_logo", withExtension: "png"),
+        let icon = NSImage(contentsOf: iconURL)
+      {
+        icon.isTemplate = true
+        let aspect = icon.size.width / icon.size.height
+        icon.size = NSSize(width: 16 * aspect, height: 16)
+        button.image = icon
+      }
     }
-
-    @MainActor @objc private func checkForUpdates() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "check_updates")
-        UpdaterViewModel.shared.checkForUpdates()
-    }
-
-    @MainActor @objc private func resetOnboarding() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "reset_onboarding")
-        AppState().resetOnboardingAndRestart()
-    }
-
-    @MainActor @objc private func reportIssue() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "report_issue")
-        FeedbackWindow.show(userEmail: AuthState.shared.userEmail)
-    }
-
-    @MainActor @objc private func signOut() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "sign_out")
-        ProactiveAssistantsPlugin.shared.stopMonitoring()
-        try? AuthService.shared.signOut()
-    }
-
-    @MainActor @objc private func quitApp() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "quit")
-        NSApplication.shared.terminate(nil)
-    }
-
-    // MARK: - Menu Bar Toggle Items
-
-    /// Create a custom NSView for a menu item with an icon, label, and toggle switch
-    private func makeToggleItemView(title: String, iconName: String, isOn: Bool, action: Selector) -> NSView {
-        let height: CGFloat = 36
-        let width: CGFloat = 260
-        let view = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
-
-        // Icon — use a fixed-size image with symbol configuration for consistent rendering
-        let iconView = NSImageView(frame: NSRect(x: 16, y: 10, width: 16, height: 16))
-        let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
-        if let img = NSImage(systemSymbolName: iconName, accessibilityDescription: title)?.withSymbolConfiguration(config) {
-            iconView.image = img
-            iconView.contentTintColor = .secondaryLabelColor
-        }
-        view.addSubview(iconView)
-
-        // Label
-        let label = NSTextField(labelWithString: title)
-        label.frame = NSRect(x: 40, y: 10, width: 150, height: 16)
-        label.font = .systemFont(ofSize: 13)
-        label.textColor = .labelColor
-        view.addSubview(label)
-
-        // Toggle switch — use .small for consistent rendering across items
-        let toggle = NSSwitch()
-        toggle.controlSize = .small
-        toggle.state = isOn ? .on : .off
-        toggle.target = self
-        toggle.action = action
-        toggle.sizeToFit()
-        // Right-aligned position, pinned to right edge even when menu resizes the view
-        let toggleX = width - toggle.frame.width - 16
-        let toggleY = (height - toggle.frame.height) / 2
-        toggle.frame = NSRect(x: toggleX, y: toggleY, width: toggle.frame.width, height: toggle.frame.height)
-        toggle.autoresizingMask = [.minXMargin]
-        view.addSubview(toggle)
-
-        // Store reference for later updates
-        if action == #selector(screenCaptureToggled(_:)) {
-            screenCaptureSwitch = toggle
-        } else if action == #selector(audioRecordingToggled(_:)) {
-            audioRecordingSwitch = toggle
-        }
-
-        return view
-    }
-
-    @MainActor @objc private func screenCaptureToggled(_ sender: NSSwitch) {
-        let enabled = sender.state == .on
-        log("AppDelegate: [MENUBAR] Screen capture toggled: \(enabled)")
-        AnalyticsManager.shared.menuBarActionClicked(action: enabled ? "screen_capture_on" : "screen_capture_off")
-        AnalyticsManager.shared.settingToggled(setting: "monitoring", enabled: enabled)
-
-        if enabled {
-            if !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
-                // No permission — revert toggle and open preferences
-                sender.state = .off
-                ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
-                return
-            }
-            AssistantSettings.shared.screenAnalysisEnabled = true
-            ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
-                DispatchQueue.main.async {
-                    if !success {
-                        log("AppDelegate: [MENUBAR] Screen capture failed to start: \(error ?? "unknown")")
-                        sender.state = .off
-                        AssistantSettings.shared.screenAnalysisEnabled = false
-                    }
-                }
-            }
-        } else {
-            AssistantSettings.shared.screenAnalysisEnabled = false
-            ProactiveAssistantsPlugin.shared.stopMonitoring()
-        }
-    }
-
-    @MainActor @objc private func audioRecordingToggled(_ sender: NSSwitch) {
-        let enabled = sender.state == .on
-        log("AppDelegate: [MENUBAR] Audio recording toggled: \(enabled)")
-        AnalyticsManager.shared.menuBarActionClicked(action: enabled ? "audio_recording_on" : "audio_recording_off")
-        AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
-
-        AssistantSettings.shared.transcriptionEnabled = enabled
-        // Request the main view to start/stop transcription (needs AppState)
-        NotificationCenter.default.post(
-            name: .toggleTranscriptionRequested,
-            object: nil,
-            userInfo: ["enabled": enabled]
+    // Safety net: verify again after a short delay
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+      let button = self?.statusBarItem?.button
+      let isPhantom = button != nil && button!.frame.width == 0
+      if self?.statusBarItem?.isVisible != true || isPhantom {
+        log(
+          "AppDelegate: [MENUBAR] Icon still not visible/phantom after refresh (frame=\(button?.frame ?? .zero)), recreating"
         )
+        self?.setupMenuBar()
+      }
+    }
+    log("AppDelegate: [MENUBAR] Refreshed status bar item after policy change")
+  }
+
+  /// Set up menu bar icon using NSStatusBar (more reliable than SwiftUI MenuBarExtra)
+  @MainActor private func setupMenuBar() {
+    log(
+      "AppDelegate: [MENUBAR] Setting up NSStatusBar menu (macOS \(ProcessInfo.processInfo.operatingSystemVersionString))"
+    )
+    log(
+      "AppDelegate: [MENUBAR] Thread: \(Thread.isMainThread ? "main" : "background"), statusBar items: \(NSStatusBar.system.thickness)"
+    )
+
+    // Explicitly remove old status item before creating a new one.
+    // Relying on ARC deallocation alone can leave "phantom" items that exist
+    // in memory but never render on screen.
+    if let old = statusBarItem {
+      NSStatusBar.system.removeStatusItem(old)
+      statusBarItem = nil
+      log("AppDelegate: [MENUBAR] Removed old status bar item before recreating")
     }
 
-    // MARK: - NSMenuDelegate
-    func menuWillOpen(_ menu: NSMenu) {
-        log("AppDelegate: [MENUBAR] Menu opened by user")
-        AnalyticsManager.shared.menuBarOpened()
-        // Refresh toggle states to match current runtime state
-        screenCaptureSwitch?.state = ProactiveAssistantsPlugin.shared.isMonitoring ? .on : .off
-        audioRecordingSwitch?.state = AssistantSettings.shared.transcriptionEnabled ? .on : .off
+    statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+    guard let statusBarItem = statusBarItem else {
+      log("AppDelegate: [MENUBAR] ERROR - Failed to create status bar item")
+      SentrySDK.capture(message: "Failed to create NSStatusItem") { scope in
+        scope.setLevel(.error)
+        scope.setTag(value: "menu_bar", key: "component")
+      }
+      return
     }
 
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        // Keep app running in menu bar when all windows are closed
-        return false
+    log("AppDelegate: [MENUBAR] NSStatusItem created successfully")
+
+    let displayName =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "omi"
+
+    // Set up the button with icon — use "omi" text logo (not a circle)
+    if let button = statusBarItem.button {
+      if OMIApp.launchMode == .rewind {
+        // Rewind mode uses SF Symbol
+        if let icon = NSImage(
+          systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: "omi Rewind")
+        {
+          icon.isTemplate = true
+          button.image = icon
+          log("AppDelegate: [MENUBAR] Rewind icon set successfully")
+        }
+      } else if let iconURL = Bundle.resourceBundle.url(
+        forResource: "omi_text_logo", withExtension: "png"),
+        let icon = NSImage(contentsOf: iconURL)
+      {
+        icon.isTemplate = true
+        // Scale to menu bar height (16pt) with proportional width
+        let aspect = icon.size.width / icon.size.height
+        icon.size = NSSize(width: 16 * aspect, height: 16)
+        button.image = icon
+        button.imagePosition = .imageOnly
+        log("AppDelegate: [MENUBAR] Omi text logo set successfully (size: \(icon.size))")
+      } else {
+        // Fallback to SF Symbol
+        if let icon = NSImage(systemSymbolName: "waveform", accessibilityDescription: "omi") {
+          icon.isTemplate = true
+          button.image = icon
+        }
+        log("AppDelegate: [MENUBAR] WARNING - Failed to load omi_text_logo, using fallback")
+      }
+      button.toolTip = OMIApp.launchMode == .rewind ? "omi Rewind" : displayName
+    } else {
+      log("AppDelegate: [MENUBAR] WARNING - statusBarItem.button is nil")
     }
 
-    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        // Always try to show the main Omi window when dock icon is clicked
-        for window in sender.windows where window.title.hasPrefix("Omi") {
-            if window.isMiniaturized {
-                window.deminiaturize(nil)
-            }
-            window.makeKeyAndOrderFront(nil)
-            sender.activate(ignoringOtherApps: true)
-            log("AppDelegate: Restored Omi window from dock click (wasVisible=\(flag))")
-            return false
-        }
-        return true
+    // Create menu
+    let menu = NSMenu()
+
+    // Quick toggles for screen capture and audio recording
+    let screenCaptureItem = NSMenuItem()
+    let screenCaptureView = makeToggleItemView(
+      title: "Screen Capture",
+      iconName: "rectangle.dashed.badge.record",
+      isOn: AssistantSettings.shared.screenAnalysisEnabled
+        && ProactiveAssistantsPlugin.shared.isMonitoring,
+      action: #selector(screenCaptureToggled(_:))
+    )
+    screenCaptureItem.view = screenCaptureView
+    menu.addItem(screenCaptureItem)
+
+    let audioRecordingItem = NSMenuItem()
+    let audioRecordingView = makeToggleItemView(
+      title: "Audio Recording",
+      iconName: "mic.fill",
+      isOn: AssistantSettings.shared.transcriptionEnabled,
+      action: #selector(audioRecordingToggled(_:))
+    )
+    audioRecordingItem.view = audioRecordingView
+    menu.addItem(audioRecordingItem)
+
+    menu.addItem(NSMenuItem.separator())
+
+    // Open app item
+    let openItem = NSMenuItem(
+      title: "Open \(displayName)", action: #selector(openOmiFromMenu), keyEquivalent: "o")
+    openItem.target = self
+    menu.addItem(openItem)
+
+    menu.addItem(NSMenuItem.separator())
+
+    // Check for Updates
+    let updatesItem = NSMenuItem(
+      title: "Check for Updates...", action: #selector(checkForUpdates), keyEquivalent: "")
+    updatesItem.target = self
+    menu.addItem(updatesItem)
+
+    menu.addItem(NSMenuItem.separator())
+
+    // Sign out / User info
+    if AuthState.shared.isSignedIn {
+      if let email = AuthState.shared.userEmail {
+        let emailItem = NSMenuItem(title: "Signed in as \(email)", action: nil, keyEquivalent: "")
+        emailItem.isEnabled = false
+        menu.addItem(emailItem)
+        menu.addItem(NSMenuItem.separator())
+      }
+
+      let resetItem = NSMenuItem(
+        title: "Reset Onboarding...", action: #selector(resetOnboarding), keyEquivalent: "")
+      resetItem.target = self
+      menu.addItem(resetItem)
+
+      menu.addItem(NSMenuItem.separator())
+
+      let reportItem = NSMenuItem(
+        title: "Report Issue...", action: #selector(reportIssue), keyEquivalent: "")
+      reportItem.target = self
+      menu.addItem(reportItem)
+
+      menu.addItem(NSMenuItem.separator())
+
+      let signOutItem = NSMenuItem(title: "Sign Out", action: #selector(signOut), keyEquivalent: "")
+      signOutItem.target = self
+      menu.addItem(signOutItem)
+    } else {
+      let notSignedInItem = NSMenuItem(title: "Not signed in", action: nil, keyEquivalent: "")
+      notSignedInItem.isEnabled = false
+      menu.addItem(notSignedInItem)
     }
 
-    func applicationWillTerminate(_ notification: Notification) {
-        // Remove window observers
-        for observer in windowObservers {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        windowObservers.removeAll()
-        // Remove hotkey monitors
-        if let monitor = globalHotkeyMonitor {
-            NSEvent.removeMonitor(monitor)
-            globalHotkeyMonitor = nil
-        }
-        if let monitor = localHotkeyMonitor {
-            NSEvent.removeMonitor(monitor)
-            localHotkeyMonitor = nil
-        }
-        // Remove floating bar shortcuts
-        GlobalShortcutManager.shared.unregisterShortcuts()
+    menu.addItem(NSMenuItem.separator())
 
-        // Stop push-to-talk
-        PushToTalkManager.shared.cleanup()
+    // Quit item
+    let quitItem = NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q")
+    quitItem.target = self
+    menu.addItem(quitItem)
 
-        // Stop heartbeat timer
-        sentryHeartbeatTimer?.invalidate()
-        sentryHeartbeatTimer = nil
+    statusBarItem.menu = menu
+    menu.delegate = self
+    log("AppDelegate: [MENUBAR] Menu bar setup completed - icon visible in status bar")
 
-        // Stop transcription retry service
-        TranscriptionRetryService.shared.stop()
+    // Verify the status item is valid
+    if let button = statusBarItem.button {
+      log(
+        "AppDelegate: [MENUBAR] VERIFY - button exists, frame: \(button.frame), isHidden: \(button.isHidden)"
+      )
+    } else {
+      log("AppDelegate: [MENUBAR] VERIFY - WARNING: button is nil after setup!")
+    }
+  }
 
-        // Stop recurring task scheduler
-        RecurringTaskScheduler.shared.stop()
+  @MainActor @objc private func openOmiFromMenu() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "open_omi")
+    NSApp.activate(ignoringOtherApps: true)
+    var foundWindow = false
+    for window in NSApp.windows {
+      if window.title.hasPrefix("Omi") {
+        foundWindow = true
+        window.makeKeyAndOrderFront(nil)
+        window.appearance = NSAppearance(named: .darkAqua)
+      }
+    }
+    // Dock icon is always visible; just activate the app
+    NSApp.activate(ignoringOtherApps: true)
+    if !foundWindow {
+      log("AppDelegate: [MENUBAR] WARNING - No Omi window found when opening from menu bar")
+    }
+  }
 
-        // Mark clean shutdown so next launch skips expensive DB integrity check
-        RewindDatabase.markCleanShutdown()
+  @MainActor @objc private func checkForUpdates() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "check_updates")
+    UpdaterViewModel.shared.checkForUpdates()
+  }
 
-        // Report final resources before termination
-        ResourceMonitor.shared.reportResourcesNow(context: "app_terminating")
-        ResourceMonitor.shared.stop()
+  @MainActor @objc private func resetOnboarding() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "reset_onboarding")
+    AppState().resetOnboardingAndRestart()
+  }
 
-        // Capture final session snapshot before termination (now enabled for dev builds too)
-        SentrySDK.capture(message: "App Terminating") { scope in
-            scope.setLevel(.info)
-            scope.setTag(value: "lifecycle", key: "event_type")
-        }
+  @MainActor @objc private func reportIssue() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "report_issue")
+    FeedbackWindow.show(userEmail: AuthState.shared.userEmail)
+  }
+
+  @MainActor @objc private func signOut() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "sign_out")
+    ProactiveAssistantsPlugin.shared.stopMonitoring()
+    try? AuthService.shared.signOut()
+  }
+
+  @MainActor @objc private func quitApp() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "quit")
+    NSApplication.shared.terminate(nil)
+  }
+
+  // MARK: - Menu Bar Toggle Items
+
+  /// Create a custom NSView for a menu item with an icon, label, and toggle switch
+  private func makeToggleItemView(title: String, iconName: String, isOn: Bool, action: Selector)
+    -> NSView
+  {
+    let height: CGFloat = 36
+    let width: CGFloat = 260
+    let view = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+
+    // Icon — use a fixed-size image with symbol configuration for consistent rendering
+    let iconView = NSImageView(frame: NSRect(x: 16, y: 10, width: 16, height: 16))
+    let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
+    if let img = NSImage(systemSymbolName: iconName, accessibilityDescription: title)?
+      .withSymbolConfiguration(config)
+    {
+      iconView.image = img
+      iconView.contentTintColor = .secondaryLabelColor
+    }
+    view.addSubview(iconView)
+
+    // Label
+    let label = NSTextField(labelWithString: title)
+    label.frame = NSRect(x: 40, y: 10, width: 150, height: 16)
+    label.font = .systemFont(ofSize: 13)
+    label.textColor = .labelColor
+    view.addSubview(label)
+
+    // Toggle switch — use .small for consistent rendering across items
+    let toggle = NSSwitch()
+    toggle.controlSize = .small
+    toggle.state = isOn ? .on : .off
+    toggle.target = self
+    toggle.action = action
+    toggle.sizeToFit()
+    // Right-aligned position, pinned to right edge even when menu resizes the view
+    let toggleX = width - toggle.frame.width - 16
+    let toggleY = (height - toggle.frame.height) / 2
+    toggle.frame = NSRect(
+      x: toggleX, y: toggleY, width: toggle.frame.width, height: toggle.frame.height)
+    toggle.autoresizingMask = [.minXMargin]
+    view.addSubview(toggle)
+
+    // Store reference for later updates
+    if action == #selector(screenCaptureToggled(_:)) {
+      screenCaptureSwitch = toggle
+    } else if action == #selector(audioRecordingToggled(_:)) {
+      audioRecordingSwitch = toggle
     }
 
-    @objc func handleGetURLEvent(_ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor) {
-        guard let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue,
-              let url = URL(string: urlString) else {
-            return
-        }
+    return view
+  }
 
-        NSLog("OMI AppDelegate: Received URL event: %@", urlString)
+  @MainActor @objc private func screenCaptureToggled(_ sender: NSSwitch) {
+    let enabled = sender.state == .on
+    log("AppDelegate: [MENUBAR] Screen capture toggled: \(enabled)")
+    AnalyticsManager.shared.menuBarActionClicked(
+      action: enabled ? "screen_capture_on" : "screen_capture_off")
+    AnalyticsManager.shared.settingToggled(setting: "monitoring", enabled: enabled)
 
-        Task { @MainActor in
-            AuthService.shared.handleOAuthCallback(url: url)
+    if enabled {
+      if !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
+        // No permission — revert toggle and open preferences
+        sender.state = .off
+        ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
+        return
+      }
+      AssistantSettings.shared.screenAnalysisEnabled = true
+      ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
+        DispatchQueue.main.async {
+          if !success {
+            log("AppDelegate: [MENUBAR] Screen capture failed to start: \(error ?? "unknown")")
+            sender.state = .off
+            AssistantSettings.shared.screenAnalysisEnabled = false
+          }
         }
+      }
+    } else {
+      AssistantSettings.shared.screenAnalysisEnabled = false
+      ProactiveAssistantsPlugin.shared.stopMonitoring()
+    }
+  }
+
+  @MainActor @objc private func audioRecordingToggled(_ sender: NSSwitch) {
+    let enabled = sender.state == .on
+    log("AppDelegate: [MENUBAR] Audio recording toggled: \(enabled)")
+    AnalyticsManager.shared.menuBarActionClicked(
+      action: enabled ? "audio_recording_on" : "audio_recording_off")
+    AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
+
+    AssistantSettings.shared.transcriptionEnabled = enabled
+    // Request the main view to start/stop transcription (needs AppState)
+    NotificationCenter.default.post(
+      name: .toggleTranscriptionRequested,
+      object: nil,
+      userInfo: ["enabled": enabled]
+    )
+  }
+
+  // MARK: - NSMenuDelegate
+  func menuWillOpen(_ menu: NSMenu) {
+    log("AppDelegate: [MENUBAR] Menu opened by user")
+    AnalyticsManager.shared.menuBarOpened()
+    // Refresh toggle states to match current runtime state
+    screenCaptureSwitch?.state = ProactiveAssistantsPlugin.shared.isMonitoring ? .on : .off
+    audioRecordingSwitch?.state = AssistantSettings.shared.transcriptionEnabled ? .on : .off
+  }
+
+  func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    // Keep app running in menu bar when all windows are closed
+    return false
+  }
+
+  func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool
+  {
+    // Always try to show the main Omi window when dock icon is clicked
+    for window in sender.windows where window.title.hasPrefix("Omi") {
+      if window.isMiniaturized {
+        window.deminiaturize(nil)
+      }
+      window.makeKeyAndOrderFront(nil)
+      sender.activate(ignoringOtherApps: true)
+      log("AppDelegate: Restored Omi window from dock click (wasVisible=\(flag))")
+      return false
+    }
+    return true
+  }
+
+  func applicationWillTerminate(_ notification: Notification) {
+    // Remove window observers
+    for observer in windowObservers {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    windowObservers.removeAll()
+    // Remove hotkey monitors
+    if let monitor = globalHotkeyMonitor {
+      NSEvent.removeMonitor(monitor)
+      globalHotkeyMonitor = nil
+    }
+    if let monitor = localHotkeyMonitor {
+      NSEvent.removeMonitor(monitor)
+      localHotkeyMonitor = nil
+    }
+    // Remove floating bar shortcuts
+    GlobalShortcutManager.shared.unregisterShortcuts()
+
+    // Stop push-to-talk
+    PushToTalkManager.shared.cleanup()
+
+    // Stop heartbeat timer
+    sentryHeartbeatTimer?.invalidate()
+    sentryHeartbeatTimer = nil
+
+    // Stop transcription retry service
+    TranscriptionRetryService.shared.stop()
+
+    // Stop recurring task scheduler
+    RecurringTaskScheduler.shared.stop()
+
+    // Mark clean shutdown so next launch skips expensive DB integrity check
+    RewindDatabase.markCleanShutdown()
+
+    // Report final resources before termination
+    ResourceMonitor.shared.reportResourcesNow(context: "app_terminating")
+    ResourceMonitor.shared.stop()
+
+    // Capture final session snapshot before termination (now enabled for dev builds too)
+    SentrySDK.capture(message: "App Terminating") { scope in
+      scope.setLevel(.info)
+      scope.setTag(value: "lifecycle", key: "event_type")
+    }
+  }
+
+  @objc func handleGetURLEvent(
+    _ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor
+  ) {
+    guard
+      let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue,
+      let url = URL(string: urlString)
+    else {
+      return
     }
 
-    /// One-time migration to enable launch at login for existing users
-    /// Only runs once, and only enables if user hasn't explicitly set a preference
-    private func migrateLaunchAtLoginDefault() {
-        let migrationKey = "didMigrateLaunchAtLoginV1"
+    NSLog("OMI AppDelegate: Received URL event: %@", urlString)
 
-        // Skip if migration already done
-        guard !UserDefaults.standard.bool(forKey: migrationKey) else {
-            return
+    Task { @MainActor in
+      AuthService.shared.handleOAuthCallback(url: url)
+    }
+  }
+
+  /// One-time migration to enable launch at login for existing users
+  /// Only runs once, and only enables if user hasn't explicitly set a preference
+  private func migrateLaunchAtLoginDefault() {
+    let migrationKey = "didMigrateLaunchAtLoginV1"
+
+    // Skip if migration already done
+    guard !UserDefaults.standard.bool(forKey: migrationKey) else {
+      return
+    }
+
+    // Mark migration as done (do this first to ensure it only runs once)
+    UserDefaults.standard.set(true, forKey: migrationKey)
+
+    // Only enable for users who have completed onboarding (existing users)
+    // New users will get this enabled at the end of onboarding
+    let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+    guard hasCompletedOnboarding else {
+      log("LaunchAtLogin migration: Skipped - user hasn't completed onboarding yet")
+      return
+    }
+
+    // Check current status - only enable if not already registered
+    // This respects users who may have explicitly disabled it via System Settings
+    Task { @MainActor in
+      let manager = LaunchAtLoginManager.shared
+      if !manager.isEnabled {
+        let success = manager.setEnabled(true)
+        log("LaunchAtLogin migration: Enabled for existing user (success: \(success))")
+        if success {
+          AnalyticsManager.shared.launchAtLoginChanged(enabled: true, source: "migration")
         }
+      } else {
+        log("LaunchAtLogin migration: Already enabled, skipping")
+      }
+    }
+  }
 
-        // Mark migration as done (do this first to ensure it only runs once)
-        UserDefaults.standard.set(true, forKey: migrationKey)
+  private func migrateAppName() {
+    // No rename migration — APFS is case-insensitive so "omi.app" and "Omi.app"
+    // collide. Renaming the running app also breaks Dock pins and Spotlight indexing.
+    // The app ships as "omi.app" for new installs; existing users keep their current
+    // bundle name and get updates in-place via Sparkle.
 
-        // Only enable for users who have completed onboarding (existing users)
-        // New users will get this enabled at the end of onboarding
-        let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-        guard hasCompletedOnboarding else {
-            log("LaunchAtLogin migration: Skipped - user hasn't completed onboarding yet")
-            return
+    // Clean up stale legacy bundles (never the running app)
+    cleanupLegacyAppBundles()
+  }
+
+  private func cleanupLegacyAppBundles() {
+    let currentPath = Bundle.main.bundlePath
+    let oldAppPaths = [
+      "/Applications/Omi Computer.app",
+      NSHomeDirectory() + "/Applications/Omi Computer.app",
+    ]
+
+    for oldPath in oldAppPaths {
+      // Never delete the running app
+      guard oldPath != currentPath else { continue }
+      guard FileManager.default.fileExists(atPath: oldPath) else { continue }
+
+      log("Found old app at \(oldPath), cleaning up...")
+
+      // Kill the old app if it's running
+      let running = NSRunningApplication.runningApplications(
+        withBundleIdentifier: "com.omi.computer-macos")
+      for app in running {
+        guard app.processIdentifier != ProcessInfo.processInfo.processIdentifier else { continue }
+        log("Terminating old Omi Computer process (PID \(app.processIdentifier))")
+        app.forceTerminate()
+      }
+
+      // Wait briefly for termination, then delete
+      DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1.0) {
+        do {
+          try FileManager.default.removeItem(atPath: oldPath)
+          log("Deleted old app at \(oldPath)")
+        } catch {
+          log("Failed to delete old app: \(error.localizedDescription)")
+          // Try moving to trash as fallback
+          do {
+            try FileManager.default.trashItem(
+              at: URL(fileURLWithPath: oldPath), resultingItemURL: nil)
+            log("Moved old app to trash")
+          } catch {
+            log("Failed to trash old app: \(error.localizedDescription)")
+          }
         }
-
-        // Check current status - only enable if not already registered
-        // This respects users who may have explicitly disabled it via System Settings
-        Task { @MainActor in
-            let manager = LaunchAtLoginManager.shared
-            if !manager.isEnabled {
-                let success = manager.setEnabled(true)
-                log("LaunchAtLogin migration: Enabled for existing user (success: \(success))")
-                if success {
-                    AnalyticsManager.shared.launchAtLoginChanged(enabled: true, source: "migration")
-                }
-            } else {
-                log("LaunchAtLogin migration: Already enabled, skipping")
-            }
-        }
+      }
     }
+  }
 
-    private func migrateAppName() {
-        // No rename migration — APFS is case-insensitive so "omi.app" and "Omi.app"
-        // collide. Renaming the running app also breaks Dock pins and Spotlight indexing.
-        // The app ships as "omi.app" for new installs; existing users keep their current
-        // bundle name and get updates in-place via Sparkle.
+  func applicationDidBecomeActive(_ notification: Notification) {
+    AnalyticsManager.shared.appBecameActive()
+    // Sync remote assistant settings so server-side changes take effect promptly
+    Task { await SettingsSyncManager.shared.syncFromServer() }
+  }
 
-        // Clean up stale legacy bundles (never the running app)
-        cleanupLegacyAppBundles()
-    }
-
-    private func cleanupLegacyAppBundles() {
-        let currentPath = Bundle.main.bundlePath
-        let oldAppPaths = [
-            "/Applications/Omi Computer.app",
-            NSHomeDirectory() + "/Applications/Omi Computer.app",
-        ]
-
-        for oldPath in oldAppPaths {
-            // Never delete the running app
-            guard oldPath != currentPath else { continue }
-            guard FileManager.default.fileExists(atPath: oldPath) else { continue }
-
-            log("Found old app at \(oldPath), cleaning up...")
-
-            // Kill the old app if it's running
-            let running = NSRunningApplication.runningApplications(withBundleIdentifier: "com.omi.computer-macos")
-            for app in running {
-                guard app.processIdentifier != ProcessInfo.processInfo.processIdentifier else { continue }
-                log("Terminating old Omi Computer process (PID \(app.processIdentifier))")
-                app.forceTerminate()
-            }
-
-            // Wait briefly for termination, then delete
-            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1.0) {
-                do {
-                    try FileManager.default.removeItem(atPath: oldPath)
-                    log("Deleted old app at \(oldPath)")
-                } catch {
-                    log("Failed to delete old app: \(error.localizedDescription)")
-                    // Try moving to trash as fallback
-                    do {
-                        try FileManager.default.trashItem(at: URL(fileURLWithPath: oldPath), resultingItemURL: nil)
-                        log("Moved old app to trash")
-                    } catch {
-                        log("Failed to trash old app: \(error.localizedDescription)")
-                    }
-                }
-            }
-        }
-    }
-
-    func applicationDidBecomeActive(_ notification: Notification) {
-        AnalyticsManager.shared.appBecameActive()
-        // Sync remote assistant settings so server-side changes take effect promptly
-        Task { await SettingsSyncManager.shared.syncFromServer() }
-    }
-
-    func applicationWillResignActive(_ notification: Notification) {
-        AnalyticsManager.shared.appResignedActive()
-    }
+  func applicationWillResignActive(_ notification: Notification) {
+    AnalyticsManager.shared.appResignedActive()
+  }
 }

--- a/desktop/Desktop/Sources/UpdaterViewModel.swift
+++ b/desktop/Desktop/Sources/UpdaterViewModel.swift
@@ -1,31 +1,31 @@
 import Foundation
-import SwiftUI
 import Sparkle
+import SwiftUI
 
 /// Update channel for staged releases
 enum UpdateChannel: String, CaseIterable {
-    case stable = "stable"
-    case beta = "beta"
+  case stable = "stable"
+  case beta = "beta"
 
-    var displayName: String {
-        switch self {
-        case .stable: return "Stable"
-        case .beta: return "Beta"
-        }
+  var displayName: String {
+    switch self {
+    case .stable: return "Stable"
+    case .beta: return "Beta"
     }
+  }
 
-    var description: String {
-        switch self {
-        case .stable: return "Recommended for most users"
-        case .beta: return "Early access to new features"
-        }
+  var description: String {
+    switch self {
+    case .stable: return "Recommended for most users"
+    case .beta: return "Early access to new features"
     }
+  }
 
-    /// App display name based on update channel: "omi" for stable, "Omi Beta" for beta
-    static var appDisplayName: String {
-        let channel = UserDefaults.standard.string(forKey: "update_channel") ?? "stable"
-        return (channel == "beta" || channel == "staging") ? "Omi Beta" : "omi"
-    }
+  /// App display name based on update channel: "omi" for stable, "Omi Beta" for beta
+  static var appDisplayName: String {
+    let channel = UserDefaults.standard.string(forKey: "update_channel") ?? "stable"
+    return (channel == "beta" || channel == "staging") ? "Omi Beta" : "omi"
+  }
 }
 
 private let kUpdateChannelKey = "update_channel"
@@ -33,330 +33,387 @@ private let kUpdateChannelKey = "update_channel"
 /// Delegate to track Sparkle update events for analytics
 final class UpdaterDelegate: NSObject, SPUUpdaterDelegate {
 
-    /// Back-reference to the view model (set after init)
-    weak var viewModel: UpdaterViewModel?
+  /// Back-reference to the view model (set after init)
+  weak var viewModel: UpdaterViewModel?
 
-    // NOTE: All delegate methods use logSync() to write synchronously to disk.
-    // Sparkle may terminate the app immediately after willInstallUpdate / didAbortWithError,
-    // so async logging (Task + logQueue.async) would be lost.
+  // NOTE: All delegate methods use logSync() to write synchronously to disk.
+  // Sparkle may terminate the app immediately after willInstallUpdate / didAbortWithError,
+  // so async logging (Task + logQueue.async) would be lost.
 
-    /// Called when Sparkle is about to check for updates (permission gate)
-    func updater(_ updater: SPUUpdater, mayPerform check: SPUUpdateCheck) throws {
-        logSync("Sparkle: Starting update check")
-        Task { @MainActor in
-            AnalyticsManager.shared.updateCheckStarted()
-        }
+  /// Called when Sparkle is about to check for updates (permission gate)
+  func updater(_ updater: SPUUpdater, mayPerform check: SPUUpdateCheck) throws {
+    logSync("Sparkle: Starting update check")
+    Task { @MainActor in
+      AnalyticsManager.shared.updateCheckStarted()
     }
+  }
 
-    /// Called when Sparkle finishes loading the appcast
-    func updater(_ updater: SPUUpdater, didFinishLoading appcast: SUAppcast) {
-        logSync("Sparkle: Appcast loaded (\(appcast.items.count) items)")
+  /// Called when Sparkle finishes loading the appcast
+  func updater(_ updater: SPUUpdater, didFinishLoading appcast: SUAppcast) {
+    logSync("Sparkle: Appcast loaded (\(appcast.items.count) items)")
 
-        // Capture latest stable build metadata for downgrade detection
-        var bestStableBuild: Int?
-        var bestStableVersion: String?
-        for item in appcast.items {
-            let isStable = item.channel == nil || item.channel?.isEmpty == true
-            guard isStable, let build = Int(item.versionString) else { continue }
-            if bestStableBuild == nil || build > bestStableBuild! {
-                bestStableBuild = build
-                bestStableVersion = item.displayVersionString
+    // Capture latest stable build metadata for downgrade detection
+    var bestStableBuild: Int?
+    var bestStableVersion: String?
+    for item in appcast.items {
+      let isStable = item.channel == nil || item.channel?.isEmpty == true
+      guard isStable, let build = Int(item.versionString) else { continue }
+      if bestStableBuild == nil || build > bestStableBuild! {
+        bestStableBuild = build
+        bestStableVersion = item.displayVersionString
+      }
+    }
+    // Always update (including nil) so stale data doesn't produce false downgrade alerts
+    Task { @MainActor in
+      self.viewModel?.latestStableBuildNumber = bestStableBuild
+      self.viewModel?.latestStableVersionString = bestStableVersion
+    }
+  }
+
+  /// Called when Sparkle finds a valid update
+  func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+    let version = item.displayVersionString
+    logSync("Sparkle: Found update v\(version)")
+    Task { @MainActor in
+      AnalyticsManager.shared.updateAvailable(version: version)
+      self.viewModel?.updateAvailable = true
+      self.viewModel?.availableVersion = version
+    }
+  }
+
+  /// Called when no update is available
+  func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
+    logSync("Sparkle: No update available")
+    Task { @MainActor in
+      AnalyticsManager.shared.updateNotFound()
+      self.viewModel?.updateAvailable = false
+    }
+  }
+
+  /// Called when the update driver aborts with an error
+  /// Note: Sparkle also calls this with "You're up to date!" when no update is found,
+  /// which is not an actual error — updaterDidNotFindUpdate handles that case.
+  func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
+    let message = error.localizedDescription
+    let nsError = error as NSError
+    let isUpToDate =
+      nsError.domain == SUSparkleErrorDomain
+      && nsError.code == 1001 /* SUNoUpdateError */
+    if isUpToDate {
+      logSync("Sparkle: Already up to date")
+    } else {
+      logSync(
+        "Sparkle: Update check failed - \(message) [domain=\(nsError.domain) code=\(nsError.code)]")
+      if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+        logSync(
+          "Sparkle: Underlying error - \(underlying.localizedDescription) [domain=\(underlying.domain) code=\(underlying.code)]"
+        )
+      }
+      for (key, value) in nsError.userInfo where key != NSUnderlyingErrorKey {
+        logSync("Sparkle: Error info [\(key)] = \(value)")
+      }
+      // Build diagnostic properties for analytics
+      let errorDomain = nsError.domain
+      let errorCode = nsError.code
+      var underlyingMessage: String? = nil
+      var underlyingDomain: String? = nil
+      var underlyingCode: Int? = nil
+
+      if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+        underlyingMessage = underlying.localizedDescription
+        underlyingDomain = underlying.domain
+        underlyingCode = underlying.code
+      }
+
+      Task { @MainActor in
+        AnalyticsManager.shared.updateCheckFailed(
+          error: message,
+          errorDomain: errorDomain,
+          errorCode: errorCode,
+          underlyingError: underlyingMessage,
+          underlyingDomain: underlyingDomain,
+          underlyingCode: underlyingCode
+        )
+      }
+
+      // SUInstallationError (4005): Sparkle's installer failed to launch.
+      // On macOS 26, AuthorizationCreate/SMJobSubmit can fail due to stricter
+      // code signature validation or on-demand-only launchd mode.
+      // Fallback: open the download page so the user can install manually.
+      let isInstallationError = nsError.domain == SUSparkleErrorDomain && nsError.code == 4005
+      if isInstallationError {
+        logSync("Sparkle: Installation failed, opening download page as fallback")
+        if let url = URL(string: "https://macos.omi.me") {
+          NSWorkspace.shared.open(url)
+        }
+      }
+    }
+  }
+
+  /// Tells Sparkle which non-default channels this client wants to see.
+  /// Channels are additive: the default (stable) channel is always included.
+  func allowedChannels(for updater: SPUUpdater) -> Set<String> {
+    let raw = UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
+    if raw == "beta" || raw == "staging" {
+      return Set(["beta"])
+    }
+    return Set()  // empty = default (stable) channel only
+  }
+
+  /// Called after Sparkle has launched the installer and submitted launchd jobs.
+  /// On macOS 26+, launchd may be in "on-demand-only mode" which prevents RunAtLoad
+  /// services from starting. We force-start them via launchctl kickstart as a backup
+  /// to Sparkle 2.9.0's built-in probe (PR #2852).
+  func updater(_ updater: SPUUpdater, didExtractUpdate item: SUAppcastItem) {
+    logSync("Sparkle: Installer launched for v\(item.displayVersionString), kickstarting services")
+    kickstartSparkleServices()
+  }
+
+  /// Force-start Sparkle's launchd services to work around macOS 26 on-demand-only mode.
+  /// Services submitted via SMJobSubmit with RunAtLoad=YES may not start immediately.
+  /// Using `launchctl kickstart` forces launchd to spawn them right away.
+  private func kickstartSparkleServices() {
+    guard let bundleID = Bundle.main.bundleIdentifier else { return }
+
+    let updaterLabel = "\(bundleID)-sparkle-updater"
+    let progressLabel = "\(bundleID)-sparkle-progress"
+    let uid = getuid()
+
+    // Try multiple times to handle timing variance
+    for delay in [0.5, 2.0, 5.0] {
+      DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + delay) {
+        for label in [progressLabel, updaterLabel] {
+          let process = Process()
+          process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+          process.arguments = ["kickstart", "-p", "gui/\(uid)/\(label)"]
+          process.standardOutput = FileHandle.nullDevice
+          process.standardError = FileHandle.nullDevice
+
+          do {
+            try process.run()
+            process.waitUntilExit()
+            if process.terminationStatus == 0 {
+              logSync("Sparkle kickstart: started \(label) (delay=\(delay)s)")
             }
+          } catch {
+            // Best effort — service may not exist yet or already running
+          }
         }
-        // Always update (including nil) so stale data doesn't produce false downgrade alerts
-        Task { @MainActor in
-            self.viewModel?.latestStableBuildNumber = bestStableBuild
-            self.viewModel?.latestStableVersionString = bestStableVersion
-        }
+      }
+    }
+  }
+
+  /// Called when an update will be installed (app may terminate immediately after)
+  func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
+    let version = item.displayVersionString
+    logSync("Sparkle: Installing update v\(version)")
+    Task { @MainActor in
+      AnalyticsManager.shared.updateInstalled(version: version)
+      self.viewModel?.updateAvailable = false
+    }
+  }
+
+  /// Called when Sparkle has downloaded an update and scheduled it for silent install on quit.
+  /// On release builds we immediately invoke the installation block so the app updates and relaunches
+  /// without waiting for the user to manually quit.
+  func updater(
+    _ updater: SPUUpdater,
+    willInstallUpdateOnQuit item: SUAppcastItem,
+    immediateInstallationBlock installationBlock: @escaping () -> Void
+  ) -> Bool {
+    let version = item.displayVersionString
+    logSync("Sparkle: Update v\(version) scheduled for install on quit")
+
+    guard !AnalyticsManager.isDevBuild else {
+      logSync("Sparkle: Leaving update scheduled for quit because this is a development build")
+      return false
     }
 
-    /// Called when Sparkle finds a valid update
-    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
-        let version = item.displayVersionString
-        logSync("Sparkle: Found update v\(version)")
-        Task { @MainActor in
-            AnalyticsManager.shared.updateAvailable(version: version)
-            self.viewModel?.updateAvailable = true
-            self.viewModel?.availableVersion = version
-        }
-    }
-
-    /// Called when no update is available
-    func updaterDidNotFindUpdate(_ updater: SPUUpdater) {
-        logSync("Sparkle: No update available")
-        Task { @MainActor in
-            AnalyticsManager.shared.updateNotFound()
-            self.viewModel?.updateAvailable = false
-        }
-    }
-
-    /// Called when the update driver aborts with an error
-    /// Note: Sparkle also calls this with "You're up to date!" when no update is found,
-    /// which is not an actual error — updaterDidNotFindUpdate handles that case.
-    func updater(_ updater: SPUUpdater, didAbortWithError error: Error) {
-        let message = error.localizedDescription
-        let nsError = error as NSError
-        let isUpToDate = nsError.domain == SUSparkleErrorDomain
-            && nsError.code == 1001 /* SUNoUpdateError */
-        if isUpToDate {
-            logSync("Sparkle: Already up to date")
-        } else {
-            logSync("Sparkle: Update check failed - \(message) [domain=\(nsError.domain) code=\(nsError.code)]")
-            if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
-                logSync("Sparkle: Underlying error - \(underlying.localizedDescription) [domain=\(underlying.domain) code=\(underlying.code)]")
-            }
-            for (key, value) in nsError.userInfo where key != NSUnderlyingErrorKey {
-                logSync("Sparkle: Error info [\(key)] = \(value)")
-            }
-            // Build diagnostic properties for analytics
-            let errorDomain = nsError.domain
-            let errorCode = nsError.code
-            var underlyingMessage: String? = nil
-            var underlyingDomain: String? = nil
-            var underlyingCode: Int? = nil
-
-            if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
-                underlyingMessage = underlying.localizedDescription
-                underlyingDomain = underlying.domain
-                underlyingCode = underlying.code
-            }
-
-            Task { @MainActor in
-                AnalyticsManager.shared.updateCheckFailed(
-                    error: message,
-                    errorDomain: errorDomain,
-                    errorCode: errorCode,
-                    underlyingError: underlyingMessage,
-                    underlyingDomain: underlyingDomain,
-                    underlyingCode: underlyingCode
-                )
-            }
-
-            // SUInstallationError (4005): Sparkle's installer failed to launch.
-            // On macOS 26, AuthorizationCreate/SMJobSubmit can fail due to stricter
-            // code signature validation or on-demand-only launchd mode.
-            // Fallback: open the download page so the user can install manually.
-            let isInstallationError = nsError.domain == SUSparkleErrorDomain && nsError.code == 4005
-            if isInstallationError {
-                logSync("Sparkle: Installation failed, opening download page as fallback")
-                if let url = URL(string: "https://macos.omi.me") {
-                    NSWorkspace.shared.open(url)
-                }
-            }
-        }
-    }
-
-    /// Tells Sparkle which non-default channels this client wants to see.
-    /// Channels are additive: the default (stable) channel is always included.
-    func allowedChannels(for updater: SPUUpdater) -> Set<String> {
-        let raw = UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
-        if raw == "beta" || raw == "staging" {
-            return Set(["beta"])
-        }
-        return Set() // empty = default (stable) channel only
-    }
-
-    /// Called after Sparkle has launched the installer and submitted launchd jobs.
-    /// On macOS 26+, launchd may be in "on-demand-only mode" which prevents RunAtLoad
-    /// services from starting. We force-start them via launchctl kickstart as a backup
-    /// to Sparkle 2.9.0's built-in probe (PR #2852).
-    func updater(_ updater: SPUUpdater, didExtractUpdate item: SUAppcastItem) {
-        logSync("Sparkle: Installer launched for v\(item.displayVersionString), kickstarting services")
-        kickstartSparkleServices()
-    }
-
-    /// Force-start Sparkle's launchd services to work around macOS 26 on-demand-only mode.
-    /// Services submitted via SMJobSubmit with RunAtLoad=YES may not start immediately.
-    /// Using `launchctl kickstart` forces launchd to spawn them right away.
-    private func kickstartSparkleServices() {
-        guard let bundleID = Bundle.main.bundleIdentifier else { return }
-
-        let updaterLabel = "\(bundleID)-sparkle-updater"
-        let progressLabel = "\(bundleID)-sparkle-progress"
-        let uid = getuid()
-
-        // Try multiple times to handle timing variance
-        for delay in [0.5, 2.0, 5.0] {
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + delay) {
-                for label in [progressLabel, updaterLabel] {
-                    let process = Process()
-                    process.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-                    process.arguments = ["kickstart", "-p", "gui/\(uid)/\(label)"]
-                    process.standardOutput = FileHandle.nullDevice
-                    process.standardError = FileHandle.nullDevice
-
-                    do {
-                        try process.run()
-                        process.waitUntilExit()
-                        if process.terminationStatus == 0 {
-                            logSync("Sparkle kickstart: started \(label) (delay=\(delay)s)")
-                        }
-                    } catch {
-                        // Best effort — service may not exist yet or already running
-                    }
-                }
-            }
-        }
-    }
-
-    /// Called when an update will be installed (app may terminate immediately after)
-    func updater(_ updater: SPUUpdater, willInstallUpdate item: SUAppcastItem) {
-        let version = item.displayVersionString
-        logSync("Sparkle: Installing update v\(version)")
-        Task { @MainActor in
-            AnalyticsManager.shared.updateInstalled(version: version)
-            self.viewModel?.updateAvailable = false
-        }
-    }
+    logSync("Sparkle: Triggering immediate installation for v\(version)")
+    installationBlock()
+    return true
+  }
 }
 
 /// View model for managing Sparkle auto-updates
 /// Provides SwiftUI bindings for the updater UI
 @MainActor
 final class UpdaterViewModel: ObservableObject {
-    static let shared = UpdaterViewModel()
+  static let shared = UpdaterViewModel()
 
-    private let updaterController: SPUStandardUpdaterController
-    private let updaterDelegate = UpdaterDelegate()
-    private var isInitialized = false
+  private let updaterController: SPUStandardUpdaterController
+  private let updaterDelegate = UpdaterDelegate()
+  private var isInitialized = false
 
-    /// Whether automatic update checks are enabled
-    @Published var automaticallyChecksForUpdates: Bool {
-        didSet {
-            updaterController.updater.automaticallyChecksForUpdates = automaticallyChecksForUpdates
-            if isInitialized {
-                AnalyticsManager.shared.settingToggled(setting: "automatic_update_checks", enabled: automaticallyChecksForUpdates)
-            }
-        }
+  var usesManagedUpdatePolicy: Bool {
+    !AnalyticsManager.isDevBuild
+  }
+
+  /// Whether automatic update checks are enabled
+  @Published var automaticallyChecksForUpdates: Bool {
+    didSet {
+      updaterController.updater.automaticallyChecksForUpdates = automaticallyChecksForUpdates
+      if isInitialized {
+        AnalyticsManager.shared.settingToggled(
+          setting: "automatic_update_checks", enabled: automaticallyChecksForUpdates)
+      }
     }
+  }
 
-    /// Whether updates are automatically downloaded and installed
-    @Published var automaticallyDownloadsUpdates: Bool {
-        didSet {
-            updaterController.updater.automaticallyDownloadsUpdates = automaticallyDownloadsUpdates
-            if isInitialized {
-                AnalyticsManager.shared.settingToggled(setting: "auto_install_updates", enabled: automaticallyDownloadsUpdates)
-            }
-        }
+  /// Whether updates are automatically downloaded and installed
+  @Published var automaticallyDownloadsUpdates: Bool {
+    didSet {
+      updaterController.updater.automaticallyDownloadsUpdates = automaticallyDownloadsUpdates
+      if isInitialized {
+        AnalyticsManager.shared.settingToggled(
+          setting: "auto_install_updates", enabled: automaticallyDownloadsUpdates)
+      }
     }
+  }
 
-    /// Whether the updater can check for updates (e.g., not already checking)
-    @Published private(set) var canCheckForUpdates: Bool = true
+  /// Whether the updater can check for updates (e.g., not already checking)
+  @Published private(set) var canCheckForUpdates: Bool = true
 
-    /// Whether Sparkle has an active update session (downloading, installing, etc.)
-    @Published private(set) var updateSessionInProgress: Bool = false {
-        didSet { UpdaterViewModel._isUpdateInProgress = updateSessionInProgress }
+  /// Whether Sparkle has an active update session (downloading, installing, etc.)
+  @Published private(set) var updateSessionInProgress: Bool = false {
+    didSet { UpdaterViewModel._isUpdateInProgress = updateSessionInProgress }
+  }
+
+  /// Nonisolated snapshot for cross-actor reads
+  private nonisolated(unsafe) static var _isUpdateInProgress: Bool = false
+
+  /// Selected update channel (persisted to UserDefaults)
+  @Published var updateChannel: UpdateChannel {
+    didSet {
+      guard oldValue != updateChannel else { return }
+
+      // Must happen before check; Sparkle delegate reads from UserDefaults
+      UserDefaults.standard.set(updateChannel.rawValue, forKey: kUpdateChannelKey)
+      activeChannelLabel = updateChannel == .stable ? "" : updateChannel.displayName
+
+      if isInitialized {
+        AnalyticsManager.shared.settingToggled(
+          setting: "update_channel", enabled: updateChannel != .stable)
+        checkForUpdatesInBackground()
+      }
     }
+  }
 
-    /// Nonisolated snapshot for cross-actor reads
-    private nonisolated(unsafe) static var _isUpdateInProgress: Bool = false
+  /// Whether a new update is available (set by delegate callbacks)
+  @Published var updateAvailable: Bool = false
 
-    /// Selected update channel (persisted to UserDefaults)
-    @Published var updateChannel: UpdateChannel {
-        didSet {
-            guard oldValue != updateChannel else { return }
+  /// Version string of the available update
+  @Published var availableVersion: String = ""
 
-            // Must happen before check; Sparkle delegate reads from UserDefaults
-            UserDefaults.standard.set(updateChannel.rawValue, forKey: kUpdateChannelKey)
-            activeChannelLabel = updateChannel == .stable ? "" : updateChannel.displayName
+  /// Latest stable build number from the appcast (for downgrade detection)
+  @Published var latestStableBuildNumber: Int?
 
-            if isInitialized {
-                AnalyticsManager.shared.settingToggled(setting: "update_channel", enabled: updateChannel != .stable)
-                checkForUpdatesInBackground()
-            }
-        }
+  /// Latest stable version string from the appcast (e.g. "0.11.48+11048")
+  @Published var latestStableVersionString: String?
+
+  /// The date of the last update check
+  var lastUpdateCheckDate: Date? {
+    updaterController.updater.lastUpdateCheckDate
+  }
+
+  private init() {
+    // Initialize the updater controller with our delegate
+    updaterController = SPUStandardUpdaterController(
+      startingUpdater: true,
+      updaterDelegate: updaterDelegate,
+      userDriverDelegate: nil
+    )
+
+    // Initialize published properties from updater state (must be before using `self`)
+    automaticallyChecksForUpdates = updaterController.updater.automaticallyChecksForUpdates
+    automaticallyDownloadsUpdates = updaterController.updater.automaticallyDownloadsUpdates
+
+    // Initialize update channel from UserDefaults
+    // Normalize legacy "staging" → "beta" for users upgrading from older builds
+    var storedChannel = UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
+    if storedChannel == "staging" { storedChannel = "beta" }
+    updateChannel = UpdateChannel(rawValue: storedChannel) ?? .stable
+
+    // Wire up delegate back-reference
+    updaterDelegate.viewModel = self
+
+    // Check for updates every 10 minutes
+    updaterController.updater.updateCheckInterval = 600
+
+    // Observe updater state changes
+    updaterController.updater.publisher(for: \.canCheckForUpdates)
+      .receive(on: DispatchQueue.main)
+      .assign(to: &$canCheckForUpdates)
+
+    updaterController.updater.publisher(for: \.sessionInProgress)
+      .receive(on: DispatchQueue.main)
+      .assign(to: &$updateSessionInProgress)
+
+    applyManagedUpdatePolicy()
+    isInitialized = true
+  }
+
+  /// Quick check if Sparkle is mid-update (safe to call from anywhere)
+  nonisolated static var isUpdateInProgress: Bool {
+    _isUpdateInProgress
+  }
+
+  /// Manually check for updates
+  func checkForUpdates() {
+    updaterController.checkForUpdates(nil)
+  }
+
+  /// Background update check (no UI). Used after channel changes.
+  func checkForUpdatesInBackground() {
+    updaterController.updater.checkForUpdatesInBackground()
+  }
+
+  /// Force the runtime update policy:
+  /// - release builds: always auto-check + auto-install
+  /// - dev builds: keep both disabled to avoid replacing the local app
+  func applyManagedUpdatePolicy() {
+    let shouldAutoUpdate = !AnalyticsManager.isDevBuild
+    automaticallyChecksForUpdates = shouldAutoUpdate
+    automaticallyDownloadsUpdates = shouldAutoUpdate
+    updaterController.updater.automaticallyChecksForUpdates = shouldAutoUpdate
+    updaterController.updater.automaticallyDownloadsUpdates = shouldAutoUpdate
+    logSync(
+      "Sparkle: Managed policy applied - isDevBuild=\(AnalyticsManager.isDevBuild) autoChecks=\(updaterController.updater.automaticallyChecksForUpdates) autoDownloads=\(updaterController.updater.automaticallyDownloadsUpdates)"
+    )
+  }
+
+  /// Trigger one immediate silent update check right after launch.
+  /// Sparkle recommends calling this only immediately after starting the updater.
+  func checkForUpdatesImmediatelyAfterLaunchIfNeeded() {
+    guard usesManagedUpdatePolicy else { return }
+    guard automaticallyChecksForUpdates else { return }
+    guard canCheckForUpdates else { return }
+    checkForUpdatesInBackground()
+  }
+
+  /// Get the current app version string
+  var currentVersion: String {
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
+  }
+
+  /// Get the current build number
+  var buildNumber: String {
+    Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "Unknown"
+  }
+
+  /// The active channel label
+  @Published var activeChannelLabel: String = {
+    let raw = UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
+    return (raw == "beta" || raw == "staging") ? "Beta" : ""
+  }()
+
+  /// Returns true if switching to stable would be a downgrade (current build > latest stable build)
+  var isDowngradeToStable: Bool {
+    guard let currentBuild = Int(buildNumber),
+      let stableBuild = latestStableBuildNumber
+    else {
+      return false
     }
-
-    /// Whether a new update is available (set by delegate callbacks)
-    @Published var updateAvailable: Bool = false
-
-    /// Version string of the available update
-    @Published var availableVersion: String = ""
-
-    /// Latest stable build number from the appcast (for downgrade detection)
-    @Published var latestStableBuildNumber: Int?
-
-    /// Latest stable version string from the appcast (e.g. "0.11.48+11048")
-    @Published var latestStableVersionString: String?
-
-    /// The date of the last update check
-    var lastUpdateCheckDate: Date? {
-        updaterController.updater.lastUpdateCheckDate
-    }
-
-    private init() {
-        // Initialize the updater controller with our delegate
-        updaterController = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: updaterDelegate,
-            userDriverDelegate: nil
-        )
-
-        // Initialize published properties from updater state (must be before using `self`)
-        automaticallyChecksForUpdates = updaterController.updater.automaticallyChecksForUpdates
-        automaticallyDownloadsUpdates = updaterController.updater.automaticallyDownloadsUpdates
-
-        // Initialize update channel from UserDefaults
-        // Normalize legacy "staging" → "beta" for users upgrading from older builds
-        var storedChannel = UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
-        if storedChannel == "staging" { storedChannel = "beta" }
-        updateChannel = UpdateChannel(rawValue: storedChannel) ?? .stable
-
-        // Wire up delegate back-reference
-        updaterDelegate.viewModel = self
-
-        // Check for updates every 10 minutes
-        updaterController.updater.updateCheckInterval = 600
-
-        // Observe updater state changes
-        updaterController.updater.publisher(for: \.canCheckForUpdates)
-            .receive(on: DispatchQueue.main)
-            .assign(to: &$canCheckForUpdates)
-
-        updaterController.updater.publisher(for: \.sessionInProgress)
-            .receive(on: DispatchQueue.main)
-            .assign(to: &$updateSessionInProgress)
-
-        isInitialized = true
-    }
-
-    /// Quick check if Sparkle is mid-update (safe to call from anywhere)
-    nonisolated static var isUpdateInProgress: Bool {
-        _isUpdateInProgress
-    }
-
-    /// Manually check for updates
-    func checkForUpdates() {
-        updaterController.checkForUpdates(nil)
-    }
-
-    /// Background update check (no UI). Used after channel changes.
-    func checkForUpdatesInBackground() {
-        updaterController.updater.checkForUpdatesInBackground()
-    }
-
-    /// Get the current app version string
-    var currentVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
-    }
-
-    /// Get the current build number
-    var buildNumber: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "Unknown"
-    }
-
-    /// The active channel label
-    @Published var activeChannelLabel: String = {
-        let raw = UserDefaults.standard.string(forKey: kUpdateChannelKey) ?? "stable"
-        return (raw == "beta" || raw == "staging") ? "Beta" : ""
-    }()
-
-    /// Returns true if switching to stable would be a downgrade (current build > latest stable build)
-    var isDowngradeToStable: Bool {
-        guard let currentBuild = Int(buildNumber),
-              let stableBuild = latestStableBuildNumber else {
-            return false
-        }
-        return currentBuild > stableBuild
-    }
+    return currentBuild > stableBuild
+  }
 }

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -36,6 +36,11 @@ BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_PATH="/Applications/$APP_NAME.app"
 SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
+AUTOMATION_ARGS=()
+if [ "${OMI_ENABLE_LOCAL_AUTOMATION:-0}" = "1" ]; then
+    AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-47777}"
+    AUTOMATION_ARGS+=(--automation-bridge "--automation-port=$AUTOMATION_PORT")
+fi
 
 # Backend configuration (Rust)
 BACKEND_DIR="$(dirname "$0")/Backend-Rust"
@@ -398,12 +403,19 @@ echo "=== Services Running (total: ${TOTAL_TIME%.*}s) ==="
 echo "Backend:  http://localhost:8080 (PID: $BACKEND_PID)"
 echo "Tunnel:   $TUNNEL_URL (PID: $TUNNEL_PID)"
 echo "App:      $APP_PATH (installed from $APP_BUNDLE)"
+if [ "${#AUTOMATION_ARGS[@]}" -gt 0 ]; then
+    echo "Automation bridge: http://127.0.0.1:${AUTOMATION_PORT}"
+fi
 echo "Using backend: $TUNNEL_URL"
 echo "========================================"
 echo ""
 
 auth_debug "BEFORE launch: $(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
-open "$APP_PATH" || "$APP_PATH/Contents/MacOS/$BINARY_NAME" &
+if [ "${#AUTOMATION_ARGS[@]}" -gt 0 ]; then
+    open "$APP_PATH" --args "${AUTOMATION_ARGS[@]}" || "$APP_PATH/Contents/MacOS/$BINARY_NAME" "${AUTOMATION_ARGS[@]}" &
+else
+    open "$APP_PATH" || "$APP_PATH/Contents/MacOS/$BINARY_NAME" &
+fi
 
 # Wait for backend process (keeps script running and shows logs)
 echo "Press Ctrl+C to stop all services..."


### PR DESCRIPTION
## Summary
- add a local-only desktop automation bridge for semantic in-app navigation and state checks
- wire the dev desktop app launcher to enable the bridge when requested
- enforce managed Sparkle auto-update behavior for release builds while keeping dev builds opt-out

## Verification
- `xcrun swift build -c debug --package-path desktop/Desktop`
- launched a local app bundle with the automation bridge and verified `GET /state` + `POST /navigate`
- launched a release-style test bundle and verified Sparkle performed an automatic launch-time update check
- confirmed Sparkle docs in the vendored dependency for launch-time background checks and immediate-install hook behavior

## Notes
- left local-only agent instruction edits out of this PR
- did not touch unrelated local worktree changes