### PR TITLE
fix: add speaker embedding matching to offline sync (issue #5907)

### DIFF
--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -34,6 +34,7 @@ from utils.other.storage import (
 AUDIO_SAMPLE_RATE = 16000
 from utils import encryption
 from utils.stt.pre_recorded import deepgram_prerecorded, postprocess_words
+from utils.stt.speech_profile import get_speech_profile_matching_predictions
 from utils.stt.vad import vad_is_empty
 from utils.fair_use import (
     record_speech_ms,
@@ -644,6 +645,17 @@ def process_segment(
     if not transcript_segments:
         logger.error('failed to get deepgram segments')
         return
+
+    # Speaker identification: match segments against stored person embeddings
+    # This uses the same pipeline as live recording (speaker_identification_task)
+    try:
+        wav_path = path.replace('.bin', '.wav')
+        matches = get_speech_profile_matching_predictions(uid, wav_path, [s.dict() for s in transcript_segments])
+        for i, seg in enumerate(transcript_segments):
+            seg.is_user = matches[i]['is_user']
+            seg.person_id = matches[i].get('person_id')
+    except Exception as e:
+        logger.error(f'Speaker matching failed for {path}: {e}')
 
     timestamp = get_timestamp_from_path(path)
     segment_end_timestamp = timestamp + transcript_segments[-1].end


### PR DESCRIPTION
## Fix: Offline sync no speaker diarization (issue #5907)

### Problem
Offline recording sync (sync_local_files / process_segment) was skipping the speaker identification pipeline, causing all transcribed segments to show generic 'SPEAKER_00', 'SPEAKER_01' labels instead of being matched against stored person embeddings. Live recording worked correctly because it runs speaker_identification_task which calls get_speech_profile_matching_predictions to identify speakers from their voice embeddings.

### Solution
Added the same speaker embedding matching call to process_segment after postprocess_words returns. The get_speech_profile_matching_predictions function extracts speaker embeddings from the audio and matches them against stored person embeddings, setting is_user and person_id on each segment.

### Changes
- backend/routers/sync.py:
  - Added import for get_speech_profile_matching_predictions
  - Added speaker matching call in process_segment (after getting transcript segments, before storing them)

### Testing
The fix follows the same pattern used in postprocess_conversation.py's _handle_segment_embedding_matching function and the speaker_identification_task in transcribe.py.

Closes #5907