### PR TITLE
Fix onboarding push-to-talk shortcut step

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -105,9 +105,6 @@ class PushToTalkManager: ObservableObject {
   // MARK: - Option Key Handling
 
   private func handleFlagsChanged(_ event: NSEvent) {
-    // Don't process PTT when the floating bar is hidden
-    guard FloatingControlBarManager.shared.isVisible else { return }
-
     let settings = ShortcutSettings.shared
 
     let pttActive: Bool
@@ -125,6 +122,15 @@ class PushToTalkManager: ObservableObject {
     case .fn:
       pttActive = event.modifierFlags.contains(.function)
     }
+
+    // Let the first shortcut press reveal the compact bar instead of requiring it
+    // to already be visible. This keeps onboarding step 3 quiet on entry while
+    // still allowing the user to trigger the bar by pressing the key.
+    if pttActive, !FloatingControlBarManager.shared.isVisible {
+      FloatingControlBarManager.shared.show()
+    }
+
+    guard FloatingControlBarManager.shared.isVisible else { return }
 
     if pttActive {
       handleOptionDown()

--- a/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
@@ -76,7 +76,7 @@ struct OnboardingVoiceShortcutStepView: View {
           .lineSpacing(2)
 
         Text(
-          "Hold the key you want to use for voice questions, ask something like \"What's on my screen?\", then release to send. If the preview reacts on the right, you're set. If not, switch to another key."
+          "Hold the key you want to use for voice questions, then release to send. Try asking \"What's on my screen?\" If the preview reacts on the right, you're set. If not, switch to another key."
         )
         .font(.system(size: 16))
         .foregroundColor(OmiColors.textSecondary)


### PR DESCRIPTION
## Summary\n- update the merged onboarding shortcut copy to say \n- allow the first push-to-talk shortcut press to reveal the floating bar during onboarding\n- keep the onboarding step quiet on entry while still making the shortcut functional\n\n## Testing\n- xcrun swift build -c debug --package-path /private/tmp/omi-audio-rebuild/desktop/Desktop\n- verified the running  bundle with OVERVIEW: CLI for AI agents to control macOS apps via Accessibility API

USAGE: agent-swift <subcommand>

OPTIONS:
  --version               Show the version.
  -h, --help              Show help information.

SUBCOMMANDS:
  doctor                  Check prerequisites and diagnose issues
  connect                 Connect to a macOS app
  disconnect              Disconnect from the connected app
  status                  Show connection status
  snapshot                Capture element tree with refs
  press                   Press element by ref
  fill                    Enter text into element by ref
  get                     Read element property by ref
  find                    Find element by locator
  screenshot              Capture app screenshot
  is                      Assert element condition
  wait                    Wait for condition or delay
  scroll                  Scroll by direction or element ref
  click                   Click element or coordinates via CGEvent
  schema                  Show command schema

  See 'agent-swift help <subcommand>' for detailed help. on the onboarding shortcut step\n