### PR TITLE
Enable pusher robustness

### DIFF
--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -311,7 +311,7 @@ readinessProbe:
 startupProbe:
   tcpSocket:
     port: 8080
-  failureThreshold: 30
+  failureThreshold: 60
   periodSeconds: 10
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
@@ -390,3 +390,29 @@ affinity:
               operator: In
               values:
                 - prod
+            - key: version
+              operator: In
+              values:
+                - v2
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        preference:
+          matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - us-central1-a
+      - weight: 70
+        preference:
+          matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - us-central1-b
+      - weight: 50
+        preference:
+          matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - us-central1-c


### PR DESCRIPTION
**Changes:**
• Increase the failureThreshold to extend the time for pusher startup
• Spread pusher nodepool with multi-AZ (us-central1-a, b, c ), to ensure the capacity availability