### PR TITLE
Block onboarding completion until goal is set

### DIFF
--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -743,6 +743,10 @@ struct OnboardingChatView: View {
           !chatProvider.isSending
         else { return }
 
+        guard OnboardingChatPersistence.isGoalCompleted || OnboardingChatPersistence.isToolCompleted else {
+          log("OnboardingChatView: Skipping auto-unlock — goal not yet completed")
+          return
+        }
         log("OnboardingChatView: Auto-unlocking Continue after recovered onboarding went idle")
         onboardingCompleted = true
       }
@@ -907,9 +911,13 @@ struct OnboardingChatView: View {
       || lower.contains("#1 goal")
       || lower.contains("number 1 goal")
       || lower.contains("goal this month")
+      || lower.contains("monthly goal")
       || lower.contains("what's your #1 goal")
       || lower.contains("top priority")
       || lower.contains("priority right now")
+      || lower.contains("goal ideas")
+      || lower.contains("main goal")
+      || lower.contains("biggest goal")
   }
 
   private func isDailyTaskQuestion(_ text: String) -> Bool {

--- a/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -95,6 +95,9 @@ class ChatToolExecutor {
             return result
 
         case "complete_onboarding":
+            if !OnboardingChatPersistence.isGoalCompleted {
+                return "ERROR: Cannot complete onboarding yet. The user has NOT set their monthly goal. You MUST call ask_followup to ask about their top goal this month BEFORE calling complete_onboarding. Call get_email_insights first for context, then ask the goal question."
+            }
             let result = await executeCompleteOnboarding(toolCall.arguments)
             AnalyticsManager.shared.onboardingChatToolUsed(tool: "complete_onboarding")
             return result


### PR DESCRIPTION
## Summary
- `complete_onboarding` tool now returns an error if the user hasn't set their monthly goal, forcing the AI to ask the goal question first
- Continue button no longer auto-shows during restart recovery until goal is completed
- Broader goal question detection patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)