### PR TITLE
Revert codemagic.yaml @Q syntax fix

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2456,7 +2456,7 @@ workflows:
           <body>
             <p>Redirecting to the latest Omi Beta download.</p>
             <p><a href="${BETA_DMG_URL}">If you are not redirected, click here.</a></p>
-            <script>window.location.replace("${BETA_DMG_URL}");</script>
+            <script>window.location.replace(${BETA_DMG_URL@Q});</script>
           </body>
           </html>
           EOF


### PR DESCRIPTION
Reverts commit 1dedb4bf0 which was pushed directly to main by mistake.

The `${BETA_DMG_URL@Q}` Bash 4.4+ syntax issue in codemagic.yaml needs a proper fix tracked in a separate issue.

---
_by AI for @beastoin_