### PR TITLE
Update CHANGELOG.json for v0.11.134 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,9 +1,14 @@
 {
-  "unreleased": [
-    "Removed intro video from Rewind tab \u2014 screenshots are shown immediately",
-    "Fixed delayed screenshot capture after onboarding \u2014 first screenshot is now taken instantly"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.134",
+      "date": "2026-03-18",
+      "changes": [
+        "Removed intro video from Rewind tab \u2014 screenshots are shown immediately",
+        "Fixed delayed screenshot capture after onboarding \u2014 first screenshot is now taken instantly"
+      ]
+    },
     {
       "version": "0.11.133",
       "date": "2026-03-18",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.134 and clears the unreleased array.