### PR TITLE
Consolidate lint into single job, skip irrelevant checks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,11 +20,13 @@ jobs:
         id: changed
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            FILES=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref }}...HEAD)
+            DIFF_BASE="origin/${{ github.base_ref }}"
           else
-            FILES=$(git diff --name-only --diff-filter=ACM HEAD~1...HEAD)
+            DIFF_BASE="HEAD~1"
           fi
+          FILES=$(git diff --name-only --diff-filter=ACM "$DIFF_BASE"...HEAD)
           echo "$FILES"
+          echo "$FILES" > /tmp/changed-files.txt
           echo "has_dart=$(echo "$FILES" | grep -q '\.dart$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_python=$(echo "$FILES" | grep -q 'backend/.*\.py$' && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "has_arb=$(echo "$FILES" | grep -q '\.arb$' && echo true || echo false)" >> $GITHUB_OUTPUT
@@ -42,7 +44,7 @@ jobs:
       - name: Check Dart formatting
         if: steps.changed.outputs.has_dart == 'true'
         run: |
-          FILES=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref || 'main' }}...HEAD -- '*.dart' | grep -v -e '\.gen\.dart$' -e '\.g\.dart$' || true)
+          FILES=$(grep '\.dart$' /tmp/changed-files.txt | grep -v -e '\.gen\.dart$' -e '\.g\.dart$' || true)
           if [ -n "$FILES" ]; then
             echo "$FILES" | xargs dart format --line-length 120 --set-exit-if-changed --output=none
           fi
@@ -52,7 +54,7 @@ jobs:
         if: steps.changed.outputs.has_python == 'true'
         run: |
           pip install -q black
-          FILES=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref || 'main' }}...HEAD -- 'backend/**.py' || true)
+          FILES=$(grep 'backend/.*\.py$' /tmp/changed-files.txt || true)
           if [ -n "$FILES" ]; then
             echo "$FILES" | xargs black --check --line-length 120 --skip-string-normalization
           fi
@@ -61,7 +63,7 @@ jobs:
       - name: Check ARB formatting
         if: steps.changed.outputs.has_arb == 'true'
         run: |
-          FILES=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref || 'main' }}...HEAD -- '*.arb' || true)
+          FILES=$(grep '\.arb$' /tmp/changed-files.txt || true)
           failed=0
           for f in $FILES; do
             if ! python3 -m json.tool "$f" > /dev/null 2>&1; then
@@ -71,12 +73,13 @@ jobs:
             fi
             if ! python3 -c "
           import json, sys
-          with open('$f') as fh:
+          f = sys.argv[1]
+          with open(f) as fh:
               original = fh.read()
           formatted = json.dumps(json.loads(original), indent=4, ensure_ascii=False) + '\n'
           if original != formatted:
               sys.exit(1)
-          " 2>/dev/null; then
+          " "$f" 2>/dev/null; then
               echo "FAIL: $f not formatted with 4-space indent"
               failed=1
             fi
@@ -90,7 +93,7 @@ jobs:
       - name: Check C/C++ formatting
         if: steps.changed.outputs.has_firmware == 'true'
         run: |
-          FILES=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref || 'main' }}...HEAD | grep -E '\.(c|cpp|cc|cxx|h|hpp)$' | grep -E '^(omi/|omiGlass/)' || true)
+          FILES=$(grep -E '^(omi|omiGlass)/.*\.(c|cpp|cc|cxx|h|hpp)$' /tmp/changed-files.txt || true)
           if [ -n "$FILES" ]; then
             echo "$FILES" | xargs clang-format --dry-run --Werror
           fi
@@ -101,6 +104,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18'
+          cache: 'npm'
+          cache-dependency-path: |
+            web/frontend/package-lock.json
+            web/personas-open-source/package-lock.json
 
       - name: Lint Frontend
         if: steps.changed.outputs.has_frontend == 'true'


### PR DESCRIPTION
## Summary

- Replaces 6 separate lint jobs with 1 smart job that detects changed files and only runs relevant checks
- Backend-only PR? Only runs `black`. App-only PR? Only runs `dart format`. No wasted CI minutes.

### How it works

1. `git diff` gets changed files in the PR
2. Sets flags: `has_dart`, `has_python`, `has_arb`, `has_firmware`, `has_frontend`, `has_personas`
3. Each check step uses `if:` to skip when its flag is false

### Checks (same rules as `scripts/pre-commit`)

| Flag | Check | Tool |
|------|-------|------|
| `has_dart` | Dart 120-char format | `dart format --line-length 120` |
| `has_python` | Python black style | `black --check --line-length 120 --skip-string-normalization` |
| `has_arb` | ARB 4-space JSON | `python3 json.dumps(indent=4)` |
| `has_firmware` | C/C++ clang-format | `clang-format --dry-run --Werror` |
| `has_frontend` | ESLint + Prettier | `npm run lint` + `npm run lint:format -- --check` |
| `has_personas` | ESLint | `npm run lint` |

All checks only run on changed files (not the whole repo).

---
_by AI for @beastoin_