### PR TITLE
Update CHANGELOG.json for v0.11.141 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,11 +1,16 @@
 {
-  "unreleased": [
-    "Reduced auth error log spam with exponential backoff across all polling operations",
-    "Fixed Tasks page showing misleading \"No Matching Tasks\" when user has no tasks",
-    "API keys are now served securely from the backend instead of bundled in the app",
-    "Fixed tasks disappearing when switching to Dashboard (missing safety guard on empty API responses)"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.141",
+      "date": "2026-03-19",
+      "changes": [
+        "Reduced auth error log spam with exponential backoff across all polling operations",
+        "Fixed Tasks page showing misleading \"No Matching Tasks\" when user has no tasks",
+        "API keys are now served securely from the backend instead of bundled in the app",
+        "Fixed tasks disappearing when switching to Dashboard (missing safety guard on empty API responses)"
+      ]
+    },
     {
       "version": "0.11.139",
       "date": "2026-03-19",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.141 and clears the unreleased array.