### PR TITLE
Hotfix: add dg_usage_ms_pending declaration in transcribe.py

### DIFF
--- a/backend/models/conversation.py
+++ b/backend/models/conversation.py
@@ -459,6 +459,7 @@ class CreateConversation(BaseModel):
 
     processing_conversation_id: Optional[str] = None
     calendar_meeting_context: Optional[CalendarMeetingContext] = None
+    is_locked: bool = False
 
     def get_transcript(self, include_timestamps: bool, people: List[Person] = None, user_name: str = None) -> str:
         return TranscriptSegment.segments_as_string(

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -666,10 +666,9 @@ def process_segment(
             finished_at=finished_at,
             transcript_segments=transcript_segments,
             source=source,
+            is_locked=is_locked,
         )
         created = process_conversation(uid, language, create_memory)
-        if is_locked:
-            conversations_db.update_conversation(uid, created.id, {'is_locked': True})
         response['new_memories'].add(created.id)
     else:
 

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -1,3 +1,4 @@
+import asyncio
 import io
 import os
 import re
@@ -20,7 +21,17 @@ from database.conversations import get_closest_conversation_to_timestamps, updat
 from models.conversation import CreateConversation, ConversationSource, Conversation
 from models.transcript_segment import TranscriptSegment
 from utils.conversations.process_conversation import process_conversation
+from utils.analytics import record_usage
+from utils.fair_use import (
+    FAIR_USE_ENABLED,
+    record_speech_ms,
+    get_rolling_speech_ms,
+    check_soft_caps,
+    trigger_classifier_if_needed,
+    is_hard_restricted,
+)
 from utils.other import endpoints as auth
+from utils.other.endpoints import rate_limit_dependency
 from utils.other.storage import (
     get_syncing_file_temporal_signed_url,
     delete_syncing_temporal_file,
@@ -28,6 +39,7 @@ from utils.other.storage import (
     get_or_create_merged_audio,
     get_merged_audio_signed_url,
 )
+from utils.subscription import has_transcription_credits
 
 # Audio constants
 AUDIO_SAMPLE_RATE = 16000
@@ -544,7 +556,7 @@ def decode_files_to_wav(files_path: List[str]):
     return wav_files
 
 
-def retrieve_vad_segments(path: str, segmented_paths: set, errors: list = None):
+def retrieve_vad_segments(path: str, segmented_paths: set, errors: list = None, speech_durations: list = None):
     try:
         start_timestamp = get_timestamp_from_path(path)
         voice_segments = vad_is_empty(path, return_segments=True, cache=True)
@@ -580,6 +592,9 @@ def retrieve_vad_segments(path: str, segmented_paths: set, errors: list = None):
         for i, segment in enumerate(segments):
             if (segment['end'] - segment['start']) < 1:
                 continue
+            # Accumulate speech duration for fair-use tracking (#5854)
+            if speech_durations is not None:
+                speech_durations.append(segment['end'] - segment['start'])
             segment_timestamp = start_timestamp + segment['start']
             segment_path = f'{path_dir}/{segment_timestamp}.wav'
             segment_aseg = aseg[segment['start'] * 1000 : segment['end'] * 1000]
@@ -702,9 +717,19 @@ def _cleanup_files(file_paths):
             logger.error(f"Failed to cleanup file {path}: {e}")
 
 
-@router.post("/v1/sync-local-files")
+@router.post(
+    "/v1/sync-local-files",
+    dependencies=[
+        Depends(rate_limit_dependency(endpoint="sync_local_files", requests_per_window=20, window_seconds=3600))
+    ],
+)
 async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_current_user_uid)):
-    # Improve a version without timestamp, to consider uploads from the stored in v2 device bytes.
+    # Pre-check gates: block over-limit users before any processing (#5854)
+    if not has_transcription_credits(uid):
+        raise HTTPException(status_code=402, detail="Monthly transcription limit reached")
+    if is_hard_restricted(uid):
+        raise HTTPException(status_code=429, detail="Account temporarily restricted due to fair-use policy")
+
     # Detect source from filenames
     source = ConversationSource.omi
     for f in files:
@@ -727,8 +752,9 @@ async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depen
                 [t.join() for t in threads[i : i + chunk_size]]
 
         vad_errors = []
+        speech_durations = []  # Thread-safe: list.append is atomic in CPython
         threads = [
-            threading.Thread(target=retrieve_vad_segments, args=(path, segmented_paths, vad_errors))
+            threading.Thread(target=retrieve_vad_segments, args=(path, segmented_paths, vad_errors, speech_durations))
             for path in wav_paths
         ]
         chunk_threads(threads)
@@ -744,7 +770,24 @@ async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depen
                 error_detail += f" (and {len(vad_errors) - 3} more)"
             raise HTTPException(status_code=500, detail=error_detail)
 
