### PR TITLE
Keep onboarding graph hints visible

### DIFF
--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -15,8 +15,6 @@ struct OnboardingView: View {
   @StateObject private var graphViewModel = MemoryGraphViewModel()
   @State private var graphHasData = false
   @State private var showTrustPreview = true
-  @State private var showGraphHints = false
-  @State private var hintsHovered = false
 
   let steps = OnboardingFlow.steps
 
@@ -134,13 +132,9 @@ struct OnboardingView: View {
                 endPoint: .bottom
               )
             )
-            .onHover { hovering in
-              hintsHovered = hovering
-            }
-            .opacity(graphHasData && (showGraphHints || hintsHovered) ? 1 : 0)
-            .animation(.easeInOut(duration: 0.3), value: showGraphHints)
-            .animation(.easeInOut(duration: 0.3), value: hintsHovered)
+            .opacity(graphHasData && !showTrustPreview ? 1 : 0)
             .animation(.easeInOut(duration: 0.3), value: graphHasData)
+            .animation(.easeInOut(duration: 0.3), value: showTrustPreview)
           }
           .onAppear {
             showTrustPreview = true
@@ -222,13 +216,6 @@ struct OnboardingView: View {
     .foregroundColor(.white.opacity(0.5))
   }
 
-  private func flashGraphHints() {
-    showGraphHints = true
-    DispatchQueue.main.asyncAfter(deadline: .now() + 5) {
-      showGraphHints = false
-    }
-  }
-
   private func handleGraphDataArrival() {
     withAnimation(.easeIn(duration: 0.35)) {
       graphHasData = true
@@ -239,7 +226,6 @@ struct OnboardingView: View {
       withAnimation(.easeInOut(duration: 0.45)) {
         showTrustPreview = false
       }
-      flashGraphHints()
     }
   }
 


### PR DESCRIPTION
## Summary
- keep the onboarding knowledge graph footer visible whenever the graph is visible
- remove the timed hint-hide state and hover-only reveal logic

## Verification
- built the desktop app from this worktree with 
- launched a local  from this worktree
- verified via OVERVIEW: CLI for AI agents to control macOS apps via Accessibility API

USAGE: agent-swift <subcommand>

OPTIONS:
  --version               Show the version.
  -h, --help              Show help information.

SUBCOMMANDS:
  doctor                  Check prerequisites and diagnose issues
  connect                 Connect to a macOS app
  disconnect              Disconnect from the connected app
  status                  Show connection status
  snapshot                Capture element tree with refs
  press                   Press element by ref
  fill                    Enter text into element by ref
  get                     Read element property by ref
  find                    Find element by locator
  screenshot              Capture app screenshot
  is                      Assert element condition
  wait                    Wait for condition or delay
  scroll                  Scroll by direction or element ref
  click                   Click element or coordinates via CGEvent
  schema                  Show command schema

  See 'agent-swift help <subcommand>' for detailed help. that , , and  were still present after 7 seconds
