### PR TITLE
feat: add prod Cloud Run deploy to desktop auto-release

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -85,8 +85,73 @@ jobs:
             ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest
             GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
 
-  tag-release:
+  deploy-desktop-backend-prod:
     needs: deploy-desktop-backend
+    environment: prod
+    permissions:
+      contents: read
+      id-token: write
+
+    runs-on: ubuntu-latest-m
+    steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Google Auth
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_CREDENTIALS }}
+
+      - name: Login to GCR
+        run: gcloud auth configure-docker
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Google Service Account
+        run: echo "${{ secrets.GCP_SERVICE_ACCOUNT }}" | base64 -d > ./desktop/Backend-Rust/google-credentials.json
+
+      - name: Build and Push Desktop Backend Image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./desktop/Backend-Rust
+          file: ./desktop/Backend-Rust/Dockerfile
+          push: true
+          tags: |
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}
+            gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:latest
+          cache-from: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache
+          cache-to: type=registry,ref=gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:buildcache,mode=max
+
+      - name: Deploy Desktop Backend to Production
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: ${{ env.SERVICE }}
+          region: ${{ env.REGION }}
+          image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}:${{ github.sha }}
+          flags: '--allow-unauthenticated'
+          env_vars: |
+            FIREBASE_PROJECT_ID=based-hardware
+            GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
+            AGENT_GCS_BUCKET=based-hardware-agent
+          secrets: |
+            GEMINI_API_KEY=GEMINI_API_KEY:latest
+            ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
+            REDIS_DB_PASSWORD=REDIS_DB_PASSWORD:latest
+            FIREBASE_API_KEY=FIREBASE_API_KEY:latest
+            PINECONE_API_KEY=PINECONE_API_KEY:latest
+            REDIS_DB_HOST=REDIS_DB_HOST:latest
+            REDIS_DB_PORT=REDIS_DB_PORT:latest
+            PINECONE_HOST=PINECONE_HOST:latest
+            DEEPGRAM_API_KEY=DESKTOP_DEEPGRAM_API_KEY:latest
+            ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest
+            GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
+
+  tag-release:
+    needs: [deploy-desktop-backend, deploy-desktop-backend-prod]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary
- Adds `deploy-desktop-backend-prod` job that deploys the Rust backend to production Cloud Run (`based-hardware`)
- Mirrors the dev deploy but uses the `prod` GitHub environment (separate GCP credentials)
- Tag-release now waits for both dev and prod deploys before creating the version tag

## Prerequisites
The `prod` GitHub environment needs:
- `GCP_CREDENTIALS` — service account JSON for `based-hardware`
- `GCP_SERVICE_ACCOUNT` — base64-encoded SA JSON (baked into Docker image)
- `GCP_PROJECT_ID` variable — `based-hardware`

Prod GCP Secret Manager needs these secrets (same as dev):
- `DESKTOP_DEEPGRAM_API_KEY`
- `DESKTOP_ANTHROPIC_API_KEY`
- `DESKTOP_GOOGLE_CALENDAR_API_KEY`
- `GEMINI_API_KEY`, `ENCRYPTION_SECRET`, `REDIS_DB_*`, `FIREBASE_API_KEY`, `PINECONE_*`

## Pipeline flow after merge
```
push to main (desktop/**)
  → deploy-desktop-backend (dev)
  → deploy-desktop-backend-prod (prod)  ← NEW
  → tag-release (waits for both)
  → Codemagic builds Swift app (triggered by tag)
```

---
_by AI for @beastoin_