### PR TITLE
Bump build number to 781 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.526+780
+version: 1.0.526+781
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Bump build number from 780 to 781 for mobile release v1.0.526.

This creates a new build number higher than the current TestFlight/internal test builds (+780) so Codemagic can publish to both stores.