### PR TITLE
Fix speaker sample extraction after WS reconnect

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -29,6 +29,7 @@ from firebase_admin.auth import InvalidIdTokenError
 
 from utils.speaker_assignment import (
     process_speaker_assigned_segments,
+    rehydrate_session_segments,
     update_speaker_assignment_maps,
     should_update_speaker_to_person_map,
 )
@@ -843,18 +844,11 @@ async def _stream_handler(
             # Rehydrate current_session_segments from persisted transcript segments so that
             # speaker sample extraction (can_assign check) works after WS reconnect (#5949)
             existing_segments = existing_conversation.get('transcript_segments', [])
-            for seg in existing_segments:
-                sid = seg.get('id') if isinstance(seg, dict) else getattr(seg, 'id', None)
-                if sid:
-                    spp = (
-                        seg.get('speech_profile_processed', True)
-                        if isinstance(seg, dict)
-                        else getattr(seg, 'speech_profile_processed', True)
-                    )
-                    current_session_segments[sid] = spp
-            if existing_segments:
+            rehydrated = rehydrate_session_segments(existing_segments)
+            current_session_segments.update(rehydrated)
+            if rehydrated:
                 logger.info(
-                    f"Rehydrated {len(current_session_segments)} segments for resumed conversation {current_conversation_id} {uid} {session_id}"
+                    f"Rehydrated {len(rehydrated)} segments for resumed conversation {current_conversation_id} {uid} {session_id}"
                 )
 
             logger.info(

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -839,6 +839,24 @@ async def _stream_handler(
 
             # Continue with the existing conversation
             current_conversation_id = existing_conversation['id']
+
+            # Rehydrate current_session_segments from persisted transcript segments so that
+            # speaker sample extraction (can_assign check) works after WS reconnect (#5949)
+            existing_segments = existing_conversation.get('transcript_segments', [])
+            for seg in existing_segments:
+                sid = seg.get('id') if isinstance(seg, dict) else getattr(seg, 'id', None)
+                if sid:
+                    spp = (
+                        seg.get('speech_profile_processed', True)
+                        if isinstance(seg, dict)
+                        else getattr(seg, 'speech_profile_processed', True)
+                    )
+                    current_session_segments[sid] = spp
+            if existing_segments:
+                logger.info(
+                    f"Rehydrated {len(current_session_segments)} segments for resumed conversation {current_conversation_id} {uid} {session_id}"
+                )
+
             logger.info(
                 f"Resuming conversation {current_conversation_id}. Will timeout in {conversation_creation_timeout - seconds_since_last_segment:.1f}s {uid} {session_id}"
             )

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -58,6 +58,7 @@ pytest tests/unit/test_fair_use_async.py -v
 pytest tests/unit/test_dg_usage_batch.py -v
 pytest tests/unit/test_sync_fair_use_gate.py -v
 pytest tests/unit/test_timeout_middleware.py -v
+pytest tests/unit/test_speaker_segment_reconnect.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_speaker_segment_reconnect.py
+++ b/backend/tests/unit/test_speaker_segment_reconnect.py
@@ -10,6 +10,7 @@ duplicated local helper).
 """
 
 import pytest
+from models.transcript_segment import TranscriptSegment
 from utils.speaker_assignment import rehydrate_session_segments
 
 
@@ -97,3 +98,26 @@ class TestRehydrateSessionSegments:
         assert result['seg-0'] is True
         assert result['seg-1'] is False
         assert result['seg-999'] is False
+
+    def test_rehydrate_from_transcript_segment_objects(self):
+        """TranscriptSegment objects (getattr branch) should also be rehydrated."""
+        seg1 = TranscriptSegment(
+            id='obj-1',
+            text='hello',
+            speaker='SPEAKER_00',
+            start=0.0,
+            end=1.0,
+            is_user=False,
+            speech_profile_processed=True,
+        )
+        seg2 = TranscriptSegment(
+            id='obj-2',
+            text='world',
+            speaker='SPEAKER_01',
+            start=1.0,
+            end=2.0,
+            is_user=False,
+            speech_profile_processed=False,
+        )
+        result = rehydrate_session_segments([seg1, seg2])
+        assert result == {'obj-1': True, 'obj-2': False}

--- a/backend/tests/unit/test_speaker_segment_reconnect.py
+++ b/backend/tests/unit/test_speaker_segment_reconnect.py
@@ -1,0 +1,110 @@
+"""Unit tests for speaker segment rehydration on WS reconnect.
+
+Tests the fix for #5949: current_session_segments must be rehydrated from
+persisted conversation transcript_segments when resuming a conversation
+after WebSocket reconnection, so that can_assign works correctly for
+speaker sample extraction.
+"""
+
+import pytest
+
+
+class TestCurrentSessionSegmentsRehydration:
+    """Tests for rehydrating current_session_segments from conversation data."""
+
+    @staticmethod
+    def _rehydrate(existing_segments):
+        """Simulate the rehydration logic from _prepare_in_progess_conversations."""
+        current_session_segments = {}
+        for seg in existing_segments:
+            sid = seg.get('id') if isinstance(seg, dict) else getattr(seg, 'id', None)
+            if sid:
+                spp = (
+                    seg.get('speech_profile_processed', True)
+                    if isinstance(seg, dict)
+                    else getattr(seg, 'speech_profile_processed', True)
+                )
+                current_session_segments[sid] = spp
+        return current_session_segments
+
+    def test_rehydrate_from_dict_segments(self):
+        """Segments stored as dicts should populate current_session_segments."""
+        segments = [
+            {'id': 'seg-1', 'text': 'hello', 'speech_profile_processed': True},
+            {'id': 'seg-2', 'text': 'world', 'speech_profile_processed': False},
+            {'id': 'seg-3', 'text': 'test', 'speech_profile_processed': True},
+        ]
+        result = self._rehydrate(segments)
+        assert result == {'seg-1': True, 'seg-2': False, 'seg-3': True}
+
+    def test_rehydrate_empty_segments(self):
+        """Empty segments list should produce empty dict."""
+        result = self._rehydrate([])
+        assert result == {}
+
+    def test_rehydrate_missing_speech_profile_processed(self):
+        """Segments without speech_profile_processed should default to True."""
+        segments = [
+            {'id': 'seg-1', 'text': 'hello'},
+            {'id': 'seg-2', 'text': 'world', 'speech_profile_processed': False},
+        ]
+        result = self._rehydrate(segments)
+        assert result == {'seg-1': True, 'seg-2': False}
+
+    def test_rehydrate_missing_id(self):
+        """Segments without id should be skipped."""
+        segments = [
+            {'text': 'no id here'},
+            {'id': 'seg-1', 'text': 'has id', 'speech_profile_processed': True},
+        ]
+        result = self._rehydrate(segments)
+        assert result == {'seg-1': True}
+
+    def test_can_assign_after_rehydration(self):
+        """After rehydration, can_assign should be True for known processed segments."""
+        segments = [
+            {'id': 'seg-1', 'text': 'hello', 'speech_profile_processed': True},
+            {'id': 'seg-2', 'text': 'world', 'speech_profile_processed': False},
+        ]
+        current_session_segments = self._rehydrate(segments)
+
+        # Simulate the can_assign check from transcribe.py:2509-2514
+        def can_assign_check(segment_ids):
+            for sid in segment_ids:
+                if sid in current_session_segments and current_session_segments[sid]:
+                    return True
+            return False
+
+        # seg-1 is processed -> can_assign
+        assert can_assign_check(['seg-1']) is True
+        # seg-2 is not processed -> cannot assign
+        assert can_assign_check(['seg-2']) is False
+        # mixed: seg-1 processed -> can_assign
+        assert can_assign_check(['seg-2', 'seg-1']) is True
+        # unknown segment -> cannot assign
+        assert can_assign_check(['seg-unknown']) is False
+
+    def test_no_cross_conversation_leakage(self):
+        """New conversation should have empty current_session_segments."""
+        old_segments = [
+            {'id': 'old-1', 'text': 'old', 'speech_profile_processed': True},
+        ]
+        old_result = self._rehydrate(old_segments)
+        assert old_result == {'old-1': True}
+
+        # Simulating new conversation (empty segments)
+        new_result = self._rehydrate([])
+        assert new_result == {}
+        # Old result should not affect new result
+        assert 'old-1' not in new_result
+
+    def test_rehydrate_large_segment_list(self):
+        """Rehydration should handle large segment lists efficiently."""
+        segments = [
+            {'id': f'seg-{i}', 'text': f'text {i}', 'speech_profile_processed': i % 2 == 0} for i in range(1000)
+        ]
+        result = self._rehydrate(segments)
+        assert len(result) == 1000
+        assert result['seg-0'] is True
+        assert result['seg-1'] is False
+        assert result['seg-999'] is False

--- a/backend/tests/unit/test_speaker_segment_reconnect.py
+++ b/backend/tests/unit/test_speaker_segment_reconnect.py
@@ -4,28 +4,17 @@ Tests the fix for #5949: current_session_segments must be rehydrated from
 persisted conversation transcript_segments when resuming a conversation
 after WebSocket reconnection, so that can_assign works correctly for
 speaker sample extraction.
+
+Tests the shared rehydrate_session_segments function directly (not a
+duplicated local helper).
 """
 
 import pytest
+from utils.speaker_assignment import rehydrate_session_segments
 
 
-class TestCurrentSessionSegmentsRehydration:
-    """Tests for rehydrating current_session_segments from conversation data."""
-
-    @staticmethod
-    def _rehydrate(existing_segments):
-        """Simulate the rehydration logic from _prepare_in_progess_conversations."""
-        current_session_segments = {}
-        for seg in existing_segments:
-            sid = seg.get('id') if isinstance(seg, dict) else getattr(seg, 'id', None)
-            if sid:
-                spp = (
-                    seg.get('speech_profile_processed', True)
-                    if isinstance(seg, dict)
-                    else getattr(seg, 'speech_profile_processed', True)
-                )
-                current_session_segments[sid] = spp
-        return current_session_segments
+class TestRehydrateSessionSegments:
+    """Tests for rehydrate_session_segments from utils/speaker_assignment.py."""
 
     def test_rehydrate_from_dict_segments(self):
         """Segments stored as dicts should populate current_session_segments."""
@@ -34,12 +23,12 @@ class TestCurrentSessionSegmentsRehydration:
             {'id': 'seg-2', 'text': 'world', 'speech_profile_processed': False},
             {'id': 'seg-3', 'text': 'test', 'speech_profile_processed': True},
         ]
-        result = self._rehydrate(segments)
+        result = rehydrate_session_segments(segments)
         assert result == {'seg-1': True, 'seg-2': False, 'seg-3': True}
 
     def test_rehydrate_empty_segments(self):
         """Empty segments list should produce empty dict."""
-        result = self._rehydrate([])
+        result = rehydrate_session_segments([])
         assert result == {}
 
     def test_rehydrate_missing_speech_profile_processed(self):
@@ -48,7 +37,7 @@ class TestCurrentSessionSegmentsRehydration:
             {'id': 'seg-1', 'text': 'hello'},
             {'id': 'seg-2', 'text': 'world', 'speech_profile_processed': False},
         ]
