### PR TITLE
feat(desktop): track full onboarding chat messages in PostHog

### DIFF
--- a/desktop/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/Desktop/Sources/AnalyticsManager.swift
@@ -86,6 +86,23 @@ class AnalyticsManager {
     PostHogManager.shared.track("Onboarding Chat Message", properties: props)
   }
 
+  /// Track full onboarding chat message content for debugging user issues.
+  /// Sent only to PostHog (not Mixpanel) to avoid event size limits.
+  func onboardingChatMessageDetailed(role: String, text: String, step: String, toolCalls: [String]? = nil, model: String? = nil, error: String? = nil) {
+    var props: [String: Any] = [
+      "role": role,
+      "step": step,
+      "text": String(text.prefix(2000)),
+      "text_length": text.count,
+    ]
+    if let toolCalls = toolCalls, !toolCalls.isEmpty {
+      props["tool_calls"] = toolCalls.joined(separator: ", ")
+    }
+    if let model = model { props["model"] = model }
+    if let error = error { props["error"] = error }
+    PostHogManager.shared.track("onboarding_chat_message_detailed", properties: props)
+  }
+
   // MARK: - Authentication Events
 
   func signInStarted(provider: String) {

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -1892,6 +1892,13 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 sender: .user
             )
             messages.append(userMessage)
+
+            // Track onboarding user messages with full content
+            if isOnboarding {
+                AnalyticsManager.shared.onboardingChatMessageDetailed(
+                    role: "user", text: trimmedText, step: "chat"
+                )
+            }
         }
 
         // Create a placeholder AI message shown immediately in the UI while
@@ -2099,6 +2106,18 @@ A screenshot may be attached — use it silently only if relevant. Never mention
 
             log("Chat response complete")
 
+            // Track onboarding AI responses with full content and tool calls
+            if isOnboarding {
+                let aiText = messages.first(where: { $0.id == aiMessageId })?.text ?? queryResult.text
+                AnalyticsManager.shared.onboardingChatMessageDetailed(
+                    role: "assistant",
+                    text: aiText,
+                    step: "chat",
+                    toolCalls: toolNames.isEmpty ? nil : toolNames,
+                    model: model ?? modelOverride
+                )
+            }
+
             // Persist the ACP session ID during onboarding so we can resume after app restart
             if isOnboarding && !queryResult.sessionId.isEmpty {
                 OnboardingChatPersistence.saveSessionId(queryResult.sessionId)
@@ -2199,6 +2218,14 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 rawError = "\(error)"
             }
             AnalyticsManager.shared.chatAgentError(error: error.localizedDescription, rawError: rawError)
+
+            // Track onboarding errors with full context
+            if isOnboarding {
+                AnalyticsManager.shared.onboardingChatMessageDetailed(
+                    role: "error", text: trimmedText, step: "chat",
+                    error: rawError
+                )
+            }
 
             // Show error to user (unless they intentionally stopped)
             if let bridgeError = error as? BridgeError, case .stopped = bridgeError {


### PR DESCRIPTION
## Summary
Adds `onboarding_chat_message_detailed` PostHog events that capture:
- **User messages**: full text sent during onboarding chat
- **AI responses**: full text, tool calls used, model
- **Errors**: raw error string when chat fails

Query in PostHog: filter by `onboarding_chat_message_detailed` and group by `distinct_id` to reconstruct any user's full onboarding conversation.

## Test plan
- [ ] Go through onboarding, check PostHog for `onboarding_chat_message_detailed` events
- [ ] Verify user messages have `role=user` and AI responses have `role=assistant`
- [ ] Verify tool calls appear in the `tool_calls` property

🤖 Generated with [Claude Code](https://claude.com/claude-code)