### PR TITLE
Onboarding: remove notification step, add smart permission help, reorder goal

### DIFF
--- a/desktop/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/Desktop/Sources/Chat/ChatPrompts.swift
@@ -678,20 +678,21 @@ struct ChatPrompts {
     If English, call `set_user_preferences(language: "en")`.
     Then call `save_knowledge_graph` with a language node (e.g. "English") connected to the user node.
 
-    STEP 2 — MONTHLY GOAL (BEFORE SCAN)
-    Ask for ONE top monthly goal first.
-    Then call `ask_followup` with 2-4 SMART options and one typed option.
+    STEP 2 — FILE SCAN
+    First, check if Full Disk Access is granted by calling `check_permission_status`. If `full_disk_access` is "not_granted", request it with `request_permission(type: "full_disk_access")`. This opens System Settings — tell the user to toggle Full Disk Access on for omi. This single permission replaces needing to approve each folder separately. WAIT for the permission to be granted before proceeding.
+    Once Full Disk Access is granted (or if it was already granted), tell the user you'll scan files, then call `scan_files`.
+    This tool BLOCKS until the scan is complete. While files are being scanned, Omi also reads your recent emails and calendar in the background.
+    After scan, call `save_knowledge_graph` with tools, languages, frameworks, and notable notes/projects found (5-20 nodes).
+
+    STEP 3 — MONTHLY GOAL (AFTER SCAN)
+    Now that you've seen the user's files, emails, and calendar, ask for ONE top monthly goal.
+    Use what you learned from the scan to suggest SMART, personalized options (not generic ones).
+    Call `ask_followup` with 2-4 options and one typed option.
     Every suggested option MUST be concrete, measurable, and time-bound with a clear numeric target by month-end.
     Avoid vague options like "work on a project" or "get organized".
     Example: ask_followup(question: "What's your top one goal this month?", options: ["Ship macOS v1 with 0 P0 bugs", "Publish 60 Instagram videos this month", "Reach 200k users by month-end", "I'll type my own"])
     WAIT for user reply (button or typed).
     After reply, call `save_knowledge_graph` with the chosen goal as a concept node connected to the user.
-
-    STEP 3 — FILE SCAN (AFTER GOAL)
-    First, check if Full Disk Access is granted by calling `check_permission_status`. If `full_disk_access` is "not_granted", request it with `request_permission(type: "full_disk_access")`. This opens System Settings — tell the user to toggle Full Disk Access on for omi. This single permission replaces needing to approve each folder separately. WAIT for the permission to be granted before proceeding.
-    Once Full Disk Access is granted (or if it was already granted), tell the user you'll scan files, then call `scan_files`.
-    This tool BLOCKS until the scan is complete.
-    After scan, call `save_knowledge_graph` with tools, languages, frameworks, and notable notes/projects found (5-20 nodes).
 
     STEP 4 — FILE DISCOVERIES + TASK CANDIDATES
     This step is MANDATORY before Step 5.

--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -124,6 +124,10 @@ struct OnboardingChatView: View {
   @State private var showSkipConfirmation = false
   @State private var recoveredOnboardingFallbackTask: Task<Void, Never>?
 
+  // Permission help notification state
+  @State private var permissionHelpTask: Task<Void, Never>?
+  @State private var permissionHelpShownFor: Set<String> = []  // permissions that already got a help notification
+
   // Timer to periodically check permission status
   let permissionCheckTimer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
 
@@ -465,8 +469,14 @@ struct OnboardingChatView: View {
     .onChange(of: quickReplyOptions) { _, _ in
       scheduleRecoveredOnboardingFallback()
     }
-    .onChange(of: pendingPermissionType) { _, _ in
+    .onChange(of: pendingPermissionType) { _, newValue in
       scheduleRecoveredOnboardingFallback()
+      // Start or cancel permission help timer
+      if let permType = newValue {
+        startPermissionHelpTimer(for: permType)
+      } else {
+        cancelPermissionHelpTimer()
+      }
     }
     .onChange(of: explorationRunning) { _, _ in
       scheduleRecoveredOnboardingFallback()
@@ -525,6 +535,117 @@ struct OnboardingChatView: View {
       Task {
         await chatProvider.sendMessage("Grant \(label) — done!")
       }
+    }
+  }
+
+  // MARK: - Permission Help Notifications
+
+  /// Start a 15-second timer for the given permission. If the permission is still not granted
+  /// when the timer fires, take a screenshot, ask Gemini for help, and show the result as
+  /// a floating bar notification.
+  private func startPermissionHelpTimer(for permissionType: String) {
+    cancelPermissionHelpTimer()
+
+    // Only show one help notification per permission type
+    guard !permissionHelpShownFor.contains(permissionType) else { return }
+
+    permissionHelpTask = Task {
+      try? await Task.sleep(nanoseconds: 15_000_000_000)  // 15 seconds
+      guard !Task.isCancelled else { return }
+
+      // Check if the permission is still pending
+      guard pendingPermissionType == permissionType else { return }
+
+      // Mark this permission so we don't spam
+      permissionHelpShownFor.insert(permissionType)
+
+      await showPermissionHelpNotification(for: permissionType)
+    }
+  }
+
+  private func cancelPermissionHelpTimer() {
+    permissionHelpTask?.cancel()
+    permissionHelpTask = nil
+  }
+
+  /// Take a screenshot, send it to Gemini with context about the permission, and show
+  /// the AI's guidance as a floating bar notification.
+  private func showPermissionHelpNotification(for permissionType: String) async {
+    let permissionLabel = permissionDisplayName(permissionType)
+
+    // Take a screenshot (off main thread to avoid blocking UI)
+    let screenshotData: Data? = await Task.detached {
+      guard let url = ScreenCaptureManager.captureScreen() else { return nil }
+      return try? Data(contentsOf: url)
+    }.value
+
+    let helpText: String
+    if let imageData = screenshotData {
+      // Ask Gemini for help using the screenshot
+      do {
+        let gemini = try GeminiClient()
+        let prompt =
+          "The user is trying to grant \(permissionLabel) permission to the Omi app on macOS. Here is a screenshot of their current screen. Give them a brief, specific instruction on where to click or what to do next to grant this permission. Be concise — max 2 sentences."
+        let systemPrompt =
+          "You are a helpful macOS support assistant. Give brief, actionable instructions for granting macOS permissions. Never use technical jargon. Always refer to visible UI elements by their exact labels."
+
+        helpText = try await gemini.sendImageTextRequest(
+          prompt: prompt,
+          imageData: imageData,
+          systemPrompt: systemPrompt
+        )
+      } catch {
+        log("OnboardingChat: Permission help Gemini call failed: \(error.localizedDescription)")
+        helpText = fallbackPermissionHelp(for: permissionType)
+      }
+    } else {
+      log("OnboardingChat: Screenshot failed for permission help, using fallback")
+      helpText = fallbackPermissionHelp(for: permissionType)
+    }
+
+    // Ensure the floating bar is set up (it's normally created in later onboarding steps)
+    FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
+    FloatingControlBarManager.shared.showTemporarily()
+
+    // Show the notification via the floating bar
+    FloatingControlBarManager.shared.showNotification(
+      title: "Need help with \(permissionLabel)?",
+      message: helpText,
+      assistantId: "onboarding",
+      sound: .none
+    )
+  }
+
+  /// Human-readable name for a permission type string
+  private func permissionDisplayName(_ type: String) -> String {
+    switch type {
+    case "screen_recording": return "Screen Recording"
+    case "microphone": return "Microphone"
+    case "notifications": return "Notifications"
+    case "accessibility": return "Accessibility"
+    case "automation": return "Automation"
+    case "full_disk_access": return "Full Disk Access"
+    default: return type
+    }
+  }
+
+  /// Fallback help text when screenshot or Gemini call fails
+  private func fallbackPermissionHelp(for permissionType: String) -> String {
+    switch permissionType {
+    case "screen_recording":
+      return "Open System Settings > Privacy & Security > Screen Recording, then toggle on Omi."
+    case "microphone":
+      return "Open System Settings > Privacy & Security > Microphone, then toggle on Omi."
+    case "accessibility":
+      return "Open System Settings > Privacy & Security > Accessibility, then toggle on Omi."
+    case "automation":
+      return "Open System Settings > Privacy & Security > Automation, then toggle on Omi."
+    case "notifications":
+      return "Open System Settings > Notifications, find Omi, and enable Allow Notifications."
+    case "full_disk_access":
+      return "Open System Settings > Privacy & Security > Full Disk Access, then toggle on Omi."
+    default:
+      return "Open System Settings > Privacy & Security and grant the permission to Omi."
     }
   }
 
@@ -1130,6 +1251,9 @@ struct OnboardingChatView: View {
     // Clean up Calendar reading
     calendarReadingTask?.cancel()
     calendarReadingTask = nil
+
+    // Clean up permission help timer
+    cancelPermissionHelpTimer()
 
     // Notify parent to advance to next step
     onComplete()

--- a/desktop/Desktop/Sources/OnboardingFlow.swift
+++ b/desktop/Desktop/Sources/OnboardingFlow.swift
@@ -1,14 +1,15 @@
 import Foundation
 
 enum OnboardingFlow {
-  static let steps = ["Chat", "Notifications", "FloatingBar", "VoiceShortcut", "Tasks"]
+  static let steps = ["Chat", "FloatingBar", "VoiceShortcut", "Tasks"]
   static let lastStepIndex = steps.count - 1
 
   static func migratedStep(
     currentStep: Int,
     hasMigratedVideoStep: Bool,
     hasInsertedVoiceShortcutStep: Bool,
-    hasMergedVoiceInputStep: Bool
+    hasMergedVoiceInputStep: Bool,
+    hasRemovedNotificationStep: Bool
   ) -> Int {
     var migratedStep = currentStep
 
@@ -21,6 +22,12 @@ enum OnboardingFlow {
     }
 
     if !hasMergedVoiceInputStep, migratedStep >= 4 {
+      migratedStep -= 1
+    }
+
+    // Notification step (old step 1) was removed — shift steps 2+ down by 1.
+    // Users on old step 1 (Notifications) land on new step 1 (FloatingBar, which was next).
+    if !hasRemovedNotificationStep, migratedStep >= 2 {
       migratedStep -= 1
     }
 

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -12,6 +12,7 @@ struct OnboardingView: View {
   @AppStorage("onboardingVoiceShortcutStepMigrationDone") private var hasInsertedVoiceShortcutStep =
     false
   @AppStorage("onboardingVoiceInputMergeMigrationDone") private var hasMergedVoiceInputStep = false
+  @AppStorage("onboardingNotificationStepRemoved") private var hasRemovedNotificationStep = false
   @StateObject private var graphViewModel = MemoryGraphViewModel()
   @State private var graphHasData = false
   @State private var showTrustPreview = true
@@ -51,11 +52,13 @@ struct OnboardingView: View {
         currentStep: currentStep,
         hasMigratedVideoStep: hasMigratedOnboardingSteps,
         hasInsertedVoiceShortcutStep: hasInsertedVoiceShortcutStep,
-        hasMergedVoiceInputStep: hasMergedVoiceInputStep
+        hasMergedVoiceInputStep: hasMergedVoiceInputStep,
+        hasRemovedNotificationStep: hasRemovedNotificationStep
       )
       hasMigratedOnboardingSteps = true
       hasInsertedVoiceShortcutStep = true
       hasMergedVoiceInputStep = true
+      hasRemovedNotificationStep = true
     }
     .task {
       // Pre-warm the ACP bridge before the chat step starts.
@@ -150,55 +153,40 @@ struct OnboardingView: View {
           }
         }
       } else if currentStep == 1 {
-        // Step 1: Smart Notifications Demo
-        OnboardingNotificationStepView(
-          appState: appState,
-          chatProvider: chatProvider,
-          onContinue: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "Notifications")
-            currentStep = 2
-          },
-          onSkip: {
-            AnalyticsManager.shared.onboardingStepCompleted(
-              step: 1, stepName: "Notifications_Skipped")
-            currentStep = 2
-          }
-        )
-      } else if currentStep == 2 {
-        // Step 2: Floating Bar Demo
+        // Step 1: Floating Bar Demo
         OnboardingFloatingBarDemoView(
           appState: appState,
           chatProvider: chatProvider,
           onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "FloatingBar")
-            currentStep = 3
+            AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "FloatingBar")
+            currentStep = 2
           },
           onSkip: {
             AnalyticsManager.shared.onboardingStepCompleted(
-              step: 2, stepName: "FloatingBar_Skipped")
-            currentStep = 3
+              step: 1, stepName: "FloatingBar_Skipped")
+            currentStep = 2
           }
         )
-      } else if currentStep == 3 {
-        // Step 3: Verify Push-to-Talk Shortcut + Voice Input
+      } else if currentStep == 2 {
+        // Step 2: Verify Push-to-Talk Shortcut + Voice Input
         OnboardingVoiceShortcutStepView(
           appState: appState,
           chatProvider: chatProvider,
           onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "VoiceShortcut")
-            currentStep = 4
+            AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "VoiceShortcut")
+            currentStep = 3
           },
           onSkip: {
             AnalyticsManager.shared.onboardingStepCompleted(
-              step: 3, stepName: "VoiceShortcut_Skipped")
-            currentStep = 4
+              step: 2, stepName: "VoiceShortcut_Skipped")
+            currentStep = 3
           }
         )
       } else {
-        // Step 4: Tasks
+        // Step 3: Tasks
         OnboardingTasksStepView(
           onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "Tasks")
+            AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "Tasks")
             handleOnboardingComplete()
           }
         )