-        result = self._rehydrate(segments)
+        result = rehydrate_session_segments(segments)
         assert result == {'seg-1': True, 'seg-2': False}
 
     def test_rehydrate_missing_id(self):
@@ -57,7 +46,7 @@ class TestCurrentSessionSegmentsRehydration:
             {'text': 'no id here'},
             {'id': 'seg-1', 'text': 'has id', 'speech_profile_processed': True},
         ]
-        result = self._rehydrate(segments)
+        result = rehydrate_session_segments(segments)
         assert result == {'seg-1': True}
 
     def test_can_assign_after_rehydration(self):
@@ -66,7 +55,7 @@ class TestCurrentSessionSegmentsRehydration:
             {'id': 'seg-1', 'text': 'hello', 'speech_profile_processed': True},
             {'id': 'seg-2', 'text': 'world', 'speech_profile_processed': False},
         ]
-        current_session_segments = self._rehydrate(segments)
+        current_session_segments = rehydrate_session_segments(segments)
 
         # Simulate the can_assign check from transcribe.py:2509-2514
         def can_assign_check(segment_ids):
@@ -89,11 +78,11 @@ class TestCurrentSessionSegmentsRehydration:
         old_segments = [
             {'id': 'old-1', 'text': 'old', 'speech_profile_processed': True},
         ]
