### PR TITLE
Update CHANGELOG.json for v0.11.152 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -2,6 +2,13 @@
   "unreleased": [],
   "releases": [
     {
+      "version": "0.11.152",
+      "date": "2026-03-23",
+      "changes": [
+        "Bug fixes and improvements"
+      ]
+    },
+    {
       "version": "0.11.151",
       "date": "2026-03-22",
       "changes": [


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.152 and clears the unreleased array.