### PR TITLE
fix: clear Claude auth state when switching bridge modes (#4937)

### DIFF
--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -615,6 +615,11 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         await acpBridge.stop()
         acpBridgeStarted = false
 
+        // Clear auth state from previous mode to prevent stale auth prompts
+        isClaudeAuthRequired = false
+        claudeAuthUrl = nil
+        claudeAuthMethods = []
+
         // Switch mode and recreate bridge with appropriate passApiKey
         bridgeMode = mode.rawValue
         acpBridge = ACPBridge(passApiKey: mode == .omiAI)


### PR DESCRIPTION
Fixes #4937

When switching from user's Claude account mode to Omi AI mode, the `isClaudeAuthRequired` flag was never cleared. This caused the auth sheet to persist in a loop even after switching to Omi mode, making AI chat completely unusable.

Fix: Clear all Claude auth state (`isClaudeAuthRequired`, `claudeAuthUrl`, `claudeAuthMethods`) when switching bridge modes.