### PR TITLE
Fix desktop test build identity and onboarding recovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,7 +118,7 @@ Key rules:
 - 15 commands: `doctor`, `connect`, `disconnect`, `status`, `snapshot`, `press`, `click`, `fill`, `get`, `find`, `screenshot`, `is`, `wait`, `scroll`, `schema`.
 - Works with any macOS app (SwiftUI, AppKit, Electron) — zero app-side setup.
 - Dev bundle ID: `com.omi.desktop-dev`. Prod: `com.omi.computer-macos`.
-- If you launch a custom-named desktop test build, keep the dev bundle identifier aligned with the app name. Example: `search.app` should use a matching dev bundle ID like `com.omi.search`, not `com.omi.desktop-dev`.
+- If you launch a custom-named desktop test build, keep the bundle suffix and app name identical so auth callbacks reopen the correct app. Example: `1233.app` should use `com.omi.1233`, `search.app` should use `com.omi.search`, and mismatches like `1233.app` with `com.omi.desktop-dev` are not allowed.
 - App flows & exploration skill: See `desktop/e2e/SKILL.md` for navigation architecture, interaction patterns, and reference flows.
 - Full command reference: `agent-swift --help` or `agent-swift schema`.
 - When asked to build or rebuild the desktop app for testing, don't stop at a successful compile: launch the dev app, interact with it programmatically to confirm it actually runs, and report any environment blocker if full interaction is impossible.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,7 +173,7 @@ agent-swift screenshot /tmp/after-change.png  # capture app window
 - 15 commands: `doctor`, `connect`, `disconnect`, `status`, `snapshot`, `press`, `click`, `fill`, `get`, `find`, `screenshot`, `is`, `wait`, `scroll`, `schema`.
 - Works with any macOS app (SwiftUI, AppKit, Electron) — no Marionette or app-side setup.
 - Bundle ID for dev: `com.omi.desktop-dev`. For prod: `com.omi.computer-macos`.
-- If you launch a custom-named desktop test build, keep the dev bundle identifier aligned with the app name. Example: `search.app` should use a matching dev bundle ID like `com.omi.search`, not `com.omi.desktop-dev`.
+- If you launch a custom-named desktop test build, keep the bundle suffix and app name identical so auth callbacks reopen the correct app. Example: `1233.app` should use `com.omi.1233`, `search.app` should use `com.omi.search`, and mismatches like `1233.app` with `com.omi.desktop-dev` are not allowed.
 - **App flows & exploration skill**: See `desktop/e2e/SKILL.md` for navigation architecture, screen map, interaction patterns (click vs press), and known flows. Read this when developing features or exploring the app.
 - When asked to build or rebuild the desktop app for testing, don't stop at a successful compile: launch the dev app, interact with it programmatically to confirm it actually runs, and report any environment blocker if full interaction is impossible.
 

--- a/desktop/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/Desktop/Sources/AnalyticsManager.swift
@@ -1,1002 +1,1061 @@
-import Foundation
 import AppKit
+import Foundation
 import Mixpanel
 
 /// Unified analytics manager that sends events to both Mixpanel and PostHog
 /// Use this instead of calling MixpanelManager and PostHogManager directly
 @MainActor
 class AnalyticsManager {
-    static let shared = AnalyticsManager()
-
-    /// Returns true if this is a development build (bundle ID ends with "-dev")
-    /// Development builds don't send analytics to avoid polluting production data
-    nonisolated static var isDevBuild: Bool {
-        Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
-    }
-
-    private var lastTranscriptionStartedAt: Date?
-
-    private init() {}
-
-    // MARK: - Initialization
-
-    func initialize() {
-        // Skip analytics in development builds
-        guard !Self.isDevBuild else {
-            log("Analytics: Skipping initialization (development build)")
-            return
-        }
-        MixpanelManager.shared.initialize()
-        PostHogManager.shared.initialize()
-        HeapManager.shared.initialize()
-    }
-
-    // MARK: - User Identification
-
-    func identify() {
-        MixpanelManager.shared.identify()
-        PostHogManager.shared.identify()
-        HeapManager.shared.identify()
-    }
-
-    func reset() {
-        MixpanelManager.shared.reset()
-        PostHogManager.shared.reset()
-        HeapManager.shared.reset()
-    }
-
-    // MARK: - Opt In/Out
-
-    func optInTracking() {
-        MixpanelManager.shared.optInTracking()
-        PostHogManager.shared.optIn()
-    }
-
-    func optOutTracking() {
-        MixpanelManager.shared.optOutTracking()
-        PostHogManager.shared.optOut()
-    }
-
-    // MARK: - Onboarding Events
-
-    func onboardingStepCompleted(step: Int, stepName: String) {
-        MixpanelManager.shared.onboardingStepCompleted(step: step, stepName: stepName)
-        PostHogManager.shared.onboardingStepCompleted(step: step, stepName: stepName)
-        HeapManager.shared.track("Onboarding Step Completed", properties: ["step": "\(step)", "step_name": stepName])
-    }
-
-    func onboardingCompleted() {
-        MixpanelManager.shared.onboardingCompleted()
-        PostHogManager.shared.onboardingCompleted()
-        HeapManager.shared.track("Onboarding Completed")
-    }
-
-    func onboardingChatToolUsed(tool: String, properties: [String: Any] = [:]) {
-        var props = properties
-        props["tool"] = tool
-        let mixpanelProps = props.compactMapValues { $0 as? MixpanelType }
-        MixpanelManager.shared.track("Onboarding Chat Tool Used", properties: mixpanelProps)
-        PostHogManager.shared.track("Onboarding Chat Tool Used", properties: props)
-    }
-
-    func onboardingChatMessage(role: String, step: String) {
-        let props: [String: Any] = ["role": role, "step": step]
-        let mixpanelProps = props.compactMapValues { $0 as? MixpanelType }
-        MixpanelManager.shared.track("Onboarding Chat Message", properties: mixpanelProps)
-        PostHogManager.shared.track("Onboarding Chat Message", properties: props)
-    }
-
-    // MARK: - Authentication Events
-
-    func signInStarted(provider: String) {
-        MixpanelManager.shared.signInStarted(provider: provider)
-        PostHogManager.shared.signInStarted(provider: provider)
-        HeapManager.shared.track("Sign In Started", properties: ["provider": provider])
-    }
-
-    func signInCompleted(provider: String) {
-        MixpanelManager.shared.signInCompleted(provider: provider)
-        PostHogManager.shared.signInCompleted(provider: provider)
-        HeapManager.shared.track("Sign In Completed", properties: ["provider": provider])
-    }
-
-    func signInFailed(provider: String, error: String) {
-        MixpanelManager.shared.signInFailed(provider: provider, error: error)
-        PostHogManager.shared.signInFailed(provider: provider, error: error)
-        HeapManager.shared.track("Sign In Failed", properties: ["provider": provider, "error": error])
-    }
-
-    func signedOut() {
-        MixpanelManager.shared.signedOut()
-        PostHogManager.shared.signedOut()
-        HeapManager.shared.track("Signed Out")
-    }
-
-    // MARK: - Monitoring Events
-
-    func monitoringStarted() {
-        MixpanelManager.shared.monitoringStarted()
-        PostHogManager.shared.monitoringStarted()
-    }
-
-    func monitoringStopped() {
-        MixpanelManager.shared.monitoringStopped()
-        PostHogManager.shared.monitoringStopped()
-    }
-
-    func distractionDetected(app: String, windowTitle: String?) {
-        MixpanelManager.shared.distractionDetected(app: app, windowTitle: windowTitle)
-        PostHogManager.shared.distractionDetected(app: app, windowTitle: windowTitle)
-    }
-
-    func focusRestored(app: String) {
-        MixpanelManager.shared.focusRestored(app: app)
-        PostHogManager.shared.focusRestored(app: app)
-    }
-
-    // MARK: - Recording Events
-
-    func transcriptionStarted() {
-        // Debounce: skip if called within 5 seconds (catches rapid wake/reconnect double-fires)
-        if let last = lastTranscriptionStartedAt, Date().timeIntervalSince(last) < 5 {
-            return
-        }
-        lastTranscriptionStartedAt = Date()
-        MixpanelManager.shared.transcriptionStarted()
-        PostHogManager.shared.transcriptionStarted()
-    }
-
-    func transcriptionStopped(wordCount: Int) {
-        MixpanelManager.shared.transcriptionStopped(wordCount: wordCount)
-        PostHogManager.shared.transcriptionStopped(wordCount: wordCount)
-    }
-
-    func recordingError(error: String) {
-        MixpanelManager.shared.recordingError(error: error)
-        PostHogManager.shared.recordingError(error: error)
-    }
-
-    // MARK: - Permission Events
-
-    func permissionRequested(permission: String, extraProperties: [String: Any] = [:]) {
-        let mixpanelProps = extraProperties.compactMapValues { $0 as? MixpanelType }
-        MixpanelManager.shared.permissionRequested(permission: permission, extraProperties: mixpanelProps)
-        PostHogManager.shared.permissionRequested(permission: permission, extraProperties: extraProperties)
-    }
-
-    func permissionGranted(permission: String, extraProperties: [String: Any] = [:]) {
-        let mixpanelProps = extraProperties.compactMapValues { $0 as? MixpanelType }
-        MixpanelManager.shared.permissionGranted(permission: permission, extraProperties: mixpanelProps)
-        PostHogManager.shared.permissionGranted(permission: permission, extraProperties: extraProperties)
-    }
-
-    func permissionDenied(permission: String, extraProperties: [String: Any] = [:]) {
-        let mixpanelProps = extraProperties.compactMapValues { $0 as? MixpanelType }
-        MixpanelManager.shared.permissionDenied(permission: permission, extraProperties: mixpanelProps)
-        PostHogManager.shared.permissionDenied(permission: permission, extraProperties: extraProperties)
-    }
-
-    func permissionSkipped(permission: String, extraProperties: [String: Any] = [:]) {
-        let mixpanelProps = extraProperties.compactMapValues { $0 as? MixpanelType }
-        MixpanelManager.shared.permissionSkipped(permission: permission, extraProperties: mixpanelProps)
-        PostHogManager.shared.permissionSkipped(permission: permission, extraProperties: extraProperties)
-    }
-
-    /// Track Bluetooth state changes for debugging
-    func bluetoothStateChanged(oldState: String, newState: String, oldStateRaw: Int, newStateRaw: Int, authorization: String, authorizationRaw: Int) {
-        let properties: [String: MixpanelType] = [
-            "old_state": oldState,
-            "new_state": newState,
-            "old_state_raw": oldStateRaw,
-            "new_state_raw": newStateRaw,
-            "authorization": authorization,
-            "authorization_raw": authorizationRaw
-        ]
-        MixpanelManager.shared.track("Bluetooth State Changed", properties: properties)
-        PostHogManager.shared.track("Bluetooth State Changed", properties: properties as [String: Any])
-    }
-
-    /// Track when ScreenCaptureKit broken state is detected (TCC granted but capture failing)
-    func screenCaptureBrokenDetected() {
-        MixpanelManager.shared.screenCaptureBrokenDetected()
-        PostHogManager.shared.screenCaptureBrokenDetected()
-    }
-
-    /// Track when user clicks reset button or notification to reset screen capture
-    func screenCaptureResetClicked(source: String) {
-        MixpanelManager.shared.screenCaptureResetClicked(source: source)
-        PostHogManager.shared.screenCaptureResetClicked(source: source)
-    }
-
-    /// Track when screen capture reset completes (success or failure)
-    func screenCaptureResetCompleted(success: Bool) {
-        MixpanelManager.shared.screenCaptureResetCompleted(success: success)
-        PostHogManager.shared.screenCaptureResetCompleted(success: success)
-    }
-
-    /// Track when notification repair is triggered (auto-repair or error-triggered)
-    func notificationRepairTriggered(reason: String, previousStatus: String, currentStatus: String) {
-        MixpanelManager.shared.notificationRepairTriggered(reason: reason, previousStatus: previousStatus, currentStatus: currentStatus)
-        PostHogManager.shared.notificationRepairTriggered(reason: reason, previousStatus: previousStatus, currentStatus: currentStatus)
-    }
-
-    /// Track notification settings status (auth, alertStyle, sound, badge)
-    func notificationSettingsChecked(
-        authStatus: String,
-        alertStyle: String,
-        soundEnabled: Bool,
-        badgeEnabled: Bool,
-        bannersDisabled: Bool
-    ) {
-        MixpanelManager.shared.notificationSettingsChecked(
-            authStatus: authStatus,
-            alertStyle: alertStyle,
-            soundEnabled: soundEnabled,
-            badgeEnabled: badgeEnabled,
-            bannersDisabled: bannersDisabled
-        )
-        PostHogManager.shared.notificationSettingsChecked(
-            authStatus: authStatus,
-            alertStyle: alertStyle,
-            soundEnabled: soundEnabled,
-            badgeEnabled: badgeEnabled,
-            bannersDisabled: bannersDisabled
-        )
-    }
-
-    // MARK: - App Lifecycle Events
-
-    func appLaunched() {
-        MixpanelManager.shared.appLaunched()
-        PostHogManager.shared.appLaunched()
-        HeapManager.shared.track("App Launched")
-    }
-
-    func trackStartupTiming(dbInitMs: Double, timeToInteractiveMs: Double, hadUncleanShutdown: Bool, databaseInitFailed: Bool) {
-        guard !Self.isDevBuild else { return }
-        let properties: [String: Any] = [
-            "db_init_ms": round(dbInitMs),
-            "time_to_interactive_ms": round(timeToInteractiveMs),
-            "had_unclean_shutdown": hadUncleanShutdown,
-            "database_init_failed": databaseInitFailed
-        ]
-        PostHogManager.shared.track("App Startup Timing", properties: properties)
-        MixpanelManager.shared.track("App Startup Timing", properties: properties.compactMapValues { $0 as? MixpanelType })
-    }
-
-    /// Track first launch with comprehensive system diagnostics
-    /// This only fires once per installation
-    func trackFirstLaunchIfNeeded() {
-        // Skip in dev builds
-        guard !Self.isDevBuild else { return }
-
-        let defaults = UserDefaults.standard
-        let hasLaunchedKey = "hasLaunchedBefore"
-
-        // Check if this is the first launch
-        guard !defaults.bool(forKey: hasLaunchedKey) else {
-            return
-        }
-
-        // Mark as launched so this only fires once
-        defaults.set(true, forKey: hasLaunchedKey)
-
-        // Collect system diagnostics
-        let diagnostics = collectSystemDiagnostics()
-
-        // Track in all analytics systems
-        MixpanelManager.shared.firstLaunch(diagnostics: diagnostics)
-        PostHogManager.shared.firstLaunch(diagnostics: diagnostics)
-        HeapManager.shared.track("First Launch")
-
-        log("Analytics: First launch diagnostics tracked")
-    }
-
-    /// Collect comprehensive system diagnostics for first launch event
-    private func collectSystemDiagnostics() -> [String: Any] {
-        var diagnostics: [String: Any] = [:]
-
-        // App version
-        diagnostics["app_version"] = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
-        diagnostics["build_number"] = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
-
-        // macOS version (detailed)
-        let osVersion = ProcessInfo.processInfo.operatingSystemVersion
-        diagnostics["os_version"] = "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
-        diagnostics["os_major_version"] = osVersion.majorVersion
-        diagnostics["os_minor_version"] = osVersion.minorVersion
-        diagnostics["os_patch_version"] = osVersion.patchVersion
-        diagnostics["os_version_string"] = ProcessInfo.processInfo.operatingSystemVersionString
-
-        // Architecture (Apple Silicon vs Intel)
-        #if arch(arm64)
-        diagnostics["architecture"] = "arm64"
-        diagnostics["is_apple_silicon"] = true
-        #elseif arch(x86_64)
-        diagnostics["architecture"] = "x86_64"
-        diagnostics["is_apple_silicon"] = false
-        #else
-        diagnostics["architecture"] = "unknown"
-        diagnostics["is_apple_silicon"] = false
-        #endif
-
-        // App bundle location - helps diagnose installation issues
-        if let bundlePath = Bundle.main.bundlePath as String? {
-            diagnostics["bundle_path"] = bundlePath
-
-            // Categorize the installation location
-            if bundlePath.hasPrefix("/Volumes/") {
-                diagnostics["install_location"] = "dmg_mounted"
-            } else if bundlePath.contains("/Downloads/") {
-                diagnostics["install_location"] = "downloads_folder"
-            } else if bundlePath.hasPrefix("/Applications/") {
-                diagnostics["install_location"] = "applications_system"
-            } else if bundlePath.contains("/Applications/") {
-                diagnostics["install_location"] = "applications_user"
-            } else if bundlePath.contains("DerivedData") || bundlePath.contains("Xcode") {
-                diagnostics["install_location"] = "xcode_build"
-            } else {
-                diagnostics["install_location"] = "other"
-            }
-        }
-
-        // Device info
-        diagnostics["processor_count"] = ProcessInfo.processInfo.processorCount
-        diagnostics["physical_memory_gb"] = Int(ProcessInfo.processInfo.physicalMemory / 1_073_741_824)
-
-        // Locale info
-        diagnostics["locale"] = Locale.current.identifier
-        diagnostics["timezone"] = TimeZone.current.identifier
-
-        return diagnostics
-    }
-
-    func appBecameActive() {
-        MixpanelManager.shared.appBecameActive()
-        PostHogManager.shared.appBecameActive()
-    }
-
-    func appResignedActive() {
-        MixpanelManager.shared.appResignedActive()
-        PostHogManager.shared.appResignedActive()
-    }
-
-    // MARK: - Conversation Events
-    // Note: The event is named "Memory Created" in analytics for historical reasons,
-    // but it actually tracks when a conversation/recording is created, not a "memory".
-
-    func conversationCreated(conversationId: String, source: String, durationSeconds: Int? = nil) {
-        MixpanelManager.shared.conversationCreated(conversationId: conversationId, source: source, durationSeconds: durationSeconds)
-        PostHogManager.shared.conversationCreated(conversationId: conversationId, source: source, durationSeconds: durationSeconds)
-        // Flush immediately to ensure this important event is sent
-        MixpanelManager.shared.flush()
-    }
-
-    func memoryDeleted(conversationId: String) {
-        MixpanelManager.shared.memoryDeleted(conversationId: conversationId)
-        PostHogManager.shared.memoryDeleted(conversationId: conversationId)
-    }
-
-    func memoryShareButtonClicked(conversationId: String) {
-        MixpanelManager.shared.memoryShareButtonClicked(conversationId: conversationId)
-        PostHogManager.shared.memoryShareButtonClicked(conversationId: conversationId)
-    }
-
-    func memoryListItemClicked(conversationId: String) {
-        MixpanelManager.shared.memoryListItemClicked(conversationId: conversationId)
-        PostHogManager.shared.memoryListItemClicked(conversationId: conversationId)
-    }
-
-    // MARK: - Chat Events
-
-    func chatMessageSent(messageLength: Int, hasContext: Bool = false, source: String) {
-        MixpanelManager.shared.chatMessageSent(messageLength: messageLength, hasContext: hasContext, source: source)
-        PostHogManager.shared.chatMessageSent(messageLength: messageLength, hasContext: hasContext, source: source)
-    }
-
-    // MARK: - Search Events
-
-    func searchQueryEntered(query: String) {
-        MixpanelManager.shared.searchQueryEntered(query: query)
-        PostHogManager.shared.searchQueryEntered(query: query)
-    }
-
-    func searchBarFocused() {
-        MixpanelManager.shared.searchBarFocused()
-        PostHogManager.shared.searchBarFocused()
-    }
-
-    // MARK: - Settings Events
-
-    func settingsPageOpened() {
-        MixpanelManager.shared.settingsPageOpened()
-        PostHogManager.shared.settingsPageOpened()
-    }
-
-    // MARK: - Page/Screen Views (PostHog specific, but tracked in both)
-
-    func pageViewed(_ pageName: String) {
-        PostHogManager.shared.pageViewed(pageName)
-        // Mixpanel doesn't have a dedicated screen view, but we track as an event
-        MixpanelManager.shared.track("Page Viewed", properties: ["page": pageName])
-    }
-
-    // MARK: - Account Events
-
-    func deleteAccountClicked() {
-        MixpanelManager.shared.deleteAccountClicked()
-        PostHogManager.shared.deleteAccountClicked()
-    }
-
-    func deleteAccountConfirmed() {
-        MixpanelManager.shared.deleteAccountConfirmed()
-        PostHogManager.shared.deleteAccountConfirmed()
-        HeapManager.shared.track("Delete Account Confirmed")
-    }
-
-    func deleteAccountCancelled() {
-        MixpanelManager.shared.deleteAccountCancelled()
-        PostHogManager.shared.deleteAccountCancelled()
-    }
-
-    // MARK: - Navigation Events
-
-    func tabChanged(tabName: String) {
-        MixpanelManager.shared.tabChanged(tabName: tabName)
-        PostHogManager.shared.tabChanged(tabName: tabName)
-    }
-
-    func conversationDetailOpened(conversationId: String) {
-        MixpanelManager.shared.conversationDetailOpened(conversationId: conversationId)
-        PostHogManager.shared.conversationDetailOpened(conversationId: conversationId)
-    }
-
-    // MARK: - Chat Events (Additional)
-
-    func chatAppSelected(appId: String?, appName: String?) {
-        MixpanelManager.shared.chatAppSelected(appId: appId, appName: appName)
-        PostHogManager.shared.chatAppSelected(appId: appId, appName: appName)
-    }
-
-    func chatCleared() {
-        MixpanelManager.shared.chatCleared()
-        PostHogManager.shared.chatCleared()
-    }
-
-    func chatSessionCreated() {
-        MixpanelManager.shared.track("Chat Session Created", properties: [:])
-        PostHogManager.shared.track("chat_session_created", properties: [:])
-    }
-
-    func chatSessionDeleted() {
-        MixpanelManager.shared.track("Chat Session Deleted", properties: [:])
-        PostHogManager.shared.track("chat_session_deleted", properties: [:])
-    }
-
-    func messageRated(rating: Int) {
-        let ratingString = rating == 1 ? "thumbs_up" : "thumbs_down"
-        MixpanelManager.shared.track("Message Rated", properties: ["rating": ratingString])
-        PostHogManager.shared.track("message_rated", properties: ["rating": ratingString])
-    }
-
-    func initialMessageGenerated(hasApp: Bool) {
-        MixpanelManager.shared.track("Initial Message Generated", properties: ["has_app": hasApp])
-        PostHogManager.shared.track("initial_message_generated", properties: ["has_app": hasApp])
-    }
-
-    func sessionTitleGenerated() {
-        MixpanelManager.shared.track("Session Title Generated", properties: [:])
-        PostHogManager.shared.track("session_title_generated", properties: [:])
-    }
-
-    func chatStarredFilterToggled(enabled: Bool) {
-        MixpanelManager.shared.track("Chat Starred Filter Toggled", properties: ["enabled": enabled])
-        PostHogManager.shared.track("chat_starred_filter_toggled", properties: ["enabled": enabled])
-    }
-
-    func sessionRenamed() {
-        MixpanelManager.shared.track("Session Renamed", properties: [:])
-        PostHogManager.shared.track("session_renamed", properties: [:])
-    }
-
-    // MARK: - Claude Agent Events
-
-    /// Track when a Claude agent query completes (one full send → response cycle)
-    func chatAgentQueryCompleted(
-        durationMs: Int,
-        toolCallCount: Int,
-        toolNames: [String],
-        costUsd: Double,
-        messageLength: Int
-    ) {
-        let props: [String: Any] = [
-            "duration_ms": durationMs,
-            "tool_call_count": toolCallCount,
-            "tool_names": toolNames.joined(separator: ","),
-            "cost_usd": costUsd,
-            "response_length": messageLength
-        ]
-        MixpanelManager.shared.track("Chat Agent Query Completed", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("chat_agent_query_completed", properties: props)
-    }
-
-    /// Track individual tool calls made by the Claude agent
-    func chatToolCallCompleted(toolName: String, durationMs: Int) {
-        let cleanName: String
-        if toolName.hasPrefix("mcp__") {
-            cleanName = String(toolName.split(separator: "__").last ?? Substring(toolName))
-        } else {
-            cleanName = toolName
-        }
-        let props: [String: Any] = [
-            "tool_name": cleanName,
-            "duration_ms": durationMs
-        ]
-        MixpanelManager.shared.track("Chat Tool Call Completed", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("chat_tool_call_completed", properties: props)
-    }
-
-    /// Track when the Claude agent bridge fails to start or errors
-    func chatAgentError(error: String) {
-        let props: [String: Any] = ["error": error]
-        MixpanelManager.shared.track("Chat Agent Error", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("chat_agent_error", properties: props)
-    }
-
-    // MARK: - Conversation Events (Additional)
-
-    func conversationReprocessed(conversationId: String, appId: String) {
-        MixpanelManager.shared.conversationReprocessed(conversationId: conversationId, appId: appId)
-        PostHogManager.shared.conversationReprocessed(conversationId: conversationId, appId: appId)
-    }
-
-    // MARK: - Settings Events (Additional)
-
-    func settingToggled(setting: String, enabled: Bool) {
-        MixpanelManager.shared.settingToggled(setting: setting, enabled: enabled)
-        PostHogManager.shared.settingToggled(setting: setting, enabled: enabled)
-    }
-
-    func languageChanged(language: String) {
-        MixpanelManager.shared.languageChanged(language: language)
-        PostHogManager.shared.languageChanged(language: language)
-    }
-
-    // MARK: - Launch At Login Events
-
-    /// Track launch at login status once per app launch (not continuously)
-    func launchAtLoginStatusChecked(enabled: Bool) {
-        MixpanelManager.shared.launchAtLoginStatusChecked(enabled: enabled)
-        PostHogManager.shared.launchAtLoginStatusChecked(enabled: enabled)
-    }
-
-    /// Track when launch at login state changes
-    /// - Parameters:
-    ///   - enabled: New state
-    ///   - source: What triggered the change (user, migration, onboarding)
-    func launchAtLoginChanged(enabled: Bool, source: String) {
-        MixpanelManager.shared.launchAtLoginChanged(enabled: enabled, source: source)
-        PostHogManager.shared.launchAtLoginChanged(enabled: enabled, source: source)
-    }
-
-    // MARK: - Feedback Events
-
-    func feedbackOpened() {
-        MixpanelManager.shared.feedbackOpened()
-        PostHogManager.shared.feedbackOpened()
-    }
-
-    func feedbackSubmitted(feedbackLength: Int) {
-        MixpanelManager.shared.feedbackSubmitted(feedbackLength: feedbackLength)
-        PostHogManager.shared.feedbackSubmitted(feedbackLength: feedbackLength)
-    }
-
-    // MARK: - Rewind Events (Desktop-specific)
-
-    func rewindSearchPerformed(queryLength: Int) {
-        MixpanelManager.shared.rewindSearchPerformed(queryLength: queryLength)
-        PostHogManager.shared.rewindSearchPerformed(queryLength: queryLength)
-    }
-
-    func rewindScreenshotViewed(timestamp: Date) {
-        MixpanelManager.shared.rewindScreenshotViewed(timestamp: timestamp)
-        PostHogManager.shared.rewindScreenshotViewed(timestamp: timestamp)
-    }
-
-    func rewindTimelineNavigated(direction: String) {
-        MixpanelManager.shared.rewindTimelineNavigated(direction: direction)
-        PostHogManager.shared.rewindTimelineNavigated(direction: direction)
-    }
-
-    // MARK: - Proactive Assistant Events (Desktop-specific)
-
-    func focusAlertShown(app: String) {
-        MixpanelManager.shared.focusAlertShown(app: app)
-        PostHogManager.shared.focusAlertShown(app: app)
-    }
-
-    func focusAlertDismissed(app: String, action: String) {
-        MixpanelManager.shared.focusAlertDismissed(app: app, action: action)
-        PostHogManager.shared.focusAlertDismissed(app: app, action: action)
-    }
-
-    func taskExtracted(taskCount: Int) {
-        MixpanelManager.shared.taskExtracted(taskCount: taskCount)
-        PostHogManager.shared.taskExtracted(taskCount: taskCount)
-    }
-
-    func taskPromoted(taskCount: Int) {
-        MixpanelManager.shared.taskPromoted(taskCount: taskCount)
-        PostHogManager.shared.taskPromoted(taskCount: taskCount)
-    }
-
-    func taskCompleted(source: String?) {
-        MixpanelManager.shared.taskCompleted(source: source)
-        PostHogManager.shared.taskCompleted(source: source)
-    }
-
-    func taskDeleted(source: String?) {
-        MixpanelManager.shared.taskDeleted(source: source)
-        PostHogManager.shared.taskDeleted(source: source)
-    }
-
-    func taskAdded() {
-        MixpanelManager.shared.taskAdded()
-        PostHogManager.shared.taskAdded()
-    }
-
-    func memoryExtracted(memoryCount: Int) {
-        MixpanelManager.shared.memoryExtracted(memoryCount: memoryCount)
-        PostHogManager.shared.memoryExtracted(memoryCount: memoryCount)
-    }
-
-    func adviceGenerated(category: String?) {
-        MixpanelManager.shared.adviceGenerated(category: category)
-        PostHogManager.shared.adviceGenerated(category: category)
-    }
-
-    // MARK: - Apps Events
-
-    func appEnabled(appId: String, appName: String) {
-        MixpanelManager.shared.appEnabled(appId: appId, appName: appName)
-        PostHogManager.shared.appEnabled(appId: appId, appName: appName)
-    }
-
-    func appDisabled(appId: String, appName: String) {
-        MixpanelManager.shared.appDisabled(appId: appId, appName: appName)
-        PostHogManager.shared.appDisabled(appId: appId, appName: appName)
-    }
-
-    func appDetailViewed(appId: String, appName: String) {
-        MixpanelManager.shared.appDetailViewed(appId: appId, appName: appName)
-        PostHogManager.shared.appDetailViewed(appId: appId, appName: appName)
-    }
-
-    // MARK: - Update Events
-
-    func updateCheckStarted() {
-        MixpanelManager.shared.updateCheckStarted()
-        PostHogManager.shared.updateCheckStarted()
-    }
-
-    func updateAvailable(version: String) {
-        MixpanelManager.shared.updateAvailable(version: version)
-        PostHogManager.shared.updateAvailable(version: version)
-    }
-
-    func updateInstalled(version: String) {
-        MixpanelManager.shared.updateInstalled(version: version)
-        PostHogManager.shared.updateInstalled(version: version)
-    }
-
-    func updateNotFound() {
-        MixpanelManager.shared.updateNotFound()
-        PostHogManager.shared.updateNotFound()
-    }
-
-    func updateCheckFailed(error: String, errorDomain: String, errorCode: Int, underlyingError: String? = nil, underlyingDomain: String? = nil, underlyingCode: Int? = nil) {
-        MixpanelManager.shared.updateCheckFailed(error: error, errorDomain: errorDomain, errorCode: errorCode, underlyingError: underlyingError, underlyingDomain: underlyingDomain, underlyingCode: underlyingCode)
-        PostHogManager.shared.updateCheckFailed(error: error, errorDomain: errorDomain, errorCode: errorCode, underlyingError: underlyingError, underlyingDomain: underlyingDomain, underlyingCode: underlyingCode)
-    }
-
-    // MARK: - Notification Events
-
-    func notificationSent(notificationId: String, title: String, assistantId: String) {
-        MixpanelManager.shared.notificationSent(notificationId: notificationId, title: title, assistantId: assistantId)
-        PostHogManager.shared.notificationSent(notificationId: notificationId, title: title, assistantId: assistantId)
-    }
-
-    func notificationClicked(notificationId: String, title: String, assistantId: String) {
-        MixpanelManager.shared.notificationClicked(notificationId: notificationId, title: title, assistantId: assistantId)
-        PostHogManager.shared.notificationClicked(notificationId: notificationId, title: title, assistantId: assistantId)
-    }
-
-    func notificationDismissed(notificationId: String, title: String, assistantId: String) {
-        MixpanelManager.shared.notificationDismissed(notificationId: notificationId, title: title, assistantId: assistantId)
-        PostHogManager.shared.notificationDismissed(notificationId: notificationId, title: title, assistantId: assistantId)
-    }
-
-    func notificationWillPresent(notificationId: String, title: String) {
-        MixpanelManager.shared.notificationWillPresent(notificationId: notificationId, title: title)
-        PostHogManager.shared.notificationWillPresent(notificationId: notificationId, title: title)
-    }
-
-    func notificationDelegateReady() {
-        MixpanelManager.shared.notificationDelegateReady()
-        PostHogManager.shared.notificationDelegateReady()
-    }
-
-    // MARK: - Menu Bar Events
-
-    /// Track when user opens the menu bar dropdown
-    func menuBarOpened() {
-        MixpanelManager.shared.menuBarOpened()
-        PostHogManager.shared.menuBarOpened()
-    }
-
-    /// Track when user clicks an action in the menu bar
-    func menuBarActionClicked(action: String) {
-        MixpanelManager.shared.menuBarActionClicked(action: action)
-        PostHogManager.shared.menuBarActionClicked(action: action)
-    }
-
-    // MARK: - Tier Events
-
-    func tierChanged(tier: Int, reason: String) {
-        MixpanelManager.shared.tierChanged(tier: tier, reason: reason)
-        PostHogManager.shared.tierChanged(tier: tier, reason: reason)
-    }
-
-    func chatBridgeModeChanged(from oldMode: String, to newMode: String) {
-        MixpanelManager.shared.chatBridgeModeChanged(from: oldMode, to: newMode)
-        PostHogManager.shared.chatBridgeModeChanged(from: oldMode, to: newMode)
-    }
-
-    // MARK: - Settings State
-
-    /// Track the current state of key settings (screenshots, memory extraction, notifications)
-    /// Called when monitoring starts and daily while monitoring is active
-    func trackSettingsState(screenshotsEnabled: Bool, memoryExtractionEnabled: Bool, memoryNotificationsEnabled: Bool) {
-        MixpanelManager.shared.settingsStateTracked(screenshotsEnabled: screenshotsEnabled, memoryExtractionEnabled: memoryExtractionEnabled, memoryNotificationsEnabled: memoryNotificationsEnabled)
-        PostHogManager.shared.settingsStateTracked(screenshotsEnabled: screenshotsEnabled, memoryExtractionEnabled: memoryExtractionEnabled, memoryNotificationsEnabled: memoryNotificationsEnabled)
-    }
-
-    // MARK: - All Settings State (Comprehensive daily report)
-
-    private let lastAllSettingsReportKey = "lastAllSettingsReportDate"
-
-    /// Report comprehensive settings state on app launch, throttled to once per calendar day.
-    /// Sends all ~45 user settings as a single analytics event for unified visibility.
-    func reportAllSettingsIfNeeded() {
-        guard !Self.isDevBuild else { return }
-
-        let defaults = UserDefaults.standard
-        let lastReport = defaults.object(forKey: lastAllSettingsReportKey) as? Date ?? .distantPast
-        guard !Calendar.current.isDateInToday(lastReport) else {
-            log("Analytics: All settings already reported today, skipping")
-            return
-        }
-
-        defaults.set(Date(), forKey: lastAllSettingsReportKey)
-
-        let properties = collectAllSettings()
-
-        MixpanelManager.shared.allSettingsStateTracked(properties: properties)
-        PostHogManager.shared.allSettingsStateTracked(properties: properties)
-
-        log("Analytics: All settings state reported (\(properties.count) properties)")
-    }
-
-    /// Collect all user settings into a flat dictionary for analytics reporting.
-    /// For string settings (custom prompts), reports has_custom + length instead of full text.
-    /// For array settings (excluded apps, keywords), reports count instead of contents.
-    private func collectAllSettings() -> [String: Any] {
-        var props: [String: Any] = [:]
-
-        // -- General / Shared Assistant Settings --
-        let shared = AssistantSettings.shared
-        props["screen_analysis_enabled"] = shared.screenAnalysisEnabled
-        props["transcription_enabled"] = shared.transcriptionEnabled
-        props["transcription_language"] = shared.transcriptionLanguage
-        props["transcription_auto_detect"] = shared.transcriptionAutoDetect
-        props["transcription_vocabulary_count"] = shared.transcriptionVocabulary.count
-        props["analysis_delay"] = shared.analysisDelay
-        props["cooldown_interval"] = shared.cooldownInterval
-        props["glow_overlay_enabled"] = shared.glowOverlayEnabled
-
-        // -- Focus Assistant --
-        let focus = FocusAssistantSettings.shared
-        props["focus_enabled"] = focus.isEnabled
-        props["focus_notifications_enabled"] = focus.notificationsEnabled
-        props["focus_cooldown_interval"] = focus.cooldownInterval
-        props["focus_has_custom_prompt"] = focus.analysisPrompt != FocusAssistantSettings.defaultAnalysisPrompt
-        props["focus_prompt_length"] = focus.analysisPrompt.count
-        props["focus_excluded_apps_count"] = focus.excludedApps.count
-
-        // -- Task Extraction Assistant --
-        let task = TaskAssistantSettings.shared
-        props["task_enabled"] = task.isEnabled
-        props["task_notifications_enabled"] = task.notificationsEnabled
-        props["task_extraction_interval"] = task.extractionInterval
-        props["task_min_confidence"] = task.minConfidence
-        props["task_has_custom_prompt"] = task.analysisPrompt != TaskAssistantSettings.defaultAnalysisPrompt
-        props["task_prompt_length"] = task.analysisPrompt.count
-        props["task_allowed_apps_count"] = task.allowedApps.count
-        props["task_browser_keywords_count"] = task.browserKeywords.count
-
-        // -- Memory Assistant --
-        let memory = MemoryAssistantSettings.shared
-        props["memory_enabled"] = memory.isEnabled
-        props["memory_extraction_interval"] = memory.extractionInterval
-        props["memory_min_confidence"] = memory.minConfidence
-        props["memory_notifications_enabled"] = memory.notificationsEnabled
-        props["memory_has_custom_prompt"] = memory.analysisPrompt != MemoryAssistantSettings.defaultAnalysisPrompt
-        props["memory_prompt_length"] = memory.analysisPrompt.count
-        props["memory_excluded_apps_count"] = memory.excludedApps.count
-
-        // -- Advice Assistant --
-        let advice = AdviceAssistantSettings.shared
-        props["advice_enabled"] = advice.isEnabled
-        props["advice_notifications_enabled"] = advice.notificationsEnabled
-        props["advice_extraction_interval"] = advice.extractionInterval
-        props["advice_min_confidence"] = advice.minConfidence
-        props["advice_has_custom_prompt"] = advice.analysisPrompt != AdviceAssistantSettings.defaultAnalysisPrompt
-        props["advice_prompt_length"] = advice.analysisPrompt.count
-        props["advice_excluded_apps_count"] = advice.excludedApps.count
-
-        // -- Task Agent --
-        let agent = TaskAgentSettings.shared
-        props["task_agent_enabled"] = agent.isEnabled
-        props["task_agent_auto_launch"] = agent.autoLaunch
-        props["task_agent_skip_permissions"] = agent.skipPermissions
-        props["task_agent_has_custom_prompt"] = !agent.customPromptPrefix.isEmpty
-
-        // -- Rewind (read from UserDefaults since these are @AppStorage in views) --
-        let ud = UserDefaults.standard
-        props["rewind_retention_days"] = ud.object(forKey: "rewindRetentionDays") as? Double ?? 7.0
-        props["rewind_capture_interval"] = ud.object(forKey: "rewindCaptureInterval") as? Double ?? 1.0
-
-        // -- AI Chat Mode --
-        props["chat_bridge_mode"] = ud.string(forKey: "chatBridgeMode") ?? "agentSDK"
-
-        // -- UI Preferences --
-        props["multi_chat_enabled"] = ud.bool(forKey: "multiChatEnabled")
-        props["conversations_compact_view"] = ud.object(forKey: "conversationsCompactView") as? Bool ?? true
-        props["tier_level"] = ud.integer(forKey: "currentTierLevel")
-
-        // -- Device --
-        let deviceId = ud.string(forKey: "pairedDeviceId") ?? ""
-        props["has_paired_device"] = !deviceId.isEmpty
-        props["paired_device_type"] = ud.string(forKey: "pairedDeviceType") ?? ""
-
-        // -- Launch at Login --
-        props["launch_at_login_enabled"] = LaunchAtLoginManager.shared.isEnabled
-
-        // -- Floating Bar (AskOmi) --
-        props["floating_bar_enabled"] = FloatingControlBarManager.shared.isEnabled
-        props["floating_bar_visible"] = FloatingControlBarManager.shared.isVisible
-
-        // -- Dev Mode --
-        props["dev_mode_enabled"] = ud.bool(forKey: "devModeEnabled")
-
-        return props
-    }
-
-    // MARK: - Floating Bar Events
-
-    /// Track when the floating bar is toggled visible/hidden
-    func floatingBarToggled(visible: Bool, source: String) {
-        let props: [String: Any] = [
-            "visible": visible,
-            "source": source
-        ]
-        MixpanelManager.shared.track("Floating Bar Toggled", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("floating_bar_toggled", properties: props)
-    }
-
-    /// Track when Ask OMI is opened (AI input panel shown)
-    func floatingBarAskOmiOpened(source: String) {
-        let props: [String: Any] = ["source": source]
-        MixpanelManager.shared.track("Floating Bar Ask OMI Opened", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("floating_bar_ask_omi_opened", properties: props)
-    }
-
-    /// Track when the AI conversation is closed
-    func floatingBarAskOmiClosed() {
-        MixpanelManager.shared.track("Floating Bar Ask OMI Closed")
-        PostHogManager.shared.track("floating_bar_ask_omi_closed")
-    }
-
-    /// Track when an AI query is sent from the floating bar
-    func floatingBarQuerySent(messageLength: Int, hasScreenshot: Bool) {
-        let props: [String: Any] = [
-            "message_length": messageLength,
-            "has_screenshot": hasScreenshot
-        ]
-        MixpanelManager.shared.track("Floating Bar Query Sent", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("floating_bar_query_sent", properties: props)
-    }
-
-    /// Track when push-to-talk starts listening
-    func floatingBarPTTStarted(mode: String) {
-        let props: [String: Any] = ["mode": mode]
-        MixpanelManager.shared.track("Floating Bar PTT Started", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("floating_bar_ptt_started", properties: props)
-    }
-
-    /// Track when push-to-talk ends and sends (or discards) transcript
-    func floatingBarPTTEnded(mode: String, hadTranscript: Bool, transcriptLength: Int) {
-        let props: [String: Any] = [
-            "mode": mode,
-            "had_transcript": hadTranscript,
-            "transcript_length": transcriptLength
-        ]
-        MixpanelManager.shared.track("Floating Bar PTT Ended", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("floating_bar_ptt_ended", properties: props)
-    }
-
-    // MARK: - Knowledge Graph Events
-
-    /// Track when knowledge graph generation starts during onboarding
-    func knowledgeGraphBuildStarted(filesIndexed: Int, hadExistingGraph: Bool) {
-        let props: [String: Any] = [
-            "files_indexed": filesIndexed,
-            "had_existing_graph": hadExistingGraph
-        ]
-        MixpanelManager.shared.track("Knowledge Graph Build Started", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("knowledge_graph_build_started", properties: props)
-    }
-
-    /// Track when knowledge graph generation completes (successfully loaded with data)
-    func knowledgeGraphBuildCompleted(nodeCount: Int, edgeCount: Int, pollAttempts: Int, hadExistingGraph: Bool) {
-        let props: [String: Any] = [
-            "node_count": nodeCount,
-            "edge_count": edgeCount,
-            "poll_attempts": pollAttempts,
-            "had_existing_graph": hadExistingGraph
-        ]
-        MixpanelManager.shared.track("Knowledge Graph Build Completed", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("knowledge_graph_build_completed", properties: props)
-    }
-
-    /// Track when knowledge graph generation fails or times out empty
-    func knowledgeGraphBuildFailed(reason: String, pollAttempts: Int, filesIndexed: Int) {
-        let props: [String: Any] = [
-            "reason": reason,
-            "poll_attempts": pollAttempts,
-            "files_indexed": filesIndexed
-        ]
-        MixpanelManager.shared.track("Knowledge Graph Build Failed", properties: props.compactMapValues { $0 as? MixpanelType })
-        PostHogManager.shared.track("knowledge_graph_build_failed", properties: props)
-    }
-
-    // MARK: - Display Info
-
-    /// Track display characteristics (notch, screen size, etc.)
-    /// Called at app launch to help diagnose menu bar visibility issues
-    func trackDisplayInfo() {
-        guard let screen = NSScreen.main else { return }
-
-        let frame = screen.frame
-        let visibleFrame = screen.visibleFrame
-        let safeAreaInsets = screen.safeAreaInsets
-
-        // Detect notch: MacBooks with notch have safeAreaInsets.top > 0
-        let hasNotch = safeAreaInsets.top > 0
-
-        // Calculate menu bar height (difference between frame and visible frame at top)
-        let menuBarHeight = frame.height - visibleFrame.height - visibleFrame.origin.y
-
-        let displayInfo: [String: Any] = [
-            "screen_width": Int(frame.width),
-            "screen_height": Int(frame.height),
-            "has_notch": hasNotch,
-            "safe_area_top": Int(safeAreaInsets.top),
-            "menu_bar_height": Int(menuBarHeight),
-            "scale_factor": screen.backingScaleFactor
-        ]
-
-        MixpanelManager.shared.displayInfoTracked(info: displayInfo)
-        PostHogManager.shared.displayInfoTracked(info: displayInfo)
-    }
+  static let shared = AnalyticsManager()
+
+  /// Returns true for non-production Omi bundles so test apps don't pollute production analytics.
+  nonisolated static var isDevBuild: Bool {
+    AppBuild.isNonProduction
+  }
+
+  private var lastTranscriptionStartedAt: Date?
+
+  private init() {}
+
+  // MARK: - Initialization
+
+  func initialize() {
+    // Skip analytics in development builds
+    guard !Self.isDevBuild else {
+      log("Analytics: Skipping initialization (development build)")
+      return
+    }
+    MixpanelManager.shared.initialize()
+    PostHogManager.shared.initialize()
+    HeapManager.shared.initialize()
+  }
+
+  // MARK: - User Identification
+
+  func identify() {
+    MixpanelManager.shared.identify()
+    PostHogManager.shared.identify()
+    HeapManager.shared.identify()
+  }
+
+  func reset() {
+    MixpanelManager.shared.reset()
+    PostHogManager.shared.reset()
+    HeapManager.shared.reset()
+  }
+
+  // MARK: - Opt In/Out
+
+  func optInTracking() {
+    MixpanelManager.shared.optInTracking()
+    PostHogManager.shared.optIn()
+  }
+
+  func optOutTracking() {
+    MixpanelManager.shared.optOutTracking()
+    PostHogManager.shared.optOut()
+  }
+
+  // MARK: - Onboarding Events
+
+  func onboardingStepCompleted(step: Int, stepName: String) {
+    MixpanelManager.shared.onboardingStepCompleted(step: step, stepName: stepName)
+    PostHogManager.shared.onboardingStepCompleted(step: step, stepName: stepName)
+    HeapManager.shared.track(
+      "Onboarding Step Completed", properties: ["step": "\(step)", "step_name": stepName])
+  }
+
+  func onboardingCompleted() {
+    MixpanelManager.shared.onboardingCompleted()
+    PostHogManager.shared.onboardingCompleted()
+    HeapManager.shared.track("Onboarding Completed")
+  }
+
+  func onboardingChatToolUsed(tool: String, properties: [String: Any] = [:]) {
+    var props = properties
+    props["tool"] = tool
+    let mixpanelProps = props.compactMapValues { $0 as? MixpanelType }
+    MixpanelManager.shared.track("Onboarding Chat Tool Used", properties: mixpanelProps)
+    PostHogManager.shared.track("Onboarding Chat Tool Used", properties: props)
+  }
+
+  func onboardingChatMessage(role: String, step: String) {
+    let props: [String: Any] = ["role": role, "step": step]
+    let mixpanelProps = props.compactMapValues { $0 as? MixpanelType }
+    MixpanelManager.shared.track("Onboarding Chat Message", properties: mixpanelProps)
+    PostHogManager.shared.track("Onboarding Chat Message", properties: props)
+  }
+
+  // MARK: - Authentication Events
+
+  func signInStarted(provider: String) {
+    MixpanelManager.shared.signInStarted(provider: provider)
+    PostHogManager.shared.signInStarted(provider: provider)
+    HeapManager.shared.track("Sign In Started", properties: ["provider": provider])
+  }
+
+  func signInCompleted(provider: String) {
+    MixpanelManager.shared.signInCompleted(provider: provider)
+    PostHogManager.shared.signInCompleted(provider: provider)
+    HeapManager.shared.track("Sign In Completed", properties: ["provider": provider])
+  }
+
+  func signInFailed(provider: String, error: String) {
+    MixpanelManager.shared.signInFailed(provider: provider, error: error)
+    PostHogManager.shared.signInFailed(provider: provider, error: error)
+    HeapManager.shared.track("Sign In Failed", properties: ["provider": provider, "error": error])
+  }
+
+  func signedOut() {
+    MixpanelManager.shared.signedOut()
+    PostHogManager.shared.signedOut()
+    HeapManager.shared.track("Signed Out")
+  }
+
+  // MARK: - Monitoring Events
+
+  func monitoringStarted() {
+    MixpanelManager.shared.monitoringStarted()
+    PostHogManager.shared.monitoringStarted()
+  }
+
+  func monitoringStopped() {
+    MixpanelManager.shared.monitoringStopped()
+    PostHogManager.shared.monitoringStopped()
+  }
+
+  func distractionDetected(app: String, windowTitle: String?) {
+    MixpanelManager.shared.distractionDetected(app: app, windowTitle: windowTitle)
+    PostHogManager.shared.distractionDetected(app: app, windowTitle: windowTitle)
+  }
+
+  func focusRestored(app: String) {
+    MixpanelManager.shared.focusRestored(app: app)
+    PostHogManager.shared.focusRestored(app: app)
+  }
+
+  // MARK: - Recording Events
+
+  func transcriptionStarted() {
+    // Debounce: skip if called within 5 seconds (catches rapid wake/reconnect double-fires)
+    if let last = lastTranscriptionStartedAt, Date().timeIntervalSince(last) < 5 {
+      return
+    }
+    lastTranscriptionStartedAt = Date()
+    MixpanelManager.shared.transcriptionStarted()
+    PostHogManager.shared.transcriptionStarted()
+  }
+
+  func transcriptionStopped(wordCount: Int) {
+    MixpanelManager.shared.transcriptionStopped(wordCount: wordCount)
+    PostHogManager.shared.transcriptionStopped(wordCount: wordCount)
+  }
+
+  func recordingError(error: String) {
+    MixpanelManager.shared.recordingError(error: error)
+    PostHogManager.shared.recordingError(error: error)
+  }
+
+  // MARK: - Permission Events
+
+  func permissionRequested(permission: String, extraProperties: [String: Any] = [:]) {
+    let mixpanelProps = extraProperties.compactMapValues { $0 as? MixpanelType }
+    MixpanelManager.shared.permissionRequested(
+      permission: permission, extraProperties: mixpanelProps)
+    PostHogManager.shared.permissionRequested(
+      permission: permission, extraProperties: extraProperties)
+  }
+
+  func permissionGranted(permission: String, extraProperties: [String: Any] = [:]) {
+    let mixpanelProps = extraProperties.compactMapValues { $0 as? MixpanelType }
+    MixpanelManager.shared.permissionGranted(permission: permission, extraProperties: mixpanelProps)
+    PostHogManager.shared.permissionGranted(
+      permission: permission, extraProperties: extraProperties)
+  }
+
+  func permissionDenied(permission: String, extraProperties: [String: Any] = [:]) {
+    let mixpanelProps = extraProperties.compactMapValues { $0 as? MixpanelType }
+    MixpanelManager.shared.permissionDenied(permission: permission, extraProperties: mixpanelProps)
+    PostHogManager.shared.permissionDenied(permission: permission, extraProperties: extraProperties)
+  }
+
+  func permissionSkipped(permission: String, extraProperties: [String: Any] = [:]) {
+    let mixpanelProps = extraProperties.compactMapValues { $0 as? MixpanelType }
+    MixpanelManager.shared.permissionSkipped(permission: permission, extraProperties: mixpanelProps)
+    PostHogManager.shared.permissionSkipped(
+      permission: permission, extraProperties: extraProperties)
+  }
+
+  /// Track Bluetooth state changes for debugging
+  func bluetoothStateChanged(
+    oldState: String, newState: String, oldStateRaw: Int, newStateRaw: Int, authorization: String,
+    authorizationRaw: Int
+  ) {
+    let properties: [String: MixpanelType] = [
+      "old_state": oldState,
+      "new_state": newState,
+      "old_state_raw": oldStateRaw,
+      "new_state_raw": newStateRaw,
+      "authorization": authorization,
+      "authorization_raw": authorizationRaw,
+    ]
+    MixpanelManager.shared.track("Bluetooth State Changed", properties: properties)
+    PostHogManager.shared.track("Bluetooth State Changed", properties: properties as [String: Any])
+  }
+
+  /// Track when ScreenCaptureKit broken state is detected (TCC granted but capture failing)
+  func screenCaptureBrokenDetected() {
+    MixpanelManager.shared.screenCaptureBrokenDetected()
+    PostHogManager.shared.screenCaptureBrokenDetected()
+  }
+
+  /// Track when user clicks reset button or notification to reset screen capture
+  func screenCaptureResetClicked(source: String) {
+    MixpanelManager.shared.screenCaptureResetClicked(source: source)
+    PostHogManager.shared.screenCaptureResetClicked(source: source)
+  }
+
+  /// Track when screen capture reset completes (success or failure)
+  func screenCaptureResetCompleted(success: Bool) {
+    MixpanelManager.shared.screenCaptureResetCompleted(success: success)
+    PostHogManager.shared.screenCaptureResetCompleted(success: success)
+  }
+
+  /// Track when notification repair is triggered (auto-repair or error-triggered)
+  func notificationRepairTriggered(reason: String, previousStatus: String, currentStatus: String) {
+    MixpanelManager.shared.notificationRepairTriggered(
+      reason: reason, previousStatus: previousStatus, currentStatus: currentStatus)
+    PostHogManager.shared.notificationRepairTriggered(
+      reason: reason, previousStatus: previousStatus, currentStatus: currentStatus)
+  }
+
+  /// Track notification settings status (auth, alertStyle, sound, badge)
+  func notificationSettingsChecked(
+    authStatus: String,
+    alertStyle: String,
+    soundEnabled: Bool,
+    badgeEnabled: Bool,
+    bannersDisabled: Bool
+  ) {
+    MixpanelManager.shared.notificationSettingsChecked(
+      authStatus: authStatus,
+      alertStyle: alertStyle,
+      soundEnabled: soundEnabled,
+      badgeEnabled: badgeEnabled,
+      bannersDisabled: bannersDisabled
+    )
+    PostHogManager.shared.notificationSettingsChecked(
+      authStatus: authStatus,
+      alertStyle: alertStyle,
+      soundEnabled: soundEnabled,
+      badgeEnabled: badgeEnabled,
+      bannersDisabled: bannersDisabled
+    )
+  }
+
+  // MARK: - App Lifecycle Events
+
+  func appLaunched() {
+    MixpanelManager.shared.appLaunched()
+    PostHogManager.shared.appLaunched()
+    HeapManager.shared.track("App Launched")
+  }
+
+  func trackStartupTiming(
+    dbInitMs: Double, timeToInteractiveMs: Double, hadUncleanShutdown: Bool,
+    databaseInitFailed: Bool
+  ) {
+    guard !Self.isDevBuild else { return }
+    let properties: [String: Any] = [
+      "db_init_ms": round(dbInitMs),
+      "time_to_interactive_ms": round(timeToInteractiveMs),
+      "had_unclean_shutdown": hadUncleanShutdown,
+      "database_init_failed": databaseInitFailed,
+    ]
+    PostHogManager.shared.track("App Startup Timing", properties: properties)
+    MixpanelManager.shared.track(
+      "App Startup Timing", properties: properties.compactMapValues { $0 as? MixpanelType })
+  }
+
+  /// Track first launch with comprehensive system diagnostics
+  /// This only fires once per installation
+  func trackFirstLaunchIfNeeded() {
+    // Skip in dev builds
+    guard !Self.isDevBuild else { return }
+
+    let defaults = UserDefaults.standard
+    let hasLaunchedKey = "hasLaunchedBefore"
+
+    // Check if this is the first launch
+    guard !defaults.bool(forKey: hasLaunchedKey) else {
+      return
+    }
+
+    // Mark as launched so this only fires once
+    defaults.set(true, forKey: hasLaunchedKey)
+
+    // Collect system diagnostics
+    let diagnostics = collectSystemDiagnostics()
+
+    // Track in all analytics systems
+    MixpanelManager.shared.firstLaunch(diagnostics: diagnostics)
+    PostHogManager.shared.firstLaunch(diagnostics: diagnostics)
+    HeapManager.shared.track("First Launch")
+
+    log("Analytics: First launch diagnostics tracked")
+  }
+
+  /// Collect comprehensive system diagnostics for first launch event
+  private func collectSystemDiagnostics() -> [String: Any] {
+    var diagnostics: [String: Any] = [:]
+
+    // App version
+    diagnostics["app_version"] =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "unknown"
+    diagnostics["build_number"] =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+
+    // macOS version (detailed)
+    let osVersion = ProcessInfo.processInfo.operatingSystemVersion
+    diagnostics["os_version"] =
+      "\(osVersion.majorVersion).\(osVersion.minorVersion).\(osVersion.patchVersion)"
+    diagnostics["os_major_version"] = osVersion.majorVersion
+    diagnostics["os_minor_version"] = osVersion.minorVersion
+    diagnostics["os_patch_version"] = osVersion.patchVersion
+    diagnostics["os_version_string"] = ProcessInfo.processInfo.operatingSystemVersionString
+
+    // Architecture (Apple Silicon vs Intel)
+    #if arch(arm64)
+      diagnostics["architecture"] = "arm64"
+      diagnostics["is_apple_silicon"] = true
+    #elseif arch(x86_64)
+      diagnostics["architecture"] = "x86_64"
+      diagnostics["is_apple_silicon"] = false
+    #else
+      diagnostics["architecture"] = "unknown"
+      diagnostics["is_apple_silicon"] = false
+    #endif
+
+    // App bundle location - helps diagnose installation issues
+    if let bundlePath = Bundle.main.bundlePath as String? {
+      diagnostics["bundle_path"] = bundlePath
+
+      // Categorize the installation location
+      if bundlePath.hasPrefix("/Volumes/") {
+        diagnostics["install_location"] = "dmg_mounted"
+      } else if bundlePath.contains("/Downloads/") {
+        diagnostics["install_location"] = "downloads_folder"
+      } else if bundlePath.hasPrefix("/Applications/") {
+        diagnostics["install_location"] = "applications_system"
+      } else if bundlePath.contains("/Applications/") {
+        diagnostics["install_location"] = "applications_user"
+      } else if bundlePath.contains("DerivedData") || bundlePath.contains("Xcode") {
+        diagnostics["install_location"] = "xcode_build"
+      } else {
+        diagnostics["install_location"] = "other"
+      }
+    }
+
+    // Device info
+    diagnostics["processor_count"] = ProcessInfo.processInfo.processorCount
+    diagnostics["physical_memory_gb"] = Int(ProcessInfo.processInfo.physicalMemory / 1_073_741_824)
+
+    // Locale info
+    diagnostics["locale"] = Locale.current.identifier
+    diagnostics["timezone"] = TimeZone.current.identifier
+
+    return diagnostics
+  }
+
+  func appBecameActive() {
+    MixpanelManager.shared.appBecameActive()
+    PostHogManager.shared.appBecameActive()
+  }
+
+  func appResignedActive() {
+    MixpanelManager.shared.appResignedActive()
+    PostHogManager.shared.appResignedActive()
+  }
+
+  // MARK: - Conversation Events
+  // Note: The event is named "Memory Created" in analytics for historical reasons,
+  // but it actually tracks when a conversation/recording is created, not a "memory".
+
+  func conversationCreated(conversationId: String, source: String, durationSeconds: Int? = nil) {
+    MixpanelManager.shared.conversationCreated(
+      conversationId: conversationId, source: source, durationSeconds: durationSeconds)
+    PostHogManager.shared.conversationCreated(
+      conversationId: conversationId, source: source, durationSeconds: durationSeconds)
+    // Flush immediately to ensure this important event is sent
+    MixpanelManager.shared.flush()
+  }
+
+  func memoryDeleted(conversationId: String) {
+    MixpanelManager.shared.memoryDeleted(conversationId: conversationId)
+    PostHogManager.shared.memoryDeleted(conversationId: conversationId)
+  }
+
+  func memoryShareButtonClicked(conversationId: String) {
+    MixpanelManager.shared.memoryShareButtonClicked(conversationId: conversationId)
+    PostHogManager.shared.memoryShareButtonClicked(conversationId: conversationId)
+  }
+
+  func memoryListItemClicked(conversationId: String) {
+    MixpanelManager.shared.memoryListItemClicked(conversationId: conversationId)
+    PostHogManager.shared.memoryListItemClicked(conversationId: conversationId)
+  }
+
+  // MARK: - Chat Events
+
+  func chatMessageSent(messageLength: Int, hasContext: Bool = false, source: String) {
+    MixpanelManager.shared.chatMessageSent(
+      messageLength: messageLength, hasContext: hasContext, source: source)
+    PostHogManager.shared.chatMessageSent(
+      messageLength: messageLength, hasContext: hasContext, source: source)
+  }
+
+  // MARK: - Search Events
+
+  func searchQueryEntered(query: String) {
+    MixpanelManager.shared.searchQueryEntered(query: query)
+    PostHogManager.shared.searchQueryEntered(query: query)
+  }
+
+  func searchBarFocused() {
+    MixpanelManager.shared.searchBarFocused()
+    PostHogManager.shared.searchBarFocused()
+  }
+
+  // MARK: - Settings Events
+
+  func settingsPageOpened() {
+    MixpanelManager.shared.settingsPageOpened()
+    PostHogManager.shared.settingsPageOpened()
+  }
+
+  // MARK: - Page/Screen Views (PostHog specific, but tracked in both)
+
+  func pageViewed(_ pageName: String) {
+    PostHogManager.shared.pageViewed(pageName)
+    // Mixpanel doesn't have a dedicated screen view, but we track as an event
+    MixpanelManager.shared.track("Page Viewed", properties: ["page": pageName])
+  }
+
+  // MARK: - Account Events
+
+  func deleteAccountClicked() {
+    MixpanelManager.shared.deleteAccountClicked()
+    PostHogManager.shared.deleteAccountClicked()
+  }
+
+  func deleteAccountConfirmed() {
+    MixpanelManager.shared.deleteAccountConfirmed()
+    PostHogManager.shared.deleteAccountConfirmed()
+    HeapManager.shared.track("Delete Account Confirmed")
+  }
+
+  func deleteAccountCancelled() {
+    MixpanelManager.shared.deleteAccountCancelled()
+    PostHogManager.shared.deleteAccountCancelled()
+  }
+
+  // MARK: - Navigation Events
+
+  func tabChanged(tabName: String) {
+    MixpanelManager.shared.tabChanged(tabName: tabName)
+    PostHogManager.shared.tabChanged(tabName: tabName)
+  }
+
+  func conversationDetailOpened(conversationId: String) {
+    MixpanelManager.shared.conversationDetailOpened(conversationId: conversationId)
+    PostHogManager.shared.conversationDetailOpened(conversationId: conversationId)
+  }
+
+  // MARK: - Chat Events (Additional)
+
+  func chatAppSelected(appId: String?, appName: String?) {
+    MixpanelManager.shared.chatAppSelected(appId: appId, appName: appName)
+    PostHogManager.shared.chatAppSelected(appId: appId, appName: appName)
+  }
+
+  func chatCleared() {
+    MixpanelManager.shared.chatCleared()
+    PostHogManager.shared.chatCleared()
+  }
+
+  func chatSessionCreated() {
+    MixpanelManager.shared.track("Chat Session Created", properties: [:])
+    PostHogManager.shared.track("chat_session_created", properties: [:])
+  }
+
+  func chatSessionDeleted() {
+    MixpanelManager.shared.track("Chat Session Deleted", properties: [:])
+    PostHogManager.shared.track("chat_session_deleted", properties: [:])
+  }
+
+  func messageRated(rating: Int) {
+    let ratingString = rating == 1 ? "thumbs_up" : "thumbs_down"
+    MixpanelManager.shared.track("Message Rated", properties: ["rating": ratingString])
+    PostHogManager.shared.track("message_rated", properties: ["rating": ratingString])
+  }
+
+  func initialMessageGenerated(hasApp: Bool) {
+    MixpanelManager.shared.track("Initial Message Generated", properties: ["has_app": hasApp])
+    PostHogManager.shared.track("initial_message_generated", properties: ["has_app": hasApp])
+  }
+
+  func sessionTitleGenerated() {
+    MixpanelManager.shared.track("Session Title Generated", properties: [:])
+    PostHogManager.shared.track("session_title_generated", properties: [:])
+  }
+
+  func chatStarredFilterToggled(enabled: Bool) {
+    MixpanelManager.shared.track("Chat Starred Filter Toggled", properties: ["enabled": enabled])
+    PostHogManager.shared.track("chat_starred_filter_toggled", properties: ["enabled": enabled])
+  }
+
+  func sessionRenamed() {
+    MixpanelManager.shared.track("Session Renamed", properties: [:])
+    PostHogManager.shared.track("session_renamed", properties: [:])
+  }
+
+  // MARK: - Claude Agent Events
+
+  /// Track when a Claude agent query completes (one full send → response cycle)
+  func chatAgentQueryCompleted(
+    durationMs: Int,
+    toolCallCount: Int,
+    toolNames: [String],
+    costUsd: Double,
+    messageLength: Int
+  ) {
+    let props: [String: Any] = [
+      "duration_ms": durationMs,
+      "tool_call_count": toolCallCount,
+      "tool_names": toolNames.joined(separator: ","),
+      "cost_usd": costUsd,
+      "response_length": messageLength,
+    ]
+    MixpanelManager.shared.track(
+      "Chat Agent Query Completed", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("chat_agent_query_completed", properties: props)
+  }
+
+  /// Track individual tool calls made by the Claude agent
+  func chatToolCallCompleted(toolName: String, durationMs: Int) {
+    let cleanName: String
+    if toolName.hasPrefix("mcp__") {
+      cleanName = String(toolName.split(separator: "__").last ?? Substring(toolName))
+    } else {
+      cleanName = toolName
+    }
+    let props: [String: Any] = [
+      "tool_name": cleanName,
+      "duration_ms": durationMs,
+    ]
+    MixpanelManager.shared.track(
+      "Chat Tool Call Completed", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("chat_tool_call_completed", properties: props)
+  }
+
+  /// Track when the Claude agent bridge fails to start or errors
+  func chatAgentError(error: String) {
+    let props: [String: Any] = ["error": error]
+    MixpanelManager.shared.track(
+      "Chat Agent Error", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("chat_agent_error", properties: props)
+  }
+
+  // MARK: - Conversation Events (Additional)
+
+  func conversationReprocessed(conversationId: String, appId: String) {
+    MixpanelManager.shared.conversationReprocessed(conversationId: conversationId, appId: appId)
+    PostHogManager.shared.conversationReprocessed(conversationId: conversationId, appId: appId)
+  }
+
+  // MARK: - Settings Events (Additional)
+
+  func settingToggled(setting: String, enabled: Bool) {
+    MixpanelManager.shared.settingToggled(setting: setting, enabled: enabled)
+    PostHogManager.shared.settingToggled(setting: setting, enabled: enabled)
+  }
+
+  func languageChanged(language: String) {
+    MixpanelManager.shared.languageChanged(language: language)
+    PostHogManager.shared.languageChanged(language: language)
+  }
+
+  // MARK: - Launch At Login Events
+
+  /// Track launch at login status once per app launch (not continuously)
+  func launchAtLoginStatusChecked(enabled: Bool) {
+    MixpanelManager.shared.launchAtLoginStatusChecked(enabled: enabled)
+    PostHogManager.shared.launchAtLoginStatusChecked(enabled: enabled)
+  }
+
+  /// Track when launch at login state changes
+  /// - Parameters:
+  ///   - enabled: New state
+  ///   - source: What triggered the change (user, migration, onboarding)
+  func launchAtLoginChanged(enabled: Bool, source: String) {
+    MixpanelManager.shared.launchAtLoginChanged(enabled: enabled, source: source)
+    PostHogManager.shared.launchAtLoginChanged(enabled: enabled, source: source)
+  }
+
+  // MARK: - Feedback Events
+
+  func feedbackOpened() {
+    MixpanelManager.shared.feedbackOpened()
+    PostHogManager.shared.feedbackOpened()
+  }
+
+  func feedbackSubmitted(feedbackLength: Int) {
+    MixpanelManager.shared.feedbackSubmitted(feedbackLength: feedbackLength)
+    PostHogManager.shared.feedbackSubmitted(feedbackLength: feedbackLength)
+  }
+
+  // MARK: - Rewind Events (Desktop-specific)
+
+  func rewindSearchPerformed(queryLength: Int) {
+    MixpanelManager.shared.rewindSearchPerformed(queryLength: queryLength)
+    PostHogManager.shared.rewindSearchPerformed(queryLength: queryLength)
+  }
+
+  func rewindScreenshotViewed(timestamp: Date) {
+    MixpanelManager.shared.rewindScreenshotViewed(timestamp: timestamp)
+    PostHogManager.shared.rewindScreenshotViewed(timestamp: timestamp)
+  }
+
+  func rewindTimelineNavigated(direction: String) {
+    MixpanelManager.shared.rewindTimelineNavigated(direction: direction)
+    PostHogManager.shared.rewindTimelineNavigated(direction: direction)
+  }
+
+  // MARK: - Proactive Assistant Events (Desktop-specific)
+
+  func focusAlertShown(app: String) {
+    MixpanelManager.shared.focusAlertShown(app: app)
+    PostHogManager.shared.focusAlertShown(app: app)
+  }
+
+  func focusAlertDismissed(app: String, action: String) {
+    MixpanelManager.shared.focusAlertDismissed(app: app, action: action)
+    PostHogManager.shared.focusAlertDismissed(app: app, action: action)
+  }
+
+  func taskExtracted(taskCount: Int) {
+    MixpanelManager.shared.taskExtracted(taskCount: taskCount)
+    PostHogManager.shared.taskExtracted(taskCount: taskCount)
+  }
+
+  func taskPromoted(taskCount: Int) {
+    MixpanelManager.shared.taskPromoted(taskCount: taskCount)
+    PostHogManager.shared.taskPromoted(taskCount: taskCount)
+  }
+
+  func taskCompleted(source: String?) {
+    MixpanelManager.shared.taskCompleted(source: source)
+    PostHogManager.shared.taskCompleted(source: source)
+  }
+
+  func taskDeleted(source: String?) {
+    MixpanelManager.shared.taskDeleted(source: source)
+    PostHogManager.shared.taskDeleted(source: source)
+  }
+
+  func taskAdded() {
+    MixpanelManager.shared.taskAdded()
+    PostHogManager.shared.taskAdded()
+  }
+
+  func memoryExtracted(memoryCount: Int) {
+    MixpanelManager.shared.memoryExtracted(memoryCount: memoryCount)
+    PostHogManager.shared.memoryExtracted(memoryCount: memoryCount)
+  }
+
+  func adviceGenerated(category: String?) {
+    MixpanelManager.shared.adviceGenerated(category: category)
+    PostHogManager.shared.adviceGenerated(category: category)
+  }
+
+  // MARK: - Apps Events
+
+  func appEnabled(appId: String, appName: String) {
+    MixpanelManager.shared.appEnabled(appId: appId, appName: appName)
+    PostHogManager.shared.appEnabled(appId: appId, appName: appName)
+  }
+
+  func appDisabled(appId: String, appName: String) {
+    MixpanelManager.shared.appDisabled(appId: appId, appName: appName)
+    PostHogManager.shared.appDisabled(appId: appId, appName: appName)
+  }
+
+  func appDetailViewed(appId: String, appName: String) {
+    MixpanelManager.shared.appDetailViewed(appId: appId, appName: appName)
+    PostHogManager.shared.appDetailViewed(appId: appId, appName: appName)
+  }
+
+  // MARK: - Update Events
+
+  func updateCheckStarted() {
+    MixpanelManager.shared.updateCheckStarted()
+    PostHogManager.shared.updateCheckStarted()
+  }
+
+  func updateAvailable(version: String) {
+    MixpanelManager.shared.updateAvailable(version: version)
+    PostHogManager.shared.updateAvailable(version: version)
+  }
+
+  func updateInstalled(version: String) {
+    MixpanelManager.shared.updateInstalled(version: version)
+    PostHogManager.shared.updateInstalled(version: version)
+  }
+
+  func updateNotFound() {
+    MixpanelManager.shared.updateNotFound()
+    PostHogManager.shared.updateNotFound()
+  }
+
+  func updateCheckFailed(
+    error: String, errorDomain: String, errorCode: Int, underlyingError: String? = nil,
+    underlyingDomain: String? = nil, underlyingCode: Int? = nil
+  ) {
+    MixpanelManager.shared.updateCheckFailed(
+      error: error, errorDomain: errorDomain, errorCode: errorCode,
+      underlyingError: underlyingError, underlyingDomain: underlyingDomain,
+      underlyingCode: underlyingCode)
+    PostHogManager.shared.updateCheckFailed(
+      error: error, errorDomain: errorDomain, errorCode: errorCode,
+      underlyingError: underlyingError, underlyingDomain: underlyingDomain,
+      underlyingCode: underlyingCode)
+  }
+
+  // MARK: - Notification Events
+
+  func notificationSent(notificationId: String, title: String, assistantId: String) {
+    MixpanelManager.shared.notificationSent(
+      notificationId: notificationId, title: title, assistantId: assistantId)
+    PostHogManager.shared.notificationSent(
+      notificationId: notificationId, title: title, assistantId: assistantId)
+  }
+
+  func notificationClicked(notificationId: String, title: String, assistantId: String) {
+    MixpanelManager.shared.notificationClicked(
+      notificationId: notificationId, title: title, assistantId: assistantId)
+    PostHogManager.shared.notificationClicked(
+      notificationId: notificationId, title: title, assistantId: assistantId)
+  }
+
+  func notificationDismissed(notificationId: String, title: String, assistantId: String) {
+    MixpanelManager.shared.notificationDismissed(
+      notificationId: notificationId, title: title, assistantId: assistantId)
+    PostHogManager.shared.notificationDismissed(
+      notificationId: notificationId, title: title, assistantId: assistantId)
+  }
+
+  func notificationWillPresent(notificationId: String, title: String) {
+    MixpanelManager.shared.notificationWillPresent(notificationId: notificationId, title: title)
+    PostHogManager.shared.notificationWillPresent(notificationId: notificationId, title: title)
+  }
+
+  func notificationDelegateReady() {
+    MixpanelManager.shared.notificationDelegateReady()
+    PostHogManager.shared.notificationDelegateReady()
+  }
+
+  // MARK: - Menu Bar Events
+
+  /// Track when user opens the menu bar dropdown
+  func menuBarOpened() {
+    MixpanelManager.shared.menuBarOpened()
+    PostHogManager.shared.menuBarOpened()
+  }
+
+  /// Track when user clicks an action in the menu bar
+  func menuBarActionClicked(action: String) {
+    MixpanelManager.shared.menuBarActionClicked(action: action)
+    PostHogManager.shared.menuBarActionClicked(action: action)
+  }
+
+  // MARK: - Tier Events
+
+  func tierChanged(tier: Int, reason: String) {
+    MixpanelManager.shared.tierChanged(tier: tier, reason: reason)
+    PostHogManager.shared.tierChanged(tier: tier, reason: reason)
+  }
+
+  func chatBridgeModeChanged(from oldMode: String, to newMode: String) {
+    MixpanelManager.shared.chatBridgeModeChanged(from: oldMode, to: newMode)
+    PostHogManager.shared.chatBridgeModeChanged(from: oldMode, to: newMode)
+  }
+
+  // MARK: - Settings State
+
+  /// Track the current state of key settings (screenshots, memory extraction, notifications)
+  /// Called when monitoring starts and daily while monitoring is active
+  func trackSettingsState(
+    screenshotsEnabled: Bool, memoryExtractionEnabled: Bool, memoryNotificationsEnabled: Bool
+  ) {
+    MixpanelManager.shared.settingsStateTracked(
+      screenshotsEnabled: screenshotsEnabled, memoryExtractionEnabled: memoryExtractionEnabled,
+      memoryNotificationsEnabled: memoryNotificationsEnabled)
+    PostHogManager.shared.settingsStateTracked(
+      screenshotsEnabled: screenshotsEnabled, memoryExtractionEnabled: memoryExtractionEnabled,
+      memoryNotificationsEnabled: memoryNotificationsEnabled)
+  }
+
+  // MARK: - All Settings State (Comprehensive daily report)
+
+  private let lastAllSettingsReportKey = "lastAllSettingsReportDate"
+
+  /// Report comprehensive settings state on app launch, throttled to once per calendar day.
+  /// Sends all ~45 user settings as a single analytics event for unified visibility.
+  func reportAllSettingsIfNeeded() {
+    guard !Self.isDevBuild else { return }
+
+    let defaults = UserDefaults.standard
+    let lastReport = defaults.object(forKey: lastAllSettingsReportKey) as? Date ?? .distantPast
+    guard !Calendar.current.isDateInToday(lastReport) else {
+      log("Analytics: All settings already reported today, skipping")
+      return
+    }
+
+    defaults.set(Date(), forKey: lastAllSettingsReportKey)
+
+    let properties = collectAllSettings()
+
+    MixpanelManager.shared.allSettingsStateTracked(properties: properties)
+    PostHogManager.shared.allSettingsStateTracked(properties: properties)
+
+    log("Analytics: All settings state reported (\(properties.count) properties)")
+  }
+
+  /// Collect all user settings into a flat dictionary for analytics reporting.
+  /// For string settings (custom prompts), reports has_custom + length instead of full text.
+  /// For array settings (excluded apps, keywords), reports count instead of contents.
+  private func collectAllSettings() -> [String: Any] {
+    var props: [String: Any] = [:]
+
+    // -- General / Shared Assistant Settings --
+    let shared = AssistantSettings.shared
+    props["screen_analysis_enabled"] = shared.screenAnalysisEnabled
+    props["transcription_enabled"] = shared.transcriptionEnabled
+    props["transcription_language"] = shared.transcriptionLanguage
+    props["transcription_auto_detect"] = shared.transcriptionAutoDetect
+    props["transcription_vocabulary_count"] = shared.transcriptionVocabulary.count
+    props["analysis_delay"] = shared.analysisDelay
+    props["cooldown_interval"] = shared.cooldownInterval
+    props["glow_overlay_enabled"] = shared.glowOverlayEnabled
+
+    // -- Focus Assistant --
+    let focus = FocusAssistantSettings.shared
+    props["focus_enabled"] = focus.isEnabled
+    props["focus_notifications_enabled"] = focus.notificationsEnabled
+    props["focus_cooldown_interval"] = focus.cooldownInterval
+    props["focus_has_custom_prompt"] =
+      focus.analysisPrompt != FocusAssistantSettings.defaultAnalysisPrompt
+    props["focus_prompt_length"] = focus.analysisPrompt.count
+    props["focus_excluded_apps_count"] = focus.excludedApps.count
+
+    // -- Task Extraction Assistant --
+    let task = TaskAssistantSettings.shared
+    props["task_enabled"] = task.isEnabled
+    props["task_notifications_enabled"] = task.notificationsEnabled
+    props["task_extraction_interval"] = task.extractionInterval
+    props["task_min_confidence"] = task.minConfidence
+    props["task_has_custom_prompt"] =
+      task.analysisPrompt != TaskAssistantSettings.defaultAnalysisPrompt
+    props["task_prompt_length"] = task.analysisPrompt.count
+    props["task_allowed_apps_count"] = task.allowedApps.count
+    props["task_browser_keywords_count"] = task.browserKeywords.count
+
+    // -- Memory Assistant --
+    let memory = MemoryAssistantSettings.shared
+    props["memory_enabled"] = memory.isEnabled
+    props["memory_extraction_interval"] = memory.extractionInterval
+    props["memory_min_confidence"] = memory.minConfidence
+    props["memory_notifications_enabled"] = memory.notificationsEnabled
+    props["memory_has_custom_prompt"] =
+      memory.analysisPrompt != MemoryAssistantSettings.defaultAnalysisPrompt
+    props["memory_prompt_length"] = memory.analysisPrompt.count
+    props["memory_excluded_apps_count"] = memory.excludedApps.count
+
+    // -- Advice Assistant --
+    let advice = AdviceAssistantSettings.shared
+    props["advice_enabled"] = advice.isEnabled
+    props["advice_notifications_enabled"] = advice.notificationsEnabled
+    props["advice_extraction_interval"] = advice.extractionInterval
+    props["advice_min_confidence"] = advice.minConfidence
+    props["advice_has_custom_prompt"] =
+      advice.analysisPrompt != AdviceAssistantSettings.defaultAnalysisPrompt
+    props["advice_prompt_length"] = advice.analysisPrompt.count
+    props["advice_excluded_apps_count"] = advice.excludedApps.count
+
+    // -- Task Agent --
+    let agent = TaskAgentSettings.shared
+    props["task_agent_enabled"] = agent.isEnabled
+    props["task_agent_auto_launch"] = agent.autoLaunch
+    props["task_agent_skip_permissions"] = agent.skipPermissions
+    props["task_agent_has_custom_prompt"] = !agent.customPromptPrefix.isEmpty
+
+    // -- Rewind (read from UserDefaults since these are @AppStorage in views) --
+    let ud = UserDefaults.standard
+    props["rewind_retention_days"] = ud.object(forKey: "rewindRetentionDays") as? Double ?? 7.0
+    props["rewind_capture_interval"] = ud.object(forKey: "rewindCaptureInterval") as? Double ?? 1.0
+
+    // -- AI Chat Mode --
+    props["chat_bridge_mode"] = ud.string(forKey: "chatBridgeMode") ?? "agentSDK"
+
+    // -- UI Preferences --
+    props["multi_chat_enabled"] = ud.bool(forKey: "multiChatEnabled")
+    props["conversations_compact_view"] =
+      ud.object(forKey: "conversationsCompactView") as? Bool ?? true
+    props["tier_level"] = ud.integer(forKey: "currentTierLevel")
+
+    // -- Device --
+    let deviceId = ud.string(forKey: "pairedDeviceId") ?? ""
+    props["has_paired_device"] = !deviceId.isEmpty
+    props["paired_device_type"] = ud.string(forKey: "pairedDeviceType") ?? ""
+
+    // -- Launch at Login --
+    props["launch_at_login_enabled"] = LaunchAtLoginManager.shared.isEnabled
+
+    // -- Floating Bar (AskOmi) --
+    props["floating_bar_enabled"] = FloatingControlBarManager.shared.isEnabled
+    props["floating_bar_visible"] = FloatingControlBarManager.shared.isVisible
+
+    // -- Dev Mode --
+    props["dev_mode_enabled"] = ud.bool(forKey: "devModeEnabled")
+
+    return props
+  }
+
+  // MARK: - Floating Bar Events
+
+  /// Track when the floating bar is toggled visible/hidden
+  func floatingBarToggled(visible: Bool, source: String) {
+    let props: [String: Any] = [
+      "visible": visible,
+      "source": source,
+    ]
+    MixpanelManager.shared.track(
+      "Floating Bar Toggled", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("floating_bar_toggled", properties: props)
+  }
+
+  /// Track when Ask OMI is opened (AI input panel shown)
+  func floatingBarAskOmiOpened(source: String) {
+    let props: [String: Any] = ["source": source]
+    MixpanelManager.shared.track(
+      "Floating Bar Ask OMI Opened", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("floating_bar_ask_omi_opened", properties: props)
+  }
+
+  /// Track when the AI conversation is closed
+  func floatingBarAskOmiClosed() {
+    MixpanelManager.shared.track("Floating Bar Ask OMI Closed")
+    PostHogManager.shared.track("floating_bar_ask_omi_closed")
+  }
+
+  /// Track when an AI query is sent from the floating bar
+  func floatingBarQuerySent(messageLength: Int, hasScreenshot: Bool) {
+    let props: [String: Any] = [
+      "message_length": messageLength,
+      "has_screenshot": hasScreenshot,
+    ]
+    MixpanelManager.shared.track(
+      "Floating Bar Query Sent", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("floating_bar_query_sent", properties: props)
+  }
+
+  /// Track when push-to-talk starts listening
+  func floatingBarPTTStarted(mode: String) {
+    let props: [String: Any] = ["mode": mode]
+    MixpanelManager.shared.track(
+      "Floating Bar PTT Started", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("floating_bar_ptt_started", properties: props)
+  }
+
+  /// Track when push-to-talk ends and sends (or discards) transcript
+  func floatingBarPTTEnded(mode: String, hadTranscript: Bool, transcriptLength: Int) {
+    let props: [String: Any] = [
+      "mode": mode,
+      "had_transcript": hadTranscript,
+      "transcript_length": transcriptLength,
+    ]
+    MixpanelManager.shared.track(
+      "Floating Bar PTT Ended", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("floating_bar_ptt_ended", properties: props)
+  }
+
+  // MARK: - Knowledge Graph Events
+
+  /// Track when knowledge graph generation starts during onboarding
+  func knowledgeGraphBuildStarted(filesIndexed: Int, hadExistingGraph: Bool) {
+    let props: [String: Any] = [
+      "files_indexed": filesIndexed,
+      "had_existing_graph": hadExistingGraph,
+    ]
+    MixpanelManager.shared.track(
+      "Knowledge Graph Build Started", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("knowledge_graph_build_started", properties: props)
+  }
+
+  /// Track when knowledge graph generation completes (successfully loaded with data)
+  func knowledgeGraphBuildCompleted(
+    nodeCount: Int, edgeCount: Int, pollAttempts: Int, hadExistingGraph: Bool
+  ) {
+    let props: [String: Any] = [
+      "node_count": nodeCount,
+      "edge_count": edgeCount,
+      "poll_attempts": pollAttempts,
+      "had_existing_graph": hadExistingGraph,
+    ]
+    MixpanelManager.shared.track(
+      "Knowledge Graph Build Completed", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("knowledge_graph_build_completed", properties: props)
+  }
+
+  /// Track when knowledge graph generation fails or times out empty
+  func knowledgeGraphBuildFailed(reason: String, pollAttempts: Int, filesIndexed: Int) {
+    let props: [String: Any] = [
+      "reason": reason,
+      "poll_attempts": pollAttempts,
+      "files_indexed": filesIndexed,
+    ]
+    MixpanelManager.shared.track(
+      "Knowledge Graph Build Failed", properties: props.compactMapValues { $0 as? MixpanelType })
+    PostHogManager.shared.track("knowledge_graph_build_failed", properties: props)
+  }
+
+  // MARK: - Display Info
+
+  /// Track display characteristics (notch, screen size, etc.)
+  /// Called at app launch to help diagnose menu bar visibility issues
+  func trackDisplayInfo() {
+    guard let screen = NSScreen.main else { return }
+
+    let frame = screen.frame
+    let visibleFrame = screen.visibleFrame
+    let safeAreaInsets = screen.safeAreaInsets
+
+    // Detect notch: MacBooks with notch have safeAreaInsets.top > 0
+    let hasNotch = safeAreaInsets.top > 0
+
+    // Calculate menu bar height (difference between frame and visible frame at top)
+    let menuBarHeight = frame.height - visibleFrame.height - visibleFrame.origin.y
+
+    let displayInfo: [String: Any] = [
+      "screen_width": Int(frame.width),
+      "screen_height": Int(frame.height),
+      "has_notch": hasNotch,
+      "safe_area_top": Int(safeAreaInsets.top),
+      "menu_bar_height": Int(menuBarHeight),
+      "scale_factor": screen.backingScaleFactor,
+    ]
+
+    MixpanelManager.shared.displayInfoTracked(info: displayInfo)
+    PostHogManager.shared.displayInfoTracked(info: displayInfo)
+  }
 }

--- a/desktop/Desktop/Sources/AppBuild.swift
+++ b/desktop/Desktop/Sources/AppBuild.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+enum AppBuild {
+  static let productionBundleIdentifier = "com.omi.computer-macos"
+  private static let updateChannelDefaultsKey = "update_channel"
+  private static let productionDesktopBackendURL = "https://desktop-backend-hhibjajaja-uc.a.run.app/"
+  private static let developmentDesktopBackendURL = "https://desktop-backend-dt5lrfkkoa-uc.a.run.app/"
+
+  static var bundleIdentifier: String {
+    Bundle.main.bundleIdentifier ?? productionBundleIdentifier
+  }
+
+  static var isNonProduction: Bool {
+    bundleIdentifier.hasPrefix("com.omi.") && bundleIdentifier != productionBundleIdentifier
+  }
+
+  static var displayName: String {
+    if let displayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String,
+      !displayName.isEmpty
+    {
+      return displayName
+    }
+
+    if let bundleName = Bundle.main.object(forInfoDictionaryKey: "CFBundleName") as? String,
+      !bundleName.isEmpty
+    {
+      return bundleName
+    }
+
+    return "omi"
+  }
+
+  static var currentUpdateChannel: String {
+    let raw = UserDefaults.standard.string(forKey: updateChannelDefaultsKey) ?? "stable"
+    return raw == "staging" ? "beta" : raw
+  }
+
+  static var prefersDevelopmentDesktopBackend: Bool {
+    isNonProduction || currentUpdateChannel == "beta"
+  }
+
+  static var managedDesktopBackendBaseURL: String {
+    prefersDevelopmentDesktopBackend ? developmentDesktopBackendURL : productionDesktopBackendURL
+  }
+
+  static func resolvedAPIBaseURL(configuredURL: String?) -> String {
+    let preferredManagedURL = managedDesktopBackendBaseURL
+
+    guard let configuredURL, !configuredURL.isEmpty else {
+      return preferredManagedURL
+    }
+
+    let normalizedURL = configuredURL.hasSuffix("/") ? configuredURL : configuredURL + "/"
+
+    if isKnownManagedDesktopBackendURL(normalizedURL) {
+      return preferredManagedURL
+    }
+
+    return normalizedURL
+  }
+
+  private static func isKnownManagedDesktopBackendURL(_ url: String) -> Bool {
+    url == productionDesktopBackendURL || url == developmentDesktopBackendURL
+  }
+}

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -446,7 +446,6 @@ class AppState: ObservableObject {
     log("Environment loaded (API keys will be fetched from backend after auth)")
   }
 
-
   func openScreenRecordingPreferences() {
     ScreenCaptureService.openScreenRecordingPreferences()
   }
@@ -1001,7 +1000,8 @@ class AppState: ObservableObject {
     do {
       try process.run()
       process.waitUntilExit()
-      let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+      let output =
+        String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
         .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
       let granted = output == "2"
       if granted != hasFullDiskAccess {
@@ -2813,19 +2813,26 @@ class AppState: ObservableObject {
       log("Failed to clean user TCC database: \(error.localizedDescription)")
     }
 
-    // Also clean entries for new dev bundle ID pattern (com.omi.desktop-dev)
+    // Also clean entries for non-production Omi bundles (for example com.omi.desktop-dev, com.omi.1233).
     let process2 = Process()
     process2.executableURL = URL(fileURLWithPath: "/usr/bin/sqlite3")
-    process2.arguments = [tccDbPath, "DELETE FROM access WHERE client LIKE '%com.omi.desktop%';"]
+    process2.arguments = [
+      tccDbPath,
+      "DELETE FROM access WHERE client LIKE 'com.omi.%' AND client != 'com.omi.computer-macos';",
+    ]
     process2.standardOutput = FileHandle.nullDevice
     process2.standardError = FileHandle.nullDevice
 
     do {
       try process2.run()
       process2.waitUntilExit()
-      log("User TCC database cleaned for desktop-dev (exit code: \(process2.terminationStatus))")
+      log(
+        "User TCC database cleaned for non-production bundles (exit code: \(process2.terminationStatus))"
+      )
     } catch {
-      log("Failed to clean user TCC database for desktop-dev: \(error.localizedDescription)")
+      log(
+        "Failed to clean user TCC database for non-production bundles: \(error.localizedDescription)"
+      )
     }
   }
 

--- a/desktop/Desktop/Sources/FeedbackView.swift
+++ b/desktop/Desktop/Sources/FeedbackView.swift
@@ -1,171 +1,173 @@
-import SwiftUI
 import Sentry
+import SwiftUI
 
 /// Window controller for the feedback dialog
 @MainActor
 class FeedbackWindow {
-    private static var window: NSWindow?
+  private static var window: NSWindow?
 
-    static func show(userEmail: String?) {
-        // Close existing window if any
-        window?.close()
+  static func show(userEmail: String?) {
+    // Close existing window if any
+    window?.close()
 
-        // Track feedback opened
-        AnalyticsManager.shared.feedbackOpened()
+    // Track feedback opened
+    AnalyticsManager.shared.feedbackOpened()
 
-        let feedbackView = FeedbackView(userEmail: userEmail) {
-            window?.close()
-            window = nil
-        }
-
-        let hostingController = NSHostingController(rootView: feedbackView.withFontScaling())
-
-        let newWindow = NSWindow(contentViewController: hostingController)
-        newWindow.title = "Report Issue"
-        newWindow.styleMask = [.titled, .closable]
-        newWindow.setContentSize(NSSize(width: 400, height: 300))
-        newWindow.center()
-        newWindow.makeKeyAndOrderFront(nil)
-        newWindow.level = .floating
-
-        window = newWindow
-
-        NSApp.activate(ignoringOtherApps: true)
+    let feedbackView = FeedbackView(userEmail: userEmail) {
+      window?.close()
+      window = nil
     }
+
+    let hostingController = NSHostingController(rootView: feedbackView.withFontScaling())
+
+    let newWindow = NSWindow(contentViewController: hostingController)
+    newWindow.title = "Report Issue"
+    newWindow.styleMask = [.titled, .closable]
+    newWindow.setContentSize(NSSize(width: 400, height: 300))
+    newWindow.center()
+    newWindow.makeKeyAndOrderFront(nil)
+    newWindow.level = .floating
+
+    window = newWindow
+
+    NSApp.activate(ignoringOtherApps: true)
+  }
 }
 
 /// SwiftUI view for collecting user feedback and sending logs
 struct FeedbackView: View {
-    let userEmail: String?
-    let onDismiss: () -> Void
+  let userEmail: String?
+  let onDismiss: () -> Void
 
-    @State private var feedbackText: String = ""
-    @State private var name: String = ""
-    @State private var email: String = ""
-    @State private var isSubmitting: Bool = false
-    @State private var showSuccess: Bool = false
+  @State private var feedbackText: String = ""
+  @State private var name: String = ""
+  @State private var email: String = ""
+  @State private var isSubmitting: Bool = false
+  @State private var showSuccess: Bool = false
 
-    init(userEmail: String?, onDismiss: @escaping () -> Void) {
-        self.userEmail = userEmail
-        self.onDismiss = onDismiss
-        // Pre-fill email from auth
-        _email = State(initialValue: userEmail ?? "")
-        // Pre-fill name from AuthService
-        _name = State(initialValue: AuthService.shared.displayName)
+  init(userEmail: String?, onDismiss: @escaping () -> Void) {
+    self.userEmail = userEmail
+    self.onDismiss = onDismiss
+    // Pre-fill email from auth
+    _email = State(initialValue: userEmail ?? "")
+    // Pre-fill name from AuthService
+    _name = State(initialValue: AuthService.shared.displayName)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      if showSuccess {
+        // Success state
+        VStack(spacing: 12) {
+          Image(systemName: "checkmark.circle.fill")
+            .scaledFont(size: 48)
+            .foregroundColor(.green)
+
+          Text("Report sent!")
+            .font(.headline)
+
+          Text("We'll look into this issue.")
+            .foregroundColor(.secondary)
+
+          Button("Close") {
+            onDismiss()
+          }
+          .keyboardShortcut(.defaultAction)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else {
+        // Form state
+        Text("Report an Issue")
+          .font(.headline)
+
+        Text("App logs will be included automatically. Optionally describe what went wrong.")
+          .font(.caption)
+          .foregroundColor(.secondary)
+
+        TextEditor(text: $feedbackText)
+          .font(.body)
+          .frame(minHeight: 100)
+          .border(Color.gray.opacity(0.3), width: 1)
+
+        HStack {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Name (optional)")
+              .font(.caption)
+              .foregroundColor(.secondary)
+            TextField("Your name", text: $name)
+              .textFieldStyle(.roundedBorder)
+          }
+
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Email")
+              .font(.caption)
+              .foregroundColor(.secondary)
+            TextField("your@email.com", text: $email)
+              .textFieldStyle(.roundedBorder)
+          }
+        }
+
+        HStack {
+          Button("Cancel") {
+            onDismiss()
+          }
+          .keyboardShortcut(.cancelAction)
+
+          Spacer()
+
+          Button("Send Report") {
+            submitFeedback()
+          }
+          .keyboardShortcut(.defaultAction)
+          .disabled(isSubmitting)
+        }
+      }
+    }
+    .padding(20)
+    .frame(width: 400, height: 300)
+  }
+
+  private func submitFeedback() {
+    isSubmitting = true
+
+    let message = feedbackText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    // Track feedback submitted
+    AnalyticsManager.shared.feedbackSubmitted(feedbackLength: message.count)
+
+    // Submit to Sentry with log file attachment (dev + prod — user explicitly chose to report)
+    let sentryMessage = message.isEmpty ? "User Report (logs only)" : "User Report: \(message)"
+
+    // Capture event with log file attached via scope
+    let eventId = SentrySDK.capture(message: sentryMessage) { scope in
+      let isDev = AppBuild.isNonProduction
+      let logPath = isDev ? "/tmp/omi-dev.log" : "/tmp/omi.log"
+      let logFilename = isDev ? "omi-dev.log" : "omi.log"
+      if FileManager.default.fileExists(atPath: logPath) {
+        let attachment = Attachment(path: logPath, filename: logFilename, contentType: "text/plain")
+        scope.addAttachment(attachment)
+      }
     }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            if showSuccess {
-                // Success state
-                VStack(spacing: 12) {
-                    Image(systemName: "checkmark.circle.fill")
-                        .scaledFont(size: 48)
-                        .foregroundColor(.green)
-
-                    Text("Report sent!")
-                        .font(.headline)
-
-                    Text("We'll look into this issue.")
-                        .foregroundColor(.secondary)
-
-                    Button("Close") {
-                        onDismiss()
-                    }
-                    .keyboardShortcut(.defaultAction)
-                }
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                // Form state
-                Text("Report an Issue")
-                    .font(.headline)
-
-                Text("App logs will be included automatically. Optionally describe what went wrong.")
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-
-                TextEditor(text: $feedbackText)
-                    .font(.body)
-                    .frame(minHeight: 100)
-                    .border(Color.gray.opacity(0.3), width: 1)
-
-                HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Name (optional)")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        TextField("Your name", text: $name)
-                            .textFieldStyle(.roundedBorder)
-                    }
-
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Email")
-                            .font(.caption)
-                            .foregroundColor(.secondary)
-                        TextField("your@email.com", text: $email)
-                            .textFieldStyle(.roundedBorder)
-                    }
-                }
-
-                HStack {
-                    Button("Cancel") {
-                        onDismiss()
-                    }
-                    .keyboardShortcut(.cancelAction)
-
-                    Spacer()
-
-                    Button("Send Report") {
-                        submitFeedback()
-                    }
-                    .keyboardShortcut(.defaultAction)
-                    .disabled(isSubmitting)
-                }
-            }
-        }
-        .padding(20)
-        .frame(width: 400, height: 300)
+    // Also send as Sentry feedback if there's a message
+    if !message.isEmpty {
+      let feedback = SentryFeedback(
+        message: message,
+        name: name.trimmingCharacters(in: .whitespacesAndNewlines),
+        email: email.trimmingCharacters(in: .whitespacesAndNewlines),
+        associatedEventId: eventId
+      )
+      SentrySDK.capture(feedback: feedback)
     }
 
-    private func submitFeedback() {
-        isSubmitting = true
+    log(
+      "User report submitted to Sentry (logs attached, message: \(message.isEmpty ? "none" : "yes"))"
+    )
 
-        let message = feedbackText.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Track feedback submitted
-        AnalyticsManager.shared.feedbackSubmitted(feedbackLength: message.count)
-
-        // Submit to Sentry with log file attachment (dev + prod — user explicitly chose to report)
-        let sentryMessage = message.isEmpty ? "User Report (logs only)" : "User Report: \(message)"
-
-        // Capture event with log file attached via scope
-        let eventId = SentrySDK.capture(message: sentryMessage) { scope in
-            let isDev = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
-            let logPath = isDev ? "/tmp/omi-dev.log" : "/tmp/omi.log"
-            let logFilename = isDev ? "omi-dev.log" : "omi.log"
-            if FileManager.default.fileExists(atPath: logPath) {
-                let attachment = Attachment(path: logPath, filename: logFilename, contentType: "text/plain")
-                scope.addAttachment(attachment)
-            }
-        }
-
-        // Also send as Sentry feedback if there's a message
-        if !message.isEmpty {
-            let feedback = SentryFeedback(
-                message: message,
-                name: name.trimmingCharacters(in: .whitespacesAndNewlines),
-                email: email.trimmingCharacters(in: .whitespacesAndNewlines),
-                associatedEventId: eventId
-            )
-            SentrySDK.capture(feedback: feedback)
-        }
-
-        log("User report submitted to Sentry (logs attached, message: \(message.isEmpty ? "none" : "yes"))")
-
-        // Show success
-        withAnimation {
-            showSuccess = true
-            isSubmitting = false
-        }
+    // Show success
+    withAnimation {
+      showSuccess = true
+      isSubmitting = false
     }
+  }
 }

--- a/desktop/Desktop/Sources/Logger.swift
+++ b/desktop/Desktop/Sources/Logger.swift
@@ -2,183 +2,186 @@ import Foundation
 import Sentry
 
 private let logFile: String = {
-    let isDev = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
-    return isDev ? "/tmp/omi-dev.log" : "/tmp/omi.log"
+  let isDev = AppBuild.isNonProduction
+  return isDev ? "/tmp/omi-dev.log" : "/tmp/omi.log"
 }()
 private let logQueue = DispatchQueue(label: "me.omi.logger", qos: .utility)
 private let dateFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "HH:mm:ss.SSS"  // Added milliseconds for perf tracking
-    return formatter
+  let formatter = DateFormatter()
+  formatter.dateFormat = "HH:mm:ss.SSS"  // Added milliseconds for perf tracking
+  return formatter
 }()
 
 /// Append data to the log file on a background queue (non-blocking)
 private func appendToLogFile(_ line: String) {
-    guard let data = (line + "\n").data(using: .utf8) else { return }
-    logQueue.async {
-        writeToLogFile(data)
-    }
+  guard let data = (line + "\n").data(using: .utf8) else { return }
+  logQueue.async {
+    writeToLogFile(data)
+  }
 }
 
 /// Append data to the log file synchronously (blocks caller until written).
 /// Use for critical events that must survive imminent app termination (e.g. Sparkle updates).
 private func appendToLogFileSync(_ line: String) {
-    guard let data = (line + "\n").data(using: .utf8) else { return }
-    logQueue.sync {
-        writeToLogFile(data)
-    }
+  guard let data = (line + "\n").data(using: .utf8) else { return }
+  logQueue.sync {
+    writeToLogFile(data)
+  }
 }
 
 /// Shared file-write implementation (must be called on logQueue)
 private func writeToLogFile(_ data: Data) {
-    if FileManager.default.fileExists(atPath: logFile) {
-        if let handle = FileHandle(forWritingAtPath: logFile) {
-            handle.seekToEndOfFile()
-            handle.write(data)
-            handle.closeFile()
-        }
-    } else {
-        FileManager.default.createFile(atPath: logFile, contents: data)
+  if FileManager.default.fileExists(atPath: logFile) {
+    if let handle = FileHandle(forWritingAtPath: logFile) {
+      handle.seekToEndOfFile()
+      handle.write(data)
+      handle.closeFile()
     }
+  } else {
+    FileManager.default.createFile(atPath: logFile, contents: data)
+  }
 }
 
 // MARK: - Performance Logging
 
 /// Log a performance event with timing info - writes to omi.log with [perf] tag
 func logPerf(_ message: String, duration: Double? = nil, cpu: Bool = false) {
-    let timestamp = dateFormatter.string(from: Date())
-    var parts = ["[\(timestamp)] [perf] \(message)"]
+  let timestamp = dateFormatter.string(from: Date())
+  var parts = ["[\(timestamp)] [perf] \(message)"]
 
-    if let duration = duration {
-        parts.append(String(format: "(%.1fms)", duration * 1000))
+  if let duration = duration {
+    parts.append(String(format: "(%.1fms)", duration * 1000))
+  }
+
+  if cpu {
+    // Get actual CPU via rusage
+    var usage = rusage()
+    if getrusage(RUSAGE_SELF, &usage) == 0 {
+      let userTime = Double(usage.ru_utime.tv_sec) + Double(usage.ru_utime.tv_usec) / 1_000_000
+      let sysTime = Double(usage.ru_stime.tv_sec) + Double(usage.ru_stime.tv_usec) / 1_000_000
+      parts.append(String(format: "[cpu: user=%.2fs sys=%.2fs]", userTime, sysTime))
     }
+  }
 
-    if cpu {
-        // Get actual CPU via rusage
-        var usage = rusage()
-        if getrusage(RUSAGE_SELF, &usage) == 0 {
-            let userTime = Double(usage.ru_utime.tv_sec) + Double(usage.ru_utime.tv_usec) / 1_000_000
-            let sysTime = Double(usage.ru_stime.tv_sec) + Double(usage.ru_stime.tv_usec) / 1_000_000
-            parts.append(String(format: "[cpu: user=%.2fs sys=%.2fs]", userTime, sysTime))
-        }
-    }
+  let line = parts.joined(separator: " ")
+  print(line)
+  fflush(stdout)
 
-    let line = parts.joined(separator: " ")
-    print(line)
-    fflush(stdout)
-
-    appendToLogFile(line)
+  appendToLogFile(line)
 }
 
 /// Timer for measuring operation duration
 class PerfTimer {
-    private let name: String
-    private let start: CFAbsoluteTime
-    private let logCPU: Bool
+  private let name: String
+  private let start: CFAbsoluteTime
+  private let logCPU: Bool
 
-    init(_ name: String, logCPU: Bool = false) {
-        self.name = name
-        self.start = CFAbsoluteTimeGetCurrent()
-        self.logCPU = logCPU
-    }
+  init(_ name: String, logCPU: Bool = false) {
+    self.name = name
+    self.start = CFAbsoluteTimeGetCurrent()
+    self.logCPU = logCPU
+  }
 
-    func stop() {
-        let duration = CFAbsoluteTimeGetCurrent() - start
-        logPerf(name, duration: duration, cpu: logCPU)
-    }
+  func stop() {
+    let duration = CFAbsoluteTimeGetCurrent() - start
+    logPerf(name, duration: duration, cpu: logCPU)
+  }
 
-    /// Log intermediate checkpoint without stopping
-    func checkpoint(_ label: String) {
-        let duration = CFAbsoluteTimeGetCurrent() - start
-        logPerf("\(name) → \(label)", duration: duration)
-    }
+  /// Log intermediate checkpoint without stopping
+  func checkpoint(_ label: String) {
+    let duration = CFAbsoluteTimeGetCurrent() - start
+    logPerf("\(name) → \(label)", duration: duration)
+  }
 }
 
 /// Measure a block of code and log its duration
 func measurePerf<T>(_ name: String, logCPU: Bool = false, _ block: () -> T) -> T {
-    let timer = PerfTimer(name, logCPU: logCPU)
-    let result = block()
-    timer.stop()
-    return result
+  let timer = PerfTimer(name, logCPU: logCPU)
+  let result = block()
+  timer.stop()
+  return result
 }
 
 /// Async version of measurePerf
 func measurePerfAsync<T>(_ name: String, logCPU: Bool = false, _ block: () async -> T) async -> T {
-    let timer = PerfTimer(name, logCPU: logCPU)
-    let result = await block()
-    timer.stop()
-    return result
+  let timer = PerfTimer(name, logCPU: logCPU)
+  let result = await block()
+  timer.stop()
+  return result
 }
 
 /// Check if this is a development build
-private let isDevBuild: Bool = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
+private let isDevBuild: Bool = AppBuild.isNonProduction
 
 /// Write to log file synchronously — guaranteed to persist even if the app terminates immediately after.
 /// Use sparingly (blocks the calling thread); prefer `log()` for normal logging.
 func logSync(_ message: String) {
-    let timestamp = dateFormatter.string(from: Date())
-    let line = "[\(timestamp)] [app] \(message)"
-    print(line)
-    fflush(stdout)
+  let timestamp = dateFormatter.string(from: Date())
+  let line = "[\(timestamp)] [app] \(message)"
+  print(line)
+  fflush(stdout)
 
-    let breadcrumb = Breadcrumb(level: .info, category: "app")
-    breadcrumb.message = message
-    SentrySDK.addBreadcrumb(breadcrumb)
+  let breadcrumb = Breadcrumb(level: .info, category: "app")
+  breadcrumb.message = message
+  SentrySDK.addBreadcrumb(breadcrumb)
 
-    appendToLogFileSync(line)
+  appendToLogFileSync(line)
 }
 
 /// Write to log file, stdout, and Sentry breadcrumbs
 func log(_ message: String) {
-    let timestamp = dateFormatter.string(from: Date())
-    let line = "[\(timestamp)] [app] \(message)"
-    print(line)
-    fflush(stdout)
+  let timestamp = dateFormatter.string(from: Date())
+  let line = "[\(timestamp)] [app] \(message)"
+  print(line)
+  fflush(stdout)
 
-    // Add breadcrumb to Sentry for context in crash reports (now enabled for dev builds too)
-    let breadcrumb = Breadcrumb(level: .info, category: "app")
-    breadcrumb.message = message
-    SentrySDK.addBreadcrumb(breadcrumb)
+  // Add breadcrumb to Sentry for context in crash reports (now enabled for dev builds too)
+  let breadcrumb = Breadcrumb(level: .info, category: "app")
+  breadcrumb.message = message
+  SentrySDK.addBreadcrumb(breadcrumb)
 
-    appendToLogFile(line)
+  appendToLogFile(line)
 }
 
 /// Log an error and capture it in Sentry
 func logError(_ message: String, error: Error? = nil) {
-    let timestamp = dateFormatter.string(from: Date())
-    let errorDesc = error?.localizedDescription ?? ""
-    let fullMessage = error != nil ? "\(message): \(errorDesc)" : message
-    let line = "[\(timestamp)] [error] \(fullMessage)"
-    print(line)
-    fflush(stdout)
+  let timestamp = dateFormatter.string(from: Date())
+  let errorDesc = error?.localizedDescription ?? ""
+  let fullMessage = error != nil ? "\(message): \(errorDesc)" : message
+  let line = "[\(timestamp)] [error] \(fullMessage)"
+  print(line)
+  fflush(stdout)
 
-    // Add error breadcrumb and capture in Sentry (now enabled for dev builds too)
-    let breadcrumb = Breadcrumb(level: .error, category: "error")
-    breadcrumb.message = fullMessage
-    SentrySDK.addBreadcrumb(breadcrumb)
+  // Add error breadcrumb and capture in Sentry (now enabled for dev builds too)
+  let breadcrumb = Breadcrumb(level: .error, category: "error")
+  breadcrumb.message = fullMessage
+  SentrySDK.addBreadcrumb(breadcrumb)
 
-    // Capture error context in Sentry without passing the raw Swift Error object.
-    // Some Swift-native error payloads can crash inside Sentry's reflection path.
-    let isCancelledRequest = (error as? URLError)?.code == .cancelled ||
-        (error as NSError?)?.domain == NSURLErrorDomain && (error as NSError?)?.code == NSURLErrorCancelled
-    if let error = error, !isCancelledRequest {
-        let nsError = error as NSError
-        let errorType = String(reflecting: type(of: error))
-        SentrySDK.capture(message: fullMessage) { scope in
-            scope.setLevel(.error)
-            scope.setContext(value: [
-                "message": message,
-                "error_type": errorType,
-                "error_domain": nsError.domain,
-                "error_code": nsError.code,
-                "localized_description": errorDesc,
-            ], key: "app_context")
-        }
-    } else if error == nil {
-        SentrySDK.capture(message: fullMessage) { scope in
-            scope.setLevel(.error)
-        }
+  // Capture error context in Sentry without passing the raw Swift Error object.
+  // Some Swift-native error payloads can crash inside Sentry's reflection path.
+  let isCancelledRequest =
+    (error as? URLError)?.code == .cancelled
+    || (error as NSError?)?.domain == NSURLErrorDomain
+      && (error as NSError?)?.code == NSURLErrorCancelled
+  if let error = error, !isCancelledRequest {
+    let nsError = error as NSError
+    let errorType = String(reflecting: type(of: error))
+    SentrySDK.capture(message: fullMessage) { scope in
+      scope.setLevel(.error)
+      scope.setContext(
+        value: [
+          "message": message,
+          "error_type": errorType,
+          "error_domain": nsError.domain,
+          "error_code": nsError.code,
+          "localized_description": errorDesc,
+        ], key: "app_context")
     }
+  } else if error == nil {
+    SentrySDK.capture(message: fullMessage) { scope in
+      scope.setLevel(.error)
+    }
+  }
 
-    appendToLogFile(line)
+  appendToLogFile(line)
 }

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -1,1086 +1,1141 @@
-import SwiftUI
-import FirebaseCore
 import FirebaseAuth
+import FirebaseCore
 import Mixpanel
 import Sentry
 import Sparkle
+import SwiftUI
 
 // MARK: - Launch Mode
 /// Determines which UI to show based on command-line arguments
 enum LaunchMode: String {
-    case full = "full"       // Normal app with full sidebar
-    case rewind = "rewind"   // Rewind-only mode (no sidebar)
+  case full = "full"  // Normal app with full sidebar
+  case rewind = "rewind"  // Rewind-only mode (no sidebar)
 
-    static func fromCommandLine() -> LaunchMode {
-        // Check for --mode=rewind argument
-        for arg in CommandLine.arguments {
-            if arg == "--mode=rewind" {
-                NSLog("OMI LaunchMode: Detected rewind mode from command line")
-                return .rewind
-            }
-        }
-        return .full
+  static func fromCommandLine() -> LaunchMode {
+    // Check for --mode=rewind argument
+    for arg in CommandLine.arguments {
+      if arg == "--mode=rewind" {
+        NSLog("OMI LaunchMode: Detected rewind mode from command line")
+        return .rewind
+      }
     }
+    return .full
+  }
 }
 
 // MARK: - Dev Flags
 /// Check for --skip-onboarding flag to bypass onboarding during development
 func shouldSkipOnboarding() -> Bool {
-    return CommandLine.arguments.contains("--skip-onboarding")
+  return CommandLine.arguments.contains("--skip-onboarding")
 }
 
 // Simple observable state without Firebase types
 @MainActor
 class AuthState: ObservableObject {
-    static let shared = AuthState()
+  static let shared = AuthState()
 
-    // UserDefaults keys (must match AuthService)
-    private static let kAuthIsSignedIn = "auth_isSignedIn"
-    private static let kAuthUserEmail = "auth_userEmail"
-    private static let kAuthUserId = "auth_userId"
+  // UserDefaults keys (must match AuthService)
+  private static let kAuthIsSignedIn = "auth_isSignedIn"
+  private static let kAuthUserEmail = "auth_userEmail"
+  private static let kAuthUserId = "auth_userId"
 
-    @Published var isSignedIn: Bool
-    @Published var isLoading: Bool = false
-    @Published var isRestoringAuth: Bool = true
-    @Published var error: String?
-    @Published var userEmail: String?
+  @Published var isSignedIn: Bool
+  @Published var isLoading: Bool = false
+  @Published var isRestoringAuth: Bool = true
+  @Published var error: String?
+  @Published var userEmail: String?
 
-    private init() {
-        // Restore auth state from UserDefaults immediately on init (before UI renders)
-        let savedSignedIn = UserDefaults.standard.bool(forKey: Self.kAuthIsSignedIn)
-        let savedEmail = UserDefaults.standard.string(forKey: Self.kAuthUserEmail)
-        self.isSignedIn = savedSignedIn
-        self.userEmail = savedEmail
-        // Show loading splash while Firebase restores session (only if user was previously signed in)
-        self.isRestoringAuth = savedSignedIn
-        NSLog("OMI AuthState: Initialized with savedSignedIn=%@, email=%@, isRestoringAuth=%@",
-              savedSignedIn ? "true" : "false", savedEmail ?? "nil", self.isRestoringAuth ? "true" : "false")
-    }
+  private init() {
+    // Restore auth state from UserDefaults immediately on init (before UI renders)
+    let savedSignedIn = UserDefaults.standard.bool(forKey: Self.kAuthIsSignedIn)
+    let savedEmail = UserDefaults.standard.string(forKey: Self.kAuthUserEmail)
+    self.isSignedIn = savedSignedIn
+    self.userEmail = savedEmail
+    // Show loading splash while Firebase restores session (only if user was previously signed in)
+    self.isRestoringAuth = savedSignedIn
+    NSLog(
+      "OMI AuthState: Initialized with savedSignedIn=%@, email=%@, isRestoringAuth=%@",
+      savedSignedIn ? "true" : "false", savedEmail ?? "nil", self.isRestoringAuth ? "true" : "false"
+    )
+  }
 
-    func update(isSignedIn: Bool, userEmail: String? = nil) {
-        self.isSignedIn = isSignedIn
-        self.userEmail = userEmail
-    }
+  func update(isSignedIn: Bool, userEmail: String? = nil) {
+    self.isSignedIn = isSignedIn
+    self.userEmail = userEmail
+  }
 
-    /// Get the user's Firebase UID from UserDefaults (fallback when Firebase SDK auth fails)
-    var userId: String? {
-        UserDefaults.standard.string(forKey: Self.kAuthUserId)
-    }
+  /// Get the user's Firebase UID from UserDefaults (fallback when Firebase SDK auth fails)
+  var userId: String? {
+    UserDefaults.standard.string(forKey: Self.kAuthUserId)
+  }
 }
 
 @main
 struct OMIApp: App {
-    @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
-    @StateObject private var appState = AppState()
-    @StateObject private var authState = AuthState.shared
-    @Environment(\.openWindow) private var openWindow
+  @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate
+  @StateObject private var appState = AppState()
+  @StateObject private var authState = AuthState.shared
+  @Environment(\.openWindow) private var openWindow
 
-    /// Launch mode determined at startup from command-line arguments
-    static let launchMode = LaunchMode.fromCommandLine()
+  /// Launch mode determined at startup from command-line arguments
+  static let launchMode = LaunchMode.fromCommandLine()
 
-    /// Window title with version number (different for rewind mode)
-    private var windowTitle: String {
-        // Keep a distinct title in dev builds so users can visually distinguish
-        // dev and production windows during side-by-side testing.
-        if Bundle.main.bundleIdentifier == "com.omi.desktop-dev" {
-            return Self.launchMode == .rewind ? "Omi Rewind Dev" : "Omi Dev"
+  /// Window title with version number (different for rewind mode)
+  private var windowTitle: String {
+    // Keep a distinct title in non-production builds so custom test apps are easy to identify.
+    if AppBuild.isNonProduction {
+      let baseName = AppBuild.displayName
+      return Self.launchMode == .rewind ? "\(baseName) Rewind" : baseName
+    }
+
+    let version =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
+    let baseName = Self.launchMode == .rewind ? "omi Rewind" : UpdateChannel.appDisplayName
+    return version.isEmpty ? baseName : "\(baseName) v\(version)"
+  }
+
+  /// Window size based on launch mode
+  private var defaultWindowSize: CGSize {
+    Self.launchMode == .rewind ? CGSize(width: 1000, height: 700) : CGSize(width: 1200, height: 800)
+  }
+
+  var body: some Scene {
+    let _ = Self.registerOpenMainWindowHandler(openWindow)
+
+    // Main desktop window - same view for both modes, sidebar hidden in rewind mode
+    return Window(windowTitle, id: "main") {
+      DesktopHomeView()
+        .withFontScaling()
+        .onAppear {
+          log("OmiApp: Main window content appeared (mode: \(Self.launchMode.rawValue))")
         }
-
-        let version = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? ""
-        let baseName = Self.launchMode == .rewind ? "omi Rewind" : UpdateChannel.appDisplayName
-        return version.isEmpty ? baseName : "\(baseName) v\(version)"
     }
-
-    /// Window size based on launch mode
-    private var defaultWindowSize: CGSize {
-        Self.launchMode == .rewind ? CGSize(width: 1000, height: 700) : CGSize(width: 1200, height: 800)
-    }
-
-    var body: some Scene {
-        let _ = Self.registerOpenMainWindowHandler(openWindow)
-
-        // Main desktop window - same view for both modes, sidebar hidden in rewind mode
-        return Window(windowTitle, id: "main") {
-            DesktopHomeView()
-                .withFontScaling()
-                .onAppear {
-                    log("OmiApp: Main window content appeared (mode: \(Self.launchMode.rawValue))")
-                }
+    .windowStyle(.titleBar)
+    .defaultSize(width: defaultWindowSize.width, height: defaultWindowSize.height)
+    .commands {
+      CommandGroup(after: .textFormatting) {
+        Button("Increase Font Size") {
+          let s = FontScaleSettings.shared
+          s.scale = min(2.0, round((s.scale + 0.05) * 20) / 20)
         }
-        .windowStyle(.titleBar)
-        .defaultSize(width: defaultWindowSize.width, height: defaultWindowSize.height)
-        .commands {
-            CommandGroup(after: .textFormatting) {
-                Button("Increase Font Size") {
-                    let s = FontScaleSettings.shared
-                    s.scale = min(2.0, round((s.scale + 0.05) * 20) / 20)
-                }
-                .keyboardShortcut("+", modifiers: .command)
+        .keyboardShortcut("+", modifiers: .command)
 
-                Button("Decrease Font Size") {
-                    let s = FontScaleSettings.shared
-                    s.scale = max(0.5, round((s.scale - 0.05) * 20) / 20)
-                }
-                .keyboardShortcut("-", modifiers: .command)
-
-                Button("Reset Font Size") {
-                    FontScaleSettings.shared.resetToDefault()
-                }
-                .keyboardShortcut("0", modifiers: .command)
-
-                Divider()
-
-                Button("Reset Window Size") {
-                    resetWindowToDefaultSize()
-                }
-            }
+        Button("Decrease Font Size") {
+          let s = FontScaleSettings.shared
+          s.scale = max(0.5, round((s.scale - 0.05) * 20) / 20)
         }
+        .keyboardShortcut("-", modifiers: .command)
 
-        // Note: Menu bar is now handled by NSStatusBar in AppDelegate.setupMenuBar()
-        // for better reliability on macOS Sequoia (SwiftUI MenuBarExtra had rendering issues)
+        Button("Reset Font Size") {
+          FontScaleSettings.shared.resetToDefault()
+        }
+        .keyboardShortcut("0", modifiers: .command)
+
+        Divider()
+
+        Button("Reset Window Size") {
+          resetWindowToDefaultSize()
+        }
+      }
     }
 
-    private static func registerOpenMainWindowHandler(_ openWindow: OpenWindowAction) {
-        AppDelegate.openMainWindow = { openWindow(id: "main") }
-    }
+    // Note: Menu bar is now handled by NSStatusBar in AppDelegate.setupMenuBar()
+    // for better reliability on macOS Sequoia (SwiftUI MenuBarExtra had rendering issues)
+  }
+
+  private static func registerOpenMainWindowHandler(_ openWindow: OpenWindowAction) {
+    AppDelegate.openMainWindow = { openWindow(id: "main") }
+  }
 }
 
 class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
-    static var openMainWindow: (() -> Void)?
+  static var openMainWindow: (() -> Void)?
 
-    private var sentryHeartbeatTimer: Timer?
-    private var globalHotkeyMonitor: Any?
-    private var localHotkeyMonitor: Any?
-    private var windowObservers: [NSObjectProtocol] = []
-    private var statusBarItem: NSStatusItem?
-    private var screenCaptureSwitch: NSSwitch?
-    private var audioRecordingSwitch: NSSwitch?
+  private var sentryHeartbeatTimer: Timer?
+  private var globalHotkeyMonitor: Any?
+  private var localHotkeyMonitor: Any?
+  private var windowObservers: [NSObjectProtocol] = []
+  private var statusBarItem: NSStatusItem?
+  private var screenCaptureSwitch: NSSwitch?
+  private var audioRecordingSwitch: NSSwitch?
 
-    func applicationDidFinishLaunching(_ notification: Notification) {
-        // Ignore SIGPIPE so broken-pipe writes return errors instead of crashing the app.
-        // Without this, writing to a dead FFmpeg stdin or agent-bridge pipe kills the process.
-        signal(SIGPIPE, SIG_IGN)
+  func applicationDidFinishLaunching(_ notification: Notification) {
+    // Ignore SIGPIPE so broken-pipe writes return errors instead of crashing the app.
+    // Without this, writing to a dead FFmpeg stdin or agent-bridge pipe kills the process.
+    signal(SIGPIPE, SIG_IGN)
 
-        DesktopAutomationBridge.shared.startIfNeeded()
+    DesktopAutomationBridge.shared.startIfNeeded()
 
-        // Strip com.apple.provenance xattrs that macOS adds when Sparkle extracts updates.
-        // These break the code signature seal, causing the NEXT update to fail with
-        // "An error occurred while running the updater."
-        stripProvenanceXattrs()
+    // Strip com.apple.provenance xattrs that macOS adds when Sparkle extracts updates.
+    // These break the code signature seal, causing the NEXT update to fail with
+    // "An error occurred while running the updater."
+    stripProvenanceXattrs()
 
-        log("AppDelegate: applicationDidFinishLaunching started (mode: \(OMIApp.launchMode.rawValue))")
-        log("AppDelegate: AuthState.isSignedIn=\(AuthState.shared.isSignedIn)")
+    log("AppDelegate: applicationDidFinishLaunching started (mode: \(OMIApp.launchMode.rawValue))")
+    log("AppDelegate: AuthState.isSignedIn=\(AuthState.shared.isSignedIn)")
 
-        // Force macOS to use the correct app icon (bypasses icon cache).
-        // Apply squircle mask with proper margins because NSApp.applicationIconImage
-        // renders the raw image without macOS auto-masking.
-        // Do NOT call NSWorkspace.setIcon(forFile:) — it writes a resource fork onto
-        // the .app bundle, which breaks the code signature and prevents Sparkle
-        // auto-updates from working ("An error occurred while running the updater").
-        if let iconURL = Bundle.resourceBundle.url(forResource: "omi_app_icon", withExtension: "png"),
-           let icon = NSImage(contentsOf: iconURL) {
-            let size = icon.size
-            let maskedIcon = NSImage(size: size)
-            maskedIcon.lockFocus()
-            // Scale content to ~88% with 6% margin on each side (matches macOS Dock icon sizing)
-            let margin = size.width * 0.06
-            let contentRect = NSRect(x: margin, y: margin,
-                                     width: size.width - margin * 2,
-                                     height: size.height - margin * 2)
-            // Corner radius ≈ 22.37% of content size
-            let radius = contentRect.width * 0.2237
-            let path = NSBezierPath(roundedRect: contentRect, xRadius: radius, yRadius: radius)
-            path.addClip()
-            icon.draw(in: contentRect)
-            maskedIcon.unlockFocus()
-            NSApp.applicationIconImage = maskedIcon
-            if let cfURL = Bundle.main.bundleURL as CFURL? {
-                LSRegisterURL(cfURL, true)
-            }
-            log("AppDelegate: Set application icon with squircle mask")
+    // Force macOS to use the correct app icon (bypasses icon cache).
+    // Apply squircle mask with proper margins because NSApp.applicationIconImage
+    // renders the raw image without macOS auto-masking.
+    // Do NOT call NSWorkspace.setIcon(forFile:) — it writes a resource fork onto
+    // the .app bundle, which breaks the code signature and prevents Sparkle
+    // auto-updates from working ("An error occurred while running the updater").
+    if let iconURL = Bundle.resourceBundle.url(forResource: "omi_app_icon", withExtension: "png"),
+      let icon = NSImage(contentsOf: iconURL)
+    {
+      let size = icon.size
+      let maskedIcon = NSImage(size: size)
+      maskedIcon.lockFocus()
+      // Scale content to ~88% with 6% margin on each side (matches macOS Dock icon sizing)
+      let margin = size.width * 0.06
+      let contentRect = NSRect(
+        x: margin, y: margin,
+        width: size.width - margin * 2,
+        height: size.height - margin * 2)
+      // Corner radius ≈ 22.37% of content size
+      let radius = contentRect.width * 0.2237
+      let path = NSBezierPath(roundedRect: contentRect, xRadius: radius, yRadius: radius)
+      path.addClip()
+      icon.draw(in: contentRect)
+      maskedIcon.unlockFocus()
+      NSApp.applicationIconImage = maskedIcon
+      if let cfURL = Bundle.main.bundleURL as CFURL? {
+        LSRegisterURL(cfURL, true)
+      }
+      log("AppDelegate: Set application icon with squircle mask")
+    }
+
+    // One-time icon cache reset: forces macOS to pick up the new squircle icon.
+    // Without this, users who had the old square icon see it cached indefinitely
+    // in the Dock, notifications, and Sparkle updater.
+    resetIconCacheIfNeeded()
+
+    // Initialize NotificationService early to set up UNUserNotificationCenterDelegate
+    // This ensures notifications display properly when app is in foreground
+    _ = NotificationService.shared
+
+    // Initialize Sparkle auto-updater early so the 10-minute check timer starts at launch
+    // Without this, the updater only starts when the user opens Settings or clicks "Check for Updates"
+    _ = UpdaterViewModel.shared
+    UpdaterViewModel.shared.checkForUpdatesImmediatelyAfterLaunchIfNeeded()
+
+    // Initialize Sentry for crash reporting and error tracking (including dev builds)
+    let isDev = AnalyticsManager.isDevBuild
+    SentrySDK.start { options in
+      options.dsn =
+        "https://8f700584deda57b26041ff015539c8c1@o4507617161314304.ingest.us.sentry.io/4510790686277632"
+      options.debug = false
+      options.enableAutoSessionTracking = true
+      options.environment = isDev ? "development" : "production"
+      // Disable automatic HTTP client error capture — the SDK creates noisy events
+      // for every 4xx/5xx response (e.g. Cloud Run 503 cold starts on /v1/crisp/unread).
+      // App code already handles HTTP errors and reports meaningful ones explicitly.
+      options.enableCaptureFailedRequests = false
+      options.maxBreadcrumbs = 100
+      options.beforeSend = { event in
+        // Allow user feedback through from all builds (dev + prod)
+        if event.message?.formatted.hasPrefix("User Report") == true { return event }
+        // Never send other events from dev builds — they pollute production Sentry data
+        if isDev { return nil }
+        // Filter out HTTP errors targeting the dev tunnel — noise when the tunnel is down
+        if let urlTag = event.tags?["url"], urlTag.contains("m13v.com") {
+          return nil
         }
-
-        // One-time icon cache reset: forces macOS to pick up the new squircle icon.
-        // Without this, users who had the old square icon see it cached indefinitely
-        // in the Dock, notifications, and Sparkle updater.
-        resetIconCacheIfNeeded()
-
-        // Initialize NotificationService early to set up UNUserNotificationCenterDelegate
-        // This ensures notifications display properly when app is in foreground
-        _ = NotificationService.shared
-
-        // Initialize Sparkle auto-updater early so the 10-minute check timer starts at launch
-        // Without this, the updater only starts when the user opens Settings or clicks "Check for Updates"
-        _ = UpdaterViewModel.shared
-        UpdaterViewModel.shared.checkForUpdatesImmediatelyAfterLaunchIfNeeded()
-
-        // Initialize Sentry for crash reporting and error tracking (including dev builds)
-        let isDev = AnalyticsManager.isDevBuild
-        SentrySDK.start { options in
-            options.dsn = "https://8f700584deda57b26041ff015539c8c1@o4507617161314304.ingest.us.sentry.io/4510790686277632"
-            options.debug = false
-            options.enableAutoSessionTracking = true
-            options.environment = isDev ? "development" : "production"
-            // Disable automatic HTTP client error capture — the SDK creates noisy events
-            // for every 4xx/5xx response (e.g. Cloud Run 503 cold starts on /v1/crisp/unread).
-            // App code already handles HTTP errors and reports meaningful ones explicitly.
-            options.enableCaptureFailedRequests = false
-            options.maxBreadcrumbs = 100
-            options.beforeSend = { event in
-                // Allow user feedback through from all builds (dev + prod)
-                if event.message?.formatted.hasPrefix("User Report") == true { return event }
-                // Never send other events from dev builds — they pollute production Sentry data
-                if isDev { return nil }
-                // Filter out HTTP errors targeting the dev tunnel — noise when the tunnel is down
-                if let urlTag = event.tags?["url"], urlTag.contains("m13v.com") {
-                    return nil
-                }
-                // Filter out NSURLErrorCancelled (-999) — these are intentional cancellations
-                // (e.g. proactive assistants cancelling in-flight Gemini requests on context switch)
-                if let exceptions = event.exceptions, exceptions.contains(where: { exc in
-                    exc.type == "NSURLErrorDomain" && exc.value.contains("Code=-999") ||
-                    exc.type == "NSURLErrorDomain" && exc.value.contains("Code: -999")
-                }) {
-                    return nil
-                }
-                // Filter out AuthError.notSignedIn — this is thrown when token refresh transiently
-                // fails (network blip, expired token mid-refresh). The user is still signed in per
-                // UserDefaults; the 30s refresh timer will retry. Not actionable as a Sentry error.
-                if let exceptions = event.exceptions, exceptions.contains(where: { exc in
-                    exc.type == "Omi_Computer.AuthError" && exc.value.contains("notSignedIn")
-                }) {
-                    return nil
-                }
-                return event
-            }
+        // Filter out NSURLErrorCancelled (-999) — these are intentional cancellations
+        // (e.g. proactive assistants cancelling in-flight Gemini requests on context switch)
+        if let exceptions = event.exceptions,
+          exceptions.contains(where: { exc in
+            exc.type == "NSURLErrorDomain" && exc.value.contains("Code=-999")
+              || exc.type == "NSURLErrorDomain" && exc.value.contains("Code: -999")
+          })
+        {
+          return nil
         }
-        log("Sentry initialized (environment: \(isDev ? "development" : "production"))")
-
-        // Initialize Firebase
-        let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist")
-
-        if let path = plistPath,
-           let options = FirebaseOptions(contentsOfFile: path) {
-            FirebaseApp.configure(options: options)
-            AuthService.shared.configure()
+        // Filter out AuthError.notSignedIn — this is thrown when token refresh transiently
+        // fails (network blip, expired token mid-refresh). The user is still signed in per
+        // UserDefaults; the 30s refresh timer will retry. Not actionable as a Sentry error.
+        if let exceptions = event.exceptions,
+          exceptions.contains(where: { exc in
+            exc.type == "Omi_Computer.AuthError" && exc.value.contains("notSignedIn")
+          })
+        {
+          return nil
         }
+        return event
+      }
+    }
+    log("Sentry initialized (environment: \(isDev ? "development" : "production"))")
 
-        // Initialize analytics (MixPanel + PostHog)
-        AnalyticsManager.shared.initialize()
-        AnalyticsManager.shared.appLaunched()
-        AnalyticsManager.shared.trackDisplayInfo()
+    // Initialize Firebase
+    let plistPath = Bundle.main.path(forResource: "GoogleService-Info", ofType: "plist")
 
-        // Tier gating: migrate old boolean key to new 6-tier system
-        TierManager.migrateExistingUsersIfNeeded()
+    if let path = plistPath,
+      let options = FirebaseOptions(contentsOfFile: path)
+    {
+      FirebaseApp.configure(options: options)
+      AuthService.shared.configure()
+    }
 
-        // All users get all features (tier 0 = show all)
-        // Note: hasLaunchedBefore is also set by trackFirstLaunchIfNeeded(), but that
-        // skips dev builds. Set it here too so tier doesn't reset on every dev launch.
-        if !UserDefaults.standard.bool(forKey: "hasLaunchedBefore") {
-            UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
-            UserDefaults.standard.set(0, forKey: "currentTierLevel")
-            UserDefaults.standard.set(0, forKey: "lastSeenTierLevel")
-            UserDefaults.standard.set(true, forKey: "userShowAllFeatures")
+    // Initialize analytics (MixPanel + PostHog)
+    AnalyticsManager.shared.initialize()
+    AnalyticsManager.shared.appLaunched()
+    AnalyticsManager.shared.trackDisplayInfo()
+
+    // Tier gating: migrate old boolean key to new 6-tier system
+    TierManager.migrateExistingUsersIfNeeded()
+
+    // All users get all features (tier 0 = show all)
+    // Note: hasLaunchedBefore is also set by trackFirstLaunchIfNeeded(), but that
+    // skips dev builds. Set it here too so tier doesn't reset on every dev launch.
+    if !UserDefaults.standard.bool(forKey: "hasLaunchedBefore") {
+      UserDefaults.standard.set(true, forKey: "hasLaunchedBefore")
+      UserDefaults.standard.set(0, forKey: "currentTierLevel")
+      UserDefaults.standard.set(0, forKey: "lastSeenTierLevel")
+      UserDefaults.standard.set(true, forKey: "userShowAllFeatures")
+    }
+
+    AnalyticsManager.shared.trackFirstLaunchIfNeeded()
+
+    // Set per-user database path before any async tasks can trigger DB initialization.
+    // This is synchronous and must happen before TierManager / TranscriptionRetryService.
+    let userId = UserDefaults.standard.string(forKey: "auth_userId")
+    RewindDatabase.currentUserId = (userId?.isEmpty == false) ? userId : "anonymous"
+
+    // Start resource monitoring (memory, CPU, disk)
+    ResourceMonitor.shared.start()
+
+    // Recover any pending/failed transcription sessions from previous runs
+    Task {
+      await TranscriptionRetryService.shared.recoverPendingTranscriptions()
+      TranscriptionRetryService.shared.start()
+    }
+
+    // Start recurring task scheduler (checks every 60s for due tasks)
+    RecurringTaskScheduler.shared.start()
+
+    // Identify user if already signed in
+    if AuthState.shared.isSignedIn {
+      AnalyticsManager.shared.identify()
+      // Set Sentry user context (now enabled for dev builds too)
+      if let email = AuthState.shared.userEmail {
+        let sentryUser = Sentry.User()
+        sentryUser.email = email
+        sentryUser.username =
+          AuthService.shared.displayName.isEmpty ? nil : AuthService.shared.displayName
+        SentrySDK.setUser(sentryUser)
+      }
+      // Fetch conversations on startup
+      AuthService.shared.fetchConversations()
+
+      // Fetch API keys from backend (keys are not bundled in the app)
+      Task {
+        await APIKeyService.shared.fetchKeys()
+      }
+
+      // Check tier eligibility (at most once per day)
+      Task {
+        await TierManager.shared.checkTierIfNeeded()
+      }
+
+      // Report comprehensive settings state (at most once per day)
+      AnalyticsManager.shared.reportAllSettingsIfNeeded()
+
+      // File indexing now runs through FileIndexingView UI (user consent required)
+      // No background scan — prevents race condition where scan finishes before UI listens
+    }
+
+    // One-time migration: Enable launch at login for existing users who haven't set it
+    migrateLaunchAtLoginDefault()
+
+    // One-time migration: Rename app bundle from legacy names to "omi.app"
+    migrateAppName()
+
+    // Track launch at login status once per app launch
+    Task { @MainActor in
+      let isEnabled = LaunchAtLoginManager.shared.isEnabled
+      AnalyticsManager.shared.launchAtLoginStatusChecked(enabled: isEnabled)
+    }
+
+    // Register for Apple Events to handle URL scheme
+    NSAppleEventManager.shared().setEventHandler(
+      self,
+      andSelector: #selector(handleGetURLEvent(_:withReplyEvent:)),
+      forEventClass: AEEventClass(kInternetEventClass),
+      andEventID: AEEventID(kAEGetURL)
+    )
+
+    // Register global hotkey for Rewind (Cmd+Shift+Space)
+    setupGlobalHotkeys()
+
+    // Register Carbon-based global shortcuts for floating control bar (Ask Omi)
+    GlobalShortcutManager.shared.registerShortcuts()
+
+    // Ensure app always shows in dock as a regular app
+    NSApp.setActivationPolicy(.regular)
+
+    // Set up menu bar icon with NSStatusBar (more reliable than SwiftUI MenuBarExtra)
+    // Called synchronously on main thread to ensure status item is created before app finishes launching
+    Task { @MainActor in
+      self.setupMenuBar()
+    }
+
+    // Periodic health check: verify menu bar icon is still visible every 30 seconds.
+    // Safety net for any edge case (macOS Sequoia bugs, activation policy races) that
+    // causes the status bar item to vanish while the process keeps running.
+    Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
+      DispatchQueue.main.async {
+        guard let self = self else { return }
+        let item = self.statusBarItem
+        let button = item?.button
+        let isPhantom = button != nil && button!.frame.width == 0
+        if item?.isVisible != true || button == nil || isPhantom {
+          log(
+            "AppDelegate: [MENUBAR] Health check: icon missing or phantom (visible=\(item?.isVisible ?? false), button=\(button != nil), frame=\(button?.frame ?? .zero)), recreating"
+          )
+          self.setupMenuBar()
         }
+      }
+    }
 
-        AnalyticsManager.shared.trackFirstLaunchIfNeeded()
+    // Start Sentry heartbeat timer (every 5 minutes) to capture breadcrumbs periodically
+    startSentryHeartbeat()
 
-        // Set per-user database path before any async tasks can trigger DB initialization.
-        // This is synchronous and must happen before TierManager / TranscriptionRetryService.
-        let userId = UserDefaults.standard.string(forKey: "auth_userId")
-        RewindDatabase.currentUserId = (userId?.isEmpty == false) ? userId : "anonymous"
-
-        // Start resource monitoring (memory, CPU, disk)
-        ResourceMonitor.shared.start()
-
-        // Recover any pending/failed transcription sessions from previous runs
-        Task {
-            await TranscriptionRetryService.shared.recoverPendingTranscriptions()
-            TranscriptionRetryService.shared.start()
+    // Activate app and show main window after a brief delay
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+      log("AppDelegate: Checking windows after 0.2s delay, count=\(NSApp.windows.count)")
+      NSApp.activate(ignoringOtherApps: true)
+      var foundOmiWindow = false
+      for window in NSApp.windows {
+        log("AppDelegate: Window title='\(window.title)', isVisible=\(window.isVisible)")
+        if window.title.hasPrefix("Omi") {
+          foundOmiWindow = true
+          window.makeKeyAndOrderFront(nil)
+          window.appearance = NSAppearance(named: .darkAqua)
+          // Ensure fullscreen always creates a dedicated Space
+          window.collectionBehavior.insert(.fullScreenPrimary)
+          log("AppDelegate: Main window shown on launch")
         }
+      }
+      if !foundOmiWindow {
+        log("AppDelegate: WARNING - 'Omi' window not found!")
+      }
+    }
 
-        // Start recurring task scheduler (checks every 60s for due tasks)
-        RecurringTaskScheduler.shared.start()
+    log("AppDelegate: applicationDidFinishLaunching completed")
+  }
 
-        // Identify user if already signed in
-        if AuthState.shared.isSignedIn {
-            AnalyticsManager.shared.identify()
-            // Set Sentry user context (now enabled for dev builds too)
-            if let email = AuthState.shared.userEmail {
-                let sentryUser = Sentry.User()
-                sentryUser.email = email
-                sentryUser.username = AuthService.shared.displayName.isEmpty ? nil : AuthService.shared.displayName
-                SentrySDK.setUser(sentryUser)
-            }
-            // Fetch conversations on startup
-            AuthService.shared.fetchConversations()
+  /// Start a timer that sends Sentry session snapshots every 5 minutes
+  /// This ensures we have breadcrumbs captured even without errors
+  private func startSentryHeartbeat() {
+    // Now runs in dev builds too since Sentry is always initialized
+    sentryHeartbeatTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
+      // Capture a session heartbeat event with current breadcrumbs
+      SentrySDK.capture(message: "Session Heartbeat") { scope in
+        scope.setLevel(.info)
+        scope.setTag(value: "heartbeat", key: "event_type")
+      }
+      log("Sentry: Session heartbeat captured")
+    }
+  }
 
-            // Fetch API keys from backend (keys are not bundled in the app)
-            Task {
-                await APIKeyService.shared.fetchKeys()
-            }
+  /// Strip com.apple.provenance extended attributes from our own bundle.
+  /// macOS adds these when Sparkle extracts the update ZIP, which breaks the code
+  /// signature seal and causes subsequent updates to fail.
+  private func stripProvenanceXattrs() {
+    let bundlePath = Bundle.main.bundlePath
+    DispatchQueue.global(qos: .utility).async {
+      let process = Process()
+      process.launchPath = "/usr/bin/xattr"
+      process.arguments = ["-cr", bundlePath]
+      process.standardOutput = nil
+      process.standardError = nil
+      try? process.run()
+      process.waitUntilExit()
+      if process.terminationStatus == 0 {
+        log("AppDelegate: Stripped provenance xattrs from bundle")
+      }
+    }
+  }
 
-            // Check tier eligibility (at most once per day)
-            Task {
-                await TierManager.shared.checkTierIfNeeded()
-            }
+  /// One-time icon cache reset to force macOS to pick up the new squircle icon.
+  /// Runs lsregister unregister/register + kills iconservicesagent (auto-restarts).
+  /// Includes a safety net to restart the Dock if it crashes during the reset.
+  private func resetIconCacheIfNeeded() {
+    let key = "hasResetIconCache_v2"
+    guard !UserDefaults.standard.bool(forKey: key) else { return }
+    UserDefaults.standard.set(true, forKey: key)
+    log("AppDelegate: Running one-time icon cache reset")
 
-            // Report comprehensive settings state (at most once per day)
-            AnalyticsManager.shared.reportAllSettingsIfNeeded()
+    let appPath = Bundle.main.bundlePath
+    let lsregister =
+      "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
 
-            // File indexing now runs through FileIndexingView UI (user consent required)
-            // No background scan — prevents race condition where scan finishes before UI listens
-        }
+    DispatchQueue.global(qos: .utility).async {
+      // Unregister to clear stale icon entries
+      let unregister = Process()
+      unregister.executableURL = URL(fileURLWithPath: lsregister)
+      unregister.arguments = ["-u", appPath]
+      unregister.standardOutput = FileHandle.nullDevice
+      unregister.standardError = FileHandle.nullDevice
+      try? unregister.run()
+      unregister.waitUntilExit()
 
-        // One-time migration: Enable launch at login for existing users who haven't set it
-        migrateLaunchAtLoginDefault()
+      // Force re-register with updated icon
+      let register = Process()
+      register.executableURL = URL(fileURLWithPath: lsregister)
+      register.arguments = ["-f", appPath]
+      register.standardOutput = FileHandle.nullDevice
+      register.standardError = FileHandle.nullDevice
+      try? register.run()
+      register.waitUntilExit()
 
-        // One-time migration: Rename app bundle from legacy names to "omi.app"
-        migrateAppName()
+      // Kill iconservicesagent to flush the icon cache (auto-restarts in <1s)
+      let killIcons = Process()
+      killIcons.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
+      killIcons.arguments = ["iconservicesagent"]
+      killIcons.standardOutput = FileHandle.nullDevice
+      killIcons.standardError = FileHandle.nullDevice
+      try? killIcons.run()
+      killIcons.waitUntilExit()
 
-        // Track launch at login status once per app launch
-        Task { @MainActor in
-            let isEnabled = LaunchAtLoginManager.shared.isEnabled
-            AnalyticsManager.shared.launchAtLoginStatusChecked(enabled: isEnabled)
-        }
+      // Safety net: verify the Dock is still running after 2 seconds.
+      // iconservicesagent restart can occasionally crash the Dock.
+      Thread.sleep(forTimeInterval: 2.0)
+      let dockCheck = Process()
+      dockCheck.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
+      dockCheck.arguments = ["-x", "Dock"]
+      dockCheck.standardOutput = FileHandle.nullDevice
+      dockCheck.standardError = FileHandle.nullDevice
+      try? dockCheck.run()
+      dockCheck.waitUntilExit()
 
-        // Register for Apple Events to handle URL scheme
-        NSAppleEventManager.shared().setEventHandler(
-            self,
-            andSelector: #selector(handleGetURLEvent(_:withReplyEvent:)),
-            forEventClass: AEEventClass(kInternetEventClass),
-            andEventID: AEEventID(kAEGetURL)
+      if dockCheck.terminationStatus != 0 {
+        // Dock is not running — restart it
+        log("AppDelegate: Dock not running after icon cache reset, restarting")
+        let restartDock = Process()
+        restartDock.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        restartDock.arguments = ["-a", "Dock"]
+        restartDock.standardOutput = FileHandle.nullDevice
+        restartDock.standardError = FileHandle.nullDevice
+        try? restartDock.run()
+        restartDock.waitUntilExit()
+      }
+
+      log("AppDelegate: Icon cache reset complete")
+    }
+  }
+
+  /// Set up global keyboard shortcuts
+  private func setupGlobalHotkeys() {
+    // Handler for Ctrl+Option+R -> Open Rewind
+    let hotkeyHandler: (NSEvent) -> NSEvent? = { event in
+      let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+      let keyCode = event.keyCode
+
+      // Log modifier key presses for debugging
+      if modifiers.contains(.control) || modifiers.contains(.option) {
+        log(
+          "AppDelegate: [HOTKEY] keyCode=\(keyCode), modifiers=\(modifiers.rawValue) (ctrl=\(modifiers.contains(.control)), opt=\(modifiers.contains(.option)))"
         )
+      }
 
-        // Register global hotkey for Rewind (Cmd+Shift+Space)
-        setupGlobalHotkeys()
+      // Check for Ctrl+Option+R (less likely to conflict with system shortcuts)
+      let isCtrlOption = modifiers.contains(.control) && modifiers.contains(.option)
+      let isR = keyCode == 15  // R key
 
-        // Register Carbon-based global shortcuts for floating control bar (Ask Omi)
-        GlobalShortcutManager.shared.registerShortcuts()
-
-        // Ensure app always shows in dock as a regular app
-        NSApp.setActivationPolicy(.regular)
-
-        // Set up menu bar icon with NSStatusBar (more reliable than SwiftUI MenuBarExtra)
-        // Called synchronously on main thread to ensure status item is created before app finishes launching
-        Task { @MainActor in
-            self.setupMenuBar()
-        }
-
-        // Periodic health check: verify menu bar icon is still visible every 30 seconds.
-        // Safety net for any edge case (macOS Sequoia bugs, activation policy races) that
-        // causes the status bar item to vanish while the process keeps running.
-        Timer.scheduledTimer(withTimeInterval: 30, repeats: true) { [weak self] _ in
-            DispatchQueue.main.async {
-                guard let self = self else { return }
-                let item = self.statusBarItem
-                let button = item?.button
-                let isPhantom = button != nil && button!.frame.width == 0
-                if item?.isVisible != true || button == nil || isPhantom {
-                    log("AppDelegate: [MENUBAR] Health check: icon missing or phantom (visible=\(item?.isVisible ?? false), button=\(button != nil), frame=\(button?.frame ?? .zero)), recreating")
-                    self.setupMenuBar()
-                }
+      if isCtrlOption && isR {
+        log("AppDelegate: [HOTKEY] Rewind hotkey MATCHED (Ctrl+Option+R)")
+        DispatchQueue.main.async {
+          log("AppDelegate: [HOTKEY] Activating app and posting notification")
+          // Bring app to front
+          NSApp.activate(ignoringOtherApps: true)
+          // Find and show main window
+          for window in NSApp.windows {
+            if window.title.hasPrefix("Omi") {
+              window.makeKeyAndOrderFront(nil)
+              break
             }
+          }
+          // Post notification to navigate to Rewind
+          NotificationCenter.default.post(name: .navigateToRewind, object: nil)
+          log("AppDelegate: [HOTKEY] Posted navigateToRewind notification")
         }
-
-        // Start Sentry heartbeat timer (every 5 minutes) to capture breadcrumbs periodically
-        startSentryHeartbeat()
-
-        // Activate app and show main window after a brief delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
-            log("AppDelegate: Checking windows after 0.2s delay, count=\(NSApp.windows.count)")
-            NSApp.activate(ignoringOtherApps: true)
-            var foundOmiWindow = false
-            for window in NSApp.windows {
-                log("AppDelegate: Window title='\(window.title)', isVisible=\(window.isVisible)")
-                if window.title.hasPrefix("Omi") {
-                    foundOmiWindow = true
-                    window.makeKeyAndOrderFront(nil)
-                    window.appearance = NSAppearance(named: .darkAqua)
-                    // Ensure fullscreen always creates a dedicated Space
-                    window.collectionBehavior.insert(.fullScreenPrimary)
-                    log("AppDelegate: Main window shown on launch")
-                }
-            }
-            if !foundOmiWindow {
-                log("AppDelegate: WARNING - 'Omi' window not found!")
-            }
-        }
-
-        log("AppDelegate: applicationDidFinishLaunching completed")
+      }
+      return event
     }
 
-    /// Start a timer that sends Sentry session snapshots every 5 minutes
-    /// This ensures we have breadcrumbs captured even without errors
-    private func startSentryHeartbeat() {
-        // Now runs in dev builds too since Sentry is always initialized
-        sentryHeartbeatTimer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { _ in
-            // Capture a session heartbeat event with current breadcrumbs
-            SentrySDK.capture(message: "Session Heartbeat") { scope in
-                scope.setLevel(.info)
-                scope.setTag(value: "heartbeat", key: "event_type")
-            }
-            log("Sentry: Session heartbeat captured")
-        }
+    // Ask Omi shortcut is registered via Carbon RegisterEventHotKey in
+    // GlobalShortcutManager (works regardless of accessibility permission state).
+
+    // Global monitor - for when OTHER apps are focused (Ctrl+Option+R only)
+    globalHotkeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+      _ = hotkeyHandler(event)
     }
 
-    /// Strip com.apple.provenance extended attributes from our own bundle.
-    /// macOS adds these when Sparkle extracts the update ZIP, which breaks the code
-    /// signature seal and causes subsequent updates to fail.
-    private func stripProvenanceXattrs() {
-        let bundlePath = Bundle.main.bundlePath
-        DispatchQueue.global(qos: .utility).async {
-            let process = Process()
-            process.launchPath = "/usr/bin/xattr"
-            process.arguments = ["-cr", bundlePath]
-            process.standardOutput = nil
-            process.standardError = nil
-            try? process.run()
-            process.waitUntilExit()
-            if process.terminationStatus == 0 {
-                log("AppDelegate: Stripped provenance xattrs from bundle")
-            }
-        }
+    // Local monitor - for when THIS app is focused (Ctrl+Option+R only)
+    localHotkeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+      return hotkeyHandler(event)
     }
 
-    /// One-time icon cache reset to force macOS to pick up the new squircle icon.
-    /// Runs lsregister unregister/register + kills iconservicesagent (auto-restarts).
-    /// Includes a safety net to restart the Dock if it crashes during the reset.
-    private func resetIconCacheIfNeeded() {
-        let key = "hasResetIconCache_v2"
-        guard !UserDefaults.standard.bool(forKey: key) else { return }
-        UserDefaults.standard.set(true, forKey: key)
-        log("AppDelegate: Running one-time icon cache reset")
+    log(
+      "AppDelegate: Hotkey monitors registered - global=\(globalHotkeyMonitor != nil), local=\(localHotkeyMonitor != nil)"
+    )
+    log("AppDelegate: Hotkey is Ctrl+Option+R (⌃⌥R), Ask Omi via Carbon hotkeys")
+  }
 
-        let appPath = Bundle.main.bundlePath
-        let lsregister = "/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+  // Dock icon is always visible — LSUIElement=false and activation policy stays .regular
 
-        DispatchQueue.global(qos: .utility).async {
-            // Unregister to clear stale icon entries
-            let unregister = Process()
-            unregister.executableURL = URL(fileURLWithPath: lsregister)
-            unregister.arguments = ["-u", appPath]
-            unregister.standardOutput = FileHandle.nullDevice
-            unregister.standardError = FileHandle.nullDevice
-            try? unregister.run()
-            unregister.waitUntilExit()
-
-            // Force re-register with updated icon
-            let register = Process()
-            register.executableURL = URL(fileURLWithPath: lsregister)
-            register.arguments = ["-f", appPath]
-            register.standardOutput = FileHandle.nullDevice
-            register.standardError = FileHandle.nullDevice
-            try? register.run()
-            register.waitUntilExit()
-
-            // Kill iconservicesagent to flush the icon cache (auto-restarts in <1s)
-            let killIcons = Process()
-            killIcons.executableURL = URL(fileURLWithPath: "/usr/bin/killall")
-            killIcons.arguments = ["iconservicesagent"]
-            killIcons.standardOutput = FileHandle.nullDevice
-            killIcons.standardError = FileHandle.nullDevice
-            try? killIcons.run()
-            killIcons.waitUntilExit()
-
-            // Safety net: verify the Dock is still running after 2 seconds.
-            // iconservicesagent restart can occasionally crash the Dock.
-            Thread.sleep(forTimeInterval: 2.0)
-            let dockCheck = Process()
-            dockCheck.executableURL = URL(fileURLWithPath: "/usr/bin/pgrep")
-            dockCheck.arguments = ["-x", "Dock"]
-            dockCheck.standardOutput = FileHandle.nullDevice
-            dockCheck.standardError = FileHandle.nullDevice
-            try? dockCheck.run()
-            dockCheck.waitUntilExit()
-
-            if dockCheck.terminationStatus != 0 {
-                // Dock is not running — restart it
-                log("AppDelegate: Dock not running after icon cache reset, restarting")
-                let restartDock = Process()
-                restartDock.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-                restartDock.arguments = ["-a", "Dock"]
-                restartDock.standardOutput = FileHandle.nullDevice
-                restartDock.standardError = FileHandle.nullDevice
-                try? restartDock.run()
-                restartDock.waitUntilExit()
-            }
-
-            log("AppDelegate: Icon cache reset complete")
-        }
+  /// Force-refresh the menu bar icon after activation policy changes.
+  /// Works around a macOS Sequoia bug where NSStatusBar items vanish
+  /// when switching to .accessory activation policy.
+  @MainActor private func refreshMenuBarIcon() {
+    guard let item = statusBarItem else {
+      // Status bar item was lost — recreate it
+      log("AppDelegate: [MENUBAR] refreshMenuBarIcon: statusBarItem is nil, recreating")
+      setupMenuBar()
+      return
     }
-
-    /// Set up global keyboard shortcuts
-    private func setupGlobalHotkeys() {
-        // Handler for Ctrl+Option+R -> Open Rewind
-        let hotkeyHandler: (NSEvent) -> NSEvent? = { event in
-            let modifiers = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            let keyCode = event.keyCode
-
-            // Log modifier key presses for debugging
-            if modifiers.contains(.control) || modifiers.contains(.option) {
-                log("AppDelegate: [HOTKEY] keyCode=\(keyCode), modifiers=\(modifiers.rawValue) (ctrl=\(modifiers.contains(.control)), opt=\(modifiers.contains(.option)))")
-            }
-
-            // Check for Ctrl+Option+R (less likely to conflict with system shortcuts)
-            let isCtrlOption = modifiers.contains(.control) && modifiers.contains(.option)
-            let isR = keyCode == 15 // R key
-
-            if isCtrlOption && isR {
-                log("AppDelegate: [HOTKEY] Rewind hotkey MATCHED (Ctrl+Option+R)")
-                DispatchQueue.main.async {
-                    log("AppDelegate: [HOTKEY] Activating app and posting notification")
-                    // Bring app to front
-                    NSApp.activate(ignoringOtherApps: true)
-                    // Find and show main window
-                    for window in NSApp.windows {
-                        if window.title.hasPrefix("Omi") {
-                            window.makeKeyAndOrderFront(nil)
-                            break
-                        }
-                    }
-                    // Post notification to navigate to Rewind
-                    NotificationCenter.default.post(name: .navigateToRewind, object: nil)
-                    log("AppDelegate: [HOTKEY] Posted navigateToRewind notification")
-                }
-            }
-            return event
+    // Re-assert visibility synchronously
+    item.isVisible = true
+    // Re-apply the icon to force the system to redraw
+    if let button = item.button {
+      if OMIApp.launchMode == .rewind {
+        if let icon = NSImage(
+          systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: "omi Rewind")
+        {
+          icon.isTemplate = true
+          button.image = icon
         }
-
-        // Ask Omi shortcut is registered via Carbon RegisterEventHotKey in
-        // GlobalShortcutManager (works regardless of accessibility permission state).
-
-        // Global monitor - for when OTHER apps are focused (Ctrl+Option+R only)
-        globalHotkeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
-            _ = hotkeyHandler(event)
-        }
-
-        // Local monitor - for when THIS app is focused (Ctrl+Option+R only)
-        localHotkeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            return hotkeyHandler(event)
-        }
-
-        log("AppDelegate: Hotkey monitors registered - global=\(globalHotkeyMonitor != nil), local=\(localHotkeyMonitor != nil)")
-        log("AppDelegate: Hotkey is Ctrl+Option+R (⌃⌥R), Ask Omi via Carbon hotkeys")
+      } else if let iconURL = Bundle.resourceBundle.url(
+        forResource: "omi_text_logo", withExtension: "png"),
+        let icon = NSImage(contentsOf: iconURL)
+      {
+        icon.isTemplate = true
+        let aspect = icon.size.width / icon.size.height
+        icon.size = NSSize(width: 16 * aspect, height: 16)
+        button.image = icon
+      }
     }
-
-    // Dock icon is always visible — LSUIElement=false and activation policy stays .regular
-
-    /// Force-refresh the menu bar icon after activation policy changes.
-    /// Works around a macOS Sequoia bug where NSStatusBar items vanish
-    /// when switching to .accessory activation policy.
-    @MainActor private func refreshMenuBarIcon() {
-        guard let item = statusBarItem else {
-            // Status bar item was lost — recreate it
-            log("AppDelegate: [MENUBAR] refreshMenuBarIcon: statusBarItem is nil, recreating")
-            setupMenuBar()
-            return
-        }
-        // Re-assert visibility synchronously
-        item.isVisible = true
-        // Re-apply the icon to force the system to redraw
-        if let button = item.button {
-            if OMIApp.launchMode == .rewind {
-                if let icon = NSImage(systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: "omi Rewind") {
-                    icon.isTemplate = true
-                    button.image = icon
-                }
-            } else if let iconURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
-                      let icon = NSImage(contentsOf: iconURL) {
-                icon.isTemplate = true
-                let aspect = icon.size.width / icon.size.height
-                icon.size = NSSize(width: 16 * aspect, height: 16)
-                button.image = icon
-            }
-        }
-        // Safety net: verify again after a short delay
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
-            let button = self?.statusBarItem?.button
-            let isPhantom = button != nil && button!.frame.width == 0
-            if self?.statusBarItem?.isVisible != true || isPhantom {
-                log("AppDelegate: [MENUBAR] Icon still not visible/phantom after refresh (frame=\(button?.frame ?? .zero)), recreating")
-                self?.setupMenuBar()
-            }
-        }
-        log("AppDelegate: [MENUBAR] Refreshed status bar item after policy change")
-    }
-
-    /// Set up menu bar icon using NSStatusBar (more reliable than SwiftUI MenuBarExtra)
-    @MainActor private func setupMenuBar() {
-        log("AppDelegate: [MENUBAR] Setting up NSStatusBar menu (macOS \(ProcessInfo.processInfo.operatingSystemVersionString))")
-        log("AppDelegate: [MENUBAR] Thread: \(Thread.isMainThread ? "main" : "background"), statusBar items: \(NSStatusBar.system.thickness)")
-
-        // Explicitly remove old status item before creating a new one.
-        // Relying on ARC deallocation alone can leave "phantom" items that exist
-        // in memory but never render on screen.
-        if let old = statusBarItem {
-            NSStatusBar.system.removeStatusItem(old)
-            statusBarItem = nil
-            log("AppDelegate: [MENUBAR] Removed old status bar item before recreating")
-        }
-
-        statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
-
-        guard let statusBarItem = statusBarItem else {
-            log("AppDelegate: [MENUBAR] ERROR - Failed to create status bar item")
-            SentrySDK.capture(message: "Failed to create NSStatusItem") { scope in
-                scope.setLevel(.error)
-                scope.setTag(value: "menu_bar", key: "component")
-            }
-            return
-        }
-
-        log("AppDelegate: [MENUBAR] NSStatusItem created successfully")
-
-        let displayName = Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "omi"
-
-        // Set up the button with icon — use "omi" text logo (not a circle)
-        if let button = statusBarItem.button {
-            if OMIApp.launchMode == .rewind {
-                // Rewind mode uses SF Symbol
-                if let icon = NSImage(systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: "omi Rewind") {
-                    icon.isTemplate = true
-                    button.image = icon
-                    log("AppDelegate: [MENUBAR] Rewind icon set successfully")
-                }
-            } else if let iconURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
-                      let icon = NSImage(contentsOf: iconURL) {
-                icon.isTemplate = true
-                // Scale to menu bar height (16pt) with proportional width
-                let aspect = icon.size.width / icon.size.height
-                icon.size = NSSize(width: 16 * aspect, height: 16)
-                button.image = icon
-                button.imagePosition = .imageOnly
-                log("AppDelegate: [MENUBAR] Omi text logo set successfully (size: \(icon.size))")
-            } else {
-                // Fallback to SF Symbol
-                if let icon = NSImage(systemSymbolName: "waveform", accessibilityDescription: "omi") {
-                    icon.isTemplate = true
-                    button.image = icon
-                }
-                log("AppDelegate: [MENUBAR] WARNING - Failed to load omi_text_logo, using fallback")
-            }
-            button.toolTip = OMIApp.launchMode == .rewind ? "omi Rewind" : displayName
-        } else {
-            log("AppDelegate: [MENUBAR] WARNING - statusBarItem.button is nil")
-        }
-
-        // Create menu
-        let menu = NSMenu()
-
-        // Quick toggles for screen capture and audio recording
-        let screenCaptureItem = NSMenuItem()
-        let screenCaptureView = makeToggleItemView(
-            title: "Screen Capture",
-            iconName: "rectangle.dashed.badge.record",
-            isOn: AssistantSettings.shared.screenAnalysisEnabled && ProactiveAssistantsPlugin.shared.isMonitoring,
-            action: #selector(screenCaptureToggled(_:))
+    // Safety net: verify again after a short delay
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+      let button = self?.statusBarItem?.button
+      let isPhantom = button != nil && button!.frame.width == 0
+      if self?.statusBarItem?.isVisible != true || isPhantom {
+        log(
+          "AppDelegate: [MENUBAR] Icon still not visible/phantom after refresh (frame=\(button?.frame ?? .zero)), recreating"
         )
-        screenCaptureItem.view = screenCaptureView
-        menu.addItem(screenCaptureItem)
+        self?.setupMenuBar()
+      }
+    }
+    log("AppDelegate: [MENUBAR] Refreshed status bar item after policy change")
+  }
 
-        let audioRecordingItem = NSMenuItem()
-        let audioRecordingView = makeToggleItemView(
-            title: "Audio Recording",
-            iconName: "mic.fill",
-            isOn: AssistantSettings.shared.transcriptionEnabled,
-            action: #selector(audioRecordingToggled(_:))
-        )
-        audioRecordingItem.view = audioRecordingView
-        menu.addItem(audioRecordingItem)
+  /// Set up menu bar icon using NSStatusBar (more reliable than SwiftUI MenuBarExtra)
+  @MainActor private func setupMenuBar() {
+    log(
+      "AppDelegate: [MENUBAR] Setting up NSStatusBar menu (macOS \(ProcessInfo.processInfo.operatingSystemVersionString))"
+    )
+    log(
+      "AppDelegate: [MENUBAR] Thread: \(Thread.isMainThread ? "main" : "background"), statusBar items: \(NSStatusBar.system.thickness)"
+    )
 
+    // Explicitly remove old status item before creating a new one.
+    // Relying on ARC deallocation alone can leave "phantom" items that exist
+    // in memory but never render on screen.
+    if let old = statusBarItem {
+      NSStatusBar.system.removeStatusItem(old)
+      statusBarItem = nil
+      log("AppDelegate: [MENUBAR] Removed old status bar item before recreating")
+    }
+
+    statusBarItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+
+    guard let statusBarItem = statusBarItem else {
+      log("AppDelegate: [MENUBAR] ERROR - Failed to create status bar item")
+      SentrySDK.capture(message: "Failed to create NSStatusItem") { scope in
+        scope.setLevel(.error)
+        scope.setTag(value: "menu_bar", key: "component")
+      }
+      return
+    }
+
+    log("AppDelegate: [MENUBAR] NSStatusItem created successfully")
+
+    let displayName =
+      Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String ?? "omi"
+
+    // Set up the button with icon — use "omi" text logo (not a circle)
+    if let button = statusBarItem.button {
+      if OMIApp.launchMode == .rewind {
+        // Rewind mode uses SF Symbol
+        if let icon = NSImage(
+          systemSymbolName: "clock.arrow.circlepath", accessibilityDescription: "omi Rewind")
+        {
+          icon.isTemplate = true
+          button.image = icon
+          log("AppDelegate: [MENUBAR] Rewind icon set successfully")
+        }
+      } else if let iconURL = Bundle.resourceBundle.url(
+        forResource: "omi_text_logo", withExtension: "png"),
+        let icon = NSImage(contentsOf: iconURL)
+      {
+        icon.isTemplate = true
+        // Scale to menu bar height (16pt) with proportional width
+        let aspect = icon.size.width / icon.size.height
+        icon.size = NSSize(width: 16 * aspect, height: 16)
+        button.image = icon
+        button.imagePosition = .imageOnly
+        log("AppDelegate: [MENUBAR] Omi text logo set successfully (size: \(icon.size))")
+      } else {
+        // Fallback to SF Symbol
+        if let icon = NSImage(systemSymbolName: "waveform", accessibilityDescription: "omi") {
+          icon.isTemplate = true
+          button.image = icon
+        }
+        log("AppDelegate: [MENUBAR] WARNING - Failed to load omi_text_logo, using fallback")
+      }
+      button.toolTip = OMIApp.launchMode == .rewind ? "omi Rewind" : displayName
+    } else {
+      log("AppDelegate: [MENUBAR] WARNING - statusBarItem.button is nil")
+    }
+
+    // Create menu
+    let menu = NSMenu()
+
+    // Quick toggles for screen capture and audio recording
+    let screenCaptureItem = NSMenuItem()
+    let screenCaptureView = makeToggleItemView(
+      title: "Screen Capture",
+      iconName: "rectangle.dashed.badge.record",
+      isOn: AssistantSettings.shared.screenAnalysisEnabled
+        && ProactiveAssistantsPlugin.shared.isMonitoring,
+      action: #selector(screenCaptureToggled(_:))
+    )
+    screenCaptureItem.view = screenCaptureView
+    menu.addItem(screenCaptureItem)
+
+    let audioRecordingItem = NSMenuItem()
+    let audioRecordingView = makeToggleItemView(
+      title: "Audio Recording",
+      iconName: "mic.fill",
+      isOn: AssistantSettings.shared.transcriptionEnabled,
+      action: #selector(audioRecordingToggled(_:))
+    )
+    audioRecordingItem.view = audioRecordingView
+    menu.addItem(audioRecordingItem)
+
+    menu.addItem(NSMenuItem.separator())
+
+    // Open app item
+    let openItem = NSMenuItem(
+      title: "Open \(displayName)", action: #selector(openOmiFromMenu), keyEquivalent: "o")
+    openItem.target = self
+    menu.addItem(openItem)
+
+    menu.addItem(NSMenuItem.separator())
+
+    // Check for Updates
+    let updatesItem = NSMenuItem(
+      title: "Check for Updates...", action: #selector(checkForUpdates), keyEquivalent: "")
+    updatesItem.target = self
+    menu.addItem(updatesItem)
+
+    menu.addItem(NSMenuItem.separator())
+
+    // Sign out / User info
+    if AuthState.shared.isSignedIn {
+      if let email = AuthState.shared.userEmail {
+        let emailItem = NSMenuItem(title: "Signed in as \(email)", action: nil, keyEquivalent: "")
+        emailItem.isEnabled = false
+        menu.addItem(emailItem)
         menu.addItem(NSMenuItem.separator())
+      }
 
-        // Open app item
-        let openItem = NSMenuItem(title: "Open \(displayName)", action: #selector(openOmiFromMenu), keyEquivalent: "o")
-        openItem.target = self
-        menu.addItem(openItem)
+      let resetItem = NSMenuItem(
+        title: "Reset Onboarding...", action: #selector(resetOnboarding), keyEquivalent: "")
+      resetItem.target = self
+      menu.addItem(resetItem)
 
-        menu.addItem(NSMenuItem.separator())
+      menu.addItem(NSMenuItem.separator())
 
-        // Check for Updates
-        let updatesItem = NSMenuItem(title: "Check for Updates...", action: #selector(checkForUpdates), keyEquivalent: "")
-        updatesItem.target = self
-        menu.addItem(updatesItem)
+      let reportItem = NSMenuItem(
+        title: "Report Issue...", action: #selector(reportIssue), keyEquivalent: "")
+      reportItem.target = self
+      menu.addItem(reportItem)
 
-        menu.addItem(NSMenuItem.separator())
+      menu.addItem(NSMenuItem.separator())
 
-        // Sign out / User info
-        if AuthState.shared.isSignedIn {
-            if let email = AuthState.shared.userEmail {
-                let emailItem = NSMenuItem(title: "Signed in as \(email)", action: nil, keyEquivalent: "")
-                emailItem.isEnabled = false
-                menu.addItem(emailItem)
-                menu.addItem(NSMenuItem.separator())
-            }
-
-            let resetItem = NSMenuItem(title: "Reset Onboarding...", action: #selector(resetOnboarding), keyEquivalent: "")
-            resetItem.target = self
-            menu.addItem(resetItem)
-
-            menu.addItem(NSMenuItem.separator())
-
-            let reportItem = NSMenuItem(title: "Report Issue...", action: #selector(reportIssue), keyEquivalent: "")
-            reportItem.target = self
-            menu.addItem(reportItem)
-
-            menu.addItem(NSMenuItem.separator())
-
-            let signOutItem = NSMenuItem(title: "Sign Out", action: #selector(signOut), keyEquivalent: "")
-            signOutItem.target = self
-            menu.addItem(signOutItem)
-        } else {
-            let notSignedInItem = NSMenuItem(title: "Not signed in", action: nil, keyEquivalent: "")
-            notSignedInItem.isEnabled = false
-            menu.addItem(notSignedInItem)
-        }
-
-        menu.addItem(NSMenuItem.separator())
-
-        // Quit item
-        let quitItem = NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q")
-        quitItem.target = self
-        menu.addItem(quitItem)
-
-        statusBarItem.menu = menu
-        menu.delegate = self
-        log("AppDelegate: [MENUBAR] Menu bar setup completed - icon visible in status bar")
-
-        // Verify the status item is valid
-        if let button = statusBarItem.button {
-            log("AppDelegate: [MENUBAR] VERIFY - button exists, frame: \(button.frame), isHidden: \(button.isHidden)")
-        } else {
-            log("AppDelegate: [MENUBAR] VERIFY - WARNING: button is nil after setup!")
-        }
+      let signOutItem = NSMenuItem(title: "Sign Out", action: #selector(signOut), keyEquivalent: "")
+      signOutItem.target = self
+      menu.addItem(signOutItem)
+    } else {
+      let notSignedInItem = NSMenuItem(title: "Not signed in", action: nil, keyEquivalent: "")
+      notSignedInItem.isEnabled = false
+      menu.addItem(notSignedInItem)
     }
 
-    @MainActor @objc private func openOmiFromMenu() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "open_omi")
-        NSApp.activate(ignoringOtherApps: true)
-        var foundWindow = revealMainWindowIfAvailable()
-        if !foundWindow {
-            Self.openMainWindow?()
-            foundWindow = revealMainWindowIfAvailable()
-        }
-        // Dock icon is always visible; just activate the app
-        NSApp.activate(ignoringOtherApps: true)
-        if !foundWindow {
-            log("AppDelegate: [MENUBAR] WARNING - No Omi window found when opening from menu bar")
-        }
+    menu.addItem(NSMenuItem.separator())
+
+    // Quit item
+    let quitItem = NSMenuItem(title: "Quit", action: #selector(quitApp), keyEquivalent: "q")
+    quitItem.target = self
+    menu.addItem(quitItem)
+
+    statusBarItem.menu = menu
+    menu.delegate = self
+    log("AppDelegate: [MENUBAR] Menu bar setup completed - icon visible in status bar")
+
+    // Verify the status item is valid
+    if let button = statusBarItem.button {
+      log(
+        "AppDelegate: [MENUBAR] VERIFY - button exists, frame: \(button.frame), isHidden: \(button.isHidden)"
+      )
+    } else {
+      log("AppDelegate: [MENUBAR] VERIFY - WARNING: button is nil after setup!")
     }
+  }
 
-    @MainActor private func revealMainWindowIfAvailable() -> Bool {
-        for window in NSApp.windows {
-            let isRealAppWindow = window.frame.width > 300 && window.frame.height > 200
-            let isMenuBarPopover = window.title.hasPrefix("Item-")
-            if isRealAppWindow && !isMenuBarPopover {
-                window.makeKeyAndOrderFront(nil)
-                window.appearance = NSAppearance(named: .darkAqua)
-                return true
-            }
-        }
-        return false
+  @MainActor @objc private func openOmiFromMenu() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "open_omi")
+    NSApp.activate(ignoringOtherApps: true)
+    var foundWindow = revealMainWindowIfAvailable()
+    if !foundWindow {
+      Self.openMainWindow?()
+      foundWindow = revealMainWindowIfAvailable()
     }
-
-    @MainActor @objc private func checkForUpdates() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "check_updates")
-        UpdaterViewModel.shared.checkForUpdates()
+    // Dock icon is always visible; just activate the app
+    NSApp.activate(ignoringOtherApps: true)
+    if !foundWindow {
+      log("AppDelegate: [MENUBAR] WARNING - No Omi window found when opening from menu bar")
     }
+  }
 
-    @MainActor @objc private func resetOnboarding() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "reset_onboarding")
-        AppState().resetOnboardingAndRestart()
-    }
-
-    @MainActor @objc private func reportIssue() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "report_issue")
-        FeedbackWindow.show(userEmail: AuthState.shared.userEmail)
-    }
-
-    @MainActor @objc private func signOut() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "sign_out")
-        ProactiveAssistantsPlugin.shared.stopMonitoring()
-        try? AuthService.shared.signOut()
-    }
-
-    @MainActor @objc private func quitApp() {
-        AnalyticsManager.shared.menuBarActionClicked(action: "quit")
-        NSApplication.shared.terminate(nil)
-    }
-
-    // MARK: - Menu Bar Toggle Items
-
-    /// Create a custom NSView for a menu item with an icon, label, and toggle switch
-    private func makeToggleItemView(title: String, iconName: String, isOn: Bool, action: Selector) -> NSView {
-        let height: CGFloat = 36
-        let width: CGFloat = 260
-        let view = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
-
-        // Icon — use a fixed-size image with symbol configuration for consistent rendering
-        let iconView = NSImageView(frame: NSRect(x: 16, y: 10, width: 16, height: 16))
-        let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
-        if let img = NSImage(systemSymbolName: iconName, accessibilityDescription: title)?.withSymbolConfiguration(config) {
-            iconView.image = img
-            iconView.contentTintColor = .secondaryLabelColor
-        }
-        view.addSubview(iconView)
-
-        // Label
-        let label = NSTextField(labelWithString: title)
-        label.frame = NSRect(x: 40, y: 10, width: 150, height: 16)
-        label.font = .systemFont(ofSize: 13)
-        label.textColor = .labelColor
-        view.addSubview(label)
-
-        // Toggle switch — use .small for consistent rendering across items
-        let toggle = NSSwitch()
-        toggle.controlSize = .small
-        toggle.state = isOn ? .on : .off
-        toggle.target = self
-        toggle.action = action
-        toggle.sizeToFit()
-        // Right-aligned position, pinned to right edge even when menu resizes the view
-        let toggleX = width - toggle.frame.width - 16
-        let toggleY = (height - toggle.frame.height) / 2
-        toggle.frame = NSRect(x: toggleX, y: toggleY, width: toggle.frame.width, height: toggle.frame.height)
-        toggle.autoresizingMask = [.minXMargin]
-        view.addSubview(toggle)
-
-        // Store reference for later updates
-        if action == #selector(screenCaptureToggled(_:)) {
-            screenCaptureSwitch = toggle
-        } else if action == #selector(audioRecordingToggled(_:)) {
-            audioRecordingSwitch = toggle
-        }
-
-        return view
-    }
-
-    @MainActor @objc private func screenCaptureToggled(_ sender: NSSwitch) {
-        let enabled = sender.state == .on
-        log("AppDelegate: [MENUBAR] Screen capture toggled: \(enabled)")
-        AnalyticsManager.shared.menuBarActionClicked(action: enabled ? "screen_capture_on" : "screen_capture_off")
-        AnalyticsManager.shared.settingToggled(setting: "monitoring", enabled: enabled)
-
-        if enabled {
-            if !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
-                // No permission — revert toggle and open preferences
-                sender.state = .off
-                ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
-                return
-            }
-            AssistantSettings.shared.screenAnalysisEnabled = true
-            ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
-                DispatchQueue.main.async {
-                    if !success {
-                        log("AppDelegate: [MENUBAR] Screen capture failed to start: \(error ?? "unknown")")
-                        sender.state = .off
-                        AssistantSettings.shared.screenAnalysisEnabled = false
-                    }
-                }
-            }
-        } else {
-            AssistantSettings.shared.screenAnalysisEnabled = false
-            ProactiveAssistantsPlugin.shared.stopMonitoring()
-        }
-    }
-
-    @MainActor @objc private func audioRecordingToggled(_ sender: NSSwitch) {
-        let enabled = sender.state == .on
-        log("AppDelegate: [MENUBAR] Audio recording toggled: \(enabled)")
-        AnalyticsManager.shared.menuBarActionClicked(action: enabled ? "audio_recording_on" : "audio_recording_off")
-        AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
-
-        AssistantSettings.shared.transcriptionEnabled = enabled
-        // Request the main view to start/stop transcription (needs AppState)
-        NotificationCenter.default.post(
-            name: .toggleTranscriptionRequested,
-            object: nil,
-            userInfo: ["enabled": enabled]
-        )
-    }
-
-    // MARK: - NSMenuDelegate
-    func menuWillOpen(_ menu: NSMenu) {
-        log("AppDelegate: [MENUBAR] Menu opened by user")
-        AnalyticsManager.shared.menuBarOpened()
-        // Refresh toggle states to match current runtime state
-        screenCaptureSwitch?.state = ProactiveAssistantsPlugin.shared.isMonitoring ? .on : .off
-        audioRecordingSwitch?.state = AssistantSettings.shared.transcriptionEnabled ? .on : .off
-    }
-
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
-        // Keep app running in menu bar when all windows are closed
-        return false
-    }
-
-    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        // Always try to show the main Omi window when dock icon is clicked
-        for window in sender.windows where window.title.hasPrefix("Omi") {
-            if window.isMiniaturized {
-                window.deminiaturize(nil)
-            }
-            window.makeKeyAndOrderFront(nil)
-            sender.activate(ignoringOtherApps: true)
-            log("AppDelegate: Restored Omi window from dock click (wasVisible=\(flag))")
-            return false
-        }
+  @MainActor private func revealMainWindowIfAvailable() -> Bool {
+    for window in NSApp.windows {
+      let isRealAppWindow = window.frame.width > 300 && window.frame.height > 200
+      let isMenuBarPopover = window.title.hasPrefix("Item-")
+      if isRealAppWindow && !isMenuBarPopover {
+        window.makeKeyAndOrderFront(nil)
+        window.appearance = NSAppearance(named: .darkAqua)
         return true
+      }
+    }
+    return false
+  }
+
+  @MainActor @objc private func checkForUpdates() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "check_updates")
+    UpdaterViewModel.shared.checkForUpdates()
+  }
+
+  @MainActor @objc private func resetOnboarding() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "reset_onboarding")
+    AppState().resetOnboardingAndRestart()
+  }
+
+  @MainActor @objc private func reportIssue() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "report_issue")
+    FeedbackWindow.show(userEmail: AuthState.shared.userEmail)
+  }
+
+  @MainActor @objc private func signOut() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "sign_out")
+    ProactiveAssistantsPlugin.shared.stopMonitoring()
+    try? AuthService.shared.signOut()
+  }
+
+  @MainActor @objc private func quitApp() {
+    AnalyticsManager.shared.menuBarActionClicked(action: "quit")
+    NSApplication.shared.terminate(nil)
+  }
+
+  // MARK: - Menu Bar Toggle Items
+
+  /// Create a custom NSView for a menu item with an icon, label, and toggle switch
+  private func makeToggleItemView(title: String, iconName: String, isOn: Bool, action: Selector)
+    -> NSView
+  {
+    let height: CGFloat = 36
+    let width: CGFloat = 260
+    let view = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+
+    // Icon — use a fixed-size image with symbol configuration for consistent rendering
+    let iconView = NSImageView(frame: NSRect(x: 16, y: 10, width: 16, height: 16))
+    let config = NSImage.SymbolConfiguration(pointSize: 13, weight: .medium)
+    if let img = NSImage(systemSymbolName: iconName, accessibilityDescription: title)?
+      .withSymbolConfiguration(config)
+    {
+      iconView.image = img
+      iconView.contentTintColor = .secondaryLabelColor
+    }
+    view.addSubview(iconView)
+
+    // Label
+    let label = NSTextField(labelWithString: title)
+    label.frame = NSRect(x: 40, y: 10, width: 150, height: 16)
+    label.font = .systemFont(ofSize: 13)
+    label.textColor = .labelColor
+    view.addSubview(label)
+
+    // Toggle switch — use .small for consistent rendering across items
+    let toggle = NSSwitch()
+    toggle.controlSize = .small
+    toggle.state = isOn ? .on : .off
+    toggle.target = self
+    toggle.action = action
+    toggle.sizeToFit()
+    // Right-aligned position, pinned to right edge even when menu resizes the view
+    let toggleX = width - toggle.frame.width - 16
+    let toggleY = (height - toggle.frame.height) / 2
+    toggle.frame = NSRect(
+      x: toggleX, y: toggleY, width: toggle.frame.width, height: toggle.frame.height)
+    toggle.autoresizingMask = [.minXMargin]
+    view.addSubview(toggle)
+
+    // Store reference for later updates
+    if action == #selector(screenCaptureToggled(_:)) {
+      screenCaptureSwitch = toggle
+    } else if action == #selector(audioRecordingToggled(_:)) {
+      audioRecordingSwitch = toggle
     }
 
-    func applicationWillTerminate(_ notification: Notification) {
-        // Remove window observers
-        for observer in windowObservers {
-            NotificationCenter.default.removeObserver(observer)
+    return view
+  }
+
+  @MainActor @objc private func screenCaptureToggled(_ sender: NSSwitch) {
+    let enabled = sender.state == .on
+    log("AppDelegate: [MENUBAR] Screen capture toggled: \(enabled)")
+    AnalyticsManager.shared.menuBarActionClicked(
+      action: enabled ? "screen_capture_on" : "screen_capture_off")
+    AnalyticsManager.shared.settingToggled(setting: "monitoring", enabled: enabled)
+
+    if enabled {
+      if !ProactiveAssistantsPlugin.shared.hasScreenRecordingPermission {
+        // No permission — revert toggle and open preferences
+        sender.state = .off
+        ProactiveAssistantsPlugin.shared.openScreenRecordingPreferences()
+        return
+      }
+      AssistantSettings.shared.screenAnalysisEnabled = true
+      ProactiveAssistantsPlugin.shared.startMonitoring { success, error in
+        DispatchQueue.main.async {
+          if !success {
+            log("AppDelegate: [MENUBAR] Screen capture failed to start: \(error ?? "unknown")")
+            sender.state = .off
+            AssistantSettings.shared.screenAnalysisEnabled = false
+          }
         }
-        windowObservers.removeAll()
-        // Remove hotkey monitors
-        if let monitor = globalHotkeyMonitor {
-            NSEvent.removeMonitor(monitor)
-            globalHotkeyMonitor = nil
-        }
-        if let monitor = localHotkeyMonitor {
-            NSEvent.removeMonitor(monitor)
-            localHotkeyMonitor = nil
-        }
-        // Remove floating bar shortcuts
-        GlobalShortcutManager.shared.unregisterShortcuts()
+      }
+    } else {
+      AssistantSettings.shared.screenAnalysisEnabled = false
+      ProactiveAssistantsPlugin.shared.stopMonitoring()
+    }
+  }
 
-        // Stop push-to-talk
-        PushToTalkManager.shared.cleanup()
+  @MainActor @objc private func audioRecordingToggled(_ sender: NSSwitch) {
+    let enabled = sender.state == .on
+    log("AppDelegate: [MENUBAR] Audio recording toggled: \(enabled)")
+    AnalyticsManager.shared.menuBarActionClicked(
+      action: enabled ? "audio_recording_on" : "audio_recording_off")
+    AnalyticsManager.shared.settingToggled(setting: "transcription", enabled: enabled)
 
-        // Stop heartbeat timer
-        sentryHeartbeatTimer?.invalidate()
-        sentryHeartbeatTimer = nil
+    AssistantSettings.shared.transcriptionEnabled = enabled
+    // Request the main view to start/stop transcription (needs AppState)
+    NotificationCenter.default.post(
+      name: .toggleTranscriptionRequested,
+      object: nil,
+      userInfo: ["enabled": enabled]
+    )
+  }
 
-        // Stop transcription retry service
-        TranscriptionRetryService.shared.stop()
+  // MARK: - NSMenuDelegate
+  func menuWillOpen(_ menu: NSMenu) {
+    log("AppDelegate: [MENUBAR] Menu opened by user")
+    AnalyticsManager.shared.menuBarOpened()
+    // Refresh toggle states to match current runtime state
+    screenCaptureSwitch?.state = ProactiveAssistantsPlugin.shared.isMonitoring ? .on : .off
+    audioRecordingSwitch?.state = AssistantSettings.shared.transcriptionEnabled ? .on : .off
+  }
 
-        // Stop recurring task scheduler
-        RecurringTaskScheduler.shared.stop()
+  func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+    // Keep app running in menu bar when all windows are closed
+    return false
+  }
 
-        // Mark clean shutdown so next launch skips expensive DB integrity check
-        RewindDatabase.markCleanShutdown()
+  func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool
+  {
+    // Always try to show the main Omi window when dock icon is clicked
+    for window in sender.windows where window.title.hasPrefix("Omi") {
+      if window.isMiniaturized {
+        window.deminiaturize(nil)
+      }
+      window.makeKeyAndOrderFront(nil)
+      sender.activate(ignoringOtherApps: true)
+      log("AppDelegate: Restored Omi window from dock click (wasVisible=\(flag))")
+      return false
+    }
+    return true
+  }
 
-        // Report final resources before termination
-        ResourceMonitor.shared.reportResourcesNow(context: "app_terminating")
-        ResourceMonitor.shared.stop()
+  func applicationWillTerminate(_ notification: Notification) {
+    // Remove window observers
+    for observer in windowObservers {
+      NotificationCenter.default.removeObserver(observer)
+    }
+    windowObservers.removeAll()
+    // Remove hotkey monitors
+    if let monitor = globalHotkeyMonitor {
+      NSEvent.removeMonitor(monitor)
+      globalHotkeyMonitor = nil
+    }
+    if let monitor = localHotkeyMonitor {
+      NSEvent.removeMonitor(monitor)
+      localHotkeyMonitor = nil
+    }
+    // Remove floating bar shortcuts
+    GlobalShortcutManager.shared.unregisterShortcuts()
 
-        // Capture final session snapshot before termination (now enabled for dev builds too)
-        SentrySDK.capture(message: "App Terminating") { scope in
-            scope.setLevel(.info)
-            scope.setTag(value: "lifecycle", key: "event_type")
-        }
+    // Stop push-to-talk
+    PushToTalkManager.shared.cleanup()
+
+    // Stop heartbeat timer
+    sentryHeartbeatTimer?.invalidate()
+    sentryHeartbeatTimer = nil
+
+    // Stop transcription retry service
+    TranscriptionRetryService.shared.stop()
+
+    // Stop recurring task scheduler
+    RecurringTaskScheduler.shared.stop()
+
+    // Mark clean shutdown so next launch skips expensive DB integrity check
+    RewindDatabase.markCleanShutdown()
+
+    // Report final resources before termination
+    ResourceMonitor.shared.reportResourcesNow(context: "app_terminating")
+    ResourceMonitor.shared.stop()
+
+    // Capture final session snapshot before termination (now enabled for dev builds too)
+    SentrySDK.capture(message: "App Terminating") { scope in
+      scope.setLevel(.info)
+      scope.setTag(value: "lifecycle", key: "event_type")
+    }
+  }
+
+  @objc func handleGetURLEvent(
+    _ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor
+  ) {
+    guard
+      let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue,
+      let url = URL(string: urlString)
+    else {
+      return
     }
 
-    @objc func handleGetURLEvent(_ event: NSAppleEventDescriptor, withReplyEvent replyEvent: NSAppleEventDescriptor) {
-        guard let urlString = event.paramDescriptor(forKeyword: AEKeyword(keyDirectObject))?.stringValue,
-              let url = URL(string: urlString) else {
-            return
-        }
+    NSLog("OMI AppDelegate: Received URL event: %@", urlString)
 
-        NSLog("OMI AppDelegate: Received URL event: %@", urlString)
+    Task { @MainActor in
+      AuthService.shared.handleOAuthCallback(url: url)
+    }
+  }
 
-        Task { @MainActor in
-            AuthService.shared.handleOAuthCallback(url: url)
-        }
+  /// One-time migration to enable launch at login for existing users
+  /// Only runs once, and only enables if user hasn't explicitly set a preference
+  private func migrateLaunchAtLoginDefault() {
+    let migrationKey = "didMigrateLaunchAtLoginV1"
+
+    // Skip if migration already done
+    guard !UserDefaults.standard.bool(forKey: migrationKey) else {
+      return
     }
 
-    /// One-time migration to enable launch at login for existing users
-    /// Only runs once, and only enables if user hasn't explicitly set a preference
-    private func migrateLaunchAtLoginDefault() {
-        let migrationKey = "didMigrateLaunchAtLoginV1"
+    // Mark migration as done (do this first to ensure it only runs once)
+    UserDefaults.standard.set(true, forKey: migrationKey)
 
-        // Skip if migration already done
-        guard !UserDefaults.standard.bool(forKey: migrationKey) else {
-            return
+    // Only enable for users who have completed onboarding (existing users)
+    // New users will get this enabled at the end of onboarding
+    let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+    guard hasCompletedOnboarding else {
+      log("LaunchAtLogin migration: Skipped - user hasn't completed onboarding yet")
+      return
+    }
+
+    // Check current status - only enable if not already registered
+    // This respects users who may have explicitly disabled it via System Settings
+    Task { @MainActor in
+      let manager = LaunchAtLoginManager.shared
+      if !manager.isEnabled {
+        let success = manager.setEnabled(true)
+        log("LaunchAtLogin migration: Enabled for existing user (success: \(success))")
+        if success {
+          AnalyticsManager.shared.launchAtLoginChanged(enabled: true, source: "migration")
         }
+      } else {
+        log("LaunchAtLogin migration: Already enabled, skipping")
+      }
+    }
+  }
 
-        // Mark migration as done (do this first to ensure it only runs once)
-        UserDefaults.standard.set(true, forKey: migrationKey)
+  private func migrateAppName() {
+    // No rename migration — APFS is case-insensitive so "omi.app" and "Omi.app"
+    // collide. Renaming the running app also breaks Dock pins and Spotlight indexing.
+    // The app ships as "omi.app" for new installs; existing users keep their current
+    // bundle name and get updates in-place via Sparkle.
 
-        // Only enable for users who have completed onboarding (existing users)
-        // New users will get this enabled at the end of onboarding
-        let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
-        guard hasCompletedOnboarding else {
-            log("LaunchAtLogin migration: Skipped - user hasn't completed onboarding yet")
-            return
+    // Clean up stale legacy bundles (never the running app)
+    cleanupLegacyAppBundles()
+  }
+
+  private func cleanupLegacyAppBundles() {
+    let currentPath = Bundle.main.bundlePath
+    let oldAppPaths = [
+      "/Applications/Omi Computer.app",
+      NSHomeDirectory() + "/Applications/Omi Computer.app",
+    ]
+
+    for oldPath in oldAppPaths {
+      // Never delete the running app
+      guard oldPath != currentPath else { continue }
+      guard FileManager.default.fileExists(atPath: oldPath) else { continue }
+
+      log("Found old app at \(oldPath), cleaning up...")
+
+      // Kill the old app if it's running
+      let running = NSRunningApplication.runningApplications(
+        withBundleIdentifier: "com.omi.computer-macos")
+      for app in running {
+        guard app.processIdentifier != ProcessInfo.processInfo.processIdentifier else { continue }
+        log("Terminating old Omi Computer process (PID \(app.processIdentifier))")
+        app.forceTerminate()
+      }
+
+      // Wait briefly for termination, then delete
+      DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1.0) {
+        do {
+          try FileManager.default.removeItem(atPath: oldPath)
+          log("Deleted old app at \(oldPath)")
+        } catch {
+          log("Failed to delete old app: \(error.localizedDescription)")
+          // Try moving to trash as fallback
+          do {
+            try FileManager.default.trashItem(
+              at: URL(fileURLWithPath: oldPath), resultingItemURL: nil)
+            log("Moved old app to trash")
+          } catch {
+            log("Failed to trash old app: \(error.localizedDescription)")
+          }
         }
-
-        // Check current status - only enable if not already registered
-        // This respects users who may have explicitly disabled it via System Settings
-        Task { @MainActor in
-            let manager = LaunchAtLoginManager.shared
-            if !manager.isEnabled {
-                let success = manager.setEnabled(true)
-                log("LaunchAtLogin migration: Enabled for existing user (success: \(success))")
-                if success {
-                    AnalyticsManager.shared.launchAtLoginChanged(enabled: true, source: "migration")
-                }
-            } else {
-                log("LaunchAtLogin migration: Already enabled, skipping")
-            }
-        }
+      }
     }
+  }
 
-    private func migrateAppName() {
-        // No rename migration — APFS is case-insensitive so "omi.app" and "Omi.app"
-        // collide. Renaming the running app also breaks Dock pins and Spotlight indexing.
-        // The app ships as "omi.app" for new installs; existing users keep their current
-        // bundle name and get updates in-place via Sparkle.
+  func applicationDidBecomeActive(_ notification: Notification) {
+    AnalyticsManager.shared.appBecameActive()
+    // Sync remote assistant settings so server-side changes take effect promptly
+    Task { await SettingsSyncManager.shared.syncFromServer() }
+  }
 
-        // Clean up stale legacy bundles (never the running app)
-        cleanupLegacyAppBundles()
-    }
-
-    private func cleanupLegacyAppBundles() {
-        let currentPath = Bundle.main.bundlePath
-        let oldAppPaths = [
-            "/Applications/Omi Computer.app",
-            NSHomeDirectory() + "/Applications/Omi Computer.app",
-        ]
-
-        for oldPath in oldAppPaths {
-            // Never delete the running app
-            guard oldPath != currentPath else { continue }
-            guard FileManager.default.fileExists(atPath: oldPath) else { continue }
-
-            log("Found old app at \(oldPath), cleaning up...")
-
-            // Kill the old app if it's running
-            let running = NSRunningApplication.runningApplications(withBundleIdentifier: "com.omi.computer-macos")
-            for app in running {
-                guard app.processIdentifier != ProcessInfo.processInfo.processIdentifier else { continue }
-                log("Terminating old Omi Computer process (PID \(app.processIdentifier))")
-                app.forceTerminate()
-            }
-
-            // Wait briefly for termination, then delete
-            DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 1.0) {
-                do {
-                    try FileManager.default.removeItem(atPath: oldPath)
-                    log("Deleted old app at \(oldPath)")
-                } catch {
-                    log("Failed to delete old app: \(error.localizedDescription)")
-                    // Try moving to trash as fallback
-                    do {
-                        try FileManager.default.trashItem(at: URL(fileURLWithPath: oldPath), resultingItemURL: nil)
-                        log("Moved old app to trash")
-                    } catch {
-                        log("Failed to trash old app: \(error.localizedDescription)")
-                    }
-                }
-            }
-        }
-    }
-
-    func applicationDidBecomeActive(_ notification: Notification) {
-        AnalyticsManager.shared.appBecameActive()
-        // Sync remote assistant settings so server-side changes take effect promptly
-        Task { await SettingsSyncManager.shared.syncFromServer() }
-    }
-
-    func applicationWillResignActive(_ notification: Notification) {
-        AnalyticsManager.shared.appResignedActive()
-    }
+  func applicationWillResignActive(_ notification: Notification) {
+    AnalyticsManager.shared.appResignedActive()
+  }
 }

--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -1,6 +1,6 @@
-import SwiftUI
-import MarkdownUI
 import GRDB
+import MarkdownUI
+import SwiftUI
 
 // MARK: - Onboarding Chat Persistence
 
@@ -8,1852 +8,2008 @@ import GRDB
 /// Messages are stored on the backend via the normal chat save path — only the ACP session ID
 /// and a mid-onboarding flag are kept in UserDefaults for restart recovery.
 enum OnboardingChatPersistence {
-    private static let sessionIdKey = "onboardingACPSessionId"
-    private static let midOnboardingKey = "onboardingMidOnboarding"
-    private static let explorationTextKey = "onboardingExplorationText"
-    private static let explorationCompletedKey = "onboardingExplorationCompleted"
-    private static let toolCompletedKey = "onboardingToolCompleted"
+  private static let sessionIdKey = "onboardingACPSessionId"
+  private static let midOnboardingKey = "onboardingMidOnboarding"
+  private static let explorationTextKey = "onboardingExplorationText"
+  private static let explorationCompletedKey = "onboardingExplorationCompleted"
+  private static let toolCompletedKey = "onboardingToolCompleted"
 
-    /// Save the ACP session ID for resume after restart
-    static func saveSessionId(_ sessionId: String) {
-        UserDefaults.standard.set(sessionId, forKey: sessionIdKey)
-    }
+  /// Save the ACP session ID for resume after restart
+  static func saveSessionId(_ sessionId: String) {
+    UserDefaults.standard.set(sessionId, forKey: sessionIdKey)
+  }
 
-    /// Load the saved ACP session ID
-    static func loadSessionId() -> String? {
-        UserDefaults.standard.string(forKey: sessionIdKey)
-    }
+  /// Load the saved ACP session ID
+  static func loadSessionId() -> String? {
+    UserDefaults.standard.string(forKey: sessionIdKey)
+  }
 
-    /// Mark that onboarding is in progress (for restart detection)
-    static func saveMidOnboarding() {
-        UserDefaults.standard.set(true, forKey: midOnboardingKey)
-    }
+  /// Mark that onboarding is in progress (for restart detection)
+  static func saveMidOnboarding() {
+    UserDefaults.standard.set(true, forKey: midOnboardingKey)
+  }
 
-    /// Whether the app was restarted mid-onboarding
-    static var isMidOnboarding: Bool {
-        UserDefaults.standard.bool(forKey: midOnboardingKey)
-    }
+  /// Whether the app was restarted mid-onboarding
+  static var isMidOnboarding: Bool {
+    UserDefaults.standard.bool(forKey: midOnboardingKey)
+  }
 
-    // MARK: - Exploration Persistence
+  // MARK: - Exploration Persistence
 
-    /// Save exploration state so it survives app restarts
-    static func saveExplorationState(text: String, completed: Bool) {
-        UserDefaults.standard.set(text, forKey: explorationTextKey)
-        UserDefaults.standard.set(completed, forKey: explorationCompletedKey)
-    }
+  /// Save exploration state so it survives app restarts
+  static func saveExplorationState(text: String, completed: Bool) {
+    UserDefaults.standard.set(text, forKey: explorationTextKey)
+    UserDefaults.standard.set(completed, forKey: explorationCompletedKey)
+  }
 
-    /// Load saved exploration state (returns nil if no exploration was saved)
-    static func loadExplorationState() -> (text: String, completed: Bool)? {
-        let text = UserDefaults.standard.string(forKey: explorationTextKey) ?? ""
-        let completed = UserDefaults.standard.bool(forKey: explorationCompletedKey)
-        guard !text.isEmpty || completed else { return nil }
-        return (text, completed)
-    }
+  /// Load saved exploration state (returns nil if no exploration was saved)
+  static func loadExplorationState() -> (text: String, completed: Bool)? {
+    let text = UserDefaults.standard.string(forKey: explorationTextKey) ?? ""
+    let completed = UserDefaults.standard.bool(forKey: explorationCompletedKey)
+    guard !text.isEmpty || completed else { return nil }
+    return (text, completed)
+  }
 
-    /// Whether exploration already completed in a prior session
-    static var isExplorationCompleted: Bool {
-        UserDefaults.standard.bool(forKey: explorationCompletedKey)
-    }
+  /// Whether exploration already completed in a prior session
+  static var isExplorationCompleted: Bool {
+    UserDefaults.standard.bool(forKey: explorationCompletedKey)
+  }
 
-    // MARK: - Tool Completion
+  // MARK: - Tool Completion
 
-    /// Mark that `complete_onboarding` tool was called (so button shows on restart)
-    static func markToolCompleted() {
-        UserDefaults.standard.set(true, forKey: toolCompletedKey)
-    }
+  /// Mark that `complete_onboarding` tool was called (so button shows on restart)
+  static func markToolCompleted() {
+    UserDefaults.standard.set(true, forKey: toolCompletedKey)
+  }
 
-    /// Whether `complete_onboarding` was already called in a prior session
-    static var isToolCompleted: Bool {
-        UserDefaults.standard.bool(forKey: toolCompletedKey)
-    }
+  /// Whether `complete_onboarding` was already called in a prior session
+  static var isToolCompleted: Bool {
+    UserDefaults.standard.bool(forKey: toolCompletedKey)
+  }
 
-    /// Clear all persisted onboarding data
-    static func clear() {
-        UserDefaults.standard.removeObject(forKey: sessionIdKey)
-        UserDefaults.standard.removeObject(forKey: midOnboardingKey)
-        UserDefaults.standard.removeObject(forKey: explorationTextKey)
-        UserDefaults.standard.removeObject(forKey: explorationCompletedKey)
-        UserDefaults.standard.removeObject(forKey: toolCompletedKey)
-        // Clean up legacy messages key if present
-        UserDefaults.standard.removeObject(forKey: "onboardingChatMessages")
-    }
+  /// Clear all persisted onboarding data
+  static func clear() {
+    UserDefaults.standard.removeObject(forKey: sessionIdKey)
+    UserDefaults.standard.removeObject(forKey: midOnboardingKey)
+    UserDefaults.standard.removeObject(forKey: explorationTextKey)
+    UserDefaults.standard.removeObject(forKey: explorationCompletedKey)
+    UserDefaults.standard.removeObject(forKey: toolCompletedKey)
+    // Clean up legacy messages key if present
+    UserDefaults.standard.removeObject(forKey: "onboardingChatMessages")
+  }
 }
 
 // MARK: - Onboarding Chat View
 
 struct OnboardingChatView: View {
-    @ObservedObject var appState: AppState
-    @ObservedObject var chatProvider: ChatProvider
-    var graphViewModel: MemoryGraphViewModel?
-    var onComplete: () -> Void
-    var onSkip: () -> Void
+  @ObservedObject var appState: AppState
+  @ObservedObject var chatProvider: ChatProvider
+  var graphViewModel: MemoryGraphViewModel?
+  var onComplete: () -> Void
+  var onSkip: () -> Void
 
-    @State private var inputText: String = ""
-    @State private var hasStarted: Bool = false
-    @State private var onboardingCompleted: Bool = false
-    @State private var quickReplyOptions: [String] = []
-    @State private var quickReplyQuestion: String = ""
-    @State private var isTaskSelectionFollowup: Bool = false
-    @State private var awaitingGoalInput: Bool = false
-    @State private var awaitingDailyTaskInput: Bool = false
-    @State private var createdGoalTitles: Set<String> = []
-    @State private var createdTaskTitles: Set<String> = []
-    @State private var isGrantingPermission: Bool = false
-    @State private var pendingPermissionType: String? = nil  // e.g. "microphone" — waiting for user to grant
-    @FocusState private var isInputFocused: Bool
+  @State private var inputText: String = ""
+  @State private var hasStarted: Bool = false
+  @State private var onboardingCompleted: Bool = false
+  @State private var quickReplyOptions: [String] = []
+  @State private var quickReplyQuestion: String = ""
+  @State private var isTaskSelectionFollowup: Bool = false
+  @State private var awaitingGoalInput: Bool = false
+  @State private var awaitingDailyTaskInput: Bool = false
+  @State private var createdGoalTitles: Set<String> = []
+  @State private var createdTaskTitles: Set<String> = []
+  @State private var isGrantingPermission: Bool = false
+  @State private var pendingPermissionType: String? = nil  // e.g. "microphone" — waiting for user to grant
+  @FocusState private var isInputFocused: Bool
 
-    // Parallel exploration state
-    @State private var explorationBridge: ACPBridge?
-    @State private var explorationRunning = false
-    @State private var explorationCompleted = false
-    @State private var explorationText = ""
-    @State private var explorationTask: Task<Void, Never>?
+  // Parallel exploration state
+  @State private var explorationBridge: ACPBridge?
+  @State private var explorationRunning = false
+  @State private var explorationCompleted = false
+  @State private var explorationText = ""
+  @State private var explorationTask: Task<Void, Never>?
 
-    // Gmail reading state (runs alongside exploration during onboarding)
-    @State private var gmailReadingRunning = false
-    @State private var gmailReadingCompleted = false
-    @State private var gmailReadingText = ""
-    @State private var gmailReadingTask: Task<Void, Never>?
+  // Gmail reading state (runs alongside exploration during onboarding)
+  @State private var gmailReadingRunning = false
+  @State private var gmailReadingCompleted = false
+  @State private var gmailReadingText = ""
+  @State private var gmailReadingTask: Task<Void, Never>?
 
-    // Calendar reading state (runs alongside exploration during onboarding)
-    @State private var calendarReadingRunning = false
-    @State private var calendarReadingCompleted = false
-    @State private var calendarReadingText = ""
-    @State private var calendarReadingTask: Task<Void, Never>?
+  // Calendar reading state (runs alongside exploration during onboarding)
+  @State private var calendarReadingRunning = false
+  @State private var calendarReadingCompleted = false
+  @State private var calendarReadingText = ""
+  @State private var calendarReadingTask: Task<Void, Never>?
 
-    @State private var showSkipConfirmation = false
+  @State private var showSkipConfirmation = false
+  @State private var recoveredOnboardingFallbackTask: Task<Void, Never>?
 
-    // Timer to periodically check permission status
-    let permissionCheckTimer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
+  // Timer to periodically check permission status
+  let permissionCheckTimer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
 
-    var body: some View {
-        VStack(spacing: 0) {
-            // Header
-            HStack {
-                if let logoImage = whiteTemplateLogoImage() {
-                    Image(nsImage: logoImage)
-                        .resizable()
-                        .renderingMode(.template)
-                        .foregroundColor(.white)
-                        .scaledToFit()
-                        .frame(width: 52, height: 18)
-                        .accessibilityLabel("omi")
-                } else {
-                    Text("omi")
-                        .font(.system(size: 18, weight: .semibold))
-                        .foregroundColor(.white)
+  var body: some View {
+    VStack(spacing: 0) {
+      // Header
+      HStack {
+        if let logoImage = whiteTemplateLogoImage() {
+          Image(nsImage: logoImage)
+            .resizable()
+            .renderingMode(.template)
+            .foregroundColor(.white)
+            .scaledToFit()
+            .frame(width: 52, height: 18)
+            .accessibilityLabel("omi")
+        } else {
+          Text("omi")
+            .font(.system(size: 18, weight: .semibold))
+            .foregroundColor(.white)
+        }
+
+        Spacer()
+
+        Button(action: { showSkipConfirmation = true }) {
+          Text("Skip")
+            .font(.system(size: 13))
+            .foregroundColor(OmiColors.textTertiary)
+        }
+        .buttonStyle(.plain)
+        .alert("Are you sure?", isPresented: $showSkipConfirmation) {
+          Button("Skip anyway", role: .destructive) { onSkip() }
+          Button("Continue setup", role: .cancel) {}
+        } message: {
+          Text("Omi won't be useful for you if it doesn't know enough about you.")
+        }
+      }
+      .padding(.horizontal, 24)
+      .padding(.vertical, 16)
+
+      Divider()
+        .background(OmiColors.backgroundTertiary)
+
+      // Chat messages
+      ScrollViewReader { proxy in
+        ScrollView {
+          VStack(spacing: 16) {
+            ForEach(chatProvider.messages) { message in
+              OnboardingChatBubble(
+                message: message,
+                hidePermissionImages: !quickReplyOptions.isEmpty || pendingPermissionType != nil
+                  || awaitingGoalInput
+              )
+              .id(message.id)
+            }
+
+            // Parallel exploration card (appears after scan_files)
+            if !shouldHideExplorationCard
+              && (explorationRunning || (explorationCompleted && !explorationText.isEmpty))
+            {
+              ExplorationProfileCard(
+                text: explorationText,
+                isRunning: explorationRunning,
+                isCompleted: explorationCompleted
+              )
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.leading, 44)  // align with message text
+              .id("exploration-card")
+            }
+
+            // Gmail insights card (appears alongside exploration)
+            if !shouldHideExplorationCard
+              && (gmailReadingRunning || (gmailReadingCompleted && !gmailReadingText.isEmpty))
+            {
+              GmailInsightsCard(
+                text: gmailReadingText,
+                isRunning: gmailReadingRunning,
+                isCompleted: gmailReadingCompleted
+              )
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.leading, 44)
+              .id("gmail-card")
+            }
+
+            // Calendar insights card (appears alongside exploration)
+            if !shouldHideExplorationCard
+              && (calendarReadingRunning
+                || (calendarReadingCompleted && !calendarReadingText.isEmpty))
+            {
+              CalendarInsightsCard(
+                text: calendarReadingText,
+                isRunning: calendarReadingRunning,
+                isCompleted: calendarReadingCompleted
+              )
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.leading, 44)
+              .id("calendar-card")
+            }
+
+            // Typing indicator (floating, no avatar)
+            if chatProvider.isSending {
+              TypingIndicator()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 44)  // align with message text (32px avatar + 12px spacing)
+                .id("typing")
+            }
+
+            // Quick reply buttons
+            if !quickReplyOptions.isEmpty && !chatProvider.isSending {
+              if !quickReplyQuestion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text(quickReplyQuestion)
+                  .font(.system(size: 14, weight: .medium))
+                  .foregroundColor(OmiColors.textPrimary)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .padding(.leading, 44)
+              }
+
+              // Show permission media for permission-related quick replies, including
+              // post-request follow-ups like "Done with Screen Recording?"
+              if let permType = permissionType(for: quickReplyQuestion, options: quickReplyOptions)
+              {
+                OnboardingPermissionImage(permissionType: permType)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .padding(.leading, 44)
+              }
+
+              HStack(spacing: 8) {
+                ForEach(quickReplyOptions, id: \.self) { option in
+                  Button(action: {
+                    handleQuickReply(option)
+                  }) {
+                    Text(option)
+                      .font(.system(size: 13, weight: .medium))
+                      .foregroundColor(isGrantButton(option) ? .white : OmiColors.purplePrimary)
+                      .padding(.horizontal, 16)
+                      .padding(.vertical, 8)
+                      .background(
+                        isGrantButton(option)
+                          ? OmiColors.purplePrimary
+                          : OmiColors.purplePrimary.opacity(0.1)
+                      )
+                      .cornerRadius(20)
+                      .overlay(
+                        RoundedRectangle(cornerRadius: 20)
+                          .stroke(OmiColors.purplePrimary.opacity(0.3), lineWidth: 1)
+                      )
+                  }
+                  .buttonStyle(.plain)
+                  .disabled(isGrantingPermission)
                 }
+              }
+              .frame(maxWidth: .infinity, alignment: .leading)
+              .padding(.leading, 44)  // align with message text
+              .id("quick-replies")
+            }
 
-                Spacer()
+            // Retry "Open System Settings" button — shown when a permission grant
+            // is pending but System Settings didn't open (or user closed it)
+            if let pending = pendingPermissionType,
+              quickReplyOptions.isEmpty && !chatProvider.isSending
+            {
+              let isStillPending: Bool = {
+                switch pending {
+                case "screen_recording": return !appState.hasScreenRecordingPermission
+                case "microphone": return !appState.hasMicrophonePermission
+                case "notifications": return !appState.hasNotificationPermission
+                case "accessibility": return !appState.hasAccessibilityPermission
+                case "automation": return !appState.hasAutomationPermission
+                case "full_disk_access": return !appState.hasFullDiskAccess
+                default: return false
+                }
+              }()
+              if isStillPending {
+                OnboardingPermissionImage(permissionType: pending)
+                  .frame(maxWidth: .infinity, alignment: .leading)
+                  .padding(.leading, 44)
 
-                Button(action: { showSkipConfirmation = true }) {
-                    Text("Skip")
-                        .font(.system(size: 13))
-                        .foregroundColor(OmiColors.textTertiary)
+                Button(action: {
+                  openSettingsForPermission(pending)
+                }) {
+                  HStack(spacing: 6) {
+                    Image(systemName: "gear")
+                      .font(.system(size: 12))
+                    Text("Open System Settings")
+                      .font(.system(size: 13, weight: .medium))
+                  }
+                  .foregroundColor(.white)
+                  .padding(.horizontal, 16)
+                  .padding(.vertical, 8)
+                  .background(OmiColors.purplePrimary)
+                  .cornerRadius(20)
                 }
                 .buttonStyle(.plain)
-                .alert("Are you sure?", isPresented: $showSkipConfirmation) {
-                    Button("Skip anyway", role: .destructive) { onSkip() }
-                    Button("Continue setup", role: .cancel) { }
-                } message: {
-                    Text("Omi won't be useful for you if it doesn't know enough about you.")
-                }
-            }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 16)
-
-            Divider()
-                .background(OmiColors.backgroundTertiary)
-
-            // Chat messages
-            ScrollViewReader { proxy in
-                ScrollView {
-                    VStack(spacing: 16) {
-                        ForEach(chatProvider.messages) { message in
-                                OnboardingChatBubble(
-                                    message: message,
-                                    hidePermissionImages: !quickReplyOptions.isEmpty || pendingPermissionType != nil || awaitingGoalInput
-                                )
-                                    .id(message.id)
-                        }
-
-                        // Parallel exploration card (appears after scan_files)
-                        if !shouldHideExplorationCard && (explorationRunning || (explorationCompleted && !explorationText.isEmpty)) {
-                            ExplorationProfileCard(
-                                text: explorationText,
-                                isRunning: explorationRunning,
-                                isCompleted: explorationCompleted
-                            )
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 44) // align with message text
-                            .id("exploration-card")
-                        }
-
-                        // Gmail insights card (appears alongside exploration)
-                        if !shouldHideExplorationCard && (gmailReadingRunning || (gmailReadingCompleted && !gmailReadingText.isEmpty)) {
-                            GmailInsightsCard(
-                                text: gmailReadingText,
-                                isRunning: gmailReadingRunning,
-                                isCompleted: gmailReadingCompleted
-                            )
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 44)
-                            .id("gmail-card")
-                        }
-
-                        // Calendar insights card (appears alongside exploration)
-                        if !shouldHideExplorationCard && (calendarReadingRunning || (calendarReadingCompleted && !calendarReadingText.isEmpty)) {
-                            CalendarInsightsCard(
-                                text: calendarReadingText,
-                                isRunning: calendarReadingRunning,
-                                isCompleted: calendarReadingCompleted
-                            )
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 44)
-                            .id("calendar-card")
-                        }
-
-                        // Typing indicator (floating, no avatar)
-                        if chatProvider.isSending {
-                            TypingIndicator()
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.leading, 44) // align with message text (32px avatar + 12px spacing)
-                                .id("typing")
-                        }
-
-                        // Quick reply buttons
-                        if !quickReplyOptions.isEmpty && !chatProvider.isSending {
-                            if !quickReplyQuestion.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                                Text(quickReplyQuestion)
-                                    .font(.system(size: 14, weight: .medium))
-                                    .foregroundColor(OmiColors.textPrimary)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.leading, 44)
-                            }
-
-                            // Show permission GIF when quick replies include a "Grant" button
-                            if let grantOption = quickReplyOptions.first(where: { isGrantButton($0) }),
-                               let permType = permissionType(from: grantOption) {
-                                OnboardingPermissionImage(permissionType: permType)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.leading, 44)
-                            }
-
-                            HStack(spacing: 8) {
-                                ForEach(quickReplyOptions, id: \.self) { option in
-                                    Button(action: {
-                                        handleQuickReply(option)
-                                    }) {
-                                        Text(option)
-                                            .font(.system(size: 13, weight: .medium))
-                                            .foregroundColor(isGrantButton(option) ? .white : OmiColors.purplePrimary)
-                                            .padding(.horizontal, 16)
-                                            .padding(.vertical, 8)
-                                            .background(
-                                                isGrantButton(option)
-                                                    ? OmiColors.purplePrimary
-                                                    : OmiColors.purplePrimary.opacity(0.1)
-                                            )
-                                            .cornerRadius(20)
-                                            .overlay(
-                                                RoundedRectangle(cornerRadius: 20)
-                                                    .stroke(OmiColors.purplePrimary.opacity(0.3), lineWidth: 1)
-                                            )
-                                    }
-                                    .buttonStyle(.plain)
-                                    .disabled(isGrantingPermission)
-                                }
-                            }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.leading, 44) // align with message text
-                            .id("quick-replies")
-                        }
-
-                        // Retry "Open System Settings" button — shown when a permission grant
-                        // is pending but System Settings didn't open (or user closed it)
-                        if let pending = pendingPermissionType, quickReplyOptions.isEmpty && !chatProvider.isSending {
-                            let isStillPending: Bool = {
-                                switch pending {
-                                case "screen_recording": return !appState.hasScreenRecordingPermission
-                                case "microphone": return !appState.hasMicrophonePermission
-                                case "notifications": return !appState.hasNotificationPermission
-                                case "accessibility": return !appState.hasAccessibilityPermission
-                                case "automation": return !appState.hasAutomationPermission
-                                case "full_disk_access": return !appState.hasFullDiskAccess
-                                default: return false
-                                }
-                            }()
-                            if isStillPending {
-                                OnboardingPermissionImage(permissionType: pending)
-                                    .frame(maxWidth: .infinity, alignment: .leading)
-                                    .padding(.leading, 44)
-
-                                Button(action: {
-                                    openSettingsForPermission(pending)
-                                }) {
-                                    HStack(spacing: 6) {
-                                        Image(systemName: "gear")
-                                            .font(.system(size: 12))
-                                        Text("Open System Settings")
-                                            .font(.system(size: 13, weight: .medium))
-                                    }
-                                    .foregroundColor(.white)
-                                    .padding(.horizontal, 16)
-                                    .padding(.vertical, 8)
-                                    .background(OmiColors.purplePrimary)
-                                    .cornerRadius(20)
-                                }
-                                .buttonStyle(.plain)
-                                .frame(maxWidth: .infinity, alignment: .leading)
-                                .padding(.leading, 44)
-                            }
-                        }
-
-                        // "Continue" button — shown only after AI calls complete_onboarding
-                        // and no pending questions or permissions remain.
-                        if onboardingCompleted && !chatProvider.isSending && quickReplyOptions.isEmpty && pendingPermissionType == nil {
-                            Button(action: {
-                                handleOnboardingComplete()
-                            }) {
-                                Text("Continue")
-                                    .font(.system(size: 15, weight: .semibold))
-                                    .foregroundColor(.white)
-                                    .frame(maxWidth: 220)
-                                    .padding(.vertical, 12)
-                                    .background(OmiColors.purplePrimary)
-                                    .cornerRadius(12)
-                            }
-                            .buttonStyle(.plain)
-                            .padding(.top, 12)
-                        }
-
-                        // Extra spacing so quick replies / buttons don't sit against the input field
-                        Spacer().frame(height: 20)
-                    }
-                    .padding(20)
-
-                    // Invisible anchor at the very bottom — always scroll to this
-                    // (same pattern as ChatMessagesView)
-                    Color.clear
-                        .frame(height: 1)
-                        .id("bottom-anchor")
-                }
-                .onChange(of: chatProvider.messages.count) { _, _ in
-                    scrollToBottom(proxy: proxy)
-                }
-                .onChange(of: chatProvider.messages.last?.text) { _, _ in
-                    scrollToBottom(proxy: proxy)
-                }
-                .onChange(of: chatProvider.messages.last?.contentBlocks.count) { _, _ in
-                    // Multiple scroll attempts: first for the text/indicator layout,
-                    // second for images/GIFs that load asynchronously and add height
-                    scrollToBottom(proxy: proxy, delay: 0.15)
-                    scrollToBottom(proxy: proxy, delay: 0.6)
-                }
-                .onChange(of: chatProvider.isSending) { _, _ in
-                    scrollToBottom(proxy: proxy)
-                }
-                .onChange(of: quickReplyOptions) { _, _ in
-                    scrollToBottom(proxy: proxy, delay: 0.1)
-                }
-                .onChange(of: explorationRunning) { _, running in
-                    if running {
-                        scrollToBottom(proxy: proxy, delay: 0.2)
-                    }
-                }
-                .onChange(of: explorationCompleted) { _, completed in
-                    if completed {
-                        scrollToBottom(proxy: proxy, delay: 0.2)
-                    }
-                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 44)
+              }
             }
 
-            // Input area
-            HStack(spacing: 12) {
-                TextField(quickReplyOptions.isEmpty ? "Type your message..." : "Or type your own answer...", text: $inputText, axis: .vertical)
-                    .textFieldStyle(.plain)
-                    .font(.system(size: 14))
-                    .foregroundColor(OmiColors.textPrimary)
-                    .focused($isInputFocused)
-                    .padding(12)
-                    .lineLimit(1...3)
-                    .onSubmit {
-                        sendMessage()
-                    }
-                    .frame(maxWidth: .infinity)
-                    .background(OmiColors.backgroundSecondary)
-                    .cornerRadius(20)
-
-                if chatProvider.isSending && inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    // Stop button when AI is responding and input is empty
-                    Button(action: stopAgent) {
-                        Image(systemName: chatProvider.isStopping ? "ellipsis.circle" : "stop.circle.fill")
-                            .font(.system(size: 32))
-                            .foregroundColor(OmiColors.purplePrimary)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(chatProvider.isStopping)
-                } else {
-                    Button(action: sendMessage) {
-                        Image(systemName: "arrow.up.circle.fill")
-                            .font(.system(size: 32))
-                            .foregroundColor(canSend ? OmiColors.purplePrimary : OmiColors.textTertiary)
-                    }
-                    .buttonStyle(.plain)
-                    .disabled(!canSend)
-                }
+            // "Continue" button — shown only after AI calls complete_onboarding
+            // and no pending questions or permissions remain.
+            if onboardingCompleted && !chatProvider.isSending && quickReplyOptions.isEmpty
+              && pendingPermissionType == nil
+            {
+              Button(action: {
+                handleOnboardingComplete()
+              }) {
+                Text("Continue")
+                  .font(.system(size: 15, weight: .semibold))
+                  .foregroundColor(.white)
+                  .frame(maxWidth: 220)
+                  .padding(.vertical, 12)
+                  .background(OmiColors.purplePrimary)
+                  .cornerRadius(12)
+              }
+              .buttonStyle(.plain)
+              .padding(.top, 12)
             }
-            .padding(.horizontal, 20)
-            .padding(.vertical, 16)
-        }
-        .onAppear {
-            startChat()
-        }
-        .onReceive(permissionCheckTimer) { _ in
-            appState.checkNotificationPermission()
-            appState.checkScreenRecordingPermission()
-            appState.checkMicrophonePermission()
-            appState.checkAccessibilityPermission()
-            appState.checkAutomationPermission()
-            appState.checkFullDiskAccess()
-        }
-        // When a pending permission is granted, bring app to front and notify the AI
-        .onChange(of: appState.hasScreenRecordingPermission) { _, granted in
-            if granted { handlePermissionGranted("screen_recording", label: "Screen Recording") }
-        }
-        .onChange(of: appState.hasMicrophonePermission) { _, granted in
-            if granted { handlePermissionGranted("microphone", label: "Microphone") }
-        }
-        .onChange(of: appState.hasNotificationPermission) { _, granted in
-            if granted { handlePermissionGranted("notifications", label: "Notifications") }
-        }
-        .onChange(of: appState.hasAccessibilityPermission) { _, granted in
-            if granted { handlePermissionGranted("accessibility", label: "Accessibility") }
-        }
-        .onChange(of: appState.hasAutomationPermission) { _, granted in
-            if granted { handlePermissionGranted("automation", label: "Automation") }
-        }
-        .onChange(of: appState.hasFullDiskAccess) { _, granted in
-            if granted { handlePermissionGranted("full_disk_access", label: "Full Disk Access") }
-        }
-    }
 
-    @ViewBuilder
-    private var omiAvatar: some View {
-        if let logoURL = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
-           let logoImage = NSImage(contentsOf: logoURL) {
-            Image(nsImage: logoImage)
-                .resizable()
-                .scaledToFit()
-                .frame(width: 20, height: 20)
-                .frame(width: 32, height: 32)
-                .background(OmiColors.backgroundTertiary)
-                .clipShape(Circle())
+            // Extra spacing so quick replies / buttons don't sit against the input field
+            Spacer().frame(height: 20)
+          }
+          .padding(20)
+
+          // Invisible anchor at the very bottom — always scroll to this
+          // (same pattern as ChatMessagesView)
+          Color.clear
+            .frame(height: 1)
+            .id("bottom-anchor")
         }
-    }
-
-    /// Open System Settings to the correct pane for a permission type
-    private func openSettingsForPermission(_ type: String) {
-        let urlString: String? = {
-            switch type {
-            case "screen_recording":
-                return "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
-            case "microphone":
-                return "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
-            case "accessibility":
-                return "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-            case "automation":
-                return "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
-            case "notifications":
-                return "x-apple.systempreferences:com.apple.preference.security?Privacy_Notifications"
-            case "full_disk_access":
-                return "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
-            default:
-                return nil
-            }
-        }()
-        if let urlString, let url = URL(string: urlString) {
-            NSWorkspace.shared.open(url)
+        .onChange(of: chatProvider.messages.count) { _, _ in
+          scrollToBottom(proxy: proxy)
         }
-    }
-
-    /// Called when a permission is detected as granted (by the 1s timer)
-    private func handlePermissionGranted(_ type: String, label: String) {
-        bringToFront()
-        // If this was the permission we were waiting for, notify the AI
-        if pendingPermissionType == type {
-            pendingPermissionType = nil
-            Task {
-                await chatProvider.sendMessage("Grant \(label) — done!")
-            }
+        .onChange(of: chatProvider.messages.last?.text) { _, _ in
+          scrollToBottom(proxy: proxy)
         }
-    }
+        .onChange(of: chatProvider.messages.last?.contentBlocks.count) { _, _ in
+          // Multiple scroll attempts: first for the text/indicator layout,
+          // second for images/GIFs that load asynchronously and add height
+          scrollToBottom(proxy: proxy, delay: 0.15)
+          scrollToBottom(proxy: proxy, delay: 0.6)
+        }
+        .onChange(of: chatProvider.isSending) { _, _ in
+          scrollToBottom(proxy: proxy)
+        }
+        .onChange(of: quickReplyOptions) { _, _ in
+          scrollToBottom(proxy: proxy, delay: 0.1)
+        }
+        .onChange(of: explorationRunning) { _, running in
+          if running {
+            scrollToBottom(proxy: proxy, delay: 0.2)
+          }
+        }
+        .onChange(of: explorationCompleted) { _, completed in
+          if completed {
+            scrollToBottom(proxy: proxy, delay: 0.2)
+          }
+        }
+      }
 
-    private var canSend: Bool {
-        !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !chatProvider.isSending
-    }
+      // Input area
+      HStack(spacing: 12) {
+        TextField(
+          quickReplyOptions.isEmpty ? "Type your message..." : "Or type your own answer...",
+          text: $inputText, axis: .vertical
+        )
+        .textFieldStyle(.plain)
+        .font(.system(size: 14))
+        .foregroundColor(OmiColors.textPrimary)
+        .focused($isInputFocused)
+        .padding(12)
+        .lineLimit(1...3)
+        .onSubmit {
+          sendMessage()
+        }
+        .frame(maxWidth: .infinity)
+        .background(OmiColors.backgroundSecondary)
+        .cornerRadius(20)
 
-    // MARK: - Scroll
-
-    private func scrollToBottom(proxy: ScrollViewProxy, delay: TimeInterval = 0) {
-        if delay > 0 {
-            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-                withAnimation { proxy.scrollTo("bottom-anchor", anchor: .bottom) }
-            }
+        if chatProvider.isSending
+          && inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        {
+          // Stop button when AI is responding and input is empty
+          Button(action: stopAgent) {
+            Image(systemName: chatProvider.isStopping ? "ellipsis.circle" : "stop.circle.fill")
+              .font(.system(size: 32))
+              .foregroundColor(OmiColors.purplePrimary)
+          }
+          .buttonStyle(.plain)
+          .disabled(chatProvider.isStopping)
         } else {
-            withAnimation { proxy.scrollTo("bottom-anchor", anchor: .bottom) }
+          Button(action: sendMessage) {
+            Image(systemName: "arrow.up.circle.fill")
+              .font(.system(size: 32))
+              .foregroundColor(canSend ? OmiColors.purplePrimary : OmiColors.textTertiary)
+          }
+          .buttonStyle(.plain)
+          .disabled(!canSend)
         }
+      }
+      .padding(.horizontal, 20)
+      .padding(.vertical, 16)
+    }
+    .onAppear {
+      startChat()
+    }
+    .onReceive(permissionCheckTimer) { _ in
+      appState.checkNotificationPermission()
+      appState.checkScreenRecordingPermission()
+      appState.checkMicrophonePermission()
+      appState.checkAccessibilityPermission()
+      appState.checkAutomationPermission()
+      appState.checkFullDiskAccess()
+    }
+    // When a pending permission is granted, bring app to front and notify the AI
+    .onChange(of: appState.hasScreenRecordingPermission) { _, granted in
+      if granted { handlePermissionGranted("screen_recording", label: "Screen Recording") }
+    }
+    .onChange(of: appState.hasMicrophonePermission) { _, granted in
+      if granted { handlePermissionGranted("microphone", label: "Microphone") }
+    }
+    .onChange(of: appState.hasNotificationPermission) { _, granted in
+      if granted { handlePermissionGranted("notifications", label: "Notifications") }
+    }
+    .onChange(of: appState.hasAccessibilityPermission) { _, granted in
+      if granted { handlePermissionGranted("accessibility", label: "Accessibility") }
+    }
+    .onChange(of: appState.hasAutomationPermission) { _, granted in
+      if granted { handlePermissionGranted("automation", label: "Automation") }
+    }
+    .onChange(of: appState.hasFullDiskAccess) { _, granted in
+      if granted { handlePermissionGranted("full_disk_access", label: "Full Disk Access") }
+    }
+    .onChange(of: chatProvider.isSending) { _, isSending in
+      if isSending {
+        cancelRecoveredOnboardingFallback()
+      } else {
+        scheduleRecoveredOnboardingFallback()
+      }
+    }
+    .onChange(of: quickReplyOptions) { _, _ in
+      scheduleRecoveredOnboardingFallback()
+    }
+    .onChange(of: pendingPermissionType) { _, _ in
+      scheduleRecoveredOnboardingFallback()
+    }
+    .onChange(of: explorationRunning) { _, _ in
+      scheduleRecoveredOnboardingFallback()
+    }
+    .onChange(of: explorationCompleted) { _, _ in
+      scheduleRecoveredOnboardingFallback()
+    }
+  }
+
+  @ViewBuilder
+  private var omiAvatar: some View {
+    if let logoURL = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
+      let logoImage = NSImage(contentsOf: logoURL)
+    {
+      Image(nsImage: logoImage)
+        .resizable()
+        .scaledToFit()
+        .frame(width: 20, height: 20)
+        .frame(width: 32, height: 32)
+        .background(OmiColors.backgroundTertiary)
+        .clipShape(Circle())
+    }
+  }
+
+  /// Open System Settings to the correct pane for a permission type
+  private func openSettingsForPermission(_ type: String) {
+    let urlString: String? = {
+      switch type {
+      case "screen_recording":
+        return "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+      case "microphone":
+        return "x-apple.systempreferences:com.apple.preference.security?Privacy_Microphone"
+      case "accessibility":
+        return "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+      case "automation":
+        return "x-apple.systempreferences:com.apple.preference.security?Privacy_Automation"
+      case "notifications":
+        return "x-apple.systempreferences:com.apple.preference.security?Privacy_Notifications"
+      case "full_disk_access":
+        return "x-apple.systempreferences:com.apple.preference.security?Privacy_AllFiles"
+      default:
+        return nil
+      }
+    }()
+    if let urlString, let url = URL(string: urlString) {
+      NSWorkspace.shared.open(url)
+    }
+  }
+
+  /// Called when a permission is detected as granted (by the 1s timer)
+  private func handlePermissionGranted(_ type: String, label: String) {
+    bringToFront()
+    // If this was the permission we were waiting for, notify the AI
+    if pendingPermissionType == type {
+      pendingPermissionType = nil
+      Task {
+        await chatProvider.sendMessage("Grant \(label) — done!")
+      }
+    }
+  }
+
+  private var canSend: Bool {
+    !inputText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !chatProvider.isSending
+  }
+
+  // MARK: - Scroll
+
+  private func scrollToBottom(proxy: ScrollViewProxy, delay: TimeInterval = 0) {
+    if delay > 0 {
+      DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+        withAnimation { proxy.scrollTo("bottom-anchor", anchor: .bottom) }
+      }
+    } else {
+      withAnimation { proxy.scrollTo("bottom-anchor", anchor: .bottom) }
+    }
+  }
+
+  // MARK: - Actions
+
+  private func startChat() {
+    guard !hasStarted else { return }
+    hasStarted = true
+    isInputFocused = true
+
+    // Wire up onboarding tools
+    ChatToolExecutor.onboardingAppState = appState
+    ChatToolExecutor.onCompleteOnboarding = {
+      onboardingCompleted = true
+    }
+    ChatToolExecutor.onQuickReplyOptions = { options in
+      quickReplyOptions = options
+      if options.isEmpty {
+        quickReplyQuestion = ""
+        isTaskSelectionFollowup = false
+      }
+      let hasTypedOption = options.contains(where: { isTypeYourOwnOption($0) })
+      awaitingGoalInput = hasTypedOption && isGoalPriorityQuestion(quickReplyQuestion)
+      isTaskSelectionFollowup = shouldTreatAsTaskSelection(
+        question: quickReplyQuestion, options: options)
+      awaitingDailyTaskInput = hasTypedOption && isTaskSelectionFollowup
+    }
+    ChatToolExecutor.onQuickReplyQuestion = { question in
+      quickReplyQuestion = question
+      awaitingGoalInput = isGoalPriorityQuestion(question)
+      isTaskSelectionFollowup = shouldTreatAsTaskSelection(
+        question: question, options: quickReplyOptions)
+      awaitingDailyTaskInput =
+        isTaskSelectionFollowup && quickReplyOptions.contains(where: { isTypeYourOwnOption($0) })
+    }
+    ChatToolExecutor.onKnowledgeGraphUpdated = { [weak graphViewModel] in
+      guard let vm = graphViewModel else { return }
+      Task { await vm.addGraphFromStorage() }
+    }
+    ChatToolExecutor.onScanFilesCompleted = { [weak graphViewModel] fileCount in
+      guard fileCount > 0 else { return }
+      startExploration(fileCount: fileCount, graphViewModel: graphViewModel)
+      startGmailReading()
+      startCalendarReading()
     }
 
-    // MARK: - Actions
+    // Build onboarding system prompt
+    let userName = AuthService.shared.displayName.isEmpty ? "there" : AuthService.shared.displayName
+    let givenName = AuthService.shared.givenName.isEmpty ? userName : AuthService.shared.givenName
+    let email = AuthState.shared.userEmail ?? ""
 
-    private func startChat() {
-        guard !hasStarted else { return }
-        hasStarted = true
-        isInputFocused = true
+    let systemPrompt = ChatPromptBuilder.buildOnboardingChat(
+      userName: userName,
+      givenName: givenName,
+      email: email
+    )
 
-        // Wire up onboarding tools
-        ChatToolExecutor.onboardingAppState = appState
-        ChatToolExecutor.onCompleteOnboarding = {
-            onboardingCompleted = true
-        }
-        ChatToolExecutor.onQuickReplyOptions = { options in
-            quickReplyOptions = options
-            if options.isEmpty {
-                quickReplyQuestion = ""
-                isTaskSelectionFollowup = false
-            }
-            let hasTypedOption = options.contains(where: { isTypeYourOwnOption($0) })
-            awaitingGoalInput = hasTypedOption && isGoalPriorityQuestion(quickReplyQuestion)
-            isTaskSelectionFollowup = shouldTreatAsTaskSelection(question: quickReplyQuestion, options: options)
-            awaitingDailyTaskInput = hasTypedOption && isTaskSelectionFollowup
-        }
-        ChatToolExecutor.onQuickReplyQuestion = { question in
-            quickReplyQuestion = question
-            awaitingGoalInput = isGoalPriorityQuestion(question)
-            isTaskSelectionFollowup = shouldTreatAsTaskSelection(question: question, options: quickReplyOptions)
-            awaitingDailyTaskInput = isTaskSelectionFollowup && quickReplyOptions.contains(where: { isTypeYourOwnOption($0) })
-        }
-        ChatToolExecutor.onKnowledgeGraphUpdated = { [weak graphViewModel] in
-            guard let vm = graphViewModel else { return }
-            Task { await vm.addGraphFromStorage() }
-        }
-        ChatToolExecutor.onScanFilesCompleted = { [weak graphViewModel] fileCount in
-            guard fileCount > 0 else { return }
-            startExploration(fileCount: fileCount, graphViewModel: graphViewModel)
-            startGmailReading()
-            startCalendarReading()
+    // Mark as onboarding so ACP session ID gets persisted for restart recovery
+    chatProvider.isOnboarding = true
+
+    // Check if we're resuming after a mid-onboarding restart (e.g. screen recording permission)
+    if OnboardingChatPersistence.isMidOnboarding {
+      let savedSessionId = OnboardingChatPersistence.loadSessionId()
+      log("OnboardingChatView: Resuming mid-onboarding, ACP session: \(savedSessionId ?? "none")")
+
+      // If complete_onboarding was already called before restart, show the button immediately
+      if OnboardingChatPersistence.isToolCompleted {
+        log("OnboardingChatView: complete_onboarding was called before restart, showing button")
+        onboardingCompleted = true
+      }
+
+      Task {
+        // Start bridge eagerly so it's ready by the time we need to send
+        async let bridgeWarmup: () = chatProvider.warmupBridge()
+
+        // Load previous messages from backend (same default chat, sessionId=nil)
+        await chatProvider.loadDefaultChatMessages()
+
+        // Restore the knowledge graph from local storage (saved before restart)
+        if let vm = graphViewModel {
+          await vm.addGraphFromStorage()
         }
 
-        // Build onboarding system prompt
-        let userName = AuthService.shared.displayName.isEmpty ? "there" : AuthService.shared.displayName
-        let givenName = AuthService.shared.givenName.isEmpty ? userName : AuthService.shared.givenName
-        let email = AuthState.shared.userEmail ?? ""
+        // If files are already indexed from prior run, kick off exploration immediately
+        await checkAndStartExploration(graphViewModel: graphViewModel)
 
-        let systemPrompt = ChatPromptBuilder.buildOnboardingChat(
-            userName: userName,
-            givenName: givenName,
-            email: email
+        // Build a conversation summary so the AI has context even if session/resume fails
+        let conversationContext = buildConversationContext(from: chatProvider.messages)
+        let resumeSystemPrompt: String
+        if conversationContext.isEmpty {
+          resumeSystemPrompt = systemPrompt
+        } else {
+          resumeSystemPrompt =
+            systemPrompt + "\n\n<conversation_so_far>\n" + conversationContext
+            + "\n</conversation_so_far>\n\nThe user's app just restarted after granting a macOS permission. Continue the onboarding from where you left off — do NOT re-ask questions the user already answered above."
+        }
+
+        // Wait for bridge warmup before sending
+        await bridgeWarmup
+
+        // Resume the conversation — tell the AI the app was restarted
+        await chatProvider.sendMessage(
+          "I'm back — the app just restarted after granting a permission. Let's continue where we left off.",
+          systemPromptPrefix: resumeSystemPrompt,
+          resume: savedSessionId
         )
 
-        // Mark as onboarding so ACP session ID gets persisted for restart recovery
-        chatProvider.isOnboarding = true
-
-        // Check if we're resuming after a mid-onboarding restart (e.g. screen recording permission)
-        if OnboardingChatPersistence.isMidOnboarding {
-            let savedSessionId = OnboardingChatPersistence.loadSessionId()
-            log("OnboardingChatView: Resuming mid-onboarding, ACP session: \(savedSessionId ?? "none")")
-
-            // If complete_onboarding was already called before restart, show the button immediately
-            if OnboardingChatPersistence.isToolCompleted {
-                log("OnboardingChatView: complete_onboarding was called before restart, showing button")
-                onboardingCompleted = true
-            }
-
-            Task {
-                // Start bridge eagerly so it's ready by the time we need to send
-                async let bridgeWarmup: () = chatProvider.warmupBridge()
-
-                // Load previous messages from backend (same default chat, sessionId=nil)
-                await chatProvider.loadDefaultChatMessages()
-
-                // Restore the knowledge graph from local storage (saved before restart)
-                if let vm = graphViewModel {
-                    await vm.addGraphFromStorage()
-                }
-
-                // If files are already indexed from prior run, kick off exploration immediately
-                await checkAndStartExploration(graphViewModel: graphViewModel)
-
-                // Build a conversation summary so the AI has context even if session/resume fails
-                let conversationContext = buildConversationContext(from: chatProvider.messages)
-                let resumeSystemPrompt: String
-                if conversationContext.isEmpty {
-                    resumeSystemPrompt = systemPrompt
-                } else {
-                    resumeSystemPrompt = systemPrompt + "\n\n<conversation_so_far>\n" + conversationContext + "\n</conversation_so_far>\n\nThe user's app just restarted after granting a macOS permission. Continue the onboarding from where you left off — do NOT re-ask questions the user already answered above."
-                }
-
-                // Wait for bridge warmup before sending
-                await bridgeWarmup
-
-                // Resume the conversation — tell the AI the app was restarted
-                await chatProvider.sendMessage(
-                    "I'm back — the app just restarted after granting a permission. Let's continue where we left off.",
-                    systemPromptPrefix: resumeSystemPrompt,
-                    resume: savedSessionId
-                )
-            }
-        } else if chatProvider.messages.isEmpty {
-            // Fresh start — clear stale messages, mark mid-onboarding, begin
-            OnboardingChatPersistence.saveMidOnboarding()
-
-            Task {
-                await chatProvider.sendMessage(
-                    "Hi, I just installed omi!",
-                    systemPromptPrefix: systemPrompt
-                )
-            }
+        await MainActor.run {
+          scheduleRecoveredOnboardingFallback()
         }
+      }
+    } else if chatProvider.messages.isEmpty {
+      // Fresh start — clear stale messages, mark mid-onboarding, begin
+      OnboardingChatPersistence.saveMidOnboarding()
+
+      Task {
+        await chatProvider.sendMessage(
+          "Hi, I just installed omi!",
+          systemPromptPrefix: systemPrompt
+        )
+      }
+    }
+  }
+
+  private func stopAgent() {
+    chatProvider.stopAgent()
+  }
+
+  private func cancelRecoveredOnboardingFallback() {
+    recoveredOnboardingFallbackTask?.cancel()
+    recoveredOnboardingFallbackTask = nil
+  }
+
+  private func scheduleRecoveredOnboardingFallback() {
+    cancelRecoveredOnboardingFallback()
+
+    guard OnboardingChatPersistence.isMidOnboarding,
+      !OnboardingChatPersistence.isToolCompleted,
+      !onboardingCompleted
+    else { return }
+
+    recoveredOnboardingFallbackTask = Task {
+      try? await Task.sleep(for: .seconds(2))
+      guard !Task.isCancelled else { return }
+
+      let shouldUnlockContinue = await shouldAutoCompleteRecoveredOnboarding()
+      guard shouldUnlockContinue else { return }
+
+      await MainActor.run {
+        guard OnboardingChatPersistence.isMidOnboarding,
+          !OnboardingChatPersistence.isToolCompleted,
+          !onboardingCompleted,
+          pendingPermissionType == nil,
+          quickReplyOptions.isEmpty,
+          !chatProvider.isSending
+        else { return }
+
+        log("OnboardingChatView: Auto-unlocking Continue after recovered onboarding went idle")
+        onboardingCompleted = true
+      }
+    }
+  }
+
+  private func shouldAutoCompleteRecoveredOnboarding() async -> Bool {
+    guard OnboardingChatPersistence.isMidOnboarding,
+      !OnboardingChatPersistence.isToolCompleted,
+      !onboardingCompleted,
+      pendingPermissionType == nil,
+      quickReplyOptions.isEmpty,
+      !chatProvider.isSending
+    else { return false }
+
+    if explorationRunning || explorationCompleted
+      || OnboardingChatPersistence.isExplorationCompleted
+    {
+      return true
     }
 
-    private func stopAgent() {
-        chatProvider.stopAgent()
+    return await FileIndexerService.shared.getIndexedFileCount() > 0
+  }
+
+  private func sendMessage() {
+    guard canSend else { return }
+
+    let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+    inputText = ""
+
+    // Clear quick replies and unblock any pending ask_followup
+    quickReplyOptions = []
+    quickReplyQuestion = ""
+    isTaskSelectionFollowup = false
+    ChatToolExecutor.resumeFollowup(with: text)
+
+    Task {
+      if awaitingGoalInput {
+        await maybeCreateGoal(from: text, source: "typed")
+      }
+      if awaitingDailyTaskInput {
+        await maybeCreateTask(from: text, source: "typed")
+        awaitingDailyTaskInput = false
+      }
+      await chatProvider.sendMessage(text)
+    }
+  }
+
+  /// Whether a quick reply option is a "Grant" permission button
+  private func isGrantButton(_ option: String) -> Bool {
+    option.hasPrefix("Grant ")
+  }
+
+  /// Extract permission type from a "Grant [Permission]" button label
+  private func permissionType(from option: String) -> String? {
+    guard isGrantButton(option) else { return nil }
+    let name = String(option.dropFirst("Grant ".count)).lowercased()
+    return permissionType(matching: name)
+  }
+
+  private func permissionType(for question: String, options: [String]) -> String? {
+    if let grantOption = options.first(where: { isGrantButton($0) }),
+      let permType = permissionType(from: grantOption)
+    {
+      return permType
     }
 
-    private func sendMessage() {
-        guard canSend else { return }
+    return permissionType(matching: question.lowercased())
+  }
 
-        let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
-        inputText = ""
+  private func permissionType(matching text: String) -> String? {
+    let mapping: [(needle: String, permission: String)] = [
+      ("screen recording", "screen_recording"),
+      ("full disk access", "full_disk_access"),
+      ("disk access", "full_disk_access"),
+      ("microphone", "microphone"),
+      ("mic", "microphone"),
+      ("notifications", "notifications"),
+      ("accessibility", "accessibility"),
+      ("automation", "automation"),
+    ]
 
-        // Clear quick replies and unblock any pending ask_followup
-        quickReplyOptions = []
-        quickReplyQuestion = ""
-        isTaskSelectionFollowup = false
-        ChatToolExecutor.resumeFollowup(with: text)
+    return mapping.first(where: { text.contains($0.needle) })?.permission
+  }
 
-        Task {
-            if awaitingGoalInput {
-                await maybeCreateGoal(from: text, source: "typed")
-            }
-            if awaitingDailyTaskInput {
-                await maybeCreateTask(from: text, source: "typed")
-                awaitingDailyTaskInput = false
-            }
-            await chatProvider.sendMessage(text)
-        }
-    }
+  /// Handle quick reply button tap — triggers permission if applicable, then sends as user message
+  private func handleQuickReply(_ option: String) {
+    let wasTaskSelectionFollowup = isTaskSelectionFollowup
+    quickReplyOptions = []
+    quickReplyQuestion = ""
+    isTaskSelectionFollowup = false
 
-    /// Whether a quick reply option is a "Grant" permission button
-    private func isGrantButton(_ option: String) -> Bool {
-        option.hasPrefix("Grant ")
-    }
+    if let permType = permissionType(from: option) {
+      // Grant button — trigger the permission directly
+      isGrantingPermission = true
+      Task {
+        let result = await ChatToolExecutor.execute(
+          ToolCall(name: "request_permission", arguments: ["type": permType], thoughtSignature: nil)
+        )
+        isGrantingPermission = false
 
-    /// Extract permission type from a "Grant [Permission]" button label
-    private func permissionType(from option: String) -> String? {
-        guard isGrantButton(option) else { return nil }
-        let name = String(option.dropFirst("Grant ".count)).lowercased()
-        let mapping: [String: String] = [
-            "microphone": "microphone",
-            "mic": "microphone",
-            "notifications": "notifications",
-            "accessibility": "accessibility",
-            "automation": "automation",
-            "screen recording": "screen_recording",
-            "full disk access": "full_disk_access",
-            "disk access": "full_disk_access",
-        ]
-        return mapping[name]
-    }
-
-    /// Handle quick reply button tap — triggers permission if applicable, then sends as user message
-    private func handleQuickReply(_ option: String) {
-        let wasTaskSelectionFollowup = isTaskSelectionFollowup
-        quickReplyOptions = []
-        quickReplyQuestion = ""
-        isTaskSelectionFollowup = false
-
-        if let permType = permissionType(from: option) {
-            // Grant button — trigger the permission directly
-            isGrantingPermission = true
-            Task {
-                let result = await ChatToolExecutor.execute(ToolCall(name: "request_permission", arguments: ["type": permType], thoughtSignature: nil))
-                isGrantingPermission = false
-
-                if result.contains("granted") {
-                    // Granted immediately — tell the AI
-                    await chatProvider.sendMessage("\(option) — done!")
-                } else if result.contains("move omi to /Applications first") {
-                    await chatProvider.sendMessage("Move omi to Applications, reopen it, then tap Grant Notifications again.")
-                } else {
-                    // Pending — wait silently for the permission check timer to detect it
-                    // The onChange handlers for appState.has*Permission will send the message
-                    pendingPermissionType = permType
-                }
-            }
+        if result.contains("granted") {
+          // Granted immediately — tell the AI
+          await chatProvider.sendMessage("\(option) — done!")
+        } else if result.contains("move omi to /Applications first") {
+          await chatProvider.sendMessage(
+            "Move omi to Applications, reopen it, then tap Grant Notifications again.")
         } else {
-            // Regular quick reply — resume the blocked ask_followup tool, then send as message
-            let shouldCreateFromSelection = awaitingGoalInput && !isTypeYourOwnOption(option)
-            if shouldCreateFromSelection {
-                awaitingGoalInput = false
-            } else if isTypeYourOwnOption(option) {
-                awaitingGoalInput = true
+          // Pending — wait silently for the permission check timer to detect it
+          // The onChange handlers for appState.has*Permission will send the message
+          pendingPermissionType = permType
+        }
+      }
+    } else {
+      // Regular quick reply — resume the blocked ask_followup tool, then send as message
+      let shouldCreateFromSelection = awaitingGoalInput && !isTypeYourOwnOption(option)
+      if shouldCreateFromSelection {
+        awaitingGoalInput = false
+      } else if isTypeYourOwnOption(option) {
+        awaitingGoalInput = true
+      }
+      let shouldCreateTaskFromSelection = wasTaskSelectionFollowup && !isTypeYourOwnOption(option)
+      if shouldCreateTaskFromSelection {
+        awaitingDailyTaskInput = false
+      } else if isTypeYourOwnOption(option) && wasTaskSelectionFollowup {
+        awaitingDailyTaskInput = true
+      }
+      ChatToolExecutor.resumeFollowup(with: option)
+      Task {
+        if shouldCreateFromSelection {
+          await maybeCreateGoal(from: option, source: "selected")
+        }
+        if shouldCreateTaskFromSelection {
+          await maybeCreateTask(from: option, source: "selected")
+        }
+        await chatProvider.sendMessage(option)
+      }
+    }
+  }
+
+  private var shouldHideExplorationCard: Bool {
+    !quickReplyOptions.isEmpty || pendingPermissionType != nil || awaitingGoalInput
+      || awaitingDailyTaskInput
+  }
+
+  private func whiteTemplateLogoImage() -> NSImage? {
+    guard
+      let logoURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
+      let loadedLogoImage = NSImage(contentsOf: logoURL)
+    else {
+      return nil
+    }
+    let logoImage = loadedLogoImage.copy() as? NSImage ?? loadedLogoImage
+    logoImage.isTemplate = true
+    return logoImage
+  }
+
+  private func isGoalPriorityQuestion(_ text: String) -> Bool {
+    let lower = text.lowercased()
+    return lower.contains("top one goal")
+      || lower.contains("top goal")
+      || lower.contains("#1 goal")
+      || lower.contains("number 1 goal")
+      || lower.contains("goal this month")
+      || lower.contains("what's your #1 goal")
+      || lower.contains("top priority")
+      || lower.contains("priority right now")
+  }
+
+  private func isDailyTaskQuestion(_ text: String) -> Bool {
+    let lower = text.lowercased()
+    return lower.contains("goal for today")
+      || lower.contains("tasks for today")
+      || lower.contains("task for today")
+      || lower.contains("daily goal")
+      || lower.contains("today's top task")
+      || lower.contains("today top task")
+      || lower.contains("daily reminder task")
+      || lower.contains("tasks that could help")
+      || lower.contains("could help today")
+      || lower.contains("what do you want to get done")
+      || lower.contains("today's priority")
+      || lower.contains("today priority")
+      || (lower.contains("set that as") && lower.contains("task"))
+  }
+
+  private func isLikelyTaskOption(_ text: String) -> Bool {
+    let lower = text.lowercased()
+    if isTypeYourOwnOption(text) || lower == "skip" || lower == "why?" || isGrantButton(text) {
+      return false
+    }
+    let taskVerbs = [
+      "record", "publish", "ship", "launch", "write", "fix", "review", "design", "test", "send",
+      "post", "call", "build", "finish",
+    ]
+    if taskVerbs.contains(where: { lower.hasPrefix($0 + " ") || lower.contains(" " + $0 + " ") }) {
+      return true
+    }
+    return lower.contains("today")
+      || lower.contains("task")
+      || lower.contains("goal")
+      || lower.contains("per day")
+      || lower.contains("daily")
+  }
+
+  private func shouldTreatAsTaskSelection(question: String, options: [String]) -> Bool {
+    if isDailyTaskQuestion(question) {
+      return true
+    }
+    guard !options.isEmpty else { return false }
+    let nonPermission = options.filter { !isGrantButton($0) }
+    let likelyTaskOptions = nonPermission.filter { isLikelyTaskOption($0) }
+    // Require at least one actionable option and a typed option to avoid false positives
+    return !likelyTaskOptions.isEmpty && options.contains(where: { isTypeYourOwnOption($0) })
+  }
+
+  private func isTypeYourOwnOption(_ text: String) -> Bool {
+    let lower = text.lowercased()
+    return lower.contains("type my own")
+      || lower.contains("i'll type my own")
+      || lower.contains("i’ll type my own")
+      || lower.contains("i'll type it")
+      || lower.contains("i’ll type it")
+      || lower.contains("type it")
+  }
+
+  private func normalizedGoalTitle(_ text: String) -> String {
+    text
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "\n", with: " ")
+  }
+
+  private func heuristicGoalTitle(_ text: String) -> String {
+    var cleaned = normalizedGoalTitle(text)
+    let lower = cleaned.lowercased()
+    let prefixes = [
+      "my goal is ",
+      "goal is ",
+      "my goal: ",
+      "goal: ",
+      "i want to ",
+      "i wanna ",
+      "i need to ",
+      "i will ",
+      "i'm going to ",
+    ]
+    for prefix in prefixes where lower.hasPrefix(prefix) {
+      cleaned = String(cleaned.dropFirst(prefix.count))
+      break
+    }
+    return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func fallbackGoalConfig(from title: String) -> (
+    goalType: GoalType, targetValue: Double, unit: String?
+  ) {
+    let lower = title.lowercased()
+    let pattern =
+      #"\b(\d+(?:\.\d+)?)\s*(k|m|b)?\s*(users?|customers?|clients?|sales?|revenue|downloads?)?\b"#
+    if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+      let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower))
+    {
+      let numberRange = match.range(at: 1)
+      let suffixRange = match.range(at: 2)
+      let unitRange = match.range(at: 3)
+      if let numberSwiftRange = Range(numberRange, in: lower),
+        let baseNumber = Double(lower[numberSwiftRange])
+      {
+        var multiplier = 1.0
+        if let suffixSwiftRange = Range(suffixRange, in: lower) {
+          switch lower[suffixSwiftRange] {
+          case "k": multiplier = 1_000
+          case "m": multiplier = 1_000_000
+          case "b": multiplier = 1_000_000_000
+          default: break
+          }
+        }
+        let unit: String? = Range(unitRange, in: lower).map { String(lower[$0]) }
+        return (.numeric, max(baseNumber * multiplier, 1), unit)
+      }
+    }
+
+    return (.boolean, 1, nil)
+  }
+
+  private func shouldSkipGoalCreation(_ title: String) -> Bool {
+    if title.isEmpty {
+      return true
+    }
+    let lower = title.lowercased()
+    if lower == "skip" || lower == "done" || lower.contains("type my own") {
+      return true
+    }
+    return false
+  }
+
+  private func normalizedTaskTitle(_ text: String) -> String {
+    text
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "\n", with: " ")
+  }
+
+  private func cleanedTaskTitle(_ text: String) -> String {
+    var cleaned = normalizedTaskTitle(text)
+    let lower = cleaned.lowercased()
+    let removablePrefixes = [
+      "my task is ",
+      "task: ",
+      "i will ",
+      "i'll ",
+      "i need to ",
+      "today i need to ",
+    ]
+    for prefix in removablePrefixes where lower.hasPrefix(prefix) {
+      cleaned = String(cleaned.dropFirst(prefix.count))
+      break
+    }
+
+    cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+    if cleaned.hasSuffix(".") {
+      cleaned.removeLast()
+    }
+    return cleaned
+  }
+
+  private func shouldSkipTaskCreation(_ title: String) -> Bool {
+    if title.isEmpty {
+      return true
+    }
+    let lower = title.lowercased()
+    if lower == "skip" || lower == "done" || lower.contains("i'll type")
+      || lower.contains("i’ll type")
+    {
+      return true
+    }
+    return false
+  }
+
+  private func isDailyTask(_ text: String) -> Bool {
+    let lower = text.lowercased()
+    return lower.contains("daily")
+      || lower.contains("per day")
+      || lower.contains("every day")
+      || lower.contains("2-videos-per-day")
+      || lower.contains("videos per day")
+  }
+
+  private func maybeCreateTask(from rawText: String, source: String) async {
+    let title = cleanedTaskTitle(rawText)
+    guard !shouldSkipTaskCreation(title) else { return }
+
+    let dedupeKey = title.lowercased()
+    guard !createdTaskTitles.contains(dedupeKey) else { return }
+
+    let createdTask: TaskActionItem?
+    if isDailyTask(rawText) {
+      createdTask = await TasksStore.shared.createDailyRecurringTask(
+        description: title,
+        priority: "medium",
+        tags: ["onboarding"]
+      )
+    } else {
+      let dueToday = Calendar.current.startOfDay(for: Date())
+      createdTask = await TasksStore.shared.createTask(
+        description: title,
+        dueAt: dueToday,
+        priority: "medium",
+        tags: ["onboarding"]
+      )
+    }
+
+    if createdTask != nil {
+      createdTaskTitles.insert(dedupeKey)
+      log("OnboardingChat: Created task from onboarding input (\(source)): \(title)")
+    } else {
+      log("OnboardingChat: Failed to create task from onboarding input (\(source)): \(title)")
+    }
+  }
+
+  private func maybeCreateGoal(from rawText: String, source: String) async {
+    let rawTitle = normalizedGoalTitle(rawText)
+    guard !shouldSkipGoalCreation(rawTitle) else { return }
+
+    let aiNormalized = await GoalsAIService.shared.normalizeOnboardingGoalInput(rawTitle)
+    let title = aiNormalized?.title ?? heuristicGoalTitle(rawTitle)
+    guard !shouldSkipGoalCreation(title) else { return }
+
+    let config: (goalType: GoalType, targetValue: Double, unit: String?) =
+      aiNormalized.map { (goalType: $0.goalType, targetValue: $0.targetValue, unit: $0.unit) }
+      ?? fallbackGoalConfig(from: title)
+    let dedupeKey = title.lowercased()
+    guard !createdGoalTitles.contains(dedupeKey) else { return }
+
+    do {
+      let goal = try await APIClient.shared.createGoal(
+        title: title,
+        description: "Added from onboarding",
+        goalType: config.goalType,
+        targetValue: config.targetValue,
+        currentValue: 0,
+        unit: config.unit,
+        source: "onboarding_\(source)"
+      )
+      _ = try? await GoalStorage.shared.syncServerGoal(goal)
+      createdGoalTitles.insert(dedupeKey)
+      awaitingGoalInput = false
+      log(
+        "OnboardingChat: Created goal from onboarding input: \(title) (\(config.goalType.rawValue), target: \(config.targetValue))"
+      )
+    } catch {
+      logError("OnboardingChat: Failed to create goal from onboarding input", error: error)
+    }
+  }
+
+  private func handleOnboardingComplete() {
+    log("OnboardingChatView: Chat step complete, advancing to next onboarding step")
+
+    // Clean up parallel exploration
+    explorationTask?.cancel()
+    explorationTask = nil
+    if let bridge = explorationBridge {
+      Task { await bridge.stop() }
+    }
+    explorationBridge = nil
+
+    // Clean up Gmail reading
+    gmailReadingTask?.cancel()
+    gmailReadingTask = nil
+
+    // Clean up Calendar reading
+    calendarReadingTask?.cancel()
+    calendarReadingTask = nil
+
+    // Notify parent to advance to next step
+    onComplete()
+  }
+
+  /// Build a compact summary of the conversation so far for inclusion in the system prompt.
+  /// This ensures the AI has context even if ACP session/resume fails and a fresh session starts.
+  private func buildConversationContext(from messages: [ChatMessage]) -> String {
+    guard !messages.isEmpty else { return "" }
+
+    var lines: [String] = []
+    for message in messages {
+      let role = message.sender == .user ? "User" : "Assistant"
+      let text = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+      guard !text.isEmpty else { continue }
+      // Truncate very long messages to keep the context compact
+      let truncated = text.count > 500 ? String(text.prefix(500)) + "..." : text
+      lines.append("\(role): \(truncated)")
+    }
+    return lines.joined(separator: "\n")
+  }
+
+  // MARK: - Parallel Exploration
+
+  /// Check if files are already indexed and start/restore exploration (for resume path)
+  private func checkAndStartExploration(graphViewModel: MemoryGraphViewModel?) async {
+    guard !explorationRunning && !explorationCompleted else { return }
+
+    // If exploration already completed in a prior session, restore from saved state
+    if let saved = OnboardingChatPersistence.loadExplorationState(), saved.completed {
+      log(
+        "OnboardingChat: Restoring completed exploration from saved state (\(saved.text.count) chars)"
+      )
+      explorationText = saved.text
+      explorationCompleted = true
+      // Re-inject the discovery card (UI state was lost on restart)
+      if !saved.text.isEmpty {
+        await injectExplorationDiscoveryCard()
+      }
+      return
+    }
+
+    // Otherwise check if files are indexed and run exploration fresh
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+    let fileCount =
+      (try? await dbQueue.read { db in
+        try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM indexed_files")
+      }) ?? 0
+
+    if fileCount > 0 {
+      log("OnboardingChat: Files already indexed (\(fileCount)), starting exploration on resume")
+      startExploration(fileCount: fileCount, graphViewModel: graphViewModel)
+      startGmailReading()
+      startCalendarReading()
+    }
+  }
+
+  private func startExploration(fileCount: Int, graphViewModel: MemoryGraphViewModel?) {
+    guard !explorationRunning else { return }
+    explorationRunning = true
+    log("OnboardingChat: Starting parallel exploration (\(fileCount) files indexed)")
+    AnalyticsManager.shared.onboardingChatToolUsed(
+      tool: "exploration_started", properties: ["file_count": fileCount])
+
+    explorationTask = Task {
+      do {
+        let bridge = ACPBridge(passApiKey: true)
+        await MainActor.run { explorationBridge = bridge }
+        try await bridge.start()
+
+        let userName =
+          AuthService.shared.displayName.isEmpty ? "User" : AuthService.shared.displayName
+        let schema = await Self.loadDatabaseSchema()
+        let systemPrompt = ChatPromptBuilder.buildOnboardingExploration(
+          userName: userName, databaseSchema: schema)
+
+        let result = try await bridge.query(
+          prompt:
+            "Begin exploration. \(fileCount) files have been indexed in the indexed_files table.",
+          systemPrompt: systemPrompt,
+          model: "claude-opus-4-6",
+          onTextDelta: { @Sendable delta in
+            Task { @MainActor in
+              explorationText += delta
+              // Persist partial text periodically (every ~500 chars) so it survives crashes
+              if explorationText.count % 500 < delta.count {
+                OnboardingChatPersistence.saveExplorationState(
+                  text: explorationText, completed: false)
+              }
             }
-            let shouldCreateTaskFromSelection = wasTaskSelectionFollowup && !isTypeYourOwnOption(option)
-            if shouldCreateTaskFromSelection {
-                awaitingDailyTaskInput = false
-            } else if isTypeYourOwnOption(option) && wasTaskSelectionFollowup {
-                awaitingDailyTaskInput = true
-            }
-            ChatToolExecutor.resumeFollowup(with: option)
-            Task {
-                if shouldCreateFromSelection {
-                    await maybeCreateGoal(from: option, source: "selected")
-                }
-                if shouldCreateTaskFromSelection {
-                    await maybeCreateTask(from: option, source: "selected")
-                }
-                await chatProvider.sendMessage(option)
-            }
+          },
+          onToolCall: { @Sendable _, name, input in
+            let toolCall = ToolCall(name: name, arguments: input, thoughtSignature: nil)
+            let result = await ChatToolExecutor.execute(toolCall)
+            log("OnboardingChat: Exploration tool \(name) executed")
+            return result
+          },
+          onToolActivity: { @Sendable name, status, _, _ in
+            log("OnboardingChat: Exploration tool \(name) \(status)")
+          }
+        )
+
+        log(
+          "OnboardingChat: Exploration completed (cost=$\(String(format: "%.4f", result.costUsd)), tokens=\(result.inputTokens)+\(result.outputTokens))"
+        )
+        AnalyticsManager.shared.onboardingChatToolUsed(
+          tool: "exploration_completed",
+          properties: [
+            "cost_usd": result.costUsd,
+            "input_tokens": result.inputTokens,
+            "output_tokens": result.outputTokens,
+          ])
+
+        let finalText = await MainActor.run {
+          explorationCompleted = true
+          explorationRunning = false
+          return explorationText
         }
+
+        // Persist so it survives app restarts
+        OnboardingChatPersistence.saveExplorationState(text: finalText, completed: true)
+
+        // Append to user profile and inject discovery card
+        await appendExplorationToProfile()
+        await injectExplorationDiscoveryCard()
+
+        await bridge.stop()
+        await MainActor.run { explorationBridge = nil }
+      } catch {
+        log("OnboardingChat: Exploration failed (non-fatal): \(error.localizedDescription)")
+        if let bridge = await MainActor.run(body: { explorationBridge }) {
+          await bridge.stop()
+        }
+        await MainActor.run {
+          explorationRunning = false
+          explorationBridge = nil
+        }
+      }
+    }
+  }
+
+  /// Load a compact database schema string from sqlite_master for the exploration prompt.
+  /// This gives the AI the actual table/column names so it doesn't hallucinate them.
+  private static func loadDatabaseSchema() async -> String {
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
+      return ""
     }
 
-    private var shouldHideExplorationCard: Bool {
-        !quickReplyOptions.isEmpty || pendingPermissionType != nil || awaitingGoalInput || awaitingDailyTaskInput
+    do {
+      let tables = try await dbQueue.read { db -> [(name: String, sql: String)] in
+        let rows = try Row.fetchAll(
+          db,
+          sql: """
+                SELECT name, sql FROM sqlite_master
+                WHERE type='table' AND sql IS NOT NULL
+                ORDER BY name
+            """)
+        return rows.compactMap { row -> (name: String, sql: String)? in
+          guard let name: String = row["name"],
+            let sql: String = row["sql"]
+          else { return nil }
+          return (name: name, sql: sql)
+        }
+      }
+
+      var lines: [String] = ["**Database schema (omi.db):**", ""]
+      for (name, sql) in tables {
+        if ChatPrompts.excludedTables.contains(name) { continue }
+        if ChatPrompts.excludedTablePrefixes.contains(where: { name.hasPrefix($0) }) { continue }
+        if name.contains("_fts") { continue }
+
+        // Extract column names from CREATE TABLE DDL
+        guard let openParen = sql.firstIndex(of: "("),
+          let closeParen = sql.lastIndex(of: ")")
+        else { continue }
+        let body = String(sql[sql.index(after: openParen)..<closeParen])
+        var columnDefs: [String] = []
+        var current = ""
+        var depth = 0
+        for char in body {
+          if char == "(" { depth += 1 } else if char == ")" { depth -= 1 }
+          if char == "," && depth == 0 {
+            let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty { columnDefs.append(trimmed) }
+            current = ""
+          } else {
+            current.append(char)
+          }
+        }
+        let last = current.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !last.isEmpty { columnDefs.append(last) }
+
+        let columnNames = columnDefs.filter { col in
+          let upper = col.uppercased().trimmingCharacters(in: .whitespaces)
+          return !upper.hasPrefix("UNIQUE") && !upper.hasPrefix("CHECK")
+            && !upper.hasPrefix("FOREIGN") && !upper.hasPrefix("CONSTRAINT")
+            && !upper.hasPrefix("PRIMARY KEY")
+        }.compactMap { col -> String? in
+          let colName =
+            col.components(separatedBy: .whitespaces).first?
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`")) ?? ""
+          return ChatPrompts.excludedColumns.contains(colName) || colName.isEmpty ? nil : colName
+        }
+        guard !columnNames.isEmpty else { continue }
+
+        let annotation = ChatPrompts.tableAnnotations[name] ?? ""
+        let header = annotation.isEmpty ? name : "\(name) — \(annotation)"
+        lines.append(header)
+        lines.append("  \(columnNames.joined(separator: ", "))")
+        lines.append("")
+      }
+      lines.append(ChatPrompts.schemaFooter)
+      return lines.joined(separator: "\n")
+    } catch {
+      logError("Failed to load schema for exploration", error: error)
+      return ""
+    }
+  }
+
+  /// Append the exploration text to the user's AI profile
+  private func appendExplorationToProfile() async {
+    let text = await MainActor.run { explorationText }
+    guard !text.isEmpty else {
+      log("OnboardingChat: No exploration text to append to profile")
+      return
     }
 
-    private func whiteTemplateLogoImage() -> NSImage? {
-        guard
-            let logoURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
-            let loadedLogoImage = NSImage(contentsOf: logoURL)
-        else {
-            return nil
-        }
-        let logoImage = loadedLogoImage.copy() as? NSImage ?? loadedLogoImage
-        logoImage.isTemplate = true
-        return logoImage
+    let service = AIUserProfileService.shared
+    let existingProfile = await service.getLatestProfile()
+
+    if let existing = existingProfile, let profileId = existing.id {
+      let updated = existing.profileText + "\n\n--- File Exploration Insights ---\n" + text
+      let success = await service.updateProfileText(id: profileId, newText: updated)
+      log("OnboardingChat: Appended exploration to AI profile (success=\(success))")
+    } else {
+      log("OnboardingChat: No existing AI profile, triggering generation")
+      _ = try? await service.generateProfile()
     }
+  }
 
-    private func isGoalPriorityQuestion(_ text: String) -> Bool {
-        let lower = text.lowercased()
-        return lower.contains("top one goal")
-            || lower.contains("top goal")
-            || lower.contains("#1 goal")
-            || lower.contains("number 1 goal")
-            || lower.contains("goal this month")
-            || lower.contains("what's your #1 goal")
-            || lower.contains("top priority")
-            || lower.contains("priority right now")
+  /// Inject a discovery card into the onboarding chat with the exploration profile
+  private func injectExplorationDiscoveryCard() async {
+    let text = await MainActor.run { explorationText }
+    guard !text.isEmpty else { return }
+
+    let summary = text.count > 120 ? String(text.prefix(120)) + "..." : text
+
+    await MainActor.run {
+      chatProvider.appendDiscoveryCard(
+        title: "Your Digital Profile",
+        summary: summary,
+        fullText: text
+      )
     }
+  }
 
-    private func isDailyTaskQuestion(_ text: String) -> Bool {
-        let lower = text.lowercased()
-        return lower.contains("goal for today")
-            || lower.contains("tasks for today")
-            || lower.contains("task for today")
-            || lower.contains("daily goal")
-            || lower.contains("today's top task")
-            || lower.contains("today top task")
-            || lower.contains("daily reminder task")
-            || lower.contains("tasks that could help")
-            || lower.contains("could help today")
-            || lower.contains("what do you want to get done")
-            || lower.contains("today's priority")
-            || lower.contains("today priority")
-            || (lower.contains("set that as") && lower.contains("task"))
+  private func bringToFront() {
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+      NSApp.activate(ignoringOtherApps: true)
+      for window in NSApp.windows {
+        if window.title.hasPrefix("Omi") {
+          window.makeKeyAndOrderFront(nil)
+          window.orderFrontRegardless()
+        }
+      }
     }
+  }
 
-    private func isLikelyTaskOption(_ text: String) -> Bool {
-        let lower = text.lowercased()
-        if isTypeYourOwnOption(text) || lower == "skip" || lower == "why?" || isGrantButton(text) {
-            return false
+  // MARK: - Gmail Reading (Parallel Onboarding Task)
+
+  private func startGmailReading() {
+    guard !gmailReadingRunning && !gmailReadingCompleted else { return }
+    gmailReadingRunning = true
+    log("OnboardingChat: Starting Gmail reading in background")
+
+    gmailReadingTask = Task {
+      do {
+        let emails = try await GmailReaderService.shared.readRecentEmails(
+          maxResults: 50, query: "newer_than:30d"
+        )
+        guard !emails.isEmpty else {
+          log("OnboardingChat: No Gmail emails found, skipping synthesis")
+          await MainActor.run {
+            gmailReadingRunning = false
+            gmailReadingCompleted = true
+          }
+          return
         }
-        let taskVerbs = [
-            "record", "publish", "ship", "launch", "write", "fix", "review", "design", "test", "send", "post", "call", "build", "finish",
-        ]
-        if taskVerbs.contains(where: { lower.hasPrefix($0 + " ") || lower.contains(" " + $0 + " ") }) {
-            return true
-        }
-        return lower.contains("today")
-            || lower.contains("task")
-            || lower.contains("goal")
-            || lower.contains("per day")
-            || lower.contains("daily")
-    }
-
-    private func shouldTreatAsTaskSelection(question: String, options: [String]) -> Bool {
-        if isDailyTaskQuestion(question) {
-            return true
-        }
-        guard !options.isEmpty else { return false }
-        let nonPermission = options.filter { !isGrantButton($0) }
-        let likelyTaskOptions = nonPermission.filter { isLikelyTaskOption($0) }
-        // Require at least one actionable option and a typed option to avoid false positives
-        return !likelyTaskOptions.isEmpty && options.contains(where: { isTypeYourOwnOption($0) })
-    }
-
-    private func isTypeYourOwnOption(_ text: String) -> Bool {
-        let lower = text.lowercased()
-        return lower.contains("type my own")
-            || lower.contains("i'll type my own")
-            || lower.contains("i’ll type my own")
-            || lower.contains("i'll type it")
-            || lower.contains("i’ll type it")
-            || lower.contains("type it")
-    }
-
-    private func normalizedGoalTitle(_ text: String) -> String {
-        text
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: "\n", with: " ")
-    }
-
-    private func heuristicGoalTitle(_ text: String) -> String {
-        var cleaned = normalizedGoalTitle(text)
-        let lower = cleaned.lowercased()
-        let prefixes = [
-            "my goal is ",
-            "goal is ",
-            "my goal: ",
-            "goal: ",
-            "i want to ",
-            "i wanna ",
-            "i need to ",
-            "i will ",
-            "i'm going to ",
-        ]
-        for prefix in prefixes where lower.hasPrefix(prefix) {
-            cleaned = String(cleaned.dropFirst(prefix.count))
-            break
-        }
-        return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func fallbackGoalConfig(from title: String) -> (goalType: GoalType, targetValue: Double, unit: String?) {
-        let lower = title.lowercased()
-        let pattern = #"\b(\d+(?:\.\d+)?)\s*(k|m|b)?\s*(users?|customers?|clients?|sales?|revenue|downloads?)?\b"#
-        if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
-           let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower)) {
-            let numberRange = match.range(at: 1)
-            let suffixRange = match.range(at: 2)
-            let unitRange = match.range(at: 3)
-            if let numberSwiftRange = Range(numberRange, in: lower),
-               let baseNumber = Double(lower[numberSwiftRange]) {
-                var multiplier = 1.0
-                if let suffixSwiftRange = Range(suffixRange, in: lower) {
-                    switch lower[suffixSwiftRange] {
-                    case "k": multiplier = 1_000
-                    case "m": multiplier = 1_000_000
-                    case "b": multiplier = 1_000_000_000
-                    default: break
-                    }
-                }
-                let unit: String? = Range(unitRange, in: lower).map { String(lower[$0]) }
-                return (.numeric, max(baseNumber * multiplier, 1), unit)
-            }
-        }
-
-        return (.boolean, 1, nil)
-    }
-
-    private func shouldSkipGoalCreation(_ title: String) -> Bool {
-        if title.isEmpty {
-            return true
-        }
-        let lower = title.lowercased()
-        if lower == "skip" || lower == "done" || lower.contains("type my own") {
-            return true
-        }
-        return false
-    }
-
-    private func normalizedTaskTitle(_ text: String) -> String {
-        text
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: "\n", with: " ")
-    }
-
-    private func cleanedTaskTitle(_ text: String) -> String {
-        var cleaned = normalizedTaskTitle(text)
-        let lower = cleaned.lowercased()
-        let removablePrefixes = [
-            "my task is ",
-            "task: ",
-            "i will ",
-            "i'll ",
-            "i need to ",
-            "today i need to ",
-        ]
-        for prefix in removablePrefixes where lower.hasPrefix(prefix) {
-            cleaned = String(cleaned.dropFirst(prefix.count))
-            break
-        }
-
-        cleaned = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
-        if cleaned.hasSuffix(".") {
-            cleaned.removeLast()
-        }
-        return cleaned
-    }
-
-    private func shouldSkipTaskCreation(_ title: String) -> Bool {
-        if title.isEmpty {
-            return true
-        }
-        let lower = title.lowercased()
-        if lower == "skip" || lower == "done" || lower.contains("i'll type") || lower.contains("i’ll type") {
-            return true
-        }
-        return false
-    }
-
-    private func isDailyTask(_ text: String) -> Bool {
-        let lower = text.lowercased()
-        return lower.contains("daily")
-            || lower.contains("per day")
-            || lower.contains("every day")
-            || lower.contains("2-videos-per-day")
-            || lower.contains("videos per day")
-    }
-
-    private func maybeCreateTask(from rawText: String, source: String) async {
-        let title = cleanedTaskTitle(rawText)
-        guard !shouldSkipTaskCreation(title) else { return }
-
-        let dedupeKey = title.lowercased()
-        guard !createdTaskTitles.contains(dedupeKey) else { return }
-
-        let createdTask: TaskActionItem?
-        if isDailyTask(rawText) {
-            createdTask = await TasksStore.shared.createDailyRecurringTask(
-                description: title,
-                priority: "medium",
-                tags: ["onboarding"]
-            )
-        } else {
-            let dueToday = Calendar.current.startOfDay(for: Date())
-            createdTask = await TasksStore.shared.createTask(
-                description: title,
-                dueAt: dueToday,
-                priority: "medium",
-                tags: ["onboarding"]
-            )
-        }
-
-        if createdTask != nil {
-            createdTaskTitles.insert(dedupeKey)
-            log("OnboardingChat: Created task from onboarding input (\(source)): \(title)")
-        } else {
-            log("OnboardingChat: Failed to create task from onboarding input (\(source)): \(title)")
-        }
-    }
-
-    private func maybeCreateGoal(from rawText: String, source: String) async {
-        let rawTitle = normalizedGoalTitle(rawText)
-        guard !shouldSkipGoalCreation(rawTitle) else { return }
-
-        let aiNormalized = await GoalsAIService.shared.normalizeOnboardingGoalInput(rawTitle)
-        let title = aiNormalized?.title ?? heuristicGoalTitle(rawTitle)
-        guard !shouldSkipGoalCreation(title) else { return }
-
-        let config: (goalType: GoalType, targetValue: Double, unit: String?) =
-            aiNormalized.map { (goalType: $0.goalType, targetValue: $0.targetValue, unit: $0.unit) }
-            ?? fallbackGoalConfig(from: title)
-        let dedupeKey = title.lowercased()
-        guard !createdGoalTitles.contains(dedupeKey) else { return }
-
-        do {
-            let goal = try await APIClient.shared.createGoal(
-                title: title,
-                description: "Added from onboarding",
-                goalType: config.goalType,
-                targetValue: config.targetValue,
-                currentValue: 0,
-                unit: config.unit,
-                source: "onboarding_\(source)"
-            )
-            _ = try? await GoalStorage.shared.syncServerGoal(goal)
-            createdGoalTitles.insert(dedupeKey)
-            awaitingGoalInput = false
-            log("OnboardingChat: Created goal from onboarding input: \(title) (\(config.goalType.rawValue), target: \(config.targetValue))")
-        } catch {
-            logError("OnboardingChat: Failed to create goal from onboarding input", error: error)
-        }
-    }
-
-    private func handleOnboardingComplete() {
-        log("OnboardingChatView: Chat step complete, advancing to next onboarding step")
-
-        // Clean up parallel exploration
-        explorationTask?.cancel()
-        explorationTask = nil
-        if let bridge = explorationBridge {
-            Task { await bridge.stop() }
-        }
-        explorationBridge = nil
-
-        // Clean up Gmail reading
-        gmailReadingTask?.cancel()
-        gmailReadingTask = nil
-
-        // Clean up Calendar reading
-        calendarReadingTask?.cancel()
-        calendarReadingTask = nil
-
-        // Notify parent to advance to next step
-        onComplete()
-    }
-
-    /// Build a compact summary of the conversation so far for inclusion in the system prompt.
-    /// This ensures the AI has context even if ACP session/resume fails and a fresh session starts.
-    private func buildConversationContext(from messages: [ChatMessage]) -> String {
-        guard !messages.isEmpty else { return "" }
-
-        var lines: [String] = []
-        for message in messages {
-            let role = message.sender == .user ? "User" : "Assistant"
-            let text = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !text.isEmpty else { continue }
-            // Truncate very long messages to keep the context compact
-            let truncated = text.count > 500 ? String(text.prefix(500)) + "..." : text
-            lines.append("\(role): \(truncated)")
-        }
-        return lines.joined(separator: "\n")
-    }
-
-    // MARK: - Parallel Exploration
-
-    /// Check if files are already indexed and start/restore exploration (for resume path)
-    private func checkAndStartExploration(graphViewModel: MemoryGraphViewModel?) async {
-        guard !explorationRunning && !explorationCompleted else { return }
-
-        // If exploration already completed in a prior session, restore from saved state
-        if let saved = OnboardingChatPersistence.loadExplorationState(), saved.completed {
-            log("OnboardingChat: Restoring completed exploration from saved state (\(saved.text.count) chars)")
-            explorationText = saved.text
-            explorationCompleted = true
-            // Re-inject the discovery card (UI state was lost on restart)
-            if !saved.text.isEmpty {
-                await injectExplorationDiscoveryCard()
-            }
-            return
-        }
-
-        // Otherwise check if files are indexed and run exploration fresh
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
-        let fileCount = (try? await dbQueue.read { db in
-            try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM indexed_files")
-        }) ?? 0
-
-        if fileCount > 0 {
-            log("OnboardingChat: Files already indexed (\(fileCount)), starting exploration on resume")
-            startExploration(fileCount: fileCount, graphViewModel: graphViewModel)
-            startGmailReading()
-            startCalendarReading()
-        }
-    }
-
-    private func startExploration(fileCount: Int, graphViewModel: MemoryGraphViewModel?) {
-        guard !explorationRunning else { return }
-        explorationRunning = true
-        log("OnboardingChat: Starting parallel exploration (\(fileCount) files indexed)")
-        AnalyticsManager.shared.onboardingChatToolUsed(tool: "exploration_started", properties: ["file_count": fileCount])
-
-        explorationTask = Task {
-            do {
-                let bridge = ACPBridge(passApiKey: true)
-                await MainActor.run { explorationBridge = bridge }
-                try await bridge.start()
-
-                let userName = AuthService.shared.displayName.isEmpty ? "User" : AuthService.shared.displayName
-                let schema = await Self.loadDatabaseSchema()
-                let systemPrompt = ChatPromptBuilder.buildOnboardingExploration(userName: userName, databaseSchema: schema)
-
-                let result = try await bridge.query(
-                    prompt: "Begin exploration. \(fileCount) files have been indexed in the indexed_files table.",
-                    systemPrompt: systemPrompt,
-                    model: "claude-opus-4-6",
-                    onTextDelta: { @Sendable delta in
-                        Task { @MainActor in
-                            explorationText += delta
-                            // Persist partial text periodically (every ~500 chars) so it survives crashes
-                            if explorationText.count % 500 < delta.count {
-                                OnboardingChatPersistence.saveExplorationState(text: explorationText, completed: false)
-                            }
-                        }
-                    },
-                    onToolCall: { @Sendable _, name, input in
-                        let toolCall = ToolCall(name: name, arguments: input, thoughtSignature: nil)
-                        let result = await ChatToolExecutor.execute(toolCall)
-                        log("OnboardingChat: Exploration tool \(name) executed")
-                        return result
-                    },
-                    onToolActivity: { @Sendable name, status, _, _ in
-                        log("OnboardingChat: Exploration tool \(name) \(status)")
-                    }
-                )
-
-                log("OnboardingChat: Exploration completed (cost=$\(String(format: "%.4f", result.costUsd)), tokens=\(result.inputTokens)+\(result.outputTokens))")
-                AnalyticsManager.shared.onboardingChatToolUsed(tool: "exploration_completed", properties: [
-                    "cost_usd": result.costUsd,
-                    "input_tokens": result.inputTokens,
-                    "output_tokens": result.outputTokens
-                ])
-
-                let finalText = await MainActor.run {
-                    explorationCompleted = true
-                    explorationRunning = false
-                    return explorationText
-                }
-
-                // Persist so it survives app restarts
-                OnboardingChatPersistence.saveExplorationState(text: finalText, completed: true)
-
-                // Append to user profile and inject discovery card
-                await appendExplorationToProfile()
-                await injectExplorationDiscoveryCard()
-
-                await bridge.stop()
-                await MainActor.run { explorationBridge = nil }
-            } catch {
-                log("OnboardingChat: Exploration failed (non-fatal): \(error.localizedDescription)")
-                if let bridge = await MainActor.run(body: { explorationBridge }) {
-                    await bridge.stop()
-                }
-                await MainActor.run {
-                    explorationRunning = false
-                    explorationBridge = nil
-                }
-            }
-        }
-    }
-
-    /// Load a compact database schema string from sqlite_master for the exploration prompt.
-    /// This gives the AI the actual table/column names so it doesn't hallucinate them.
-    private static func loadDatabaseSchema() async -> String {
-        guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else {
-            return ""
-        }
-
-        do {
-            let tables = try await dbQueue.read { db -> [(name: String, sql: String)] in
-                let rows = try Row.fetchAll(db, sql: """
-                    SELECT name, sql FROM sqlite_master
-                    WHERE type='table' AND sql IS NOT NULL
-                    ORDER BY name
-                """)
-                return rows.compactMap { row -> (name: String, sql: String)? in
-                    guard let name: String = row["name"],
-                          let sql: String = row["sql"] else { return nil }
-                    return (name: name, sql: sql)
-                }
-            }
-
-            var lines: [String] = ["**Database schema (omi.db):**", ""]
-            for (name, sql) in tables {
-                if ChatPrompts.excludedTables.contains(name) { continue }
-                if ChatPrompts.excludedTablePrefixes.contains(where: { name.hasPrefix($0) }) { continue }
-                if name.contains("_fts") { continue }
-
-                // Extract column names from CREATE TABLE DDL
-                guard let openParen = sql.firstIndex(of: "("),
-                      let closeParen = sql.lastIndex(of: ")") else { continue }
-                let body = String(sql[sql.index(after: openParen)..<closeParen])
-                var columnDefs: [String] = []
-                var current = ""
-                var depth = 0
-                for char in body {
-                    if char == "(" { depth += 1 } else if char == ")" { depth -= 1 }
-                    if char == "," && depth == 0 {
-                        let trimmed = current.trimmingCharacters(in: .whitespacesAndNewlines)
-                        if !trimmed.isEmpty { columnDefs.append(trimmed) }
-                        current = ""
-                    } else { current.append(char) }
-                }
-                let last = current.trimmingCharacters(in: .whitespacesAndNewlines)
-                if !last.isEmpty { columnDefs.append(last) }
-
-                let columnNames = columnDefs.filter { col in
-                    let upper = col.uppercased().trimmingCharacters(in: .whitespaces)
-                    return !upper.hasPrefix("UNIQUE") && !upper.hasPrefix("CHECK") &&
-                           !upper.hasPrefix("FOREIGN") && !upper.hasPrefix("CONSTRAINT") &&
-                           !upper.hasPrefix("PRIMARY KEY")
-                }.compactMap { col -> String? in
-                    let colName = col.components(separatedBy: .whitespaces).first?
-                        .trimmingCharacters(in: CharacterSet(charactersIn: "\"'`")) ?? ""
-                    return ChatPrompts.excludedColumns.contains(colName) || colName.isEmpty ? nil : colName
-                }
-                guard !columnNames.isEmpty else { continue }
-
-                let annotation = ChatPrompts.tableAnnotations[name] ?? ""
-                let header = annotation.isEmpty ? name : "\(name) — \(annotation)"
-                lines.append(header)
-                lines.append("  \(columnNames.joined(separator: ", "))")
-                lines.append("")
-            }
-            lines.append(ChatPrompts.schemaFooter)
-            return lines.joined(separator: "\n")
-        } catch {
-            logError("Failed to load schema for exploration", error: error)
-            return ""
-        }
-    }
-
-    /// Append the exploration text to the user's AI profile
-    private func appendExplorationToProfile() async {
-        let text = await MainActor.run { explorationText }
-        guard !text.isEmpty else {
-            log("OnboardingChat: No exploration text to append to profile")
-            return
-        }
-
-        let service = AIUserProfileService.shared
-        let existingProfile = await service.getLatestProfile()
-
-        if let existing = existingProfile, let profileId = existing.id {
-            let updated = existing.profileText + "\n\n--- File Exploration Insights ---\n" + text
-            let success = await service.updateProfileText(id: profileId, newText: updated)
-            log("OnboardingChat: Appended exploration to AI profile (success=\(success))")
-        } else {
-            log("OnboardingChat: No existing AI profile, triggering generation")
-            _ = try? await service.generateProfile()
-        }
-    }
-
-    /// Inject a discovery card into the onboarding chat with the exploration profile
-    private func injectExplorationDiscoveryCard() async {
-        let text = await MainActor.run { explorationText }
-        guard !text.isEmpty else { return }
-
-        let summary = text.count > 120 ? String(text.prefix(120)) + "..." : text
+        log("OnboardingChat: Fetched \(emails.count) Gmail emails, starting synthesis")
 
         await MainActor.run {
-            chatProvider.appendDiscoveryCard(
-                title: "Your Digital Profile",
-                summary: summary,
-                fullText: text
-            )
+          gmailReadingText = "Analyzing \(emails.count) emails..."
         }
-    }
 
-    private func bringToFront() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
-            NSApp.activate(ignoringOtherApps: true)
-            for window in NSApp.windows {
-                if window.title.hasPrefix("Omi") {
-                    window.makeKeyAndOrderFront(nil)
-                    window.orderFrontRegardless()
-                }
-            }
+        let result = await GmailReaderService.shared.synthesizeFromEmails(emails: emails)
+
+        let summaryText =
+          result.profileSummary.isEmpty
+          ? "Created \(result.memories) memories and \(result.tasks) tasks from your emails."
+          : result.profileSummary
+
+        await MainActor.run {
+          gmailReadingText = summaryText
+          gmailReadingCompleted = true
+          gmailReadingRunning = false
         }
-    }
 
-    // MARK: - Gmail Reading (Parallel Onboarding Task)
+        log(
+          "OnboardingChat: Gmail synthesis complete — \(result.memories) memories, \(result.tasks) tasks"
+        )
 
-    private func startGmailReading() {
-        guard !gmailReadingRunning && !gmailReadingCompleted else { return }
-        gmailReadingRunning = true
-        log("OnboardingChat: Starting Gmail reading in background")
-
-        gmailReadingTask = Task {
-            do {
-                let emails = try await GmailReaderService.shared.readRecentEmails(
-                    maxResults: 50, query: "newer_than:30d"
-                )
-                guard !emails.isEmpty else {
-                    log("OnboardingChat: No Gmail emails found, skipping synthesis")
-                    await MainActor.run {
-                        gmailReadingRunning = false
-                        gmailReadingCompleted = true
-                    }
-                    return
-                }
-                log("OnboardingChat: Fetched \(emails.count) Gmail emails, starting synthesis")
-
-                await MainActor.run {
-                    gmailReadingText = "Analyzing \(emails.count) emails..."
-                }
-
-                let result = await GmailReaderService.shared.synthesizeFromEmails(emails: emails)
-
-                let summaryText = result.profileSummary.isEmpty
-                    ? "Created \(result.memories) memories and \(result.tasks) tasks from your emails."
-                    : result.profileSummary
-
-                await MainActor.run {
-                    gmailReadingText = summaryText
-                    gmailReadingCompleted = true
-                    gmailReadingRunning = false
-                }
-
-                log("OnboardingChat: Gmail synthesis complete — \(result.memories) memories, \(result.tasks) tasks")
-
-                // Append Gmail insights to AI profile
-                let text = await MainActor.run { gmailReadingText }
-                if !text.isEmpty {
-                    let service = AIUserProfileService.shared
-                    let existingProfile = await service.getLatestProfile()
-                    if let existing = existingProfile, let profileId = existing.id {
-                        let updated = existing.profileText + "\n\n--- Gmail Insights ---\n" + text
-                        let success = await service.updateProfileText(id: profileId, newText: updated)
-                        log("OnboardingChat: Appended Gmail insights to AI profile (success=\(success))")
-                    }
-                }
-
-            } catch {
-                log("OnboardingChat: Gmail reading failed (non-fatal): \(error.localizedDescription)")
-                await MainActor.run {
-                    gmailReadingRunning = false
-                }
-            }
+        // Append Gmail insights to AI profile
+        let text = await MainActor.run { gmailReadingText }
+        if !text.isEmpty {
+          let service = AIUserProfileService.shared
+          let existingProfile = await service.getLatestProfile()
+          if let existing = existingProfile, let profileId = existing.id {
+            let updated = existing.profileText + "\n\n--- Gmail Insights ---\n" + text
+            let success = await service.updateProfileText(id: profileId, newText: updated)
+            log("OnboardingChat: Appended Gmail insights to AI profile (success=\(success))")
+          }
         }
-    }
 
-    // MARK: - Calendar Reading (Parallel Onboarding Task)
-
-    private func startCalendarReading() {
-        guard !calendarReadingRunning && !calendarReadingCompleted else { return }
-        calendarReadingRunning = true
-        log("OnboardingChat: Starting Calendar reading in background")
-
-        calendarReadingTask = Task {
-            do {
-                let events = try await CalendarReaderService.shared.readEvents(
-                    daysBack: 90, daysForward: 14, maxResults: 200
-                )
-                guard !events.isEmpty else {
-                    log("OnboardingChat: No calendar events found, skipping synthesis")
-                    await MainActor.run {
-                        calendarReadingRunning = false
-                        calendarReadingCompleted = true
-                    }
-                    return
-                }
-                log("OnboardingChat: Fetched \(events.count) calendar events, starting synthesis")
-
-                await MainActor.run {
-                    calendarReadingText = "Analyzing \(events.count) calendar events..."
-                }
-
-                let result = await CalendarReaderService.shared.synthesizeFromEvents(events: events)
-
-                let summaryText = result.profileSummary.isEmpty
-                    ? "Created \(result.memories) memories and \(result.tasks) tasks from your calendar."
-                    : result.profileSummary
-
-                await MainActor.run {
-                    calendarReadingText = summaryText
-                    calendarReadingCompleted = true
-                    calendarReadingRunning = false
-                }
-
-                log("OnboardingChat: Calendar synthesis complete — \(result.memories) memories, \(result.tasks) tasks")
-
-                // Append Calendar insights to AI profile
-                let text = await MainActor.run { calendarReadingText }
-                if !text.isEmpty {
-                    let service = AIUserProfileService.shared
-                    let existingProfile = await service.getLatestProfile()
-                    if let existing = existingProfile, let profileId = existing.id {
-                        let updated = existing.profileText + "\n\n--- Calendar Insights ---\n" + text
-                        let success = await service.updateProfileText(id: profileId, newText: updated)
-                        log("OnboardingChat: Appended Calendar insights to AI profile (success=\(success))")
-                    }
-                }
-
-            } catch {
-                log("OnboardingChat: Calendar reading failed (non-fatal): \(error.localizedDescription)")
-                await MainActor.run {
-                    calendarReadingRunning = false
-                }
-            }
+      } catch {
+        log("OnboardingChat: Gmail reading failed (non-fatal): \(error.localizedDescription)")
+        await MainActor.run {
+          gmailReadingRunning = false
         }
+      }
     }
+  }
+
+  // MARK: - Calendar Reading (Parallel Onboarding Task)
+
+  private func startCalendarReading() {
+    guard !calendarReadingRunning && !calendarReadingCompleted else { return }
+    calendarReadingRunning = true
+    log("OnboardingChat: Starting Calendar reading in background")
+
+    calendarReadingTask = Task {
+      do {
+        let events = try await CalendarReaderService.shared.readEvents(
+          daysBack: 90, daysForward: 14, maxResults: 200
+        )
+        guard !events.isEmpty else {
+          log("OnboardingChat: No calendar events found, skipping synthesis")
+          await MainActor.run {
+            calendarReadingRunning = false
+            calendarReadingCompleted = true
+          }
+          return
+        }
+        log("OnboardingChat: Fetched \(events.count) calendar events, starting synthesis")
+
+        await MainActor.run {
+          calendarReadingText = "Analyzing \(events.count) calendar events..."
+        }
+
+        let result = await CalendarReaderService.shared.synthesizeFromEvents(events: events)
+
+        let summaryText =
+          result.profileSummary.isEmpty
+          ? "Created \(result.memories) memories and \(result.tasks) tasks from your calendar."
+          : result.profileSummary
+
+        await MainActor.run {
+          calendarReadingText = summaryText
+          calendarReadingCompleted = true
+          calendarReadingRunning = false
+        }
+
+        log(
+          "OnboardingChat: Calendar synthesis complete — \(result.memories) memories, \(result.tasks) tasks"
+        )
+
+        // Append Calendar insights to AI profile
+        let text = await MainActor.run { calendarReadingText }
+        if !text.isEmpty {
+          let service = AIUserProfileService.shared
+          let existingProfile = await service.getLatestProfile()
+          if let existing = existingProfile, let profileId = existing.id {
+            let updated = existing.profileText + "\n\n--- Calendar Insights ---\n" + text
+            let success = await service.updateProfileText(id: profileId, newText: updated)
+            log("OnboardingChat: Appended Calendar insights to AI profile (success=\(success))")
+          }
+        }
+
+      } catch {
+        log("OnboardingChat: Calendar reading failed (non-fatal): \(error.localizedDescription)")
+        await MainActor.run {
+          calendarReadingRunning = false
+        }
+      }
+    }
+  }
 }
 
 // MARK: - Gmail Insights Card
 
 struct GmailInsightsCard: View {
-    let text: String
-    let isRunning: Bool
-    let isCompleted: Bool
+  let text: String
+  let isRunning: Bool
+  let isCompleted: Bool
 
-    @State private var isExpanded = false
+  @State private var isExpanded = false
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Button(action: {
-                guard !text.isEmpty else { return }
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isExpanded.toggle()
-                }
-            }) {
-                HStack(spacing: 8) {
-                    if isRunning {
-                        ProgressView()
-                            .controlSize(.mini)
-                    } else {
-                        Image(systemName: "envelope.open.fill")
-                            .font(.system(size: 12))
-                            .foregroundColor(OmiColors.purplePrimary)
-                    }
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(isRunning ? "Reading your emails..." : "Email Insights")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        if !text.isEmpty {
-                            Text(String(text.prefix(100)).replacingOccurrences(of: "\n", with: " "))
-                                .font(.system(size: 12))
-                                .foregroundColor(OmiColors.textSecondary)
-                                .lineLimit(2)
-                        }
-                    }
-
-                    Spacer(minLength: 4)
-
-                    if !text.isEmpty {
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 10))
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-            }
-            .buttonStyle(.plain)
-
-            if isExpanded && !text.isEmpty {
-                Divider()
-                    .padding(.horizontal, 10)
-
-                ScrollView {
-                    Markdown(text)
-                        .markdownTheme(.aiMessage())
-                        .textSelection(.enabled)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
-                }
-                .frame(maxHeight: 300)
-            }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Button(action: {
+        guard !text.isEmpty else { return }
+        withAnimation(.easeInOut(duration: 0.2)) {
+          isExpanded.toggle()
         }
-        .background(OmiColors.backgroundTertiary.opacity(0.5))
-        .cornerRadius(12)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(OmiColors.purplePrimary.opacity(0.2), lineWidth: 1)
-        )
+      }) {
+        HStack(spacing: 8) {
+          if isRunning {
+            ProgressView()
+              .controlSize(.mini)
+          } else {
+            Image(systemName: "envelope.open.fill")
+              .font(.system(size: 12))
+              .foregroundColor(OmiColors.purplePrimary)
+          }
+
+          VStack(alignment: .leading, spacing: 2) {
+            Text(isRunning ? "Reading your emails..." : "Email Insights")
+              .font(.system(size: 13, weight: .semibold))
+              .foregroundColor(OmiColors.textPrimary)
+
+            if !text.isEmpty {
+              Text(String(text.prefix(100)).replacingOccurrences(of: "\n", with: " "))
+                .font(.system(size: 12))
+                .foregroundColor(OmiColors.textSecondary)
+                .lineLimit(2)
+            }
+          }
+
+          Spacer(minLength: 4)
+
+          if !text.isEmpty {
+            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+              .font(.system(size: 10))
+              .foregroundColor(OmiColors.textTertiary)
+          }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+      }
+      .buttonStyle(.plain)
+
+      if isExpanded && !text.isEmpty {
+        Divider()
+          .padding(.horizontal, 10)
+
+        ScrollView {
+          Markdown(text)
+            .markdownTheme(.aiMessage())
+            .textSelection(.enabled)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+        }
+        .frame(maxHeight: 300)
+      }
     }
+    .background(OmiColors.backgroundTertiary.opacity(0.5))
+    .cornerRadius(12)
+    .overlay(
+      RoundedRectangle(cornerRadius: 12)
+        .stroke(OmiColors.purplePrimary.opacity(0.2), lineWidth: 1)
+    )
+  }
 }
 
 // MARK: - Calendar Insights Card
 
 struct CalendarInsightsCard: View {
-    let text: String
-    let isRunning: Bool
-    let isCompleted: Bool
+  let text: String
+  let isRunning: Bool
+  let isCompleted: Bool
 
-    @State private var isExpanded = false
+  @State private var isExpanded = false
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            Button(action: {
-                guard !text.isEmpty else { return }
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isExpanded.toggle()
-                }
-            }) {
-                HStack(spacing: 8) {
-                    if isRunning {
-                        ProgressView()
-                            .controlSize(.mini)
-                    } else {
-                        Image(systemName: "calendar.badge.checkmark")
-                            .font(.system(size: 12))
-                            .foregroundColor(OmiColors.purplePrimary)
-                    }
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(isRunning ? "Reading your calendar..." : "Calendar Insights")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        if !text.isEmpty {
-                            Text(String(text.prefix(100)).replacingOccurrences(of: "\n", with: " "))
-                                .font(.system(size: 12))
-                                .foregroundColor(OmiColors.textSecondary)
-                                .lineLimit(2)
-                        }
-                    }
-
-                    Spacer(minLength: 4)
-
-                    if !text.isEmpty {
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 10))
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-            }
-            .buttonStyle(.plain)
-
-            if isExpanded && !text.isEmpty {
-                Divider()
-                    .padding(.horizontal, 10)
-
-                ScrollView {
-                    Markdown(text)
-                        .markdownTheme(.aiMessage())
-                        .textSelection(.enabled)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
-                }
-                .frame(maxHeight: 300)
-            }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      Button(action: {
+        guard !text.isEmpty else { return }
+        withAnimation(.easeInOut(duration: 0.2)) {
+          isExpanded.toggle()
         }
-        .background(OmiColors.backgroundTertiary.opacity(0.5))
-        .cornerRadius(12)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(OmiColors.purplePrimary.opacity(0.2), lineWidth: 1)
-        )
+      }) {
+        HStack(spacing: 8) {
+          if isRunning {
+            ProgressView()
+              .controlSize(.mini)
+          } else {
+            Image(systemName: "calendar.badge.checkmark")
+              .font(.system(size: 12))
+              .foregroundColor(OmiColors.purplePrimary)
+          }
+
+          VStack(alignment: .leading, spacing: 2) {
+            Text(isRunning ? "Reading your calendar..." : "Calendar Insights")
+              .font(.system(size: 13, weight: .semibold))
+              .foregroundColor(OmiColors.textPrimary)
+
+            if !text.isEmpty {
+              Text(String(text.prefix(100)).replacingOccurrences(of: "\n", with: " "))
+                .font(.system(size: 12))
+                .foregroundColor(OmiColors.textSecondary)
+                .lineLimit(2)
+            }
+          }
+
+          Spacer(minLength: 4)
+
+          if !text.isEmpty {
+            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+              .font(.system(size: 10))
+              .foregroundColor(OmiColors.textTertiary)
+          }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+      }
+      .buttonStyle(.plain)
+
+      if isExpanded && !text.isEmpty {
+        Divider()
+          .padding(.horizontal, 10)
+
+        ScrollView {
+          Markdown(text)
+            .markdownTheme(.aiMessage())
+            .textSelection(.enabled)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+        }
+        .frame(maxHeight: 300)
+      }
     }
+    .background(OmiColors.backgroundTertiary.opacity(0.5))
+    .cornerRadius(12)
+    .overlay(
+      RoundedRectangle(cornerRadius: 12)
+        .stroke(OmiColors.purplePrimary.opacity(0.2), lineWidth: 1)
+    )
+  }
 }
 
 // MARK: - Onboarding Chat Bubble
 
 struct OnboardingChatBubble: View {
-    let message: ChatMessage
-    var hidePermissionImages: Bool = false
+  let message: ChatMessage
+  var hidePermissionImages: Bool = false
 
-    /// Whether this AI message has any visible content (non-empty text or visible tool calls)
-    private var hasVisibleContent: Bool {
-        if message.sender != .ai { return true }
-        // Messages loaded from backend have empty contentBlocks but non-empty text
-        if message.contentBlocks.isEmpty {
-            return !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-        }
-        return message.contentBlocks.contains { block in
-            switch block {
-            case .toolCall(_, let name, _, _, _, _):
-                return name != "ask_followup" // ask_followup renders its own UI separately
-            case .text(_, let text):
-                return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-            case .thinking:
-                return false
-            case .discoveryCard:
-                return true
-            }
-        }
+  /// Whether this AI message has any visible content (non-empty text or visible tool calls)
+  private var hasVisibleContent: Bool {
+    if message.sender != .ai { return true }
+    // Messages loaded from backend have empty contentBlocks but non-empty text
+    if message.contentBlocks.isEmpty {
+      return !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
-
-    var body: some View {
-        if hasVisibleContent {
-            HStack(alignment: .top, spacing: 12) {
-                if message.sender == .ai {
-                    // Omi logo
-                    if let logoURL = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
-                       let logoImage = NSImage(contentsOf: logoURL) {
-                        Image(nsImage: logoImage)
-                            .resizable()
-                            .scaledToFit()
-                            .frame(width: 20, height: 20)
-                            .frame(width: 32, height: 32)
-                            .background(OmiColors.backgroundTertiary)
-                            .clipShape(Circle())
-                    }
-                }
-
-                VStack(alignment: message.sender == .user ? .trailing : .leading, spacing: 4) {
-                    if message.sender == .ai {
-                        if message.contentBlocks.isEmpty {
-                            // Fallback for messages loaded from backend (no contentBlocks, only flat text)
-                            if !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                                Markdown(message.text)
-                                    .markdownTheme(.aiMessage())
-                                    .textSelection(.enabled)
-                                    .padding(.horizontal, 14)
-                                    .padding(.vertical, 10)
-                                    .background(OmiColors.backgroundSecondary)
-                                    .cornerRadius(18)
-                            }
-                        } else {
-                            // Use the full message text (which streams continuously) for a single bubble.
-                            // contentBlocks splits text around tool calls, but message.text is uninterrupted.
-                            let allText = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                            if !allText.isEmpty {
-                                Markdown(allText)
-                                    .markdownTheme(.aiMessage())
-                                    .textSelection(.enabled)
-                                    .padding(.horizontal, 14)
-                                    .padding(.vertical, 10)
-                                    .background(OmiColors.backgroundSecondary)
-                                    .cornerRadius(18)
-                            }
-
-                            ForEach(message.contentBlocks) { block in
-                                switch block {
-                                case .toolCall(_, let name, let status, _, let input, _):
-                                    let indicator = OnboardingToolIndicator(
-                                        toolName: name,
-                                        status: status,
-                                        input: input,
-                                        hidePermissionImage: hidePermissionImages
-                                    )
-                                    if !indicator.isHidden {
-                                        indicator
-                                    }
-                                case .discoveryCard(_, let title, let summary, let fullText):
-                                    DiscoveryCard(title: title, summary: summary, fullText: fullText)
-                                default:
-                                    EmptyView()
-                                }
-                            }
-                        }
-                    } else {
-                        if !message.text.isEmpty {
-                            Markdown(message.text)
-                                .markdownTheme(.userMessage())
-                                .textSelection(.enabled)
-                                .padding(.horizontal, 14)
-                                .padding(.vertical, 10)
-                                .background(OmiColors.purplePrimary)
-                                .cornerRadius(18)
-                        }
-                    }
-                }
-
-                if message.sender == .user {
-                    // User avatar
-                    Image(systemName: "person.fill")
-                        .font(.system(size: 14))
-                        .foregroundColor(OmiColors.textSecondary)
-                        .frame(width: 32, height: 32)
-                        .background(OmiColors.backgroundTertiary)
-                        .clipShape(Circle())
-                }
-            }
-            .frame(maxWidth: .infinity, alignment: message.sender == .user ? .trailing : .leading)
-        }
+    return message.contentBlocks.contains { block in
+      switch block {
+      case .toolCall(_, let name, _, _, _, _):
+        return name != "ask_followup"  // ask_followup renders its own UI separately
+      case .text(_, let text):
+        return !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      case .thinking:
+        return false
+      case .discoveryCard:
+        return true
+      }
     }
+  }
+
+  var body: some View {
+    if hasVisibleContent {
+      HStack(alignment: .top, spacing: 12) {
+        if message.sender == .ai {
+          // Omi logo
+          if let logoURL = Bundle.resourceBundle.url(forResource: "herologo", withExtension: "png"),
+            let logoImage = NSImage(contentsOf: logoURL)
+          {
+            Image(nsImage: logoImage)
+              .resizable()
+              .scaledToFit()
+              .frame(width: 20, height: 20)
+              .frame(width: 32, height: 32)
+              .background(OmiColors.backgroundTertiary)
+              .clipShape(Circle())
+          }
+        }
+
+        VStack(alignment: message.sender == .user ? .trailing : .leading, spacing: 4) {
+          if message.sender == .ai {
+            if message.contentBlocks.isEmpty {
+              // Fallback for messages loaded from backend (no contentBlocks, only flat text)
+              if !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Markdown(message.text)
+                  .markdownTheme(.aiMessage())
+                  .textSelection(.enabled)
+                  .padding(.horizontal, 14)
+                  .padding(.vertical, 10)
+                  .background(OmiColors.backgroundSecondary)
+                  .cornerRadius(18)
+              }
+            } else {
+              // Use the full message text (which streams continuously) for a single bubble.
+              // contentBlocks splits text around tool calls, but message.text is uninterrupted.
+              let allText = message.text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+              if !allText.isEmpty {
+                Markdown(allText)
+                  .markdownTheme(.aiMessage())
+                  .textSelection(.enabled)
+                  .padding(.horizontal, 14)
+                  .padding(.vertical, 10)
+                  .background(OmiColors.backgroundSecondary)
+                  .cornerRadius(18)
+              }
+
+              ForEach(message.contentBlocks) { block in
+                switch block {
+                case .toolCall(_, let name, let status, _, let input, _):
+                  let indicator = OnboardingToolIndicator(
+                    toolName: name,
+                    status: status,
+                    input: input,
+                    hidePermissionImage: hidePermissionImages
+                  )
+                  if !indicator.isHidden {
+                    indicator
+                  }
+                case .discoveryCard(_, let title, let summary, let fullText):
+                  DiscoveryCard(title: title, summary: summary, fullText: fullText)
+                default:
+                  EmptyView()
+                }
+              }
+            }
+          } else {
+            if !message.text.isEmpty {
+              Markdown(message.text)
+                .markdownTheme(.userMessage())
+                .textSelection(.enabled)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(OmiColors.purplePrimary)
+                .cornerRadius(18)
+            }
+          }
+        }
+
+        if message.sender == .user {
+          // User avatar
+          Image(systemName: "person.fill")
+            .font(.system(size: 14))
+            .foregroundColor(OmiColors.textSecondary)
+            .frame(width: 32, height: 32)
+            .background(OmiColors.backgroundTertiary)
+            .clipShape(Circle())
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: message.sender == .user ? .trailing : .leading)
+    }
+  }
 
 }
 
 // MARK: - Tool Activity Indicator
 
 struct OnboardingToolIndicator: View {
-    let toolName: String
-    let status: ToolCallStatus
-    var input: ToolCallInput? = nil
-    var hidePermissionImage: Bool = false
+  let toolName: String
+  let status: ToolCallStatus
+  var input: ToolCallInput? = nil
+  var hidePermissionImage: Bool = false
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack(spacing: 6) {
-                if status == .running {
-                    ProgressView()
-                        .controlSize(.mini)
-                } else {
-                    Image(systemName: "checkmark.circle.fill")
-                        .font(.system(size: 10))
-                        .foregroundColor(.green)
-                }
-
-                Text(displayText)
-                    .font(.system(size: 12))
-                    .foregroundColor(OmiColors.textTertiary)
-            }
-
-            // Show permission guide image automatically for scan_files and request_permission
-            if !hidePermissionImage, let permImage = permissionImageType {
-                OnboardingPermissionImage(permissionType: permImage)
-            }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      HStack(spacing: 6) {
+        if status == .running {
+          ProgressView()
+            .controlSize(.mini)
+        } else {
+          Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: 10))
+            .foregroundColor(.green)
         }
-        .padding(.vertical, 2)
-    }
 
-    /// Whether this tool should be hidden from the UI (e.g. ask_followup renders its own UI)
-    var isHidden: Bool {
-        cleanToolName == "ask_followup"
-            || cleanToolName == "save_knowledge_graph"
-    }
+        Text(displayText)
+          .font(.system(size: 12))
+          .foregroundColor(OmiColors.textTertiary)
+      }
 
-    /// Strip MCP prefix from tool name (e.g. "mcp__omi-tools__scan_files" → "scan_files")
-    private var cleanToolName: String {
-        if toolName.hasPrefix("mcp__") {
-            return String(toolName.split(separator: "__").last ?? Substring(toolName))
-        }
-        return toolName
+      // Show permission guide image automatically for scan_files and request_permission
+      if !hidePermissionImage, let permImage = permissionImageType {
+        OnboardingPermissionImage(permissionType: permImage)
+      }
     }
+    .padding(.vertical, 2)
+  }
 
-    /// Determines which permission image to show based on the tool name and input
-    private var permissionImageType: String? {
-        switch cleanToolName {
-        case "scan_files", "start_file_scan":
-            return "folder_access"
-        case "request_permission":
-            return input?.summary // summary contains the permission type (e.g., "microphone")
-        default:
-            return nil
-        }
-    }
+  /// Whether this tool should be hidden from the UI (e.g. ask_followup renders its own UI)
+  var isHidden: Bool {
+    cleanToolName == "ask_followup"
+      || cleanToolName == "save_knowledge_graph"
+  }
 
-    private var displayText: String {
-        switch cleanToolName {
-        case "scan_files", "start_file_scan":
-            return status == .running ? "Scanning your files..." : "Files scanned"
-        case "check_permission_status":
-            return status == .running ? "Checking permissions..." : "Permissions checked"
-        case "request_permission":
-            return status == .running ? "Requesting permission..." : "Permission requested"
-        case "set_user_preferences":
-            return status == .running ? "Saving preferences..." : "Preferences saved"
-        case "complete_onboarding":
-            return status == .running ? "Finishing setup..." : "Setup complete"
-        case "save_knowledge_graph":
-            return status == .running ? "Updating your profile..." : "Profile updated"
-        default:
-            if toolName == "WebSearch" || toolName.contains("search") || toolName.contains("web") {
-                return status == .running ? "Learning more about you..." : "Learned more about you"
-            }
-            if toolName.hasPrefix("WebFetch:") || toolName == "WebFetch" {
-                return status == .running ? "Reading context..." : "Context updated"
-            }
-            return status == .running ? "Working..." : "Done"
-        }
+  /// Strip MCP prefix from tool name (e.g. "mcp__omi-tools__scan_files" → "scan_files")
+  private var cleanToolName: String {
+    if toolName.hasPrefix("mcp__") {
+      return String(toolName.split(separator: "__").last ?? Substring(toolName))
     }
+    return toolName
+  }
+
+  /// Determines which permission image to show based on the tool name and input
+  private var permissionImageType: String? {
+    switch cleanToolName {
+    case "request_permission":
+      return input?.summary  // summary contains the permission type (e.g., "microphone")
+    default:
+      return nil
+    }
+  }
+
+  private var displayText: String {
+    switch cleanToolName {
+    case "scan_files", "start_file_scan":
+      return status == .running ? "Scanning your files..." : "Files scanned"
+    case "check_permission_status":
+      return status == .running ? "Checking permissions..." : "Permissions checked"
+    case "request_permission":
+      return status == .running ? "Requesting permission..." : "Permission requested"
+    case "set_user_preferences":
+      return status == .running ? "Saving preferences..." : "Preferences saved"
+    case "complete_onboarding":
+      return status == .running ? "Finishing setup..." : "Setup complete"
+    case "save_knowledge_graph":
+      return status == .running ? "Updating your profile..." : "Profile updated"
+    default:
+      if toolName == "WebSearch" || toolName.contains("search") || toolName.contains("web") {
+        return status == .running ? "Learning more about you..." : "Learned more about you"
+      }
+      if toolName.hasPrefix("WebFetch:") || toolName == "WebFetch" {
+        return status == .running ? "Reading context..." : "Context updated"
+      }
+      return status == .running ? "Working..." : "Done"
+    }
+  }
 }
 
 // MARK: - Permission Guide Image
 
 struct OnboardingPermissionImage: View {
-    let permissionType: String
+  let permissionType: String
 
-    private var resourceInfo: (name: String, ext: String)? {
-        switch permissionType {
-        case "microphone":
-            return ("microphone-settings", "png")
-        case "notifications":
-            return ("enable_notifications", "gif")
-        case "accessibility":
-            return ("accessibility_permission", "gif")
-        case "screen_recording":
-            return ("permissions", "gif")
-        case "folder_access":
-            return ("folder_access", "png")
-        case "full_disk_access":
-            return ("full_disk_access", "png")
-        default:
-            return nil
-        }
+  private var resourceInfo: (name: String, ext: String)? {
+    switch permissionType {
+    case "microphone":
+      return ("microphone-settings", "png")
+    case "notifications":
+      return ("enable_notifications", "gif")
+    case "accessibility":
+      return ("accessibility_permission", "gif")
+    case "screen_recording":
+      return ("permissions", "gif")
+    case "folder_access":
+      return ("folder_access", "png")
+    case "full_disk_access":
+      return ("full_disk_access", "png")
+    default:
+      return nil
     }
+  }
 
-    var body: some View {
-        if let info = resourceInfo {
-            if info.ext == "gif" {
-                AnimatedGIFView(gifName: info.name)
-                    .frame(maxWidth: 320, maxHeight: 200)
-                    .cornerRadius(12)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(OmiColors.backgroundQuaternary, lineWidth: 1)
-                    )
-            } else if let url = Bundle.resourceBundle.url(forResource: info.name, withExtension: info.ext),
-                      let nsImage = NSImage(contentsOf: url) {
-                Image(nsImage: nsImage)
-                    .resizable()
-                    .scaledToFit()
-                    .frame(maxWidth: 320, maxHeight: 200)
-                    .cornerRadius(12)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(OmiColors.backgroundQuaternary, lineWidth: 1)
-                    )
-            }
-        }
+  var body: some View {
+    if let info = resourceInfo {
+      if info.ext == "gif" {
+        AnimatedGIFView(gifName: info.name)
+          .frame(maxWidth: 320, maxHeight: 200)
+          .cornerRadius(12)
+          .overlay(
+            RoundedRectangle(cornerRadius: 12)
+              .stroke(OmiColors.backgroundQuaternary, lineWidth: 1)
+          )
+      } else if let url = Bundle.resourceBundle.url(
+        forResource: info.name, withExtension: info.ext),
+        let nsImage = NSImage(contentsOf: url)
+      {
+        Image(nsImage: nsImage)
+          .resizable()
+          .scaledToFit()
+          .frame(maxWidth: 320, maxHeight: 200)
+          .cornerRadius(12)
+          .overlay(
+            RoundedRectangle(cornerRadius: 12)
+              .stroke(OmiColors.backgroundQuaternary, lineWidth: 1)
+          )
+      }
     }
+  }
 }
 
 // MARK: - Exploration Profile Card
 
 /// Shows streaming exploration progress during onboarding, then becomes a collapsible profile card
 struct ExplorationProfileCard: View {
-    let text: String
-    let isRunning: Bool
-    let isCompleted: Bool
+  let text: String
+  let isRunning: Bool
+  let isCompleted: Bool
 
-    @State private var isExpanded = false
+  @State private var isExpanded = false
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header
-            Button(action: {
-                guard !text.isEmpty else { return }
-                withAnimation(.easeInOut(duration: 0.2)) {
-                    isExpanded.toggle()
-                }
-            }) {
-                HStack(spacing: 8) {
-                    if isRunning {
-                        ProgressView()
-                            .controlSize(.mini)
-                    } else {
-                        Image(systemName: "doc.text.magnifyingglass")
-                            .font(.system(size: 12))
-                            .foregroundColor(OmiColors.purplePrimary)
-                    }
-
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(isRunning ? "Learning about you..." : "Your Digital Profile")
-                            .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(OmiColors.textPrimary)
-
-                        if !text.isEmpty {
-                            Text(String(text.prefix(100)).replacingOccurrences(of: "\n", with: " "))
-                                .font(.system(size: 12))
-                                .foregroundColor(OmiColors.textSecondary)
-                                .lineLimit(2)
-                        }
-                    }
-
-                    Spacer(minLength: 4)
-
-                    if !text.isEmpty {
-                        Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
-                            .font(.system(size: 10))
-                            .foregroundColor(OmiColors.textTertiary)
-                    }
-                }
-                .padding(.horizontal, 12)
-                .padding(.vertical, 10)
-            }
-            .buttonStyle(.plain)
-
-            // Expanded content
-            if isExpanded && !text.isEmpty {
-                Divider()
-                    .padding(.horizontal, 10)
-
-                ScrollView {
-                    Markdown(text)
-                        .markdownTheme(.aiMessage())
-                        .textSelection(.enabled)
-                        .padding(.horizontal, 12)
-                        .padding(.vertical, 10)
-                }
-                .frame(maxHeight: 300)
-            }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 0) {
+      // Header
+      Button(action: {
+        guard !text.isEmpty else { return }
+        withAnimation(.easeInOut(duration: 0.2)) {
+          isExpanded.toggle()
         }
-        .background(OmiColors.backgroundTertiary.opacity(0.5))
-        .cornerRadius(12)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(OmiColors.purplePrimary.opacity(0.2), lineWidth: 1)
-        )
+      }) {
+        HStack(spacing: 8) {
+          if isRunning {
+            ProgressView()
+              .controlSize(.mini)
+          } else {
+            Image(systemName: "doc.text.magnifyingglass")
+              .font(.system(size: 12))
+              .foregroundColor(OmiColors.purplePrimary)
+          }
+
+          VStack(alignment: .leading, spacing: 2) {
+            Text(isRunning ? "Learning about you..." : "Your Digital Profile")
+              .font(.system(size: 13, weight: .semibold))
+              .foregroundColor(OmiColors.textPrimary)
+
+            if !text.isEmpty {
+              Text(String(text.prefix(100)).replacingOccurrences(of: "\n", with: " "))
+                .font(.system(size: 12))
+                .foregroundColor(OmiColors.textSecondary)
+                .lineLimit(2)
+            }
+          }
+
+          Spacer(minLength: 4)
+
+          if !text.isEmpty {
+            Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+              .font(.system(size: 10))
+              .foregroundColor(OmiColors.textTertiary)
+          }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+      }
+      .buttonStyle(.plain)
+
+      // Expanded content
+      if isExpanded && !text.isEmpty {
+        Divider()
+          .padding(.horizontal, 10)
+
+        ScrollView {
+          Markdown(text)
+            .markdownTheme(.aiMessage())
+            .textSelection(.enabled)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+        }
+        .frame(maxHeight: 300)
+      }
     }
+    .background(OmiColors.backgroundTertiary.opacity(0.5))
+    .cornerRadius(12)
+    .overlay(
+      RoundedRectangle(cornerRadius: 12)
+        .stroke(OmiColors.purplePrimary.opacity(0.2), lineWidth: 1)
+    )
+  }
 }

--- a/desktop/Desktop/Sources/ResourceMonitor.swift
+++ b/desktop/Desktop/Sources/ResourceMonitor.swift
@@ -5,554 +5,583 @@ import Sentry
 /// Monitors system resources (memory, CPU, disk) and reports to Sentry
 @MainActor
 class ResourceMonitor {
-    static let shared = ResourceMonitor()
+  static let shared = ResourceMonitor()
 
-    /// Check if this is a development build (avoids Sentry calls in dev)
-    private let isDevBuild: Bool = Bundle.main.bundleIdentifier?.hasSuffix("-dev") == true
+  /// Check if this is a non-production build (avoids Sentry calls in test apps)
+  private let isDevBuild: Bool = AppBuild.isNonProduction
 
-    // MARK: - Configuration
+  // MARK: - Configuration
 
-    /// How often to sample resources (seconds)
-    private let sampleInterval: TimeInterval = 30
+  /// How often to sample resources (seconds)
+  private let sampleInterval: TimeInterval = 30
 
-    /// Memory threshold (MB) - warn when exceeded
-    private let memoryWarningThreshold: UInt64 = 500
+  /// Memory threshold (MB) - warn when exceeded
+  private let memoryWarningThreshold: UInt64 = 500
 
-    /// Memory threshold (MB) - critical alert
-    private let memoryCriticalThreshold: UInt64 = 800
+  /// Memory threshold (MB) - critical alert
+  private let memoryCriticalThreshold: UInt64 = 800
 
-    /// Memory growth rate threshold (MB/min) - detect leaks
-    private let memoryGrowthRateThreshold: Double = 50
+  /// Memory growth rate threshold (MB/min) - detect leaks
+  private let memoryGrowthRateThreshold: Double = 50
 
-    /// Extreme memory threshold - auto-restart to prevent system from becoming unusable.
-    /// Keep this well below the point where free RAM is exhausted — at 4GB the system
-    /// has ~120MB free and the new instance fails to launch, leaving the user stuck.
-    /// At 3GB there is still ~10-13GB free on typical 16GB machines.
-    private let memoryAutoRestartThreshold: UInt64 = 3000 // 3GB
+  /// Extreme memory threshold - auto-restart to prevent system from becoming unusable.
+  /// Keep this well below the point where free RAM is exhausted — at 4GB the system
+  /// has ~120MB free and the new instance fails to launch, leaving the user stuck.
+  /// At 3GB there is still ~10-13GB free on typical 16GB machines.
+  private let memoryAutoRestartThreshold: UInt64 = 3000  // 3GB
 
-    // MARK: - State
+  // MARK: - State
 
-    private var monitorTimer: Timer?
-    private var isMonitoring = false
-    private var memorySamples: [(timestamp: Date, memoryMB: UInt64)] = []
-    private let maxSamples = 20 // Keep last 20 samples for trend analysis
-    private var lastWarningTime: Date?
-    private var lastCriticalTime: Date?
-    private var peakMemoryObserved: UInt64 = 0 // Track peak memory manually
-    private var autoRestartTriggered = false // Only auto-restart once per session
+  private var monitorTimer: Timer?
+  private var isMonitoring = false
+  private var memorySamples: [(timestamp: Date, memoryMB: UInt64)] = []
+  private let maxSamples = 20  // Keep last 20 samples for trend analysis
+  private var lastWarningTime: Date?
+  private var lastCriticalTime: Date?
+  private var peakMemoryObserved: UInt64 = 0  // Track peak memory manually
+  private var autoRestartTriggered = false  // Only auto-restart once per session
 
-    // Minimum time between warnings (prevent spam)
-    private let warningCooldown: TimeInterval = 300 // 5 minutes
+  // Minimum time between warnings (prevent spam)
+  private let warningCooldown: TimeInterval = 300  // 5 minutes
 
-    private init() {}
+  private init() {}
 
-    // MARK: - Public API
+  // MARK: - Public API
 
-    /// Start monitoring resources
-    func start() {
-        guard !isMonitoring else { return }
-        isMonitoring = true
+  /// Start monitoring resources
+  func start() {
+    guard !isMonitoring else { return }
+    isMonitoring = true
 
-        log("ResourceMonitor: Starting resource monitoring (interval: \(Int(sampleInterval))s)")
+    log("ResourceMonitor: Starting resource monitoring (interval: \(Int(sampleInterval))s)")
 
-        // Take initial sample
-        Task {
-            await sampleResources()
-        }
-
-        // Start periodic sampling
-        monitorTimer = Timer.scheduledTimer(withTimeInterval: sampleInterval, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                await self?.sampleResources()
-            }
-        }
+    // Take initial sample
+    Task {
+      await sampleResources()
     }
 
-    /// Stop monitoring resources
-    func stop() {
-        guard isMonitoring else { return }
-        isMonitoring = false
-        monitorTimer?.invalidate()
-        monitorTimer = nil
-        memorySamples.removeAll()
-        log("ResourceMonitor: Stopped resource monitoring")
+    // Start periodic sampling
+    monitorTimer = Timer.scheduledTimer(withTimeInterval: sampleInterval, repeats: true) {
+      [weak self] _ in
+      Task { @MainActor in
+        await self?.sampleResources()
+      }
+    }
+  }
+
+  /// Stop monitoring resources
+  func stop() {
+    guard isMonitoring else { return }
+    isMonitoring = false
+    monitorTimer?.invalidate()
+    monitorTimer = nil
+    memorySamples.removeAll()
+    log("ResourceMonitor: Stopped resource monitoring")
+  }
+
+  /// Get current resource snapshot
+  func getCurrentResources() -> ResourceSnapshot {
+    return ResourceSnapshot(
+      memoryUsageMB: getMemoryUsageMB(),
+      memoryFootprintMB: getMemoryFootprintMB(),
+      peakMemoryMB: getPeakMemoryMB(),
+      memoryPercent: getMemoryPercentage(),
+      totalSystemRAM_MB: getTotalSystemRAM(),
+      systemMemoryPressure: getSystemMemoryPressure(),
+      cpuUsage: getCPUUsage(),
+      diskUsedGB: getDiskUsedGB(),
+      diskFreeGB: getDiskFreeGB(),
+      threadCount: getThreadCount(),
+      timestamp: Date()
+    )
+  }
+
+  /// Manually report current resources to Sentry (call before known heavy operations)
+  func reportResourcesNow(context: String) {
+    let snapshot = getCurrentResources()
+
+    // Add as breadcrumb (skip in dev builds)
+    if !isDevBuild {
+      let breadcrumb = Breadcrumb(level: .info, category: "resources")
+      breadcrumb.message =
+        "[\(context)] Memory: \(snapshot.memoryUsageMB)MB, Footprint: \(snapshot.memoryFootprintMB)MB, CPU: \(String(format: "%.1f", snapshot.cpuUsage))%"
+      breadcrumb.data = snapshot.asDictionary()
+      SentrySDK.addBreadcrumb(breadcrumb)
     }
 
-    /// Get current resource snapshot
-    func getCurrentResources() -> ResourceSnapshot {
-        return ResourceSnapshot(
-            memoryUsageMB: getMemoryUsageMB(),
-            memoryFootprintMB: getMemoryFootprintMB(),
-            peakMemoryMB: getPeakMemoryMB(),
-            memoryPercent: getMemoryPercentage(),
-            totalSystemRAM_MB: getTotalSystemRAM(),
-            systemMemoryPressure: getSystemMemoryPressure(),
-            cpuUsage: getCPUUsage(),
-            diskUsedGB: getDiskUsedGB(),
-            diskFreeGB: getDiskFreeGB(),
-            threadCount: getThreadCount(),
-            timestamp: Date()
+    log("ResourceMonitor: [\(context)] \(snapshot.summary)")
+  }
+
+  // MARK: - Private Methods
+
+  private func sampleResources() async {
+    let snapshot = getCurrentResources()
+
+    // Store memory sample for trend analysis
+    memorySamples.append((timestamp: snapshot.timestamp, memoryMB: snapshot.memoryFootprintMB))
+    if memorySamples.count > maxSamples {
+      memorySamples.removeFirst()
+    }
+
+    // Update Sentry context with current resources
+    updateSentryContext(snapshot)
+
+    // Check for issues
+    checkMemoryThresholds(snapshot)
+    checkMemoryGrowthRate()
+
+    // Log periodically (every 5th sample = ~2.5 min)
+    if memorySamples.count % 5 == 0 {
+      log("ResourceMonitor: \(snapshot.summary)")
+    }
+
+    // Log per-component memory diagnostics every 10th sample (~5 min)
+    if memorySamples.count % 10 == 0 {
+      await logComponentDiagnostics(snapshot: snapshot)
+    }
+  }
+
+  /// Collect and log per-component memory diagnostics to help identify leak sources
+  private func logComponentDiagnostics(snapshot: ResourceSnapshot) async {
+    var components: [String: Any] = [:]
+
+    // LiveNotesMonitor buffers (MainActor — direct access)
+    let liveNotes = LiveNotesMonitor.shared
+    components["liveNotes_wordBuffer"] = liveNotes.wordBufferCount
+    components["liveNotes_notesContext"] = liveNotes.existingNotesContextCount
+    components["liveNotes_notesCount"] = liveNotes.notes.count
+
+    // VideoChunkEncoder buffer (actor — await)
+    let bufferStatus = await VideoChunkEncoder.shared.getBufferStatus()
+    components["videoEncoder_frameCount"] = bufferStatus.frameCount
+    if let age = bufferStatus.oldestFrameAge {
+      components["videoEncoder_oldestFrameAgeSec"] = Int(age)
+    }
+
+    // FocusAssistant pending tasks (actor — await, optional since it may not be initialized)
+    if let focusAssistant = ProactiveAssistantsPlugin.shared.currentFocusAssistant {
+      components["focus_pendingTasks"] = await focusAssistant.pendingTasksCount
+      components["focus_historyCount"] = await focusAssistant.analysisHistoryCount
+    }
+
+    // Rewind backpressure stats (MainActor — direct access)
+    let plugin = ProactiveAssistantsPlugin.shared
+    components["rewind_droppedFrames"] = plugin.droppedFrameCount
+    components["rewind_isProcessing"] = plugin.isProcessingRewindFrame
+
+    // Thread count is already in snapshot
+    components["threadCount"] = snapshot.threadCount
+
+    let componentSummary = components.map { "\($0.key)=\($0.value)" }.sorted().joined(
+      separator: ", ")
+    log("ResourceMonitor: COMPONENTS: \(componentSummary)")
+
+    // Add to Sentry context for crash diagnostics
+    if !isDevBuild {
+      SentrySDK.configureScope { scope in
+        scope.setContext(value: components, key: "memory_components")
+      }
+
+      // Add breadcrumb when memory is elevated
+      if snapshot.memoryFootprintMB >= memoryWarningThreshold {
+        let breadcrumb = Breadcrumb(level: .warning, category: "memory_diagnostics")
+        breadcrumb.message = "Component diagnostics at \(snapshot.memoryFootprintMB)MB"
+        breadcrumb.data = components
+        SentrySDK.addBreadcrumb(breadcrumb)
+      }
+    }
+  }
+
+  private func updateSentryContext(_ snapshot: ResourceSnapshot) {
+    // Set resource context that will be attached to all future events (skip in dev builds)
+    guard !isDevBuild else { return }
+    SentrySDK.configureScope { scope in
+      scope.setContext(value: snapshot.asDictionary(), key: "resources")
+    }
+  }
+
+  private func checkMemoryThresholds(_ snapshot: ResourceSnapshot) {
+    let now = Date()
+
+    // Extreme threshold - auto-restart to prevent the system from becoming unresponsive.
+    // Without this, memory can climb to 7GB+, causing SQLite I/O failures and making
+    // the app impossible to reopen without a full computer restart.
+    if snapshot.memoryFootprintMB >= memoryAutoRestartThreshold && !autoRestartTriggered
+      && !isDevBuild
+    {
+      autoRestartTriggered = true
+      log(
+        "ResourceMonitor: EXTREME memory \(snapshot.memoryFootprintMB)MB — auto-restarting to prevent system degradation"
+      )
+
+      SentrySDK.capture(message: "App Auto-Restarting Due to Extreme Memory") { scope in
+        scope.setLevel(.fatal)
+        scope.setTag(value: "auto_restart", key: "resource_alert")
+        scope.setContext(value: snapshot.asDictionary(), key: "resources")
+      }
+
+      // Give Sentry 3 seconds to flush, then relaunch and terminate.
+      // Only terminate if the relaunch succeeds — otherwise the user would be
+      // left with no running app and would need a full computer restart.
+      DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
+        let task = Process()
+        task.launchPath = "/usr/bin/open"
+        task.arguments = ["-n", Bundle.main.bundleURL.path]
+        do {
+          try task.run()
+          NSApp.terminate(nil)
+        } catch {
+          logError(
+            "ResourceMonitor: Failed to relaunch app during auto-restart, aborting terminate to avoid leaving user stuck",
+            error: error)
+          self.autoRestartTriggered = false  // Allow retry on next threshold check
+        }
+      }
+      return
+    }
+
+    // Critical threshold
+    if snapshot.memoryFootprintMB >= memoryCriticalThreshold {
+      if lastCriticalTime == nil || now.timeIntervalSince(lastCriticalTime!) > warningCooldown {
+        lastCriticalTime = now
+
+        log(
+          "ResourceMonitor: CRITICAL - Memory usage \(snapshot.memoryFootprintMB)MB exceeds \(memoryCriticalThreshold)MB threshold"
         )
-    }
 
-    /// Manually report current resources to Sentry (call before known heavy operations)
-    func reportResourcesNow(context: String) {
-        let snapshot = getCurrentResources()
-
-        // Add as breadcrumb (skip in dev builds)
-        if !isDevBuild {
-            let breadcrumb = Breadcrumb(level: .info, category: "resources")
-            breadcrumb.message = "[\(context)] Memory: \(snapshot.memoryUsageMB)MB, Footprint: \(snapshot.memoryFootprintMB)MB, CPU: \(String(format: "%.1f", snapshot.cpuUsage))%"
-            breadcrumb.data = snapshot.asDictionary()
-            SentrySDK.addBreadcrumb(breadcrumb)
-        }
-
-        log("ResourceMonitor: [\(context)] \(snapshot.summary)")
-    }
-
-    // MARK: - Private Methods
-
-    private func sampleResources() async {
-        let snapshot = getCurrentResources()
-
-        // Store memory sample for trend analysis
-        memorySamples.append((timestamp: snapshot.timestamp, memoryMB: snapshot.memoryFootprintMB))
-        if memorySamples.count > maxSamples {
-            memorySamples.removeFirst()
-        }
-
-        // Update Sentry context with current resources
-        updateSentryContext(snapshot)
-
-        // Check for issues
-        checkMemoryThresholds(snapshot)
-        checkMemoryGrowthRate()
-
-        // Log periodically (every 5th sample = ~2.5 min)
-        if memorySamples.count % 5 == 0 {
-            log("ResourceMonitor: \(snapshot.summary)")
-        }
-
-        // Log per-component memory diagnostics every 10th sample (~5 min)
-        if memorySamples.count % 10 == 0 {
-            await logComponentDiagnostics(snapshot: snapshot)
-        }
-    }
-
-    /// Collect and log per-component memory diagnostics to help identify leak sources
-    private func logComponentDiagnostics(snapshot: ResourceSnapshot) async {
-        var components: [String: Any] = [:]
-
-        // LiveNotesMonitor buffers (MainActor — direct access)
-        let liveNotes = LiveNotesMonitor.shared
-        components["liveNotes_wordBuffer"] = liveNotes.wordBufferCount
-        components["liveNotes_notesContext"] = liveNotes.existingNotesContextCount
-        components["liveNotes_notesCount"] = liveNotes.notes.count
-
-        // VideoChunkEncoder buffer (actor — await)
-        let bufferStatus = await VideoChunkEncoder.shared.getBufferStatus()
-        components["videoEncoder_frameCount"] = bufferStatus.frameCount
-        if let age = bufferStatus.oldestFrameAge {
-            components["videoEncoder_oldestFrameAgeSec"] = Int(age)
-        }
-
-        // FocusAssistant pending tasks (actor — await, optional since it may not be initialized)
-        if let focusAssistant = ProactiveAssistantsPlugin.shared.currentFocusAssistant {
-            components["focus_pendingTasks"] = await focusAssistant.pendingTasksCount
-            components["focus_historyCount"] = await focusAssistant.analysisHistoryCount
-        }
-
-        // Rewind backpressure stats (MainActor — direct access)
-        let plugin = ProactiveAssistantsPlugin.shared
-        components["rewind_droppedFrames"] = plugin.droppedFrameCount
-        components["rewind_isProcessing"] = plugin.isProcessingRewindFrame
-
-        // Thread count is already in snapshot
-        components["threadCount"] = snapshot.threadCount
-
-        let componentSummary = components.map { "\($0.key)=\($0.value)" }.sorted().joined(separator: ", ")
-        log("ResourceMonitor: COMPONENTS: \(componentSummary)")
-
-        // Add to Sentry context for crash diagnostics
-        if !isDevBuild {
-            SentrySDK.configureScope { scope in
-                scope.setContext(value: components, key: "memory_components")
-            }
-
-            // Add breadcrumb when memory is elevated
-            if snapshot.memoryFootprintMB >= memoryWarningThreshold {
-                let breadcrumb = Breadcrumb(level: .warning, category: "memory_diagnostics")
-                breadcrumb.message = "Component diagnostics at \(snapshot.memoryFootprintMB)MB"
-                breadcrumb.data = components
-                SentrySDK.addBreadcrumb(breadcrumb)
-            }
-        }
-    }
-
-    private func updateSentryContext(_ snapshot: ResourceSnapshot) {
-        // Set resource context that will be attached to all future events (skip in dev builds)
-        guard !isDevBuild else { return }
-        SentrySDK.configureScope { scope in
-            scope.setContext(value: snapshot.asDictionary(), key: "resources")
-        }
-    }
-
-    private func checkMemoryThresholds(_ snapshot: ResourceSnapshot) {
-        let now = Date()
-
-        // Extreme threshold - auto-restart to prevent the system from becoming unresponsive.
-        // Without this, memory can climb to 7GB+, causing SQLite I/O failures and making
-        // the app impossible to reopen without a full computer restart.
-        if snapshot.memoryFootprintMB >= memoryAutoRestartThreshold && !autoRestartTriggered && !isDevBuild {
-            autoRestartTriggered = true
-            log("ResourceMonitor: EXTREME memory \(snapshot.memoryFootprintMB)MB — auto-restarting to prevent system degradation")
-
-            SentrySDK.capture(message: "App Auto-Restarting Due to Extreme Memory") { scope in
-                scope.setLevel(.fatal)
-                scope.setTag(value: "auto_restart", key: "resource_alert")
-                scope.setContext(value: snapshot.asDictionary(), key: "resources")
-            }
-
-            // Give Sentry 3 seconds to flush, then relaunch and terminate.
-            // Only terminate if the relaunch succeeds — otherwise the user would be
-            // left with no running app and would need a full computer restart.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-                let task = Process()
-                task.launchPath = "/usr/bin/open"
-                task.arguments = ["-n", Bundle.main.bundleURL.path]
-                do {
-                    try task.run()
-                    NSApp.terminate(nil)
-                } catch {
-                    logError("ResourceMonitor: Failed to relaunch app during auto-restart, aborting terminate to avoid leaving user stuck", error: error)
-                    self.autoRestartTriggered = false  // Allow retry on next threshold check
-                }
-            }
-            return
-        }
-
-        // Critical threshold
-        if snapshot.memoryFootprintMB >= memoryCriticalThreshold {
-            if lastCriticalTime == nil || now.timeIntervalSince(lastCriticalTime!) > warningCooldown {
-                lastCriticalTime = now
-
-                log("ResourceMonitor: CRITICAL - Memory usage \(snapshot.memoryFootprintMB)MB exceeds \(memoryCriticalThreshold)MB threshold")
-
-                // Collect component diagnostics immediately at critical threshold
-                Task {
-                    await logComponentDiagnostics(snapshot: snapshot)
-                }
-
-                // Attempt to free memory by flushing heavy components
-                triggerMemoryRemediation()
-
-                // Send Sentry event (skip in dev builds)
-                if !isDevBuild {
-                    let threshold = self.memoryCriticalThreshold
-                    SentrySDK.capture(message: "Critical Memory Usage") { scope in
-                        scope.setLevel(.error)
-                        scope.setTag(value: "memory_critical", key: "resource_alert")
-                        scope.setContext(value: snapshot.asDictionary(), key: "resources")
-                        scope.setContext(value: [
-                            "threshold_mb": threshold,
-                            "current_mb": snapshot.memoryFootprintMB,
-                            "peak_mb": snapshot.peakMemoryMB
-                        ], key: "memory_details")
-                    }
-                }
-            }
-        }
-        // Warning threshold
-        else if snapshot.memoryFootprintMB >= memoryWarningThreshold {
-            if lastWarningTime == nil || now.timeIntervalSince(lastWarningTime!) > warningCooldown {
-                lastWarningTime = now
-
-                log("ResourceMonitor: WARNING - Memory usage \(snapshot.memoryFootprintMB)MB exceeds \(memoryWarningThreshold)MB threshold")
-
-                // Add warning breadcrumb (skip in dev builds)
-                if !isDevBuild {
-                    let breadcrumb = Breadcrumb(level: .warning, category: "resources")
-                    breadcrumb.message = "High memory usage: \(snapshot.memoryFootprintMB)MB"
-                    breadcrumb.data = snapshot.asDictionary()
-                    SentrySDK.addBreadcrumb(breadcrumb)
-                }
-            }
-        }
-    }
-
-    private func checkMemoryGrowthRate() {
-        guard memorySamples.count >= 5 else { return }
-
-        // Calculate growth rate over last 5 samples
-        let recentSamples = Array(memorySamples.suffix(5))
-        guard let first = recentSamples.first, let last = recentSamples.last else { return }
-
-        let timeDiffMinutes = last.timestamp.timeIntervalSince(first.timestamp) / 60.0
-        guard timeDiffMinutes > 0 else { return }
-
-        let memoryGrowthMB = Double(Int64(last.memoryMB) - Int64(first.memoryMB))
-        let growthRateMBPerMin = memoryGrowthMB / timeDiffMinutes
-
-        // Detect potential memory leak
-        if growthRateMBPerMin > memoryGrowthRateThreshold {
-            log("ResourceMonitor: WARNING - Memory growing at \(String(format: "%.1f", growthRateMBPerMin))MB/min (potential leak)")
-
-            // Add breadcrumb (skip in dev builds)
-            if !isDevBuild {
-                let breadcrumb = Breadcrumb(level: .warning, category: "resources")
-                breadcrumb.message = "Potential memory leak detected: \(String(format: "%.1f", growthRateMBPerMin))MB/min growth rate"
-                breadcrumb.data = [
-                    "growth_rate_mb_per_min": growthRateMBPerMin,
-                    "samples_analyzed": recentSamples.count,
-                    "time_span_minutes": timeDiffMinutes,
-                    "start_memory_mb": first.memoryMB,
-                    "end_memory_mb": last.memoryMB
-                ]
-                SentrySDK.addBreadcrumb(breadcrumb)
-            }
-        }
-    }
-
-    // MARK: - Memory Remediation
-
-    /// Attempt to free memory by flushing heavy components.
-    /// Called at most once per warningCooldown (5 min) when critical threshold is exceeded.
-    /// Closure called during memory remediation to trim transcript state.
-    /// Set by AppState on init to avoid tight coupling.
-    var onMemoryPressureTrimTranscript: (() -> Void)?
-
-    private func triggerMemoryRemediation() {
-        log("ResourceMonitor: Triggering memory remediation — flushing video encoder, clearing assistant pending work, trimming transcript, pausing AgentSync")
-
-        let memoryBefore = getMemoryFootprintMB()
-
-        // Clear queued frames in assistant coordinator
-        AssistantCoordinator.shared.clearAllPendingWork()
-
-        // Trim in-memory transcript segments (already persisted in SQLite)
-        onMemoryPressureTrimTranscript?()
-
+        // Collect component diagnostics immediately at critical threshold
         Task {
-            // Flush VideoChunkEncoder and await completion
-            _ = try? await VideoChunkEncoder.shared.flushCurrentChunk()
-
-            // Clear focus assistant pending tasks specifically
-            if let focusAssistant = ProactiveAssistantsPlugin.shared.currentFocusAssistant {
-                await focusAssistant.clearPendingWork()
-            }
-
-            // Pause AgentSync to reduce memory pressure and resume after 60s
-            await AgentSyncService.shared.pause()
-            Task {
-                try? await Task.sleep(nanoseconds: 60_000_000_000) // 60s
-                await AgentSyncService.shared.resume()
-                log("ResourceMonitor: AgentSync resumed after 60s cooldown")
-            }
-
-            let memoryAfter = await MainActor.run { self.getMemoryFootprintMB() }
-            log("ResourceMonitor: Memory remediation completed — \(memoryBefore)MB -> \(memoryAfter)MB")
+          await logComponentDiagnostics(snapshot: snapshot)
         }
 
+        // Attempt to free memory by flushing heavy components
+        triggerMemoryRemediation()
+
+        // Send Sentry event (skip in dev builds)
         if !isDevBuild {
-            let breadcrumb = Breadcrumb(level: .warning, category: "memory_remediation")
-            breadcrumb.message = "Memory remediation triggered at critical threshold"
-            breadcrumb.data = [
-                "memory_footprint_mb": memoryBefore,
-                "threshold_mb": memoryCriticalThreshold
-            ]
-            SentrySDK.addBreadcrumb(breadcrumb)
+          let threshold = self.memoryCriticalThreshold
+          SentrySDK.capture(message: "Critical Memory Usage") { scope in
+            scope.setLevel(.error)
+            scope.setTag(value: "memory_critical", key: "resource_alert")
+            scope.setContext(value: snapshot.asDictionary(), key: "resources")
+            scope.setContext(
+              value: [
+                "threshold_mb": threshold,
+                "current_mb": snapshot.memoryFootprintMB,
+                "peak_mb": snapshot.peakMemoryMB,
+              ], key: "memory_details")
+          }
         }
+      }
+    }
+    // Warning threshold
+    else if snapshot.memoryFootprintMB >= memoryWarningThreshold {
+      if lastWarningTime == nil || now.timeIntervalSince(lastWarningTime!) > warningCooldown {
+        lastWarningTime = now
+
+        log(
+          "ResourceMonitor: WARNING - Memory usage \(snapshot.memoryFootprintMB)MB exceeds \(memoryWarningThreshold)MB threshold"
+        )
+
+        // Add warning breadcrumb (skip in dev builds)
+        if !isDevBuild {
+          let breadcrumb = Breadcrumb(level: .warning, category: "resources")
+          breadcrumb.message = "High memory usage: \(snapshot.memoryFootprintMB)MB"
+          breadcrumb.data = snapshot.asDictionary()
+          SentrySDK.addBreadcrumb(breadcrumb)
+        }
+      }
+    }
+  }
+
+  private func checkMemoryGrowthRate() {
+    guard memorySamples.count >= 5 else { return }
+
+    // Calculate growth rate over last 5 samples
+    let recentSamples = Array(memorySamples.suffix(5))
+    guard let first = recentSamples.first, let last = recentSamples.last else { return }
+
+    let timeDiffMinutes = last.timestamp.timeIntervalSince(first.timestamp) / 60.0
+    guard timeDiffMinutes > 0 else { return }
+
+    let memoryGrowthMB = Double(Int64(last.memoryMB) - Int64(first.memoryMB))
+    let growthRateMBPerMin = memoryGrowthMB / timeDiffMinutes
+
+    // Detect potential memory leak
+    if growthRateMBPerMin > memoryGrowthRateThreshold {
+      log(
+        "ResourceMonitor: WARNING - Memory growing at \(String(format: "%.1f", growthRateMBPerMin))MB/min (potential leak)"
+      )
+
+      // Add breadcrumb (skip in dev builds)
+      if !isDevBuild {
+        let breadcrumb = Breadcrumb(level: .warning, category: "resources")
+        breadcrumb.message =
+          "Potential memory leak detected: \(String(format: "%.1f", growthRateMBPerMin))MB/min growth rate"
+        breadcrumb.data = [
+          "growth_rate_mb_per_min": growthRateMBPerMin,
+          "samples_analyzed": recentSamples.count,
+          "time_span_minutes": timeDiffMinutes,
+          "start_memory_mb": first.memoryMB,
+          "end_memory_mb": last.memoryMB,
+        ]
+        SentrySDK.addBreadcrumb(breadcrumb)
+      }
+    }
+  }
+
+  // MARK: - Memory Remediation
+
+  /// Attempt to free memory by flushing heavy components.
+  /// Called at most once per warningCooldown (5 min) when critical threshold is exceeded.
+  /// Closure called during memory remediation to trim transcript state.
+  /// Set by AppState on init to avoid tight coupling.
+  var onMemoryPressureTrimTranscript: (() -> Void)?
+
+  private func triggerMemoryRemediation() {
+    log(
+      "ResourceMonitor: Triggering memory remediation — flushing video encoder, clearing assistant pending work, trimming transcript, pausing AgentSync"
+    )
+
+    let memoryBefore = getMemoryFootprintMB()
+
+    // Clear queued frames in assistant coordinator
+    AssistantCoordinator.shared.clearAllPendingWork()
+
+    // Trim in-memory transcript segments (already persisted in SQLite)
+    onMemoryPressureTrimTranscript?()
+
+    Task {
+      // Flush VideoChunkEncoder and await completion
+      _ = try? await VideoChunkEncoder.shared.flushCurrentChunk()
+
+      // Clear focus assistant pending tasks specifically
+      if let focusAssistant = ProactiveAssistantsPlugin.shared.currentFocusAssistant {
+        await focusAssistant.clearPendingWork()
+      }
+
+      // Pause AgentSync to reduce memory pressure and resume after 60s
+      await AgentSyncService.shared.pause()
+      Task {
+        try? await Task.sleep(nanoseconds: 60_000_000_000)  // 60s
+        await AgentSyncService.shared.resume()
+        log("ResourceMonitor: AgentSync resumed after 60s cooldown")
+      }
+
+      let memoryAfter = await MainActor.run { self.getMemoryFootprintMB() }
+      log("ResourceMonitor: Memory remediation completed — \(memoryBefore)MB -> \(memoryAfter)MB")
     }
 
-    // MARK: - Resource Getters (macOS specific)
+    if !isDevBuild {
+      let breadcrumb = Breadcrumb(level: .warning, category: "memory_remediation")
+      breadcrumb.message = "Memory remediation triggered at critical threshold"
+      breadcrumb.data = [
+        "memory_footprint_mb": memoryBefore,
+        "threshold_mb": memoryCriticalThreshold,
+      ]
+      SentrySDK.addBreadcrumb(breadcrumb)
+    }
+  }
 
-    /// Get current memory usage in MB (resident set size)
-    private func getMemoryUsageMB() -> UInt64 {
-        var info = mach_task_basic_info()
-        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+  // MARK: - Resource Getters (macOS specific)
 
-        let result = withUnsafeMutablePointer(to: &info) {
-            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
-            }
-        }
+  /// Get current memory usage in MB (resident set size)
+  private func getMemoryUsageMB() -> UInt64 {
+    var info = mach_task_basic_info()
+    var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
 
-        if result == KERN_SUCCESS {
-            return info.resident_size / (1024 * 1024)
-        }
-        return 0
+    let result = withUnsafeMutablePointer(to: &info) {
+      $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+        task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+      }
     }
 
-    /// Get physical memory footprint in MB (more accurate for macOS)
-    private func getMemoryFootprintMB() -> UInt64 {
-        var info = task_vm_info_data_t()
-        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info>.size) / 4
+    if result == KERN_SUCCESS {
+      return info.resident_size / (1024 * 1024)
+    }
+    return 0
+  }
 
-        let result = withUnsafeMutablePointer(to: &info) {
-            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
-            }
-        }
+  /// Get physical memory footprint in MB (more accurate for macOS)
+  private func getMemoryFootprintMB() -> UInt64 {
+    var info = task_vm_info_data_t()
+    var count = mach_msg_type_number_t(MemoryLayout<task_vm_info>.size) / 4
 
-        if result == KERN_SUCCESS {
-            return UInt64(info.phys_footprint) / (1024 * 1024)
-        }
-        return getMemoryUsageMB() // Fallback
+    let result = withUnsafeMutablePointer(to: &info) {
+      $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+        task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+      }
     }
 
-    /// Get peak memory usage in MB (tracked manually since phys_footprint_peak unavailable)
-    private func getPeakMemoryMB() -> UInt64 {
-        let current = getMemoryFootprintMB()
-        if current > peakMemoryObserved {
-            peakMemoryObserved = current
-        }
-        return peakMemoryObserved
+    if result == KERN_SUCCESS {
+      return UInt64(info.phys_footprint) / (1024 * 1024)
+    }
+    return getMemoryUsageMB()  // Fallback
+  }
+
+  /// Get peak memory usage in MB (tracked manually since phys_footprint_peak unavailable)
+  private func getPeakMemoryMB() -> UInt64 {
+    let current = getMemoryFootprintMB()
+    if current > peakMemoryObserved {
+      peakMemoryObserved = current
+    }
+    return peakMemoryObserved
+  }
+
+  /// Get CPU usage percentage (0-100+, can exceed 100% on multi-core)
+  private func getCPUUsage() -> Double {
+    var threadList: thread_act_array_t?
+    var threadCount: mach_msg_type_number_t = 0
+
+    guard task_threads(mach_task_self_, &threadList, &threadCount) == KERN_SUCCESS,
+      let threads = threadList
+    else {
+      return 0
     }
 
-    /// Get CPU usage percentage (0-100+, can exceed 100% on multi-core)
-    private func getCPUUsage() -> Double {
-        var threadList: thread_act_array_t?
-        var threadCount: mach_msg_type_number_t = 0
-
-        guard task_threads(mach_task_self_, &threadList, &threadCount) == KERN_SUCCESS,
-              let threads = threadList else {
-            return 0
-        }
-
-        defer {
-            vm_deallocate(mach_task_self_, vm_address_t(bitPattern: threads), vm_size_t(threadCount) * vm_size_t(MemoryLayout<thread_t>.size))
-        }
-
-        var totalCPU: Double = 0
-
-        for i in 0..<Int(threadCount) {
-            var info = thread_basic_info()
-            var count = mach_msg_type_number_t(MemoryLayout<thread_basic_info>.size / MemoryLayout<natural_t>.size)
-
-            let result = withUnsafeMutablePointer(to: &info) {
-                $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-                    thread_info(threads[i], thread_flavor_t(THREAD_BASIC_INFO), $0, &count)
-                }
-            }
-
-            if result == KERN_SUCCESS && (info.flags & TH_FLAGS_IDLE) == 0 {
-                totalCPU += Double(info.cpu_usage) / Double(TH_USAGE_SCALE) * 100.0
-            }
-        }
-
-        return totalCPU
+    defer {
+      vm_deallocate(
+        mach_task_self_, vm_address_t(bitPattern: threads),
+        vm_size_t(threadCount) * vm_size_t(MemoryLayout<thread_t>.size))
     }
 
-    /// Get disk space used in GB
-    private func getDiskUsedGB() -> Double {
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        do {
-            let values = try homeDir.resourceValues(forKeys: [.volumeTotalCapacityKey, .volumeAvailableCapacityKey])
-            let total = values.volumeTotalCapacity ?? 0
-            let available = values.volumeAvailableCapacity ?? 0
-            return Double(total - available) / (1024 * 1024 * 1024)
-        } catch {
-            return 0
+    var totalCPU: Double = 0
+
+    for i in 0..<Int(threadCount) {
+      var info = thread_basic_info()
+      var count = mach_msg_type_number_t(
+        MemoryLayout<thread_basic_info>.size / MemoryLayout<natural_t>.size)
+
+      let result = withUnsafeMutablePointer(to: &info) {
+        $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+          thread_info(threads[i], thread_flavor_t(THREAD_BASIC_INFO), $0, &count)
         }
+      }
+
+      if result == KERN_SUCCESS && (info.flags & TH_FLAGS_IDLE) == 0 {
+        totalCPU += Double(info.cpu_usage) / Double(TH_USAGE_SCALE) * 100.0
+      }
     }
 
-    /// Get disk space free in GB
-    private func getDiskFreeGB() -> Double {
-        let homeDir = FileManager.default.homeDirectoryForCurrentUser
-        do {
-            let values = try homeDir.resourceValues(forKeys: [.volumeAvailableCapacityKey])
-            return Double(values.volumeAvailableCapacity ?? 0) / (1024 * 1024 * 1024)
-        } catch {
-            return 0
-        }
+    return totalCPU
+  }
+
+  /// Get disk space used in GB
+  private func getDiskUsedGB() -> Double {
+    let homeDir = FileManager.default.homeDirectoryForCurrentUser
+    do {
+      let values = try homeDir.resourceValues(forKeys: [
+        .volumeTotalCapacityKey, .volumeAvailableCapacityKey,
+      ])
+      let total = values.volumeTotalCapacity ?? 0
+      let available = values.volumeAvailableCapacity ?? 0
+      return Double(total - available) / (1024 * 1024 * 1024)
+    } catch {
+      return 0
+    }
+  }
+
+  /// Get disk space free in GB
+  private func getDiskFreeGB() -> Double {
+    let homeDir = FileManager.default.homeDirectoryForCurrentUser
+    do {
+      let values = try homeDir.resourceValues(forKeys: [.volumeAvailableCapacityKey])
+      return Double(values.volumeAvailableCapacity ?? 0) / (1024 * 1024 * 1024)
+    } catch {
+      return 0
+    }
+  }
+
+  /// Get current thread count
+  private func getThreadCount() -> Int {
+    var threadList: thread_act_array_t?
+    var threadCount: mach_msg_type_number_t = 0
+
+    guard task_threads(mach_task_self_, &threadList, &threadCount) == KERN_SUCCESS,
+      let threads = threadList
+    else {
+      return 0
     }
 
-    /// Get current thread count
-    private func getThreadCount() -> Int {
-        var threadList: thread_act_array_t?
-        var threadCount: mach_msg_type_number_t = 0
+    vm_deallocate(
+      mach_task_self_, vm_address_t(bitPattern: threads),
+      vm_size_t(threadCount) * vm_size_t(MemoryLayout<thread_t>.size))
 
-        guard task_threads(mach_task_self_, &threadList, &threadCount) == KERN_SUCCESS,
-              let threads = threadList else {
-            return 0
-        }
+    return Int(threadCount)
+  }
 
-        vm_deallocate(mach_task_self_, vm_address_t(bitPattern: threads), vm_size_t(threadCount) * vm_size_t(MemoryLayout<thread_t>.size))
+  /// Get total system RAM in MB
+  private func getTotalSystemRAM() -> UInt64 {
+    return UInt64(ProcessInfo.processInfo.physicalMemory) / (1024 * 1024)
+  }
 
-        return Int(threadCount)
+  /// Get app's memory usage as percentage of total system RAM
+  private func getMemoryPercentage() -> Double {
+    let totalRAM = getTotalSystemRAM()
+    guard totalRAM > 0 else { return 0 }
+    let footprint = getMemoryFootprintMB()
+    return (Double(footprint) / Double(totalRAM)) * 100.0
+  }
+
+  /// Get system-wide memory pressure (percentage of total RAM in use by all apps)
+  private func getSystemMemoryPressure() -> Double {
+    var stats = vm_statistics64()
+    var count = mach_msg_type_number_t(
+      MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size)
+
+    let result = withUnsafeMutablePointer(to: &stats) {
+      $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+        host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
+      }
     }
 
-    /// Get total system RAM in MB
-    private func getTotalSystemRAM() -> UInt64 {
-        return UInt64(ProcessInfo.processInfo.physicalMemory) / (1024 * 1024)
-    }
+    guard result == KERN_SUCCESS else { return 0 }
 
-    /// Get app's memory usage as percentage of total system RAM
-    private func getMemoryPercentage() -> Double {
-        let totalRAM = getTotalSystemRAM()
-        guard totalRAM > 0 else { return 0 }
-        let footprint = getMemoryFootprintMB()
-        return (Double(footprint) / Double(totalRAM)) * 100.0
-    }
+    let pageSize = UInt64(vm_kernel_page_size)
+    let totalRAM = ProcessInfo.processInfo.physicalMemory
 
-    /// Get system-wide memory pressure (percentage of total RAM in use by all apps)
-    private func getSystemMemoryPressure() -> Double {
-        var stats = vm_statistics64()
-        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.size / MemoryLayout<integer_t>.size)
+    // Active + Wired + Compressed = memory in use
+    let activeBytes = UInt64(stats.active_count) * pageSize
+    let wiredBytes = UInt64(stats.wire_count) * pageSize
+    let compressedBytes = UInt64(stats.compressor_page_count) * pageSize
+    let usedBytes = activeBytes + wiredBytes + compressedBytes
 
-        let result = withUnsafeMutablePointer(to: &stats) {
-            $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
-                host_statistics64(mach_host_self(), HOST_VM_INFO64, $0, &count)
-            }
-        }
-
-        guard result == KERN_SUCCESS else { return 0 }
-
-        let pageSize = UInt64(vm_kernel_page_size)
-        let totalRAM = ProcessInfo.processInfo.physicalMemory
-
-        // Active + Wired + Compressed = memory in use
-        let activeBytes = UInt64(stats.active_count) * pageSize
-        let wiredBytes = UInt64(stats.wire_count) * pageSize
-        let compressedBytes = UInt64(stats.compressor_page_count) * pageSize
-        let usedBytes = activeBytes + wiredBytes + compressedBytes
-
-        return (Double(usedBytes) / Double(totalRAM)) * 100.0
-    }
+    return (Double(usedBytes) / Double(totalRAM)) * 100.0
+  }
 }
 
 // MARK: - Resource Snapshot
 
 struct ResourceSnapshot {
-    let memoryUsageMB: UInt64      // Resident set size
-    let memoryFootprintMB: UInt64  // Physical footprint (more accurate)
-    let peakMemoryMB: UInt64       // Peak memory since launch
-    let memoryPercent: Double      // App memory as % of total RAM
-    let totalSystemRAM_MB: UInt64  // Total system RAM
-    let systemMemoryPressure: Double // System-wide RAM usage %
-    let cpuUsage: Double           // CPU percentage
-    let diskUsedGB: Double         // Disk used
-    let diskFreeGB: Double         // Disk free
-    let threadCount: Int           // Number of threads
-    let timestamp: Date
+  let memoryUsageMB: UInt64  // Resident set size
+  let memoryFootprintMB: UInt64  // Physical footprint (more accurate)
+  let peakMemoryMB: UInt64  // Peak memory since launch
+  let memoryPercent: Double  // App memory as % of total RAM
+  let totalSystemRAM_MB: UInt64  // Total system RAM
+  let systemMemoryPressure: Double  // System-wide RAM usage %
+  let cpuUsage: Double  // CPU percentage
+  let diskUsedGB: Double  // Disk used
+  let diskFreeGB: Double  // Disk free
+  let threadCount: Int  // Number of threads
+  let timestamp: Date
 
-    var summary: String {
-        "Memory: \(memoryFootprintMB)MB/\(totalSystemRAM_MB / 1024)GB (\(String(format: "%.2f", memoryPercent))%), System RAM: \(String(format: "%.1f", systemMemoryPressure))% used, CPU: \(String(format: "%.1f", cpuUsage))%, Threads: \(threadCount)"
-    }
+  var summary: String {
+    "Memory: \(memoryFootprintMB)MB/\(totalSystemRAM_MB / 1024)GB (\(String(format: "%.2f", memoryPercent))%), System RAM: \(String(format: "%.1f", systemMemoryPressure))% used, CPU: \(String(format: "%.1f", cpuUsage))%, Threads: \(threadCount)"
+  }
 
-    func asDictionary() -> [String: Any] {
-        return [
-            "memory_usage_mb": memoryUsageMB,
-            "memory_footprint_mb": memoryFootprintMB,
-            "peak_memory_mb": peakMemoryMB,
-            "memory_percent": memoryPercent,
-            "total_system_ram_mb": totalSystemRAM_MB,
-            "system_memory_pressure_percent": systemMemoryPressure,
-            "cpu_usage_percent": cpuUsage,
-            "disk_used_gb": diskUsedGB,
-            "disk_free_gb": diskFreeGB,
-            "thread_count": threadCount,
-            "timestamp": ISO8601DateFormatter().string(from: timestamp)
-        ]
-    }
+  func asDictionary() -> [String: Any] {
+    return [
+      "memory_usage_mb": memoryUsageMB,
+      "memory_footprint_mb": memoryFootprintMB,
+      "peak_memory_mb": peakMemoryMB,
+      "memory_percent": memoryPercent,
+      "total_system_ram_mb": totalSystemRAM_MB,
+      "system_memory_pressure_percent": systemMemoryPressure,
+      "cpu_usage_percent": cpuUsage,
+      "disk_used_gb": diskUsedGB,
+      "disk_free_gb": diskFreeGB,
+      "thread_count": threadCount,
+      "timestamp": ISO8601DateFormatter().string(from: timestamp),
+    ]
+  }
 }

--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -31,12 +31,42 @@ substep() {
 # App configuration
 BINARY_NAME="Omi Computer"  # Package.swift target — binary paths, pkill, CFBundleExecutable
 APP_NAME="${OMI_APP_NAME:-Omi Dev}"
-BUNDLE_ID="${OMI_BUNDLE_ID:-com.omi.desktop-dev}"
+
+slugify_identifier() {
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g'
+}
+
+if [ "$APP_NAME" = "Omi Dev" ]; then
+    EXPECTED_BUNDLE_ID="com.omi.desktop-dev"
+    EXPECTED_URL_SCHEME="omi-computer-dev"
+else
+    APP_SLUG="$(slugify_identifier "$APP_NAME")"
+    if [ -z "$APP_SLUG" ]; then
+        echo "ERROR: OMI_APP_NAME must contain at least one letter or number"
+        exit 1
+    fi
+    EXPECTED_BUNDLE_ID="com.omi.$APP_SLUG"
+    EXPECTED_URL_SCHEME="omi-$APP_SLUG"
+fi
+
+BUNDLE_ID="${OMI_BUNDLE_ID:-$EXPECTED_BUNDLE_ID}"
 BUILD_DIR="build"
 APP_BUNDLE="$BUILD_DIR/$APP_NAME.app"
 APP_PATH="/Applications/$APP_NAME.app"
+APP_DESKTOP_PATH="$HOME/Desktop/$APP_NAME.app"
+APP_DOWNLOADS_PATH="$HOME/Downloads/$APP_NAME.app"
 SIGN_IDENTITY="${OMI_SIGN_IDENTITY:-}"
-URL_SCHEME="${OMI_URL_SCHEME:-omi-computer-dev}"
+URL_SCHEME="${OMI_URL_SCHEME:-$EXPECTED_URL_SCHEME}"
+
+if [ "$BUNDLE_ID" != "$EXPECTED_BUNDLE_ID" ]; then
+    echo "ERROR: APP_NAME '$APP_NAME' must use bundle ID '$EXPECTED_BUNDLE_ID' (got '$BUNDLE_ID')"
+    exit 1
+fi
+
+if [ "$URL_SCHEME" != "$EXPECTED_URL_SCHEME" ]; then
+    echo "ERROR: APP_NAME '$APP_NAME' must use URL scheme '$EXPECTED_URL_SCHEME' (got '$URL_SCHEME')"
+    exit 1
+fi
 AUTOMATION_ARGS=()
 if [ "${OMI_ENABLE_LOCAL_AUTOMATION:-0}" = "1" ]; then
     AUTOMATION_PORT="${OMI_AUTOMATION_PORT:-47777}"
@@ -89,10 +119,11 @@ rm -f /tmp/omi-dev.log 2>/dev/null || true
 step "Cleaning up conflicting app bundles..."
 # Clean old build names from local build dir
 rm -rf "$BUILD_DIR/Omi Computer.app" 2>/dev/null
+rm -rf "$APP_BUNDLE" 2>/dev/null
 CONFLICTING_APPS=(
-    "/Applications/Omi Dev.app"
-    "$HOME/Desktop/Omi Dev.app"
-    "$HOME/Downloads/Omi Dev.app"
+    "$APP_PATH"
+    "$APP_DESKTOP_PATH"
+    "$APP_DOWNLOADS_PATH"
     "$(dirname "$0")/../app/build/macos/Build/Products/Debug/Omi.app"
     "$(dirname "$0")/../app/build/macos/Build/Products/Release/Omi.app"
 )
@@ -103,10 +134,10 @@ for app in "${CONFLICTING_APPS[@]}"; do
     fi
 done
 # Also remove any stale dev app bundles nested inside Flutter builds.
-find "$(dirname "$0")/../app/build" -name "Omi Dev.app" -type d -exec rm -rf {} + 2>/dev/null || true
-# Kill stale "Omi Dev.app" bundles from other repo clones (e.g. ~/omi-desktop/)
-# These confuse LaunchServices and get launched instead of /Applications/Omi Dev.app
-find "$HOME" -maxdepth 4 -name "Omi Dev.app" -type d -not -path "$APP_BUNDLE" -not -path "$APP_PATH" 2>/dev/null | while read stale; do
+find "$(dirname "$0")/../app/build" -name "$APP_NAME.app" -type d -exec rm -rf {} + 2>/dev/null || true
+# Kill stale app bundles from other repo clones (e.g. ~/omi-desktop/)
+# These confuse LaunchServices and get launched instead of the /Applications copy.
+find "$HOME" -maxdepth 4 -name "$APP_NAME.app" -type d -not -path "$APP_BUNDLE" -not -path "$APP_PATH" 2>/dev/null | while read stale; do
     substep "Removing stale clone: $stale"
     rm -rf "$stale"
 done
@@ -243,12 +274,13 @@ cp -f Desktop/Info.plist "$APP_BUNDLE/Contents/Info.plist"
 
 auth_debug "AFTER plist edits: auth_isSignedIn=$(defaults read "$BUNDLE_ID" auth_isSignedIn 2>&1 || true)"
 
-substep "Copying GoogleService-Info.plist (dev version for com.omi.desktop-dev)"
+substep "Copying GoogleService-Info.plist"
 if [ -f "Desktop/Sources/GoogleService-Info-Dev.plist" ]; then
     cp -f Desktop/Sources/GoogleService-Info-Dev.plist "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist"
 else
     cp -f Desktop/Sources/GoogleService-Info.plist "$APP_BUNDLE/Contents/Resources/"
 fi
+/usr/libexec/PlistBuddy -c "Set :BUNDLE_ID $BUNDLE_ID" "$APP_BUNDLE/Contents/Resources/GoogleService-Info.plist" 2>/dev/null || true
 
 # Copy resource bundle (contains app assets like permissions.gif, herologo.png, etc.)
 RESOURCE_BUNDLE="Desktop/.build/arm64-apple-macosx/debug/Omi Computer_Omi Computer.bundle"


### PR DESCRIPTION
## Summary
- align custom macOS desktop test builds so app name, bundle ID, and auth callback scheme stay consistent
- treat non-production com.omi.* bundles as dev/test builds and preserve custom app naming in the desktop app
- add a minimal onboarding recovery fallback so resumed onboarding cannot get stuck waiting forever for complete_onboarding
- remove the stale folder-access onboarding image while keeping real permission guidance, including screen recording/full disk access follow-ups

## Verification
- xcrun swift test -c debug --package-path Desktop
- built and relaunched /Applications/1233.app
- verified the running app with agent-swift against bundle id com.omi.1233
- verified custom callback scheme routing for the 1233 test app during earlier local auth testing