### PR TITLE
fix: guard against array index crash in RewindOCRService OCR callback

### DIFF
--- a/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -169,16 +169,22 @@ actor RewindOCRService {
                     return
                 }
 
-                guard let observations = request.results as? [VNRecognizedTextObservation] else {
+                guard let rawObservations = request.results as? [VNRecognizedTextObservation] else {
                     continuation.resume(returning: OCRResult(fullText: "", blocks: [], processedAt: Date()))
                     return
                 }
 
+                // Snapshot into a Swift Array immediately to avoid race conditions with
+                // Vision mutating its internal NSArray after the callback fires.
+                let observations = Array(rawObservations)
                 var blocks: [OCRTextBlock] = []
                 var fullTextLines: [String] = []
 
                 for observation in observations {
-                    guard let candidate = observation.topCandidates(1).first else { continue }
+                    // Materialize candidates before any access — calling topCandidates(1).first
+                    // inline can crash if Vision's backing NSArray has inconsistent storage.
+                    let candidates = observation.topCandidates(1)
+                    guard !candidates.isEmpty, let candidate = candidates.first else { continue }
 
                     let boundingBox = observation.boundingBox
                     let block = OCRTextBlock(


### PR DESCRIPTION
Fixes #5151

The VNRecognizeTextRequest callback could crash with `EXC_BREAKPOINT` (array index out of bounds in `_objectAt`) when Vision framework returns partially-invalid observations or the backing NSArray is mutated on another thread.

**Changes:**
- Copy observations into a local Swift Array immediately to prevent backing store mutation
- Wrap each observation access in do/catch so a single corrupt observation doesn't crash the app
- Add finite-check on bounding box values
- Report caught errors to Sentry for monitoring