### PR TITLE
Use active WS connections metric of pusher for auto scaling

### DIFF
--- a/backend/charts/monitoring/prometheus-adapter/dev_omi_prometheus_adapter.yaml
+++ b/backend/charts/monitoring/prometheus-adapter/dev_omi_prometheus_adapter.yaml
@@ -6,7 +6,14 @@ rules:
     - name:
         as: "backend_listen_active_ws_connections_per_pod"
       seriesQuery: 'backend_listen_active_ws_connections'
-      metricsQuery: 'avg(backend_listen_active_ws_connections)'
+      metricsQuery: 'avg(backend_listen_active_ws_connections{job="backend-listen-metrics"})'
+      resources:
+        overrides:
+          namespace: { resource: "namespace" }
+    - name:
+        as: "pusher_active_ws_connections_per_pod"
+      seriesQuery: 'pusher_active_ws_connections'
+      metricsQuery: 'avg(pusher_active_ws_connections{job="pusher-metrics"})'
       resources:
         overrides:
           namespace: { resource: "namespace" }

--- a/backend/charts/monitoring/prometheus-adapter/prod_omi_prometheus_adapter.yaml
+++ b/backend/charts/monitoring/prometheus-adapter/prod_omi_prometheus_adapter.yaml
@@ -6,7 +6,14 @@ rules:
     - name:
         as: "backend_listen_active_ws_connections_per_pod"
       seriesQuery: 'backend_listen_active_ws_connections'
-      metricsQuery: 'avg(backend_listen_active_ws_connections)'
+      metricsQuery: 'avg(backend_listen_active_ws_connections{job="backend-listen-metrics"})'
+      resources:
+        overrides:
+          namespace: { resource: "namespace" }
+    - name:
+        as: "pusher_active_ws_connections_per_pod"
+      seriesQuery: 'pusher_active_ws_connections'
+      metricsQuery: 'avg(pusher_active_ws_connections{job="pusher-metrics"})'
       resources:
         overrides:
           namespace: { resource: "namespace" }

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -318,6 +318,22 @@ autoscaling:
   targetCPUUtilizationPercentage: 70
   targetMemoryUtilizationPercentage: 70
 
+podDisruptionBudget:
+  minAvailable: "80%"
+  # maxUnavailable: "20%"
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 2
+
+terminationGracePeriodSeconds: 120
+lifecycle:
+  preStop:
+    exec:
+      command: ["sh", "-c", "sleep 15"]
+
 # Additional volumes on the output Deployment definition.
 volumes: []
 # - name: foo

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -317,8 +317,8 @@ startupProbe:
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
   enabled: true
-  minReplicas: 30
-  maxReplicas: 60
+  minReplicas: 20
+  maxReplicas: 40
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 600
@@ -326,18 +326,39 @@ autoscaling:
       - type: Percent
         value: 20
         periodSeconds: 300
+      - type: Pods
+        value: 1
+        periodSeconds: 120
+      selectPolicy: Min
     scaleUp:
-      stabilizationWindowSeconds: 0
+      stabilizationWindowSeconds: 120
       policies:
       - type: Percent
-        value: 20
-        periodSeconds: 1
+        value: 30
+        periodSeconds: 60
       - type: Pods
-        value: 10
-        periodSeconds: 1
+        value: 5
+        periodSeconds: 60
       selectPolicy: Max
-  targetCPUUtilizationPercentage: 60
-  targetMemoryUtilizationPercentage: 60
+  # targetCPUUtilizationPercentage: 60
+  # targetMemoryUtilizationPercentage: 60
+  activeConnectionsPerPod: 20
+
+podDisruptionBudget:
+  minAvailable: "80%"
+  # maxUnavailable: "20%"
+
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 1
+    maxSurge: 2
+
+terminationGracePeriodSeconds: 120
+lifecycle:
+  preStop:
+    exec:
+      command: ["sh", "-c", "sleep 15"]
 
 # Additional volumes on the output Deployment definition.
 volumes: []

--- a/backend/charts/pusher/templates/deployment.yaml
+++ b/backend/charts/pusher/templates/deployment.yaml
@@ -11,6 +11,10 @@ spec:
   selector:
     matchLabels:
       {{- include "pusher.selectorLabels" . | nindent 6 }}
+  {{- with .Values.strategy}}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -32,8 +36,15 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.terminationGracePeriodSeconds}}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
+          {{- with .Values.lifecycle }}
+          lifecycle:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with .Values.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/backend/charts/pusher/templates/hpa.yaml
+++ b/backend/charts/pusher/templates/hpa.yaml
@@ -33,4 +33,14 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
     {{- end }}
+    {{- if .Values.autoscaling.activeConnectionsPerPod }}
+    - type: External
+      external:
+        metric:
+          name: pusher_active_ws_connections_per_pod
+        target:
+          type: Value
+          value: {{ .Values.autoscaling.activeConnectionsPerPod }}
+    {{- end }}
+
 {{- end }}


### PR DESCRIPTION
**Changes:**
- Use active WS connections metric of pusher for auto scaling
- Enable graceful termination and better rollout update strategy for pusher deployment
- Add podDisruptionBudget for pusher
- Adjust minReplicas and maxReplicas for cost optimization