### PR TITLE
Revert hotfix: remove Deepgram/Gemini keys from config endpoint

### DIFF
--- a/desktop/Backend-Rust/src/routes/config.rs
+++ b/desktop/Backend-Rust/src/routes/config.rs
@@ -1,8 +1,8 @@
 // Client configuration routes
 // Serves API keys to authenticated desktop clients so keys are not bundled in the app binary.
 //
-// New clients (v0.11.147+) use /v1/proxy/* for Deepgram and Gemini (see proxy.rs, issue #5861).
-// Deepgram and Gemini keys are STILL served here for backward compatibility with older clients.
+// Deepgram and Gemini keys are NO LONGER served here — they are proxied server-side
+// via /v1/proxy/deepgram/* and /v1/proxy/gemini/* (see proxy.rs, issue #5861).
 
 use axum::{extract::State, routing::get, Json, Router};
 use serde::Serialize;
@@ -13,10 +13,6 @@ use crate::AppState;
 #[derive(Serialize)]
 struct ApiKeysResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
-    deepgram_api_key: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    gemini_api_key: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     anthropic_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     firebase_api_key: Option<String>,
@@ -25,12 +21,9 @@ struct ApiKeysResponse {
 }
 
 /// GET /v1/config/api-keys — return API keys for the authenticated user
-/// Deepgram and Gemini keys still served for backward compat with pre-v0.11.147 clients.
-/// New clients use /v1/proxy/* endpoints instead (issue #5861).
+/// NOTE: Deepgram and Gemini keys removed — now proxied server-side (issue #5861)
 async fn get_api_keys(State(state): State<AppState>, _user: AuthUser) -> Json<ApiKeysResponse> {
     Json(ApiKeysResponse {
-        deepgram_api_key: state.config.deepgram_api_key.clone(),
-        gemini_api_key: state.config.gemini_api_key.clone(),
         anthropic_api_key: state.config.anthropic_api_key.clone(),
         firebase_api_key: state.config.firebase_api_key.clone(),
         google_calendar_api_key: state.config.google_calendar_api_key.clone(),


### PR DESCRIPTION
## Summary
- Reverts commit c720b65 which was incorrectly pushed directly to main
- Removes `deepgram_api_key` and `gemini_api_key` from `/v1/config/api-keys` response
- v0.11.147 clients use `/v1/proxy/*` endpoints instead — old clients will auto-update via Sparkle

## Why
The hotfix was unnecessary. v0.11.147 (with proxy support) is building via Codemagic and will auto-update all users via Sparkle. No need to maintain backward compat for v0.11.146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_