### PR TITLE
fix(desktop): show download progress on update button

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/SidebarView.swift
+++ b/desktop/Desktop/Sources/MainWindow/SidebarView.swift
@@ -278,7 +278,7 @@ struct SidebarView: View {
                     }
 
                     // Update available widget
-                    if updaterViewModel.updateAvailable {
+                    if updaterViewModel.updateAvailable || updaterViewModel.updateSessionInProgress {
                         Spacer().frame(height: 12)
                         updateAvailableWidget
                             .transition(.opacity)
@@ -629,22 +629,32 @@ struct SidebarView: View {
     @State private var updateGlowAnimating = false
 
     private var updateAvailableWidget: some View {
-        Button(action: {
-            updaterViewModel.checkForUpdates()
+        let isDownloading = updaterViewModel.updateSessionInProgress
+
+        return Button(action: {
+            if updaterViewModel.canCheckForUpdates {
+                updaterViewModel.checkForUpdates()
+            }
         }) {
             HStack(spacing: 12) {
-                Image(systemName: "arrow.down.circle.fill")
-                    .scaledFont(size: 17)
-                    .foregroundColor(.white)
-                    .frame(width: iconWidth)
+                if isDownloading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .frame(width: iconWidth)
+                } else {
+                    Image(systemName: "arrow.down.circle.fill")
+                        .scaledFont(size: 17)
+                        .foregroundColor(.white)
+                        .frame(width: iconWidth)
+                }
 
                 if !isCollapsed {
                     VStack(alignment: .leading, spacing: 2) {
-                        Text("Update Available")
+                        Text(isDownloading ? "Downloading Update…" : "Update Available")
                             .scaledFont(size: 13, weight: .semibold)
                             .foregroundColor(.white)
 
-                        if !updaterViewModel.availableVersion.isEmpty {
+                        if !isDownloading, !updaterViewModel.availableVersion.isEmpty {
                             Text("v\(updaterViewModel.availableVersion)")
                                 .scaledFont(size: 11)
                                 .foregroundColor(.white.opacity(0.8))
@@ -653,9 +663,11 @@ struct SidebarView: View {
 
                     Spacer()
 
-                    Image(systemName: "chevron.right")
-                        .scaledFont(size: 12)
-                        .foregroundColor(.white.opacity(0.7))
+                    if !isDownloading {
+                        Image(systemName: "chevron.right")
+                            .scaledFont(size: 12)
+                            .foregroundColor(.white.opacity(0.7))
+                    }
                 }
             }
             .padding(.horizontal, 12)
@@ -667,7 +679,7 @@ struct SidebarView: View {
             .shadow(color: OmiColors.purplePrimary.opacity(updateGlowAnimating ? 0.7 : 0.3), radius: 8)
         }
         .buttonStyle(.plain)
-        .help(isCollapsed ? "Update Available — click to install" : "")
+        .help(isCollapsed ? (isDownloading ? "Downloading update…" : "Update Available — click to install") : "")
         .onAppear {
             withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
                 updateGlowAnimating = true


### PR DESCRIPTION
## Summary
- When Sparkle auto-downloads an update in the background, clicking the "Update Available" sidebar button was silently ignored (`canCheckForUpdates=false` during active session)
- Now shows a spinner and "Downloading Update…" text when Sparkle is mid-session, so users know the update is in progress
- Guards the click handler with `canCheckForUpdates` to avoid the silent no-op

## Test plan
- [ ] Build and run prod beta app
- [ ] Wait for update banner to appear
- [ ] Verify spinner + "Downloading Update…" shows during download phase
- [ ] Verify clicking during download doesn't cause errors
- [ ] Verify clicking after download completes (if banner reappears) triggers install

🤖 Generated with [Claude Code](https://claude.com/claude-code)