### PR TITLE
Migrate mobile chat from OpenAI/LangGraph to Anthropic Claude Opus 4.6

### DIFF
--- a/app/lib/providers/message_provider.dart
+++ b/app/lib/providers/message_provider.dart
@@ -642,12 +642,19 @@ class MessageProvider extends ChangeNotifier {
           flushBuffer();
           agentLog('[MessageProvider] think: ${chunk.text.length > 100 ? chunk.text.substring(0, 100) : chunk.text}');
           message.thinkings.add(chunk.text);
+          if (message.text.isNotEmpty) {
+            agentThinkingAfterText = true;
+          }
           notifyListeners();
           continue;
         }
 
         if (chunk.type == MessageChunkType.data) {
           if (chunkCount <= 3) agentLog('[MessageProvider] first data chunk received');
+          if (agentThinkingAfterText) {
+            agentThinkingAfterText = false;
+            notifyListeners();
+          }
           textBuffer += chunk.text;
           timer ??= Timer.periodic(const Duration(milliseconds: 100), (_) {
             flushBuffer();

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,6 +2,9 @@ import json
 import logging
 import os
 
+from dotenv import load_dotenv
+load_dotenv()  # No-op if .env doesn't exist (production); loads local dev secrets otherwise
+
 logging.basicConfig(level=logging.INFO)
 
 import firebase_admin

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ aiosignal==1.3.1
 aiostream==0.5.2
 alembic==1.13.2
 altair==5.4.0
+anthropic>=0.52.0
 annotated-types==0.7.0
 antlr4-python3-runtime==4.9.3
 anyio==4.4.0

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -38,9 +38,8 @@ from utils.llm.goals import extract_and_update_goal_progress
 from database.redis_db import try_acquire_goal_extraction_lock
 from utils.other import endpoints as auth, storage
 from utils.other.chat_file import FileChatTool
-from utils.retrieval.graph import execute_graph_chat, execute_graph_chat_stream, execute_persona_chat_stream
+from utils.retrieval.graph import execute_graph_chat, execute_chat_stream, execute_persona_chat_stream
 from utils.llm.usage_tracker import set_usage_context, reset_usage_context, Features
-from utils.retrieval.agentic import execute_agentic_chat, execute_agentic_chat_stream
 import logging
 
 logger = logging.getLogger(__name__)
@@ -179,8 +178,7 @@ def send_message(
         # Set usage context for streaming (can't use 'with' across yields)
         usage_token = set_usage_context(uid, Features.CHAT)
         try:
-            # Using the new agentic system via graph routing
-            async for chunk in execute_graph_chat_stream(
+            async for chunk in execute_chat_stream(
                 uid,
                 messages,
                 app,

--- a/backend/tests/unit/test_prompt_cache_integration.py
+++ b/backend/tests/unit/test_prompt_cache_integration.py
@@ -94,6 +94,9 @@ clients_mod.llm_medium_stream = mock_llm
 clients_mod.llm_medium_experiment = mock_llm
 clients_mod.llm_agent = mock_llm
 clients_mod.llm_agent_stream = mock_llm
+clients_mod.anthropic_client = MagicMock()
+clients_mod.ANTHROPIC_AGENT_MODEL = "claude-sonnet-4-6-20250514"
+clients_mod.ANTHROPIC_AGENT_COMPLEX_MODEL = "claude-opus-4-6-20250414"
 clients_mod.embeddings = MagicMock()
 clients_mod.encoding = MagicMock()
 clients_mod.num_tokens_from_string = MagicMock(return_value=100)
@@ -121,6 +124,7 @@ if not hasattr(obs_mod, "__path__"):
     obs_mod.__path__ = []
 langsmith_mod = _stub_module("utils.observability.langsmith")
 langsmith_mod.get_chat_tracer_callbacks = MagicMock(return_value=[])
+langsmith_mod.is_langsmith_enabled = MagicMock(return_value=False)
 langsmith_prompts_mod = _stub_module("utils.observability.langsmith_prompts")
 langsmith_prompts_mod.get_agentic_system_prompt_template = MagicMock(side_effect=Exception("not available"))
 langsmith_prompts_mod.render_prompt = MagicMock()
@@ -253,16 +257,35 @@ def _get_agentic_module():
         "search_files_tool",
         "manage_daily_summary_tool",
         "create_chart_tool",
+        "get_screen_activity_tool",
+        "search_screen_activity_tool",
+        "save_user_preference_tool",
     ]
     for name in tool_names:
         mock_tool = MagicMock()
-        mock_tool.name = name.replace("_tool", "")
+        mock_tool.name = name
+        # Add args_schema for _convert_tools to work
+        mock_schema = MagicMock()
+        mock_schema.schema.return_value = {"properties": {"query": {"type": "string"}}, "required": ["query"]}
+        mock_tool.args_schema = mock_schema
+        mock_tool.description = f"Mock tool: {name}"
         setattr(tools_pkg, name, mock_tool)
+
+    # Stub sub-modules
+    _stub_module("utils.retrieval.tools.preference_tools")
 
     # Stub app_tools
     app_tools_mod = _stub_module("utils.retrieval.tools.app_tools")
     app_tools_mod.load_app_tools = MagicMock(return_value=[])
     app_tools_mod.get_tool_status_message = MagicMock(return_value=None)
+
+    # Stub Anthropic client
+    anthropic_mod = _stub_module("anthropic")
+    anthropic_mod.AsyncAnthropic = MagicMock
+
+    # Stub langsmith traceable
+    langsmith_mod = _stub_module("langsmith")
+    langsmith_mod.traceable = lambda **kwargs: lambda func: func
 
     return _load_module_from_file("utils.retrieval.agentic", BACKEND_DIR / "utils" / "retrieval" / "agentic.py")
 
@@ -470,10 +493,10 @@ def test_static_prefix_exceeds_minimum_cache_tokens():
 # ---------------------------------------------------------------------------
 
 
-def test_core_tools_has_22_tools():
-    """CORE_TOOLS must contain exactly 22 tools."""
+def test_core_tools_has_25_tools():
+    """CORE_TOOLS must contain exactly 25 tools."""
     agentic_mod = _get_agentic_module()
-    assert len(agentic_mod.CORE_TOOLS) == 22, f"CORE_TOOLS has {len(agentic_mod.CORE_TOOLS)} tools, expected 22"
+    assert len(agentic_mod.CORE_TOOLS) == 25, f"CORE_TOOLS has {len(agentic_mod.CORE_TOOLS)} tools, expected 25"
 
 
 def test_core_tools_list_creates_independent_copy():
@@ -496,9 +519,9 @@ def test_core_tools_list_creates_independent_copy():
     mock_app_tool.name = "custom_app_tool"
     tools_a.append(mock_app_tool)
 
-    assert len(tools_a) == 23
-    assert len(tools_b) == 22
-    assert len(agentic_mod.CORE_TOOLS) == 22, "CORE_TOOLS was mutated!"
+    assert len(tools_a) == 26
+    assert len(tools_b) == 25
+    assert len(agentic_mod.CORE_TOOLS) == 25, "CORE_TOOLS was mutated!"
 
 
 def test_core_tools_order_matches_exports():
@@ -509,28 +532,31 @@ def test_core_tools_order_matches_exports():
     agentic_mod = _get_agentic_module()
 
     expected_names = [
-        "get_conversations",
-        "search_conversations",
-        "get_memories",
-        "search_memories",
-        "get_action_items",
-        "create_action_item",
-        "update_action_item",
-        "get_omi_product_info",
-        "perplexity_web_search",
-        "get_calendar_events",
-        "create_calendar_event",
-        "update_calendar_event",
-        "delete_calendar_event",
-        "get_gmail_messages",
-        "get_apple_health_steps",
-        "get_apple_health_sleep",
-        "get_apple_health_heart_rate",
-        "get_apple_health_workouts",
-        "get_apple_health_summary",
-        "search_files",
-        "manage_daily_summary",
-        "create_chart",
+        "get_conversations_tool",
+        "search_conversations_tool",
+        "get_memories_tool",
+        "search_memories_tool",
+        "get_action_items_tool",
+        "create_action_item_tool",
+        "update_action_item_tool",
+        "get_omi_product_info_tool",
+        "perplexity_web_search_tool",
+        "get_calendar_events_tool",
+        "create_calendar_event_tool",
+        "update_calendar_event_tool",
+        "delete_calendar_event_tool",
+        "get_gmail_messages_tool",
+        "get_apple_health_steps_tool",
+        "get_apple_health_sleep_tool",
+        "get_apple_health_heart_rate_tool",
+        "get_apple_health_workouts_tool",
+        "get_apple_health_summary_tool",
+        "search_files_tool",
+        "manage_daily_summary_tool",
+        "create_chart_tool",
+        "get_screen_activity_tool",
+        "search_screen_activity_tool",
+        "save_user_preference_tool",
     ]
 
     actual_names = [t.name for t in agentic_mod.CORE_TOOLS]
@@ -583,15 +609,21 @@ def test_llm_agent_model_kwargs_via_real_instantiation():
     source = (BACKEND_DIR / "utils" / "llm" / "clients.py").read_text()
     source = source.replace("from langchain_openai import ChatOpenAI, OpenAIEmbeddings", "")
     source = source.replace("import tiktoken", "")
+    source = source.replace("import anthropic", "")
     source = source.replace("from langchain_core.output_parsers import PydanticOutputParser", "")
     source = source.replace("from models.conversation import Structured", "")
     source = source.replace("from utils.llm.usage_tracker import get_usage_callback", "")
+
+    # Create a fake anthropic module with AsyncAnthropic
+    fake_anthropic = _stub_module("anthropic_fake")
+    fake_anthropic.AsyncAnthropic = MagicMock
 
     ns = {
         "os": os,
         "ChatOpenAI": FakeChatOpenAI,
         "OpenAIEmbeddings": FakeOpenAIEmbeddings,
         "tiktoken": fake_tiktoken,
+        "anthropic": fake_anthropic,
         "PydanticOutputParser": MagicMock(),
         "Structured": MagicMock(),
         "get_usage_callback": MagicMock(return_value=[]),
@@ -627,96 +659,71 @@ def test_llm_agent_model_kwargs_via_real_instantiation():
 # ---------------------------------------------------------------------------
 
 
-def test_execute_agentic_chat_tool_order_via_create_react_agent():
+def test_convert_tools_produces_valid_anthropic_schemas():
     """
-    Call execute_agentic_chat and intercept create_react_agent to capture
-    the actual tools list passed at runtime. Verifies core tools come first
-    and app tools are appended after.
+    _convert_tools should produce valid Anthropic tool schemas from CORE_TOOLS,
+    filtering out the 'config' parameter and preserving tool order.
     """
     agentic_mod = _get_agentic_module()
 
-    # Set up mock app tools — patch on the agentic module directly since
-    # it already imported load_app_tools at module load time
+    tool_schemas, tool_registry = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS)
+
+    assert len(tool_schemas) == len(agentic_mod.CORE_TOOLS), "Should produce one schema per tool"
+    assert len(tool_registry) == len(agentic_mod.CORE_TOOLS), "Should register all tools"
+
+    for schema in tool_schemas:
+        assert "name" in schema, "Schema must have a name"
+        assert "description" in schema, "Schema must have a description"
+        assert "input_schema" in schema, "Schema must have input_schema"
+        # Config parameter should be filtered out
+        props = schema["input_schema"].get("properties", {})
+        assert "config" not in props, f"Tool {schema['name']} should not expose 'config' parameter"
+        # Core tools should NOT have defer_loading
+        assert "defer_loading" not in schema, f"Core tool {schema['name']} should not have defer_loading"
+
+
+def test_convert_tools_defers_app_tools():
+    """
+    App tools should be marked with defer_loading=True and tool_search_tool
+    should be added when app tools are present.
+    """
+    agentic_mod = _get_agentic_module()
+
     mock_app_tool = MagicMock()
     mock_app_tool.name = "custom_weather_app"
-    agentic_mod.load_app_tools = MagicMock(return_value=[mock_app_tool])
+    mock_schema = MagicMock()
+    mock_schema.schema.return_value = {"properties": {"query": {"type": "string"}}, "required": ["query"]}
+    mock_app_tool.args_schema = mock_schema
+    mock_app_tool.description = "Mock app tool"
 
-    # Intercept create_react_agent to capture the tools argument
-    captured_tools = []
-    original_create = agentic_mod.create_react_agent
+    tool_schemas, tool_registry = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS, [mock_app_tool])
 
-    def fake_create_react_agent(**kwargs):
-        captured_tools.append(kwargs.get("tools", []))
-        # Return a mock agent that returns a valid result
-        mock_agent = MagicMock()
-        mock_result = {"messages": [MagicMock(content="test answer", tool_calls=[], additional_kwargs={})]}
-        mock_agent.invoke = MagicMock(return_value=mock_result)
-        return mock_agent
+    # Should have tool_search_tool + core tools + 1 app tool
+    assert len(tool_schemas) == len(agentic_mod.CORE_TOOLS) + 2  # +1 search tool, +1 app tool
 
-    agentic_mod.create_react_agent = fake_create_react_agent
+    # First should be tool_search_tool
+    assert tool_schemas[0]["type"] == "tool_search_tool_regex_20251119"
 
-    # Patch _get_agentic_qa_prompt and tracer callbacks on the module
-    agentic_mod._get_agentic_qa_prompt = MagicMock(return_value="test system prompt")
-    agentic_mod.get_chat_tracer_callbacks = MagicMock(return_value=[])
+    # Last should be the deferred app tool
+    assert tool_schemas[-1]["name"] == "custom_weather_app"
+    assert tool_schemas[-1]["defer_loading"] is True
 
-    try:
-        # Create a minimal message
-        msg = MagicMock()
-        msg.sender = "human"
-        msg.text = "hello"
-
-        agentic_mod.execute_agentic_chat("test_uid", [msg])
-
-        assert len(captured_tools) == 1, "create_react_agent should have been called once"
-        tools = captured_tools[0]
-
-        # First 22 should be CORE_TOOLS
-        assert len(tools) == 23, f"Expected 22 core + 1 app = 23 tools, got {len(tools)}"
-        core_names = [t.name for t in tools[:22]]
-        expected_core = [t.name for t in agentic_mod.CORE_TOOLS]
-        assert core_names == expected_core, "Core tools order was disrupted in execute path"
-        assert tools[22].name == "custom_weather_app", "App tool should be appended at end"
-    finally:
-        agentic_mod.create_react_agent = original_create
+    # Registry should include all tools
+    assert "custom_weather_app" in tool_registry
 
 
-def test_execute_agentic_chat_no_app_tools_gives_core_only():
+def test_convert_tools_preserves_core_tool_order():
     """
-    Call execute_agentic_chat with no app tools and verify only CORE_TOOLS
-    are passed to create_react_agent.
+    Tool schemas should be in the same order as CORE_TOOLS to ensure
+    deterministic serialization for prompt caching.
     """
     agentic_mod = _get_agentic_module()
 
-    # No app tools — patch on the module directly
-    agentic_mod.load_app_tools = MagicMock(return_value=[])
+    tool_schemas, _ = agentic_mod._convert_tools(agentic_mod.CORE_TOOLS)
 
-    captured_tools = []
-    original_create = agentic_mod.create_react_agent
-
-    def fake_create_react_agent(**kwargs):
-        captured_tools.append(kwargs.get("tools", []))
-        mock_agent = MagicMock()
-        mock_result = {"messages": [MagicMock(content="test", tool_calls=[], additional_kwargs={})]}
-        mock_agent.invoke = MagicMock(return_value=mock_result)
-        return mock_agent
-
-    agentic_mod.create_react_agent = fake_create_react_agent
-    agentic_mod._get_agentic_qa_prompt = MagicMock(return_value="test system prompt")
-    agentic_mod.get_chat_tracer_callbacks = MagicMock(return_value=[])
-
-    try:
-        msg = MagicMock()
-        msg.sender = "human"
-        msg.text = "hello"
-
-        agentic_mod.execute_agentic_chat("test_uid", [msg])
-
-        assert len(captured_tools) == 1
-        tools = captured_tools[0]
-        assert len(tools) == 22, f"Expected exactly 22 core tools, got {len(tools)}"
-        assert [t.name for t in tools] == [t.name for t in agentic_mod.CORE_TOOLS]
-    finally:
-        agentic_mod.create_react_agent = original_create
+    schema_names = [s["name"] for s in tool_schemas]
+    core_names = [t.name for t in agentic_mod.CORE_TOOLS]
+    assert schema_names == core_names, "Tool schema order must match CORE_TOOLS order"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_prompt_cache_optimization.py
+++ b/backend/tests/unit/test_prompt_cache_optimization.py
@@ -149,11 +149,11 @@ def test_core_tools_constant_exists():
 
 
 def test_core_tools_used_in_both_functions():
-    """Both execute_agentic_chat and execute_agentic_chat_stream should use CORE_TOOLS."""
+    """execute_agentic_chat_stream should use CORE_TOOLS."""
     source = _read_agentic_source()
     assert (
-        source.count("list(CORE_TOOLS)") >= 2
-    ), "Both execute functions should use list(CORE_TOOLS) instead of inline tool lists"
+        source.count("list(CORE_TOOLS)") >= 1
+    ), "Execute function should use list(CORE_TOOLS) instead of inline tool lists"
 
 
 def test_no_duplicate_inline_tool_lists():

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -727,6 +727,7 @@ When the user asks about specific dates/times, they are ALWAYS referring to date
 - Show times/dates in {user_name}'s timezone ({tz}), in a natural, friendly way (e.g., "3:45 PM, Tuesday, Oct 16th").
 - If you don’t know, say so honestly.
 - Only suggest truly relevant, context-specific follow-up questions (no generic ones).
+- When you learn a new preference, habit, or personal detail about {user_name} during conversation, save it using save_user_preference_tool so you remember it next time. Don't ask — just save silently. Don't save things you already know from existing memories.
 {plugin_instruction_hint}
 - Follow <quality_control> rules.
 {plugin_personality_hint}

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -1,6 +1,7 @@
 import os
 from typing import List
 
+import anthropic
 import httpx
 from langchain_core.output_parsers import PydanticOutputParser
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
@@ -8,6 +9,12 @@ import tiktoken
 
 from models.conversation import Structured
 from utils.llm.usage_tracker import get_usage_callback
+
+# Anthropic client for chat agent
+anthropic_client = anthropic.AsyncAnthropic()  # uses ANTHROPIC_API_KEY env var
+
+ANTHROPIC_AGENT_MODEL = "claude-opus-4-6"
+ANTHROPIC_AGENT_COMPLEX_MODEL = "claude-opus-4-6"
 
 # Get the usage tracking callback
 _usage_callback = get_usage_callback()

--- a/backend/utils/retrieval/agentic.py
+++ b/backend/utils/retrieval/agentic.py
@@ -1,25 +1,18 @@
 """
-Agentic chat system using LangGraph tools.
+Agentic chat system using Anthropic native tool use.
 
 This module implements a tool-calling agent that autonomously decides which tools
-to use to gather context and answer user questions. Unlike the previous graph-based
-approach, this lets the LLM make decisions about what information it needs.
+to use to gather context and answer user questions. Uses Anthropic's native
+tool use API with streaming for real-time responses.
 """
 
-import re
 import uuid
 import asyncio
 import contextvars
-from datetime import datetime, timezone
+import traceback
 from typing import List, Optional, AsyncGenerator, Any, Tuple
 
-import database.notifications as notification_db
-
-from langchain.callbacks.base import BaseCallbackHandler
-from langchain_core.messages import SystemMessage, AIMessage, HumanMessage
-from langgraph.checkpoint.memory import MemorySaver
-from langgraph.prebuilt import create_react_agent
-from langgraph.prebuilt.chat_agent_executor import AgentState
+from langchain_core.runnables import RunnableConfig
 
 # Context variable to store config for tools
 agent_config_context: contextvars.ContextVar[dict] = contextvars.ContextVar('agent_config', default=None)
@@ -52,20 +45,30 @@ from utils.retrieval.tools import (
     create_chart_tool,
     get_screen_activity_tool,
     search_screen_activity_tool,
+    save_user_preference_tool,
 )
 from utils.retrieval.tools.app_tools import load_app_tools, get_tool_status_message
 from utils.retrieval.safety import AgentSafetyGuard, SafetyGuardError
-from utils.llm.clients import llm_agent, llm_agent_stream
+from utils.llm.clients import anthropic_client, ANTHROPIC_AGENT_MODEL
 from utils.llm.chat import _get_agentic_qa_prompt
-from utils.observability.langsmith import get_chat_tracer_callbacks
 from utils.other.endpoints import timeit
+from utils.observability.langsmith import is_langsmith_enabled
 import logging
+
+# Import langsmith traceable if available
+try:
+    from langsmith import traceable as _traceable
+except ImportError:
+    def _traceable(**kwargs):
+        def decorator(func):
+            return func
+        return decorator
 
 logger = logging.getLogger(__name__)
 
 # PROMPT CACHE OPTIMIZATION: This list MUST stay fixed and in this exact order.
-# OpenAI serializes tools before the system prompt.  If the tool definitions are
-# byte-identical across requests the first ~11 000 tokens are cached (90 % off).
+# Anthropic caches the tools array as part of the request prefix.  If the tool
+# definitions are identical across requests they are cached automatically.
 # Dynamic per-user app tools are appended AFTER this list so the prefix stays stable.
 CORE_TOOLS = [
     get_conversations_tool,
@@ -92,29 +95,24 @@ CORE_TOOLS = [
     create_chart_tool,
     get_screen_activity_tool,
     search_screen_activity_tool,
+    save_user_preference_tool,
 ]
+
+# Standard tool names (used to detect app tools by exclusion)
+STANDARD_TOOL_NAMES = {t.name for t in CORE_TOOLS}
 
 
 def get_tool_display_name(tool_name: str, tool_obj: Optional[Any] = None) -> str:
-    """
-    Convert tool name to user-friendly display name.
-
-    Args:
-        tool_name: Internal tool name (e.g., 'search_notion_pages_tool')
-        tool_obj: Optional tool object that may have status_message attribute
-
-    Returns:
-        User-friendly display name (e.g., 'Searching Notion')
-    """
-    # Check if tool has a custom status_message (for app tools)
-    # First check the global mapping
+    """Convert tool name to user-friendly display name."""
+    # Check global mapping from app_tools first
     status_msg = get_tool_status_message(tool_name)
     if status_msg:
         return status_msg
 
-    # Fallback: check if tool object has status_message attribute
+    # Check tool object for custom status_message
     if tool_obj and hasattr(tool_obj, 'status_message') and tool_obj.status_message:
         return tool_obj.status_message
+
     tool_display_map = {
         'get_calendar_events_tool': 'Checking calendar',
         'create_calendar_event_tool': 'Creating calendar event',
@@ -134,13 +132,12 @@ def get_tool_display_name(tool_name: str, tool_obj: Optional[Any] = None) -> str
         'create_chart_tool': 'Creating chart',
         'get_screen_activity_tool': 'Checking screen activity',
         'search_screen_activity_tool': 'Searching screen activity',
+        'save_user_preference_tool': 'Saving preference',
     }
 
-    # Try exact match first
     if tool_name in tool_display_map:
         return tool_display_map[tool_name]
 
-    # Try partial matches for common patterns
     if 'calendar' in tool_name.lower():
         return 'Checking calendar'
     elif 'perplexity' in tool_name.lower() or 'search' in tool_name.lower():
@@ -152,179 +149,343 @@ def get_tool_display_name(tool_name: str, tool_obj: Optional[Any] = None) -> str
     elif 'action' in tool_name.lower():
         return 'Checking action items'
 
-    # Default: convert snake_case to Title Case
     return tool_name.replace('_', ' ').title()
 
 
-class AsyncStreamingCallback(BaseCallbackHandler):
-    """Callback handler for streaming LLM responses with data and thought prefixes."""
+class AsyncStreamingCallback:
+    """Callback for streaming LLM responses with data and thought prefixes."""
 
     def __init__(self):
         self.queue = asyncio.Queue()
 
     async def put_data(self, text):
-        """Add a data chunk to the queue."""
         await self.queue.put(f"data: {text}")
 
     async def put_thought(self, text, app_id: Optional[str] = None):
-        """Add a thought/status message to the queue."""
         if app_id:
             await self.queue.put(f"think: {text}|app_id:{app_id}")
         else:
             await self.queue.put(f"think: {text}")
 
     def put_thought_nowait(self, text, app_id: Optional[str] = None):
-        """Add a thought/status message to the queue without waiting."""
         if app_id:
             self.queue.put_nowait(f"think: {text}|app_id:{app_id}")
         else:
             self.queue.put_nowait(f"think: {text}")
 
     def put_data_nowait(self, text):
-        """Add a data chunk to the queue without waiting."""
         self.queue.put_nowait(f"data: {text}")
 
     async def end(self):
-        """Signal the end of the stream."""
         await self.queue.put(None)
 
     def end_nowait(self):
-        """Signal the end of the stream without waiting."""
         self.queue.put_nowait(None)
 
-    async def on_llm_new_token(self, token: str, **kwargs) -> None:
-        """Handle new tokens from the LLM."""
-        await self.put_data(token)
 
-    async def on_llm_end(self, response, **kwargs) -> None:
-        """Handle LLM completion."""
-        await self.end()
-
-    async def on_llm_error(self, error: Exception, **kwargs) -> None:
-        """Handle LLM errors."""
-        logger.error(f"Error on LLM: {error}")
-        await self.end()
+# ---------------------------------------------------------------------------
+# Tool schema conversion: LangChain @tool -> Anthropic tool format
+# ---------------------------------------------------------------------------
 
 
-def _messages_to_langchain(messages: List[Message]) -> List:
-    """Convert chat messages to LangChain message format."""
-    lc_messages = []
+def _langchain_tool_to_anthropic(lc_tool, defer_loading: bool = False) -> dict:
+    """Convert a LangChain @tool to Anthropic tool schema format."""
+    schema = lc_tool.args_schema.schema()
+    properties = {k: v for k, v in schema.get('properties', {}).items() if k != 'config'}
+    required = [r for r in schema.get('required', []) if r != 'config']
 
-    for msg in messages:
-        if msg.sender == 'ai':
-            lc_messages.append(AIMessage(content=msg.text))
-        else:
-            lc_messages.append(HumanMessage(content=msg.text))
+    # Clean up schema: remove 'title' keys that Pydantic adds (not needed by Anthropic)
+    cleaned_properties = {}
+    for k, v in properties.items():
+        cleaned = {pk: pv for pk, pv in v.items() if pk != 'title'}
+        cleaned_properties[k] = cleaned
 
-    return lc_messages
-
-
-@timeit
-def execute_agentic_chat(
-    uid: str,
-    messages: List[Message],
-    app: Optional[App] = None,
-) -> Tuple[str, bool, List[Conversation]]:
-    """
-    Execute an agentic chat interaction (non-streaming).
-
-    Args:
-        uid: User ID
-        messages: Chat message history
-        app: Optional app/plugin
-
-    Returns:
-        Tuple of (answer, ask_for_nps, conversations_referenced)
-    """
-    # Build system prompt
-    system_prompt = _get_agentic_qa_prompt(uid, app)
-
-    # Get prompt metadata for tracing/versioning
-    try:
-        from utils.observability.langsmith_prompts import get_prompt_metadata
-
-        prompt_name, prompt_commit, prompt_source = get_prompt_metadata()
-    except Exception as e:
-        logger.error(f"⚠️ Could not get prompt metadata: {e}")
-        prompt_name, prompt_commit, prompt_source = None, None, None
-
-    # Core tools (fixed order) + dynamic app tools appended at end
-    tools = list(CORE_TOOLS)
-
-    # Load tools from enabled apps (appended AFTER core tools to preserve cache prefix)
-    try:
-        app_tools = load_app_tools(uid)
-        tools.extend(app_tools)
-        if app_tools:
-            logger.info(f"🔧 Added {len(app_tools)} app tools to chat")
-    except Exception as e:
-        logger.error(f"⚠️ Error loading app tools: {e}")
-
-    # Convert messages to LangChain format and prepend system message
-    lc_messages = [SystemMessage(content=system_prompt)]
-    lc_messages.extend(_messages_to_langchain(messages))
-
-    # Create agent with tools
-    agent = create_react_agent(
-        model=llm_agent,
-        tools=tools,
-    )
-
-    # Get per-request LangSmith tracer callbacks (enables tracing without global env)
-    tracer_callbacks = get_chat_tracer_callbacks(
-        run_name="chat.agentic",
-        tags=["chat", "agentic"],
-        metadata={
-            "uid": uid,
-            "app_id": app.id if app else None,
-            "app_name": app.name if app else None,
-            "prompt_name": prompt_name,
-            "prompt_commit": prompt_commit,
-            "prompt_source": prompt_source,
-        },
-    )
-
-    # Run agent with LangSmith tracing metadata
-    config = {
-        "configurable": {
-            "user_id": uid,
-            "thread_id": str(uuid.uuid4()),
-        },
-        "callbacks": tracer_callbacks,
-        "run_name": "chat.agentic",
-        "tags": ["chat", "agentic"],
-        "metadata": {
-            "uid": uid,
-            "app_id": app.id if app else None,
-            "app_name": app.name if app else None,
-            "prompt_name": prompt_name,
-            "prompt_commit": prompt_commit,
-            "prompt_source": prompt_source,
+    tool_def = {
+        "name": lc_tool.name,
+        "description": lc_tool.description,
+        "input_schema": {
+            "type": "object",
+            "properties": cleaned_properties,
+            "required": required,
         },
     }
-
-    # Store config in context for tools to access
-    agent_config_context.set(config)
-
-    result = agent.invoke(
-        {"messages": lc_messages},
-        config=config,
-    )
-
-    # Extract answer from result
-    answer = result["messages"][-1].content if result.get("messages") else "I'm sorry, I couldn't generate a response."
-
-    # Determine if we should ask for NPS
-    # Ask for NPS if tools were used (meaning we accessed user data)
-    ask_for_nps = len(result.get("messages", [])) > len(lc_messages) + 1
-
-    # Extract any conversations that were referenced
-    # For now, return empty list - in the future we could parse tool outputs
-    conversations_referenced = []
-
-    return answer, ask_for_nps, conversations_referenced
+    if defer_loading:
+        tool_def["defer_loading"] = True
+    return tool_def
 
 
+# Tool search tool definition — Anthropic's built-in tool discovery
+TOOL_SEARCH_TOOL = {
+    "type": "tool_search_tool_regex_20251119",
+    "name": "tool_search_tool_regex",
+}
+
+
+def _convert_tools(core_tools: list, app_tools: list = None) -> tuple:
+    """Convert all tools and build name->object registry.
+
+    Core tools are always visible to Claude. App tools are marked with
+    defer_loading=True so Claude discovers them on-demand via tool search,
+    keeping the context window small.
+
+    Returns:
+        (tool_schemas, tool_registry) where tool_schemas is a list of Anthropic
+        tool definitions and tool_registry maps tool name -> LangChain tool object.
+    """
+    schemas = []
+
+    # Add tool search tool if there are app tools to discover
+    if app_tools:
+        schemas.append(TOOL_SEARCH_TOOL)
+
+    # Core tools — always visible
+    for t in core_tools:
+        schemas.append(_langchain_tool_to_anthropic(t, defer_loading=False))
+
+    # App tools — deferred, discovered on-demand
+    for t in (app_tools or []):
+        schemas.append(_langchain_tool_to_anthropic(t, defer_loading=True))
+
+    # Registry includes ALL tools (core + app) for execution
+    all_tools = list(core_tools) + list(app_tools or [])
+    registry = {t.name: t for t in all_tools}
+    return schemas, registry
+
+
+@_traceable(name="chat.tool_execution", run_type="tool")
+async def _execute_tool(tool_name: str, tool_input: dict, registry: dict, configurable: dict) -> str:
+    """Execute a LangChain tool by name, injecting RunnableConfig."""
+    tool_obj = registry[tool_name]
+    config = RunnableConfig(configurable=configurable)
+    result = await tool_obj.ainvoke(tool_input, config=config)
+    return str(result)
+
+
+# ---------------------------------------------------------------------------
+# App ID extraction for non-standard tools
+# ---------------------------------------------------------------------------
+
+
+def _extract_app_id(tool_name: str) -> Optional[str]:
+    """Extract app_id from an app tool name (format: appid_toolname)."""
+    if tool_name not in STANDARD_TOOL_NAMES and '_' in tool_name:
+        parts = tool_name.split('_', 1)
+        if len(parts) == 2:
+            return parts[0]
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Calendar tool status messages
+# ---------------------------------------------------------------------------
+
+
+async def _emit_calendar_status(callback: AsyncStreamingCallback, tool_name: str, output: str):
+    """Emit calendar-specific completion status messages."""
+    if 'calendar' not in tool_name.lower():
+        return
+
+    if 'create' in tool_name.lower():
+        if output and ('Successfully created' in output or '✅' in output):
+            await callback.put_thought('Event created successfully')
+        elif output and ('Error' in output or 'error' in output.lower()):
+            await callback.put_thought('Failed to create event')
+        else:
+            await callback.put_thought('Creating event...')
+    elif 'update' in tool_name.lower():
+        if output and ('Successfully updated' in output or '✅' in output):
+            await callback.put_thought('Event updated successfully')
+        elif output and ('Error' in output or 'error' in output.lower()):
+            await callback.put_thought('Failed to update event')
+        else:
+            await callback.put_thought('Updating event...')
+    elif 'delete' in tool_name.lower():
+        if output and ('Successfully deleted' in output or '✅' in output):
+            await callback.put_thought('Event deleted successfully')
+        elif output and ('Error' in output or 'error' in output.lower()):
+            await callback.put_thought('Failed to delete event')
+        else:
+            await callback.put_thought('Deleting event...')
+    elif 'get' in tool_name.lower() or 'search' in tool_name.lower():
+        if output and len(output) > 0:
+            await callback.put_thought('Found calendar events')
+        else:
+            await callback.put_thought('No events found')
+
+
+# ---------------------------------------------------------------------------
+# Message format conversion
+# ---------------------------------------------------------------------------
+
+
+def _messages_to_anthropic(messages: List[Message]) -> list:
+    """Convert chat messages to Anthropic API format."""
+    anthropic_messages = []
+    for msg in messages:
+        role = "assistant" if msg.sender == "ai" else "user"
+        anthropic_messages.append({"role": role, "content": msg.text})
+    return anthropic_messages
+
+
+# ---------------------------------------------------------------------------
+# Core Anthropic agent streaming loop
+# ---------------------------------------------------------------------------
+
+
+async def _run_anthropic_agent_stream(
+    system_prompt: str,
+    messages: list,
+    tool_schemas: list,
+    tool_registry: dict,
+    callback: AsyncStreamingCallback,
+    full_response: list,
+    safety_guard: AgentSafetyGuard,
+    configurable: dict,
+):
+    """Run the Anthropic tool-use loop with streaming.
+
+    This replaces LangGraph's create_react_agent + astream_events with a simple
+    while loop that calls Anthropic's messages API, executes any tool calls,
+    and feeds results back until the model stops requesting tools.
+    """
+    # System prompt with cache_control for Anthropic prompt caching
+    system_blocks = [
+        {"type": "text", "text": system_prompt, "cache_control": {"type": "ephemeral"}}
+    ]
+
+    loop_iteration = 0
+
+    while True:
+        loop_iteration += 1
+        first_text_in_iteration = True
+
+        try:
+            async with anthropic_client.messages.stream(
+                model=ANTHROPIC_AGENT_MODEL,
+                system=system_blocks,
+                messages=messages,
+                tools=tool_schemas,
+                max_tokens=8192,
+            ) as stream:
+                async for event in stream:
+                    # Stream text tokens
+                    if event.type == "content_block_delta" and hasattr(event.delta, 'type'):
+                        if event.delta.type == "text_delta":
+                            # Add separator between loop iterations so text doesn't run together
+                            if first_text_in_iteration and loop_iteration > 1 and full_response:
+                                last_char = full_response[-1][-1] if full_response[-1] else ''
+                                first_char = event.delta.text[0] if event.delta.text else ''
+                                if last_char and first_char and last_char not in (' ', '\n') and first_char not in (' ', '\n'):
+                                    full_response.append('\n\n')
+                                    await callback.put_data('\n\n')
+                            first_text_in_iteration = False
+                            full_response.append(event.delta.text)
+                            await callback.put_data(event.delta.text)
+                        elif event.delta.type == "thinking_delta":
+                            pass  # Don't stream thinking to client
+
+                    # Emit status when tool call starts
+                    elif event.type == "content_block_start":
+                        if hasattr(event.content_block, 'type') and event.content_block.type == "tool_use":
+                            tool_name = event.content_block.name
+                            # Skip tool_search_tool — handled server-side by Anthropic
+                            if 'tool_search' in tool_name:
+                                logger.info(f"Tool search invoked (server-side)")
+                                continue
+                            app_id = _extract_app_id(tool_name)
+                            tool_obj = tool_registry.get(tool_name)
+                            display_name = get_tool_display_name(tool_name, tool_obj)
+                            await callback.put_thought(display_name, app_id=app_id)
+                            logger.info(f"Tool started: {tool_name}")
+
+                # Get final message while stream is still open
+                response = await stream.get_final_message()
+
+        except Exception as e:
+            logger.error(f"Anthropic API error: {e}")
+            await callback.put_data(f"\n\nSorry, I encountered an error. Please try again.")
+            await callback.end()
+            return
+
+        # If no tool_use, we're done
+        if response.stop_reason != "tool_use":
+            break
+
+        # Execute tool calls
+        tool_use_blocks = [b for b in response.content if b.type == "tool_use"]
+        tool_results = []
+        should_stop = False
+
+        for block in tool_use_blocks:
+            # Safety guard: validate before execution
+            try:
+                safety_guard.validate_tool_call(block.name, block.input)
+                warning = safety_guard.should_warn_user()
+                if warning:
+                    await callback.put_thought(warning)
+            except SafetyGuardError as e:
+                await callback.put_data(f"\n\n{str(e)}")
+                logger.error(f"Safety Guard blocked tool call: {e}")
+                await callback.end()
+                return
+
+            # Execute tool
+            try:
+                result = await _execute_tool(block.name, block.input, tool_registry, configurable)
+            except Exception as e:
+                logger.error(f"Tool execution error ({block.name}): {e}")
+                result = f"Error executing tool: {str(e)}"
+
+            logger.info(f"Tool ended: {block.name}")
+
+            # Calendar status messages
+            await _emit_calendar_status(callback, block.name, result)
+
+            # Safety guard: check context size after execution
+            try:
+                safety_guard.check_context_size(result)
+            except SafetyGuardError as e:
+                await callback.put_data(f"\n\n{str(e)}")
+                logger.error(f"Safety Guard blocked due to context size: {e}")
+                await callback.end()
+                return
+
+            tool_results.append({
+                "type": "tool_result",
+                "tool_use_id": block.id,
+                "content": result,
+            })
+
+        # Append assistant message + tool results for next iteration
+        # Serialize content blocks for the messages array
+        assistant_content = []
+        for block in response.content:
+            if block.type == "text":
+                assistant_content.append({"type": "text", "text": block.text})
+            elif block.type == "tool_use":
+                assistant_content.append({
+                    "type": "tool_use",
+                    "id": block.id,
+                    "name": block.name,
+                    "input": block.input,
+                })
+
+        messages.append({"role": "assistant", "content": assistant_content})
+        messages.append({"role": "user", "content": tool_results})
+
+    # Log final safety guard stats
+    stats = safety_guard.get_stats()
+    logger.info(f"Safety Guard final stats: {stats}")
+
+    await callback.end()
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+@_traceable(name="chat.anthropic.stream", run_type="chain")
 async def execute_agentic_chat_stream(
     uid: str,
     messages: List[Message],
@@ -333,134 +494,83 @@ async def execute_agentic_chat_stream(
     chat_session: Optional[ChatSession] = None,
     context: Optional[PageContext] = None,
 ) -> AsyncGenerator[str, None]:
-    """
-    Execute an agentic chat interaction with streaming.
+    """Execute an agentic chat interaction with streaming.
 
-    Args:
-        uid: User ID
-        messages: Chat message history
-        app: Optional app/plugin
-        callback_data: Dict to store callback data (answer, memories, etc.)
-        chat_session: Optional chat session for file context
-        context: Optional page context (type, id, title)
-
-    Yields:
-        Formatted chunks with "data: " or "think: " prefixes
+    Yields formatted chunks with "data: " or "think: " prefixes.
     """
-    # Build system prompt with file context and page context
+    # Build system prompt
     system_prompt = _get_agentic_qa_prompt(uid, app, messages, context=context)
 
     # Get prompt metadata for tracing/versioning
+    prompt_name, prompt_commit, prompt_source = None, None, None
     try:
         from utils.observability.langsmith_prompts import get_prompt_metadata
-
         prompt_name, prompt_commit, prompt_source = get_prompt_metadata()
     except Exception as e:
-        logger.error(f"⚠️ Could not get prompt metadata: {e}")
-        prompt_name, prompt_commit, prompt_source = None, None, None
+        logger.error(f"Could not get prompt metadata: {e}")
 
-    # Core tools (fixed order) + dynamic app tools appended at end
-    tools = list(CORE_TOOLS)
+    # Core tools (fixed order) — always visible to Claude
+    core_tools = list(CORE_TOOLS)
 
-    # Load tools from enabled apps (appended AFTER core tools to preserve cache prefix)
+    # Dynamic app tools — deferred, discovered on-demand via tool search
+    app_tools = []
     try:
         app_tools = load_app_tools(uid)
-        tools.extend(app_tools)
         if app_tools:
-            logger.info(f"🔧 Added {len(app_tools)} app tools to chat")
+            logger.info(f"Loaded {len(app_tools)} app tools (deferred via tool search)")
     except Exception as e:
-        logger.error(f"⚠️ Error loading app tools: {e}")
+        logger.error(f"Error loading app tools: {e}")
 
-    # Convert messages to LangChain format and prepend system message
-    lc_messages = [SystemMessage(content=system_prompt)]
-    lc_messages.extend(_messages_to_langchain(messages))
+    # Convert tools to Anthropic format (core = visible, app = defer_loading)
+    tool_schemas, tool_registry = _convert_tools(core_tools, app_tools)
+
+    # Convert messages to Anthropic format
+    anthropic_messages = _messages_to_anthropic(messages)
 
     callback = AsyncStreamingCallback()
 
-    # Create streaming agent with callback
-    agent = create_react_agent(
-        model=llm_agent_stream,
-        tools=tools,
-    )
-
-    # Run agent with streaming
-    # Add a list to collect conversations from tools for citation
+    # Conversations collected by tools for citation
     conversations_collected = []
 
-    # Initialize safety guard
+    # Safety guard
     safety_guard = AgentSafetyGuard(max_tool_calls=25, max_context_tokens=500000)
 
-    # Generate run_id for LangSmith tracing (allows feedback attachment later)
+    # Generate run_id for LangSmith tracing
     langsmith_run_id = str(uuid.uuid4())
 
-    # Get per-request LangSmith tracer callbacks (enables tracing without global env)
-    tracer_callbacks = get_chat_tracer_callbacks(
-        run_id=langsmith_run_id,
-        run_name="chat.agentic.stream",
-        tags=["chat", "agentic", "streaming"],
-        metadata={
-            "uid": uid,
-            "app_id": app.id if app else None,
-            "app_name": app.name if app else None,
-            "chat_session_id": chat_session.id if chat_session else None,
-            "has_context": context is not None,
-            "context_type": context.type if context else None,
-            "num_tools": len(tools),
-            "prompt_name": prompt_name,
-            "prompt_commit": prompt_commit,
-            "prompt_source": prompt_source,
-        },
-    )
-
-    # LangSmith tracing metadata
-    config = {
-        "run_id": langsmith_run_id,  # Explicit run_id for LangSmith feedback
-        "configurable": {
-            "user_id": uid,
-            "thread_id": str(uuid.uuid4()),
-            "conversations_collected": conversations_collected,
-            "safety_guard": safety_guard,
-            "chat_session_id": chat_session.id if chat_session else None,
-            "tools": tools,  # Store tools for status message lookup
-        },
-        "callbacks": tracer_callbacks,
-        "run_name": "chat.agentic.stream",
-        "tags": ["chat", "agentic", "streaming"],
-        "metadata": {
-            "uid": uid,
-            "app_id": app.id if app else None,
-            "app_name": app.name if app else None,
-            "chat_session_id": chat_session.id if chat_session else None,
-            "has_context": context is not None,
-            "context_type": context.type if context else None,
-            "num_tools": len(tools),
-            "prompt_name": prompt_name,
-            "prompt_commit": prompt_commit,
-            "prompt_source": prompt_source,
-        },
+    # Config for tools to access via RunnableConfig
+    configurable = {
+        "user_id": uid,
+        "thread_id": str(uuid.uuid4()),
+        "conversations_collected": conversations_collected,
+        "safety_guard": safety_guard,
+        "chat_session_id": chat_session.id if chat_session else None,
+        "tools": core_tools + app_tools,
     }
 
-    # Store run_id and prompt metadata in callback_data for message persistence
+    # Store config in context variable for tools that use agent_config_context
+    agent_config_context.set({"configurable": configurable})
+
+    # Store run_id and prompt metadata in callback_data
     if callback_data is not None:
         callback_data['langsmith_run_id'] = langsmith_run_id
         callback_data['prompt_name'] = prompt_name
         callback_data['prompt_commit'] = prompt_commit
-
-    # Store config in context for tools to access
-    agent_config_context.set(config)
 
     full_response = []
     tool_usage_count = 0
 
     # Start agent task
     task = asyncio.create_task(
-        _run_agent_stream(
-            agent,
-            lc_messages,
-            config,
+        _run_anthropic_agent_stream(
+            system_prompt,
+            anthropic_messages,
+            tool_schemas,
+            tool_registry,
             callback,
             full_response,
-            callback_data,
+            safety_guard,
+            configurable,
         )
     )
 
@@ -471,235 +581,30 @@ async def execute_agentic_chat_stream(
             if chunk is None:
                 break
 
-            # Track tool usage from think messages
-            if chunk.startswith("think: Using "):
+            if chunk.startswith("think: "):
                 tool_usage_count += 1
 
             yield chunk
 
-        # Wait for task to complete
         await task
 
         # Store results in callback_data
         if callback_data is not None:
             callback_data['answer'] = ''.join(full_response)
-            # Extract conversations collected by tools
             callback_data['memories_found'] = conversations_collected if conversations_collected else []
             callback_data['ask_for_nps'] = tool_usage_count > 0
-            # Extract chart data if a chart tool was used
-            chart_data_from_config = config.get('configurable', {}).get('chart_data')
+            chart_data_from_config = configurable.get('chart_data')
             if chart_data_from_config:
                 callback_data['chart_data'] = chart_data_from_config
-            logger.info(f"📚 Collected {len(callback_data['memories_found'])} conversations for citation")
+            logger.info(f"Collected {len(callback_data['memories_found'])} conversations for citation")
 
     except asyncio.CancelledError:
         task.cancel()
         raise
     except Exception as e:
-        logger.error(f"❌ Error in execute_agentic_chat_stream: {e}")
-        import traceback
-
+        logger.error(f"Error in execute_agentic_chat_stream: {e}")
         traceback.print_exc()
         if callback_data is not None:
             callback_data['error'] = str(e)
 
     yield None  # Signal completion
-
-
-async def _run_agent_stream(
-    agent,
-    messages: List,
-    config: dict,
-    callback: AsyncStreamingCallback,
-    full_response: List[str],
-    callback_data: dict,
-):
-    """
-    Internal function to run the agent and populate the callback queue.
-
-    Args:
-        agent: The LangGraph agent
-        messages: Messages to send to agent
-        config: Agent configuration
-        callback: Callback to send chunks to
-        full_response: List to accumulate response tokens
-        callback_data: Dict to store metadata
-    """
-    safety_guard = config['configurable'].get('safety_guard')
-
-    try:
-        async for event in agent.astream_events(
-            {"messages": messages},
-            config=config,
-            version="v2",
-        ):
-            kind = event.get("event")
-
-            # Stream LLM tokens
-            if kind == "on_chat_model_stream":
-                chunk = event.get("data", {}).get("chunk")
-                if chunk and hasattr(chunk, "content") and chunk.content:
-                    token = chunk.content
-                    full_response.append(token)
-                    await callback.put_data(token)
-
-            # Track tool usage and validate with safety guard
-            elif kind == "on_tool_start":
-                tool_name = event.get("name", "unknown")
-                tool_input = event.get("data", {}).get("input", {})
-                logger.info(f"🔧 Tool started: {tool_name}")
-
-                # Extract app_id from tool name if it's from an app tool
-                # App tools have format: app_id_tool_name
-                app_id = None
-                tools_list = config.get('configurable', {}).get('tools', [])
-
-                # Standard tool names that don't come from apps
-                standard_tool_names = {
-                    'get_conversations_tool',
-                    'search_conversations_tool',
-                    'get_memories_tool',
-                    'search_memories_tool',
-                    'get_action_items_tool',
-                    'create_action_item_tool',
-                    'update_action_item_tool',
-                    'get_omi_product_info_tool',
-                    'perplexity_web_search_tool',
-                    'get_calendar_events_tool',
-                    'create_calendar_event_tool',
-                    'update_calendar_event_tool',
-                    'delete_calendar_event_tool',
-                    'get_gmail_messages_tool',
-                    'search_files_tool',
-                    'create_chart_tool',
-                }
-
-                # If tool name is not a standard tool and contains underscore, it's likely an app tool
-                if tool_name not in standard_tool_names and '_' in tool_name:
-                    parts = tool_name.split('_', 1)
-                    if len(parts) == 2:
-                        # First part is likely the app_id
-                        app_id = parts[0]
-
-                # Send user-friendly tool call message to frontend
-                # Get tool object to check for custom status_message
-                tool_obj = None
-                for tool in tools_list:
-                    if hasattr(tool, 'name') and tool.name == tool_name:
-                        tool_obj = tool
-                        break
-
-                tool_display_name = get_tool_display_name(tool_name, tool_obj)
-                await callback.put_thought(tool_display_name, app_id=app_id)
-
-                # Validate tool call with safety guard
-                if safety_guard:
-                    try:
-                        safety_guard.validate_tool_call(tool_name, tool_input)
-
-                        # Check if we should warn user about approaching limits
-                        warning = safety_guard.should_warn_user()
-                        if warning:
-                            await callback.put_thought(warning)
-                    except SafetyGuardError as e:
-                        # Send friendly error message to user (no technical jargon)
-                        error_msg = f"\n\n{str(e)}"
-                        await callback.put_data(error_msg)
-                        logger.error(f"🛡️ Safety Guard blocked tool call: {e}")
-                        # Signal completion and stop processing
-                        await callback.end()
-                        return
-
-            elif kind == "on_tool_end":
-                tool_name = event.get("name", "unknown")
-                output_raw = event.get("data", {}).get("output", "")
-
-                # Extract string content from output (could be ToolMessage object or string)
-                if hasattr(output_raw, 'content'):
-                    output = str(output_raw.content)
-                elif isinstance(output_raw, str):
-                    output = output_raw
-                else:
-                    output = str(output_raw)
-
-                logger.info(f"✅ Tool ended: {tool_name}")
-
-                # Send completion message for calendar tools to update status
-                if 'calendar' in tool_name.lower():
-                    if 'create' in tool_name.lower():
-                        # Clear the "Creating calendar event" status
-                        # The tool output will contain the success message which the LLM will include
-                        if output and ('Successfully created' in output or '✅' in output):
-                            # Send a brief completion status that will be replaced by the actual response
-                            await callback.put_thought('Event created successfully')
-                        elif output and ('Error' in output or 'error' in output.lower()):
-                            await callback.put_thought('Failed to create event')
-                        else:
-                            await callback.put_thought('Creating event...')
-                    elif 'update' in tool_name.lower():
-                        # Clear the "Updating calendar event" status
-                        if output and ('Successfully updated' in output or '✅' in output):
-                            await callback.put_thought('Event updated successfully')
-                        elif output and ('Error' in output or 'error' in output.lower()):
-                            await callback.put_thought('Failed to update event')
-                        else:
-                            await callback.put_thought('Updating event...')
-                    elif 'delete' in tool_name.lower():
-                        # Clear the "Deleting calendar event" status
-                        if output and ('Successfully deleted' in output or '✅' in output):
-                            await callback.put_thought('Event deleted successfully')
-                        elif output and ('Error' in output or 'error' in output.lower()):
-                            await callback.put_thought('Failed to delete event')
-                        else:
-                            await callback.put_thought('Deleting event...')
-                    elif 'get' in tool_name.lower() or 'search' in tool_name.lower():
-                        # For read operations, clear the "Checking calendar" status
-                        # The actual results will be in the response
-                        if output and len(output) > 0:
-                            await callback.put_thought('Found calendar events')
-                        else:
-                            await callback.put_thought('No events found')
-
-                # Check context size with safety guard
-                if safety_guard and output:
-                    try:
-                        safety_guard.check_context_size(output)
-                    except SafetyGuardError as e:
-                        # Send friendly error message to user (no technical jargon)
-                        error_msg = f"\n\n{str(e)}"
-                        await callback.put_data(error_msg)
-                        logger.error(f"🛡️ Safety Guard blocked due to context size: {e}")
-                        # Signal completion and stop processing
-                        await callback.end()
-                        return
-
-            elif kind == "on_tool_error":
-                tool_name = event.get("name", "unknown")
-                error = event.get("data", {}).get("error", "")
-                logger.error(f"❌ Tool error: {tool_name}")
-                logger.error(f"   Error: {error}")
-
-            elif kind == "on_chain_error":
-                error = event.get("data", {}).get("error", "")
-                logger.error(f"❌ Chain error: {error}")
-
-        # Log final stats
-        if safety_guard:
-            stats = safety_guard.get_stats()
-            logger.info(f"🛡️ Safety Guard final stats: {stats}")
-
-        # Signal completion
-        await callback.end()
-
-    except SafetyGuardError as e:
-        # Send friendly error message to user (no technical jargon)
-        error_msg = f"\n\n{str(e)}"
-        await callback.put_data(error_msg)
-        logger.error(f"🛡️ Safety Guard stopped execution: {e}")
-        await callback.end()
-    except Exception as e:
-        logger.error(f"❌ Error in _run_agent_stream: {e}")
-        import traceback
-
-        traceback.print_exc()
-        await callback.end()

--- a/backend/utils/retrieval/graph.py
+++ b/backend/utils/retrieval/graph.py
@@ -1,642 +1,105 @@
-import datetime
+"""
+Chat routing — dispatches to persona, file-chat, or agentic paths.
+
+Replaces the previous LangGraph state machine with a simple async router.
+Claude decides implicitly whether to use tools, eliminating the need for
+the requires_context() LLM classification call.
+"""
+
 import uuid
 import asyncio
 from typing import List, Optional, AsyncGenerator, Tuple
 
-from langchain.callbacks.base import BaseCallbackHandler
 from langchain_core.messages import SystemMessage, AIMessage, HumanMessage
 from langchain_openai import ChatOpenAI
-from langgraph.checkpoint.memory import MemorySaver
-from langgraph.constants import END
-from langgraph.graph import START, StateGraph
-from typing_extensions import TypedDict, Literal
 
-# import os
-# os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = '../../' + os.getenv('GOOGLE_APPLICATION_CREDENTIALS')
-import database.conversations as conversations_db
-import database.users as users_db
-from database.redis_db import get_filter_category_items
-from database.vector_db import query_vectors_by_metadata
 import database.notifications as notification_db
 from models.app import App
 from models.chat import ChatSession, Message, PageContext
 from models.conversation import Conversation
-from models.other import Person
-from utils.llm.chat import (
-    answer_omi_question,
-    answer_omi_question_stream,
-    requires_context,
-    answer_simple_message,
-    answer_simple_message_stream,
-    retrieve_context_dates_by_question,
-    qa_rag,
-    qa_rag_stream,
-    retrieve_is_an_omi_question,
-    retrieve_is_file_question,
-    select_structured_filters,
-    extract_question_from_conversation,
-)
+from utils.llm.chat import retrieve_is_file_question
 from utils.llm.persona import answer_persona_question_stream
 from utils.other.chat_file import FileChatTool
-from utils.other.endpoints import timeit
-from utils.app_integrations import get_github_docs_content
-from utils.retrieval.agentic import execute_agentic_chat_stream
+from utils.retrieval.agentic import AsyncStreamingCallback, execute_agentic_chat_stream
 from utils.observability.langsmith import get_chat_tracer_callbacks
 import logging
 
 logger = logging.getLogger(__name__)
 
-model = ChatOpenAI(model="gpt-4.1-mini")
 llm_medium_stream = ChatOpenAI(model='gpt-4.1', streaming=True)
 
 
-class StructuredFilters(TypedDict):
-    topics: List[str]
-    people: List[str]
-    entities: List[str]
-    dates: List[datetime.date]
+# ---------------------------------------------------------------------------
+# File chat helper
+# ---------------------------------------------------------------------------
 
 
-class DateRangeFilters(TypedDict):
-    start: datetime.datetime
-    end: datetime.datetime
-
-
-class AsyncStreamingCallback(BaseCallbackHandler):
-    def __init__(self):
-        self.queue = asyncio.Queue()
-        self._loop = asyncio.get_event_loop()
-
-    async def put_data(self, text):
-        await self.queue.put(f"data: {text}")
-
-    async def put_thought(self, text):
-        await self.queue.put(f"think: {text}")
-
-    def put_thought_nowait(self, text):
-        self._loop.call_soon_threadsafe(self.queue.put_nowait, f"think: {text}")
-
-    async def end(self):
-        await self.queue.put(None)
-
-    async def on_llm_new_token(self, token: str, **kwargs) -> None:
-        await self.put_data(token)
-
-    async def on_llm_end(self, response, **kwargs) -> None:
-        await self.end()
-
-    async def on_llm_error(self, error: Exception, **kwargs) -> None:
-        logger.error(f"Error on LLM {error}")
-        await self.end()
-
-    def put_data_nowait(self, text):
-        self._loop.call_soon_threadsafe(self.queue.put_nowait, f"data: {text}")
-
-    def end_nowait(self):
-        self._loop.call_soon_threadsafe(self.queue.put_nowait, None)
-
-
-class GraphState(TypedDict):
-    uid: str
-    messages: List[Message]
-    plugin_selected: Optional[App]
-    tz: str
-    cited: Optional[bool] = False
-
-    streaming: Optional[bool] = False
-    callback: Optional[AsyncStreamingCallback] = None
-
-    filters: Optional[StructuredFilters]
-    date_filters: Optional[DateRangeFilters]
-
-    memories_found: Optional[List[Conversation]]
-
-    parsed_question: Optional[str]
-    answer: Optional[str]
-    ask_for_nps: Optional[bool]
-
-    chat_session: Optional[ChatSession]
-    context: Optional[PageContext]
-    chart_data: Optional[dict]
-
-
-def determine_conversation(state: GraphState):
-    logger.info("determine_conversation")
-    question = extract_question_from_conversation(state.get("messages", []))
-    logger.info(f"determine_conversation parsed question: {question}")
-
-    # # stream
-    # if state.get('streaming', False):
-    #     state['callback'].put_thought_nowait(question)
-
-    return {"parsed_question": question}
-
-
-def determine_conversation_type(
-    state: GraphState,
-) -> Literal[
-    "no_context_conversation",
-    "agentic_context_dependent_conversation",
-    "persona_question",
-    "file_chat_question",
-]:
-    logger.info("determine_conversation_type")
-
-    # persona
-    app: App = state.get("plugin_selected")
-    if app and app.is_a_persona():
-        return "persona_question"
-
-    # file chat — check if the last message has file attachments
-    messages = state.get("messages", [])
-    last_message = messages[-1] if messages else None
+def _has_file_context(last_message: Optional[Message], chat_session: Optional[ChatSession]) -> bool:
+    """Check if the request involves file attachments."""
     if last_message and last_message.files_id and len(last_message.files_id) > 0:
-        chat_session = state.get("chat_session")
-        if chat_session:
-            logger.info(f"Routing to file_chat_question with {len(last_message.files_id)} files")
-            return "file_chat_question"
+        return chat_session is not None
 
-    # file chat — user asks about previously uploaded files
-    chat_session = state.get("chat_session")
     if chat_session and chat_session.file_ids and len(chat_session.file_ids) > 0:
-        question = state.get("parsed_question", "")
+        question = last_message.text if last_message else ""
         if question and retrieve_is_file_question(question):
-            return "file_chat_question"
+            return True
 
-    # chat
-    # no context
-    question = state.get("parsed_question", "")
-    if not question or len(question) == 0:
-        return "no_context_conversation"
-
-    requires = requires_context(question)
-    if requires:
-        return "agentic_context_dependent_conversation"
-    return "no_context_conversation"
+    return False
 
 
-def no_context_conversation(state: GraphState):
-    logger.info("no_context_conversation node")
-
-    # streaming
-    streaming = state.get("streaming")
-    if streaming:
-        # state['callback'].put_thought_nowait("Reasoning")
-        answer: str = answer_simple_message_stream(
-            state.get("uid"), state.get("messages"), state.get("plugin_selected"), callbacks=[state.get('callback')]
-        )
-        return {"answer": answer, "ask_for_nps": False}
-
-    # no streaming
-    answer: str = answer_simple_message(
-        state.get("uid"),
-        state.get("messages"),
-        state.get("plugin_selected"),
-    )
-    return {"answer": answer, "ask_for_nps": False}
-
-
-def omi_question(state: GraphState):
-    logger.info("no_context_omi_question node")
-
-    context: dict = get_github_docs_content()
-    context_str = 'Documentation:\n\n'.join([f'{k}:\n {v}' for k, v in context.items()])
-
-    # streaming
-    streaming = state.get("streaming")
-    if streaming:
-        # state['callback'].put_thought_nowait("Reasoning")
-        answer: str = answer_omi_question_stream(
-            state.get("messages", []), context_str, callbacks=[state.get('callback')]
-        )
-        return {'answer': answer, 'ask_for_nps': True}
-
-    # no streaming
-    answer = answer_omi_question(state.get("messages", []), context_str)
-    return {'answer': answer, 'ask_for_nps': True}
-
-
-def persona_question(state: GraphState):
-    logger.info("persona_question node")
-
-    # streaming
-    streaming = state.get("streaming")
-    if streaming:
-        # state['callback'].put_thought_nowait("Reasoning")
-        answer: str = answer_persona_question_stream(
-            state.get("plugin_selected"), state.get("messages", []), callbacks=[state.get('callback')]
-        )
-        return {'answer': answer, 'ask_for_nps': True}
-
-    # no streaming
-    return {'answer': "Oops", 'ask_for_nps': True}
-
-
-def context_dependent_conversation(state: GraphState):
-    return state
-
-
-def agentic_context_dependent_conversation(state: GraphState):
-    """Handle context-dependent conversations using the agentic system"""
-    logger.info("agentic_context_dependent_conversation node")
-
-    uid = state.get("uid")
-    messages = state.get("messages", [])
-    app = state.get("plugin_selected")
-
-    # streaming
-    streaming = state.get("streaming")
-    if streaming:
-        callback_data = {}
-
-        async def run_agentic_stream():
-            async for chunk in execute_agentic_chat_stream(
-                uid,
-                messages,
-                app,
-                callback_data=callback_data,
-                chat_session=state.get("chat_session"),
-                context=state.get("context"),
-            ):
-                if chunk:
-                    # Forward streaming chunks through callback
-                    if chunk.startswith("data: "):
-                        state.get('callback').put_data_nowait(chunk.replace("data: ", ""))
-                    elif chunk.startswith("think: "):
-                        state.get('callback').put_thought_nowait(chunk.replace("think: ", ""))
-
-        # Run the async streaming
-        asyncio.run(run_agentic_stream())
-
-        # Signal completion to the callback
-        state.get('callback').end_nowait()
-
-        # Extract results from callback_data
-        answer = callback_data.get('answer', '')
-        memories_found = callback_data.get('memories_found', [])
-        ask_for_nps = callback_data.get('ask_for_nps', False)
-        chart_data = callback_data.get('chart_data')
-
-        result = {"answer": answer, "memories_found": memories_found, "ask_for_nps": ask_for_nps}
-        if chart_data:
-            result["chart_data"] = chart_data
-        return result
-
-    # no streaming - not yet implemented
-    return {"answer": "Streaming required for agentic mode", "ask_for_nps": False}
-
-
-# !! include a question extractor? node?
-
-
-def retrieve_topics_filters(state: GraphState):
-    logger.info("retrieve_topics_filters")
-    filters = {
-        "people": get_filter_category_items(state.get("uid"), "people", limit=1000),
-        "topics": get_filter_category_items(state.get("uid"), "topics", limit=1000),
-        "entities": get_filter_category_items(state.get("uid"), "entities", limit=1000),
-        # 'dates': get_filter_category_items(state.get('uid'), 'dates'),
-    }
-    result = select_structured_filters(state.get("parsed_question", ""), filters)
-    filters = {
-        "topics": result.get("topics", []),
-        "people": result.get("people", []),
-        "entities": result.get("entities", []),
-        # 'dates': result.get('dates', []),
-    }
-    logger.info(f"retrieve_topics_filters filters {filters}")
-    return {"filters": filters}
-
-
-def retrieve_date_filters(state: GraphState):
-    logger.info('retrieve_date_filters')
-    # TODO: if this makes vector search fail further, query firestore instead
-    dates_range = retrieve_context_dates_by_question(state.get("parsed_question", ""), state.get("tz", "UTC"))
-    logger.info(f'retrieve_date_filters dates_range: {dates_range}')
-    if dates_range and len(dates_range) >= 2:
-        return {"date_filters": {"start": dates_range[0], "end": dates_range[1]}}
-    return {"date_filters": {}}
-
-
-def query_vectors(state: GraphState):
-    logger.info("query_vectors")
-
-    # # stream
-    # if state.get('streaming', False):
-    #     state['callback'].put_thought_nowait("Searching through your memories")
-
-    date_filters = state.get("date_filters")
-    uid = state.get("uid")
-    # vector = (
-    #    generate_embedding(state.get("parsed_question", ""))
-    #    if state.get("parsed_question")
-    #    else [0] * 3072
-    # )
-
-    # Use [1] * dimension to trigger the score distance to fetch all vectors by meta filters
-    vector = [1] * 3072
-    logger.info(f"query_vectors vector: {vector[:5]}")
-
-    # TODO: enable it when the in-accurate topic filter get fixed
-    is_topic_filter_enabled = date_filters.get("start") is None
-    memories_id = query_vectors_by_metadata(
-        uid,
-        vector,
-        dates_filter=[date_filters.get("start"), date_filters.get("end")],
-        people=state.get("filters", {}).get("people", []) if is_topic_filter_enabled else [],
-        topics=state.get("filters", {}).get("topics", []) if is_topic_filter_enabled else [],
-        entities=state.get("filters", {}).get("entities", []) if is_topic_filter_enabled else [],
-        dates=state.get("filters", {}).get("dates", []),
-        limit=100,
-    )
-    memories = conversations_db.get_conversations_by_id(uid, memories_id)
-
-    # Filter out locked conversations if user doesn't have premium access
-    memories = [m for m in memories if not m.get('is_locked', False)]
-
-    # stream
-    # if state.get('streaming', False):
-    #    if len(memories) == 0:
-    #        msg = "No relevant memories found"
-    #    else:
-    #        msg = f"Found {len(memories)} relevant memories"
-    #    state['callback'].put_thought_nowait(msg)
-
-    # print(memories_id)
-    return {"memories_found": memories}
-
-
-def qa_handler(state: GraphState):
-    uid = state.get("uid")
-    memories = state.get("memories_found", [])
-
-    all_person_ids = []
-    for m in memories:
-        # m is a dict
-        segments = m.get('transcript_segments', [])
-        all_person_ids.extend([s.get('person_id') for s in segments if s.get('person_id')])
-
-    people = []
-    if all_person_ids:
-        people_data = users_db.get_people_by_ids(uid, list(set(all_person_ids)))
-        people = [Person(**p) for p in people_data]
-
-    # streaming
-    streaming = state.get("streaming")
-    if streaming:
-        # state['callback'].put_thought_nowait("Reasoning")
-        response: str = qa_rag_stream(
-            uid,
-            state.get("parsed_question"),
-            Conversation.conversations_to_string(memories, False, people=people),
-            state.get("plugin_selected"),
-            cited=state.get("cited"),
-            messages=state.get("messages"),
-            tz=state.get("tz"),
-            callbacks=[state.get('callback')],
-        )
-        return {"answer": response, "ask_for_nps": True}
-
-    # no streaming
-    response: str = qa_rag(
-        uid,
-        state.get("parsed_question"),
-        Conversation.conversations_to_string(memories, False, people=people),
-        state.get("plugin_selected"),
-        cited=state.get("cited"),
-        messages=state.get("messages"),
-        tz=state.get("tz"),
-    )
-    return {"answer": response, "ask_for_nps": True}
-
-
-def file_chat_question(state: GraphState):
-    logger.info("chat_with_file_question node")
-
-    uid = state.get("uid", "")
-    question = state.get("parsed_question", "")
-
-    messages = state.get("messages", [])
+async def _execute_file_chat_stream(
+    uid: str,
+    messages: List[Message],
+    chat_session: ChatSession,
+    callback_data: dict,
+) -> AsyncGenerator[str, None]:
+    """Handle file chat with streaming."""
     last_message = messages[-1] if messages else None
-
-    file_ids = []
-
-    chat_session = state.get("chat_session")
-    if not chat_session:
-        logger.error("ERROR: Chat session required for file chat but not found")
-        raise ValueError("Chat session required for file chat")
-
-    logger.info(f"Creating FileChatTool for user {uid}, session {chat_session.id}")
+    question = last_message.text if last_message else ""
 
     try:
-        # Create FileChatTool with session context
         fc_tool = FileChatTool(uid, chat_session.id)
-        logger.info(
-            f"FileChatTool created successfully. Thread: {fc_tool.thread_id}, Assistant: {fc_tool.assistant_id}"
-        )
     except Exception as e:
-        logger.error(f"ERROR: Failed to create FileChatTool: {e}")
+        logger.error(f"Failed to create FileChatTool: {e}")
         raise
 
     # Determine which files to use
-    if last_message and len(last_message.files_id) > 0:
+    if last_message and last_message.files_id and len(last_message.files_id) > 0:
         file_ids = last_message.files_id
     else:
-        # if user asked about file but not attach new file, will get all file in session
         file_ids = chat_session.file_ids if chat_session.file_ids else []
 
     logger.info(f"Processing file chat with {len(file_ids)} files")
 
-    streaming = state.get("streaming")
-    try:
-        if streaming:
-            logger.info("Processing with streaming")
-            answer = fc_tool.process_chat_with_file_stream(question, file_ids, callback=state.get('callback'))
-            logger.info("Streaming completed")
-            return {'answer': answer, 'ask_for_nps': True}
-
-        logger.info("Processing without streaming")
-        answer = fc_tool.process_chat_with_file(question, file_ids)
-        logger.info("Processing completed")
-        return {'answer': answer, 'ask_for_nps': True}
-    except Exception as e:
-        logger.error(f"ERROR in file_chat_question: {e}")
-        raise
-
-
-workflow = StateGraph(GraphState)
-
-workflow.add_edge(START, "determine_conversation")
-
-workflow.add_node("determine_conversation", determine_conversation)
-
-workflow.add_conditional_edges("determine_conversation", determine_conversation_type)
-
-workflow.add_node("no_context_conversation", no_context_conversation)
-# workflow.add_node("omi_question", omi_question)
-# workflow.add_node("context_dependent_conversation", context_dependent_conversation)
-workflow.add_node("agentic_context_dependent_conversation", agentic_context_dependent_conversation)
-workflow.add_node("file_chat_question", file_chat_question)
-workflow.add_node("persona_question", persona_question)
-
-workflow.add_edge("no_context_conversation", END)
-# workflow.add_edge("omi_question", END)
-workflow.add_edge("persona_question", END)
-workflow.add_edge("file_chat_question", END)
-workflow.add_edge("agentic_context_dependent_conversation", END)
-# workflow.add_edge("context_dependent_conversation", "retrieve_topics_filters")
-# workflow.add_edge("context_dependent_conversation", "retrieve_date_filters")
-#
-# workflow.add_node("retrieve_topics_filters", retrieve_topics_filters)
-# workflow.add_node("retrieve_date_filters", retrieve_date_filters)
-#
-# workflow.add_edge("retrieve_topics_filters", "query_vectors")
-# workflow.add_edge("retrieve_date_filters", "query_vectors")
-#
-# workflow.add_node("query_vectors", query_vectors)
-#
-# workflow.add_edge("query_vectors", "qa_handler")
-#
-# workflow.add_node("qa_handler", qa_handler)
-#
-# workflow.add_edge("qa_handler", END)
-
-checkpointer = MemorySaver()
-graph = workflow.compile(checkpointer=checkpointer)
-
-graph_stream = workflow.compile()
-
-
-@timeit
-def execute_graph_chat(
-    uid: str, messages: List[Message], app: Optional[App] = None, cited: Optional[bool] = False
-) -> Tuple[str, bool, List[Conversation]]:
-    logger.info(f'execute_graph_chat app    : {app.id if app else "<none>"}')
-    tz = notification_db.get_user_time_zone(uid)
-
-    # Get per-request LangSmith tracer callbacks (enables tracing without global env)
-    tracer_callbacks = get_chat_tracer_callbacks(
-        run_name="chat.graph",
-        tags=["chat", "graph"],
-        metadata={
-            "uid": uid,
-            "app_id": app.id if app else None,
-            "cited": cited,
-            "tz": tz,
-        },
-    )
-
-    # LangSmith tracing metadata
-    run_config = {
-        "configurable": {"thread_id": str(uuid.uuid4())},
-        "callbacks": tracer_callbacks,
-        "run_name": "chat.graph",
-        "tags": ["chat", "graph"],
-        "metadata": {
-            "uid": uid,
-            "app_id": app.id if app else None,
-            "cited": cited,
-            "tz": tz,
-        },
-    }
-
-    result = graph.invoke(
-        {"uid": uid, "tz": tz, "cited": cited, "messages": messages, "plugin_selected": app},
-        run_config,
-    )
-    return result.get("answer"), result.get('ask_for_nps', False), result.get("memories_found", [])
-
-
-async def execute_graph_chat_stream(
-    uid: str,
-    messages: List[Message],
-    app: Optional[App] = None,
-    cited: Optional[bool] = False,
-    callback_data: dict = {},
-    chat_session: Optional[ChatSession] = None,
-    context: Optional[PageContext] = None,
-) -> AsyncGenerator[str, None]:
-    logger.info(f'execute_graph_chat_stream app:  {app.id if app else "<none>"}')
-    tz = notification_db.get_user_time_zone(uid)
     callback = AsyncStreamingCallback()
 
-    # Generate run_id for LangSmith tracing (allows feedback attachment later)
-    langsmith_run_id = str(uuid.uuid4())
+    try:
+        answer = fc_tool.process_chat_with_file_stream(question, file_ids, callback=callback)
 
-    # Get per-request LangSmith tracer callbacks (enables tracing without global env)
-    tracer_callbacks = get_chat_tracer_callbacks(
-        run_id=langsmith_run_id,
-        run_name="chat.graph.stream",
-        tags=["chat", "graph", "streaming"],
-        metadata={
-            "uid": uid,
-            "app_id": app.id if app else None,
-            "cited": cited,
-            "tz": tz,
-            "chat_session_id": chat_session.id if chat_session else None,
-            "has_context": context is not None,
-            "context_type": context.type if context else None,
-        },
-    )
-
-    # LangSmith tracing metadata
-    run_config = {
-        "run_id": langsmith_run_id,  # Explicit run_id for LangSmith feedback
-        "configurable": {"thread_id": str(uuid.uuid4())},
-        "callbacks": tracer_callbacks,
-        "run_name": "chat.graph.stream",
-        "tags": ["chat", "graph", "streaming"],
-        "metadata": {
-            "uid": uid,
-            "app_id": app.id if app else None,
-            "cited": cited,
-            "tz": tz,
-            "chat_session_id": chat_session.id if chat_session else None,
-            "has_context": context is not None,
-            "context_type": context.type if context else None,
-        },
-    }
-
-    # Store run_id in callback_data for message persistence
-    callback_data['langsmith_run_id'] = langsmith_run_id
-
-    task = asyncio.create_task(
-        graph_stream.ainvoke(
-            {
-                "uid": uid,
-                "tz": tz,
-                "cited": cited,
-                "messages": messages,
-                "plugin_selected": app,
-                "streaming": True,
-                "callback": callback,
-                "chat_session": chat_session,
-                "context": context,
-            },
-            run_config,
-        )
-    )
-
-    while True:
-        try:
+        # Yield chunks from callback
+        while True:
             chunk = await callback.queue.get()
             if chunk:
                 yield chunk
             else:
                 break
-        except asyncio.CancelledError:
-            break
-    await task
-    result = task.result()
-    callback_data['answer'] = result.get("answer")
-    callback_data['memories_found'] = result.get("memories_found", [])
-    callback_data['ask_for_nps'] = result.get('ask_for_nps', False)
-    chart_data = result.get('chart_data')
-    if chart_data:
-        callback_data['chart_data'] = chart_data
 
-    yield None
-    return
+        if callback_data is not None:
+            callback_data['answer'] = answer
+            callback_data['memories_found'] = []
+            callback_data['ask_for_nps'] = True
+
+        yield None
+    except Exception as e:
+        logger.error(f"Error in file chat: {e}")
+        if callback_data is not None:
+            callback_data['error'] = str(e)
+        yield None
+
+
+# ---------------------------------------------------------------------------
+# Persona chat (kept on existing LangChain/OpenAI for now)
+# ---------------------------------------------------------------------------
 
 
 async def execute_persona_chat_stream(
@@ -647,8 +110,7 @@ async def execute_persona_chat_stream(
     callback_data: dict = None,
     chat_session: Optional[str] = None,
 ) -> AsyncGenerator[str, None]:
-    """Handle streaming chat responses for persona-type apps"""
-
+    """Handle streaming chat responses for persona-type apps."""
     system_prompt = app.persona_prompt
     formatted_messages = [SystemMessage(content=system_prompt)]
 
@@ -661,10 +123,9 @@ async def execute_persona_chat_stream(
     full_response = []
     callback = AsyncStreamingCallback()
 
-    # Generate run_id for LangSmith tracing (allows feedback attachment later)
+    # Generate run_id for LangSmith tracing
     langsmith_run_id = str(uuid.uuid4())
 
-    # Get per-request LangSmith tracer callbacks (enables tracing without global env)
     tracer_callbacks = get_chat_tracer_callbacks(
         run_id=langsmith_run_id,
         run_name="chat.persona.stream",
@@ -677,12 +138,10 @@ async def execute_persona_chat_stream(
         },
     )
 
-    # Combine streaming callback with tracer callbacks
     all_callbacks = [callback] + tracer_callbacks
 
-    # LangSmith tracing metadata
     run_metadata = {
-        "run_id": langsmith_run_id,  # Explicit run_id for LangSmith feedback
+        "run_id": langsmith_run_id,
         "run_name": "chat.persona.stream",
         "tags": ["chat", "persona", "streaming"],
         "metadata": {
@@ -693,7 +152,6 @@ async def execute_persona_chat_stream(
         },
     }
 
-    # Store run_id in callback_data for message persistence
     if callback_data is not None:
         callback_data['langsmith_run_id'] = langsmith_run_id
 
@@ -730,3 +188,75 @@ async def execute_persona_chat_stream(
             callback_data['error'] = str(e)
         yield None
         return
+
+
+# ---------------------------------------------------------------------------
+# Main router
+# ---------------------------------------------------------------------------
+
+
+async def execute_chat_stream(
+    uid: str,
+    messages: List[Message],
+    app: Optional[App] = None,
+    cited: Optional[bool] = False,
+    callback_data: dict = {},
+    chat_session: Optional[ChatSession] = None,
+    context: Optional[PageContext] = None,
+) -> AsyncGenerator[str, None]:
+    """Route chat requests to the appropriate handler.
+
+    - Persona apps -> persona chat (LangChain/OpenAI)
+    - File attachments -> file chat (OpenAI Assistants)
+    - Everything else -> Anthropic agentic chat (Claude decides whether to use tools)
+    """
+    logger.info(f'execute_chat_stream app: {app.id if app else "<none>"}')
+
+    # 1. Persona apps
+    if app and app.is_a_persona():
+        async for chunk in execute_persona_chat_stream(
+            uid, messages, app, cited=cited, callback_data=callback_data, chat_session=chat_session
+        ):
+            yield chunk
+        return
+
+    # 2. File attachments
+    last_msg = messages[-1] if messages else None
+    if _has_file_context(last_msg, chat_session):
+        async for chunk in _execute_file_chat_stream(uid, messages, chat_session, callback_data):
+            yield chunk
+        return
+
+    # 3. Default: Anthropic agentic chat
+    # Claude decides implicitly whether to use tools — no requires_context() needed
+    async for chunk in execute_agentic_chat_stream(
+        uid, messages, app, callback_data=callback_data, chat_session=chat_session, context=context
+    ):
+        yield chunk
+
+
+# Backward compatibility aliases
+execute_graph_chat_stream = execute_chat_stream
+
+
+def execute_graph_chat(
+    uid: str, messages: List[Message], app: Optional[App] = None, cited: Optional[bool] = False
+) -> Tuple[str, bool, List[Conversation]]:
+    """Synchronous chat execution (backward compatibility).
+
+    Runs the streaming chat and collects the result.
+    """
+    callback_data = {}
+
+    async def _run():
+        async for _ in execute_chat_stream(
+            uid, messages, app, cited=cited, callback_data=callback_data
+        ):
+            pass
+
+    asyncio.run(_run())
+    return (
+        callback_data.get('answer', ''),
+        callback_data.get('ask_for_nps', False),
+        callback_data.get('memories_found', []),
+    )

--- a/backend/utils/retrieval/tools/__init__.py
+++ b/backend/utils/retrieval/tools/__init__.py
@@ -53,6 +53,9 @@ from .screen_activity_tools import (
     get_screen_activity_tool,
     search_screen_activity_tool,
 )
+from .preference_tools import (
+    save_user_preference_tool,
+)
 
 __all__ = [
     'get_conversations_tool',
@@ -79,4 +82,5 @@ __all__ = [
     'create_chart_tool',
     'get_screen_activity_tool',
     'search_screen_activity_tool',
+    'save_user_preference_tool',
 ]

--- a/backend/utils/retrieval/tools/preference_tools.py
+++ b/backend/utils/retrieval/tools/preference_tools.py
@@ -1,0 +1,90 @@
+"""
+Tools for learning and saving user preferences during conversation.
+"""
+
+import contextvars
+import uuid
+from datetime import datetime, timezone
+
+from langchain_core.tools import tool
+from langchain_core.runnables import RunnableConfig
+
+import database.memories as memory_db
+import database.vector_db as vector_db
+import logging
+
+logger = logging.getLogger(__name__)
+
+# Import agent_config_context for fallback config access
+try:
+    from utils.retrieval.agentic import agent_config_context
+except ImportError:
+    agent_config_context = contextvars.ContextVar('agent_config', default=None)
+
+
+def _get_uid(config: RunnableConfig) -> str:
+    """Extract user ID from config or context variable."""
+    if config and 'configurable' in config:
+        uid = config['configurable'].get('user_id')
+        if uid:
+            return uid
+    ctx = agent_config_context.get()
+    if ctx and 'configurable' in ctx:
+        return ctx['configurable'].get('user_id', '')
+    return ''
+
+
+@tool
+def save_user_preference_tool(preference: str, config: RunnableConfig = None) -> str:
+    """Save a learned user preference or personal detail for future conversations.
+
+    Call this when you learn something about the user's preferences, habits, or
+    personal details that would be useful to remember across conversations. Examples:
+    - "Prefers Google Calendar over Outlook"
+    - "Default meeting length is 30 minutes"
+    - "Works at Acme Corp as a product manager"
+    - "Prefers metric units over imperial"
+
+    Do NOT save ephemeral information (today's mood, current task).
+    Do NOT save something already known from existing memories.
+    Do NOT ask for confirmation — just save it silently when you learn it.
+
+    Args:
+        preference: A clear, concise statement of the preference or personal detail.
+    """
+    uid = _get_uid(config)
+    if not uid:
+        return "Error: Could not determine user ID"
+
+    # Check for duplicate preferences via semantic search
+    try:
+        existing = vector_db.find_similar_memories(uid, preference, threshold=0.90, limit=3)
+        if existing:
+            content = existing[0].get('content', '')
+            score = existing[0].get('score', 0)
+            logger.info(f"Skipping duplicate preference (score={score:.2f}): {content[:80]}")
+            return f"Similar preference already exists: {content}"
+    except Exception as e:
+        logger.warning(f"Could not check for duplicate preferences: {e}")
+
+    now = datetime.now(timezone.utc)
+    memory_id = str(uuid.uuid4())
+    memory_data = {
+        'id': memory_id,
+        'content': preference,
+        'category': 'system',
+        'manually_added': False,
+        'created_at': now,
+        'updated_at': now,
+        'reviewed': False,
+        'visibility': 'private',
+        'tags': ['agent-learned'],
+    }
+
+    try:
+        memory_db.create_memory(uid, memory_data)
+        logger.info(f"Saved user preference: {preference[:80]}")
+        return f"Preference saved: {preference}"
+    except Exception as e:
+        logger.error(f"Failed to save preference: {e}")
+        return f"Error saving preference: {str(e)}"


### PR DESCRIPTION
## Summary

- **Replace OpenAI GPT-5.1 + LangGraph ReAct agent** with Anthropic Claude Opus 4.6 native tool use API for the mobile chat backend
- **Simplify routing**: remove LangGraph state machine and `requires_context()` LLM classification call — Claude decides implicitly whether to use tools
- **Add `defer_loading`** for app tools via Anthropic's tool search tool — 79 app tools are discoverable on-demand instead of loaded into context upfront
- **Add preference learning**: new `save_user_preference_tool` stores learned user preferences as memories, automatically included in future system prompts
- **Fix tool progress indicator**: show thinking shimmer below already-rendered text when Claude calls tools after starting its response

## Architecture changes

| Before | After |
|--------|-------|
| LangGraph StateGraph with 4-way routing | Simple if/else: persona → file → Anthropic agent |
| `requires_context()` LLM call per request | Eliminated — Claude decides implicitly |
| OpenAI GPT-5.1 with ReAct agent | Anthropic Claude Opus 4.6 native tool use |
| 104 tools loaded into context | 25 core visible + 79 deferred via tool search |
| Sequential tool calls | Parallel tool calls (Anthropic native) |
| No preference learning | `save_user_preference_tool` with duplicate detection |

## Files changed

**Backend (core migration):**
- `backend/requirements.txt` — add `anthropic>=0.52.0`
- `backend/main.py` — add `load_dotenv()` for local dev
- `backend/utils/llm/clients.py` — add Anthropic client + model constants
- `backend/utils/retrieval/agentic.py` — **rewritten**: Anthropic tool-use loop, schema converter, defer_loading
- `backend/utils/retrieval/graph.py` — **simplified**: remove LangGraph, simple router
- `backend/routers/chat.py` — update import path
- `backend/utils/llm/chat.py` — add preference learning instruction to prompt
- `backend/utils/retrieval/tools/preference_tools.py` — **new**: preference learning tool
- `backend/utils/retrieval/tools/__init__.py` — export new tool

**Flutter (tool indicator fix):**
- `app/lib/providers/message_provider.dart` — set `agentThinkingAfterText` in server chat path

**Tests:**
- `backend/tests/unit/test_prompt_cache_integration.py` — update tool counts, add defer_loading tests
- `backend/tests/unit/test_prompt_cache_optimization.py` — update assertion for single execute function

## What stays unchanged
- All 23 existing tool implementation files — zero modifications
- `backend/utils/retrieval/safety.py` — SafetyGuard used identically
- Persona and file chat paths — still on LangChain/OpenAI
- Flutter SSE protocol (`data:`, `think:`, `done:`) — no client changes needed
- LangSmith prompt versioning and feedback — fully working
- Citation system — same `[1][2]` markers with conversation references

## Test plan
- [x] All 182 passing backend tests still pass (5 pre-existing failures in unrelated `test_process_conversation_usage_context.py`)
- [x] New `test_convert_tools_defers_app_tools` test validates defer_loading behavior
- [x] Manual testing: simple greetings, memory queries, calendar CRUD, parallel tool calls, conversation search
- [x] Tool progress indicator shows during multi-tool operations
- [x] Text separator prevents run-together paragraphs between tool-use loop iterations

🤖 Generated with [Claude Code](https://claude.com/claude-code)