### PR TITLE
Fix floating bar notification collapse state

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -23,6 +23,7 @@ class FloatingControlBarState: NSObject, ObservableObject {
     @Published var duration: Int = 0
     @Published var isInitialising: Bool = false
     @Published var isDragging: Bool = false
+    @Published var isHoveringBar: Bool = false
     @Published var currentNotification: FloatingBarNotification? = nil
 
     // AI conversation state

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -25,19 +25,6 @@ struct FloatingControlBarView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .onHover { hovering in
-            // Resize window BEFORE updating SwiftUI state on expand so the expanded
-            // content never renders in a too-small window (which causes overflow).
-            if hovering {
-                (window as? FloatingControlBarWindow)?.resizeForHover(expanded: true)
-            }
-            withAnimation(.easeInOut(duration: 0.2)) {
-                isHovering = hovering
-            }
-            if !hovering {
-                (window as? FloatingControlBarWindow)?.resizeForHover(expanded: false)
-            }
-        }
         .animation(.spring(response: 0.35, dampingFraction: 0.82), value: state.currentNotification?.id)
     }
 
@@ -113,6 +100,22 @@ struct FloatingControlBarView: View {
         .clipped()
         .background(DraggableAreaView(targetWindow: window))
         .floatingBackground(cornerRadius: isHovering || state.showingAIConversation || state.isVoiceListening || state.isShowingNotification ? 20 : 5)
+        .onHover(perform: handleBarHover)
+    }
+
+    private func handleBarHover(_ hovering: Bool) {
+        state.isHoveringBar = hovering
+        // Resize window BEFORE updating SwiftUI state on expand so the expanded
+        // content never renders in a too-small window (which causes overflow).
+        if hovering {
+            (window as? FloatingControlBarWindow)?.resizeForHover(expanded: true)
+        }
+        withAnimation(.easeInOut(duration: 0.2)) {
+            isHovering = hovering
+        }
+        if !hovering {
+            (window as? FloatingControlBarWindow)?.resizeForHover(expanded: false)
+        }
     }
 
     private func notificationView(_ notification: FloatingBarNotification) -> some View {

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -573,7 +573,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
         if state.isVoiceListening {
             targetSize = NSSize(width: Self.expandedWidth, height: Self.expandedBarSize.height)
         } else {
-            targetSize = frame.contains(NSEvent.mouseLocation) ? Self.expandedBarSize : Self.minBarSize
+            targetSize = state.isHoveringBar ? Self.expandedBarSize : Self.minBarSize
         }
         resizeAnchored(to: targetSize, makeResizable: false, animated: animated, anchorTop: true)
     }


### PR DESCRIPTION
## Summary
- track hover state on the actual floating control bar instead of the full notification container
- use that explicit hover state when collapsing after a notification dismisses
- prevent the compact floating line from staying expanded because the cursor was inside the old notification frame

## Verification
- xcrun swift build -c debug --package-path Desktop
