### PR TITLE
Fix desktop notification preview regressions

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -578,6 +578,13 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         resizeAnchored(to: targetSize, makeResizable: false, animated: animated, anchorTop: true)
     }
 
+    /// Restore the compact pill size when we temporarily surface the bar outside
+    /// of an active hover, notification, voice session, or AI conversation.
+    func normalizeForTemporaryShow() {
+        guard !state.showingAIConversation, !state.isVoiceListening, state.currentNotification == nil else { return }
+        resizeAnchored(to: Self.minBarSize, makeResizable: false, animated: false, anchorTop: true)
+    }
+
     private func resizeToResponseHeight(animated: Bool = false) {
         // Determine the 2× cap from the user's saved (or default) preferred height.
         let savedSize = UserDefaults.standard.string(forKey: FloatingControlBarWindow.sizeKey)
@@ -870,6 +877,7 @@ class FloatingControlBarManager {
     func showTemporarily() {
         guard window != nil else { return }
         log("FloatingControlBarManager: showTemporarily() — showing bar above Chrome")
+        window?.normalizeForTemporaryShow()
         window?.makeKeyAndOrderFront(nil)
     }
 

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -204,6 +204,36 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
             assistantId: assistantId,
             sound: sound
         )
+
+        // Keep the floating-bar preview, but still deliver the real macOS
+        // notification when authorization is available.
+        UNUserNotificationCenter.current().getNotificationSettings { [weak self] settings in
+            Task { @MainActor in
+                guard settings.authorizationStatus == .authorized else {
+                    log("Notification skipped (auth=\(settings.authorizationStatus.rawValue)): \(title)")
+
+                    // If auth reverted to notDetermined (not explicitly denied), trigger repair.
+                    // Debounce: at most once per 10 minutes to avoid hammering lsregister.
+                    if settings.authorizationStatus == .notDetermined {
+                        let now = Date()
+                        if self?.lastRepairAttempt == nil || now.timeIntervalSince(self?.lastRepairAttempt ?? .distantPast) > 600 {
+                            self?.lastRepairAttempt = now
+                            log("Notification auth is notDetermined at send time — triggering repair")
+                            AnalyticsManager.shared.notificationRepairTriggered(
+                                reason: "send_time_not_determined",
+                                previousStatus: "unknown",
+                                currentStatus: "notDetermined"
+                            )
+                            ProactiveAssistantsPlugin.repairNotificationRegistration()
+                        }
+                    }
+
+                    return
+                }
+
+                self?.deliverNotification(title: title, message: message, assistantId: assistantId, sound: sound)
+            }
+        }
     }
 
     private func deliverNotification(title: String, message: String, assistantId: String, sound: NotificationSound) {


### PR DESCRIPTION
## Summary
- restore real macOS notifications while keeping the new floating-bar preview
- reset the temporary floating bar to the compact pill before showing it
- preserve the existing notification auth repair path for notDetermined authorization

## Testing
- swift build -c debug --package-path Desktop
- manual dev app launch attempted; environment blocked full onboarding verification in pre-auth launch state