### PR TITLE
fix: add missing import random for pusher circuit breaker

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 import os
+import random
 import struct
 import time
 import uuid


### PR DESCRIPTION
## Summary
- PR #6030's `_pusher_reconnect_loop` uses `random.random()` for backoff jitter but never imported the `random` module
- Every pusher reconnect attempt crashes with `NameError: name 'random' is not defined`
- Circuit breaker never reconnects — sessions die on first pusher disconnect
- 60 errors across 15 pods since deploy at 08:44 UTC

## Fix
Add `import random` to the imports in `transcribe.py`.

## Test plan
- [ ] Deploy to prod, verify `NameError` errors stop
- [ ] Verify pusher reconnect loop completes successfully with jittered backoff

🤖 Generated with [Claude Code](https://claude.com/claude-code)