### PR TITLE
Fix plugins Cloud Run deploy: remove broken mentor import

### DIFF
--- a/plugins/main.py
+++ b/plugins/main.py
@@ -11,7 +11,6 @@ from zapier import conversation_created as zapier_conversation_created_router
 from chatgpt import main as chatgpt_router
 from subscription import main as subscription_router
 from notifications import hey_omi
-from notifications.mentor import main as omi_mentor
 from iq_rating import main as iq_rating_router
 
 # from ahda import client as ahda_realtime_transcription_router
@@ -92,7 +91,6 @@ app.include_router(subscription_router.router)
 
 # Notifications
 app.include_router(hey_omi.router)
-app.include_router(omi_mentor.router)
 
 # IQ Rating
 app.include_router(iq_rating_router.router)


### PR DESCRIPTION
## Summary
- Remove broken `from notifications.mentor import main as omi_mentor` import in `plugins/main.py`
- Remove corresponding `app.include_router(omi_mentor.router)` registration

## Root Cause
Commit `2bce7af29` (Feb 20, @kodjima33) renamed `plugins/notifications/mentor/` → `plugins/notifications/mentor (deprecated)/` but did **not** update `plugins/main.py`. The import on line 14 still referenced the old path, causing the plugins Cloud Run service to fail on every deploy since Feb 21.

## Why removal (not path fix)
The commit message for `2bce7af29` states: *"Mentor app functionality has been integrated into Omi core"*. The mentor plugin is deprecated — the correct fix is to remove the dead import, not restore the old directory.

## Changes
| File | Change |
|------|--------|
| `plugins/main.py` | Delete import line 14 + router registration line 95 |

## Test plan
- [x] Verified no other files reference `notifications.mentor`
- [x] Two-line deletion, no new code paths

_by AI for @beastoin_

🤖 Generated with [Claude Code](https://claude.com/claude-code)