### PR TITLE
fix(desktop): fix MainActor isolation breaking Codemagic builds since v0.11.167

### DIFF
--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -20,7 +20,12 @@ final class APIKeyService: ObservableObject {
     @Published private(set) var loadError: String?
 
     /// The in-flight fetch task, so callers can await it instead of polling.
-    private(set) var fetchTask: Task<Void, Never>?
+    private var fetchTask: Task<Void, Never>?
+
+    /// Start fetching keys in the background. Callers can await via waitForKeys().
+    func startFetchingKeys() {
+        fetchTask = Task { await self.fetchKeys() }
+    }
 
     /// Wait for keys to be loaded. Returns immediately if already loaded.
     func waitForKeys() async {

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -336,7 +336,7 @@ class AuthService {
 
         AnalyticsManager.shared.identify()
         AnalyticsManager.shared.signInCompleted(provider: "apple")
-        APIKeyService.shared.fetchTask = Task { await APIKeyService.shared.fetchKeys() }
+        APIKeyService.shared.startFetchingKeys()
 
         if !AnalyticsManager.isDevBuild {
             let sentryUser = User(userId: userId)
@@ -452,7 +452,7 @@ class AuthService {
             // (identify must happen before events for PostHog person profiles to work)
             AnalyticsManager.shared.identify()
             AnalyticsManager.shared.signInCompleted(provider: provider)
-            APIKeyService.shared.fetchTask = Task { await APIKeyService.shared.fetchKeys() }
+            APIKeyService.shared.startFetchingKeys()
 
             // Set Sentry user context for error tracking (skip in dev builds)
             if !AnalyticsManager.isDevBuild {


### PR DESCRIPTION
## Summary
- `fetchTask` was `private(set)` on `@MainActor` `APIKeyService` but set directly from `AuthService` — strict concurrency in Xcode 16.4 release mode made this a compile error
- All Codemagic builds have been failing since v0.11.167 (4+ builds)
- Fix: replace direct property assignment with `startFetchingKeys()` method

## Test plan
- [x] `xcrun swift build -c release --package-path Desktop --triple arm64-apple-macosx` passes locally
- [ ] Codemagic build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)