### PR TITLE
fix(desktop): start screen capture after chat onboarding step

### DIFF
--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -81,9 +81,17 @@ struct OnboardingView: View {
             graphViewModel: graphViewModel,
             onComplete: {
               AnalyticsManager.shared.onboardingStepCompleted(step: 0, stepName: "Chat")
+              // Start screen capture early so Rewind tab has screenshots by the time
+              // the user finishes onboarding (permissions are granted during chat step)
+              if !ProactiveAssistantsPlugin.shared.isMonitoring {
+                ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
+              }
               currentStep = 1
             },
             onSkip: {
+              if !ProactiveAssistantsPlugin.shared.isMonitoring {
+                ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
+              }
               currentStep = 1
             }
           )


### PR DESCRIPTION
## Summary
- Screen capture only started after the full onboarding (Tasks step), but permissions are granted during the chat step
- Users would finish onboarding, click Rewind, and see no screenshots because capture hadn't started yet
- Now `startMonitoring()` fires right after the chat step (step 0) completes, giving 2-3 minutes of screenshots to accumulate while the user goes through the remaining onboarding steps (floating bar, voice shortcut, tasks)

## Test plan
- [ ] Reset onboarding, go through chat step, complete it
- [ ] While on floating bar / voice shortcut steps, verify screenshots are being captured (check log for "captureFrame")
- [ ] Finish onboarding, open Rewind tab — should already have screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)