### PR TITLE
fix: restore Device Settings section in settings sidebar

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -636,6 +636,7 @@ struct DesktopHomeView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .navigateToDeviceSettings)) { _ in
       // Set the section directly and navigate to settings
+      selectedSettingsSection = .device
       withAnimation(.easeInOut(duration: 0.2)) {
         selectedIndex = SidebarNavItem.settings.rawValue
       }

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -237,6 +237,7 @@ struct SettingsContentView: View {
 
     enum SettingsSection: String, CaseIterable {
         case general = "General"
+        case device = "Device"
         case rewind = "Rewind"
         case transcription = "Transcription"
         case notifications = "Notifications"
@@ -375,6 +376,8 @@ struct SettingsContentView: View {
                 switch selectedSection {
                 case .general:
                     generalSection
+                case .device:
+                    DeviceSettingsPage()
                 case .rewind:
                     rewindSection
                 case .transcription:

--- a/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -315,6 +315,7 @@ struct SettingsSidebarItem: View {
     private var icon: String {
         switch section {
         case .general: return "gearshape"
+        case .device: return "cable.connector"
         case .rewind: return "clock.arrow.circlepath"
         case .transcription: return "waveform"
         case .notifications: return "bell"


### PR DESCRIPTION
## Summary
Restores the Device Settings section that was accidentally removed in commit badf72be8 ("Flatten Advanced settings").

## Changes
- Added `case device = "Device"` back to `SettingsSection` enum
- Added `DeviceSettingsPage()` to the settings content switch
- Added `selectedSettingsSection = .device` in the `navigateToDeviceSettings` handler
- Added device icon to `SettingsSidebar`

## Impact
Users can now access Device Settings to pair BLE devices. This was a P1 regression — without this, there was no UI path to scan/pair Omi hardware on macOS.

Fixes #5917