### PR TITLE
Desktop: Add Cmd+1..6 keyboard shortcuts for sidebar navigation

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -3000,6 +3000,8 @@ extension Notification.Name {
   /// Posted to navigate to AI Chat page
   static let navigateToChat = Notification.Name("navigateToChat")
   static let navigateToTasks = Notification.Name("navigateToTasks")
+  /// Posted by keyboard shortcuts to navigate sidebar. userInfo: ["rawValue": Int]
+  static let navigateToSidebarItem = Notification.Name("navigateToSidebarItem")
   /// Posted by the local desktop automation bridge to request semantic navigation.
   static let desktopAutomationNavigateRequested = Notification.Name(
     "desktopAutomationNavigateRequested")

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -651,6 +651,15 @@ struct DesktopHomeView: View {
         selectedIndex = SidebarNavItem.tasks.rawValue
       }
     }
+    .onReceive(NotificationCenter.default.publisher(for: .navigateToSidebarItem)) { notification in
+      if let rawValue = notification.userInfo?["rawValue"] as? Int,
+        let item = SidebarNavItem(rawValue: rawValue)
+      {
+        withAnimation(.easeInOut(duration: 0.2)) {
+          selectedIndex = item.rawValue
+        }
+      }
+    }
     .onChange(of: selectedIndex) { oldValue, newValue in
       // Track the previous index when navigating to settings
       if newValue == SidebarNavItem.settings.rawValue

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -137,6 +137,53 @@ struct OMIApp: App {
           resetWindowToDefaultSize()
         }
       }
+
+      // Sidebar navigation shortcuts: Cmd+1..6 for main pages, Cmd+, for Settings
+      CommandGroup(after: .sidebar) {
+        Button("Dashboard") {
+          NotificationCenter.default.post(name: .navigateToSidebarItem, object: nil,
+            userInfo: ["rawValue": SidebarNavItem.dashboard.rawValue])
+        }
+        .keyboardShortcut("1", modifiers: .command)
+
+        Button("Chat") {
+          NotificationCenter.default.post(name: .navigateToSidebarItem, object: nil,
+            userInfo: ["rawValue": SidebarNavItem.chat.rawValue])
+        }
+        .keyboardShortcut("2", modifiers: .command)
+
+        Button("Memories") {
+          NotificationCenter.default.post(name: .navigateToSidebarItem, object: nil,
+            userInfo: ["rawValue": SidebarNavItem.memories.rawValue])
+        }
+        .keyboardShortcut("3", modifiers: .command)
+
+        Button("Tasks") {
+          NotificationCenter.default.post(name: .navigateToSidebarItem, object: nil,
+            userInfo: ["rawValue": SidebarNavItem.tasks.rawValue])
+        }
+        .keyboardShortcut("4", modifiers: .command)
+
+        Button("Rewind") {
+          NotificationCenter.default.post(name: .navigateToSidebarItem, object: nil,
+            userInfo: ["rawValue": SidebarNavItem.rewind.rawValue])
+        }
+        .keyboardShortcut("5", modifiers: .command)
+
+        Button("Apps") {
+          NotificationCenter.default.post(name: .navigateToSidebarItem, object: nil,
+            userInfo: ["rawValue": SidebarNavItem.apps.rawValue])
+        }
+        .keyboardShortcut("6", modifiers: .command)
+
+        Divider()
+
+        Button("Settings") {
+          NotificationCenter.default.post(name: .navigateToSidebarItem, object: nil,
+            userInfo: ["rawValue": SidebarNavItem.settings.rawValue])
+        }
+        .keyboardShortcut(",", modifiers: .command)
+      }
     }
 
     // Note: Menu bar is now handled by NSStatusBar in AppDelegate.setupMenuBar()


### PR DESCRIPTION
## Summary
- Adds keyboard shortcuts for sidebar navigation: Cmd+1 Dashboard, Cmd+2 Chat, Cmd+3 Memories, Cmd+4 Tasks, Cmd+5 Rewind, Cmd+6 Apps, Cmd+, Settings
- Shortcuts appear in the macOS View menu (standard `CommandGroup(after: .sidebar)`)
- Uses a `navigateToSidebarItem` notification pattern matching existing navigation infrastructure

Fixes #5784 (friction #9)

## Architecture
- `AppState.swift`: New `navigateToSidebarItem` notification name
- `OmiApp.swift`: `CommandGroup(after: .sidebar)` with 7 keyboard shortcuts that post the notification
- `DesktopHomeView.swift`: `.onReceive` handler that reads `rawValue` from userInfo and animates to the target sidebar page

The order matches `SidebarNavItem.mainItems` (dashboard, chat, memories, tasks, rewind, apps). Cmd+, for Settings follows macOS convention.

## Test plan
- [ ] Build succeeds
- [ ] Cmd+1 through Cmd+6 navigate to correct sidebar pages
- [ ] Cmd+, opens Settings
- [ ] Shortcuts appear in the View menu
- [ ] Existing Cmd+/- font shortcuts still work

_by AI for @beastoin_

🤖 Generated with [Claude Code](https://claude.com/claude-code)