### PR TITLE
Revert "fix: replace fixed 15s WebSocket reconnect with exponential backoff + jitter (#5617)"

### DIFF
--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -75,8 +75,6 @@ class CaptureProvider extends ChangeNotifier
   TranscriptSegmentSocketService? _socket;
   Timer? _keepAliveTimer;
   DateTime? _keepAliveLastExecutedAt;
-  int _reconnectAttempt = 0;
-  static const int _maxBackoffSeconds = 120;
 
   // Method channel for system audio permissions
   static late MethodChannel _screenCaptureChannel;
@@ -1324,28 +1322,26 @@ class CaptureProvider extends ChangeNotifier
     _startKeepAliveServices();
   }
 
-  Duration _getReconnectDelay() {
-    final cap = min(pow(2, _reconnectAttempt), _maxBackoffSeconds).toInt();
-    final jitterMs = cap > 0 ? Random().nextInt(cap * 1000) : 1000;
-    return Duration(milliseconds: jitterMs);
-  }
-
   void _startKeepAliveServices() {
     _keepAliveTimer?.cancel();
-    final delay = _getReconnectDelay();
-    _reconnectAttempt++;
-    Logger.debug(
-      "[Provider] keep alive - scheduling reconnect in ${delay.inMilliseconds}ms (attempt $_reconnectAttempt)",
-    );
-    _keepAliveTimer = Timer(delay, () async {
+    _keepAliveTimer = Timer.periodic(const Duration(seconds: 15), (t) async {
       Logger.debug("[Provider] keep alive");
+      // rate 1/15s
+      if (_keepAliveLastExecutedAt != null &&
+          DateTime.now().subtract(const Duration(seconds: 15)).isBefore(_keepAliveLastExecutedAt!)) {
+        Logger.debug("[Provider] keep alive - hitting rate limits 1/15s");
+        return;
+      }
 
+      _keepAliveLastExecutedAt = DateTime.now();
       if (!recordingDeviceServiceReady || _socket?.state == SocketServiceState.connected) {
+        t.cancel();
         return;
       }
 
       if (!AuthService.instance.isSignedIn()) {
         Logger.debug("[Provider] keep alive - user not signed in, cancelling reconnect");
+        t.cancel();
         return;
       }
 
@@ -1365,8 +1361,6 @@ class CaptureProvider extends ChangeNotifier
             audioCodec: BleAudioCodec.pcm16, sampleRate: 16000, source: ConversationSource.desktop.name);
         return;
       }
-      // If we get here without reconnecting, schedule another attempt
-      _startKeepAliveServices();
     });
   }
 
@@ -1389,7 +1383,6 @@ class CaptureProvider extends ChangeNotifier
 
   @override
   void onConnected() {
-    _reconnectAttempt = 0;
     _transcriptServiceReady = true;
     notifyListeners();
   }

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.526+780
+version: 1.0.526+781
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
Reverts PR #5617 by @kodjima33 — this PR added `min()`, `pow()`, `Random()` calls without importing `dart:math`, breaking the Codemagic build. The import was previously carried by #5618 which was already reverted in #5695, leaving #5617's code broken.

Restores the original fixed 15s WebSocket reconnect delay. Exponential backoff can be re-added properly with the required import.

Also bumps build to +781 to trigger a clean Codemagic build.

**Please wait ~5 min after merging before merging other app PRs.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)