### PR TITLE
Bump app version to 1.0.527+785

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.526+784
+version: 1.0.527+785
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bump version from 1.0.526+784 to 1.0.527+785
- iOS 1.0.526 was already in the App Store, so bumping minor version to 527
- Triggers fresh Codemagic build with Fair Use changes for TestFlight

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_