### PR TITLE
fix(desktop): improve onboarding UX — clearer text, fix floating bar resize bug

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -555,8 +555,10 @@ class PushToTalkManager: ObservableObject {
       barState.voiceTranscript = ""
     }
 
-    // Skip resize when in follow-up mode or expanded AI conversation (already at full size)
-    guard !skipResize && !barState.isVoiceFollowUp && !barState.showingAIConversation else { return }
+    // Skip resize when in follow-up mode, expanded AI conversation, or during onboarding
+    // (during onboarding the floating bar shouldn't appear as a separate window)
+    let isOnboarding = !UserDefaults.standard.bool(forKey: "hasCompletedOnboarding")
+    guard !skipResize && !barState.isVoiceFollowUp && !barState.showingAIConversation && !isOnboarding else { return }
     if barState.isVoiceListening && !wasListening {
       FloatingControlBarManager.shared.resizeForPTT(expanded: true)
     } else if !barState.isVoiceListening && wasListening {

--- a/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
@@ -49,13 +49,13 @@ struct OnboardingFloatingBarShortcutStepView: View {
             Spacer()
 
             VStack(alignment: .leading, spacing: 18) {
-                Text("Open the floating bar\nwith a shortcut")
+                Text("Set your\nkeyboard shortcut")
                     .font(.system(size: 40, weight: .bold))
                     .foregroundColor(OmiColors.textPrimary)
                     .lineSpacing(2)
 
                 Text(
-                    "Use this keyboard shortcut to open the floating bar anytime. Type a question, hit Enter, and get an answer right where you're working."
+                    "Press the shortcut to check it works. You'll use this to quickly ask omi anything, right where you're working."
                 )
                 .font(.system(size: 16))
                 .foregroundColor(OmiColors.textSecondary)

--- a/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
@@ -57,13 +57,13 @@ struct OnboardingVoiceShortcutStepView: View {
       Spacer()
 
       VStack(alignment: .leading, spacing: 18) {
-        Text("Hold the shortcut\nand ask a question")
+        Text("Set your voice\nshortcut")
           .font(.system(size: 40, weight: .bold))
           .foregroundColor(OmiColors.textPrimary)
           .lineSpacing(2)
 
         Text(
-          "Hold the key you want to use for voice questions, then release to send. Try asking \"What's on my screen?\" If the preview reacts on the right, you're set. If not, switch to another key."
+          "Pick a key to hold for voice input. Press and hold it now to check it works — if the preview lights up on the right, you're set."
         )
         .font(.system(size: 16))
         .foregroundColor(OmiColors.textSecondary)


### PR DESCRIPTION
## Summary
- **Shortcut step**: "Open the floating bar with a shortcut" → "Set your keyboard shortcut" (users don't know what "floating bar" is yet)
- **Voice step**: "Hold the shortcut and ask a question" → "Set your voice shortcut" (simpler, just test the key works)
- **Floating bar bug**: PTT resize during onboarding caused the floating bar to expand to 430px and center on screen — now skipped during onboarding

## Test plan
- [ ] Go through onboarding — shortcut step should say "Set your keyboard shortcut"
- [ ] Voice step should say "Set your voice shortcut"  
- [ ] Holding voice shortcut during onboarding should NOT cause floating bar to appear/resize

🤖 Generated with [Claude Code](https://claude.com/claude-code)