### PR TITLE
Add block-no-verify beforeShellExecution hook to .cursor/hooks.json

### DIFF
--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,6 +1,8 @@
 {
   "version": 1,
-  "_comment": "This file is optional. Uncomment and configure hooks as needed.",
-  "_comment2": "See https://cursor.com/docs/agent/hooks for documentation.",
-  "hooks": {}
+  "hooks": {
+    "beforeShellExecution": [
+      { "command": "npx block-no-verify@1.1.2", "event": "beforeShellExecution" }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary

Fills in the empty `hooks` object in `.cursor/hooks.json` with `block-no-verify@1.1.2` as a `beforeShellExecution` hook to prevent Cursor agents from bypassing git hooks.

## Details

When an agent runs `git commit` or `git push` with the hook-bypass flag, it silently disables pre-commit, commit-msg, and pre-push hooks. `block-no-verify` reads the command from the Cursor hook stdin, detects the hook-bypass flag across all git subcommands, and exits 2 to block. The `version: 1` config is preserved unchanged.

Closes #5838

---

_Disclosure: I am the author and maintainer of `block-no-verify`._
