### PR TITLE
Fix API key race: wait inside ensureBridgeStarted, not callers

### DIFF
--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -378,9 +378,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       AuthService.shared.fetchConversations()
 
       // Fetch API keys from backend (keys are not bundled in the app)
-      Task {
-        await APIKeyService.shared.fetchKeys()
-      }
+      APIKeyService.shared.fetchTask = Task { await APIKeyService.shared.fetchKeys() }
 
       // Check tier eligibility (at most once per day)
       Task {

--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -658,10 +658,8 @@ struct OnboardingChatView: View {
       }
 
       Task {
-        // Wait for API keys (fetchKeys() started during sign-in as a parallel Task)
-        await APIKeyService.shared.waitForKeys()
-
         // Start bridge eagerly so it's ready by the time we need to send
+        // (ensureBridgeStarted waits for API keys internally)
         async let bridgeWarmup: () = chatProvider.warmupBridge()
 
         // Load previous messages from backend (same default chat, sessionId=nil)
@@ -705,10 +703,6 @@ struct OnboardingChatView: View {
       OnboardingChatPersistence.saveMidOnboarding()
 
       Task {
-        // Wait for API keys (fetchKeys() started during sign-in as a parallel Task).
-        // The bridge needs ANTHROPIC_API_KEY in the environment before launching.
-        await APIKeyService.shared.waitForKeys()
-
         await chatProvider.sendMessage(
           "Hi, I just installed omi!",
           systemPromptPrefix: systemPrompt

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -565,6 +565,12 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             }
         }
         guard !acpBridgeStarted else { return true }
+        // Wait for API keys before starting the bridge — the subprocess reads
+        // ANTHROPIC_API_KEY from environment on launch. Without this, Mode B
+        // (no key / OAuth) is used even when the user should be on Mode A.
+        if acpBridge.passApiKey {
+            await APIKeyService.shared.waitForKeys()
+        }
         do {
             try await acpBridge.start()
             acpBridgeStarted = true


### PR DESCRIPTION
## Summary
Previous fix (#5987) added `waitForKeys()` in OnboardingChatView before `sendMessage()`, but the bridge was already started by `ViewModelContainer.warmupBridge()` → `ensureBridgeStarted()` — 26ms before keys loaded. The bridge launched in Mode B (no API key) every time.

**Root cause**: `ensureBridgeStarted()` calls `acpBridge.start()` which spawns a subprocess that reads `ANTHROPIC_API_KEY` from environment. If the key isn't set yet, it starts in OAuth mode — which fails for new users who don't have a Claude account.

**Fix**: Move `waitForKeys()` into `ensureBridgeStarted()` itself, right before `acpBridge.start()`. One place, covers all callers. Also store `fetchTask` from OmiApp launch so `waitForKeys()` can always await it.

## Test plan
- [ ] Clean install → sign in → verify bridge starts in Mode A (check log for "Mode A (Omi API key)")
- [ ] Verify onboarding chat works without Claude OAuth session

🤖 Generated with [Claude Code](https://claude.com/claude-code)