### PR TITLE
Update CHANGELOG.json for v0.11.110 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed Gemini API key for proactive notifications (memory, tasks, advice, focus)"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.110",
+      "date": "2026-03-16",
+      "changes": [
+        "Fixed Gemini API key for proactive notifications (memory, tasks, advice, focus)"
+      ]
+    },
     {
       "version": "0.11.109",
       "date": "2026-03-16",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.110 and clears the unreleased array.