### PR TITLE
fix(desktop): unify onboarding step UI — consistent dark theme with top bar

### DIFF
--- a/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
@@ -16,136 +16,67 @@ struct OnboardingFloatingBarShortcutStepView: View {
     @State private var keyMonitor: Any?
 
     var body: some View {
-        HStack(spacing: 0) {
-            leftPane
+        VStack(spacing: 0) {
+            // Header
+            HStack {
+                Text("Set your keyboard shortcut")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(OmiColors.textPrimary)
+
+                Spacer()
+
+                Button(action: onSkip) {
+                    Text("Skip")
+                        .font(.system(size: 13))
+                        .foregroundColor(OmiColors.textTertiary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 16)
 
             Divider()
                 .background(OmiColors.backgroundTertiary)
 
-            rightPane
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(OmiColors.backgroundPrimary)
-        .onAppear {
-            // Unregister the global hotkey so the floating bar does NOT open.
-            // We detect the keypress ourselves via a local NSEvent monitor.
-            GlobalShortcutManager.shared.unregisterShortcuts()
-            installKeyMonitor()
-        }
-        .onDisappear {
-            if let monitor = keyMonitor {
-                NSEvent.removeMonitor(monitor)
-                keyMonitor = nil
-            }
-            // Re-register the global hotkey for the next step.
-            GlobalShortcutManager.shared.registerShortcuts()
-        }
-    }
-
-    // MARK: - Left Pane
-
-    private var leftPane: some View {
-        VStack(spacing: 0) {
             Spacer()
 
-            VStack(alignment: .leading, spacing: 18) {
-                Text("Set your\nkeyboard shortcut")
-                    .font(.system(size: 40, weight: .bold))
+            // Content
+            VStack(spacing: 24) {
+                Text("Press this shortcut.\nDo the buttons light up?")
+                    .font(.system(size: 22, weight: .semibold))
                     .foregroundColor(OmiColors.textPrimary)
-                    .lineSpacing(2)
+                    .multilineTextAlignment(.center)
 
-                Text(
-                    "Press the shortcut to check it works. You'll use this to quickly ask omi anything, right where you're working."
-                )
-                .font(.system(size: 16))
-                .foregroundColor(OmiColors.textSecondary)
-                .lineSpacing(4)
-                .frame(maxWidth: 420, alignment: .leading)
-            }
-
-            Spacer()
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.horizontal, 50)
-    }
-
-    // MARK: - Right Pane
-
-    private var rightPane: some View {
-        ZStack {
-            LinearGradient(
-                colors: [
-                    Color(red: 0.17, green: 0.16, blue: 0.08).opacity(0.12),
-                    Color(red: 0.57, green: 0.48, blue: 0.08).opacity(0.08),
-                    Color.clear,
-                ],
-                startPoint: .topLeading,
-                endPoint: .bottomTrailing
-            )
-            .ignoresSafeArea()
-
-            VStack(spacing: 28) {
-                HStack {
-                    Spacer()
-                    Button(action: onSkip) {
-                        Text("Skip")
-                            .font(.system(size: 13))
-                            .foregroundColor(OmiColors.textTertiary)
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(OmiColors.backgroundSecondary)
+                    .frame(height: 128)
+                    .frame(maxWidth: 400)
+                    .overlay {
+                        shortcutKeyPreview
                     }
-                    .buttonStyle(.plain)
-                }
-                .padding(.bottom, -16)
 
-                VStack(alignment: .leading, spacing: 18) {
-                    Text("Press this shortcut.\nDo the buttons light up?")
-                        .font(.system(size: 22, weight: .semibold))
-                        .foregroundColor(Color.black.opacity(0.86))
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(spacing: 12) {
+                    Text("Choose a different shortcut:")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(OmiColors.textSecondary)
 
-                    RoundedRectangle(cornerRadius: 16, style: .continuous)
-                        .fill(Color(red: 0.95, green: 0.94, blue: 0.92))
-                        .frame(height: 128)
-                        .overlay {
-                            shortcutKeyPreview
-                        }
-
-                    VStack(alignment: .leading, spacing: 12) {
-                        Text("Choose a different shortcut:")
-                            .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(Color.black.opacity(0.68))
-
-                        HStack(spacing: 10) {
-                            ForEach(ShortcutSettings.AskOmiKey.allCases, id: \.self) { key in
-                                shortcutChoiceButton(key)
-                            }
+                    HStack(spacing: 10) {
+                        ForEach(ShortcutSettings.AskOmiKey.allCases, id: \.self) { key in
+                            shortcutChoiceButton(key)
                         }
                     }
-                }
-                .padding(32)
-                .background(
-                    RoundedRectangle(cornerRadius: 24, style: .continuous)
-                        .fill(Color.white.opacity(0.97))
-                        .shadow(color: .black.opacity(0.08), radius: 26, x: 0, y: 14)
-                )
-                .frame(maxWidth: 520)
-
-                if !showContinue {
-                    Text("Try pressing the shortcut now")
-                        .font(.system(size: 13))
-                        .foregroundColor(Color.black.opacity(0.55))
-                        .italic()
                 }
 
                 HStack(spacing: 14) {
                     Button(action: cycleShortcut) {
                         Text("Change shortcut")
                             .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(Color.black.opacity(0.72))
+                            .foregroundColor(OmiColors.textSecondary)
                             .padding(.horizontal, 18)
                             .padding(.vertical, 12)
                             .background(
                                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .fill(Color.white.opacity(0.82))
+                                    .fill(OmiColors.backgroundSecondary)
                             )
                     }
                     .buttonStyle(.plain)
@@ -167,9 +98,25 @@ struct OnboardingFloatingBarShortcutStepView: View {
                     }
                 }
             }
-            .padding(.horizontal, 40)
+
+            Spacer()
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(OmiColors.backgroundPrimary)
+        .onAppear {
+            // Unregister the global hotkey so the floating bar does NOT open.
+            // We detect the keypress ourselves via a local NSEvent monitor.
+            GlobalShortcutManager.shared.unregisterShortcuts()
+            installKeyMonitor()
+        }
+        .onDisappear {
+            if let monitor = keyMonitor {
+                NSEvent.removeMonitor(monitor)
+                keyMonitor = nil
+            }
+            // Re-register the global hotkey for the next step.
+            GlobalShortcutManager.shared.registerShortcuts()
+        }
     }
 
     // MARK: - Shortcut Key Preview
@@ -184,26 +131,25 @@ struct OnboardingFloatingBarShortcutStepView: View {
 
             Text(shortcutDetected ? "Shortcut detected" : "Press to test")
                 .font(.system(size: 13, weight: .medium))
-                .foregroundColor(Color.black.opacity(0.55))
+                .foregroundColor(OmiColors.textTertiary)
         }
     }
 
     private func keyCap(_ label: String) -> some View {
         RoundedRectangle(cornerRadius: 10, style: .continuous)
-            .fill(shortcutDetected ? OmiColors.purplePrimary : Color.white)
+            .fill(shortcutDetected ? OmiColors.purplePrimary : OmiColors.backgroundTertiary)
             .frame(width: 48, height: 48)
             .overlay(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .stroke(
-                        shortcutDetected ? OmiColors.purplePrimary : Color.black.opacity(0.12),
+                        shortcutDetected ? OmiColors.purplePrimary : OmiColors.textTertiary.opacity(0.3),
                         lineWidth: 2
                     )
             )
-            .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 6)
             .overlay {
                 Text(label)
                     .font(.system(size: 18, weight: .semibold))
-                    .foregroundColor(shortcutDetected ? .white : Color.black.opacity(0.7))
+                    .foregroundColor(shortcutDetected ? .white : OmiColors.textPrimary)
             }
     }
 
@@ -222,16 +168,12 @@ struct OnboardingFloatingBarShortcutStepView: View {
                         .font(.system(size: 13, weight: .medium))
                 }
             }
-            .foregroundColor(isSelected ? .white : Color.black.opacity(0.7))
+            .foregroundColor(isSelected ? .white : OmiColors.textSecondary)
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
             .background(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(isSelected ? OmiColors.purplePrimary : Color.white)
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .stroke(isSelected ? OmiColors.purplePrimary : Color.black.opacity(0.08), lineWidth: 1)
+                    .fill(isSelected ? OmiColors.purplePrimary : OmiColors.backgroundSecondary)
             )
         }
         .buttonStyle(.plain)

--- a/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
@@ -15,13 +15,90 @@ struct OnboardingVoiceShortcutStepView: View {
   @State private var showContinue = false
 
   var body: some View {
-    HStack(spacing: 0) {
-      leftPane
+    VStack(spacing: 0) {
+      // Header
+      HStack {
+        Text("Set your voice shortcut")
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundColor(OmiColors.textPrimary)
+
+        Spacer()
+
+        Button(action: onSkip) {
+          Text("Skip")
+            .font(.system(size: 13))
+            .foregroundColor(OmiColors.textTertiary)
+        }
+        .buttonStyle(.plain)
+      }
+      .padding(.horizontal, 24)
+      .padding(.vertical, 16)
 
       Divider()
         .background(OmiColors.backgroundTertiary)
 
-      rightPane
+      Spacer()
+
+      // Content
+      VStack(spacing: 24) {
+        Text("Press and hold to test.\nDoes the button light up?")
+          .font(.system(size: 22, weight: .semibold))
+          .foregroundColor(OmiColors.textPrimary)
+          .multilineTextAlignment(.center)
+
+        RoundedRectangle(cornerRadius: 16, style: .continuous)
+          .fill(OmiColors.backgroundSecondary)
+          .frame(height: 128)
+          .frame(maxWidth: 400)
+          .overlay {
+            shortcutKeyPreview
+          }
+
+        VStack(spacing: 12) {
+          Text("Try another key if it doesn't react:")
+            .font(.system(size: 14, weight: .medium))
+            .foregroundColor(OmiColors.textSecondary)
+
+          HStack(spacing: 10) {
+            ForEach(ShortcutSettings.PTTKey.allCases, id: \.self) { key in
+              shortcutChoiceButton(key)
+            }
+          }
+        }
+
+        HStack(spacing: 14) {
+          Button(action: cycleShortcut) {
+            Text("Change shortcut")
+              .font(.system(size: 15, weight: .semibold))
+              .foregroundColor(OmiColors.textSecondary)
+              .padding(.horizontal, 18)
+              .padding(.vertical, 12)
+              .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                  .fill(OmiColors.backgroundSecondary)
+              )
+          }
+          .buttonStyle(.plain)
+
+          if showContinue {
+            Button(action: onComplete) {
+              Text("Continue")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(.white)
+                .padding(.horizontal, 28)
+                .padding(.vertical, 12)
+                .background(
+                  RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(OmiColors.purplePrimary)
+                )
+            }
+            .buttonStyle(.plain)
+            .transition(.move(edge: .trailing).combined(with: .opacity))
+          }
+        }
+      }
+
+      Spacer()
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .background(OmiColors.backgroundPrimary)
@@ -52,158 +129,32 @@ struct OnboardingVoiceShortcutStepView: View {
     }
   }
 
-  private var leftPane: some View {
-    VStack(spacing: 0) {
-      Spacer()
-
-      VStack(alignment: .leading, spacing: 18) {
-        Text("Set your voice\nshortcut")
-          .font(.system(size: 40, weight: .bold))
-          .foregroundColor(OmiColors.textPrimary)
-          .lineSpacing(2)
-
-        Text(
-          "Pick a key to hold for voice input. Press and hold it now to check it works — if the preview lights up on the right, you're set."
-        )
-        .font(.system(size: 16))
-        .foregroundColor(OmiColors.textSecondary)
-        .lineSpacing(4)
-        .frame(maxWidth: 420, alignment: .leading)
-      }
-
-      Spacer()
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .padding(.horizontal, 50)
-  }
-
-  private var rightPane: some View {
-    ZStack {
-      LinearGradient(
-        colors: [
-          Color(red: 0.17, green: 0.16, blue: 0.08).opacity(0.12),
-          Color(red: 0.57, green: 0.48, blue: 0.08).opacity(0.08),
-          Color.clear,
-        ],
-        startPoint: .topLeading,
-        endPoint: .bottomTrailing
-      )
-      .ignoresSafeArea()
-
-      VStack(spacing: 28) {
-        HStack {
-          Spacer()
-          Button(action: onSkip) {
-            Text("Skip")
-              .font(.system(size: 13))
-              .foregroundColor(OmiColors.textTertiary)
-          }
-          .buttonStyle(.plain)
-        }
-        .padding(.bottom, -16)
-
-        VStack(alignment: .leading, spacing: 18) {
-          Text("Press this shortcut.\nDo the buttons light up?")
-            .font(.system(size: 22, weight: .semibold))
-            .foregroundColor(Color.black.opacity(0.86))
-            .frame(maxWidth: .infinity, alignment: .leading)
-
-          RoundedRectangle(cornerRadius: 16, style: .continuous)
-            .fill(Color(red: 0.95, green: 0.94, blue: 0.92))
-            .frame(height: 128)
-            .overlay {
-              shortcutKeyPreview
-            }
-
-          VStack(alignment: .leading, spacing: 12) {
-            Text("Try another key if it doesn't react:")
-              .font(.system(size: 14, weight: .medium))
-              .foregroundColor(Color.black.opacity(0.68))
-
-            HStack(spacing: 10) {
-              ForEach(ShortcutSettings.PTTKey.allCases, id: \.self) { key in
-                shortcutChoiceButton(key)
-              }
-            }
-          }
-        }
-        .padding(32)
-        .background(
-          RoundedRectangle(cornerRadius: 24, style: .continuous)
-            .fill(Color.white.opacity(0.97))
-            .shadow(color: .black.opacity(0.08), radius: 26, x: 0, y: 14)
-        )
-        .frame(maxWidth: 520)
-
-        if !showContinue {
-          Text("Try asking: \"What's on my screen?\"")
-            .font(.system(size: 13))
-            .foregroundColor(Color.black.opacity(0.55))
-            .italic()
-        }
-
-        HStack(spacing: 14) {
-          Button(action: cycleShortcut) {
-            Text("Change shortcut")
-              .font(.system(size: 15, weight: .semibold))
-              .foregroundColor(Color.black.opacity(0.72))
-              .padding(.horizontal, 18)
-              .padding(.vertical, 12)
-              .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                  .fill(Color.white.opacity(0.82))
-              )
-          }
-          .buttonStyle(.plain)
-
-          if showContinue {
-            Button(action: onComplete) {
-              Text("Continue")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.white)
-                .padding(.horizontal, 28)
-                .padding(.vertical, 12)
-                .background(
-                  RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(OmiColors.purplePrimary)
-                )
-            }
-            .buttonStyle(.plain)
-            .transition(.move(edge: .trailing).combined(with: .opacity))
-          }
-        }
-      }
-      .padding(.horizontal, 40)
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-  }
-
   private var shortcutKeyPreview: some View {
     VStack(spacing: 12) {
       RoundedRectangle(cornerRadius: 14, style: .continuous)
-        .fill(isShortcutActive ? OmiColors.purplePrimary : Color.white)
+        .fill(isShortcutActive ? OmiColors.purplePrimary : OmiColors.backgroundTertiary)
         .frame(width: 64, height: 64)
         .overlay(
           RoundedRectangle(cornerRadius: 14, style: .continuous)
             .stroke(
-              isShortcutActive ? OmiColors.purplePrimary : Color.black.opacity(0.12), lineWidth: 2)
+              isShortcutActive ? OmiColors.purplePrimary : OmiColors.textTertiary.opacity(0.3),
+              lineWidth: 2)
         )
-        .shadow(color: .black.opacity(0.12), radius: 10, x: 0, y: 6)
         .overlay {
           VStack(spacing: 6) {
             Text(shortcutLabelTop)
               .font(.system(size: 13, weight: .semibold))
-              .foregroundColor(isShortcutActive ? .white : Color.black.opacity(0.7))
+              .foregroundColor(isShortcutActive ? .white : OmiColors.textPrimary)
 
             Text(shortcutLabelBottom)
               .font(.system(size: 14, weight: .medium))
-              .foregroundColor(isShortcutActive ? .white.opacity(0.95) : Color.black.opacity(0.65))
+              .foregroundColor(isShortcutActive ? .white.opacity(0.95) : OmiColors.textSecondary)
           }
         }
 
       Text(isShortcutActive ? "Shortcut detected" : "Press and hold to test")
         .font(.system(size: 13, weight: .medium))
-        .foregroundColor(Color.black.opacity(0.55))
+        .foregroundColor(OmiColors.textTertiary)
     }
   }
 
@@ -220,16 +171,12 @@ struct OnboardingVoiceShortcutStepView: View {
         Text(pttChoiceTitle(for: key))
           .font(.system(size: 13, weight: .semibold))
       }
-      .foregroundColor(isSelected ? .white : Color.black.opacity(0.7))
+      .foregroundColor(isSelected ? .white : OmiColors.textSecondary)
       .padding(.horizontal, 14)
       .padding(.vertical, 10)
       .background(
         RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .fill(isSelected ? OmiColors.purplePrimary : Color.white)
-      )
-      .overlay(
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .stroke(isSelected ? OmiColors.purplePrimary : Color.black.opacity(0.08), lineWidth: 1)
+          .fill(isSelected ? OmiColors.purplePrimary : OmiColors.backgroundSecondary)
       )
     }
     .buttonStyle(.plain)


### PR DESCRIPTION
All 5 post-chat steps now use same layout: dark bg, top header bar with Skip, centered content. No more split-pane grey/white/yellow inconsistency.