### PR TITLE
Add accessibility labels to sidebar navigation items

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/SidebarView.swift
+++ b/desktop/Desktop/Sources/MainWindow/SidebarView.swift
@@ -1293,6 +1293,9 @@ struct NavItemView: View {
         }
         .padding(.bottom, 2)
         .help(isCollapsed ? label : "")
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier("sidebar_\(label.lowercased().replacingOccurrences(of: " ", with: "_"))")
     }
 
     /// Lock icon that reacts on hover and unlocks on click
@@ -1419,6 +1422,9 @@ struct NavItemWithStatusView: View {
         }
         .padding(.bottom, 2)
         .help(isCollapsed ? "\(label) (\(isOn ? "On" : "Off")) - Click icon to toggle" : "Click icon to toggle")
+        .accessibilityLabel("\(label) (\(isOn ? "On" : "Off"))")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier("sidebar_\(label.lowercased().replacingOccurrences(of: " ", with: "_"))")
     }
 }
 
@@ -1621,6 +1627,9 @@ struct BottomNavItemView: View {
         }
         .padding(.bottom, 2)
         .help(isCollapsed ? label : "")
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityIdentifier("sidebar_\(label.lowercased().replacingOccurrences(of: " ", with: "_"))")
     }
 }
 


### PR DESCRIPTION
## Summary
- Added `accessibilityLabel`, `accessibilityAddTraits(.isButton)`, and `accessibilityIdentifier` to all three sidebar navigation view components: `NavItemView`, `NavItemWithStatusView`, and `BottomNavItemView`
- Identifiers follow the pattern `sidebar_dashboard`, `sidebar_chat`, `sidebar_memories`, etc.
- Enables VoiceOver navigation and programmatic UI testing via agent-swift (`find key sidebar_dashboard click`)

## Test plan
- [ ] Build compiles (verified on Mac Mini with `xcrun swift build`)
- [ ] agent-swift `find key sidebar_dashboard` returns the Dashboard nav item
- [ ] VoiceOver can read sidebar item labels when focused

Fixes friction #8 from #5784.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>