-        logger.info(f'sync_local_files len(segmented_paths) {len(segmented_paths)}')
+        # Fair-use: record speech duration before Deepgram spend (#5854)
+        total_speech_seconds = int(sum(speech_durations))
+        total_speech_ms = total_speech_seconds * 1000
+        if FAIR_USE_ENABLED and total_speech_ms > 0:
+            record_speech_ms(uid, total_speech_ms, source='sync')
+            speech_totals = None
+            try:
+                speech_totals = get_rolling_speech_ms(uid)
+                triggered_caps = check_soft_caps(uid, speech_totals=speech_totals)
+                if triggered_caps:
+                    logger.info(f'fair_use: sync soft cap triggered uid={uid} caps={triggered_caps}')
+                    asyncio.create_task(trigger_classifier_if_needed(uid, triggered_caps, f'sync-{uid}'))
+            except Exception as e:
+                logger.error(f'fair_use: sync cap check error uid={uid}: {e}')
+
+        logger.info(
+            f'sync_local_files len(segmented_paths) {len(segmented_paths)} speech_seconds={total_speech_seconds}'
+        )
 
         response = {'updated_memories': set(), 'new_memories': set()}
         threads = [
@@ -761,7 +804,10 @@ async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depen
         ]
         chunk_threads(threads)
 