--- a/desktop/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Core/GeminiClient.swift
@@ -364,6 +364,80 @@ actor GeminiClient {
     throw lastError!
   }
 
+  /// Send an image + text request to the Gemini API and return plain text (no structured output).
+  /// Retries up to 2 times for transient errors (3 total attempts).
+  /// - Parameters:
+  ///   - prompt: Text prompt to send alongside the image
+  ///   - imageData: JPEG image data to analyze
+  ///   - systemPrompt: System instructions for the model
+  /// - Returns: The plain-text response from the model
+  func sendImageTextRequest(
+    prompt: String,
+    imageData: Data,
+    systemPrompt: String
+  ) async throws -> String {
+    let maxRetries = 2
+    var lastError: Error?
+
+    for attempt in 0...maxRetries {
+      do {
+        let requestBody: Data = try autoreleasepool {
+          let base64Data = imageData.base64EncodedString()
+
+          let request = GeminiRequest(
+            contents: [
+              GeminiRequest.Content(parts: [
+                GeminiRequest.Part(text: prompt),
+                GeminiRequest.Part(mimeType: "image/jpeg", data: base64Data),
+              ])
+            ],
+            systemInstruction: GeminiRequest.SystemInstruction(
+              parts: [GeminiRequest.SystemInstruction.TextPart(text: systemPrompt)]
+            ),
+            generationConfig: nil
+          )
+
+          return try JSONEncoder().encode(request)
+        }
+
+        let url = URL(
+          string:
+            "https://generativelanguage.googleapis.com/v1beta/models/\(model):generateContent?key=\(apiKey)"
+        )!
+        var urlRequest = URLRequest(url: url)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        urlRequest.timeoutInterval = 30
+        urlRequest.httpBody = requestBody
+
+        let (data, _) = try await URLSession.shared.data(for: urlRequest)
+
+        let response = try JSONDecoder().decode(GeminiResponse.self, from: data)
+
+        if let error = response.error {
+          try throwAPIError(error.message)
+        }
+
+        guard let text = response.candidates?.first?.content?.parts?.first?.text else {
+          try throwBlockedOrInvalidResponse(
+            blockReason: response.promptFeedback?.blockReason,
+            finishReason: response.candidates?.first?.finishReason
+          )
+        }
+
+        return text
+      } catch {
+        lastError = error
+        guard attempt < maxRetries && isTransientError(error) else {
+          throw error
+        }
+        await retryBackoff(attempt: attempt, error: error)
+      }
+    }
+
+    throw lastError!
+  }
+
   /// Send a text-only request to the Gemini API
   /// Retries up to 2 times for transient errors (3 total attempts).
   /// - Parameters:


