### PR TITLE
chore: changelog entries to trigger Codemagic build

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,9 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed DMG installer to show drag-to-Applications arrow",
+    "App now comes to foreground after sign-in across Spaces",
+    "Screenshots start capturing earlier during onboarding"
+  ],
   "releases": [
     {
       "version": "0.11.155",


### PR DESCRIPTION
Codemagic dropped v0.11.167-168 builds. Triggering a new build to test the DMG fix.