### PR TITLE
chore(app): bump build number to 789

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.528+788
+version: 1.0.528+789
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Bump build number from 788 to 789 to trigger new Codemagic release with the staging banner fix (#5950).

---
_by AI for @beastoin_