### PR TITLE
Desktop: Bring app to foreground after OAuth redirect

### DIFF
--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -1036,6 +1036,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     Task { @MainActor in
       AuthService.shared.handleOAuthCallback(url: url)
+      // Bring app to foreground after OAuth redirect — Safari stays in front otherwise
+      NSApp.activate(ignoringOtherApps: true)
     }
   }
 


### PR DESCRIPTION
## Summary
- After OAuth login via Safari, the desktop app stayed in the background while Safari displayed "Authentication Successful"
- Adds `NSApp.activate(ignoringOtherApps: true)` after handling the OAuth callback URL in `handleGetURLEvent`
- App now immediately comes to foreground after the auth redirect

Fixes #5784 (friction #7)

## How it works
When macOS receives the custom URL scheme callback (`omidesktop://auth/callback`), `handleGetURLEvent` fires. After passing the URL to `AuthService.handleOAuthCallback()`, the app now calls `NSApp.activate(ignoringOtherApps: true)` to bring itself to the foreground — the same pattern used throughout the app (27 existing call sites).

## Test plan
- [ ] Sign out → sign in via Google OAuth → verify app comes to foreground after Safari redirect
- [ ] Verify Safari "Authentication Successful" page doesn't stay in front

_by AI for @beastoin_

🤖 Generated with [Claude Code](https://claude.com/claude-code)