### PR TITLE
Desktop: Add auth error backoff to all polling operations

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Reduced auth error log spam with exponential backoff across all polling operations"
+  ],
   "releases": [
     {
       "version": "0.11.131",

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -1899,6 +1899,8 @@ class AppState: ObservableObject {
   func refreshConversations() async {
     // Skip if user is signed out (tokens are cleared)
     guard AuthState.shared.isSignedIn else { return }
+    // Skip if in auth backoff period (recent 401 errors)
+    guard !AuthBackoffTracker.shared.shouldSkipRequest() else { return }
     // Skip if currently doing a full load
     guard !isLoadingConversations else { return }
 
@@ -1939,7 +1941,11 @@ class AppState: ObservableObject {
           _ = try? await TranscriptionStorage.shared.syncServerConversation(conversation)
         }
       }
+      AuthBackoffTracker.shared.reportSuccess()
     } catch {
+      if case APIError.unauthorized = error {
+        AuthBackoffTracker.shared.reportAuthFailure()
+      }
       // Silently ignore errors during auto-refresh — cached data stays visible.
       // Auth errors (notSignedIn) are transient: token refresh may fail momentarily
       // while the user is still signed in. Don't send these to Sentry.

--- a/desktop/Desktop/Sources/AuthBackoffTracker.swift
+++ b/desktop/Desktop/Sources/AuthBackoffTracker.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Tracks consecutive auth failures and provides exponential backoff for polling operations.
+/// When API calls return 401/Unauthorized, callers report the failure here. Subsequent polls
+/// check `shouldSkipRequest()` to avoid flooding logs with repeated auth errors.
+/// Resets automatically on any successful auth call.
+@MainActor
+final class AuthBackoffTracker {
+    static let shared = AuthBackoffTracker()
+    private init() {}
+
+    private var consecutiveFailures = 0
+    private var lastFailureTime: Date?
+
+    /// Backoff intervals: 5s, 15s, 30s, 60s (cap)
+    private let backoffIntervals: [TimeInterval] = [5, 15, 30, 60]
+
+    /// Whether a polling request should be skipped due to recent auth failures.
+    /// Returns true if we're in a backoff period.
+    func shouldSkipRequest() -> Bool {
+        guard consecutiveFailures > 0, let lastFailure = lastFailureTime else {
+            return false
+        }
+        let index = min(consecutiveFailures - 1, backoffIntervals.count - 1)
+        let backoff = backoffIntervals[index]
+        let elapsed = Date().timeIntervalSince(lastFailure)
+        return elapsed < backoff
+    }
+
+    /// Report an auth failure (401/Unauthorized). Increments the backoff counter.
+    func reportAuthFailure() {
+        consecutiveFailures += 1
+        lastFailureTime = Date()
+        if consecutiveFailures == 1 {
+            log("AuthBackoff: first auth failure, backing off")
+        }
+    }
+
+    /// Report a successful auth call. Resets the backoff counter.
+    func reportSuccess() {
+        if consecutiveFailures > 0 {
+            log("AuthBackoff: auth recovered after \(consecutiveFailures) failure(s)")
+        }
+        consecutiveFailures = 0
+        lastFailureTime = nil
+    }
+
+    /// Current consecutive failure count (for diagnostics).
+    var failureCount: Int { consecutiveFailures }
+}

--- a/desktop/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/Desktop/Sources/MainWindow/CrispManager.swift
@@ -91,6 +91,8 @@ class CrispManager: ObservableObject {
 
     private func pollForMessages() {
         Task {
+            // Skip if in auth backoff period (recent 401 errors)
+            guard !AuthBackoffTracker.shared.shouldSkipRequest() else { return }
             do {
                 let messages = try await fetchUnreadMessages()
                 log("CrispManager: poll returned \(messages.count) messages (since=\(self.lastSeenTimestamp))")
@@ -122,7 +124,11 @@ class CrispManager: ObservableObject {
                         assistantId: "crisp"
                     )
                 }
+                AuthBackoffTracker.shared.reportSuccess()
             } catch {
+                if case APIError.unauthorized = error {
+                    AuthBackoffTracker.shared.reportAuthFailure()
+                }
                 log("CrispManager: poll failed: \(error)")
             }
         }

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -218,6 +218,8 @@ class MemoriesViewModel: ObservableObject {
     private func refreshMemoriesIfNeeded() async {
         // Skip if user is signed out (tokens are cleared)
         guard AuthState.shared.isSignedIn else { return }
+        // Skip if in auth backoff period (recent 401 errors)
+        guard !AuthBackoffTracker.shared.shouldSkipRequest() else { return }
         // Skip if page is not visible
         guard isActive else { return }
 
@@ -244,7 +246,11 @@ class MemoriesViewModel: ObservableObject {
             memories = mergedMemories
             currentOffset = mergedMemories.count
             hasMoreMemories = mergedMemories.count >= reloadLimit
+            AuthBackoffTracker.shared.reportSuccess()
         } catch {
+            if case APIError.unauthorized = error {
+                AuthBackoffTracker.shared.reportAuthFailure()
+            }
             // Silently ignore errors during auto-refresh
             logError("MemoriesViewModel: Auto-refresh failed", error: error)
         }

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -1660,6 +1660,8 @@ A screenshot may be attached — use it silently only if relevant. Never mention
     private func pollForNewMessages() async {
         // Skip if user is signed out (tokens are cleared)
         guard AuthState.shared.isSignedIn else { return }
+        // Skip if in auth backoff period (recent 401 errors)
+        guard !AuthBackoffTracker.shared.shouldSkipRequest() else { return }
         // Skip if we're actively sending. Note: isSending is released *before* the AI
         // message is saved to the backend (to unblock the next query). This means the
         // poll can run while saveMessage() is still in-flight — see the race note below.
@@ -1727,7 +1729,11 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 messages.append(contentsOf: genuinelyNewMessages)
                 messages.sort(by: { $0.createdAt < $1.createdAt })
             }
+            AuthBackoffTracker.shared.reportSuccess()
         } catch {
+            if case APIError.unauthorized = error {
+                AuthBackoffTracker.shared.reportAuthFailure()
+            }
             // Silent failure — polling errors shouldn't disrupt the user
             logError("ChatProvider poll failed", error: error)
         }

--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -177,6 +177,8 @@ class TasksStore: ObservableObject {
     private func refreshTasksIfNeeded() async {
         // Skip if not signed in
         guard AuthService.shared.isSignedIn else { return }
+        // Skip if in auth backoff period (recent 401 errors)
+        guard !AuthBackoffTracker.shared.shouldSkipRequest() else { return }
 
         // Skip if page is not visible
         guard isActive else { return }
@@ -241,7 +243,11 @@ class TasksStore: ObservableObject {
             let newHasMore = mergedTasks.count >= reloadLimit
             if hasMoreIncompleteTasks != newHasMore { hasMoreIncompleteTasks = newHasMore }
             await loadDashboardTasks()
+            AuthBackoffTracker.shared.reportSuccess()
         } catch {
+            if case APIError.unauthorized = error {
+                AuthBackoffTracker.shared.reportAuthFailure()
+            }
             // Silently ignore errors during auto-refresh
             logError("TasksStore: Auto-refresh failed", error: error)
         }


### PR DESCRIPTION
## Summary
- Adds `AuthBackoffTracker` — a shared singleton with exponential backoff (5s → 15s → 30s → 60s cap) that tracks consecutive 401/Unauthorized errors
- Integrates backoff into all 5 polling call sites: ChatProvider (15s), AppState conversations (30s), TasksStore (30s), MemoriesPage (30s), CrispManager (120s)
- Each poller skips its cycle when in backoff period, reports auth failures on 401, and resets on success
- Eliminates repetitive Unauthorized error log spam that makes local dev logs unusable for real debugging

Fixes #5784 (friction #10)

## How it works
When any poller gets a 401, `AuthBackoffTracker.shared.reportAuthFailure()` is called. All subsequent pollers check `shouldSkipRequest()` at entry — if we're in a backoff window, they return early without hitting the API. On any successful API call, `reportSuccess()` resets the counter. This means one 401 immediately suppresses all polling, and recovery is instant on the first successful call.

## Test plan
- [ ] Build succeeds on macOS (verified locally on Mac Mini)
- [ ] Sign in → verify all pollers work normally (no backoff)
- [ ] Sign out or use expired token → verify log spam stops after first 401
- [ ] Sign back in → verify pollers resume immediately

_by AI for @beastoin_

🤖 Generated with [Claude Code](https://claude.com/claude-code)