### PR TITLE
Bump build number to 790 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.528+789
+version: 1.0.528+790
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
- Bump build number from 789 to 790 for mobile release
- Version: 1.0.528+790

## Context
- iOS TestFlight internal: 1.0.528+789
- Google Play internal: 1.0.528+789
- New build 790 > both internal tracks

_by AI for @beastoin_