### PR TITLE
chore(app): bump version to 1.0.528+788

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.527+786
+version: 1.0.528+788
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Bump app version for TestFlight/internal testing release with clock skew detection (#5929).

`1.0.527+786` → `1.0.528+788`

After merge, tag with `v1.0.528+788-mobile-cm` to trigger Codemagic build.

---
_by AI for @beastoin_