### PR TITLE
Fix run.sh credentials path resolution

### DIFF
--- a/desktop/run.sh
+++ b/desktop/run.sh
@@ -165,7 +165,7 @@ elif [ ! -f "google-credentials.json" ] && [ -f "../Backend/google-credentials.j
 fi
 
 # Force local backend to use prod Firestore credentials for testing.
-CREDS_PATH="$BACKEND_DIR/google-credentials.json"
+CREDS_PATH="$(pwd)/google-credentials.json"
 if [ ! -f "$CREDS_PATH" ]; then
     echo "Missing credentials file: $CREDS_PATH"
     exit 1


### PR DESCRIPTION
## Summary
- `CREDS_PATH` used `$BACKEND_DIR` (relative `./Backend-Rust`) after the script had already `cd`'d into `Backend-Rust/`, causing it to look for `Backend-Rust/Backend-Rust/google-credentials.json`
- Use `$(pwd)` instead since we're already in the right directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)