### PR TITLE
Delay onboarding web search until after file access

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,6 +118,7 @@ Key rules:
 - 15 commands: `doctor`, `connect`, `disconnect`, `status`, `snapshot`, `press`, `click`, `fill`, `get`, `find`, `screenshot`, `is`, `wait`, `scroll`, `schema`.
 - Works with any macOS app (SwiftUI, AppKit, Electron) — zero app-side setup.
 - Dev bundle ID: `com.omi.desktop-dev`. Prod: `com.omi.computer-macos`.
+- If you launch a custom-named desktop test build, keep the dev bundle identifier aligned with the app name. Example: `search.app` should use a matching dev bundle ID like `com.omi.search`, not `com.omi.desktop-dev`.
 - App flows & exploration skill: See `desktop/e2e/SKILL.md` for navigation architecture, interaction patterns, and reference flows.
 - Full command reference: `agent-swift --help` or `agent-swift schema`.
 - When asked to build or rebuild the desktop app for testing, don't stop at a successful compile: launch the dev app, interact with it programmatically to confirm it actually runs, and report any environment blocker if full interaction is impossible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,6 +173,7 @@ agent-swift screenshot /tmp/after-change.png  # capture app window
 - 15 commands: `doctor`, `connect`, `disconnect`, `status`, `snapshot`, `press`, `click`, `fill`, `get`, `find`, `screenshot`, `is`, `wait`, `scroll`, `schema`.
 - Works with any macOS app (SwiftUI, AppKit, Electron) — no Marionette or app-side setup.
 - Bundle ID for dev: `com.omi.desktop-dev`. For prod: `com.omi.computer-macos`.
+- If you launch a custom-named desktop test build, keep the dev bundle identifier aligned with the app name. Example: `search.app` should use a matching dev bundle ID like `com.omi.search`, not `com.omi.desktop-dev`.
 - **App flows & exploration skill**: See `desktop/e2e/SKILL.md` for navigation architecture, screen map, interaction patterns (click vs press), and known flows. Read this when developing features or exploring the app.
 - When asked to build or rebuild the desktop app for testing, don't stop at a successful compile: launch the dev app, interact with it programmatically to confirm it actually runs, and report any environment blocker if full interaction is impossible.
 

--- a/desktop/Desktop/Package.swift
+++ b/desktop/Desktop/Package.swift
@@ -43,6 +43,11 @@ let package = Package(
                 .process("GoogleService-Info.plist"),
                 .process("Resources")
             ]
+        ),
+        .testTarget(
+            name: "OmiComputerTests",
+            dependencies: ["Omi Computer"],
+            path: "Tests"
         )
     ]
 )

