### PR TITLE
Fix desktop sidebar hosting layout glitch

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -540,7 +540,6 @@ struct DesktopHomeView: View {
             isCollapsed: $isSidebarCollapsed,
             appState: appState
           )
-          .clickThrough(enabled: !isInSettings)
           .opacity(isInSettings ? 0 : 1)
           .allowsHitTesting(!isInSettings)
         }


### PR DESCRIPTION
## Summary
- remove the custom click-through host wrapper from the desktop sidebar
- keep the existing settings fade/hit-testing behavior without the extra hosting layer
- address the sidebar icon/label desync still visible after v0.11.130

## Verification
- cd desktop && xcrun swift build -c debug --package-path Desktop