### PR TITLE
fix: add missing PlanType import in payment.py (production crash)

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -15,7 +15,7 @@ from database import (
 )
 from database.redis_db import set_credits_invalidation_signal
 from utils.notifications import send_notification, send_subscription_paid_personalized_notification
-from models.users import Subscription, SubscriptionStatus, PlanLimits
+from models.users import PlanType, Subscription, SubscriptionStatus, PlanLimits
 from utils.subscription import (
     get_basic_plan_limits,
     get_paid_plan_definitions,


### PR DESCRIPTION
## Bug

`stripe_webhook` in `payment.py` crashes with `NameError: name 'PlanType' is not defined` every time it processes a canceled/unpaid Stripe subscription.

**Impact:** ~10+ crashes/hour in production (55 backend errors in last 24h from this alone). Users whose subscriptions expire are not being properly downgraded to the basic plan.

## Fix

Add `PlanType` to the import from `models.users` on line 18. It was already used on line 93 but never imported.

## Logs

```
File "/app/routers/payment.py", line 93, in _build_subscription_from_stripe_object
    plan = PlanType.basic
           ^^^^^^^^
NameError: name 'PlanType' is not defined
```