### PR TITLE
fix(desktop): bring app to foreground across Spaces on OAuth callback

### DIFF
--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -1086,8 +1086,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     Task { @MainActor in
       AuthService.shared.handleOAuthCallback(url: url)
-      // Bring app to foreground after OAuth redirect — Safari stays in front otherwise
+      // Bring app to foreground after OAuth redirect — Safari stays in front otherwise.
+      // NSApp.activate() alone doesn't switch macOS Spaces; ordering a window front does.
       NSApp.activate()
+      if let window = NSApp.windows.first(where: { $0.isVisible && !$0.isMiniaturized }) ?? NSApp.windows.first(where: { !$0.isMiniaturized }) {
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- After OAuth sign-in, clicking "Open App Manually" triggers the URL scheme but the app doesn't come to the foreground when it's on a different macOS Space/screen
- `NSApp.activate()` alone doesn't switch Spaces — added `makeKeyAndOrderFront` + `orderFrontRegardless` on the first visible window to trigger the Space switch

## Test plan
- [ ] Sign out, sign back in via OAuth
- [ ] While waiting for auth, switch to a different macOS Space
- [ ] Click "Open App Manually" — app should now switch to its Space and come to front

🤖 Generated with [Claude Code](https://claude.com/claude-code)