### PR TITLE
docs: fix broken Notion CRM example link in Integrations page

### DIFF
--- a/docs/doc/developer/apps/Integrations.mdx
+++ b/docs/doc/developer/apps/Integrations.mdx
@@ -132,7 +132,7 @@ Your endpoint receives a POST request with the memory object:
 ```
 
 <Tip>
-Check out the [Notion CRM Example](https://github.com/BasedHardware/Omi/blob/main/plugins/example/main.py) for a complete implementation.
+Check out the [Notion CRM Example](https://github.com/BasedHardware/Omi/blob/main/plugins/oauth/conversation_created.py) for a complete implementation.
 </Tip>
 
 ---


### PR DESCRIPTION
## Summary

Fix broken "Notion CRM Example" link in the Integrations documentation page.

## Background

The link at `docs/doc/developer/apps/Integrations.mdx` points to `plugins/example/main.py`, which no longer exists.

Commit fff6516b3 ("Move plugins from plugins/example/ to plugins/") flattened the plugin directory, moving all files from `plugins/example/` up one level. The documentation link was not updated in that change, resulting in a 404.

The previous target (`plugins/example/main.py`, now `plugins/main.py`) was only a FastAPI router aggregation file — it never contained Notion CRM logic itself. The actual Notion CRM implementation lives in `plugins/oauth/conversation_created.py`, which handles the `/notion-crm` webhook endpoint, OAuth setup, and Notion row creation. This is the file the documentation intended to reference as a "complete implementation" example.

## Changes

- **`docs/doc/developer/apps/Integrations.mdx`**: Updated the "Notion CRM Example" link from `plugins/example/main.py` (404) to `plugins/oauth/conversation_created.py` (the actual implementation)

## References

- fff6516b3 - Move plugins from plugins/example/ to plugins/
- 53e3f1205 - docs: revamp Omi apps introduction and prompt-based apps documentation (introduced the current broken link)
- https://docs.omi.me/doc/developer/apps/Integrations#how-it-works
