### PR TITLE
Adjust backend-listen HPA for cost saving

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -342,8 +342,8 @@ startupProbe:
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: true
-  minReplicas: 26
-  maxReplicas: 50
+  minReplicas: 20
+  maxReplicas: 40
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 600


### PR DESCRIPTION
**Change:**
Thanks to the new backend-listen WS connections metric, now we can adjust the HPA with the real WS connections in backend-listen for cost optimization
- minReplicas: 26 -> 20
- maxReplicas: 50 -> 40