### PR TITLE
chore: bump build number to 780 (retry cancelled +779)

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.526+779
+version: 1.0.526+780
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- +779 Codemagic builds (ios-internal-auto + android-internal-auto) were cancelled by PR #5706 merging concurrently
- Bump to +780 to retrigger Codemagic builds
- Includes all app changes up to and including PR #5670 (free plan 1200→4800 mins)

**Please wait ~5 min after merging before merging other app PRs** to avoid another cancellation (`cancel_previous_builds: true` in codemagic.yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)