--- a/desktop/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/Desktop/Sources/Chat/ChatPrompts.swift
@@ -678,15 +678,7 @@ struct ChatPrompts {
     If English, call `set_user_preferences(language: "en")`.
     Then call `save_knowledge_graph` with a language node (e.g. "English") connected to the user node.
 
-    STEP 2 — WEB RESEARCH (ONE SEARCH AT A TIME)
-    Do up to 3 web searches, ONE PER TURN. After EACH search, output a 1-sentence reaction before doing the next search. Never batch multiple searches.
-    Turn 1: web_search("{user_name} {email_domain}") → "Oh you work at [company] — cool!"
-    Turn 2: web_search("[company] [product]") → "So you're building [X], nice."
-    Turn 3: web_search("[specific project]") → "[specific impressed reaction]"
-    Be specific: name their company, role, projects. Skip a search if you already know enough.
-    After EACH search, call `save_knowledge_graph` with the new entities you discovered (company, role, projects, etc.) and edges connecting them to existing nodes.
-
-    STEP 3 — MONTHLY GOAL (BEFORE SCAN)
+    STEP 2 — MONTHLY GOAL (BEFORE SCAN)
     Ask for ONE top monthly goal first.
     Then call `ask_followup` with 2-4 SMART options and one typed option.
     Every suggested option MUST be concrete, measurable, and time-bound with a clear numeric target by month-end.
@@ -695,16 +687,16 @@ struct ChatPrompts {
     WAIT for user reply (button or typed).
     After reply, call `save_knowledge_graph` with the chosen goal as a concept node connected to the user.
 
-    STEP 4 — FILE SCAN (AFTER GOAL)
+    STEP 3 — FILE SCAN (AFTER GOAL)
     Tell the user you'll scan files, then call `scan_files`. A folder access guide image is shown automatically in the UI.
     This tool BLOCKS until the scan is complete. macOS may show folder access dialogs — the guide image helps the user click Allow.
     If any folders were denied access, tell the user and call `scan_files` again after they allow.
     After scan, call `save_knowledge_graph` with tools, languages, frameworks, and notable notes/projects found (5-20 nodes).
 
-    STEP 5 — FILE DISCOVERIES + TASK CANDIDATES
-    This step is MANDATORY before Step 6.
+    STEP 4 — FILE DISCOVERIES + TASK CANDIDATES
+    This step is MANDATORY before Step 5.
     You MUST ask ONE task-selection follow-up in this step and WAIT for the reply before requesting permissions.
-    Share 1-2 specific observations connecting web research + goal + file findings.
+    Share 1-2 specific observations connecting the user's goal + file findings.
     Then identify up to 2-3 candidate tasks that could help the user's monthly goal.
     RULES:
     - Prefer existing tasks found in scan results if clearly relevant.
@@ -715,6 +707,17 @@ struct ChatPrompts {
     If you found confident task candidates, present them with `ask_followup` (2-4 options, include at least one typed option) and WAIT for the user's reply.
     If confidence is low or no good task candidates exist, ask manually: "What is your goal for today?" with `ask_followup` (2-4 concrete options, include at least one typed option), then WAIT for the user's reply.
     After the reply, call `save_knowledge_graph` with today's goal/task context as concept nodes connected to the user.
+
+    STEP 5 — WEB RESEARCH (ONLY AFTER FILES + EMAIL ATTEMPT)
+    Do NOT search the web earlier in onboarding.
+    Only do web research AFTER the user has shared file access via `scan_files` and AFTER Omi has already attempted to read recent Gmail in the background.
+    Do up to 3 web searches, ONE PER TURN. After EACH search, output a 1-sentence reaction before doing the next search. Never batch multiple searches.
+    Turn 1: web_search("{user_name} {email_domain}") → "Oh you work at [company] — cool!"
+    Turn 2: web_search("[company] [product]") → "So you're building [X], nice."
+    Turn 3: web_search("[specific project]") → "[specific impressed reaction]"
+    Be specific: name their company, role, projects. Skip a search if you already know enough.
+    Use what you learned from the file scan and today's goal to make the searches more targeted.
+    After EACH search, call `save_knowledge_graph` with the new entities you discovered (company, role, projects, etc.) and edges connecting them to existing nodes.
 
     STEP 6 — PRIVACY NOTE + PERMISSIONS
     Before asking for any permissions, send a trust-building message about data ownership. Example:
@@ -807,7 +810,7 @@ struct ChatPrompts {
     **request_permission**: Request a specific macOS permission from the user.
     - Parameters: type (required) — one of: screen_recording, microphone, notifications, accessibility, automation
     - Triggers the macOS system permission dialog. Returns "granted", "pending - ...", or "denied".
-    - In Step 5, do NOT call this directly — use `ask_followup` with "Grant [X]" buttons instead. The UI handles triggering the permission.
+    - In Step 6, do NOT call this directly — use `ask_followup` with "Grant [X]" buttons instead. The UI handles triggering the permission.
 
     **set_user_preferences**: Save user preferences (language, name).
     - Parameters: language (optional, language code like "en", "es", "ja"), name (optional, string)

--- a/desktop/Desktop/Tests/ChatPromptsTests.swift
+++ b/desktop/Desktop/Tests/ChatPromptsTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import Omi_Computer
+
+final class ChatPromptsTests: XCTestCase {
+    func testOnboardingDefersWebResearchUntilAfterFileScanAndEmailAttempt() throws {
+        let prompt = ChatPromptBuilder.buildOnboardingChat(
+            userName: "Taylor Swift",
+            givenName: "Taylor",
+            email: "taylor@example.com"
+        )
+
+        let step2Range = try XCTUnwrap(prompt.range(of: "STEP 2 — MONTHLY GOAL (BEFORE SCAN)"))
+        let step3Range = try XCTUnwrap(prompt.range(of: "STEP 3 — FILE SCAN (AFTER GOAL)"))
+        let step4Range = try XCTUnwrap(prompt.range(of: "STEP 4 — FILE DISCOVERIES + TASK CANDIDATES"))
+        let step5Range = try XCTUnwrap(prompt.range(of: "STEP 5 — WEB RESEARCH (ONLY AFTER FILES + EMAIL ATTEMPT)"))
+        let gateRange = try XCTUnwrap(
+            prompt.range(
+                of: "Only do web research AFTER the user has shared file access via `scan_files` and AFTER Omi has already attempted to read recent Gmail in the background."
+            )
+        )
+
+        XCTAssertLessThan(step2Range.lowerBound, step3Range.lowerBound)
+        XCTAssertLessThan(step3Range.lowerBound, step4Range.lowerBound)
+        XCTAssertLessThan(step4Range.lowerBound, step5Range.lowerBound)
+        XCTAssertGreaterThan(gateRange.lowerBound, step5Range.lowerBound)
+    }
+}

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -30,12 +30,13 @@ substep() {
 
 # App configuration
 BINARY_NAME="Omi Computer"  # Package.swift target — binary paths, pkill, CFBundleExecutable
-APP_NAME="Omi Dev"
-BUNDLE_ID="com.omi.desktop-dev"
+APP_NAME="${OMI_APP_NAME:-Omi Dev}"
+BUNDLE_ID="${OMI_BUNDLE_ID:-com.omi.desktop-dev}"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_PATH="/Applications/$APP_NAME.app"
 SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
+URL_SCHEME="${OMI_URL_SCHEME:-omi-computer-dev}"
 AUTOMATION_ARGS=()
 if [ "${OMI_ENABLE_LOCAL_AUTOMATION:-0}" = "1" ]; then
     AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-47777}"
@@ -238,7 +239,7 @@ cp -f Desktop/Info.plist "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier $BUNDLE_ID" "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleName $APP_NAME" "$APP_BUNDLE/Contents/Info.plist"
 /usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName $APP_NAME" "$APP_BUNDLE/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 omi-computer-dev" "$APP_BUNDLE/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:0:CFBundleURLSchemes:0 $URL_SCHEME" "$APP_BUNDLE/Contents/Info.plist"
 
 auth_debug "AFTER plist edits: auth_isSignedIn=$(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
 


### PR DESCRIPTION
## Summary
- move onboarding web research until after file scan, task follow-up, and the background Gmail read attempt
- add a Swift package test that locks the onboarding prompt ordering
- allow custom desktop dev app names to carry matching bundle identifiers and document that rule in AGENTS/CLAUDE

## Verification
- `cd desktop/Desktop && swift test`
- `cd desktop/Desktop && swift build`
- built and launched `/Applications/search.app` as `com.omi.search`
- runtime onboarding check in the built bundle confirmed file scan completed first, Gmail started next, and only then the post-scan "learning about you" phase appeared