### PR TITLE
fix task date picker hidden behind next card

### DIFF
--- a/web/app/src/components/tasks/TaskCard.tsx
+++ b/web/app/src/components/tasks/TaskCard.tsx
@@ -201,6 +201,7 @@ export function TaskCard({
         'border-l-4 transition-all duration-150',
         'bg-white/[0.02] hover:bg-white/[0.05]',
         'p-4',
+        showDatePicker && 'z-10',
         // Left border color based on status
         task.completed
           ? 'border-l-success/50'


### PR DESCRIPTION
## Problem

When clicking the due date badge on a task in the Hub view, the date picker popover appeared behind the next task card, making it unusable.

## Root Cause

`TaskCard` uses the `noise-overlay` CSS class, which applies `position: relative; z-index: 1` to all direct children via `.noise-overlay > *`. This traps the popover (z-50) inside a `z-index: 1` stacking context. The next card's children are also `z-index: 1` but paint on top due to DOM order.

## Fix

Add `z-10` to the `TaskCard` outer element when the date picker is open, so the active card's stacking context outranks sibling cards.

## Demo

**Before**

<img width="604" height="449" alt="Before fix" src="https://github.com/user-attachments/assets/f3eb6d0f-efa9-497a-92a9-6241a5fb61de" />

**After**

<img width="1108" height="487" alt="After fix" src="https://github.com/user-attachments/assets/48a00646-df43-4d66-bedf-54b6c7ab4723" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)