### PR TITLE
fix: Codemagic bash compat — replace @Q syntax

### DIFF
--- a/codemagic.yaml
+++ b/codemagic.yaml
@@ -2456,7 +2456,7 @@ workflows:
           <body>
             <p>Redirecting to the latest Omi Beta download.</p>
             <p><a href="${BETA_DMG_URL}">If you are not redirected, click here.</a></p>
-            <script>window.location.replace(${BETA_DMG_URL@Q});</script>
+            <script>window.location.replace("${BETA_DMG_URL}");</script>
           </body>
           </html>
           EOF


### PR DESCRIPTION
Replace `${BETA_DMG_URL@Q}` (Bash 4.4+ parameter transformation) with `"${BETA_DMG_URL}"` in the Codemagic post-build redirect page script. Codemagic's shell doesn't support `@Q`, causing "bad substitution" that kills the script before prod Cloud Run deploy runs.

v0.11.140 and v0.11.141 both failed on this. Once merged, the next tag will trigger a clean Codemagic build that completes prod deploy.

Closes #5822

---
_by AI for @beastoin_