### PR TITLE
Fix: add missing dart:math import in capture_provider + bump to 781

### DIFF
--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
+import 'dart:math';
 
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.526+780
+version: 1.0.526+781
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Adds missing `import 'dart:math';` to `capture_provider.dart` — fixes Codemagic build failure
- `min()`, `pow()`, `Random()` at line 1328-1329 require `dart:math`
- Bumps build to +781 (both +779 and +780 failed to upload)

## Context
Codemagic iOS+Android builds have been failing since this import was missing. This was introduced by a recent PR that added exponential backoff reconnect logic without the required import.

**Please wait ~5 min after merging before merging other app PRs** to avoid `cancel_previous_builds` cancellation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)