### PR TITLE
feat: add workflow_dispatch to desktop auto-release

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - 'desktop/**'
       - '!desktop/CHANGELOG.json'
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch` trigger so the desktop release workflow can be manually triggered via `gh workflow run` or the GitHub Actions UI. Useful when changes outside `desktop/` (like `codemagic.yaml`) need a new build.

After merge, trigger with:
```
gh workflow run desktop_auto_release.yml --repo BasedHardware/omi
```

---
_by AI for @beastoin_