### PR DESCRIPTION
## Summary

- **Remove the Notifications onboarding step** — it just showed a demo notification with no real value. Steps are now: Chat → FloatingBar → VoiceShortcut → Tasks. Includes migration for users mid-onboarding.

- **Add smart permission-help floating bar notifications during onboarding chat** — when a user is stuck on a permission for 15+ seconds, the app takes a screenshot, sends it to Gemini asking "where should they click?", and shows the AI's answer as a floating bar notification. Only fires once per permission type. Falls back to static instructions if screenshot or Gemini fails.

- **Move the goal question after file scanning** — the goal is now asked AFTER file scan + email + calendar reading (Step 3), so the AI can suggest personalized SMART goals based on what it learned, instead of generic ones.

## Changes

| File | What |
|------|------|
| `OnboardingFlow.swift` | Removed "Notifications" from steps, added migration |
| `OnboardingView.swift` | Renumbered steps 1-3, removed notification step view reference |
| `OnboardingChatView.swift` | Added 15s timer + screenshot + Gemini help + floating bar notification |
| `GeminiClient.swift` | Added `sendImageTextRequest()` for image+text prompts without structured output |
| `ChatPrompts.swift` | Swapped Step 2 (goal) and Step 3 (file scan); goal now uses scan context |

## Test plan

- [ ] Fresh install: verify onboarding flows Chat → FloatingBar → VoiceShortcut → Tasks
- [ ] Mid-onboarding migration: users on old step 1 (Notifications) land on FloatingBar
- [ ] Permission help: wait 15s on a permission step → floating bar shows AI guidance
- [ ] Permission help only fires once per permission type
- [ ] Goal question appears after file scan with personalized suggestions
- [ ] Build compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)