### PR TITLE
fix: chat responses truncating mid-answer since 3/19

### DIFF
--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -534,6 +534,7 @@ Write like a real human texting - not an AI writing an essay.
 
 Length:
 - Default: 2-8 lines, conversational
+- Complex/detailed questions (plans, analyses, lists, step-by-step instructions): as long as needed — NEVER cut off or truncate, always finish the full answer
 - Reflections/planning: can be longer but NO SUMMARIES of what they said
 - Quick replies: 1-3 lines
 - **"I don't know" responses: 1-2 lines MAX** - just say you don't have it and stop
@@ -577,7 +578,7 @@ Examples:
 
 <quality_control>
 Before finalizing your response, perform these quality checks:
-- Review your response for accuracy and completeness - ensure you've fully answered the user's question
+- Review your response for accuracy and completeness - ensure you've **fully** answered the user's question — NEVER truncate or end mid-list/mid-explanation
 - Verify all formatting is correct and consistent throughout your response
 - Check that all citations are relevant and properly placed according to the citing rules
 - Ensure the tone matches the instructions (casual, friendly, concise)

--- a/backend/utils/observability/langsmith_prompts.py
+++ b/backend/utils/observability/langsmith_prompts.py
@@ -252,6 +252,7 @@ Write like a real human texting - not an AI writing an essay.
 
 Length:
 - Default: 2-8 lines, conversational
+- Complex/detailed questions (plans, analyses, lists, step-by-step instructions): as long as needed — NEVER cut off or truncate, always finish the full answer
 - Reflections/planning: can be longer but NO SUMMARIES of what they said
 - Quick replies: 1-3 lines
 - **"I don't know" responses: 1-2 lines MAX** - just say you don't have it and stop
@@ -359,7 +360,7 @@ Examples:
 
 <quality_control>
 Before finalizing your response, perform these quality checks:
-- Review your response for accuracy and completeness - ensure you've fully answered the user's question
+- Review your response for accuracy and completeness - ensure you've **fully** answered the user's question — NEVER truncate or end mid-list/mid-explanation
 - Verify all formatting is correct and consistent throughout your response
 - Check that all citations are relevant and properly placed according to the citing rules
 - Ensure the tone matches the instructions (casual, friendly, concise)


### PR DESCRIPTION
## Problem

Since 3/19, Omi chat responses were cutting off mid-answer — users had to repeatedly say "continue" to get the full output.

## Root Cause

The `<response_style>` prompt section has a `"Default: 2-8 lines"` length rule, added back in Dec 2025 to prevent essay-style responses to simple messages. That rule worked fine when the agentic chat used GPT-4.1 — it treated it loosely.

The Mar 16 rewrite (`fb2e37983`) switched agentic chat from LangGraph/GPT-4.1 to **Anthropic native tool use with Claude Sonnet**. The "2-8 lines" instruction was fine with GPT — it treated it loosely. Claude made that rule apply too strictly — it hard-stops at 8 lines even mid-list or mid-explanation on complex questions.

## Fix

Added an explicit exception to the length rules in both fallback prompts (`utils/llm/chat.py` and `utils/observability/langsmith_prompts.py`):

```
- Complex/detailed questions (plans, analyses, lists, step-by-step instructions): as long as needed — NEVER cut off or truncate, always finish the full answer
```

Also strengthened the quality control check to explicitly say `NEVER truncate or end mid-list/mid-explanation`.

## Note

The primary prompt is served from LangSmith (`omi-agentic-system`). These fallback changes will take effect when LangSmith is unavailable. **The same changes should also be applied to the LangSmith prompt to fix it in production immediately.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)