-        # notify through FCM too ?
+        # Record subscription usage for transcription time (#5854)
+        if total_speech_seconds > 0:
+            record_usage(uid, transcription_seconds=total_speech_seconds, speech_seconds=total_speech_seconds)
+
         return response
     finally:
         # Clean up any remaining temporary files

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -567,6 +567,14 @@ def retrieve_vad_segments(path: str, segmented_paths: set, errors: list = None, 
             errors.append(error_msg)
         raise  # Re-raise to ensure thread failure is visible
 
+    # Accumulate raw VAD speech durations BEFORE merging (#5854)
+    # Raw segments = actual speech spans; merged segments include silence gaps up to 120s.
+    if speech_durations is not None:
+        for seg in voice_segments:
+            dur = seg['end'] - seg['start']
+            if dur >= 1:
+                speech_durations.append(dur)
+
     segments = []
     # should we merge more aggressively, to avoid too many small segments? ~ not for now
     # Pros -> lesser segments, faster, less concurrency
@@ -592,9 +600,6 @@ def retrieve_vad_segments(path: str, segmented_paths: set, errors: list = None, 
         for i, segment in enumerate(segments):
             if (segment['end'] - segment['start']) < 1:
                 continue
-            # Accumulate speech duration for fair-use tracking (#5854)
-            if speech_durations is not None:
-                speech_durations.append(segment['end'] - segment['start'])
             segment_timestamp = start_timestamp + segment['start']
             segment_path = f'{path_dir}/{segment_timestamp}.wav'
             segment_aseg = aseg[segment['start'] * 1000 : segment['end'] * 1000]

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -31,7 +31,6 @@ from utils.fair_use import (
     is_hard_restricted,
 )
 from utils.other import endpoints as auth
-from utils.other.endpoints import rate_limit_dependency
 from utils.other.storage import (
     get_syncing_file_temporal_signed_url,
     delete_syncing_temporal_file,
@@ -638,7 +637,9 @@ def _reprocess_conversation_after_update(uid: str, conversation_id: str, languag
     logger.info(f'Successfully reprocessed conversation {conversation_id}')
 
 
-def process_segment(path: str, uid: str, response: dict, source: ConversationSource = ConversationSource.omi):
+def process_segment(
+    path: str, uid: str, response: dict, source: ConversationSource = ConversationSource.omi, is_locked: bool = False
+):
     url = get_syncing_file_temporal_signed_url(path)
 
     def delete_file():
@@ -667,6 +668,8 @@ def process_segment(path: str, uid: str, response: dict, source: ConversationSou
             source=source,
         )
         created = process_conversation(uid, language, create_memory)
+        if is_locked:
+            conversations_db.update_conversation(uid, created.id, {'is_locked': True})
         response['new_memories'].add(created.id)
     else:
 
@@ -705,6 +708,8 @@ def process_segment(path: str, uid: str, response: dict, source: ConversationSou
         # save with updated finished_at
         response['updated_memories'].add(closest_memory['id'])
         update_conversation_segments(uid, closest_memory['id'], segments, finished_at=new_finished_at)
+        if is_locked:
+            conversations_db.update_conversation(uid, closest_memory['id'], {'is_locked': True})
 
         # If the conversation was previously discarded, reprocess it with the new segments
         if closest_memory.get('discarded', False):
@@ -722,18 +727,14 @@ def _cleanup_files(file_paths):
             logger.error(f"Failed to cleanup file {path}: {e}")
 
 
-@router.post(
-    "/v1/sync-local-files",
-    dependencies=[
-        Depends(rate_limit_dependency(endpoint="sync_local_files", requests_per_window=20, window_seconds=3600))
-    ],
-)
+@router.post("/v1/sync-local-files")
 async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depends(auth.get_current_user_uid)):
-    # Pre-check gates: block over-limit users before any processing (#5854)
-    if not has_transcription_credits(uid):
-        raise HTTPException(status_code=402, detail="Monthly transcription limit reached")
+    # Pre-check gates (#5854)
     if is_hard_restricted(uid):
         raise HTTPException(status_code=429, detail="Account temporarily restricted due to fair-use policy")
+
+    # Check credits: if exhausted, still process but lock the conversation so user can pay to unlock
+    should_lock = not has_transcription_credits(uid)
 
     # Detect source from filenames
     source = ConversationSource.omi
@@ -803,6 +804,7 @@ async def sync_local_files(files: List[UploadFile] = File(...), uid: str = Depen
                     uid,
                     response,
                     source,
+                    should_lock,
                 ),
             )
             for path in segmented_paths

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -403,8 +403,6 @@ async def _stream_handler(
     fair_use_last_check_ts: float = 0.0
     # DG budget gate for restricted users — checked at session start + per cap-check interval
     fair_use_dg_budget_exhausted: bool = False
-    # DG usage accumulator: batch Redis writes every 60s instead of per-chunk (#5854)
-    dg_usage_ms_pending: int = 0
 
     # Session-start DG budget check: prevent reconnect bypass (#5748 reviewer fix)
     if FAIR_USE_ENABLED and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
@@ -426,7 +424,6 @@ async def _stream_handler(
         nonlocal freemium_threshold_sent
         nonlocal remaining_seconds_cache, remaining_seconds_cache_ts, remaining_seconds_cache_initialized
         nonlocal fair_use_last_check_ts, fair_use_dg_budget_exhausted
-        nonlocal dg_usage_ms_pending
 
         while websocket_active:
             await asyncio.sleep(60)
@@ -2290,7 +2287,7 @@ async def _stream_handler(
         stt_buffer_flush_size = int(sample_rate * 2 * 0.03)  # 30ms at 16-bit mono (e.g., 6400 bytes at 16kHz)
 
         async def flush_stt_buffer(force: bool = False):
-            nonlocal stt_audio_buffer, soniox_profile_socket, deepgram_profile_socket, dg_usage_ms_pending
+            nonlocal stt_audio_buffer, soniox_profile_socket, deepgram_profile_socket
 
             if not stt_audio_buffer:
                 return
@@ -2310,10 +2307,10 @@ async def _stream_handler(
                         pass  # Audio not forwarded to DG — budget exhausted
                     else:
                         dg_socket.send(chunk)
-                        # Accumulate DG usage locally, flushed every 60s (#5854)
+                        # Track DG usage for restricted users
                         if FAIR_USE_ENABLED and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
                             chunk_ms = len(chunk) * 1000 // (sample_rate * 2)  # 16-bit mono
-                            dg_usage_ms_pending += chunk_ms
+                            record_dg_usage_ms(uid, chunk_ms)
                     if deepgram_profile_socket:
                         logger.info(f'Scheduling delayed close of deepgram_profile_socket {uid} {session_id}')
                         socket_to_close = deepgram_profile_socket
@@ -2340,10 +2337,10 @@ async def _stream_handler(
             if soniox_sock is not None and not fair_use_dg_budget_exhausted:
                 if profile_complete or not soniox_profile_socket:
                     await soniox_sock.send(chunk)
-                    # Accumulate DG usage locally, flushed every 60s (#5854)
+                    # Track STT usage for restricted users
                     if FAIR_USE_ENABLED and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
                         chunk_ms = len(chunk) * 1000 // (sample_rate * 2)
-                        dg_usage_ms_pending += chunk_ms
+                        record_dg_usage_ms(uid, chunk_ms)
                     if soniox_profile_socket:
                         logger.info(f'Scheduling delayed close of soniox_profile_socket {uid} {session_id}')
                         socket_to_close = soniox_profile_socket
@@ -2360,10 +2357,10 @@ async def _stream_handler(
 
             if speechmatics_sock is not None and not fair_use_dg_budget_exhausted:
                 await speechmatics_sock.send(chunk)
-                # Accumulate DG usage locally, flushed every 60s (#5854)
+                # Track STT usage for restricted users
                 if FAIR_USE_ENABLED and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
                     chunk_ms = len(chunk) * 1000 // (sample_rate * 2)
-                    dg_usage_ms_pending += chunk_ms
+                    record_dg_usage_ms(uid, chunk_ms)
 
         try:
             while websocket_active:
@@ -2422,10 +2419,10 @@ async def _stream_handler(
                                     stt_sockets_multi[ch_idx].send(pcm_16k)
                                 else:
                                     await stt_sockets_multi[ch_idx].send(pcm_16k)
-                                # Accumulate DG usage locally, flushed every 60s (#5854)
+                                # Track STT usage for restricted users
                                 if FAIR_USE_ENABLED and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
                                     mc_chunk_ms = len(pcm_16k) * 1000 // (TARGET_SAMPLE_RATE * 2)
-                                    dg_usage_ms_pending += mc_chunk_ms
+                                    record_dg_usage_ms(uid, mc_chunk_ms)
                             except Exception as e:
                                 logger.error(f"[MC-STT] ch={ch_idx} send error: {e} {uid} {session_id}")
 
@@ -2669,11 +2666,6 @@ async def _stream_handler(
                 if FAIR_USE_ENABLED and speech_ms > 0:
                     record_speech_ms(uid, speech_ms)
                     logger.debug(f'fair_use: session end flush {speech_ms}ms speech uid={uid} session={session_id}')
-
-            # Flush pending DG usage accumulator (#5854)
-            if FAIR_USE_ENABLED and FAIR_USE_RESTRICT_DAILY_DG_MS > 0 and dg_usage_ms_pending > 0:
-                record_dg_usage_ms(uid, dg_usage_ms_pending)
-                dg_usage_ms_pending = 0
 
             if transcription_seconds > 0 or words_to_record > 0 or speech_seconds_delta > 0:
                 record_usage(

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -403,6 +403,8 @@ async def _stream_handler(
     fair_use_last_check_ts: float = 0.0
     # DG budget gate for restricted users — checked at session start + per cap-check interval
     fair_use_dg_budget_exhausted: bool = False
+    # Batched DG usage tracking — flushed to Redis every 60s (#5854)
+    dg_usage_ms_pending: int = 0
 
     # Session-start DG budget check: prevent reconnect bypass (#5748 reviewer fix)
     if FAIR_USE_ENABLED and FAIR_USE_RESTRICT_DAILY_DG_MS > 0:
@@ -423,7 +425,7 @@ async def _stream_handler(
         nonlocal last_audio_received_time, last_transcript_time, user_has_credits
         nonlocal freemium_threshold_sent
         nonlocal remaining_seconds_cache, remaining_seconds_cache_ts, remaining_seconds_cache_initialized
-        nonlocal fair_use_last_check_ts, fair_use_dg_budget_exhausted
+        nonlocal fair_use_last_check_ts, fair_use_dg_budget_exhausted, dg_usage_ms_pending
 
         while websocket_active:
             await asyncio.sleep(60)

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -56,11 +56,13 @@ pytest tests/unit/test_fair_use_engine.py -v
 pytest tests/unit/test_fair_use_classifier.py -v
 pytest tests/unit/test_fair_use_async.py -v
 pytest tests/unit/test_dg_usage_batch.py -v
+pytest tests/unit/test_sync_fair_use_gate.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then
   pytest tests/integration/test_fair_use_live.py -v
   pytest tests/integration/test_fair_use_api.py -v
+  pytest tests/integration/test_sync_fair_use_live.py -v
 else
   echo "SKIP: fair-use integration tests (Redis not available)"
 fi

--- a/backend/tests/integration/test_sync_fair_use_live.py
+++ b/backend/tests/integration/test_sync_fair_use_live.py
@@ -1,0 +1,172 @@
+"""
+Live integration tests for sync fair-use gates (#5854).
+
+Requires: Redis on localhost:6379 (no password).
+Tests the actual Redis operations (record_speech_ms with source param,
+rolling window queries, and check_soft_caps) against a real Redis instance.
+"""
+
+import os
+import time
+
+import pytest
+import redis
+
+# Set up environment before importing fair_use
+os.environ.setdefault('FAIR_USE_ENABLED', 'true')
+os.environ.setdefault('FAIR_USE_KILL_SWITCH', 'false')
+os.environ.setdefault('FAIR_USE_EXEMPT_UIDS', '')
+os.environ.setdefault('ENCRYPTION_SECRET', 'test-secret-key-that-is-long-enough-for-encryption-32ch')
+
+# Stub heavy deps
+import sys
+from types import ModuleType
+
+for mod_name in [
+    'database._client',
+    'database.fair_use',
+    'database.users',
+    'database.user_usage',
+    'database.conversations',
+    'firebase_admin',
+    'firebase_admin.messaging',
+]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = ModuleType(mod_name)
+
+sys.modules['database._client'].db = None
+
+
+# Check Redis availability
+def _redis_available():
+    try:
+        r = redis.Redis(host='localhost', port=6379, socket_connect_timeout=2)
+        r.ping()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(not _redis_available(), reason="Redis not available on localhost:6379")
+
+
+@pytest.fixture(autouse=True)
+def patch_redis():
+    """Patch the fair_use module to use local Redis."""
+    import database.redis_db as redis_db_mod
+
+    local_redis = redis.Redis(host='localhost', port=6379, decode_responses=False)
+    redis_db_mod.r = local_redis
+
+    import utils.fair_use as fu
+
+    fu.redis_client = local_redis
+    # Ensure enabled
+    original_enabled = fu.FAIR_USE_ENABLED
+    fu.FAIR_USE_ENABLED = True
+
+    yield local_redis
+
+    fu.FAIR_USE_ENABLED = original_enabled
+
+
+@pytest.fixture
+def test_uid():
+    """Unique test UID to avoid collisions."""
+    uid = f'test-sync-{int(time.time() * 1000)}'
+    yield uid
+    # Cleanup
+    import utils.fair_use as fu
+
+    r = fu.redis_client
+    r.delete(f'fair_use:speech:{uid}')
+    r.delete(f'fair_use:bucket:{uid}')
+
+
+class TestSyncFairUseLiveRedis:
+    """Test fair-use operations with real Redis — simulating sync endpoint flow."""
+
+    def test_record_speech_ms_source_sync_writes_to_redis(self, test_uid, patch_redis):
+        """record_speech_ms with source='sync' writes to the same Redis keys as realtime."""
+        import utils.fair_use as fu
+
+        fu.record_speech_ms(test_uid, 30000, source='sync')
+
+        # Verify data in Redis
+        totals = fu.get_rolling_speech_ms(test_uid)
+        assert totals['daily_ms'] == 30000
+        assert totals['three_day_ms'] == 30000
+        assert totals['weekly_ms'] == 30000
+
+    def test_record_speech_ms_source_realtime_same_pool(self, test_uid, patch_redis):
+        """Source='sync' and source='realtime' write to the same pool."""
+        import utils.fair_use as fu
+
+        fu.record_speech_ms(test_uid, 10000, source='realtime')
+        fu.record_speech_ms(test_uid, 20000, source='sync')
+
+        totals = fu.get_rolling_speech_ms(test_uid)
+        # Both sources accumulate in the same pool
+        assert totals['daily_ms'] == 30000
+
+    def test_check_soft_caps_with_sync_speech(self, test_uid, patch_redis):
+        """Sync speech contributes to soft cap checks."""
+        import utils.fair_use as fu
+
+        # Record enough to be under cap
+        fu.record_speech_ms(test_uid, 1000, source='sync')
+        caps = fu.check_soft_caps(test_uid)
+        assert caps == []
+
+    def test_sync_speech_triggers_daily_cap(self, test_uid, patch_redis):
+        """Large sync upload can trigger daily soft cap."""
+        import utils.fair_use as fu
+
+        original_cap = fu.FAIR_USE_DAILY_SPEECH_MS
+        fu.FAIR_USE_DAILY_SPEECH_MS = 5000  # Low cap for test
+
+        try:
+            fu.record_speech_ms(test_uid, 6000, source='sync')
+            totals = fu.get_rolling_speech_ms(test_uid)
+            caps = fu.check_soft_caps(test_uid, speech_totals=totals)
+            assert len(caps) > 0
+            assert caps[0]['trigger'].value == 'daily'
+        finally:
+            fu.FAIR_USE_DAILY_SPEECH_MS = original_cap
+
+    def test_precomputed_totals_match_redis(self, test_uid, patch_redis):
+        """get_rolling_speech_ms returns data that check_soft_caps can use."""
+        import utils.fair_use as fu
+
+        fu.record_speech_ms(test_uid, 5000, source='sync')
+        totals = fu.get_rolling_speech_ms(test_uid)
+
+        assert totals['daily_ms'] == 5000
+        caps = fu.check_soft_caps(test_uid, speech_totals=totals)
+        assert caps == []  # Under default caps
+
+    def test_full_sync_flow_simulation(self, test_uid, patch_redis):
+        """Simulate the full sync endpoint fair-use flow:
+        1. Record speech from VAD segments
+        2. Check soft caps
+        3. Verify totals
+        """
+        import utils.fair_use as fu
+
+        # Simulate VAD segments: 3 segments of ~30s each
+        vad_segments = [
+            {'start': 0.0, 'end': 30.0},
+            {'start': 150.0, 'end': 180.0},
+            {'start': 300.0, 'end': 330.0},
+        ]
+        total_speech_ms = int(sum(s['end'] - s['start'] for s in vad_segments)) * 1000
+        assert total_speech_ms == 90000  # 90 seconds
+
+        # Phase 1: Record speech
+        fu.record_speech_ms(test_uid, total_speech_ms, source='sync')
+
+        # Phase 2: Check caps
+        totals = fu.get_rolling_speech_ms(test_uid)
+        assert totals['daily_ms'] == 90000
+        caps = fu.check_soft_caps(test_uid, speech_totals=totals)
+        assert caps == []  # 90s << 2h daily cap

--- a/backend/tests/unit/test_sync_fair_use_gate.py
+++ b/backend/tests/unit/test_sync_fair_use_gate.py
@@ -177,3 +177,149 @@ class TestSyncEndpointImports:
         assert callable(fair_use_mod.is_hard_restricted)
         assert hasattr(fair_use_mod, 'FAIR_USE_ENABLED')
         assert hasattr(fair_use_mod, 'trigger_classifier_if_needed')
+
+
+class TestCreateConversationLockPropagation:
+    """Test is_locked field on CreateConversation flows through to Conversation."""
+
+    def test_create_conversation_default_unlocked(self):
+        """CreateConversation defaults to is_locked=False."""
+        from models.conversation import CreateConversation, TranscriptSegment
+        from datetime import datetime, timezone
+
+        cc = CreateConversation(
+            started_at=datetime.now(timezone.utc),
+            finished_at=datetime.now(timezone.utc),
+            transcript_segments=[],
+        )
+        assert cc.is_locked is False
+
+    def test_create_conversation_locked(self):
+        """CreateConversation accepts is_locked=True."""
+        from models.conversation import CreateConversation
+        from datetime import datetime, timezone
+
+        cc = CreateConversation(
+            started_at=datetime.now(timezone.utc),
+            finished_at=datetime.now(timezone.utc),
+            transcript_segments=[],
+            is_locked=True,
+        )
+        assert cc.is_locked is True
+
+    def test_locked_propagates_through_dict(self):
+        """is_locked=True appears in .dict() for **kwargs unpacking."""
+        from models.conversation import CreateConversation
+        from datetime import datetime, timezone
+
+        cc = CreateConversation(
+            started_at=datetime.now(timezone.utc),
+            finished_at=datetime.now(timezone.utc),
+            transcript_segments=[],
+            is_locked=True,
+        )
+        d = cc.dict()
+        assert d['is_locked'] is True
+
+    def test_conversation_inherits_lock_from_create(self):
+        """Conversation(**create_dict) inherits is_locked=True."""
+        from models.conversation import CreateConversation, Conversation, Structured
+        from datetime import datetime, timezone
+
+        cc = CreateConversation(
+            started_at=datetime.now(timezone.utc),
+            finished_at=datetime.now(timezone.utc),
+            transcript_segments=[],
+            is_locked=True,
+        )
+        cc_dict = cc.dict()
+        cc_dict.pop('calendar_meeting_context', None)
+        conv = Conversation(
+            id='test-id',
+            created_at=datetime.now(timezone.utc),
+            structured=Structured(),
+            **cc_dict,
+        )
+        assert conv.is_locked is True
+
+
+class TestSyncEndpointCodeStructure:
+    """Structural tests: verify sync.py gates match expected design."""
+
+    @staticmethod
+    def _read_sync_source():
+        import os
+
+        sync_path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'sync.py')
+        with open(sync_path) as f:
+            return f.read()
+
+    def test_no_rate_limit_dependency(self):
+        """sync.py must not use rate_limit_dependency (removed per manager)."""
+        source = self._read_sync_source()
+        assert 'rate_limit_dependency' not in source
+
+    def test_no_402_block(self):
+        """sync.py must not raise 402 (lock instead of block)."""
+        source = self._read_sync_source()
+        assert 'status_code=402' not in source
+
+    def test_should_lock_flag_exists(self):
+        """sync.py must use should_lock flag for credit-exhausted locking."""
+        source = self._read_sync_source()
+        assert 'should_lock' in source
+
+    def test_is_locked_passed_to_create_conversation(self):
+        """sync.py passes is_locked to CreateConversation."""
+        source = self._read_sync_source()
+        assert 'is_locked=is_locked' in source
+
+    def test_hard_restricted_gate_exists(self):
+        """sync.py must check is_hard_restricted."""
+        source = self._read_sync_source()
+        assert 'is_hard_restricted(uid)' in source
+
+    def test_zero_speech_skips_recording(self):
+        """Verify zero-speech guard in code: only records when total_speech_ms > 0."""
+        source = self._read_sync_source()
+        assert 'total_speech_ms > 0' in source
+
+
+class TestSoftCapBoundary:
+    """Test check_soft_caps at exact boundary values."""
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'FAIR_USE_DAILY_SPEECH_MS', 7200000)
+    @patch.object(fair_use_mod, 'get_rolling_speech_ms')
+    def test_exactly_at_cap_does_not_trigger(self, mock_speech):
+        """Usage exactly at daily cap should NOT trigger (only over)."""
+        precomputed = {'daily_ms': 7200000, 'three_day_ms': 7200000, 'weekly_ms': 7200000}
+        result = fair_use_mod.check_soft_caps('user1', speech_totals=precomputed)
+        # At cap exactly — triggers only when OVER
+        mock_speech.assert_not_called()
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'FAIR_USE_DAILY_SPEECH_MS', 7200000)
+    @patch.object(fair_use_mod, 'get_rolling_speech_ms')
+    def test_one_ms_over_cap_triggers(self, mock_speech):
+        """Usage 1ms over daily cap should trigger."""
+        precomputed = {'daily_ms': 7200001, 'three_day_ms': 7200001, 'weekly_ms': 7200001}
+        result = fair_use_mod.check_soft_caps('user1', speech_totals=precomputed)
+        assert len(result) > 0
+        mock_speech.assert_not_called()
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'FAIR_USE_DAILY_SPEECH_MS', 7200000)
+    @patch.object(fair_use_mod, 'get_rolling_speech_ms')
+    def test_zero_speech_no_cap_trigger(self, mock_speech):
+        """Zero speech should never trigger any cap."""
+        precomputed = {'daily_ms': 0, 'three_day_ms': 0, 'weekly_ms': 0}
+        result = fair_use_mod.check_soft_caps('user1', speech_totals=precomputed)
+        assert result == []
+        mock_speech.assert_not_called()

--- a/backend/tests/unit/test_sync_fair_use_gate.py
+++ b/backend/tests/unit/test_sync_fair_use_gate.py
@@ -1,0 +1,159 @@
+"""Tests for sync endpoint fair-use gates (#5854)."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+# --- Stubs to isolate from heavy deps ---
+import sys
+from types import ModuleType
+
+# Stub database modules
+for mod_name in [
+    'database._client',
+    'database.redis_db',
+    'database.fair_use',
+    'database.users',
+    'database.user_usage',
+    'database.conversations',
+    'firebase_admin',
+    'firebase_admin.messaging',
+]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = ModuleType(mod_name)
+
+# Stub redis_db.r
+_mock_redis = MagicMock()
+sys.modules['database.redis_db'].r = _mock_redis
+
+# Stub database._client.db
+sys.modules['database._client'].db = MagicMock()
+
+import utils.fair_use as fair_use_mod
+
+
+class TestRecordSpeechMsSource:
+    """Test that source param is accepted and doesn't change Redis behavior."""
+
+    def setup_method(self):
+        _mock_redis.reset_mock()
+        _mock_redis.pipeline.return_value = MagicMock()
+        _mock_redis.zrangebyscore.return_value = []
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_source_defaults_to_realtime(self):
+        """Calling without source uses 'realtime' default."""
+        fair_use_mod.record_speech_ms('user1', 5000)
+        pipe = _mock_redis.pipeline.return_value
+        pipe.hincrby.assert_called_once()
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_source_sync_accepted(self):
+        """Calling with source='sync' works the same — same Redis keys."""
+        fair_use_mod.record_speech_ms('user1', 5000, source='sync')
+        pipe = _mock_redis.pipeline.return_value
+        pipe.hincrby.assert_called_once()
+        # Verify same Redis key pattern (no source in key)
+        call_args = pipe.hincrby.call_args
+        assert 'fair_use:bucket:user1' in str(call_args)
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    def test_source_does_not_change_redis_keys(self):
+        """Source param is for logging only — Redis keys are identical."""
+        pipe_mock = MagicMock()
+        _mock_redis.pipeline.return_value = pipe_mock
+
+        fair_use_mod.record_speech_ms('user1', 1000, source='realtime')
+        realtime_calls = [str(c) for c in pipe_mock.method_calls]
+
+        pipe_mock.reset_mock()
+        _mock_redis.pipeline.return_value = pipe_mock
+
+        fair_use_mod.record_speech_ms('user1', 1000, source='sync')
+        sync_calls = [str(c) for c in pipe_mock.method_calls]
+
+        # Same Redis operations regardless of source
+        assert realtime_calls == sync_calls
+
+
+class TestCheckSoftCapsWithPrecomputedTotals:
+    """Test check_soft_caps with speech_totals param (used by sync path)."""
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', set())
+    @patch.object(fair_use_mod, 'FAIR_USE_DAILY_SPEECH_MS', 7200000)
+    @patch.object(fair_use_mod, 'get_rolling_speech_ms')
+    def test_precomputed_totals_trigger_caps(self, mock_speech):
+        """When speech_totals passed, uses them and skips Redis."""
+        precomputed = {'daily_ms': 8000000, 'three_day_ms': 8000000, 'weekly_ms': 8000000}
+        result = fair_use_mod.check_soft_caps('user1', speech_totals=precomputed)
+        assert len(result) > 0
+        mock_speech.assert_not_called()
+
+
+class TestSpeechDurationComputation:
+    """Test the speech duration accumulation logic used in sync endpoint."""
+
+    def test_duration_from_vad_segments(self):
+        """Segments with start/end produce correct total duration."""
+        segments = [
+            {'start': 0.0, 'end': 30.0},
+            {'start': 150.0, 'end': 180.0},
+        ]
+        durations = [s['end'] - s['start'] for s in segments if (s['end'] - s['start']) >= 1]
+        assert sum(durations) == pytest.approx(60.0)
+
+    def test_short_segments_excluded(self):
+        """Segments shorter than 1s are excluded."""
+        segments = [
+            {'start': 0.0, 'end': 0.5},   # Too short
+            {'start': 10.0, 'end': 40.0},  # Valid
+        ]
+        durations = [s['end'] - s['start'] for s in segments if (s['end'] - s['start']) >= 1]
+        assert len(durations) == 1
+        assert durations[0] == pytest.approx(30.0)
+
+    def test_empty_segments(self):
+        """No segments produce zero duration."""
+        segments = []
+        durations = [s['end'] - s['start'] for s in segments if (s['end'] - s['start']) >= 1]
+        assert sum(durations) == 0
+
+    def test_conversion_to_ms(self):
+        """Seconds to milliseconds conversion for record_speech_ms."""
+        total_seconds = 45
+        total_ms = total_seconds * 1000
+        assert total_ms == 45000
+
+
+class TestIsHardRestrictedGate:
+    """Test is_hard_restricted works for sync pre-check."""
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', False)
+    def test_disabled_returns_false(self):
+        assert fair_use_mod.is_hard_restricted('user1') is False
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', True)
+    def test_kill_switch_returns_false(self):
+        assert fair_use_mod.is_hard_restricted('user1') is False
+
+    @patch.object(fair_use_mod, 'FAIR_USE_ENABLED', True)
+    @patch.object(fair_use_mod, 'FAIR_USE_KILL_SWITCH', False)
+    @patch.object(fair_use_mod, 'FAIR_USE_EXEMPT_UIDS', {'exempt-user'})
+    def test_exempt_user_returns_false(self):
+        assert fair_use_mod.is_hard_restricted('exempt-user') is False
+
+
+class TestSyncEndpointImports:
+    """Verify that all fair-use imports are available from utils.fair_use."""
+
+    def test_all_required_functions_importable(self):
+        """All functions needed by sync.py are importable from utils.fair_use."""
+        assert callable(fair_use_mod.record_speech_ms)
+        assert callable(fair_use_mod.get_rolling_speech_ms)
+        assert callable(fair_use_mod.check_soft_caps)
+        assert callable(fair_use_mod.is_hard_restricted)
+        assert hasattr(fair_use_mod, 'FAIR_USE_ENABLED')
+        assert hasattr(fair_use_mod, 'trigger_classifier_if_needed')

--- a/backend/tests/unit/test_sync_fair_use_gate.py
+++ b/backend/tests/unit/test_sync_fair_use_gate.py
@@ -93,21 +93,41 @@ class TestCheckSoftCapsWithPrecomputedTotals:
 
 
 class TestSpeechDurationComputation:
-    """Test the speech duration accumulation logic used in sync endpoint."""
+    """Test the speech duration accumulation logic used in sync endpoint.
 
-    def test_duration_from_vad_segments(self):
-        """Segments with start/end produce correct total duration."""
-        segments = [
+    Duration is computed from raw VAD segments BEFORE merging, so silence
+    gaps between merged segments are not counted as speech.
+    """
+
+    def test_duration_from_raw_vad_segments(self):
+        """Raw VAD segments produce correct total duration (no silence gaps)."""
+        # Two separate 30s speech spans
+        raw_segments = [
             {'start': 0.0, 'end': 30.0},
             {'start': 150.0, 'end': 180.0},
         ]
-        durations = [s['end'] - s['start'] for s in segments if (s['end'] - s['start']) >= 1]
+        durations = [s['end'] - s['start'] for s in raw_segments if (s['end'] - s['start']) >= 1]
+        # 30 + 30 = 60s (the 120s gap is NOT counted)
         assert sum(durations) == pytest.approx(60.0)
+
+    def test_merged_segments_would_overcount(self):
+        """Merged segments include silence gaps — raw segments don't."""
+        # After merging (gap < 120s), these become one segment: 0-180
+        # But raw speech is only 30+30 = 60s
+        raw_segments = [
+            {'start': 0.0, 'end': 30.0},
+            {'start': 100.0, 'end': 130.0},  # Gap = 70s < 120s → merged
+        ]
+        raw_duration = sum(s['end'] - s['start'] for s in raw_segments if (s['end'] - s['start']) >= 1)
+        merged_duration = 130.0 - 0.0  # What merged would give
+        assert raw_duration == pytest.approx(60.0)
+        assert merged_duration == pytest.approx(130.0)
+        assert raw_duration < merged_duration  # Raw is correct, merged is inflated
 
     def test_short_segments_excluded(self):
         """Segments shorter than 1s are excluded."""
         segments = [
-            {'start': 0.0, 'end': 0.5},   # Too short
+            {'start': 0.0, 'end': 0.5},  # Too short
             {'start': 10.0, 'end': 40.0},  # Valid
         ]
         durations = [s['end'] - s['start'] for s in segments if (s['end'] - s['start']) >= 1]

--- a/backend/utils/fair_use.py
+++ b/backend/utils/fair_use.py
@@ -110,16 +110,22 @@ def _release_lock(key: str, token: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def record_speech_ms(uid: str, speech_ms: int) -> None:
+def record_speech_ms(uid: str, speech_ms: int, source: str = 'realtime') -> None:
     """Record speech milliseconds into the current minute bucket.
 
     Uses a Redis sorted set where:
       - member = Unix minute timestamp (as string)
       - score = Unix minute timestamp (for range queries)
     The speech_ms is stored in a separate hash keyed by minute.
+
+    Args:
+        source: Ingestion path for log traceability ('realtime' or 'sync').
+            Same Redis pool regardless of source — no separate enforcement.
     """
     if not FAIR_USE_ENABLED or speech_ms <= 0:
         return
+
+    logger.info(f'fair_use: record_speech_ms uid={uid} ms={speech_ms} source={source}')
 
     try:
         now = int(time.time())


### PR DESCRIPTION
## Summary
- Fixes `SyntaxError: no binding for nonlocal 'dg_usage_ms_pending' found` that broke Cloud Run deploy
- Adds `dg_usage_ms_pending: int = 0` declaration in the enclosing `websocket_endpoint` scope
- Adds `nonlocal dg_usage_ms_pending` to `_record_usage_periodically()` which writes to it

## Root cause
PR #5863 merge introduced `dg_usage_ms_pending` references (from the DG usage batch tracking in PR #5748) as `nonlocal` in two nested functions (`receive_data` and `_record_usage_periodically`) but the variable was never declared in the enclosing function scope.

## Test plan
- [x] `python3 -c "import py_compile; py_compile.compile('routers/transcribe.py', doraise=True)"` passes
- [x] No other `nonlocal` references without enclosing declarations

Closes deploy failure from run 23376180307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)