### PR TITLE
Send raw error to analytics for chat agent failures

### DIFF
--- a/desktop/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/Desktop/Sources/AnalyticsManager.swift
@@ -559,8 +559,11 @@ class AnalyticsManager {
   }
 
   /// Track when the Claude agent bridge fails to start or errors
-  func chatAgentError(error: String) {
-    let props: [String: Any] = ["error": error]
+  func chatAgentError(error: String, rawError: String? = nil) {
+    var props: [String: Any] = ["error": error]
+    if let raw = rawError, raw != error {
+      props["raw_error"] = String(raw.prefix(500))
+    }
     MixpanelManager.shared.track(
       "Chat Agent Error", properties: props.compactMapValues { $0 as? MixpanelType })
     PostHogManager.shared.track("chat_agent_error", properties: props)

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -2191,7 +2191,14 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             }
 
             logError("Failed to get AI response", error: error)
-            AnalyticsManager.shared.chatAgentError(error: error.localizedDescription)
+            // Send both user-friendly and raw error to analytics for remote debugging
+            let rawError: String
+            if let bridgeError = error as? BridgeError {
+                rawError = String(describing: bridgeError)
+            } else {
+                rawError = "\(error)"
+            }
+            AnalyticsManager.shared.chatAgentError(error: error.localizedDescription, rawError: rawError)
 
             // Show error to user (unless they intentionally stopped)
             if let bridgeError = error as? BridgeError, case .stopped = bridgeError {


### PR DESCRIPTION
## Summary
Previously `chat_agent_error` PostHog events only contained the sanitized user-friendly message (e.g., "AI service is temporarily unavailable"), making it impossible to diagnose failures remotely. Now sends the raw `BridgeError` alongside (e.g., `agentError("Internal error: Invalid API key")`) so we can see the actual cause in analytics.

This was discovered investigating Miles Feldstein's failed onboarding — we could see the error happened but couldn't determine the root cause because the raw error was stripped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)