### PR TITLE
Await API key fetch instead of polling in onboarding

### DIFF
--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -19,6 +19,15 @@ final class APIKeyService: ObservableObject {
     @Published private(set) var isLoaded: Bool = false
     @Published private(set) var loadError: String?
 
+    /// The in-flight fetch task, so callers can await it instead of polling.
+    private(set) var fetchTask: Task<Void, Never>?
+
+    /// Wait for keys to be loaded. Returns immediately if already loaded.
+    func waitForKeys() async {
+        if isLoaded { return }
+        await fetchTask?.value
+    }
+
     /// Effective key: developer override > backend-provided > nil
     var effectiveDeepgramKey: String? {
         nonEmpty(UserDefaults.standard.string(forKey: "dev_deepgram_api_key")) ?? deepgramApiKey

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -336,7 +336,7 @@ class AuthService {
 
         AnalyticsManager.shared.identify()
         AnalyticsManager.shared.signInCompleted(provider: "apple")
-        Task { await APIKeyService.shared.fetchKeys() }
+        APIKeyService.shared.fetchTask = Task { await APIKeyService.shared.fetchKeys() }
 
         if !AnalyticsManager.isDevBuild {
             let sentryUser = User(userId: userId)
@@ -452,7 +452,7 @@ class AuthService {
             // (identify must happen before events for PostHog person profiles to work)
             AnalyticsManager.shared.identify()
             AnalyticsManager.shared.signInCompleted(provider: provider)
-            Task { await APIKeyService.shared.fetchKeys() }
+            APIKeyService.shared.fetchTask = Task { await APIKeyService.shared.fetchKeys() }
 
             // Set Sentry user context for error tracking (skip in dev builds)
             if !AnalyticsManager.isDevBuild {

--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -658,11 +658,8 @@ struct OnboardingChatView: View {
       }
 
       Task {
-        // Wait for API keys before starting the bridge (same race condition as fresh start)
-        for _ in 0..<30 {
-          if APIKeyService.shared.isLoaded { break }
-          try? await Task.sleep(nanoseconds: 200_000_000)
-        }
+        // Wait for API keys (fetchKeys() started during sign-in as a parallel Task)
+        await APIKeyService.shared.waitForKeys()
 
         // Start bridge eagerly so it's ready by the time we need to send
         async let bridgeWarmup: () = chatProvider.warmupBridge()
@@ -708,17 +705,9 @@ struct OnboardingChatView: View {
       OnboardingChatPersistence.saveMidOnboarding()
 
       Task {
-        // Wait for API keys to be fetched before starting the chat bridge.
-        // fetchKeys() runs as a detached Task after sign-in — if we start
-        // the ACP bridge before it completes, ANTHROPIC_API_KEY is nil and
-        // the bridge fails with "Invalid API key".
-        for _ in 0..<30 {
-          if APIKeyService.shared.isLoaded { break }
-          try? await Task.sleep(nanoseconds: 200_000_000)
-        }
-        if !APIKeyService.shared.isLoaded {
-          log("OnboardingChat: WARNING — API keys not loaded after 6s, starting chat anyway")
-        }
+        // Wait for API keys (fetchKeys() started during sign-in as a parallel Task).
+        // The bridge needs ANTHROPIC_API_KEY in the environment before launching.
+        await APIKeyService.shared.waitForKeys()
 
         await chatProvider.sendMessage(
           "Hi, I just installed omi!",


### PR DESCRIPTION
## Summary
Replace the 6s polling loop with direct Task await. `fetchKeys()` Task is now stored on `APIKeyService.fetchTask` so callers can `await waitForKeys()`. Zero extra delay when keys load fast (typically <1s), no wasted polling cycles.

Replaces the polling approach from #5986.

🤖 Generated with [Claude Code](https://claude.com/claude-code)