### PR TITLE
Track bridge start failures, make waitForKeys self-healing

### DIFF
--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -23,8 +23,13 @@ final class APIKeyService: ObservableObject {
     private(set) var fetchTask: Task<Void, Never>?
 
     /// Wait for keys to be loaded. Returns immediately if already loaded.
+    /// If no fetch is in-flight, starts one (handles app-restart-while-signed-in case).
     func waitForKeys() async {
         if isLoaded { return }
+        if fetchTask == nil {
+            log("APIKeyService: waitForKeys called but no fetch in-flight, starting one")
+            fetchTask = Task { await fetchKeys() }
+        }
         await fetchTask?.value
     }
 

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -597,6 +597,8 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             return true
         } catch {
             logError("Failed to start ACP bridge", error: error)
+            let rawError = String(describing: error)
+            AnalyticsManager.shared.chatAgentError(error: "AI not available: bridge failed to start", rawError: rawError)
             errorMessage = "AI not available: \(error.localizedDescription)"
             return false
         }


### PR DESCRIPTION
## Summary
Two fixes discovered while investigating Alex Hudym's silent onboarding failure on v172:

1. **Track bridge start failures**: `ensureBridgeStarted()` now sends `chat_agent_error` to PostHog when the ACP bridge fails to start. Previously this was a completely silent failure — no analytics, no Sentry event. Alex's onboarding produced zero error events because this path swallowed the error.

2. **Self-healing waitForKeys()**: If `waitForKeys()` is called but no fetch Task is in-flight (e.g., app restarted while signed in, or sign-in completed through an unexpected path), it now starts a fetch instead of returning immediately with no key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)