### PR TITLE
desktop: replace chat onboarding with paged onboarding

### DIFF
--- a/desktop/Desktop/Sources/CalendarReaderService.swift
+++ b/desktop/Desktop/Sources/CalendarReaderService.swift
@@ -4,603 +4,608 @@ import Security
 // MARK: - Models
 
 struct CalendarEvent: Identifiable {
-    let id: String
-    let summary: String
-    let startTime: String
-    let endTime: String
-    let attendees: [String]
-    let location: String
-    let description: String
-    let isAllDay: Bool
+  let id: String
+  let summary: String
+  let startTime: String
+  let endTime: String
+  let attendees: [String]
+  let location: String
+  let description: String
+  let isAllDay: Bool
 }
 
 enum CalendarReaderError: LocalizedError {
-    case noBrowserFound
-    case noGoogleCookies
-    case cookieDecryptionFailed(String)
-    case networkError(String)
-    case authFailed
-    case pythonNotFound
+  case noBrowserFound
+  case noGoogleCookies
+  case cookieDecryptionFailed(String)
+  case networkError(String)
+  case authFailed
+  case pythonNotFound
 
-    var errorDescription: String? {
-        switch self {
-        case .noBrowserFound:
-            return "No browser with Google session found. Log into Google in Chrome, Arc, Brave, or Edge."
-        case .noGoogleCookies:
-            return "No Google session cookies found. Make sure you're logged into Google."
-        case .cookieDecryptionFailed(let msg):
-            return "Cookie decryption failed: \(msg)"
-        case .networkError(let msg):
-            return "Network error: \(msg)"
-        case .authFailed:
-            return "Google Calendar authentication failed. Try refreshing your Google session in the browser."
-        case .pythonNotFound:
-            return "Python 3 not found. Install it via Homebrew: brew install python3"
-        }
+  var errorDescription: String? {
+    switch self {
+    case .noBrowserFound:
+      return "No browser with Google session found. Log into Google in Chrome, Arc, Brave, or Edge."
+    case .noGoogleCookies:
+      return "No Google session cookies found. Make sure you're logged into Google."
+    case .cookieDecryptionFailed(let msg):
+      return "Cookie decryption failed: \(msg)"
+    case .networkError(let msg):
+      return "Network error: \(msg)"
+    case .authFailed:
+      return
+        "Google Calendar authentication failed. Try refreshing your Google session in the browser."
+    case .pythonNotFound:
+      return "Python 3 not found. Install it via Homebrew: brew install python3"
     }
+  }
 }
 
 // MARK: - Browser Config (same as Gmail)
 
 private struct CalBrowserConfig {
-    let name: String
-    let keychainService: String
-    let cookiePath: String
+  let name: String
+  let keychainService: String
+  let cookiePath: String
 
-    static func allBrowsers() -> [CalBrowserConfig] {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return [
-            CalBrowserConfig(
-                name: "Arc",
-                keychainService: "Arc Safe Storage",
-                cookiePath: "\(home)/Library/Application Support/Arc/User Data/Default/Cookies"
-            ),
-            CalBrowserConfig(
-                name: "Chrome",
-                keychainService: "Chrome Safe Storage",
-                cookiePath: "\(home)/Library/Application Support/Google/Chrome/Default/Cookies"
-            ),
-        ]
-    }
+  static func allBrowsers() -> [CalBrowserConfig] {
+    let home = FileManager.default.homeDirectoryForCurrentUser.path
+    return [
+      CalBrowserConfig(
+        name: "Arc",
+        keychainService: "Arc Safe Storage",
+        cookiePath: "\(home)/Library/Application Support/Arc/User Data/Default/Cookies"
+      ),
+      CalBrowserConfig(
+        name: "Chrome",
+        keychainService: "Chrome Safe Storage",
+        cookiePath: "\(home)/Library/Application Support/Google/Chrome/Default/Cookies"
+      ),
+    ]
+  }
 }
 
 // MARK: - CalendarReaderService
 
 actor CalendarReaderService {
-    static let shared = CalendarReaderService()
+  static let shared = CalendarReaderService()
 
-    /// Read calendar events using browser cookies + SAPISID auth.
-    /// Tries Arc, Chrome, Brave, Edge, Vivaldi in order.
-    /// Fetches events from `daysBack` days ago to `daysForward` days from now.
-    func readEvents(daysBack: Int = 90, daysForward: Int = 14, maxResults: Int = 200) async throws -> [CalendarEvent] {
-        let events = try fetchCalendarViaCookies(daysBack: daysBack, daysForward: daysForward, maxResults: maxResults)
-        return events.sorted { $0.startTime > $1.startTime }
+  /// Read calendar events using browser cookies + SAPISID auth.
+  /// Tries Arc, Chrome, Brave, Edge, Vivaldi in order.
+  /// Fetches events from `daysBack` days ago to `daysForward` days from now.
+  func readEvents(daysBack: Int = 90, daysForward: Int = 14, maxResults: Int = 200) async throws
+    -> [CalendarEvent]
+  {
+    let events = try fetchCalendarViaCookies(
+      daysBack: daysBack, daysForward: daysForward, maxResults: maxResults)
+    return events.sorted { $0.startTime > $1.startTime }
+  }
+
+  /// Synthesize profile memories and tasks from calendar events.
+  /// Uses local LLM (ACPBridge) to extract ~10 memories and 2-3 tasks.
+  func synthesizeFromEvents(events: [CalendarEvent]) async -> (
+    memories: Int, tasks: Int, profileSummary: String
+  ) {
+    guard !events.isEmpty else { return (0, 0, "") }
+
+    // Format events compactly for the LLM
+    var eventLines: [String] = []
+    for event in events {
+      var parts = ["[\(event.startTime)] \(event.summary)"]
+      if !event.attendees.isEmpty {
+        parts.append("With: \(event.attendees.prefix(5).joined(separator: ", "))")
+      }
+      if !event.location.isEmpty {
+        parts.append("Location: \(event.location)")
+      }
+      if !event.description.isEmpty {
+        let desc = String(event.description.prefix(150))
+        parts.append("Notes: \(desc)")
+      }
+      eventLines.append(parts.joined(separator: " | "))
     }
+    let eventsText = eventLines.joined(separator: "\n")
 
-    /// Synthesize profile memories and tasks from calendar events.
-    /// Uses local LLM (ACPBridge) to extract ~10 memories and 2-3 tasks.
-    func synthesizeFromEvents(events: [CalendarEvent]) async -> (memories: Int, tasks: Int, profileSummary: String) {
-        guard !events.isEmpty else { return (0, 0, "") }
+    let today = ISO8601DateFormatter().string(from: Date()).prefix(10)
+    let synthesisPrompt = """
+      Analyze these \(events.count) Google Calendar events and extract profile information about the user.
 
-        // Format events compactly for the LLM
-        var eventLines: [String] = []
-        for event in events {
-            var parts = ["[\(event.startTime)] \(event.summary)"]
-            if !event.attendees.isEmpty {
-                parts.append("With: \(event.attendees.prefix(5).joined(separator: ", "))")
-            }
-            if !event.location.isEmpty {
-                parts.append("Location: \(event.location)")
-            }
-            if !event.description.isEmpty {
-                let desc = String(event.description.prefix(150))
-                parts.append("Notes: \(desc)")
-            }
-            eventLines.append(parts.joined(separator: " | "))
+      CALENDAR EVENTS:
+      \(eventsText)
+
+      Today's date: \(today)
+
+      Respond ONLY with valid JSON (no markdown, no code fences):
+      {
+        "memories": [
+          "factual statement about the user based on calendar patterns"
+        ],
+        "tasks": [
+          {"description": "actionable item based on upcoming events", "priority": "high", "due_at": "2026-03-20T09:00:00Z"}
+        ],
+        "profile": "2-3 sentence summary of who this user is based on their calendar"
+      }
+
+      RULES:
+      - Extract 10-15 memories (facts about their role, recurring meetings, relationships, routines, interests, work schedule, hobbies, social life)
+      - Extract 3-5 tasks (upcoming preparation, follow-ups, deadlines from future events)
+      - Focus on PATTERNS (weekly standups, regular gym, recurring 1-on-1s) not one-off events
+      - Each memory should be a single clear factual statement in third person ("The user...")
+      - Tasks should only reference FUTURE events with ISO date in due_at
+      - Task priorities: "high", "medium", or "low"
+      - Profile should summarize professional identity and schedule patterns
+      - Do NOT include raw event details — synthesize and generalize
+      - Do NOT include sensitive medical or financial details
+      """
+
+    do {
+      let bridge = ACPBridge(passApiKey: true)
+      try await bridge.start()
+      defer { Task { await bridge.stop() } }
+
+      let result = try await bridge.query(
+        prompt: synthesisPrompt,
+        systemPrompt:
+          "You are a profile extraction assistant. Analyze calendar events and output structured JSON. Be concise and factual.",
+        model: "claude-opus-4-6",
+        onTextDelta: { @Sendable _ in },
+        onToolCall: { @Sendable _, _, _ in return "" },
+        onToolActivity: { @Sendable _, _, _, _ in }
+      )
+
+      var responseText = result.text
+      log(
+        "CalendarReaderService: Synthesis raw response (\(responseText.count) chars): \(responseText.prefix(300))"
+      )
+
+      // Extract JSON from response — handle markdown code fences and leading text
+      if let jsonStart = responseText.range(of: "```json") {
+        responseText = String(responseText[jsonStart.upperBound...])
+        if let jsonEnd = responseText.range(of: "```") {
+          responseText = String(responseText[..<jsonEnd.lowerBound])
         }
-        let eventsText = eventLines.joined(separator: "\n")
-
-        let today = ISO8601DateFormatter().string(from: Date()).prefix(10)
-        let synthesisPrompt = """
-        Analyze these \(events.count) Google Calendar events and extract profile information about the user.
-
-        CALENDAR EVENTS:
-        \(eventsText)
-
-        Today's date: \(today)
-
-        Respond ONLY with valid JSON (no markdown, no code fences):
-        {
-          "memories": [
-            "factual statement about the user based on calendar patterns"
-          ],
-          "tasks": [
-            {"description": "actionable item based on upcoming events", "priority": "high", "due_at": "2026-03-20T09:00:00Z"}
-          ],
-          "profile": "2-3 sentence summary of who this user is based on their calendar"
+      } else if let jsonStart = responseText.range(of: "```") {
+        responseText = String(responseText[jsonStart.upperBound...])
+        if let jsonEnd = responseText.range(of: "```") {
+          responseText = String(responseText[..<jsonEnd.lowerBound])
         }
+      }
+      // Also try finding raw JSON object if there's leading text
+      if let braceStart = responseText.firstIndex(of: "{") {
+        responseText = String(responseText[braceStart...])
+      }
+      responseText = responseText.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        RULES:
-        - Extract 10-15 memories (facts about their role, recurring meetings, relationships, routines, interests, work schedule, hobbies, social life)
-        - Extract 3-5 tasks (upcoming preparation, follow-ups, deadlines from future events)
-        - Focus on PATTERNS (weekly standups, regular gym, recurring 1-on-1s) not one-off events
-        - Each memory should be a single clear factual statement in third person ("The user...")
-        - Tasks should only reference FUTURE events with ISO date in due_at
-        - Task priorities: "high", "medium", or "low"
-        - Profile should summarize professional identity and schedule patterns
-        - Do NOT include raw event details — synthesize and generalize
-        - Do NOT include sensitive medical or financial details
-        """
+      guard let jsonData = responseText.data(using: .utf8),
+        let parsed = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
+      else {
+        log(
+          "CalendarReaderService: Failed to parse synthesis response: \(responseText.prefix(200))")
+        return (0, 0, "")
+      }
 
+      let memoryStrings = parsed["memories"] as? [String] ?? []
+      let taskDicts = parsed["tasks"] as? [[String: Any]] ?? []
+      let profileSummary = parsed["profile"] as? String ?? ""
+
+      // Save memories
+      var memoriesSaved = 0
+      for memory in memoryStrings {
         do {
-            let bridge = ACPBridge(passApiKey: true)
-            try await bridge.start()
-            defer { Task { await bridge.stop() } }
-
-            let result = try await bridge.query(
-                prompt: synthesisPrompt,
-                systemPrompt:
-                    "You are a profile extraction assistant. Analyze calendar events and output structured JSON. Be concise and factual.",
-                model: "claude-opus-4-6",
-                onTextDelta: { @Sendable _ in },
-                onToolCall: { @Sendable _, _, _ in return "" },
-                onToolActivity: { @Sendable _, _, _, _ in }
-            )
-
-            var responseText = result.text
-            log("CalendarReaderService: Synthesis raw response (\(responseText.count) chars): \(responseText.prefix(300))")
-
-            // Extract JSON from response — handle markdown code fences and leading text
-            if let jsonStart = responseText.range(of: "```json") {
-                responseText = String(responseText[jsonStart.upperBound...])
-                if let jsonEnd = responseText.range(of: "```") {
-                    responseText = String(responseText[..<jsonEnd.lowerBound])
-                }
-            } else if let jsonStart = responseText.range(of: "```") {
-                responseText = String(responseText[jsonStart.upperBound...])
-                if let jsonEnd = responseText.range(of: "```") {
-                    responseText = String(responseText[..<jsonEnd.lowerBound])
-                }
-            }
-            // Also try finding raw JSON object if there's leading text
-            if let braceStart = responseText.firstIndex(of: "{") {
-                responseText = String(responseText[braceStart...])
-            }
-            responseText = responseText.trimmingCharacters(in: .whitespacesAndNewlines)
-
-            guard let jsonData = responseText.data(using: .utf8),
-                let parsed = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any]
-            else {
-                log("CalendarReaderService: Failed to parse synthesis response: \(responseText.prefix(200))")
-                return (0, 0, "")
-            }
-
-            let memoryStrings = parsed["memories"] as? [String] ?? []
-            let taskDicts = parsed["tasks"] as? [[String: Any]] ?? []
-            let profileSummary = parsed["profile"] as? String ?? ""
-
-            // Save memories
-            var memoriesSaved = 0
-            for memory in memoryStrings {
-                do {
-                    _ = try await APIClient.shared.createMemory(
-                        content: memory,
-                        visibility: "private",
-                        tags: ["calendar", "onboarding", "profile"],
-                        source: "google_calendar",
-                        headline: "Calendar Profile Insight"
-                    )
-                    memoriesSaved += 1
-                } catch {
-                    log("CalendarReaderService: Failed to save memory: \(error)")
-                }
-            }
-
-            // Save tasks
-            var tasksSaved = 0
-            for taskDict in taskDicts {
-                guard let description = taskDict["description"] as? String else { continue }
-                let priority = taskDict["priority"] as? String ?? "medium"
-                let dueAtStr = taskDict["due_at"] as? String
-                var dueAt: Date? = nil
-                if let dueAtStr = dueAtStr {
-                    dueAt = ISO8601DateFormatter().date(from: dueAtStr)
-                }
-                let task = await TasksStore.shared.createTask(
-                    description: description,
-                    dueAt: dueAt,
-                    priority: priority,
-                    tags: ["calendar", "onboarding"]
-                )
-                if task != nil { tasksSaved += 1 }
-            }
-
-            log(
-                "CalendarReaderService: Synthesis complete — \(memoriesSaved) memories, \(tasksSaved) tasks, profile: \(profileSummary.prefix(80))"
-            )
-            return (memoriesSaved, tasksSaved, profileSummary)
-
+          _ = try await APIClient.shared.createMemory(
+            content: memory,
+            visibility: "private",
+            tags: ["calendar", "onboarding", "profile"],
+            source: "google_calendar",
+            headline: "Calendar Profile Insight"
+          )
+          memoriesSaved += 1
         } catch {
-            log("CalendarReaderService: Synthesis failed: \(error)")
-            return (0, 0, "")
+          log("CalendarReaderService: Failed to save memory: \(error)")
         }
-    }
+      }
 
-    // MARK: - Python: decrypt cookies + fetch Calendar events via SAPISID auth
-
-    private func fetchCalendarViaCookies(daysBack: Int, daysForward: Int, maxResults: Int) throws -> [CalendarEvent] {
-        // Build browser configs as JSON for Python
-        // Pass the ORIGINAL db path — Python opens it read-only to avoid WAL/journal corruption from file copy
-        var browserConfigs: [[String: String]] = []
-        for browser in CalBrowserConfig.allBrowsers() {
-            guard FileManager.default.fileExists(atPath: browser.cookiePath) else { continue }
-            guard let password = getKeychainPassword(service: browser.keychainService) else { continue }
-
-            browserConfigs.append([
-                "name": browser.name,
-                "db_path": browser.cookiePath,
-                "password": password,
-            ])
+      // Save tasks
+      var tasksSaved = 0
+      for taskDict in taskDicts {
+        guard let description = taskDict["description"] as? String else { continue }
+        let priority = taskDict["priority"] as? String ?? "medium"
+        let dueAtStr = taskDict["due_at"] as? String
+        var dueAt: Date? = nil
+        if let dueAtStr = dueAtStr {
+          dueAt = ISO8601DateFormatter().date(from: dueAtStr)
         }
-
-        guard !browserConfigs.isEmpty else {
-            throw CalendarReaderError.noBrowserFound
-        }
-
-        let configJSON: String
-        do {
-            let data = try JSONSerialization.data(withJSONObject: browserConfigs)
-            configJSON = String(data: data, encoding: .utf8) ?? "[]"
-        } catch {
-            throw CalendarReaderError.networkError("Failed to serialize browser configs")
-        }
-
-        // No temp file cleanup needed — we read the original DB directly in read-only mode
-
-        let pythonScript = """
-import sys, json, os, sqlite3, hashlib, time, urllib.request, urllib.error
-from http.cookiejar import MozillaCookieJar, Cookie
-from datetime import datetime, timedelta, timezone
-
-try:
-    from Crypto.Cipher import AES
-except ImportError:
-    try:
-        from Cryptodome.Cipher import AES
-    except ImportError:
-        import subprocess
-        def decrypt_aes_cbc(key, iv, data):
-            p = subprocess.run(['openssl', 'enc', '-aes-128-cbc', '-d', '-K', key.hex(), '-iv', iv.hex(), '-nopad'],
-                               input=data, capture_output=True)
-            return p.stdout
-        USE_OPENSSL = True
-    else:
-        USE_OPENSSL = False
-else:
-    USE_OPENSSL = False
-
-browsers = json.loads(sys.argv[1])
-days_back = int(sys.argv[2]) if len(sys.argv) > 2 else 30
-days_forward = int(sys.argv[3]) if len(sys.argv) > 3 else 14
-max_results = int(sys.argv[4]) if len(sys.argv) > 4 else 100
-
-def decrypt_cookies(db_path, password):
-    key = hashlib.pbkdf2_hmac('sha1', password.encode('utf-8'), b'saltysalt', 1003, dklen=16)
-    iv = b' ' * 16
-    try:
-        conn = sqlite3.connect(f'file:{db_path}?mode=ro&immutable=1', uri=True, timeout=5)
-        c = conn.cursor()
-        c.execute('SELECT value FROM meta WHERE key="version"')
-        row = c.fetchone()
-        db_version = int(row[0]) if row else 0
-        c.execute("SELECT host_key, name, encrypted_value, path, is_secure, expires_utc FROM cookies WHERE host_key LIKE '%google.com%'")
-        rows = c.fetchall()
-        conn.close()
-    except Exception as e:
-        return None, str(e)
-
-    cookies = []
-    for host_key, name, enc, path, is_secure, expires_utc in rows:
-        if not enc:
-            continue
-        enc = bytes(enc) if not isinstance(enc, bytes) else enc
-        value = None
-        if enc[:3] in (b'v10', b'v11'):
-            ciphertext = enc[3:]
-            try:
-                if USE_OPENSSL:
-                    decrypted = decrypt_aes_cbc(key, iv, ciphertext)
-                else:
-                    cipher = AES.new(key, AES.MODE_CBC, IV=iv)
-                    decrypted = cipher.decrypt(ciphertext)
-                pad_len = decrypted[-1] if decrypted else 0
-                if 1 <= pad_len <= 16:
-                    decrypted = decrypted[:-pad_len]
-                if db_version >= 24 and len(decrypted) > 32:
-                    decrypted = decrypted[32:]
-                value = decrypted.decode('utf-8', errors='replace')
-            except Exception:
-                continue
-        elif enc:
-            try:
-                value = enc.decode('utf-8', errors='replace')
-            except Exception:
-                continue
-        if value:
-            cookies.append({
-                'domain': host_key,
-                'name': name,
-                'value': value,
-                'path': path or '/',
-                'secure': bool(is_secure),
-            })
-    return cookies, None
-
-def make_cookie_jar(cookie_list):
-    jar = MozillaCookieJar()
-    for c in cookie_list:
-        cookie = Cookie(
-            version=0, name=c['name'], value=c['value'],
-            port=None, port_specified=False,
-            domain=c['domain'], domain_specified=True,
-            domain_initial_dot=c['domain'].startswith('.'),
-            path=c['path'], path_specified=True,
-            secure=c['secure'], expires=int(time.time()) + 86400,
-            discard=False, comment=None, comment_url=None,
-            rest={}, rfc2109=False
+        let task = await TasksStore.shared.createTask(
+          description: description,
+          dueAt: dueAt,
+          priority: priority,
+          tags: ["calendar", "onboarding"]
         )
-        jar.set_cookie(cookie)
-    return jar
+        if task != nil { tasksSaved += 1 }
+      }
 
-def get_sapisidhash(sapisid, origin):
-    timestamp = str(int(time.time()))
-    raw = timestamp + " " + sapisid + " " + origin
-    hash_val = hashlib.sha1(raw.encode('utf-8')).hexdigest()
-    return "SAPISIDHASH " + timestamp + "_" + hash_val
+      log(
+        "CalendarReaderService: Synthesis complete — \(memoriesSaved) memories, \(tasksSaved) tasks, profile: \(profileSummary.prefix(80))"
+      )
+      return (memoriesSaved, tasksSaved, profileSummary)
 
-def fetch_calendar_events(jar, cookies_list, days_back, days_forward, max_results):
-    # Find SAPISID cookie
-    sapisid = None
-    for c in cookies_list:
-        if c['name'] == 'SAPISID':
-            sapisid = c['value']
-            break
-    if not sapisid:
-        # Try __Secure-3PAPISID
-        for c in cookies_list:
-            if c['name'] == '__Secure-3PAPISID':
-                sapisid = c['value']
-                break
-    if not sapisid:
-        return None, "No SAPISID cookie found"
+    } catch {
+      log("CalendarReaderService: Synthesis failed: \(error)")
+      return (0, 0, "")
+    }
+  }
 
-    origin = "https://calendar.google.com"
-    auth_header = get_sapisidhash(sapisid, origin)
+  // MARK: - Python: decrypt cookies + fetch Calendar events via SAPISID auth
 
-    now = datetime.now(timezone.utc)
-    time_min = (now - timedelta(days=days_back)).strftime('%Y-%m-%dT%H:%M:%SZ')
-    time_max = (now + timedelta(days=days_forward)).strftime('%Y-%m-%dT%H:%M:%SZ')
+  private func fetchCalendarViaCookies(daysBack: Int, daysForward: Int, maxResults: Int) throws
+    -> [CalendarEvent]
+  {
+    // Build browser configs as JSON for Python
+    // Pass the ORIGINAL db path — Python opens it read-only to avoid WAL/journal corruption from file copy
+    var browserConfigs: [[String: String]] = []
+    for browser in CalBrowserConfig.allBrowsers() {
+      guard FileManager.default.fileExists(atPath: browser.cookiePath) else { continue }
+      guard let password = getKeychainPassword(service: browser.keychainService) else { continue }
 
-    url = (
-        f"https://clients6.google.com/calendar/v3/calendars/primary/events"
-        f"?timeMin={time_min}&timeMax={time_max}"
-        f"&singleEvents=true&orderBy=startTime&maxResults={max_results}"
-        f"&key={os.environ.get('GOOGLE_CALENDAR_API_KEY', '')}"
-    )
-
-    opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar))
-    req = urllib.request.Request(url)
-    req.add_header('Authorization', auth_header)
-    req.add_header('Origin', origin)
-    req.add_header('Referer', 'https://calendar.google.com/')
-    req.add_header('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/122.0.0.0 Safari/537.36')
-    req.add_header('X-Goog-AuthUser', '0')
-
-    try:
-        resp = opener.open(req, timeout=30)
-        status = resp.getcode()
-        body = resp.read()
-        if status != 200:
-            return None, f"HTTP {status}"
-        data = json.loads(body)
-        return data.get('items', []), None
-    except urllib.error.HTTPError as e:
-        body = e.read().decode('utf-8', errors='replace')[:200] if e.fp else ''
-        return None, f"HTTP {e.code}: {body}"
-    except Exception as e:
-        return None, str(e)
-
-# Try each browser
-for browser in browsers:
-    cookies, err = decrypt_cookies(browser['db_path'], browser['password'])
-    if err or not cookies:
-        continue
-
-    # Check for auth cookies
-    auth_names = {'SID', 'HSID', 'SSID', 'APISID', 'SAPISID', '__Secure-1PSID', '__Secure-3PSID'}
-    found_auth = [c for c in cookies if c['name'] in auth_names]
-    if not found_auth:
-        continue
-
-    jar = make_cookie_jar(cookies)
-    events, fetch_err = fetch_calendar_events(jar, cookies, days_back, days_forward, max_results)
-    if fetch_err or events is None:
-        continue
-
-    # Format events for output
-    result_events = []
-    for ev in events:
-        start = ev.get('start', {})
-        end = ev.get('end', {})
-        attendees = []
-        for a in ev.get('attendees', []):
-            if not a.get('self', False):
-                attendees.append(a.get('email', a.get('displayName', '')))
-
-        result_events.append({
-            'id': ev.get('id', ''),
-            'summary': ev.get('summary', 'Untitled'),
-            'start_time': start.get('dateTime', start.get('date', '')),
-            'end_time': end.get('dateTime', end.get('date', '')),
-            'attendees': attendees,
-            'location': ev.get('location', ''),
-            'description': (ev.get('description', '') or '')[:300],
-            'is_all_day': 'date' in start and 'dateTime' not in start,
-        })
-
-    # Write to temp file to avoid pipe buffer truncation with large event lists
-    import tempfile
-    outfile = tempfile.mktemp(suffix='.json', prefix='omi_cal_')
-    with open(outfile, 'w') as f:
-        json.dump({'ok': True, 'browser': browser['name'], 'events': result_events, 'count': len(result_events)}, f)
-    print(outfile)
-    sys.exit(0)
-
-import tempfile
-outfile = tempfile.mktemp(suffix='.json', prefix='omi_cal_')
-with open(outfile, 'w') as f:
-    json.dump({'ok': False, 'error': 'No browser with valid Google session found'}, f)
-print(outfile)
-sys.exit(0)
-"""
-
-        // Find Python
-        let pythonPaths = ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"]
-        guard let pythonPath = pythonPaths.first(where: { FileManager.default.fileExists(atPath: $0) })
-        else {
-            throw CalendarReaderError.pythonNotFound
-        }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: pythonPath)
-        process.arguments = [
-            "-c", pythonScript, configJSON,
-            String(daysBack), String(daysForward), String(maxResults),
-        ]
-        let pipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = errPipe
-
-        // Read pipe data asynchronously to avoid deadlock
-        // (waitUntilExit blocks if pipe buffers are full)
-        var outputData = Data()
-        var errData = Data()
-        let outputSem = DispatchSemaphore(value: 0)
-        let errSem = DispatchSemaphore(value: 0)
-        pipe.fileHandleForReading.readabilityHandler = { handle in
-            let d = handle.availableData
-            if d.isEmpty {
-                pipe.fileHandleForReading.readabilityHandler = nil
-                outputSem.signal()
-            } else {
-                outputData.append(d)
-            }
-        }
-        errPipe.fileHandleForReading.readabilityHandler = { handle in
-            let d = handle.availableData
-            if d.isEmpty {
-                errPipe.fileHandleForReading.readabilityHandler = nil
-                errSem.signal()
-            } else {
-                errData.append(d)
-            }
-        }
-
-        do {
-            try process.run()
-            // Timeout after 60 seconds
-            DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(60)) {
-                if process.isRunning { process.terminate() }
-            }
-            process.waitUntilExit()
-        } catch {
-            throw CalendarReaderError.networkError("Failed to run Python: \(error.localizedDescription)")
-        }
-
-        // Wait for pipe reads to finish (max 5s after process exit)
-        _ = outputSem.wait(timeout: .now() + .seconds(5))
-        _ = errSem.wait(timeout: .now() + .seconds(5))
-
-        let errOutput = String(data: errData, encoding: .utf8) ?? ""
-        if !errOutput.isEmpty {
-            log("CalendarReaderService: Python stderr: \(errOutput.prefix(500))")
-        }
-
-        // Python writes JSON to a temp file and prints the path to stdout
-        let outputPath = String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !outputPath.isEmpty, FileManager.default.fileExists(atPath: outputPath) else {
-            throw CalendarReaderError.networkError("Python did not produce output file (stdout: \(outputPath.prefix(200)))")
-        }
-        defer { try? FileManager.default.removeItem(atPath: outputPath) }
-
-        let output = try Data(contentsOf: URL(fileURLWithPath: outputPath))
-        guard let json = try? JSONSerialization.jsonObject(with: output) as? [String: Any] else {
-            let raw = String(data: output, encoding: .utf8) ?? "(empty)"
-            throw CalendarReaderError.networkError("Python returned invalid JSON: \(raw.prefix(200))")
-        }
-
-        guard json["ok"] as? Bool == true else {
-            let errMsg = json["error"] as? String ?? "Unknown error"
-            throw CalendarReaderError.networkError(errMsg)
-        }
-
-        guard let eventDicts = json["events"] as? [[String: Any]] else {
-            return []
-        }
-
-        let browserName = json["browser"] as? String ?? "unknown"
-        log("CalendarReaderService: Got \(eventDicts.count) events from \(browserName)")
-
-        return eventDicts.compactMap { dict -> CalendarEvent? in
-            guard let id = dict["id"] as? String,
-                let summary = dict["summary"] as? String
-            else { return nil }
-
-            return CalendarEvent(
-                id: id,
-                summary: summary,
-                startTime: dict["start_time"] as? String ?? "",
-                endTime: dict["end_time"] as? String ?? "",
-                attendees: dict["attendees"] as? [String] ?? [],
-                location: dict["location"] as? String ?? "",
-                description: dict["description"] as? String ?? "",
-                isAllDay: dict["is_all_day"] as? Bool ?? false
-            )
-        }
+      browserConfigs.append([
+        "name": browser.name,
+        "db_path": browser.cookiePath,
+        "password": password,
+      ])
     }
 
-    // MARK: - Keychain
-
-    private func getKeychainPassword(service: String) -> String? {
-        // Check shared cache first to avoid duplicate keychain prompts
-        if let cached = BrowserKeychainCache.shared.get(service) {
-            return cached.isEmpty ? nil : cached
-        }
-        if BrowserKeychainCache.shared.hasAttempted(service) {
-            return nil
-        }
-
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let data = result as? Data,
-            let password = String(data: data, encoding: .utf8)
-        else {
-            BrowserKeychainCache.shared.markFailed(service)
-            if status != errSecItemNotFound {
-                log("CalendarReaderService: Keychain lookup for '\(service)' failed with status \(status)")
-            }
-            return nil
-        }
-        if !password.isEmpty {
-            BrowserKeychainCache.shared.set(service, password: password)
-        }
-        return password.isEmpty ? nil : password
+    guard !browserConfigs.isEmpty else {
+      throw CalendarReaderError.noBrowserFound
     }
+
+    let configJSON: String
+    do {
+      let data = try JSONSerialization.data(withJSONObject: browserConfigs)
+      configJSON = String(data: data, encoding: .utf8) ?? "[]"
+    } catch {
+      throw CalendarReaderError.networkError("Failed to serialize browser configs")
+    }
+
+    // No temp file cleanup needed — we read the original DB directly in read-only mode
+
+    let pythonScript = """
+      import sys, json, os, sqlite3, hashlib, time, urllib.request, urllib.error
+      from http.cookiejar import MozillaCookieJar, Cookie
+      from datetime import datetime, timedelta, timezone
+
+      try:
+          from Crypto.Cipher import AES
+      except ImportError:
+          try:
+              from Cryptodome.Cipher import AES
+          except ImportError:
+              import subprocess
+              def decrypt_aes_cbc(key, iv, data):
+                  p = subprocess.run(['openssl', 'enc', '-aes-128-cbc', '-d', '-K', key.hex(), '-iv', iv.hex(), '-nopad'],
+                                     input=data, capture_output=True)
+                  return p.stdout
+              USE_OPENSSL = True
+          else:
+              USE_OPENSSL = False
+      else:
+          USE_OPENSSL = False
+
+      browsers = json.loads(sys.argv[1])
+      days_back = int(sys.argv[2]) if len(sys.argv) > 2 else 30
+      days_forward = int(sys.argv[3]) if len(sys.argv) > 3 else 14
+      max_results = int(sys.argv[4]) if len(sys.argv) > 4 else 100
+
+      def decrypt_cookies(db_path, password):
+          key = hashlib.pbkdf2_hmac('sha1', password.encode('utf-8'), b'saltysalt', 1003, dklen=16)
+          iv = b' ' * 16
+          try:
+              conn = sqlite3.connect(f'file:{db_path}?mode=ro&immutable=1', uri=True, timeout=5)
+              c = conn.cursor()
+              c.execute('SELECT value FROM meta WHERE key="version"')
+              row = c.fetchone()
+              db_version = int(row[0]) if row else 0
+              c.execute("SELECT host_key, name, encrypted_value, path, is_secure, expires_utc FROM cookies WHERE host_key LIKE '%google.com%'")
+              rows = c.fetchall()
+              conn.close()
+          except Exception as e:
+              return None, str(e)
+
+          cookies = []
+          for host_key, name, enc, path, is_secure, expires_utc in rows:
+              if not enc:
+                  continue
+              enc = bytes(enc) if not isinstance(enc, bytes) else enc
+              value = None
+              if enc[:3] in (b'v10', b'v11'):
+                  ciphertext = enc[3:]
+                  try:
+                      if USE_OPENSSL:
+                          decrypted = decrypt_aes_cbc(key, iv, ciphertext)
+                      else:
+                          cipher = AES.new(key, AES.MODE_CBC, IV=iv)
+                          decrypted = cipher.decrypt(ciphertext)
+                      pad_len = decrypted[-1] if decrypted else 0
+                      if 1 <= pad_len <= 16:
+                          decrypted = decrypted[:-pad_len]
+                      if db_version >= 24 and len(decrypted) > 32:
+                          decrypted = decrypted[32:]
+                      value = decrypted.decode('utf-8', errors='replace')
+                  except Exception:
+                      continue
+              elif enc:
+                  try:
+                      value = enc.decode('utf-8', errors='replace')
+                  except Exception:
+                      continue
+              if value:
+                  cookies.append({
+                      'domain': host_key,
+                      'name': name,
+                      'value': value,
+                      'path': path or '/',
+                      'secure': bool(is_secure),
+                  })
+          return cookies, None
+
+      def make_cookie_jar(cookie_list):
+          jar = MozillaCookieJar()
+          for c in cookie_list:
+              cookie = Cookie(
+                  version=0, name=c['name'], value=c['value'],
+                  port=None, port_specified=False,
+                  domain=c['domain'], domain_specified=True,
+                  domain_initial_dot=c['domain'].startswith('.'),
+                  path=c['path'], path_specified=True,
+                  secure=c['secure'], expires=int(time.time()) + 86400,
+                  discard=False, comment=None, comment_url=None,
+                  rest={}, rfc2109=False
+              )
+              jar.set_cookie(cookie)
+          return jar
+
+      def get_sapisidhash(sapisid, origin):
+          timestamp = str(int(time.time()))
+          raw = timestamp + " " + sapisid + " " + origin
+          hash_val = hashlib.sha1(raw.encode('utf-8')).hexdigest()
+          return "SAPISIDHASH " + timestamp + "_" + hash_val
+
+      def fetch_calendar_events(jar, cookies_list, days_back, days_forward, max_results):
+          # Find SAPISID cookie
+          sapisid = None
+          for c in cookies_list:
+              if c['name'] == 'SAPISID':
+                  sapisid = c['value']
+                  break
+          if not sapisid:
+              # Try __Secure-3PAPISID
+              for c in cookies_list:
+                  if c['name'] == '__Secure-3PAPISID':
+                      sapisid = c['value']
+                      break
+          if not sapisid:
+              return None, "No SAPISID cookie found"
+
+          origin = "https://calendar.google.com"
+          auth_header = get_sapisidhash(sapisid, origin)
+
+          now = datetime.now(timezone.utc)
+          time_min = (now - timedelta(days=days_back)).strftime('%Y-%m-%dT%H:%M:%SZ')
+          time_max = (now + timedelta(days=days_forward)).strftime('%Y-%m-%dT%H:%M:%SZ')
+
+          url = (
+              f"https://clients6.google.com/calendar/v3/calendars/primary/events"
+              f"?timeMin={time_min}&timeMax={time_max}"
+              f"&singleEvents=true&orderBy=startTime&maxResults={max_results}"
+              f"&key={os.environ.get('GOOGLE_CALENDAR_API_KEY', '')}"
+          )
+
+          opener = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(jar))
+          req = urllib.request.Request(url)
+          req.add_header('Authorization', auth_header)
+          req.add_header('Origin', origin)
+          req.add_header('Referer', 'https://calendar.google.com/')
+          req.add_header('User-Agent', 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/122.0.0.0 Safari/537.36')
+          req.add_header('X-Goog-AuthUser', '0')
+
+          try:
+              resp = opener.open(req, timeout=30)
+              status = resp.getcode()
+              body = resp.read()
+              if status != 200:
+                  return None, f"HTTP {status}"
+              data = json.loads(body)
+              return data.get('items', []), None
+          except urllib.error.HTTPError as e:
+              body = e.read().decode('utf-8', errors='replace')[:200] if e.fp else ''
+              return None, f"HTTP {e.code}: {body}"
+          except Exception as e:
+              return None, str(e)
+
+      # Try each browser
+      for browser in browsers:
+          cookies, err = decrypt_cookies(browser['db_path'], browser['password'])
+          if err or not cookies:
+              continue
+
+          # Check for auth cookies
+          auth_names = {'SID', 'HSID', 'SSID', 'APISID', 'SAPISID', '__Secure-1PSID', '__Secure-3PSID'}
+          found_auth = [c for c in cookies if c['name'] in auth_names]
+          if not found_auth:
+              continue
+
+          jar = make_cookie_jar(cookies)
+          events, fetch_err = fetch_calendar_events(jar, cookies, days_back, days_forward, max_results)
+          if fetch_err or events is None:
+              continue
+
+          # Format events for output
+          result_events = []
+          for ev in events:
+              start = ev.get('start', {})
+              end = ev.get('end', {})
+              attendees = []
+              for a in ev.get('attendees', []):
+                  if not a.get('self', False):
+                      attendees.append(a.get('email', a.get('displayName', '')))
+
+              result_events.append({
+                  'id': ev.get('id', ''),
+                  'summary': ev.get('summary', 'Untitled'),
+                  'start_time': start.get('dateTime', start.get('date', '')),
+                  'end_time': end.get('dateTime', end.get('date', '')),
+                  'attendees': attendees,
+                  'location': ev.get('location', ''),
+                  'description': (ev.get('description', '') or '')[:300],
+                  'is_all_day': 'date' in start and 'dateTime' not in start,
+              })
+
+          # Write to temp file to avoid pipe buffer truncation with large event lists
+          import tempfile
+          outfile = tempfile.mktemp(suffix='.json', prefix='omi_cal_')
+          with open(outfile, 'w') as f:
+              json.dump({'ok': True, 'browser': browser['name'], 'events': result_events, 'count': len(result_events)}, f)
+          print(outfile)
+          sys.exit(0)
+
+      import tempfile
+      outfile = tempfile.mktemp(suffix='.json', prefix='omi_cal_')
+      with open(outfile, 'w') as f:
+          json.dump({'ok': False, 'error': 'No browser with valid Google session found'}, f)
+      print(outfile)
+      sys.exit(0)
+      """
+
+    // Find Python
+    let pythonPaths = ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"]
+    guard let pythonPath = pythonPaths.first(where: { FileManager.default.fileExists(atPath: $0) })
+    else {
+      throw CalendarReaderError.pythonNotFound
+    }
+
+    let process = Process()
+    process.executableURL = URL(fileURLWithPath: pythonPath)
+    process.arguments = [
+      "-c", pythonScript, configJSON,
+      String(daysBack), String(daysForward), String(maxResults),
+    ]
+    let pipe = Pipe()
+    let errPipe = Pipe()
+    process.standardOutput = pipe
+    process.standardError = errPipe
+
+    // Read pipe data asynchronously to avoid deadlock
+    // (waitUntilExit blocks if pipe buffers are full)
+    var outputData = Data()
+    var errData = Data()
+    let outputSem = DispatchSemaphore(value: 0)
+    let errSem = DispatchSemaphore(value: 0)
+    pipe.fileHandleForReading.readabilityHandler = { handle in
+      let d = handle.availableData
+      if d.isEmpty {
+        pipe.fileHandleForReading.readabilityHandler = nil
+        outputSem.signal()
+      } else {
+        outputData.append(d)
+      }
+    }
+    errPipe.fileHandleForReading.readabilityHandler = { handle in
+      let d = handle.availableData
+      if d.isEmpty {
+        errPipe.fileHandleForReading.readabilityHandler = nil
+        errSem.signal()
+      } else {
+        errData.append(d)
+      }
+    }
+
+    do {
+      try process.run()
+      // Timeout after 60 seconds
+      DispatchQueue.global().asyncAfter(deadline: .now() + .seconds(60)) {
+        if process.isRunning { process.terminate() }
+      }
+      process.waitUntilExit()
+    } catch {
+      throw CalendarReaderError.networkError("Failed to run Python: \(error.localizedDescription)")
+    }
+
+    // Wait for pipe reads to finish (max 5s after process exit)
+    _ = outputSem.wait(timeout: .now() + .seconds(5))
+    _ = errSem.wait(timeout: .now() + .seconds(5))
+
+    let errOutput = String(data: errData, encoding: .utf8) ?? ""
+    if !errOutput.isEmpty {
+      log("CalendarReaderService: Python stderr: \(errOutput.prefix(500))")
+    }
+
+    // Python writes JSON to a temp file and prints the path to stdout
+    let outputPath =
+      String(data: outputData, encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines)
+      ?? ""
+    guard !outputPath.isEmpty, FileManager.default.fileExists(atPath: outputPath) else {
+      throw CalendarReaderError.networkError(
+        "Python did not produce output file (stdout: \(outputPath.prefix(200)))")
+    }
+    defer { try? FileManager.default.removeItem(atPath: outputPath) }
+
+    let output = try Data(contentsOf: URL(fileURLWithPath: outputPath))
+    guard let json = try? JSONSerialization.jsonObject(with: output) as? [String: Any] else {
+      let raw = String(data: output, encoding: .utf8) ?? "(empty)"
+      throw CalendarReaderError.networkError("Python returned invalid JSON: \(raw.prefix(200))")
+    }
+
+    guard json["ok"] as? Bool == true else {
+      let errMsg = json["error"] as? String ?? "Unknown error"
+      throw CalendarReaderError.networkError(errMsg)
+    }
+
+    guard let eventDicts = json["events"] as? [[String: Any]] else {
+      return []
+    }
+
+    let browserName = json["browser"] as? String ?? "unknown"
+    log("CalendarReaderService: Got \(eventDicts.count) events from \(browserName)")
+
+    return eventDicts.compactMap { dict -> CalendarEvent? in
+      guard let id = dict["id"] as? String,
+        let summary = dict["summary"] as? String
+      else { return nil }
+
+      return CalendarEvent(
+        id: id,
+        summary: summary,
+        startTime: dict["start_time"] as? String ?? "",
+        endTime: dict["end_time"] as? String ?? "",
+        attendees: dict["attendees"] as? [String] ?? [],
+        location: dict["location"] as? String ?? "",
+        description: dict["description"] as? String ?? "",
+        isAllDay: dict["is_all_day"] as? Bool ?? false
+      )
+    }
+  }
+
+  // MARK: - Keychain
+
+  private func getKeychainPassword(service: String) -> String? {
+    BrowserKeychainCache.shared.password(for: service) {
+      let query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecReturnData as String: true,
+        kSecMatchLimit as String: kSecMatchLimitOne,
+      ]
+      var result: AnyObject?
+      let status = SecItemCopyMatching(query as CFDictionary, &result)
+      guard status == errSecSuccess, let data = result as? Data,
+        let password = String(data: data, encoding: .utf8)
+      else {
+        if status != errSecItemNotFound {
+          log(
+            "CalendarReaderService: Keychain lookup for '\(service)' failed with status \(status)")
+        }
+        return nil
+      }
+      return password.isEmpty ? nil : password
+    }
+  }
 }

--- a/desktop/Desktop/Sources/GmailReaderService.swift
+++ b/desktop/Desktop/Sources/GmailReaderService.swift
@@ -69,31 +69,40 @@ private struct BrowserConfig {
 final class BrowserKeychainCache: @unchecked Sendable {
   static let shared = BrowserKeychainCache()
   private var cache: [String: String] = [:]
+  private var inFlight: [String: DispatchGroup] = [:]
   private let lock = NSLock()
 
-  func get(_ service: String) -> String? {
-    lock.lock()
-    defer { lock.unlock() }
-    return cache[service]
-  }
+  /// Ensures only one keychain lookup runs per browser service at a time.
+  func password(for service: String, loader: () -> String?) -> String? {
+    loop: while true {
+      lock.lock()
 
-  func set(_ service: String, password: String) {
-    lock.lock()
-    defer { lock.unlock() }
-    cache[service] = password
-  }
+      if let cached = cache[service] {
+        lock.unlock()
+        return cached.isEmpty ? nil : cached
+      }
 
-  /// Returns true if we already tried and failed for this service
-  func hasAttempted(_ service: String) -> Bool {
-    lock.lock()
-    defer { lock.unlock() }
-    return cache.keys.contains(service)
-  }
+      if let group = inFlight[service] {
+        lock.unlock()
+        group.wait()
+        continue loop
+      }
 
-  func markFailed(_ service: String) {
-    lock.lock()
-    defer { lock.unlock() }
-    cache[service] = ""
+      let group = DispatchGroup()
+      group.enter()
+      inFlight[service] = group
+      lock.unlock()
+
+      let password = loader()
+
+      lock.lock()
+      cache[service] = password ?? ""
+      let completedGroup = inFlight.removeValue(forKey: service)
+      lock.unlock()
+
+      completedGroup?.leave()
+      return password
+    }
   }
 }
 
@@ -106,14 +115,18 @@ actor GmailReaderService {
   /// - Parameters:
   ///   - maxResults: Maximum number of emails to return
   ///   - query: Gmail search query (default: "newer_than:1d"). For onboarding use "newer_than:30d".
-  func readRecentEmails(maxResults: Int = 50, query: String = "newer_than:1d") async throws -> [GmailEmail] {
+  func readRecentEmails(maxResults: Int = 50, query: String = "newer_than:1d") async throws
+    -> [GmailEmail]
+  {
     let emails = try fetchGmailViaAtomFeed(maxResults: maxResults, query: query)
     return emails.sorted { $0.date > $1.date }
   }
 
   /// Synthesize profile memories and tasks from a batch of emails.
   /// Uses an LLM call to extract ~10 memories and 2-3 tasks.
-  func synthesizeFromEmails(emails: [GmailEmail]) async -> (memories: Int, tasks: Int, profileSummary: String) {
+  func synthesizeFromEmails(emails: [GmailEmail]) async -> (
+    memories: Int, tasks: Int, profileSummary: String
+  ) {
     guard !emails.isEmpty else { return (0, 0, "") }
 
     // Format emails compactly for the LLM
@@ -123,37 +136,38 @@ actor GmailReaderService {
     for email in emails {
       let date = dateFormatter.string(from: email.date)
       let sender =
-        email.from.components(separatedBy: "<").first?.trimmingCharacters(in: .whitespaces) ?? email.from
+        email.from.components(separatedBy: "<").first?.trimmingCharacters(in: .whitespaces)
+        ?? email.from
       emailLines.append("[\(date)] From: \(sender) | Subject: \(email.subject) | \(email.snippet)")
     }
     let emailText = emailLines.joined(separator: "\n")
 
     let synthesisPrompt = """
-    Analyze these \(emails.count) recent emails and extract profile information about the user.
+      Analyze these \(emails.count) recent emails and extract profile information about the user.
 
-    EMAILS:
-    \(emailText)
+      EMAILS:
+      \(emailText)
 
-    Respond ONLY with valid JSON (no markdown, no code fences, no backticks):
-    {
-      "memories": [
-        "factual statement about the user based on email patterns"
-      ],
-      "tasks": [
-        {"description": "actionable follow-up item", "priority": "high"}
-      ],
-      "profile": "2-3 sentence summary of who this user is"
-    }
+      Respond ONLY with valid JSON (no markdown, no code fences, no backticks):
+      {
+        "memories": [
+          "factual statement about the user based on email patterns"
+        ],
+        "tasks": [
+          {"description": "actionable follow-up item", "priority": "high"}
+        ],
+        "profile": "2-3 sentence summary of who this user is"
+      }
 
-    RULES:
-    - Extract exactly 10 memories (facts about their role, company, projects, relationships, interests, tools, communication patterns)
-    - Extract 2-3 tasks (pending replies, upcoming deadlines, things to follow up on)
-    - Each memory should be a single clear factual statement
-    - Task priorities: "high", "medium", or "low"
-    - Profile should summarize professional identity and key interests
-    - Do NOT include raw email content — synthesize and generalize
-    - Output ONLY the JSON object, nothing else
-    """
+      RULES:
+      - Extract exactly 10 memories (facts about their role, company, projects, relationships, interests, tools, communication patterns)
+      - Extract 2-3 tasks (pending replies, upcoming deadlines, things to follow up on)
+      - Each memory should be a single clear factual statement
+      - Task priorities: "high", "medium", or "low"
+      - Profile should summarize professional identity and key interests
+      - Do NOT include raw email content — synthesize and generalize
+      - Output ONLY the JSON object, nothing else
+      """
 
     do {
       let bridge = ACPBridge(passApiKey: true)
@@ -181,7 +195,8 @@ actor GmailReaderService {
         }
         // Remove closing fence
         if responseText.hasSuffix("```") {
-          responseText = String(responseText.dropLast(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+          responseText = String(responseText.dropLast(3)).trimmingCharacters(
+            in: .whitespacesAndNewlines)
         }
       }
 
@@ -272,7 +287,9 @@ actor GmailReaderService {
 
   // MARK: - All-in-one Python: decrypt cookies + fetch Atom feed + return JSON
 
-  private func fetchGmailViaAtomFeed(maxResults: Int, query: String = "newer_than:1d") throws -> [GmailEmail] {
+  private func fetchGmailViaAtomFeed(maxResults: Int, query: String = "newer_than:1d") throws
+    -> [GmailEmail]
+  {
     // Build browser configs as JSON for Python
     var browserConfigs: [[String: String]] = []
     for browser in BrowserConfig.allBrowsers() {
@@ -514,7 +531,8 @@ actor GmailReaderService {
     }
 
     let output = pipe.fileHandleForReading.readDataToEndOfFile()
-    let errOutput = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+    let errOutput =
+      String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
     if !errOutput.isEmpty {
       log("GmailReaderService: Python stderr: \(errOutput.prefix(500))")
     }
@@ -560,35 +578,25 @@ actor GmailReaderService {
   // MARK: - Keychain
 
   private func getKeychainPassword(service: String) -> String? {
-    // Check shared cache first to avoid duplicate keychain prompts
-    if let cached = BrowserKeychainCache.shared.get(service) {
-      return cached.isEmpty ? nil : cached
-    }
-    if BrowserKeychainCache.shared.hasAttempted(service) {
-      return nil
-    }
-
-    let query: [String: Any] = [
-      kSecClass as String: kSecClassGenericPassword,
-      kSecAttrService as String: service,
-      kSecReturnData as String: true,
-      kSecMatchLimit as String: kSecMatchLimitOne,
-    ]
-    var result: AnyObject?
-    let status = SecItemCopyMatching(query as CFDictionary, &result)
-    guard status == errSecSuccess, let data = result as? Data,
-      let password = String(data: data, encoding: .utf8)
-    else {
-      BrowserKeychainCache.shared.markFailed(service)
-      if status != errSecItemNotFound {
-        log("GmailReaderService: Keychain lookup for '\(service)' failed with status \(status)")
+    BrowserKeychainCache.shared.password(for: service) {
+      let query: [String: Any] = [
+        kSecClass as String: kSecClassGenericPassword,
+        kSecAttrService as String: service,
+        kSecReturnData as String: true,
+        kSecMatchLimit as String: kSecMatchLimitOne,
+      ]
+      var result: AnyObject?
+      let status = SecItemCopyMatching(query as CFDictionary, &result)
+      guard status == errSecSuccess, let data = result as? Data,
+        let password = String(data: data, encoding: .utf8)
+      else {
+        if status != errSecItemNotFound {
+          log("GmailReaderService: Keychain lookup for '\(service)' failed with status \(status)")
+        }
+        return nil
       }
-      return nil
+      return password.isEmpty ? nil : password
     }
-    if !password.isEmpty {
-      BrowserKeychainCache.shared.set(service, password: password)
-    }
-    return password.isEmpty ? nil : password
   }
 
   // MARK: - Date Parsing
@@ -601,7 +609,9 @@ actor GmailReaderService {
     iso.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     if let d = iso.date(from: str) { return d }
     // Fallback: RFC 2822
-    let formats = ["EEE, dd MMM yyyy HH:mm:ss Z", "dd MMM yyyy HH:mm:ss Z", "yyyy-MM-dd'T'HH:mm:ssZ"]
+    let formats = [
+      "EEE, dd MMM yyyy HH:mm:ss Z", "dd MMM yyyy HH:mm:ss Z", "yyyy-MM-dd'T'HH:mm:ssZ",
+    ]
     for fmt in formats {
       let f = DateFormatter()
       f.dateFormat = fmt

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -378,7 +378,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
       AuthService.shared.fetchConversations()
 
       // Fetch API keys from backend (keys are not bundled in the app)
-      APIKeyService.shared.fetchTask = Task { await APIKeyService.shared.fetchKeys() }
+      APIKeyService.shared.startFetchingKeys()
 
       // Check tier eligibility (at most once per day)
       Task {

--- a/desktop/Desktop/Sources/OnboardingFileScanStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingFileScanStepView.swift
@@ -1,0 +1,100 @@
+import SwiftUI
+
+struct OnboardingFileScanStepView: View {
+  @ObservedObject var appState: AppState
+  @ObservedObject var coordinator: OnboardingPagedIntroCoordinator
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+  let stepIndex: Int
+  let totalSteps: Int
+  let onContinue: () -> Void
+  let onSkip: () -> Void
+
+  var body: some View {
+    OnboardingStepScaffold(
+      graphViewModel: graphViewModel,
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      eyebrow: "Discovery",
+      title: "Map your work once.",
+      description: "Omi scans projects and recent files.",
+      showsSkip: true,
+      onSkip: onSkip
+    ) {
+      VStack(alignment: .leading, spacing: 24) {
+        ZStack {
+          RoundedRectangle(cornerRadius: 28, style: .continuous)
+            .fill(OmiColors.backgroundSecondary)
+            .overlay(
+              RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .stroke(Color.white.opacity(0.08), lineWidth: 1)
+            )
+
+          VStack(spacing: 20) {
+            OnboardingLoadingAnimation(progress: scanProgress)
+              .frame(height: 160)
+
+            Text(coordinator.scanStatusText)
+              .font(.system(size: 18, weight: .semibold))
+              .foregroundColor(OmiColors.textPrimary)
+
+            if let snapshot = coordinator.scanSnapshot {
+              Text("\(snapshot.fileCount.formatted()) files indexed")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(OmiColors.textTertiary)
+                .monospacedDigit()
+            } else {
+              Text("Your graph and suggestions will build from this scan.")
+                .font(.system(size: 13))
+                .foregroundColor(OmiColors.textTertiary)
+            }
+          }
+          .padding(28)
+        }
+        .frame(maxWidth: 560, maxHeight: 280)
+
+        if let snapshot = coordinator.scanSnapshot {
+          OnboardingInsightCard(
+            icon: "shippingbox.fill",
+            title: "Mapped",
+            detail: [
+              snapshot.projectNames.prefix(3).joined(separator: ", "),
+              snapshot.technologies.prefix(3).joined(separator: ", "),
+            ]
+            .filter { !$0.isEmpty }
+            .joined(separator: "  •  ")
+          )
+          .frame(maxWidth: 560)
+        }
+
+        if coordinator.scanSnapshot != nil {
+          Button("Continue") {
+            onContinue()
+          }
+          .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+        } else {
+          Text("Scanning your workspace…")
+            .font(.system(size: 13))
+            .foregroundColor(OmiColors.textTertiary)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .task {
+        await coordinator.startFileScanIfNeeded(appState: appState)
+        await graphViewModel.addGraphFromStorage()
+      }
+    }
+  }
+
+  private var scanProgress: Double {
+    switch coordinator.scanState {
+    case .idle:
+      return 0.12
+    case .scanning:
+      return coordinator.scanSnapshot == nil ? 0.55 : 0.82
+    case .complete:
+      return 1
+    case .failed:
+      return 0.2
+    }
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingFlow.swift
+++ b/desktop/Desktop/Sources/OnboardingFlow.swift
@@ -1,7 +1,27 @@
 import Foundation
 
 enum OnboardingFlow {
-  static let steps = ["Chat", "FloatingBarShortcut", "FloatingBar", "VoiceShortcut", "VoiceDemo", "Tasks"]
+  static let steps = [
+    "Trust",
+    "Name",
+    "Language",
+    "FullDiskAccess",
+    "FileScan",
+    "Microphone",
+    "Notifications",
+    "Accessibility",
+    "Automation",
+    "Research",
+    "ScreenRecording",
+    "Goal",
+    "FloatingBarShortcut",
+    "FloatingBar",
+    "VoiceShortcut",
+    "VoiceDemo",
+    "Tasks",
+  ]
+  static let introStepCount = 12
+  static let legacyPostIntroOffset = 11
   static let lastStepIndex = steps.count - 1
 
   static func migratedStep(
@@ -10,7 +30,8 @@ enum OnboardingFlow {
     hasInsertedVoiceShortcutStep: Bool,
     hasMergedVoiceInputStep: Bool,
     hasRemovedNotificationStep: Bool,
-    hasInsertedFloatingBarShortcutStep: Bool
+    hasInsertedFloatingBarShortcutStep: Bool,
+    hasMigratedPagedIntro: Bool
   ) -> Int {
     var migratedStep = currentStep
 
@@ -34,6 +55,10 @@ enum OnboardingFlow {
     // FloatingBarShortcut step inserted at index 1; shift users at 1+ up
     if !hasInsertedFloatingBarShortcutStep, migratedStep >= 1 {
       migratedStep += 1
+    }
+
+    if !hasMigratedPagedIntro, migratedStep > 0 {
+      migratedStep += legacyPostIntroOffset
     }
 
     return min(max(0, migratedStep), lastStepIndex)

--- a/desktop/Desktop/Sources/OnboardingGoalStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingGoalStepView.swift
@@ -1,0 +1,136 @@
+import SwiftUI
+
+struct OnboardingGoalStepView: View {
+  @ObservedObject var appState: AppState
+  @ObservedObject var coordinator: OnboardingPagedIntroCoordinator
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+  let stepIndex: Int
+  let totalSteps: Int
+  let onContinue: () -> Void
+
+  @State private var customGoalSelected = false
+
+  private static let customGoalOption = "Type my own"
+
+  var body: some View {
+    OnboardingStepScaffold(
+      graphViewModel: graphViewModel,
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      eyebrow: "Goal",
+      title: "Pick one goal.",
+      description: "Omi will optimize for this first."
+    ) {
+      VStack(alignment: .leading, spacing: 18) {
+        GoalChipGrid(
+          items: suggestionItems,
+          selectedItem: selectedSuggestion,
+          onSelect: { suggestion in
+            if suggestion == Self.customGoalOption {
+              customGoalSelected = true
+              coordinator.goalDraft = ""
+            } else {
+              customGoalSelected = false
+              coordinator.goalDraft = suggestion
+              coordinator.clearLastActionError()
+            }
+          }
+        )
+        .frame(maxWidth: 560, alignment: .leading)
+
+        if customGoalSelected {
+          TextField("Type your goal", text: $coordinator.goalDraft)
+            .textFieldStyle(.plain)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .background(
+              RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(OmiColors.backgroundSecondary)
+                .overlay(
+                  RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                )
+            )
+            .foregroundColor(OmiColors.textPrimary)
+            .frame(maxWidth: 560)
+        }
+
+        if let error = coordinator.lastActionError {
+          Text(error)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(OmiColors.warning)
+        }
+
+        Button(coordinator.isSavingGoal ? "Saving…" : "Continue") {
+          Task {
+            coordinator.goalSaved = false
+            await coordinator.saveGoalIfNeeded()
+            guard coordinator.goalSaved else { return }
+            let completed = await coordinator.completeIntro(appState: appState)
+            if completed {
+              onContinue()
+            }
+          }
+        }
+        .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+        .disabled(coordinator.isSavingGoal || trimmedGoal.isEmpty)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .onAppear {
+        customGoalSelected =
+          !coordinator.goalDraft.isEmpty && !baseSuggestions.contains(coordinator.goalDraft)
+      }
+    }
+  }
+
+  private var baseSuggestions: [String] {
+    coordinator.goalSuggestionCards().filter { $0 != "I’ll type my own" }
+  }
+
+  private var suggestionItems: [String] {
+    Array(baseSuggestions.prefix(4)) + [Self.customGoalOption]
+  }
+
+  private var selectedSuggestion: String? {
+    if customGoalSelected {
+      return Self.customGoalOption
+    }
+    return suggestionItems.contains(coordinator.goalDraft) ? coordinator.goalDraft : nil
+  }
+
+  private var trimmedGoal: String {
+    coordinator.goalDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}
+
+private struct GoalChipGrid: View {
+  let items: [String]
+  let selectedItem: String?
+  let onSelect: (String) -> Void
+
+  var body: some View {
+    LazyVGrid(columns: [GridItem(.adaptive(minimum: 180), spacing: 10)], spacing: 10) {
+      ForEach(items, id: \.self) { item in
+        let isSelected = selectedItem == item
+
+        Button(action: { onSelect(item) }) {
+          Text(item)
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundColor(isSelected ? .white : OmiColors.textSecondary)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .background(
+              RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(isSelected ? OmiColors.purplePrimary : Color.white.opacity(0.05))
+                .overlay(
+                  RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .stroke(Color.white.opacity(isSelected ? 0 : 0.08), lineWidth: 1)
+                )
+            )
+        }
+        .buttonStyle(.plain)
+      }
+    }
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingLanguageStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingLanguageStepView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+
+struct OnboardingLanguageStepView: View {
+  @ObservedObject var coordinator: OnboardingPagedIntroCoordinator
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+  let stepIndex: Int
+  let totalSteps: Int
+  let onContinue: () -> Void
+
+  @State private var showingCustomLanguage = false
+
+  var body: some View {
+    OnboardingStepScaffold(
+      graphViewModel: graphViewModel,
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      eyebrow: "Language",
+      title: "Pick your language.",
+      description: "Omi will use it for prompts and transcripts."
+    ) {
+      VStack(alignment: .leading, spacing: 18) {
+        HStack(spacing: 12) {
+          OnboardingSelectableChip(
+            title: "English",
+            isSelected: coordinator.selectedLanguageCode == "en"
+          ) {
+            showingCustomLanguage = false
+            Task {
+              await coordinator.selectEnglish()
+              if coordinator.lastActionError == nil {
+                onContinue()
+              }
+            }
+          }
+
+          OnboardingSelectableChip(
+            title: "Other",
+            isSelected: showingCustomLanguage && coordinator.selectedLanguageCode != "en"
+          ) {
+            showingCustomLanguage = true
+          }
+        }
+
+        if showingCustomLanguage {
+          VStack(alignment: .leading, spacing: 12) {
+            TextField("Spanish, Portuguese, Japanese…", text: $coordinator.customLanguage)
+              .textFieldStyle(.plain)
+              .padding(.horizontal, 16)
+              .padding(.vertical, 14)
+              .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                  .fill(OmiColors.backgroundSecondary)
+                  .overlay(
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                      .stroke(Color.white.opacity(0.08), lineWidth: 1)
+                  )
+              )
+              .foregroundColor(OmiColors.textPrimary)
+
+            Button("Save language") {
+              Task {
+                await coordinator.setCustomLanguage()
+                if coordinator.lastActionError == nil {
+                  onContinue()
+                }
+              }
+            }
+            .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          }
+        }
+
+        if let error = coordinator.lastActionError {
+          Text(error)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(OmiColors.warning)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+    }
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -1,0 +1,907 @@
+import Foundation
+import GRDB
+import SwiftUI
+
+@MainActor
+final class OnboardingPagedIntroCoordinator: ObservableObject {
+  struct ScanSnapshot {
+    let fileCount: Int
+    let projectNames: [String]
+    let applications: [String]
+    let technologies: [String]
+    let recentFiles: [String]
+  }
+
+  enum ScanState: Equatable {
+    case idle
+    case scanning
+    case complete
+    case failed(String)
+  }
+
+  private struct EnrichmentEntity {
+    let label: String
+    let nodeType: String
+    let relation: String
+  }
+
+  private struct EnrichmentAnalysis {
+    let summary: String
+    let entities: [EnrichmentEntity]
+    let goals: [String]
+  }
+
+  @Published var preferredName: String
+  @Published var draftName: String
+  @Published var selectedLanguageCode: String
+  @Published var selectedLanguageLabel: String
+  @Published var customLanguage: String = ""
+  @Published var scanState: ScanState = .idle
+  @Published var scanStatusText: String = "Ready to scan your files."
+  @Published var scanSnapshot: ScanSnapshot?
+  @Published var emailSummary: String = ""
+  @Published var calendarSummary: String = ""
+  @Published var webResearchSummary: String = ""
+  @Published var isLoadingInsights = false
+  @Published var insightStatusText: String = ""
+  @Published var isResearchComplete = false
+  @Published var goalDraft: String = ""
+  @Published var suggestedGoals: [String] = []
+  @Published var goalSaved = OnboardingChatPersistence.isGoalCompleted
+  @Published var isSavingGoal = false
+  @Published var lastActionError: String?
+
+  private var insightsStarted = false
+  private var gmailInsightsFinished = false
+  private var calendarInsightsFinished = false
+  private var gmailTask: Task<Void, Never>?
+  private var calendarTask: Task<Void, Never>?
+  private var webResearchTask: Task<Void, Never>?
+
+  init() {
+    let givenName = AuthService.shared.givenName.trimmingCharacters(in: .whitespacesAndNewlines)
+    let displayName = AuthService.shared.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+    let initialName = givenName.isEmpty ? (displayName.isEmpty ? "there" : displayName) : givenName
+
+    preferredName = initialName
+    draftName = initialName
+
+    let languageCode = AssistantSettings.shared.transcriptionLanguage
+    selectedLanguageCode = languageCode
+    selectedLanguageLabel = Self.displayName(forLanguageCode: languageCode)
+  }
+
+  deinit {
+    gmailTask?.cancel()
+    calendarTask?.cancel()
+    webResearchTask?.cancel()
+  }
+
+  func prepare(appState: AppState) {
+    ChatToolExecutor.onboardingAppState = appState
+    OnboardingChatPersistence.saveMidOnboarding()
+    appState.checkAllPermissions()
+
+    if scanSnapshot == nil {
+      Task { await refreshSnapshotIfAvailable() }
+    }
+  }
+
+  func refreshPermissions(appState: AppState) {
+    ChatToolExecutor.onboardingAppState = appState
+    appState.checkAllPermissions()
+  }
+
+  func clearLastActionError() {
+    lastActionError = nil
+  }
+
+  func userEmail() -> String? {
+    AuthState.shared.userEmail
+  }
+
+  func confirmPreferredName() async {
+    lastActionError = nil
+    let trimmed = draftName.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      lastActionError = "Pick a name first."
+      return
+    }
+
+    if trimmed != AuthService.shared.givenName, trimmed != AuthService.shared.displayName {
+      let result = await executeTool(name: "set_user_preferences", arguments: ["name": trimmed])
+      if result.lowercased().contains("error") {
+        lastActionError = result
+        return
+      }
+    }
+
+    preferredName = trimmed
+    await saveGraph(
+      nodes: [
+        [
+          "id": "user", "label": trimmed, "node_type": "person",
+          "aliases": [AuthService.shared.displayName],
+        ]
+      ],
+      edges: []
+    )
+  }
+
+  func selectEnglish() async {
+    await setLanguage(code: "en", label: "English")
+  }
+
+  func setCustomLanguage() async {
+    let trimmed = customLanguage.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      lastActionError = "Add a language first."
+      return
+    }
+
+    let normalizedCode =
+      Locale.availableIdentifiers
+      .compactMap { Locale(identifier: $0) }
+      .first(where: { locale in
+        locale.localizedString(forIdentifier: locale.identifier)?
+          .localizedCaseInsensitiveContains(trimmed) == true
+          || locale.localizedString(
+            forLanguageCode: locale.language.languageCode?.identifier ?? "")?
+            .localizedCaseInsensitiveContains(trimmed) == true
+      })?
+      .language
+      .languageCode?
+      .identifier ?? trimmed.lowercased()
+
+    await setLanguage(code: normalizedCode, label: trimmed.capitalized)
+  }
+
+  private func setLanguage(code: String, label: String) async {
+    lastActionError = nil
+    let result = await executeTool(name: "set_user_preferences", arguments: ["language": code])
+    if result.lowercased().contains("error") {
+      lastActionError = result
+      return
+    }
+
+    selectedLanguageCode = code
+    selectedLanguageLabel = label
+
+    await saveGraph(
+      nodes: [
+        ["id": "language_\(code)", "label": label, "node_type": "concept", "aliases": [code]]
+      ],
+      edges: [
+        ["source_id": "user", "target_id": "language_\(code)", "label": "prefers"]
+      ]
+    )
+  }
+
+  func requestPermission(_ type: String, appState: AppState) async -> Bool {
+    lastActionError = nil
+    ChatToolExecutor.onboardingAppState = appState
+
+    let result = await executeTool(name: "request_permission", arguments: ["type": type])
+    refreshPermissions(appState: appState)
+
+    if result.contains("move omi to /Applications first") {
+      lastActionError = result
+    }
+
+    return isPermissionGranted(type, appState: appState)
+  }
+
+  func isPermissionGranted(_ type: String, appState: AppState) -> Bool {
+    switch type {
+    case "full_disk_access":
+      return appState.hasFullDiskAccess
+    case "microphone":
+      return appState.hasMicrophonePermission
+    case "notifications":
+      return appState.hasNotificationPermission
+    case "accessibility":
+      return appState.hasAccessibilityPermission && !appState.isAccessibilityBroken
+    case "automation":
+      return appState.hasAutomationPermission
+    case "screen_recording":
+      return appState.hasScreenRecordingPermission
+    default:
+      return false
+    }
+  }
+
+  func startFileScanIfNeeded(appState: AppState) async {
+    guard case .idle = scanState else { return }
+    lastActionError = nil
+    ChatToolExecutor.onboardingAppState = appState
+    scanState = .scanning
+    scanStatusText = "Scanning your projects and apps..."
+
+    let result = await executeTool(name: "scan_files", arguments: [:])
+    if result.lowercased().hasPrefix("error") {
+      scanState = .failed(result)
+      lastActionError = result
+      return
+    }
+
+    await refreshSnapshotIfAvailable()
+    scanState = .complete
+    scanStatusText = "Your workspace is mapped."
+    await startBackgroundInsightsIfNeeded()
+  }
+
+  func refreshSnapshotIfAvailable() async {
+    guard let dbQueue = await RewindDatabase.shared.getDatabaseQueue() else { return }
+
+    do {
+      let snapshot = try await dbQueue.read { db in
+        let total = try Int.fetchOne(db, sql: "SELECT COUNT(*) FROM indexed_files") ?? 0
+        guard total > 0 else { return ScanSnapshot?(nil) }
+
+        let projectIndicators = try Row.fetchAll(
+          db,
+          sql: """
+              SELECT path
+              FROM indexed_files
+              WHERE filename IN ('package.json', 'Cargo.toml', 'Podfile', 'go.mod',
+                'requirements.txt', 'Pipfile', 'setup.py', 'pyproject.toml',
+                'build.gradle', 'pom.xml', 'CMakeLists.txt', 'Makefile',
+                'Package.swift', 'Gemfile', 'composer.json', 'mix.exs', 'pubspec.yaml')
+              LIMIT 12
+            """)
+
+        let apps = try Row.fetchAll(
+          db,
+          sql: """
+              SELECT filename
+              FROM indexed_files
+              WHERE folder = '/Applications' AND fileExtension = 'app'
+              ORDER BY filename
+              LIMIT 8
+            """)
+
+        let recentFiles = try Row.fetchAll(
+          db,
+          sql: """
+              SELECT filename
+              FROM indexed_files
+              ORDER BY modifiedAt DESC
+              LIMIT 6
+            """)
+
+        let extensions = try Row.fetchAll(
+          db,
+          sql: """
+              SELECT fileExtension, COUNT(*) as count
+              FROM indexed_files
+              WHERE fileExtension IS NOT NULL AND fileExtension != ''
+              GROUP BY fileExtension
+              ORDER BY count DESC
+              LIMIT 12
+            """)
+
+        let projects = projectIndicators.compactMap { row -> String? in
+          guard let path = row["path"] as? String else { return nil }
+          let directory = (path as NSString).deletingLastPathComponent
+          let projectName = (directory as NSString).lastPathComponent
+          return projectName.isEmpty ? nil : projectName
+        }
+
+        let technologies =
+          extensions
+          .compactMap { row -> String? in
+            guard let raw = row["fileExtension"] as? String else { return nil }
+            return Self.technologyName(forFileExtension: raw)
+          }
+
+        return ScanSnapshot(
+          fileCount: total,
+          projectNames: Array(Set(projects)).sorted().prefix(6).map(\.self),
+          applications: apps.compactMap {
+            ($0["filename"] as? String)?.replacingOccurrences(of: ".app", with: "")
+          },
+          technologies: Array(Set(technologies)).sorted().prefix(6).map(\.self),
+          recentFiles: recentFiles.compactMap { $0["filename"] as? String }
+        )
+      }
+
+      guard let snapshot else { return }
+      scanSnapshot = snapshot
+      suggestedGoals = buildSuggestedGoals(from: snapshot)
+
+      var nodes: [[String: Any]] = []
+      var edges: [[String: Any]] = []
+
+      for project in snapshot.projectNames.prefix(4) {
+        let id = "project_\(slug(project))"
+        nodes.append(["id": id, "label": project, "node_type": "thing", "aliases": []])
+        edges.append(["source_id": "user", "target_id": id, "label": "works_on"])
+      }
+
+      for tech in snapshot.technologies.prefix(4) {
+        let id = "tech_\(slug(tech))"
+        nodes.append(["id": id, "label": tech, "node_type": "thing", "aliases": []])
+        edges.append(["source_id": "user", "target_id": id, "label": "uses"])
+      }
+
+      for application in snapshot.applications.prefix(3) {
+        let id = "app_\(slug(application))"
+        nodes.append(["id": id, "label": application, "node_type": "thing", "aliases": []])
+        edges.append(["source_id": "user", "target_id": id, "label": "opens"])
+      }
+
+      if !nodes.isEmpty {
+        await saveGraph(nodes: nodes, edges: edges)
+      }
+    } catch {
+      logError("OnboardingPagedIntroCoordinator: Failed to load scan snapshot", error: error)
+    }
+  }
+
+  func startBackgroundInsightsIfNeeded() async {
+    guard !insightsStarted else { return }
+    insightsStarted = true
+    isLoadingInsights = true
+    isResearchComplete = false
+    insightStatusText = "Reading Gmail and calendar..."
+    gmailInsightsFinished = false
+    calendarInsightsFinished = false
+    webResearchSummary = ""
+
+    gmailTask = Task {
+      do {
+        let emails = try await GmailReaderService.shared.readRecentEmails(
+          maxResults: 50,
+          query: "newer_than:30d"
+        )
+        guard !Task.isCancelled else { return }
+
+        if emails.isEmpty {
+          await MainActor.run {
+            self.emailSummary = ""
+            ChatToolExecutor.emailInsightsText = nil
+          }
+          await self.markInsightFinished(.gmail)
+          return
+        }
+
+        let result = await GmailReaderService.shared.synthesizeFromEmails(emails: emails)
+        guard !Task.isCancelled else { return }
+
+        let summary =
+          result.profileSummary.isEmpty
+          ? "Your email suggests active follow-ups and recurring projects."
+          : result.profileSummary
+
+        await self.saveGraph(
+          nodes: [
+            ["id": "integration_gmail", "label": "Gmail", "node_type": "thing", "aliases": []]
+          ],
+          edges: [
+            ["source_id": "user", "target_id": "integration_gmail", "label": "checks"]
+          ]
+        )
+
+        await MainActor.run {
+          self.emailSummary = summary
+          ChatToolExecutor.emailInsightsText = summary
+          self.suggestedGoals = self.buildSuggestedGoals(
+            from: self.scanSnapshot, email: summary, calendar: self.calendarSummary)
+        }
+        await self.markInsightFinished(.gmail)
+      } catch {
+        log(
+          "OnboardingPagedIntroCoordinator: Gmail insights unavailable: \(error.localizedDescription)"
+        )
+        await self.markInsightFinished(.gmail)
+      }
+    }
+
+    calendarTask = Task {
+      do {
+        let events = try await CalendarReaderService.shared.readEvents(
+          daysBack: 90,
+          daysForward: 14,
+          maxResults: 200
+        )
+        guard !Task.isCancelled else { return }
+
+        if events.isEmpty {
+          await MainActor.run {
+            self.calendarSummary = ""
+            ChatToolExecutor.calendarInsightsText = nil
+          }
+          await self.markInsightFinished(.calendar)
+          return
+        }
+
+        let result = await CalendarReaderService.shared.synthesizeFromEvents(events: events)
+        guard !Task.isCancelled else { return }
+
+        let summary =
+          result.profileSummary.isEmpty
+          ? "Your calendar is busy enough that Omi can start surfacing deadlines and prep work."
+          : result.profileSummary
+
+        await self.saveGraph(
+          nodes: [
+            [
+              "id": "integration_calendar", "label": "Calendar", "node_type": "thing",
+              "aliases": [],
+            ]
+          ],
+          edges: [
+            ["source_id": "user", "target_id": "integration_calendar", "label": "plans_with"]
+          ]
+        )
+
+        await MainActor.run {
+          self.calendarSummary = summary
+          ChatToolExecutor.calendarInsightsText = summary
+          self.suggestedGoals = self.buildSuggestedGoals(
+            from: self.scanSnapshot, email: self.emailSummary, calendar: summary)
+        }
+        await self.markInsightFinished(.calendar)
+      } catch {
+        log(
+          "OnboardingPagedIntroCoordinator: Calendar insights unavailable: \(error.localizedDescription)"
+        )
+        await self.markInsightFinished(.calendar)
+      }
+    }
+  }
+
+  private enum InsightSource {
+    case gmail
+    case calendar
+  }
+
+  private func markInsightFinished(_ source: InsightSource) async {
+    switch source {
+    case .gmail:
+      gmailInsightsFinished = true
+    case .calendar:
+      calendarInsightsFinished = true
+    }
+
+    await maybeStartWebResearch()
+  }
+
+  private func maybeStartWebResearch() async {
+    guard gmailInsightsFinished && calendarInsightsFinished else { return }
+    guard webResearchTask == nil && !isResearchComplete else { return }
+
+    insightStatusText = "Searching the web..."
+
+    webResearchTask = Task {
+      let results = await OnboardingWebResearchService.shared.search(queries: buildWebQueries())
+      guard !Task.isCancelled else { return }
+
+      let analysis = await analyzeEnrichment(webResults: results)
+      guard !Task.isCancelled else { return }
+
+      if !analysis.entities.isEmpty {
+        let nodes = analysis.entities.map { entity in
+          [
+            "id": "insight_\(slug(entity.label))",
+            "label": entity.label,
+            "node_type": entity.nodeType,
+            "aliases": [],
+          ] as [String: Any]
+        }
+        let edges = analysis.entities.map { entity in
+          [
+            "source_id": "user",
+            "target_id": "insight_\(slug(entity.label))",
+            "label": entity.relation,
+          ] as [String: Any]
+        }
+        await saveGraph(nodes: nodes, edges: edges)
+      }
+
+      if !analysis.summary.isEmpty {
+        webResearchSummary = analysis.summary
+      }
+
+      if !analysis.goals.isEmpty {
+        suggestedGoals = Array(
+          NSOrderedSet(
+            array: analysis.goals + suggestedGoals.filter { $0 != "I’ll type my own" } + [
+              "I’ll type my own"
+            ]
+          ).array as? [String] ?? suggestedGoals
+        )
+      }
+
+      isLoadingInsights = false
+      isResearchComplete = true
+      insightStatusText = ""
+      webResearchTask = nil
+    }
+  }
+
+  private func analyzeEnrichment(
+    webResults: [OnboardingWebSearchResult]
+  ) async -> EnrichmentAnalysis {
+    let scanLines =
+      scanSnapshot.map { snapshot in
+        [
+          "Projects: \(snapshot.projectNames.joined(separator: ", "))",
+          "Applications: \(snapshot.applications.joined(separator: ", "))",
+          "Technologies: \(snapshot.technologies.joined(separator: ", "))",
+        ]
+        .filter { !$0.hasSuffix(": ") }
+        .joined(separator: "\n")
+      } ?? "No file scan context."
+
+    let webLines =
+      webResults.isEmpty
+      ? "No web search results."
+      : webResults.prefix(6).map { result in
+        "[\(result.query)] \(result.title) | \(result.snippet) | \(result.url)"
+      }.joined(separator: "\n")
+
+    let prompt = """
+      You are preparing a Mac app onboarding summary.
+
+      USER:
+      Name: \(preferredName)
+      Email: \(userEmail() ?? "unknown")
+
+      FILE SCAN:
+      \(scanLines)
+
+      EMAIL SUMMARY:
+      \(emailSummary.isEmpty ? "None" : emailSummary)
+
+      CALENDAR SUMMARY:
+      \(calendarSummary.isEmpty ? "None" : calendarSummary)
+
+      WEB RESULTS:
+      \(webLines)
+
+      Return ONLY valid JSON:
+      {
+        "summary": "1-2 sentence summary",
+        "entities": [
+          {"label": "entity name", "node_type": "organization", "relation": "works_with"}
+        ],
+        "goals": [
+          "specific goal suggestion"
+        ]
+      }
+
+      RULES:
+      - Use only facts grounded in the provided context
+      - entities: at most 6
+      - node_type must be one of: person, organization, place, thing, concept
+      - relation must connect the user to the entity, like works_on, uses, works_with, follows, plans_with, researches
+      - goals: at most 4, concrete and specific, not generic
+      - Prefer project names, organizations, tools, and recurring commitments
+      """
+
+    do {
+      let bridge = ACPBridge(passApiKey: true)
+      try await bridge.start()
+      defer { Task { await bridge.stop() } }
+
+      let result = try await bridge.query(
+        prompt: prompt,
+        systemPrompt:
+          "You are a structured onboarding research assistant. Output only valid JSON.",
+        model: "claude-opus-4-6",
+        onTextDelta: { @Sendable _ in },
+        onToolCall: { @Sendable _, _, _ in return "" },
+        onToolActivity: { @Sendable _, _, _, _ in }
+      )
+
+      let responseText = sanitizeJSONResponse(result.text)
+      guard
+        let data = responseText.data(using: .utf8),
+        let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+      else {
+        return EnrichmentAnalysis(summary: fallbackWebSummary(webResults), entities: [], goals: [])
+      }
+
+      let summary = parsed["summary"] as? String ?? fallbackWebSummary(webResults)
+      let rawEntities: [[String: Any]] = parsed["entities"] as? [[String: Any]] ?? []
+      let entities: [EnrichmentEntity] = rawEntities.compactMap { raw in
+        guard
+          let label = raw["label"] as? String,
+          let nodeType = raw["node_type"] as? String,
+          let relation = raw["relation"] as? String
+        else {
+          return nil
+        }
+        return EnrichmentEntity(label: label, nodeType: nodeType, relation: relation)
+      }
+      let goals = (parsed["goals"] as? [String] ?? []).filter {
+        !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+      }
+
+      return EnrichmentAnalysis(summary: summary, entities: entities, goals: goals)
+    } catch {
+      log(
+        "OnboardingPagedIntroCoordinator: Enrichment analysis failed: \(error.localizedDescription)"
+      )
+      return EnrichmentAnalysis(summary: fallbackWebSummary(webResults), entities: [], goals: [])
+    }
+  }
+
+  private func buildWebQueries() -> [String] {
+    var queries: [String] = []
+
+    if let organization = searchableOrganizationHint() {
+      queries.append("\(preferredName) \(organization)")
+    }
+
+    if let project = scanSnapshot?.projectNames.first, !project.isEmpty {
+      let projectQuery =
+        searchableOrganizationHint().map { "\($0) \(project)" } ?? "\(preferredName) \(project)"
+      queries.append(projectQuery)
+    } else if let technology = scanSnapshot?.technologies.first, !technology.isEmpty {
+      queries.append("\(preferredName) \(technology)")
+    }
+
+    return Array(NSOrderedSet(array: queries).array as? [String] ?? queries).prefix(2).map(\.self)
+  }
+
+  private func searchableOrganizationHint() -> String? {
+    guard let email = userEmail(), let domain = email.split(separator: "@").last?.lowercased()
+    else {
+      return nil
+    }
+
+    let publicDomains: Set<String> = [
+      "gmail.com", "googlemail.com", "icloud.com", "me.com", "mac.com", "yahoo.com",
+      "outlook.com", "hotmail.com", "live.com", "proton.me", "protonmail.com",
+    ]
+
+    guard !publicDomains.contains(domain) else { return nil }
+    return organizationHint()
+  }
+
+  private func fallbackWebSummary(_ webResults: [OnboardingWebSearchResult]) -> String {
+    guard let firstResult = webResults.first else { return "" }
+    if !firstResult.snippet.isEmpty {
+      return firstResult.snippet
+    }
+    return firstResult.title
+  }
+
+  private func sanitizeJSONResponse(_ text: String) -> String {
+    var responseText = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if responseText.hasPrefix("```") {
+      if let firstNewline = responseText.firstIndex(of: "\n") {
+        responseText = String(responseText[responseText.index(after: firstNewline)...])
+      }
+      if responseText.hasSuffix("```") {
+        responseText = String(responseText.dropLast(3)).trimmingCharacters(
+          in: .whitespacesAndNewlines)
+      }
+    }
+
+    if let braceIndex = responseText.firstIndex(of: "{") {
+      responseText = String(responseText[braceIndex...])
+    }
+
+    return responseText.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  func saveGoalIfNeeded() async {
+    let trimmed = goalDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else {
+      lastActionError = "Add a goal first."
+      return
+    }
+
+    guard !goalSaved else { return }
+
+    isSavingGoal = true
+    defer { isSavingGoal = false }
+    lastActionError = nil
+
+    let rawTitle = trimmed
+    let aiNormalized = await GoalsAIService.shared.normalizeOnboardingGoalInput(rawTitle)
+    let title = aiNormalized?.title ?? heuristicGoalTitle(rawTitle)
+    guard !title.isEmpty else {
+      lastActionError = "That goal needs a little more detail."
+      return
+    }
+
+    let config =
+      aiNormalized.map { (goalType: $0.goalType, targetValue: $0.targetValue, unit: $0.unit) }
+      ?? fallbackGoalConfig(from: title)
+
+    do {
+      let goal = try await APIClient.shared.createGoal(
+        title: title,
+        description: "Added from onboarding",
+        goalType: config.goalType,
+        targetValue: config.targetValue,
+        currentValue: 0,
+        unit: config.unit,
+        source: "onboarding_step_flow"
+      )
+      _ = try? await GoalStorage.shared.syncServerGoal(goal)
+
+      goalDraft = title
+      goalSaved = true
+      OnboardingChatPersistence.markGoalCompleted()
+
+      await saveGraph(
+        nodes: [
+          ["id": "goal_\(slug(title))", "label": title, "node_type": "concept", "aliases": []]
+        ],
+        edges: [
+          ["source_id": "user", "target_id": "goal_\(slug(title))", "label": "prioritizes"]
+        ]
+      )
+    } catch {
+      logError("OnboardingPagedIntroCoordinator: Failed to save onboarding goal", error: error)
+      lastActionError = error.localizedDescription
+    }
+  }
+
+  func completeIntro(appState: AppState) async -> Bool {
+    ChatToolExecutor.onboardingAppState = appState
+    let result = await executeTool(name: "complete_onboarding", arguments: [:])
+    if result.lowercased().contains("error") {
+      lastActionError = result
+      return false
+    }
+    return true
+  }
+
+  func goalSuggestionCards() -> [String] {
+    if !suggestedGoals.isEmpty {
+      return Array(suggestedGoals.prefix(4))
+    }
+
+    return [
+      "Finish my main launch",
+      "Ship the current desktop milestone",
+      "Protect more focus time this week",
+      "I’ll type my own",
+    ]
+  }
+
+  func organizationHint() -> String? {
+    guard let email = AuthState.shared.userEmail, let domain = email.split(separator: "@").last
+    else {
+      return nil
+    }
+    let cleaned = domain.replacingOccurrences(of: ".com", with: "")
+      .replacingOccurrences(of: ".io", with: "")
+      .replacingOccurrences(of: ".ai", with: "")
+      .replacingOccurrences(of: "-", with: " ")
+      .replacingOccurrences(of: ".", with: " ")
+      .capitalized
+    return cleaned.isEmpty ? nil : cleaned
+  }
+
+  private func buildSuggestedGoals(
+    from snapshot: ScanSnapshot?,
+    email: String = "",
+    calendar: String = ""
+  ) -> [String] {
+    var suggestions: [String] = []
+
+    if let snapshot {
+      for project in snapshot.projectNames.prefix(2) {
+        suggestions.append("Ship \(project)")
+      }
+      if let technology = snapshot.technologies.first {
+        suggestions.append("Make faster progress in \(technology)")
+      }
+    }
+
+    if !email.isEmpty {
+      suggestions.append("Stay ahead of important follow-ups")
+    }
+
+    if !calendar.isEmpty {
+      suggestions.append("Create more focus time between meetings")
+    }
+
+    suggestions.append("I’ll type my own")
+    return Array(NSOrderedSet(array: suggestions).array as? [String] ?? suggestions)
+  }
+
+  private func executeTool(name: String, arguments: [String: Any]) async -> String {
+    await ChatToolExecutor.execute(
+      ToolCall(name: name, arguments: arguments, thoughtSignature: nil)
+    )
+  }
+
+  private func saveGraph(nodes: [[String: Any]], edges: [[String: Any]]) async {
+    guard !nodes.isEmpty else { return }
+    _ = await executeTool(
+      name: "save_knowledge_graph",
+      arguments: ["nodes": nodes, "edges": edges]
+    )
+  }
+
+  private func heuristicGoalTitle(_ text: String) -> String {
+    var cleaned = text.trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "\n", with: " ")
+    let lower = cleaned.lowercased()
+    let prefixes = [
+      "my goal is ",
+      "goal is ",
+      "my goal: ",
+      "goal: ",
+      "i want to ",
+      "i wanna ",
+      "i need to ",
+      "i will ",
+      "i'm going to ",
+    ]
+    for prefix in prefixes where lower.hasPrefix(prefix) {
+      cleaned = String(cleaned.dropFirst(prefix.count))
+      break
+    }
+    return cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private func fallbackGoalConfig(from title: String) -> (
+    goalType: GoalType, targetValue: Double, unit: String?
+  ) {
+    let lower = title.lowercased()
+    let pattern =
+      #"\b(\d+(?:\.\d+)?)\s*(k|m|b)?\s*(users?|customers?|clients?|sales?|revenue|downloads?)?\b"#
+    if let regex = try? NSRegularExpression(pattern: pattern, options: .caseInsensitive),
+      let match = regex.firstMatch(in: lower, range: NSRange(lower.startIndex..., in: lower))
+    {
+      let numberRange = match.range(at: 1)
+      let suffixRange = match.range(at: 2)
+      let unitRange = match.range(at: 3)
+      if let numberSwiftRange = Range(numberRange, in: lower),
+        let baseNumber = Double(lower[numberSwiftRange])
+      {
+        var multiplier = 1.0
+        if let suffixSwiftRange = Range(suffixRange, in: lower) {
+          switch lower[suffixSwiftRange] {
+          case "k": multiplier = 1_000
+          case "m": multiplier = 1_000_000
+          case "b": multiplier = 1_000_000_000
+          default: break
+          }
+        }
+        let unit: String? = Range(unitRange, in: lower).map { String(lower[$0]) }
+        return (.numeric, max(baseNumber * multiplier, 1), unit)
+      }
+    }
+
+    return (.boolean, 1, nil)
+  }
+
+  nonisolated private static func displayName(forLanguageCode code: String) -> String {
+    Locale.current.localizedString(forLanguageCode: code)?.capitalized ?? code.uppercased()
+  }
+
+  nonisolated private static func technologyName(forFileExtension raw: String) -> String? {
+    switch raw.lowercased() {
+    case "swift": return "Swift"
+    case "dart": return "Flutter"
+    case "ts", "tsx": return "TypeScript"
+    case "js", "jsx": return "JavaScript"
+    case "py": return "Python"
+    case "rs": return "Rust"
+    case "go": return "Go"
+    case "kt": return "Kotlin"
+    case "java": return "Java"
+    case "rb": return "Ruby"
+    case "mdx": return "Mintlify"
+    default: return nil
+    }
+  }
+
+  private func slug(_ value: String) -> String {
+    value
+      .lowercased()
+      .replacingOccurrences(of: "[^a-z0-9]+", with: "_", options: .regularExpression)
+      .trimmingCharacters(in: CharacterSet(charactersIn: "_"))
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingPermissionStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingPermissionStepView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+struct OnboardingPermissionStepView: View {
+  @Environment(\.scenePhase) private var scenePhase
+
+  @ObservedObject var appState: AppState
+  @ObservedObject var coordinator: OnboardingPagedIntroCoordinator
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+
+  let stepIndex: Int
+  let totalSteps: Int
+  let eyebrow: String
+  let title: String
+  let description: String
+  let permissionType: String
+  let icon: String
+  let reasonTitle: String
+  let reasonDetail: String
+  let primaryActionLabel: String
+  let requiresRestart: Bool
+  let onContinue: () -> Void
+  let onSkip: () -> Void
+
+  @State private var isRequesting = false
+  @State private var hasAutoAdvanced = false
+  @State private var advanceTask: Task<Void, Never>?
+  @State private var screenRecordingRefreshTask: Task<Void, Never>?
+  private let timer = Timer.publish(every: 1.0, on: .main, in: .common).autoconnect()
+
+  var body: some View {
+    OnboardingStepScaffold(
+      graphViewModel: graphViewModel,
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      eyebrow: eyebrow,
+      title: title,
+      description: description,
+      showsSkip: true,
+      onSkip: onSkip
+    ) {
+      VStack(alignment: .leading, spacing: 20) {
+        VStack(alignment: .leading, spacing: 18) {
+          HStack(spacing: 14) {
+            ZStack {
+              RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .fill(OmiColors.backgroundSecondary)
+                .frame(width: 58, height: 58)
+
+              Image(systemName: icon)
+                .font(.system(size: 24, weight: .semibold))
+                .foregroundColor(OmiColors.purplePrimary)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+              Text(reasonTitle)
+                .font(.system(size: 18, weight: .semibold))
+                .foregroundColor(OmiColors.textPrimary)
+
+              Text(statusText)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(isGranted ? OmiColors.success : OmiColors.textTertiary)
+            }
+
+            Spacer()
+          }
+
+          Text(reasonDetail)
+            .font(.system(size: 14))
+            .foregroundColor(OmiColors.textSecondary)
+            .lineSpacing(4)
+
+          if permissionType == "full_disk_access", let email = coordinator.userEmail() {
+            Text(email)
+              .font(.system(size: 13, weight: .medium))
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          if requiresRestart {
+            Text("macOS may relaunch Omi here. This flow will resume on the same step.")
+              .font(.system(size: 13, weight: .medium))
+              .foregroundColor(OmiColors.textTertiary)
+          }
+
+          if let error = coordinator.lastActionError, !isGranted {
+            Text(error)
+              .font(.system(size: 12, weight: .medium))
+              .foregroundColor(OmiColors.warning)
+          }
+        }
+        .frame(maxWidth: 540, alignment: .leading)
+
+        if isGranted {
+          Text("Permission granted. Continuing…")
+            .font(.system(size: 13, weight: .medium))
+            .foregroundColor(OmiColors.textTertiary)
+        } else {
+          Button(isRequesting ? "Waiting for macOS…" : primaryActionLabel) {
+            Task {
+              isRequesting = true
+              _ = await coordinator.requestPermission(permissionType, appState: appState)
+              isRequesting = false
+              refreshPermissionState()
+              if isGranted {
+                scheduleAutoAdvance()
+              }
+            }
+          }
+          .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          .disabled(isRequesting)
+
+          Text("This page advances automatically as soon as macOS confirms the change.")
+            .font(.system(size: 13))
+            .foregroundColor(OmiColors.textTertiary)
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .onReceive(timer) { _ in
+        refreshPermissionState()
+        if isGranted {
+          scheduleAutoAdvance()
+        }
+      }
+      .onChange(of: scenePhase) { _, newPhase in
+        guard newPhase == .active else { return }
+        refreshPermissionState()
+      }
+      .onChange(of: isGranted) { _, granted in
+        if granted {
+          scheduleAutoAdvance()
+        }
+      }
+      .onDisappear {
+        advanceTask?.cancel()
+        screenRecordingRefreshTask?.cancel()
+      }
+      .onAppear {
+        hasAutoAdvanced = false
+        advanceTask?.cancel()
+        screenRecordingRefreshTask?.cancel()
+        coordinator.clearLastActionError()
+        refreshPermissionState()
+        if isGranted {
+          scheduleAutoAdvance()
+        }
+      }
+    }
+  }
+
+  private var isGranted: Bool {
+    coordinator.isPermissionGranted(permissionType, appState: appState)
+  }
+
+  private var statusText: String {
+    if isGranted {
+      return "Granted"
+    }
+    if isRequesting {
+      return "Waiting for macOS..."
+    }
+    return "Not granted yet"
+  }
+
+  private func scheduleAutoAdvance() {
+    guard !hasAutoAdvanced else { return }
+    hasAutoAdvanced = true
+    advanceTask?.cancel()
+    advanceTask = Task {
+      try? await Task.sleep(nanoseconds: 350_000_000)
+      guard !Task.isCancelled else { return }
+      await MainActor.run {
+        onContinue()
+      }
+    }
+  }
+
+  private func refreshPermissionState() {
+    coordinator.refreshPermissions(appState: appState)
+
+    guard permissionType == "screen_recording", !appState.hasScreenRecordingPermission else {
+      return
+    }
+    guard screenRecordingRefreshTask == nil else { return }
+
+    screenRecordingRefreshTask = Task {
+      let granted = await Task.detached(priority: .utility) {
+        ScreenCaptureService.checkPermission()
+      }.value
+
+      guard !Task.isCancelled else { return }
+
+      appState.hasScreenRecordingPermission = granted
+      if granted {
+        appState.isScreenRecordingStale = false
+        appState.isScreenCaptureKitBroken = false
+        appState.screenRecordingGrantAttempts = 0
+        scheduleAutoAdvance()
+      }
+      screenRecordingRefreshTask = nil
+    }
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingResearchStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingResearchStepView.swift
@@ -1,0 +1,92 @@
+import SwiftUI
+
+struct OnboardingResearchStepView: View {
+  @ObservedObject var coordinator: OnboardingPagedIntroCoordinator
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+  let stepIndex: Int
+  let totalSteps: Int
+  let onContinue: () -> Void
+
+  var body: some View {
+    OnboardingStepScaffold(
+      graphViewModel: graphViewModel,
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      eyebrow: "Second Brain",
+      title: "Your graph is live.",
+      description: "Omi now has real context."
+    ) {
+      VStack(alignment: .leading, spacing: 14) {
+        if let snapshot = coordinator.scanSnapshot, !snapshot.projectNames.isEmpty {
+          OnboardingInsightCard(
+            icon: "shippingbox.fill",
+            title: "From your machine",
+            detail: snapshot.projectNames.prefix(3).joined(separator: ", ")
+          )
+        }
+
+        if let email = coordinator.userEmail() {
+          OnboardingInsightCard(
+            icon: "at",
+            title: "Signed in",
+            detail: email
+          )
+        }
+
+        if coordinator.isLoadingInsights {
+          OnboardingInsightCard(
+            icon: "bolt.fill",
+            title: coordinator.insightStatusText.isEmpty
+              ? "Collecting context" : coordinator.insightStatusText,
+            detail: "This finishes before goal selection."
+          )
+        }
+
+        if !coordinator.emailSummary.isEmpty {
+          OnboardingInsightCard(
+            icon: "envelope.fill",
+            title: "From Gmail",
+            detail: coordinator.emailSummary
+          )
+        }
+
+        if !coordinator.calendarSummary.isEmpty {
+          OnboardingInsightCard(
+            icon: "calendar",
+            title: "From your calendar",
+            detail: coordinator.calendarSummary
+          )
+        }
+
+        if !coordinator.webResearchSummary.isEmpty {
+          OnboardingInsightCard(
+            icon: "globe",
+            title: "From the web",
+            detail: coordinator.webResearchSummary
+          )
+        }
+
+        if coordinator.emailSummary.isEmpty && coordinator.calendarSummary.isEmpty
+          && coordinator.webResearchSummary.isEmpty,
+          let organization = coordinator.organizationHint()
+        {
+          OnboardingInsightCard(
+            icon: "building.2.fill",
+            title: "Identity hint",
+            detail: organization
+          )
+        }
+
+        Button(coordinator.isResearchComplete ? "Continue" : "Finishing…") {
+          onContinue()
+        }
+        .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+        .disabled(!coordinator.isResearchComplete)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .task {
+        await graphViewModel.addGraphFromStorage()
+      }
+    }
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingStepScaffold.swift
+++ b/desktop/Desktop/Sources/OnboardingStepScaffold.swift
@@ -1,0 +1,373 @@
+import AppKit
+import SwiftUI
+
+enum OnboardingRightPaneMode {
+  case graph
+  case message(title: String, detail: String)
+}
+
+enum OnboardingLayoutMode {
+  case split
+  case centered
+}
+
+struct OnboardingStepScaffold<Content: View>: View {
+  @ObservedObject private var graphViewModel: MemoryGraphViewModel
+
+  let stepIndex: Int
+  let totalSteps: Int
+  let eyebrow: String
+  let title: String
+  let description: String
+  let layoutMode: OnboardingLayoutMode
+  let rightPaneMode: OnboardingRightPaneMode
+  let showsSkip: Bool
+  let onSkip: (() -> Void)?
+  let content: Content
+
+  init(
+    graphViewModel: MemoryGraphViewModel,
+    stepIndex: Int,
+    totalSteps: Int,
+    eyebrow: String,
+    title: String,
+    description: String,
+    layoutMode: OnboardingLayoutMode = .split,
+    rightPaneMode: OnboardingRightPaneMode = .graph,
+    showsSkip: Bool = false,
+    onSkip: (() -> Void)? = nil,
+    @ViewBuilder content: () -> Content
+  ) {
+    _graphViewModel = ObservedObject(wrappedValue: graphViewModel)
+    self.stepIndex = stepIndex
+    self.totalSteps = totalSteps
+    self.eyebrow = eyebrow
+    self.title = title
+    self.description = description
+    self.layoutMode = layoutMode
+    self.rightPaneMode = rightPaneMode
+    self.showsSkip = showsSkip
+    self.onSkip = onSkip
+    self.content = content()
+  }
+
+  var body: some View {
+    switch layoutMode {
+    case .split:
+      HStack(spacing: 0) {
+        splitPane
+          .frame(minWidth: 470, idealWidth: 520, maxWidth: 560)
+
+        Divider()
+          .background(OmiColors.backgroundTertiary)
+
+        OnboardingSecondBrainPane(graphViewModel: graphViewModel, mode: rightPaneMode)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(OmiColors.backgroundPrimary)
+
+    case .centered:
+      VStack(spacing: 0) {
+        header
+
+        Divider()
+          .background(OmiColors.backgroundTertiary)
+
+        GeometryReader { geometry in
+          ScrollView(showsIndicators: false) {
+            VStack(spacing: 28) {
+              progressRow(centered: true)
+              titleBlock(centered: true)
+              content
+            }
+            .frame(maxWidth: 560)
+            .frame(
+              minWidth: 0, maxWidth: .infinity, minHeight: geometry.size.height,
+              maxHeight: .infinity, alignment: .center
+            )
+            .padding(.horizontal, 40)
+            .padding(.vertical, 36)
+          }
+        }
+      }
+      .frame(maxWidth: .infinity, maxHeight: .infinity)
+      .background(OmiColors.backgroundPrimary)
+    }
+  }
+
+  private var splitPane: some View {
+    VStack(spacing: 0) {
+      header
+
+      Divider()
+        .background(OmiColors.backgroundTertiary)
+
+      ScrollView(showsIndicators: false) {
+        VStack(alignment: .leading, spacing: 28) {
+          progressRow(centered: false)
+          titleBlock(centered: false)
+          content
+        }
+        .frame(maxWidth: 500, alignment: .leading)
+        .padding(.horizontal, 40)
+        .padding(.vertical, 36)
+      }
+    }
+    .background(OmiColors.backgroundPrimary)
+  }
+
+  private var header: some View {
+    HStack {
+      if let logoImage = onboardingLogoImage() {
+        Image(nsImage: logoImage)
+          .resizable()
+          .renderingMode(.template)
+          .foregroundColor(.white)
+          .scaledToFit()
+          .frame(width: 52, height: 18)
+          .accessibilityLabel("omi")
+      } else {
+        Text("omi")
+          .font(.system(size: 18, weight: .semibold))
+          .foregroundColor(.white)
+      }
+
+      Spacer()
+
+      if showsSkip, let onSkip {
+        Button(action: onSkip) {
+          Text("Skip")
+            .font(.system(size: 13, weight: .medium))
+            .foregroundColor(OmiColors.textTertiary)
+        }
+        .buttonStyle(.plain)
+      }
+    }
+    .padding(.horizontal, 24)
+    .padding(.vertical, 16)
+  }
+
+  private func progressRow(centered: Bool) -> some View {
+    HStack(spacing: 8) {
+      ForEach(0..<totalSteps, id: \.self) { index in
+        Capsule()
+          .fill(index <= stepIndex ? OmiColors.purplePrimary : Color.white.opacity(0.1))
+          .frame(width: index == stepIndex ? 28 : 8, height: 6)
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: centered ? .center : .leading)
+  }
+
+  private func titleBlock(centered: Bool) -> some View {
+    VStack(alignment: centered ? .center : .leading, spacing: 14) {
+      Text(eyebrow.uppercased())
+        .font(.system(size: 12, weight: .semibold))
+        .tracking(1.2)
+        .foregroundColor(OmiColors.purplePrimary)
+
+      Text(title)
+        .font(.system(size: 40, weight: .bold))
+        .foregroundColor(OmiColors.textPrimary)
+        .lineSpacing(2)
+        .multilineTextAlignment(centered ? .center : .leading)
+
+      Text(description)
+        .font(.system(size: 16))
+        .foregroundColor(OmiColors.textSecondary)
+        .lineSpacing(4)
+        .multilineTextAlignment(centered ? .center : .leading)
+        .frame(maxWidth: 460, alignment: centered ? .center : .leading)
+    }
+    .frame(maxWidth: .infinity, alignment: centered ? .center : .leading)
+  }
+
+  private func onboardingLogoImage() -> NSImage? {
+    guard
+      let logoURL = Bundle.resourceBundle.url(forResource: "omi_text_logo", withExtension: "png"),
+      let loadedLogoImage = NSImage(contentsOf: logoURL)
+    else {
+      return nil
+    }
+    let logoImage = loadedLogoImage.copy() as? NSImage ?? loadedLogoImage
+    logoImage.isTemplate = true
+    return logoImage
+  }
+}
+
+private struct OnboardingSecondBrainPane: View {
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+  let mode: OnboardingRightPaneMode
+
+  var body: some View {
+    ZStack {
+      OmiColors.backgroundSecondary
+        .ignoresSafeArea()
+
+      switch mode {
+      case .message(let title, let detail):
+        VStack(spacing: 12) {
+          Text(title)
+            .font(.system(size: 28, weight: .bold))
+            .foregroundColor(OmiColors.textPrimary)
+            .multilineTextAlignment(.center)
+
+          Text(detail)
+            .font(.system(size: 15))
+            .foregroundColor(OmiColors.textTertiary)
+            .multilineTextAlignment(.center)
+            .frame(maxWidth: 320)
+        }
+      case .graph:
+        if graphViewModel.isEmpty {
+          VStack(spacing: 14) {
+            Text("Your graph appears once Omi has something real to map.")
+              .font(.system(size: 15, weight: .medium))
+              .foregroundColor(OmiColors.textTertiary)
+              .multilineTextAlignment(.center)
+              .frame(maxWidth: 320)
+          }
+        } else {
+          MemoryGraphSceneView(viewModel: graphViewModel)
+            .ignoresSafeArea()
+        }
+      }
+    }
+    .overlay(alignment: .top) {
+      if case .graph = mode, !graphViewModel.isEmpty {
+        Text("This is your second brain.")
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundColor(.white)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 6)
+          .background(Color.black.opacity(0.35))
+          .cornerRadius(8)
+          .padding(.top, 18)
+      }
+    }
+    .overlay(alignment: .bottom) {
+      if case .graph = mode, !graphViewModel.isEmpty {
+        HStack(spacing: 20) {
+          graphHintItem(icon: "arrow.triangle.2.circlepath", label: "Drag to rotate")
+          graphHintItem(icon: "magnifyingglass", label: "Scroll to zoom")
+          graphHintItem(icon: "hand.draw", label: "Two-finger to pan")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(
+          LinearGradient(
+            colors: [Color.black.opacity(0), Color.black.opacity(0.5)],
+            startPoint: .top,
+            endPoint: .bottom
+          )
+        )
+      }
+    }
+    .task {
+      await graphViewModel.addGraphFromStorage()
+      if graphViewModel.isEmpty {
+        await graphViewModel.loadGraph()
+      }
+    }
+  }
+
+  private func graphHintItem(icon: String, label: String) -> some View {
+    HStack(spacing: 4) {
+      Image(systemName: icon)
+        .font(.system(size: 11))
+      Text(label)
+        .font(.system(size: 11))
+    }
+    .foregroundColor(.white.opacity(0.5))
+  }
+}
+
+struct OnboardingCardButtonStyle: ButtonStyle {
+  let isPrimary: Bool
+
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .font(.system(size: 15, weight: .semibold))
+      .foregroundColor(isPrimary ? .white : OmiColors.textPrimary)
+      .padding(.horizontal, 18)
+      .padding(.vertical, 12)
+      .background(
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+          .fill(isPrimary ? OmiColors.purplePrimary : OmiColors.backgroundTertiary)
+      )
+      .overlay(
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+          .stroke(Color.white.opacity(isPrimary ? 0 : 0.08), lineWidth: 1)
+      )
+      .opacity(configuration.isPressed ? 0.92 : 1)
+      .scaleEffect(configuration.isPressed ? 0.985 : 1)
+      .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+  }
+}
+
+struct OnboardingInsightCard: View {
+  let icon: String
+  let title: String
+  let detail: String
+
+  var body: some View {
+    HStack(alignment: .top, spacing: 14) {
+      ZStack {
+        RoundedRectangle(cornerRadius: 14, style: .continuous)
+          .fill(OmiColors.backgroundQuaternary)
+          .frame(width: 42, height: 42)
+
+        Image(systemName: icon)
+          .font(.system(size: 16, weight: .semibold))
+          .foregroundColor(OmiColors.purplePrimary)
+      }
+
+      VStack(alignment: .leading, spacing: 6) {
+        Text(title)
+          .font(.system(size: 15, weight: .semibold))
+          .foregroundColor(OmiColors.textPrimary)
+
+        Text(detail)
+          .font(.system(size: 13))
+          .foregroundColor(OmiColors.textTertiary)
+          .lineSpacing(3)
+      }
+
+      Spacer()
+    }
+    .padding(18)
+    .background(
+      RoundedRectangle(cornerRadius: 20, style: .continuous)
+        .fill(OmiColors.backgroundSecondary)
+        .overlay(
+          RoundedRectangle(cornerRadius: 20, style: .continuous)
+            .stroke(Color.white.opacity(0.08), lineWidth: 1)
+        )
+    )
+  }
+}
+
+struct OnboardingSelectableChip: View {
+  let title: String
+  let isSelected: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      Text(title)
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundColor(isSelected ? .white : OmiColors.textSecondary)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+        .background(
+          Capsule()
+            .fill(isSelected ? OmiColors.purplePrimary : OmiColors.backgroundSecondary)
+        )
+        .overlay(
+          Capsule()
+            .stroke(Color.white.opacity(isSelected ? 0 : 0.08), lineWidth: 1)
+        )
+    }
+    .buttonStyle(.plain)
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingTrustStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingTrustStepView.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+
+struct OnboardingTrustStepView: View {
+  @ObservedObject var coordinator: OnboardingPagedIntroCoordinator
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+  let stepIndex: Int
+  let totalSteps: Int
+  let onContinue: () -> Void
+
+  var body: some View {
+    OnboardingStepScaffold(
+      graphViewModel: graphViewModel,
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      eyebrow: "",
+      title: "Trust",
+      description:
+        "In onboarding, Omi needs to learn about you and access a few permissions to be useful. Without them, Omi cannot help much. Can we proceed?",
+      layoutMode: .centered
+    ) {
+      VStack(spacing: 18) {
+        HStack(spacing: 12) {
+          Button("Yes, let's go") {
+            coordinator.clearLastActionError()
+            onContinue()
+          }
+          .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+
+          Button("No, show the source code") {
+            guard let url = URL(string: "https://github.com/BasedHardware/omi") else { return }
+            NSWorkspace.shared.open(url)
+          }
+          .buttonStyle(OnboardingCardButtonStyle(isPrimary: false))
+        }
+      }
+      .frame(maxWidth: .infinity, alignment: .center)
+      .onAppear {
+        coordinator.clearLastActionError()
+      }
+    }
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -8,15 +8,16 @@ struct OnboardingView: View {
   @ObservedObject var chatProvider: ChatProvider
   var onComplete: (() -> Void)? = nil
   @AppStorage("onboardingStep") private var currentStep = 0
+  @AppStorage("onboardingPagedIntroMigrationDone") private var hasMigratedPagedIntro = false
   @AppStorage("onboardingVideoStepMigrationDone") private var hasMigratedOnboardingSteps = false
   @AppStorage("onboardingVoiceShortcutStepMigrationDone") private var hasInsertedVoiceShortcutStep =
     false
   @AppStorage("onboardingVoiceInputMergeMigrationDone") private var hasMergedVoiceInputStep = false
   @AppStorage("onboardingNotificationStepRemoved") private var hasRemovedNotificationStep = false
-  @AppStorage("onboardingFloatingBarShortcutStepInserted") private var hasInsertedFloatingBarShortcutStep = false
+  @AppStorage("onboardingFloatingBarShortcutStepInserted") private
+    var hasInsertedFloatingBarShortcutStep = false
+  @StateObject private var introCoordinator = OnboardingPagedIntroCoordinator()
   @StateObject private var graphViewModel = MemoryGraphViewModel()
-  @State private var graphHasData = false
-  @State private var showTrustPreview = true
 
   let steps = OnboardingFlow.steps
 
@@ -55,20 +56,27 @@ struct OnboardingView: View {
         hasInsertedVoiceShortcutStep: hasInsertedVoiceShortcutStep,
         hasMergedVoiceInputStep: hasMergedVoiceInputStep,
         hasRemovedNotificationStep: hasRemovedNotificationStep,
-        hasInsertedFloatingBarShortcutStep: hasInsertedFloatingBarShortcutStep
+        hasInsertedFloatingBarShortcutStep: hasInsertedFloatingBarShortcutStep,
+        hasMigratedPagedIntro: hasMigratedPagedIntro
       )
+      hasMigratedPagedIntro = true
       hasMigratedOnboardingSteps = true
       hasInsertedVoiceShortcutStep = true
       hasMergedVoiceInputStep = true
       hasRemovedNotificationStep = true
       hasInsertedFloatingBarShortcutStep = true
+      introCoordinator.prepare(appState: appState)
     }
     .task {
       // Pre-warm the ACP bridge before the chat step starts.
       await chatProvider.warmupBridge()
+      await graphViewModel.addGraphFromStorage()
+      if graphViewModel.isEmpty {
+        await graphViewModel.loadGraph()
+      }
     }
     .onReceive(NotificationCenter.default.publisher(for: .resetOnboardingRequested)) { _ in
-      log("OnboardingView: resetOnboardingRequested — returning to chat step for current app")
+      log("OnboardingView: resetOnboardingRequested — returning to the first onboarding step")
       currentStep = 0
     }
   }
@@ -76,188 +84,302 @@ struct OnboardingView: View {
   private var onboardingContent: some View {
     Group {
       if currentStep == 0 {
-        // Step 0: Interactive AI Chat + Live Knowledge Graph
-        HStack(spacing: 0) {
-          OnboardingChatView(
-            appState: appState,
-            chatProvider: chatProvider,
-            graphViewModel: graphViewModel,
-            onComplete: {
-              AnalyticsManager.shared.onboardingStepCompleted(step: 0, stepName: "Chat")
-              // Start screen capture early so Rewind tab has screenshots by the time
-              // the user finishes onboarding (permissions are granted during chat step)
-              if !ProactiveAssistantsPlugin.shared.isMonitoring {
-                ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
-              }
-              currentStep = 1
-            },
-            onSkip: {
-              if !ProactiveAssistantsPlugin.shared.isMonitoring {
-                ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
-              }
-              currentStep = 1
-            }
-          )
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-
-          // Right pane: Knowledge graph (dark background, graph appears when data arrives)
-          ZStack {
-            OmiColors.backgroundSecondary.ignoresSafeArea()
-
-            if graphHasData && !showTrustPreview {
-              MemoryGraphSceneView(viewModel: graphViewModel)
-                .ignoresSafeArea()
-                .transition(.opacity)
-            }
-
-            if showTrustPreview {
-              OnboardingTrustPreviewCard()
-                .padding(.horizontal, 48)
-                .transition(.opacity.combined(with: .scale(scale: 0.97)))
-            }
+        OnboardingTrustStepView(
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 0,
+          totalSteps: OnboardingFlow.introStepCount,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 0, stepName: "Trust")
+            currentStep = 1
           }
-          .frame(maxWidth: .infinity, maxHeight: .infinity)
-          .overlay(alignment: .top) {
-            if graphHasData && !showTrustPreview {
-              Text("This is your second brain.")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundColor(.white)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 6)
-                .background(Color.black.opacity(0.35))
-                .cornerRadius(8)
-                .padding(.top, 18)
-                .transition(.opacity)
-            }
-          }
-          // Use .overlay so hints composite above the NSViewRepresentable SCNView
-          .overlay(alignment: .bottom) {
-            HStack(spacing: 20) {
-              graphHintItem(icon: "arrow.triangle.2.circlepath", label: "Drag to rotate")
-              graphHintItem(icon: "magnifyingglass", label: "Scroll to zoom")
-              graphHintItem(icon: "hand.draw", label: "Two-finger to pan")
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-            .background(
-              LinearGradient(
-                colors: [Color.black.opacity(0), Color.black.opacity(0.5)],
-                startPoint: .top,
-                endPoint: .bottom
-              )
-            )
-            .opacity(graphHasData && !showTrustPreview ? 1 : 0)
-            .animation(.easeInOut(duration: 0.3), value: graphHasData)
-            .animation(.easeInOut(duration: 0.3), value: showTrustPreview)
-          }
-          .onAppear {
-            showTrustPreview = true
-            // Handle case where graph already has data on appear
-            if !graphViewModel.isEmpty && !graphHasData {
-              handleGraphDataArrival()
-            }
-          }
-          .onChange(of: graphViewModel.isEmpty) { _, isEmpty in
-            if !isEmpty && !graphHasData {
-              handleGraphDataArrival()
-            }
-          }
-        }
+        )
       } else if currentStep == 1 {
-        // Step 1: Floating Bar Shortcut Selection
-        OnboardingFloatingBarShortcutStepView(
-          appState: appState,
-          chatProvider: chatProvider,
-          onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "FloatingBarShortcut")
-            currentStep = 2
-          },
-          onSkip: {
-            AnalyticsManager.shared.onboardingStepCompleted(
-              step: 1, stepName: "FloatingBarShortcut_Skipped")
+        OnboardingWelcomeStepView(
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 1,
+          totalSteps: OnboardingFlow.introStepCount,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "Name")
             currentStep = 2
           }
         )
       } else if currentStep == 2 {
-        // Step 2: Floating Bar Demo (type a question)
-        OnboardingFloatingBarDemoView(
-          appState: appState,
-          chatProvider: chatProvider,
-          onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "FloatingBar")
-            currentStep = 3
-          },
-          onSkip: {
-            AnalyticsManager.shared.onboardingStepCompleted(
-              step: 2, stepName: "FloatingBar_Skipped")
+        OnboardingLanguageStepView(
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 2,
+          totalSteps: OnboardingFlow.introStepCount,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "Language")
             currentStep = 3
           }
         )
       } else if currentStep == 3 {
-        // Step 3: Verify Push-to-Talk Shortcut
-        OnboardingVoiceShortcutStepView(
+        OnboardingPermissionStepView(
           appState: appState,
-          chatProvider: chatProvider,
-          onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "VoiceShortcut")
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 3,
+          totalSteps: OnboardingFlow.introStepCount,
+          eyebrow: "Access",
+          title: "Let Omi scan your work.",
+          description: "File access lets Omi map your projects and files.",
+          permissionType: "full_disk_access",
+          icon: "externaldrive.fill.badge.person.crop",
+          reasonTitle: "Full Disk Access",
+          reasonDetail: "This lets Omi scan your projects and recent files.",
+          primaryActionLabel: "Open Full Disk Access",
+          requiresRestart: false,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 3, stepName: "FullDiskAccess")
             currentStep = 4
           },
           onSkip: {
             AnalyticsManager.shared.onboardingStepCompleted(
-              step: 3, stepName: "VoiceShortcut_Skipped")
+              step: 3, stepName: "FullDiskAccess_Skipped")
             currentStep = 4
           }
         )
       } else if currentStep == 4 {
-        // Step 4: Voice Demo (hold shortcut and ask a question)
+        OnboardingFileScanStepView(
+          appState: appState,
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 4,
+          totalSteps: OnboardingFlow.introStepCount,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "FileScan")
+            currentStep = 5
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "FileScan_Skipped")
+            currentStep = 5
+          }
+        )
+      } else if currentStep == 5 {
+        OnboardingPermissionStepView(
+          appState: appState,
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 5,
+          totalSteps: OnboardingFlow.introStepCount,
+          eyebrow: "Permission",
+          title: "Let Omi use your mic.",
+          description: "Microphone lets Omi transcribe meetings.",
+          permissionType: "microphone",
+          icon: "mic.fill",
+          reasonTitle: "Microphone",
+          reasonDetail: "This lets Omi transcribe meetings and voice notes.",
+          primaryActionLabel: "Grant microphone access",
+          requiresRestart: false,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 5, stepName: "Microphone")
+            currentStep = 6
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 5, stepName: "Microphone_Skipped")
+            currentStep = 6
+          }
+        )
+      } else if currentStep == 6 {
+        OnboardingPermissionStepView(
+          appState: appState,
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 6,
+          totalSteps: OnboardingFlow.introStepCount,
+          eyebrow: "Permission",
+          title: "Let Omi send reminders.",
+          description: "Notifications let Omi send proactive tips.",
+          permissionType: "notifications",
+          icon: "bell.badge.fill",
+          reasonTitle: "Notifications",
+          reasonDetail: "This lets Omi send reminders and proactive tips.",
+          primaryActionLabel: "Enable notifications",
+          requiresRestart: false,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 6, stepName: "Notifications")
+            currentStep = 7
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 6, stepName: "Notifications_Skipped")
+            currentStep = 7
+          }
+        )
+      } else if currentStep == 7 {
+        OnboardingPermissionStepView(
+          appState: appState,
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 7,
+          totalSteps: OnboardingFlow.introStepCount,
+          eyebrow: "Permission",
+          title: "Let Omi see the active app.",
+          description: "Accessibility lets Omi know which app is active.",
+          permissionType: "accessibility",
+          icon: "figure.wave",
+          reasonTitle: "Accessibility",
+          reasonDetail: "This lets Omi know which app you are using.",
+          primaryActionLabel: "Open Accessibility settings",
+          requiresRestart: false,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 7, stepName: "Accessibility")
+            currentStep = 8
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 7, stepName: "Accessibility_Skipped")
+            currentStep = 8
+          }
+        )
+      } else if currentStep == 8 {
+        OnboardingPermissionStepView(
+          appState: appState,
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 8,
+          totalSteps: OnboardingFlow.introStepCount,
+          eyebrow: "Permission",
+          title: "Let Omi act when asked.",
+          description: "Automation lets Omi take actions for you.",
+          permissionType: "automation",
+          icon: "bolt.horizontal.circle.fill",
+          reasonTitle: "Automation",
+          reasonDetail: "This lets Omi take actions when you ask.",
+          primaryActionLabel: "Open Automation settings",
+          requiresRestart: false,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 8, stepName: "Automation")
+            currentStep = 9
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 8, stepName: "Automation_Skipped")
+            currentStep = 9
+          }
+        )
+      } else if currentStep == 9 {
+        OnboardingResearchStepView(
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 9,
+          totalSteps: OnboardingFlow.introStepCount,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 9, stepName: "Research")
+            currentStep = 10
+          }
+        )
+      } else if currentStep == 10 {
+        OnboardingPermissionStepView(
+          appState: appState,
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 10,
+          totalSteps: OnboardingFlow.introStepCount,
+          eyebrow: "Permission",
+          title: "Let Omi read your screen.",
+          description: "Screen Recording lets Omi see what you're working on.",
+          permissionType: "screen_recording",
+          icon: "display.and.arrow.down",
+          reasonTitle: "Screen Recording",
+          reasonDetail: "This lets Omi see what is on screen.",
+          primaryActionLabel: "Open Screen Recording settings",
+          requiresRestart: true,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 10, stepName: "ScreenRecording")
+            currentStep = 11
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 10, stepName: "ScreenRecording_Skipped")
+            currentStep = 11
+          }
+        )
+      } else if currentStep == 11 {
+        OnboardingGoalStepView(
+          appState: appState,
+          coordinator: introCoordinator,
+          graphViewModel: graphViewModel,
+          stepIndex: 11,
+          totalSteps: OnboardingFlow.introStepCount,
+          onContinue: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 11, stepName: "Goal")
+            if !ProactiveAssistantsPlugin.shared.isMonitoring {
+              ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
+            }
+            currentStep = 12
+          }
+        )
+      } else if currentStep == 12 {
+        OnboardingFloatingBarShortcutStepView(
+          appState: appState,
+          chatProvider: chatProvider,
+          onComplete: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 12, stepName: "FloatingBarShortcut")
+            currentStep = 13
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 12, stepName: "FloatingBarShortcut_Skipped")
+            currentStep = 13
+          }
+        )
+      } else if currentStep == 13 {
+        OnboardingFloatingBarDemoView(
+          appState: appState,
+          chatProvider: chatProvider,
+          onComplete: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 13, stepName: "FloatingBar")
+            currentStep = 14
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 13, stepName: "FloatingBar_Skipped")
+            currentStep = 14
+          }
+        )
+      } else if currentStep == 14 {
+        OnboardingVoiceShortcutStepView(
+          appState: appState,
+          chatProvider: chatProvider,
+          onComplete: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 14, stepName: "VoiceShortcut")
+            currentStep = 15
+          },
+          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 14, stepName: "VoiceShortcut_Skipped")
+            currentStep = 15
+          }
+        )
+      } else if currentStep == 15 {
         OnboardingVoiceDemoView(
           appState: appState,
           chatProvider: chatProvider,
           onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 4, stepName: "VoiceDemo")
-            currentStep = 5
+            AnalyticsManager.shared.onboardingStepCompleted(step: 15, stepName: "VoiceDemo")
+            currentStep = 16
           },
           onSkip: {
             AnalyticsManager.shared.onboardingStepCompleted(
-              step: 4, stepName: "VoiceDemo_Skipped")
-            currentStep = 5
+              step: 15, stepName: "VoiceDemo_Skipped")
+            currentStep = 16
           }
         )
       } else {
-        // Step 5: Tasks
         OnboardingTasksStepView(
           onComplete: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 5, stepName: "Tasks")
+            AnalyticsManager.shared.onboardingStepCompleted(step: 16, stepName: "Tasks")
             handleOnboardingComplete()
           },
           onSkip: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 5, stepName: "Tasks_Skipped")
+            AnalyticsManager.shared.onboardingStepCompleted(step: 16, stepName: "Tasks_Skipped")
             handleOnboardingComplete()
           }
         )
-      }
-    }
-  }
-
-  private func graphHintItem(icon: String, label: String) -> some View {
-    HStack(spacing: 4) {
-      Image(systemName: icon)
-        .font(.system(size: 11))
-      Text(label)
-        .font(.system(size: 11))
-    }
-    .foregroundColor(.white.opacity(0.5))
-  }
-
-  private func handleGraphDataArrival() {
-    withAnimation(.easeIn(duration: 0.35)) {
-      graphHasData = true
-    }
-
-    // Keep the trust panel visible briefly, then transition to the graph.
-    DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
-      withAnimation(.easeInOut(duration: 0.45)) {
-        showTrustPreview = false
       }
     }
   }
@@ -315,7 +437,7 @@ struct OnboardingView: View {
   }
 }
 
-private struct OnboardingTrustPreviewCard: View {
+struct OnboardingTrustPreviewCard: View {
   var body: some View {
     VStack(spacing: 24) {
       OnboardingVideoView(cornerRadius: 14)

--- a/desktop/Desktop/Sources/OnboardingWebResearchService.swift
+++ b/desktop/Desktop/Sources/OnboardingWebResearchService.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+struct OnboardingWebSearchResult: Sendable {
+  let query: String
+  let title: String
+  let url: String
+  let snippet: String
+}
+
+actor OnboardingWebResearchService {
+  static let shared = OnboardingWebResearchService()
+
+  func search(queries: [String], maxResultsPerQuery: Int = 3) async -> [OnboardingWebSearchResult] {
+    var allResults: [OnboardingWebSearchResult] = []
+    var seenURLs = Set<String>()
+
+    for query in queries where !query.isEmpty {
+      let results = await search(query: query, maxResults: maxResultsPerQuery)
+      for result in results where seenURLs.insert(result.url).inserted {
+        allResults.append(result)
+      }
+    }
+
+    return allResults
+  }
+
+  private func search(query: String, maxResults: Int) async -> [OnboardingWebSearchResult] {
+    guard
+      let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
+      let url = URL(string: "https://html.duckduckgo.com/html/?q=\(encodedQuery)")
+    else {
+      return []
+    }
+
+    var request = URLRequest(url: url)
+    request.setValue(
+      "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36",
+      forHTTPHeaderField: "User-Agent"
+    )
+    request.timeoutInterval = 20
+
+    do {
+      let (data, response) = try await URLSession.shared.data(for: request)
+      guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+        return []
+      }
+
+      let html = String(decoding: data, as: UTF8.self)
+      return parse(html: html, query: query, maxResults: maxResults)
+    } catch {
+      log(
+        "OnboardingWebResearchService: Search failed for '\(query)': \(error.localizedDescription)")
+      return []
+    }
+  }
+
+  private func parse(
+    html: String,
+    query: String,
+    maxResults: Int
+  ) -> [OnboardingWebSearchResult] {
+    guard
+      let titleRegex = try? NSRegularExpression(
+        pattern: #"<a[^>]*class="[^"]*result__a[^"]*"[^>]*href="([^"]+)"[^>]*>(.*?)</a>"#,
+        options: [.dotMatchesLineSeparators, .caseInsensitive]
+      ),
+      let snippetRegex = try? NSRegularExpression(
+        pattern:
+          #"<a[^>]*class="[^"]*result__snippet[^"]*"[^>]*>(.*?)</a>|<div[^>]*class="[^"]*result__snippet[^"]*"[^>]*>(.*?)</div>"#,
+        options: [.dotMatchesLineSeparators, .caseInsensitive]
+      )
+    else {
+      return []
+    }
+
+    let nsHTML = html as NSString
+    let titleMatches = titleRegex.matches(
+      in: html, range: NSRange(location: 0, length: nsHTML.length))
+    let snippetMatches = snippetRegex.matches(
+      in: html, range: NSRange(location: 0, length: nsHTML.length))
+
+    var results: [OnboardingWebSearchResult] = []
+
+    for (index, titleMatch) in titleMatches.prefix(maxResults).enumerated() {
+      guard titleMatch.numberOfRanges >= 3 else { continue }
+
+      let rawURL = nsHTML.substring(with: titleMatch.range(at: 1))
+      let rawTitle = nsHTML.substring(with: titleMatch.range(at: 2))
+      let rawSnippet: String
+      if index < snippetMatches.count {
+        let snippetMatch = snippetMatches[index]
+        if snippetMatch.numberOfRanges > 2, snippetMatch.range(at: 1).location != NSNotFound {
+          rawSnippet = nsHTML.substring(with: snippetMatch.range(at: 1))
+        } else if snippetMatch.numberOfRanges > 2, snippetMatch.range(at: 2).location != NSNotFound
+        {
+          rawSnippet = nsHTML.substring(with: snippetMatch.range(at: 2))
+        } else {
+          rawSnippet = ""
+        }
+      } else {
+        rawSnippet = ""
+      }
+
+      let resolvedURL = unwrapDuckDuckGoRedirect(rawURL) ?? rawURL
+      let title = cleanHTML(rawTitle)
+      let snippet = cleanHTML(rawSnippet)
+
+      guard !title.isEmpty, !resolvedURL.isEmpty else { continue }
+
+      results.append(
+        OnboardingWebSearchResult(query: query, title: title, url: resolvedURL, snippet: snippet)
+      )
+    }
+
+    return results
+  }
+
+  private func unwrapDuckDuckGoRedirect(_ rawURL: String) -> String? {
+    guard let url = URL(string: rawURL) else { return rawURL }
+
+    if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+      let target = components.queryItems?.first(where: { $0.name == "uddg" })?.value,
+      let decoded = target.removingPercentEncoding
+    {
+      return decoded
+    }
+
+    return rawURL
+  }
+
+  private func cleanHTML(_ text: String) -> String {
+    let withoutTags = text.replacingOccurrences(
+      of: #"<[^>]+>"#,
+      with: " ",
+      options: .regularExpression
+    )
+
+    let decoded =
+      withoutTags
+      .replacingOccurrences(of: "&amp;", with: "&")
+      .replacingOccurrences(of: "&quot;", with: "\"")
+      .replacingOccurrences(of: "&#39;", with: "'")
+      .replacingOccurrences(of: "&apos;", with: "'")
+      .replacingOccurrences(of: "&lt;", with: "<")
+      .replacingOccurrences(of: "&gt;", with: ">")
+      .replacingOccurrences(of: "&nbsp;", with: " ")
+
+    return decoded.replacingOccurrences(of: #"\s+"#, with: " ", options: .regularExpression)
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingWelcomeStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingWelcomeStepView.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+struct OnboardingWelcomeStepView: View {
+  @ObservedObject var coordinator: OnboardingPagedIntroCoordinator
+  @ObservedObject var graphViewModel: MemoryGraphViewModel
+  let stepIndex: Int
+  let totalSteps: Int
+  let onContinue: () -> Void
+
+  var body: some View {
+    OnboardingStepScaffold(
+      graphViewModel: graphViewModel,
+      stepIndex: stepIndex,
+      totalSteps: totalSteps,
+      eyebrow: "Name",
+      title: "What should Omi call you?",
+      description: "",
+      layoutMode: .centered
+    ) {
+      VStack(spacing: 18) {
+        TextField("Your name", text: $coordinator.draftName)
+          .textFieldStyle(.plain)
+          .padding(.horizontal, 16)
+          .padding(.vertical, 14)
+          .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+              .fill(OmiColors.backgroundSecondary)
+              .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                  .stroke(Color.white.opacity(0.08), lineWidth: 1)
+              )
+          )
+          .foregroundColor(OmiColors.textPrimary)
+          .frame(maxWidth: 320)
+
+        if let error = coordinator.lastActionError {
+          Text(error)
+            .font(.system(size: 12, weight: .medium))
+            .foregroundColor(OmiColors.warning)
+            .multilineTextAlignment(.center)
+        }
+
+        Button("Continue") {
+          Task {
+            await coordinator.confirmPreferredName()
+            if coordinator.lastActionError == nil {
+              onContinue()
+            }
+          }
+        }
+        .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+      }
+      .frame(maxWidth: .infinity, alignment: .center)
+      .onAppear {
+        coordinator.clearLastActionError()
+        coordinator.draftName = coordinator.preferredName
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- replace the desktop chat onboarding intro with restart-safe paged onboarding steps
- simplify the onboarding UI, permission prompts, and goal selection flow
- start file scan enrichment, Gmail/calendar reads, and web research before the goal step and feed the graph from those results

## Verification
- swift build --package-path desktop/Desktop