### PR TITLE
hotfix(transcribe): add missing import random (#6022)

### DIFF
--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -4,6 +4,7 @@ import io
 import json
 import logging
 import os
+import random
 import struct
 import time
 import uuid


### PR DESCRIPTION
Fixes NameError in production: `name 'random' is not defined` at transcribe.py:1514.

The `_pusher_reconnect_loop` (from PR #6030) uses `random.random()` for backoff jitter but the `import random` statement was missing. This causes the reconnect loop to crash immediately, preventing circuit breaker recovery.

One-line fix: add `import random` to the stdlib imports.

---
_by AI for @beastoin_