### PR TITLE
docs: add named test bundle instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,9 +215,10 @@ agent-swift screenshot /tmp/after-change.png  # capture app window
 - 15 commands: `doctor`, `connect`, `disconnect`, `status`, `snapshot`, `press`, `click`, `fill`, `get`, `find`, `screenshot`, `is`, `wait`, `scroll`, `schema`.
 - Works with any macOS app (SwiftUI, AppKit, Electron) — no Marionette or app-side setup.
 - Bundle ID for dev: `com.omi.desktop-dev`. For prod: `com.omi.computer-macos`.
-- If you launch a custom-named desktop test build, keep the bundle suffix and app name identical so auth callbacks reopen the correct app. Example: `1233.app` should use `com.omi.1233`, `search.app` should use `com.omi.search`, and mismatches like `1233.app` with `com.omi.desktop-dev` are not allowed.
+- **Named test bundles**: When testing a feature or bug fix, ALWAYS create a separate named bundle with `OMI_APP_NAME="feature-name" ./run.sh`. This installs to `/Applications/feature-name.app` with bundle ID `com.omi.feature-name`, running side-by-side with "Omi Dev" and "Omi Beta". NEVER overwrite "Omi Dev" when testing a specific change — the user may have it running. Connect agent-swift with `--bundle-id com.omi.feature-name`.
+- Keep the bundle suffix and app name identical so auth callbacks reopen the correct app. Example: `1233.app` should use `com.omi.1233`, `search.app` should use `com.omi.search`, and mismatches like `1233.app` with `com.omi.desktop-dev` are not allowed.
 - **App flows & exploration skill**: See `desktop/e2e/SKILL.md` for navigation architecture, screen map, interaction patterns (click vs press), and known flows. Read this when developing features or exploring the app.
-- When asked to build or rebuild the desktop app for testing, don't stop at a successful compile: launch the dev app, interact with it programmatically to confirm it actually runs, and report any environment blocker if full interaction is impossible.
+- When asked to build or rebuild the desktop app for testing, don't stop at a successful compile: launch the named test app, interact with it programmatically to confirm it actually runs, and report any environment blocker if full interaction is impossible.
 
 ## Formatting
 <!-- Maintainers: @Thinh (Jan 19) -->

--- a/desktop/CLAUDE.md
+++ b/desktop/CLAUDE.md
@@ -126,9 +126,22 @@ See `.claude/settings.json` for connection details.
 - When updating resources (icons, assets, etc.) in built app bundles, update BOTH
 - To check which app is currently running: `ps aux | grep "Omi"`
 
+### Testing with Named Bundles
+When the user asks to test a feature or bug fix, **always create a separate named bundle** so it can run side-by-side with the existing dev/prod apps:
+```bash
+OMI_APP_NAME="fix-rewind-delay" ./run.sh
+```
+This creates `/Applications/fix-rewind-delay.app` with bundle ID `com.omi.fix-rewind-delay`, completely independent of "Omi Dev" and "Omi Beta". Name it after the feature/bug being tested (e.g., `OMI_APP_NAME="onboarding-capture" ./run.sh`). The user can then run multiple test builds simultaneously without interfering with each other or the production app.
+
+**Rules:**
+- NEVER use the default `./run.sh` (which overwrites "Omi Dev") when testing a specific feature — always set `OMI_APP_NAME`
+- Keep the name short and descriptive (it becomes both the app name and bundle ID suffix)
+- The named bundle gets its own permissions, database, and auth state — the user may need to re-grant permissions and sign in
+- To connect agent-swift: `agent-swift connect --bundle-id com.omi.fix-rewind-delay`
+
 ### After Implementing Changes
 - `xcrun swift build` is for **compile checks only** — it does NOT start the backend
-- To actually test, ALWAYS use `./run.sh` — it starts Rust backend + Cloudflare tunnel + Swift app together
+- To actually test, ALWAYS use `./run.sh` with `OMI_APP_NAME` — it starts Rust backend + Cloudflare tunnel + Swift app together
 - **When the user says "test it"**, use the `test-local` skill to build, run, and verify via macOS automation
 
 ### Verifying UI Changes (agent-swift)


### PR DESCRIPTION
## Summary
- Added clear instructions to both root and desktop CLAUDE.md that when testing a feature/bug, always create a separate named bundle with `OMI_APP_NAME="feature-name" ./run.sh`
- This prevents overwriting "Omi Dev" and allows running multiple test builds simultaneously
- Added a full "Testing with Named Bundles" section to desktop/CLAUDE.md with rules and examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)