-        old_result = self._rehydrate(old_segments)
+        old_result = rehydrate_session_segments(old_segments)
         assert old_result == {'old-1': True}
 
         # Simulating new conversation (empty segments)
-        new_result = self._rehydrate([])
+        new_result = rehydrate_session_segments([])
         assert new_result == {}
         # Old result should not affect new result
         assert 'old-1' not in new_result
@@ -103,7 +92,7 @@ class TestCurrentSessionSegmentsRehydration:
         segments = [
             {'id': f'seg-{i}', 'text': f'text {i}', 'speech_profile_processed': i % 2 == 0} for i in range(1000)
         ]
-        result = self._rehydrate(segments)
+        result = rehydrate_session_segments(segments)
         assert len(result) == 1000
         assert result['seg-0'] is True
         assert result['seg-1'] is False

--- a/backend/utils/speaker_assignment.py
+++ b/backend/utils/speaker_assignment.py
@@ -76,6 +76,33 @@ def update_speaker_assignment_maps(
     return True
 
 
+def rehydrate_session_segments(existing_segments: List) -> Dict[str, bool]:
+    """Rehydrate current_session_segments from persisted conversation segments.
+
+    When a WS reconnection resumes an existing conversation, the session-local
+    current_session_segments dict is empty. This function rebuilds it from the
+    conversation's persisted transcript_segments so that can_assign works
+    correctly for speaker sample extraction (#5949).
+
+    Args:
+        existing_segments: List of segment dicts (from Firestore) or TranscriptSegment objects.
+
+    Returns:
+        Dict mapping segment ID -> speech_profile_processed status.
+    """
+    result: Dict[str, bool] = {}
+    for seg in existing_segments:
+        sid = seg.get('id') if isinstance(seg, dict) else getattr(seg, 'id', None)
+        if sid:
+            spp = (
+                seg.get('speech_profile_processed', True)
+                if isinstance(seg, dict)
+                else getattr(seg, 'speech_profile_processed', True)
+            )
+            result[sid] = spp
+    return result
+
+
 def should_update_speaker_to_person_map(speaker_id: Optional[int]) -> bool:
     """Check if speaker_to_person_map should be updated for text detection.
 


### PR DESCRIPTION
## Summary

Fixes #5949 (scoped to the **real backend bug** — see analysis below).

- **Bug**: `current_session_segments` dict in `transcribe.py` is declared inside `_stream_handler()` and resets on every new WebSocket connection. After WS reconnect, `can_assign` returns `false` because segment IDs from the previous session are gone, blocking speaker sample extraction for **all users** who experience WS reconnect during recording (not just TestFlight).
- **Fix**: Extract `rehydrate_session_segments()` to `utils/speaker_assignment.py` and call it from `transcribe.py` when resuming a conversation after reconnect. Uses defensive reads (`seg.get('id')`, `seg.get('speech_profile_processed', True)`) and logs the rehydration count.
- **Scope note**: The issue's core narrative (prod/staging backend split on reconnect) was verified as **not reproducible** from code — `Env.overrideApiBaseUrl` is set once at init, no mid-session mutation exists. The staging banner claim was already fixed by commit `2f2b2e01d`. This PR fixes the one real bug: session-local segment state loss on reconnect.

## Changes

| File | Change |
|------|--------|
| `backend/utils/speaker_assignment.py` | New `rehydrate_session_segments()` shared utility function |
| `backend/routers/transcribe.py` | Import + call `rehydrate_session_segments()` in `_prepare_in_progess_conversations()` resume path |
| `backend/tests/unit/test_speaker_segment_reconnect.py` | 8 unit tests: dict segments, empty, missing fields, can_assign, cross-convo leakage, large list, TranscriptSegment objects |
| `backend/test.sh` | Add new test file to test runner |

## Testing

```
$ cd backend && pytest tests/unit/test_speaker_segment_reconnect.py tests/unit/test_speaker_assignment.py -v
22 passed in 0.11s
```

## Review Cycle
- **Round 1**: Reviewer flagged tests re-implementing logic locally → extracted to shared utility
- **Round 2**: Approved (no blocking issues, 22 tests pass)
- **Tester**: Added TranscriptSegment object test for getattr branch → 8 tests, TESTS_APPROVED

## Risks / Edge Cases

1. **Cross-conversation leakage**: Not a risk — `current_session_segments` is initialized empty at `_stream_handler()` entry; rehydration only on resume
2. **Missing `speech_profile_processed`**: Defaults to `True` (matching model default)
3. **Large conversations**: O(n) pass acceptable — conversation already in memory
4. **Speaker map continuity**: NOT rehydrating `speaker_to_person_map` / `segment_person_assignment_map` — `speaker_id` continuity not guaranteed across reconnect

## Issue Analysis (Codex-verified)

| Issue Claim | Verified |
|---|---|
| `testFlightApiEnvironment` defaults to staging | TRUE |
| `main.dart` overrides `apiBaseUrl` for TestFlight | TRUE |
| WS reconnect uses current `apiBaseUrl` | TRUE |
| **Prod→staging split on reconnect** | **FALSE** — no mid-session URL mutation |
| `current_session_segments` resets on reconnect | **TRUE — THIS PR** |
| Staging banner broken (`isUsingStagingApi`) | FALSE — already fixed |

Closes #5949

---
_by AI for @beastoin_