### PR TITLE
Simplify onboarding restart message and goal flow

### DIFF
--- a/desktop/Desktop/Sources/Chat/ChatPrompts.swift
+++ b/desktop/Desktop/Sources/Chat/ChatPrompts.swift
@@ -731,12 +731,11 @@ struct ChatPrompts {
     If the tool returns nothing, don't mention email — just continue.
 
     Then ask for ONE top monthly goal using EVERYTHING you learned (file scan, web research, email insights).
-    Call `ask_followup` with 2-4 SMART options and one typed option.
-    Every suggested option MUST be concrete, measurable, and time-bound with a clear numeric target by month-end.
-    Avoid vague options like "work on a project" or "get organized".
+    Call `ask_followup` with 2-4 options and one typed option.
     Tailor options to the user's actual projects, tools, and email context.
-    Example: ask_followup(question: "What's your top one goal this month?", options: ["Ship macOS v1 with 0 P0 bugs", "Publish 60 Instagram videos this month", "Reach 200k users by month-end", "I'll type my own"])
+    Example: ask_followup(question: "What's your top one goal this month?", options: ["Ship macOS v1", "Publish 60 Instagram videos", "Reach 200k users", "I'll type my own"])
     WAIT for user reply (button or typed).
+    Accept whatever the user picks — do NOT ask follow-up questions to refine the goal. Just save it and move on immediately to Step 7.
     After reply, call `save_knowledge_graph` with the chosen goal as a concept node connected to the user.
 
     STEP 7 — COMPLETE (MANDATORY TOOL CALL)

--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -687,14 +687,8 @@ struct OnboardingChatView: View {
         await bridgeWarmup
 
         // Resume the conversation — tell the AI the app was restarted
-        let resumeMessage: String
-        if OnboardingChatPersistence.isGoalCompleted {
-          resumeMessage = "I'm back — the app just restarted after granting a permission. Let's continue where we left off."
-        } else {
-          resumeMessage = "I'm back — the app just restarted after granting a permission. I haven't set my monthly goal yet — can you help me pick one?"
-        }
         await chatProvider.sendMessage(
-          resumeMessage,
+          "I'm back — the app just restarted after granting a permission. Let's continue where we left off.",
           systemPromptPrefix: resumeSystemPrompt,
           resume: savedSessionId
         )


### PR DESCRIPTION
## Summary
- Remove "I haven't set my monthly goal yet" from restart resume message — no longer needed since goal is always after permissions
- Remove follow-up refinement question after goal selection — accept the answer and move straight to complete_onboarding

🤖 Generated with [Claude Code](https://claude.com/claude-code)