### PR TITLE
Fix: wait for API keys before starting onboarding chat

### DIFF
--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -658,6 +658,12 @@ struct OnboardingChatView: View {
       }
 
       Task {
+        // Wait for API keys before starting the bridge (same race condition as fresh start)
+        for _ in 0..<30 {
+          if APIKeyService.shared.isLoaded { break }
+          try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+
         // Start bridge eagerly so it's ready by the time we need to send
         async let bridgeWarmup: () = chatProvider.warmupBridge()
 
@@ -702,6 +708,18 @@ struct OnboardingChatView: View {
       OnboardingChatPersistence.saveMidOnboarding()
 
       Task {
+        // Wait for API keys to be fetched before starting the chat bridge.
+        // fetchKeys() runs as a detached Task after sign-in — if we start
+        // the ACP bridge before it completes, ANTHROPIC_API_KEY is nil and
+        // the bridge fails with "Invalid API key".
+        for _ in 0..<30 {
+          if APIKeyService.shared.isLoaded { break }
+          try? await Task.sleep(nanoseconds: 200_000_000)
+        }
+        if !APIKeyService.shared.isLoaded {
+          log("OnboardingChat: WARNING — API keys not loaded after 6s, starting chat anyway")
+        }
+
         await chatProvider.sendMessage(
           "Hi, I just installed omi!",
           systemPromptPrefix: systemPrompt


### PR DESCRIPTION
## Summary
Race condition fix: `fetchKeys()` runs as a detached Task after sign-in, but the onboarding chat starts immediately. If the ACP bridge launches before `ANTHROPIC_API_KEY` is set in the environment, it fails with "Invalid API key" and the onboarding chat never starts.

**Root cause confirmed** for Miles Feldstein's failed onboarding (v161): sign-in completed at 05:01:16, chat errored at 05:01:28 with "AI service is temporarily unavailable" (sanitized from "Internal error: Invalid API key"). The 12-second gap matches the key fetch timing.

**Fix:** Poll `APIKeyService.isLoaded` (up to 6s) before sending the first chat message. Applied to both fresh start and restart recovery paths.

## Test plan
- [ ] Fresh install + sign-in → onboarding chat starts successfully
- [ ] Simulate slow network → chat waits for keys, then starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)