### PR TITLE
chore: bump build number to 779

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.526+778
+version: 1.0.526+779
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bump build number from +777 to +779 to trigger Codemagic TestFlight/Play Store build
- +777 and +778 are already on TestFlight — need +779 for a new upload
- Includes PR #5670 l10n changes: free plan minutes 1,200 → 4,800 across all 34 locales

## Test plan
- [ ] Codemagic auto-build triggers on merge
- [ ] iOS TestFlight build +779 uploads successfully
- [ ] Android internal build +779 uploads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)