### PR TITLE
fix(app): staging banner not showing on TestFlight builds

### DIFF
--- a/app/lib/env/env.dart
+++ b/app/lib/env/env.dart
@@ -34,10 +34,7 @@ abstract class Env {
   static bool get isUsingStagingApi {
     final effective = apiBaseUrl;
     if (effective == null) return false;
-    // Only show staging banner if STAGING_API_URL is explicitly configured
-    final configuredStagingUrl = _instance.stagingApiUrl;
-    if (configuredStagingUrl == null || configuredStagingUrl.isEmpty) return false;
-    return _normalizeUrl(effective) == _normalizeUrl(configuredStagingUrl);
+    return _normalizeUrl(effective) == _normalizeUrl(stagingApiUrl);
   }
 
   static String _normalizeUrl(String url) {


### PR DESCRIPTION
Fixes the staging environment banner never appearing despite the app running on `api.omiapi.com`.

`isUsingStagingApi` (`env.dart:34-41`) was reading `_instance.stagingApiUrl` directly — which is always empty because `STAGING_API_URL` env var is not set in prod builds. The `stagingApiUrl` getter has a hardcoded fallback to `https://api.omiapi.com/`, but the banner check bypassed it. Introduced in commit `2f2b2e01d3` (Mar 16).

Fix: use the `stagingApiUrl` getter (with fallback) instead of the raw `_instance.stagingApiUrl`.

Closes part of #5949

---
_by AI for @beastoin_