### PR TITLE
Fix: clear server knowledge graph on onboarding reset

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -2642,10 +2642,16 @@ class AppState: ObservableObject {
     OnboardingChatPersistence.clear()
     log("Cleared onboarding chat persistence")
 
-    // Clear local knowledge graph so the onboarding chart starts fresh
+    // Clear knowledge graph (local + server) so the onboarding chart starts fresh
     Task {
       await KnowledgeGraphStorage.shared.clearAll()
       log("Cleared local knowledge graph storage")
+      do {
+        try await APIClient.shared.deleteKnowledgeGraph()
+        log("Cleared server knowledge graph")
+      } catch {
+        logError("Failed to clear server knowledge graph during onboarding reset", error: error)
+      }
     }
 
     // Clear persisted backend chat messages so onboarding does not resume old history.


### PR DESCRIPTION
## Summary
- Add `deleteKnowledgeGraph()` API call to `resetOnboardingAndRestart` so the graph is cleared on the server too, not just locally. Previously, resetting onboarding would show stale graph data from the user's account on the next run.

## Test plan
- [ ] Reset onboarding → verify graph is empty on restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)