### PR TITLE
desktop: route beta builds to dev backend

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -15,8 +15,63 @@ concurrency:
   group: desktop-auto-release-main
   cancel-in-progress: false
 
+env:
+  SERVICE: desktop-backend
+  REGION: us-central1
+
 jobs:
+  deploy-desktop-backend:
+    environment: development
+    permissions:
+      contents: read
+      id-token: write
+
+    runs-on: ubuntu-latest-m
+    steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Google Auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Login to GCR
+        run: gcloud auth configure-docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Google Service Account
+        run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./desktop/Backend-Rust/google-credentials.json
+
+      - name: Build and Push Desktop Backend Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./desktop/Backend-Rust
+          file: ./desktop/Backend-Rust/Dockerfile
+          push: true
+          tags: |
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
+          cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
+          cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
+
+      - name: Deploy Desktop Backend to Development
+        run: |
+          gcloud run deploy "${{ env.SERVICE }}" \
+            --image "gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}" \
+            --project "${{ vars.GCP_PROJECT_ID }}" \
+            --region "${{ env.REGION }}" \
+            --platform managed \
+            --allow-unauthenticated \
+            --quiet
+
   tag-release:
+    needs: deploy-desktop-backend
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -2,20 +2,23 @@ import Foundation
 
 actor APIClient {
     static let shared = APIClient()
+    private static let productionBundleIdentifier = "com.omi.computer-macos"
+    private static let updateChannelDefaultsKey = "update_channel"
+    private static let productionDesktopBackendURL = "https://desktop-backend-hhibjajaja-uc.a.run.app/"
+    private static let developmentDesktopBackendURL = "https://desktop-backend-dt5lrfkkoa-uc.a.run.app/"
 
     // OMI Backend base URL - loaded from .env file (OMI_API_URL)
     // Production URL is set in .env.app, dev URL is set by run.sh
     var baseURL: String {
         // First check getenv() for values set by setenv() in loadEnvironment()
         if let cString = getenv("OMI_API_URL"), let url = String(validatingUTF8: cString), !url.isEmpty {
-            return url.hasSuffix("/") ? url : url + "/"
+            return Self.resolvedAPIBaseURL(configuredURL: url)
         }
         // Fallback to ProcessInfo (launch-time snapshot)
         if let envURL = ProcessInfo.processInfo.environment["OMI_API_URL"], !envURL.isEmpty {
-            return envURL.hasSuffix("/") ? envURL : envURL + "/"
+            return Self.resolvedAPIBaseURL(configuredURL: envURL)
         }
-        // No hardcoded default - must be set via .env file
-        fatalError("OMI_API_URL not set. Ensure .env file is present in app bundle.")
+        return Self.resolvedAPIBaseURL(configuredURL: nil)
     }
 
     let session: URLSession
@@ -54,6 +57,47 @@ actor APIClient {
 
             throw DecodingError.dataCorruptedError(in: container, debugDescription: "Invalid date format: \(dateString)")
         }
+    }
+
+    private static var currentBundleIdentifier: String {
+        Bundle.main.bundleIdentifier ?? productionBundleIdentifier
+    }
+
+    private static var isNonProductionBuild: Bool {
+        currentBundleIdentifier.hasPrefix("com.omi.") && currentBundleIdentifier != productionBundleIdentifier
+    }
+
+    private static var currentUpdateChannel: String {
+        let raw = UserDefaults.standard.string(forKey: updateChannelDefaultsKey) ?? "stable"
+        return raw == "staging" ? "beta" : raw
+    }
+
+    private static var prefersDevelopmentDesktopBackend: Bool {
+        isNonProductionBuild || currentUpdateChannel == "beta"
+    }
+
+    private static var managedDesktopBackendBaseURL: String {
+        prefersDevelopmentDesktopBackend ? developmentDesktopBackendURL : productionDesktopBackendURL
+    }
+
+    private static func resolvedAPIBaseURL(configuredURL: String?) -> String {
+        let preferredManagedURL = managedDesktopBackendBaseURL
+
+        guard let configuredURL, !configuredURL.isEmpty else {
+            return preferredManagedURL
+        }
+
+        let normalizedURL = configuredURL.hasSuffix("/") ? configuredURL : configuredURL + "/"
+
+        if isKnownManagedDesktopBackendURL(normalizedURL) {
+            return preferredManagedURL
+        }
+
+        return normalizedURL
+    }
+
+    private static func isKnownManagedDesktopBackendURL(_ url: String) -> Bool {
+        url == productionDesktopBackendURL || url == developmentDesktopBackendURL
     }
 
     // MARK: - Request Building


### PR DESCRIPTION
## Summary
- route managed desktop API traffic to the dev desktop backend for beta/staging clients and to prod for stable clients
- deploy the desktop backend to the development environment before the GitHub-driven macOS release tag is created

## Verification
- `swift build -c debug --package-path desktop/Desktop`
- YAML parse for `.github/workflows/desktop_auto_release.yml`