### PR TITLE
feat(app): allow users to rename their Omi device (#2824)

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -54,6 +54,24 @@ class SharedPreferencesUtil {
 
   String get deviceName => getString('deviceName');
 
+  set deviceNameDeviceId(String value) => saveString('deviceNameDeviceId', value);
+
+  String get deviceNameDeviceId => getString('deviceNameDeviceId');
+
+  /// Update deviceName on connection, preserving user-set custom names.
+  /// Resets to hardware name when switching to a different device.
+  void updateDeviceNameOnConnect(String newDeviceId, String hardwareName) {
+    final previousId = deviceNameDeviceId;
+    if (previousId.isEmpty) {
+      deviceName = hardwareName;
+    } else if (previousId != newDeviceId) {
+      deviceName = hardwareName;
+    } else if (deviceName.isEmpty) {
+      deviceName = hardwareName;
+    }
+    deviceNameDeviceId = newDeviceId;
+  }
+
   bool get deviceIsV2 => getBool('deviceIsV2');
 
   set deviceIsV2(bool value) => saveBool('deviceIsV2', value);

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -631,6 +631,22 @@
     "@deviceName": {
         "description": "Device name label"
     },
+    "renameDevice": "Rename Device",
+    "@renameDevice": {
+        "description": "Title for the rename device dialog"
+    },
+    "enterDeviceName": "Enter device name",
+    "@enterDeviceName": {
+        "description": "Hint text for the device name input field"
+    },
+    "deviceNameCannotBeEmpty": "Device name cannot be empty",
+    "@deviceNameCannotBeEmpty": {
+        "description": "Error shown when the device name field is empty"
+    },
+    "deviceNameUpdated": "Device name updated",
+    "@deviceNameUpdated": {
+        "description": "Snackbar shown after updating the device name"
+    },
     "deviceId": "Device ID",
     "@deviceId": {
         "description": "Label for device ID field"

--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -215,14 +215,13 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
             chipValue: provider.connectedDevice == null
                 ? context.l10n.offline
                 : provider.havingNewFirmware
-                ? context.l10n.available
-                : null,
+                    ? context.l10n.available
+                    : null,
             onTap: provider.connectedDevice != null
                 ? () {
                     // Route to OmiGlass OTA page for openglass devices
                     final deviceName = provider.connectedDevice?.name?.toLowerCase() ?? '';
-                    final isOpenGlass =
-                        provider.connectedDevice?.type == DeviceType.openglass ||
+                    final isOpenGlass = provider.connectedDevice?.type == DeviceType.openglass ||
                         deviceName.contains('openglass') ||
                         deviceName.contains('omiglass') ||
                         deviceName.contains('glass');
@@ -290,9 +289,8 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               chipColor: pendingSeconds > 0 ? const Color(0xFF3D3520) : null,
               chipTextColor: pendingSeconds > 0 ? const Color(0xFFFFD060) : null,
               onTap: () {
-                final page = context.read<DeviceProvider>().supportsMultiFileSync
-                    ? const AutoSyncPage()
-                    : const SyncPage();
+                final page =
+                    context.read<DeviceProvider>().supportsMultiFileSync ? const AutoSyncPage() : const SyncPage();
                 Navigator.of(context).push(MaterialPageRoute(builder: (context) => page));
               },
             ),
@@ -353,6 +351,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               // Clear stored device
               await SharedPreferencesUtil().btDeviceSet(BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0));
               SharedPreferencesUtil().deviceName = '';
+              SharedPreferencesUtil().deviceNameDeviceId = '';
 
               // Fully tear down connection, transport, and native service
               if (deviceId.isNotEmpty) {
@@ -410,6 +409,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
                         BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0),
                       );
                       SharedPreferencesUtil().deviceName = '';
+                      SharedPreferencesUtil().deviceNameDeviceId = '';
                       if (provider.connectedDevice != null) {
                         await _bleUnpairDevice(provider.connectedDevice!);
                       }
@@ -465,8 +465,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
     final manufacturer = provider.pairedDevice?.manufacturerName ?? context.l10n.unknown;
     final firmware = provider.pairedDevice?.firmwareRevision ?? context.l10n.unknown;
     final deviceId = provider.pairedDevice?.id ?? context.l10n.unknown;
-    final serialNumber =
-        provider.pairedDevice?.serialNumber ??
+    final serialNumber = provider.pairedDevice?.serialNumber ??
         provider.pairedDevice?.id.replaceAll(':', '').replaceAll('-', '').toUpperCase() ??
         context.l10n.unknown;
 

--- a/app/lib/pages/settings/device_settings.dart
+++ b/app/lib/pages/settings/device_settings.dart
@@ -23,6 +23,7 @@ import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/other/temp.dart';
 import 'package:omi/utils/platform/platform_service.dart';
+import 'package:omi/utils/alerts/app_snackbar.dart';
 import 'package:omi/widgets/dialog.dart';
 
 class DeviceSettings extends StatefulWidget {
@@ -80,6 +81,105 @@ class _DeviceSettingsState extends State<DeviceSettings> {
     _debounce?.cancel();
     _micGainDebounce?.cancel();
     super.dispose();
+  }
+
+  void _showRenameDeviceDialog(BtDevice? device) {
+    final storedName = SharedPreferencesUtil().deviceName;
+    final currentName = storedName.isNotEmpty ? storedName : (device?.name ?? 'Omi DevKit');
+    final controller = TextEditingController(text: currentName);
+
+    showDialog(
+      context: context,
+      builder: (ctx) => Dialog(
+        backgroundColor: const Color(0xFF1C1C1E),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                context.l10n.renameDevice,
+                style: const TextStyle(color: Colors.white, fontSize: 20, fontWeight: FontWeight.w600),
+              ),
+              const SizedBox(height: 20),
+              Container(
+                decoration: BoxDecoration(color: const Color(0xFF2C2C2E), borderRadius: BorderRadius.circular(10)),
+                child: TextField(
+                  controller: controller,
+                  autofocus: true,
+                  style: const TextStyle(color: Colors.white, fontSize: 16),
+                  decoration: InputDecoration(
+                    hintText: context.l10n.enterDeviceName,
+                    hintStyle: TextStyle(color: Colors.grey.shade600, fontSize: 16),
+                    contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+                    border: InputBorder.none,
+                    enabledBorder: InputBorder.none,
+                    focusedBorder: OutlineInputBorder(
+                      borderRadius: BorderRadius.circular(10),
+                      borderSide: const BorderSide(color: Colors.white24, width: 1),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              Row(
+                children: [
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () => Navigator.of(ctx).pop(),
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        decoration: BoxDecoration(
+                          color: const Color(0xFF2A2A2E),
+                          borderRadius: BorderRadius.circular(10),
+                        ),
+                        child: Center(
+                          child: Text(
+                            context.l10n.cancel,
+                            style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: GestureDetector(
+                      onTap: () {
+                        final newName = controller.text.trim();
+                        if (newName.isEmpty) {
+                          AppSnackbar.showSnackbarError(context.l10n.deviceNameCannotBeEmpty);
+                          return;
+                        }
+                        SharedPreferencesUtil().deviceName = newName;
+                        if (device != null) {
+                          SharedPreferencesUtil().deviceNameDeviceId = device.id;
+                        }
+                        Navigator.of(ctx).pop();
+                        if (mounted) setState(() {});
+                        AppSnackbar.showSnackbar(context.l10n.deviceNameUpdated);
+                      },
+                      child: Container(
+                        padding: const EdgeInsets.symmetric(vertical: 14),
+                        decoration: BoxDecoration(color: Colors.white, borderRadius: BorderRadius.circular(10)),
+                        child: Center(
+                          child: Text(
+                            context.l10n.save,
+                            style: const TextStyle(color: Colors.black, fontSize: 16, fontWeight: FontWeight.w600),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    ).then((_) => controller.dispose());
   }
 
   void _loadInitialDimRatio() async {
@@ -233,7 +333,8 @@ class _DeviceSettingsState extends State<DeviceSettings> {
   }
 
   Widget _buildDeviceInfoSection(BtDevice? device, DeviceProvider provider) {
-    final deviceName = device?.name ?? 'Omi DevKit';
+    final storedName = SharedPreferencesUtil().deviceName;
+    final deviceName = storedName.isNotEmpty ? storedName : (device?.name ?? 'Omi DevKit');
     final deviceId = device?.id ?? '12AB34CD:56EF78GH';
 
     String truncateId(String id) {
@@ -251,8 +352,8 @@ class _DeviceSettingsState extends State<DeviceSettings> {
             icon: FontAwesomeIcons.microchip,
             title: context.l10n.deviceName,
             chipValue: deviceName,
-            copyValue: deviceName,
-            showChevron: false,
+            showChevron: true,
+            onTap: () => _showRenameDeviceDialog(device),
           ),
           const Divider(height: 1, color: Color(0xFF3C3C43)),
           _buildProfileStyleItem(
@@ -779,6 +880,7 @@ class _DeviceSettingsState extends State<DeviceSettings> {
 
                 await SharedPreferencesUtil().btDeviceSet(BtDevice(id: '', name: '', type: DeviceType.omi, rssi: 0));
                 SharedPreferencesUtil().deviceName = '';
+                SharedPreferencesUtil().deviceNameDeviceId = '';
 
                 if (deviceId.isNotEmpty) {
                   await ServiceManager.instance().device.forgetDevice(deviceId);

--- a/app/lib/providers/device_provider.dart
+++ b/app/lib/providers/device_provider.dart
@@ -203,9 +203,8 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     // Throttle notifyListeners to reduce battery drain from excessive UI rebuilds
     // Only notify when: first reading, >=5% change, 15min elapsed, or crosses 20% threshold
     final delta = (_lastNotifiedBatteryLevel - value).abs();
-    final elapsed = _lastBatteryNotifyTime == null
-        ? const Duration(minutes: 999)
-        : currentTime.difference(_lastBatteryNotifyTime!);
+    final elapsed =
+        _lastBatteryNotifyTime == null ? const Duration(minutes: 999) : currentTime.difference(_lastBatteryNotifyTime!);
     final crossedLowBatteryThreshold =
         (value < 20 && _lastNotifiedBatteryLevel >= 20) || (value >= 20 && _lastNotifiedBatteryLevel < 20);
     final shouldNotify =
@@ -292,7 +291,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
       if (connection != null) {
         await setConnectedDevice(connection.device);
         setisDeviceStorageSupport();
-        SharedPreferencesUtil().deviceName = connection.device.name;
+        SharedPreferencesUtil().updateDeviceNameOnConnect(connection.device.id, connection.device.name);
         MixpanelManager().deviceConnected();
         setIsConnected(true);
       }
@@ -423,7 +422,7 @@ class DeviceProvider extends ChangeNotifier implements IDeviceServiceSubsciption
     await captureProvider?.streamDeviceRecording(device: device);
 
     await getDeviceInfo();
-    SharedPreferencesUtil().deviceName = device.name;
+    SharedPreferencesUtil().updateDeviceNameOnConnect(device.id, device.name);
 
     // Wals
     ServiceManager.instance().wal.getSyncs().sdcard.setDevice(device);

--- a/app/lib/providers/onboarding_provider.dart
+++ b/app/lib/providers/onboarding_provider.dart
@@ -203,7 +203,7 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       var cDevice = await _getConnectedDevice(deviceId);
       if (cDevice != null) {
         deviceProvider!.setConnectedDevice(cDevice);
-        SharedPreferencesUtil().deviceName = cDevice.name;
+        SharedPreferencesUtil().updateDeviceNameOnConnect(cDevice.id, cDevice.name);
         deviceProvider!.setIsConnected(true);
       }
       await deviceProvider?.scanAndConnectToDevice();
@@ -215,7 +215,7 @@ class OnboardingProvider extends BaseProvider with MessageNotifierMixin implemen
       notifyListeners();
       await Future.delayed(const Duration(seconds: 2));
       SharedPreferencesUtil().btDevice = connectedDevice!;
-      SharedPreferencesUtil().deviceName = connectedDevice.name;
+      SharedPreferencesUtil().updateDeviceNameOnConnect(connectedDevice.id, connectedDevice.name);
 
       foundDevicesMap.clear();
       deviceList.clear();

--- a/app/test/unit/device_name_preferences_test.dart
+++ b/app/test/unit/device_name_preferences_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() async {
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  test('sets hardware name on first device connection', () {
+    final prefs = SharedPreferencesUtil();
+
+    prefs.updateDeviceNameOnConnect('device-a', 'Omi Alpha');
+
+    expect(prefs.deviceName, 'Omi Alpha');
+    expect(prefs.deviceNameDeviceId, 'device-a');
+  });
+
+  test('preserves custom name when reconnecting to the same device', () {
+    final prefs = SharedPreferencesUtil();
+    prefs.deviceName = 'Desk Omi';
+    prefs.deviceNameDeviceId = 'device-a';
+
+    prefs.updateDeviceNameOnConnect('device-a', 'Omi Alpha');
+
+    expect(prefs.deviceName, 'Desk Omi');
+    expect(prefs.deviceNameDeviceId, 'device-a');
+  });
+
+  test('resets to hardware name when switching devices', () {
+    final prefs = SharedPreferencesUtil();
+    prefs.deviceName = 'Desk Omi';
+    prefs.deviceNameDeviceId = 'device-a';
+
+    prefs.updateDeviceNameOnConnect('device-b', 'Omi Beta');
+
+    expect(prefs.deviceName, 'Omi Beta');
+    expect(prefs.deviceNameDeviceId, 'device-b');
+  });
+
+  test('fills empty stored name when reconnecting to the same device', () {
+    final prefs = SharedPreferencesUtil();
+    prefs.deviceName = '';
+    prefs.deviceNameDeviceId = 'device-a';
+
+    prefs.updateDeviceNameOnConnect('device-a', 'Omi Alpha');
+
+    expect(prefs.deviceName, 'Omi Alpha');
+    expect(prefs.deviceNameDeviceId, 'device-a');
+  });
+}


### PR DESCRIPTION
## Summary

- Problem: Users cannot rename their Omi device — the settings UI shows the hardware BLE name with no way to customize it
- What changed: Added a rename dialog in device settings that persists custom names locally and tracks device ownership to auto-reset on device switch
- What did NOT change (scope boundary): No backend changes, no BLE protocol changes, no new dependencies

## Linked Issue / Bounty

- Closes #2824

## Root Cause

- N/A — new feature

## How It Works

1. `SharedPreferencesUtil.updateDeviceNameOnConnect()` tracks the current device ID alongside the custom name — if a different device connects, the name resets to hardware default
2. `_showRenameDeviceDialog()` in device settings presents a modal text field; saves to SharedPreferences on confirm
3. Forget/unpair flows clear both `deviceName` and `deviceNameDeviceId` to prevent stale state
4. All user-facing strings are localized via `app_en.arb`

## Change Type

- [x] Feature

## Scope

- [x] Mobile app

## Security Impact

- New permissions or capabilities introduced? No
- Auth or token handling changed? No
- Data access scope changed (screen data, OCR, user data)? No
- New or changed network calls? No
- Plugin or tool execution surface changed? No

## Testing

- [x] Built locally
- [x] Manual verification: rename flow tested on iOS simulator — rename, reconnect, device switch, forget/unpair
- [x] Existing tests pass (`flutter test test/providers/device_provider_test.dart`)
- [x] `flutter analyze` clean on touched files
- [ ] New tests added — no unit tests for dialog UI; rename logic is thin enough that integration test would be more valuable

## Human Verification

- Verified scenarios: rename → reconnect preserves name; switch device → resets to hardware name; forget → clears both fields; empty name rejected
- Edge cases checked: empty string submission, very long name, rapid rename-then-disconnect
- What I did **not** verify: Android (tested iOS only); multi-device BLE pairing race conditions

## Evidence

Demo recording: https://github.com/user-attachments/assets/b6802017-8ad2-4470-86e6-cc91bed9e7af

## Docs

- [x] N/A — no docs impact (settings UI feature, no API or config changes)

## Performance, Privacy, and Reliability

No impact — SharedPreferences read/write only, no network calls added

## Migration / Backward Compatibility

- Backward compatible? Yes — new SharedPreferences keys are additive, existing users see hardware name until they rename
- Migration needed? No

## Risks and Mitigations

- `deviceNameDeviceId` could become stale if the device ID format changes upstream — mitigated by always falling back to hardware name when ID mismatch occurs

## AI Disclosure

🤖 Built with [Claude Code](https://claude.ai/claude-code)
- AI-assisted: initial implementation scaffold, rebase onto latest main
- How I verified correctness: manual testing on iOS simulator, flutter analyze, existing test suite