### PR TITLE
fix: remove duplicate 'Unlimited' suffix from plan names

### DIFF
--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -1839,7 +1839,7 @@ class _PlansSheetState extends State<PlansSheet> {
     bool isPopular = false,
     required VoidCallback onTap,
   }) {
-    final title = '${planData['title']} Unlimited';
+    final title = planData['title'] as String;
     final priceString = planData['price_string'] as String;
     final interval = planData['interval'] as String;
     final unitAmount = planData['unit_amount'] as int;


### PR DESCRIPTION
## Summary
- Commit 2db36d8a (Mar 14 — "Add desktop Plan and Usage subscriptions") changed the backend to return full plan titles like "Unlimited Plan Monthly" / "Unlimited Plan Annual" instead of just "Monthly" / "Annual"
- The app-side code in `_buildDynamicPlanOption()` was still appending " Unlimited", resulting in "Unlimited Plan Monthly Unlimited" and "Unlimited Plan Annual Unlimited"
- Removed the redundant suffix so plan names display correctly

## Test plan
- [ ] Open the plans sheet and verify plan names no longer show duplicate "Unlimited" text

🤖 Generated with [Claude Code](https://claude.com/claude-code)