### PR TITLE
Add clock skew tolerance to stale request check (#5929)

### DIFF
--- a/backend/tests/unit/test_timeout_middleware.py
+++ b/backend/tests/unit/test_timeout_middleware.py
@@ -65,17 +65,24 @@ def test_within_clock_skew_tolerance_passes():
     assert response.status_code == 200
 
 
-def test_beyond_tolerance_rejected():
-    """Request beyond max_age + skew_allowance is rejected with 408.
+def test_beyond_tolerance_rejected_with_clock_skew_json():
+    """Request beyond max_age + skew_allowance returns 408 with clock skew JSON.
 
     Default: max_age=5min, skew_allowance=5min, effective threshold=10min.
-    A 15-minute-old request should be rejected.
+    A 15-minute-old request should be rejected with diagnostic info.
     """
     app = _make_app()
     client = TestClient(app)
     very_stale_time = str(time.time() - 900)  # 15 minutes ago
     response = client.get("/ok", headers={"X-Request-Start-Time": very_stale_time})
     assert response.status_code == 408
+    body = response.json()
+    assert body["error"] == "clock_skew"
+    assert "server_time" in body
+    assert "client_time" in body
+    assert "skew_seconds" in body
+    assert body["skew_seconds"] >= 900
+    assert "hint" in body
 
 
 def test_at_exact_boundary_rejected():

--- a/backend/tests/unit/test_timeout_middleware.py
+++ b/backend/tests/unit/test_timeout_middleware.py
@@ -76,8 +76,7 @@ def test_multipart_with_boundary_skips_stale_check():
         },
         content=b"fake",
     )
-    # Should not be 408 — multipart skips stale check
-    assert response.status_code != 408
+    assert response.status_code == 200
 
 
 def test_fresh_non_multipart_passes():
@@ -127,11 +126,11 @@ def test_uppercase_multipart_skips_stale_check():
         },
         content=b"fake",
     )
-    assert response.status_code != 408
+    assert response.status_code == 200
 
 
-def test_non_multipart_with_multipart_token_still_rejected():
-    """Non-multipart content-type is not tricked by substring containing 'multipart/form-data'."""
+def test_non_multipart_with_multipart_substring_still_rejected():
+    """Content-type containing 'multipart/form-data' as substring but not as base type still gets 408."""
     app = _make_app()
     client = TestClient(app)
     stale_time = str(time.time() - 600)
@@ -139,9 +138,9 @@ def test_non_multipart_with_multipart_token_still_rejected():
         "/ok",
         headers={
             "X-Request-Start-Time": stale_time,
-            "Content-Type": "application/json",
+            "Content-Type": "application/x-multipart/form-data-wrapper",
         },
-        content=b'{"key": "value"}',
+        content=b'fake',
     )
     assert response.status_code == 408
 

--- a/backend/tests/unit/test_timeout_middleware.py
+++ b/backend/tests/unit/test_timeout_middleware.py
@@ -1,16 +1,17 @@
 """Unit tests for TimeoutMiddleware stale request check (#5929).
 
 Verifies:
-- Stale non-multipart requests are rejected with 408
-- Multipart file uploads skip the stale check (clock skew safe)
+- Clock skew tolerance: requests within max_age + skew_allowance pass
+- Truly stale requests (beyond tolerance) are rejected with 408
 - Malformed headers are ignored (request proceeds)
 - Future-dated headers are not rejected
+- Clock skew allowance is configurable via env var
 - Timeout path returns 504
 """
 
 import asyncio
+import os
 import time
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from starlette.testclient import TestClient
@@ -41,50 +42,73 @@ def _make_app(methods_timeout=None):
     return app
 
 
-def test_stale_non_multipart_rejected():
-    """Non-multipart request with stale X-Request-Start-Time gets 408."""
-    app = _make_app()
-    client = TestClient(app)
-    stale_time = str(time.time() - 600)  # 10 minutes ago
-    response = client.get("/ok", headers={"X-Request-Start-Time": stale_time})
-    assert response.status_code == 408
-
-
-def test_multipart_skips_stale_check():
-    """Multipart file upload with stale header should NOT get 408 (#5929)."""
-    app = _make_app()
-    client = TestClient(app)
-    stale_time = str(time.time() - 600)  # 10 minutes ago
-    response = client.post(
-        "/ok",
-        files={"file": ("test.wav", b"fake audio data", "audio/wav")},
-        headers={"X-Request-Start-Time": stale_time},
-    )
-    assert response.status_code == 200
-
-
-def test_multipart_with_boundary_skips_stale_check():
-    """Multipart with boundary param in content-type still skips stale check."""
-    app = _make_app()
-    client = TestClient(app)
-    stale_time = str(time.time() - 600)
-    response = client.post(
-        "/ok",
-        headers={
-            "X-Request-Start-Time": stale_time,
-            "Content-Type": "multipart/form-data; boundary=----WebKitFormBoundary",
-        },
-        content=b"fake",
-    )
-    assert response.status_code == 200
-
-
-def test_fresh_non_multipart_passes():
-    """Non-multipart request with fresh header passes through."""
+def test_fresh_request_passes():
+    """Request with fresh timestamp passes through."""
     app = _make_app()
     client = TestClient(app)
     fresh_time = str(time.time())
     response = client.get("/ok", headers={"X-Request-Start-Time": fresh_time})
+    assert response.status_code == 200
+
+
+def test_within_clock_skew_tolerance_passes():
+    """Request from phone with ~5min clock skew passes (within tolerance).
+
+    Default: max_age=5min, skew_allowance=5min, effective threshold=10min.
+    A 7-minute-old request should pass.
+    """
+    app = _make_app()
+    client = TestClient(app)
+    # 7 minutes ago — beyond max_age (5min) but within max_age + skew_allowance (10min)
+    skewed_time = str(time.time() - 420)
+    response = client.get("/ok", headers={"X-Request-Start-Time": skewed_time})
+    assert response.status_code == 200
+
+
+def test_beyond_tolerance_rejected():
+    """Request beyond max_age + skew_allowance is rejected with 408.
+
+    Default: max_age=5min, skew_allowance=5min, effective threshold=10min.
+    A 15-minute-old request should be rejected.
+    """
+    app = _make_app()
+    client = TestClient(app)
+    very_stale_time = str(time.time() - 900)  # 15 minutes ago
+    response = client.get("/ok", headers={"X-Request-Start-Time": very_stale_time})
+    assert response.status_code == 408
+
+
+def test_at_exact_boundary_rejected():
+    """Request exactly at max_age + skew_allowance + 1s is rejected."""
+    app = _make_app()
+    client = TestClient(app)
+    # Default threshold: 5*60 + 5*60 = 600s. Set to 601s ago.
+    boundary_time = str(time.time() - 601)
+    response = client.get("/ok", headers={"X-Request-Start-Time": boundary_time})
+    assert response.status_code == 408
+
+
+def test_just_within_boundary_passes():
+    """Request just within max_age + skew_allowance passes."""
+    app = _make_app()
+    client = TestClient(app)
+    # Default threshold: 600s. Set to 590s ago (10s margin).
+    within_time = str(time.time() - 590)
+    response = client.get("/ok", headers={"X-Request-Start-Time": within_time})
+    assert response.status_code == 200
+
+
+def test_multipart_upload_with_skew_passes():
+    """Multipart file upload with clock skew within tolerance passes (#5929)."""
+    app = _make_app()
+    client = TestClient(app)
+    # 7 minutes ago — simulates phone clock 5min behind + 2min transfer
+    skewed_time = str(time.time() - 420)
+    response = client.post(
+        "/ok",
+        files={"file": ("test.wav", b"fake audio data", "audio/wav")},
+        headers={"X-Request-Start-Time": skewed_time},
+    )
     assert response.status_code == 200
 
 
@@ -113,43 +137,24 @@ def test_future_dated_header_passes():
     assert response.status_code == 200
 
 
-def test_uppercase_multipart_skips_stale_check():
-    """Mixed-case Content-Type 'Multipart/Form-Data' still skips stale check."""
+def test_custom_skew_allowance_via_env(monkeypatch):
+    """HTTP_CLOCK_SKEW_ALLOWANCE env var controls clock skew tolerance."""
+    monkeypatch.setenv("HTTP_CLOCK_SKEW_ALLOWANCE", "60")  # only 1 min allowance
     app = _make_app()
     client = TestClient(app)
-    stale_time = str(time.time() - 600)
-    response = client.post(
-        "/ok",
-        headers={
-            "X-Request-Start-Time": stale_time,
-            "Content-Type": "Multipart/Form-Data; boundary=----abc",
-        },
-        content=b"fake",
-    )
-    assert response.status_code == 200
-
-
-def test_non_multipart_with_multipart_substring_still_rejected():
-    """Content-type containing 'multipart/form-data' as substring but not as base type still gets 408."""
-    app = _make_app()
-    client = TestClient(app)
-    stale_time = str(time.time() - 600)
-    response = client.post(
-        "/ok",
-        headers={
-            "X-Request-Start-Time": stale_time,
-            "Content-Type": "application/x-multipart/form-data-wrapper",
-        },
-        content=b'fake',
-    )
+    # 7 minutes ago — beyond max_age(5min) + skew(1min) = 6min threshold
+    skewed_time = str(time.time() - 420)
+    response = client.get("/ok", headers={"X-Request-Start-Time": skewed_time})
     assert response.status_code == 408
 
 
-def test_missing_content_type_still_checked():
-    """Request with no Content-Type header still gets stale check."""
+def test_zero_skew_allowance_original_behavior(monkeypatch):
+    """With zero skew allowance, behavior matches original (max_age only)."""
+    monkeypatch.setenv("HTTP_CLOCK_SKEW_ALLOWANCE", "0")
     app = _make_app()
     client = TestClient(app)
-    stale_time = str(time.time() - 600)
+    # 6 minutes ago — beyond max_age(5min) + skew(0) = 5min threshold
+    stale_time = str(time.time() - 360)
     response = client.get("/ok", headers={"X-Request-Start-Time": stale_time})
     assert response.status_code == 408
 

--- a/backend/tests/unit/test_timeout_middleware.py
+++ b/backend/tests/unit/test_timeout_middleware.py
@@ -1,0 +1,122 @@
+"""Unit tests for TimeoutMiddleware stale request check (#5929).
+
+Verifies:
+- Stale non-multipart requests are rejected with 408
+- Multipart file uploads skip the stale check (clock skew safe)
+- Malformed headers are ignored (request proceeds)
+- Future-dated headers are not rejected
+- Timeout path returns 504
+"""
+
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.testclient import TestClient
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+
+from utils.other.timeout import TimeoutMiddleware
+
+
+def _make_app(methods_timeout=None):
+    """Create a minimal Starlette app with TimeoutMiddleware."""
+
+    async def ok_endpoint(request):
+        return PlainTextResponse("ok")
+
+    async def slow_endpoint(request):
+        await asyncio.sleep(10)
+        return PlainTextResponse("slow")
+
+    app = Starlette(
+        routes=[
+            Route("/ok", ok_endpoint, methods=["GET", "POST"]),
+            Route("/slow", slow_endpoint, methods=["GET"]),
+        ],
+    )
+    app.add_middleware(TimeoutMiddleware, methods_timeout=methods_timeout or {})
+    return app
+
+
+def test_stale_non_multipart_rejected():
+    """Non-multipart request with stale X-Request-Start-Time gets 408."""
+    app = _make_app()
+    client = TestClient(app)
+    stale_time = str(time.time() - 600)  # 10 minutes ago
+    response = client.get("/ok", headers={"X-Request-Start-Time": stale_time})
+    assert response.status_code == 408
+
+
+def test_multipart_skips_stale_check():
+    """Multipart file upload with stale header should NOT get 408 (#5929)."""
+    app = _make_app()
+    client = TestClient(app)
+    stale_time = str(time.time() - 600)  # 10 minutes ago
+    response = client.post(
+        "/ok",
+        files={"file": ("test.wav", b"fake audio data", "audio/wav")},
+        headers={"X-Request-Start-Time": stale_time},
+    )
+    assert response.status_code == 200
+
+
+def test_multipart_with_boundary_skips_stale_check():
+    """Multipart with boundary param in content-type still skips stale check."""
+    app = _make_app()
+    client = TestClient(app)
+    stale_time = str(time.time() - 600)
+    response = client.post(
+        "/ok",
+        headers={
+            "X-Request-Start-Time": stale_time,
+            "Content-Type": "multipart/form-data; boundary=----WebKitFormBoundary",
+        },
+        content=b"fake",
+    )
+    # Should not be 408 — multipart skips stale check
+    assert response.status_code != 408
+
+
+def test_fresh_non_multipart_passes():
+    """Non-multipart request with fresh header passes through."""
+    app = _make_app()
+    client = TestClient(app)
+    fresh_time = str(time.time())
+    response = client.get("/ok", headers={"X-Request-Start-Time": fresh_time})
+    assert response.status_code == 200
+
+
+def test_malformed_header_passes():
+    """Malformed X-Request-Start-Time header is ignored, request proceeds."""
+    app = _make_app()
+    client = TestClient(app)
+    response = client.get("/ok", headers={"X-Request-Start-Time": "not-a-number"})
+    assert response.status_code == 200
+
+
+def test_no_header_passes():
+    """Request without X-Request-Start-Time header proceeds normally."""
+    app = _make_app()
+    client = TestClient(app)
+    response = client.get("/ok")
+    assert response.status_code == 200
+
+
+def test_future_dated_header_passes():
+    """Future-dated X-Request-Start-Time (client clock ahead) should not 408."""
+    app = _make_app()
+    client = TestClient(app)
+    future_time = str(time.time() + 600)  # 10 minutes in future
+    response = client.get("/ok", headers={"X-Request-Start-Time": future_time})
+    assert response.status_code == 200
+
+
+def test_timeout_returns_504():
+    """Request exceeding timeout returns 504."""
+    app = _make_app(methods_timeout={"GET": 0.1})
+    client = TestClient(app)
+    response = client.get("/slow")
+    assert response.status_code == 504

--- a/backend/tests/unit/test_timeout_middleware.py
+++ b/backend/tests/unit/test_timeout_middleware.py
@@ -114,6 +114,47 @@ def test_future_dated_header_passes():
     assert response.status_code == 200
 
 
+def test_uppercase_multipart_skips_stale_check():
+    """Mixed-case Content-Type 'Multipart/Form-Data' still skips stale check."""
+    app = _make_app()
+    client = TestClient(app)
+    stale_time = str(time.time() - 600)
+    response = client.post(
+        "/ok",
+        headers={
+            "X-Request-Start-Time": stale_time,
+            "Content-Type": "Multipart/Form-Data; boundary=----abc",
+        },
+        content=b"fake",
+    )
+    assert response.status_code != 408
+
+
+def test_non_multipart_with_multipart_token_still_rejected():
+    """Non-multipart content-type is not tricked by substring containing 'multipart/form-data'."""
+    app = _make_app()
+    client = TestClient(app)
+    stale_time = str(time.time() - 600)
+    response = client.post(
+        "/ok",
+        headers={
+            "X-Request-Start-Time": stale_time,
+            "Content-Type": "application/json",
+        },
+        content=b'{"key": "value"}',
+    )
+    assert response.status_code == 408
+
+
+def test_missing_content_type_still_checked():
+    """Request with no Content-Type header still gets stale check."""
+    app = _make_app()
+    client = TestClient(app)
+    stale_time = str(time.time() - 600)
+    response = client.get("/ok", headers={"X-Request-Start-Time": stale_time})
+    assert response.status_code == 408
+
+
 def test_timeout_returns_504():
     """Request exceeding timeout returns 504."""
     app = _make_app(methods_timeout={"GET": 0.1})

--- a/backend/utils/other/timeout.py
+++ b/backend/utils/other/timeout.py
@@ -37,18 +37,21 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         # Check for stale request header first
+        # Skip stale check for multipart file uploads — large uploads are
+        # vulnerable to client clock skew + transfer delay causing false 408s (#5929)
         request_start_header = request.headers.get("x-request-start-time")
-        if request_start_header:
+        content_type = request.headers.get("content-type", "")
+        is_file_upload = "multipart/form-data" in content_type
+
+        if request_start_header and not is_file_upload:
             try:
                 request_start_time = float(request_start_header)
                 current_time = time.time()
                 request_age = current_time - request_start_time
 
                 if request_age > self.maximum_age_seconds:
-                    # 408 Request Timeout is a fitting status code.
                     return Response(status_code=408, content="Request is too old and has been rejected.")
             except (ValueError, TypeError):
-                # Header is malformed, proceed as normal or reject with 400
                 pass
 
         timeout = self.methods_timeout.get(request.method, self.default_timeout)

--- a/backend/utils/other/timeout.py
+++ b/backend/utils/other/timeout.py
@@ -41,7 +41,7 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
         # vulnerable to client clock skew + transfer delay causing false 408s (#5929)
         request_start_header = request.headers.get("x-request-start-time")
         content_type = request.headers.get("content-type", "")
-        is_file_upload = "multipart/form-data" in content_type
+        is_file_upload = content_type.split(";", 1)[0].strip().lower() == "multipart/form-data"
 
         if request_start_header and not is_file_upload:
             try:

--- a/backend/utils/other/timeout.py
+++ b/backend/utils/other/timeout.py
@@ -12,6 +12,7 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
 
         self.default_timeout = self._get_timeout_from_env("HTTP_DEFAULT_TIMEOUT", default=2 * 60)
         self.maximum_age_seconds = self._get_timeout_from_env("HTTP_MAXIMUM_AGE_SECONDS", default=5 * 60)
+        self.clock_skew_allowance = self._get_timeout_from_env("HTTP_CLOCK_SKEW_ALLOWANCE", default=5 * 60)
 
         self.methods_timeout = self._parse_methods_timeout(methods_timeout or {})
 
@@ -37,19 +38,15 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         # Check for stale request header first
-        # Skip stale check for multipart file uploads — large uploads are
-        # vulnerable to client clock skew + transfer delay causing false 408s (#5929)
+        # Uses clock_skew_allowance to tolerate client/server clock drift (#5929)
         request_start_header = request.headers.get("x-request-start-time")
-        content_type = request.headers.get("content-type", "")
-        is_file_upload = content_type.split(";", 1)[0].strip().lower() == "multipart/form-data"
-
-        if request_start_header and not is_file_upload:
+        if request_start_header:
             try:
                 request_start_time = float(request_start_header)
                 current_time = time.time()
                 request_age = current_time - request_start_time
 
-                if request_age > self.maximum_age_seconds:
+                if request_age > self.maximum_age_seconds + self.clock_skew_allowance:
                     return Response(status_code=408, content="Request is too old and has been rejected.")
             except (ValueError, TypeError):
                 pass

--- a/backend/utils/other/timeout.py
+++ b/backend/utils/other/timeout.py
@@ -1,5 +1,5 @@
 from starlette.middleware.base import BaseHTTPMiddleware
-from starlette.responses import Response
+from starlette.responses import JSONResponse, Response
 from fastapi import Request
 import asyncio
 import os
@@ -47,7 +47,17 @@ class TimeoutMiddleware(BaseHTTPMiddleware):
                 request_age = current_time - request_start_time
 
                 if request_age > self.maximum_age_seconds + self.clock_skew_allowance:
-                    return Response(status_code=408, content="Request is too old and has been rejected.")
+                    return JSONResponse(
+                        status_code=408,
+                        content={
+                            "error": "clock_skew",
+                            "message": "Request rejected — your device clock may be out of sync",
+                            "server_time": current_time,
+                            "client_time": request_start_time,
+                            "skew_seconds": round(request_age, 1),
+                            "hint": "Check your device date/time settings and enable automatic time",
+                        },
+                    )
             except (ValueError, TypeError):
                 pass
 


### PR DESCRIPTION
## Summary
- Add configurable clock skew tolerance to `TimeoutMiddleware` stale request check
- Return JSON 408 response with clock skew diagnostics (server_time, client_time, skew_seconds) so the app can detect drift and show a user-facing warning
- Fixes voice chat transcription 408 failures caused by client clock skew vs server

## Problem
`TimeoutMiddleware` compares `time.time()` against client-set `X-Request-Start-Time` header with a 5-minute threshold. When a user's phone clock is ~5 minutes behind server UTC, requests get rejected with 408 "Request is too old" even though they just arrived. The plain-text 408 response gave no diagnostic info, so the app couldn't tell the user what was wrong.

## Solution

### 1. Clock skew tolerance (industry-standard, like AWS SigV4)
- New `HTTP_CLOCK_SKEW_ALLOWANCE` env var (default: 5 minutes)
- Effective stale threshold = `max_age` (5min) + `clock_skew_allowance` (5min) = **10 minutes**
- A phone with 5-min clock drift + reasonable transfer delay stays well within tolerance
- Set `HTTP_CLOCK_SKEW_ALLOWANCE=0` to restore original behavior
- Stale check protects ALL endpoints (no content-type bypass)

### 2. JSON 408 response with clock skew diagnostics
When a request IS rejected, the 408 response now returns:
```json
{
  "error": "clock_skew",
  "message": "Request rejected — your device clock may be out of sync",
  "server_time": 1742691120.5,
  "client_time": 1742690820.5,
  "skew_seconds": 300.0,
  "hint": "Check your device date/time settings and enable automatic time"
}
```
This enables the app to detect clock drift and show a user-facing warning (Flutter side handled separately by @kelvin).

## Changes
**`backend/utils/other/timeout.py`**:
- Add `clock_skew_allowance` from `HTTP_CLOCK_SKEW_ALLOWANCE` env var
- Stale threshold = `max_age + clock_skew_allowance`
- Return `JSONResponse` with diagnostic fields on 408

**`backend/tests/unit/test_timeout_middleware.py`** — 12 tests:
- Fresh request passes
- Within clock skew tolerance passes (7min old, threshold 10min)
- Beyond tolerance → 408 with JSON diagnostics (error, server_time, client_time, skew_seconds, hint)
- Boundary behavior (exact threshold ± 1s)
- Multipart upload with clock skew passes
- Malformed/missing/future headers handled correctly
- Custom skew allowance via env var
- Zero allowance restores original behavior
- Timeout → 504

## Test plan
- [x] 12 unit tests pass
- [x] `black` formatting clean
- [x] Codex reviewer approved (PR_APPROVED_LGTM)
- [x] Codex tester approved (TESTS_APPROVED)
- [ ] CP9A: build and run backend, verify stale check + JSON response
- [ ] CP9B: build and run backend + app integrated

Fixes #5929

🤖 Generated with [Claude Code](https://claude.com/claude-code)