### PR TITLE
fix(desktop): hide app extension in DMG + trigger build

### DIFF
--- a/desktop/dmg-assets/dmgbuild_settings.py
+++ b/desktop/dmg-assets/dmgbuild_settings.py
@@ -43,6 +43,9 @@ icon_locations = {
     "Applications": (455, 175),
 }
 
+# Hide extension for the app
+hide_extensions = [app_name + ".app"]
+
 # Volume icon
 if icon_path:
     badge_icon = icon_path


### PR DESCRIPTION
Triggers Codemagic build to test dmgbuild DMG fix (v0.11.167-168 were dropped).