### PR TITLE
Revert WebSocket reconnect exponential backoff (#5617)

### DIFF
--- a/app/lib/providers/capture_provider.dart
+++ b/app/lib/providers/capture_provider.dart
@@ -75,8 +75,6 @@ class CaptureProvider extends ChangeNotifier
   TranscriptSegmentSocketService? _socket;
   Timer? _keepAliveTimer;
   DateTime? _keepAliveLastExecutedAt;
-  int _reconnectAttempt = 0;
-  static const int _maxBackoffSeconds = 120;
 
   // Method channel for system audio permissions
   static late MethodChannel _screenCaptureChannel;
@@ -1324,28 +1322,26 @@ class CaptureProvider extends ChangeNotifier
     _startKeepAliveServices();
   }
 
-  Duration _getReconnectDelay() {
-    final cap = min(pow(2, _reconnectAttempt), _maxBackoffSeconds).toInt();
-    final jitterMs = cap > 0 ? Random().nextInt(cap * 1000) : 1000;
-    return Duration(milliseconds: jitterMs);
-  }
-
   void _startKeepAliveServices() {
     _keepAliveTimer?.cancel();
-    final delay = _getReconnectDelay();
-    _reconnectAttempt++;
-    Logger.debug(
-      "[Provider] keep alive - scheduling reconnect in ${delay.inMilliseconds}ms (attempt $_reconnectAttempt)",
-    );
-    _keepAliveTimer = Timer(delay, () async {
+    _keepAliveTimer = Timer.periodic(const Duration(seconds: 15), (t) async {
       Logger.debug("[Provider] keep alive");
+      // rate 1/15s
+      if (_keepAliveLastExecutedAt != null &&
+          DateTime.now().subtract(const Duration(seconds: 15)).isBefore(_keepAliveLastExecutedAt!)) {
+        Logger.debug("[Provider] keep alive - hitting rate limits 1/15s");
+        return;
+      }
 
+      _keepAliveLastExecutedAt = DateTime.now();
       if (!recordingDeviceServiceReady || _socket?.state == SocketServiceState.connected) {
+        t.cancel();
         return;
       }
 
       if (!AuthService.instance.isSignedIn()) {
         Logger.debug("[Provider] keep alive - user not signed in, cancelling reconnect");
+        t.cancel();
         return;
       }
 
@@ -1365,8 +1361,6 @@ class CaptureProvider extends ChangeNotifier
             audioCodec: BleAudioCodec.pcm16, sampleRate: 16000, source: ConversationSource.desktop.name);
         return;
       }
-      // If we get here without reconnecting, schedule another attempt
-      _startKeepAliveServices();
     });
   }
 
@@ -1389,7 +1383,6 @@ class CaptureProvider extends ChangeNotifier
 
   @override
   void onConnected() {
-    _reconnectAttempt = 0;
     _transcriptServiceReady = true;
     notifyListeners();
   }


### PR DESCRIPTION
Reverts #5617 per CTO request.

This PR added exponential backoff + jitter for WebSocket reconnection (replacing fixed 15s interval). It introduced `min()`, `pow()`, and `Random()` calls without importing `dart:math`, which broke the Codemagic build after the related #5618 revert removed the import. The reconnection logic change also affects the core audio capture flow and needs proper testing before re-merging.

---
_by AI for @beastoin_