### PR TITLE
Refine onboarding follow-up flow

### DIFF
--- a/desktop/Desktop/Sources/FileIndexing/OnboardingLoadingAnimation.swift
+++ b/desktop/Desktop/Sources/FileIndexing/OnboardingLoadingAnimation.swift
@@ -18,8 +18,8 @@ struct OnboardingLoadingAnimation: View {
                 let pulseScale = 0.15 + 0.08 * sin(time * 1.8)
                 let pulseRadius = radius * pulseScale
                 let pulseGradient = Gradient(colors: [
-                    OmiColors.purplePrimary.opacity(0.4),
-                    OmiColors.purplePrimary.opacity(0.0),
+                    Color.white.opacity(0.4),
+                    Color.white.opacity(0.0),
                 ])
                 let pulseShading = GraphicsContext.Shading.radialGradient(
                     pulseGradient,
@@ -39,7 +39,7 @@ struct OnboardingLoadingAnimation: View {
                 trackPath.addArc(center: center, radius: radius,
                                  startAngle: .degrees(0), endAngle: .degrees(360),
                                  clockwise: false)
-                context.stroke(trackPath, with: .color(OmiColors.purplePrimary.opacity(0.12)),
+                context.stroke(trackPath, with: .color(Color.white.opacity(0.12)),
                                lineWidth: 3)
 
                 // --- Orbital ring (filled arc) ---
@@ -51,8 +51,8 @@ struct OnboardingLoadingAnimation: View {
                                    endAngle: .degrees(-90 + arcEnd),
                                    clockwise: false)
                     let arcGradient = Gradient(colors: [
-                        OmiColors.purplePrimary,
-                        OmiColors.purpleSecondary,
+                        Color.white,
+                        Color.gray,
                     ])
                     context.stroke(arcPath,
                                    with: .linearGradient(arcGradient,
@@ -77,8 +77,8 @@ struct OnboardingLoadingAnimation: View {
                     let glowSize = pSize * 3
                     let glowRect = CGRect(x: px - glowSize, y: py - glowSize, width: glowSize * 2, height: glowSize * 2)
                     let glowGradient = Gradient(colors: [
-                        OmiColors.purpleSecondary.opacity(particleOpacities[i] * 0.5),
-                        OmiColors.purpleSecondary.opacity(0),
+                        Color.gray.opacity(particleOpacities[i] * 0.5),
+                        Color.gray.opacity(0),
                     ])
                     context.fill(Circle().path(in: glowRect),
                                  with: .radialGradient(glowGradient, center: CGPoint(x: px, y: py),

--- a/desktop/Desktop/Sources/OnboardingFileScanStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingFileScanStepView.swift
@@ -15,7 +15,7 @@ struct OnboardingFileScanStepView: View {
       stepIndex: stepIndex,
       totalSteps: totalSteps,
       eyebrow: "Discovery",
-      title: "Map your work once.",
+      title: "Start building your profile.",
       description: "Omi scans projects and recent files.",
       showsSkip: true,
       onSkip: onSkip
@@ -51,20 +51,6 @@ struct OnboardingFileScanStepView: View {
           .padding(28)
         }
         .frame(maxWidth: 560, maxHeight: 280)
-
-        if let snapshot = coordinator.scanSnapshot {
-          OnboardingInsightCard(
-            icon: "shippingbox.fill",
-            title: "Mapped",
-            detail: [
-              snapshot.projectNames.prefix(3).joined(separator: ", "),
-              snapshot.technologies.prefix(3).joined(separator: ", "),
-            ]
-            .filter { !$0.isEmpty }
-            .joined(separator: "  •  ")
-          )
-          .frame(maxWidth: 560)
-        }
 
         if coordinator.scanSnapshot != nil {
           Button("Continue") {

--- a/desktop/Desktop/Sources/OnboardingFloatingBarDemoView.swift
+++ b/desktop/Desktop/Sources/OnboardingFloatingBarDemoView.swift
@@ -39,30 +39,29 @@ struct OnboardingFloatingBarDemoView: View {
             Spacer()
 
             // Content
-            VStack(spacing: 24) {
-                MacLineupPreview()
-                    .frame(maxWidth: 980)
-
+            VStack(spacing: 28) {
                 VStack(spacing: 12) {
                     Text("The Floating Bar")
                         .font(.system(size: 24, weight: .bold))
                         .foregroundColor(OmiColors.textPrimary)
 
-                    Text("Type: Which computer suits me best?")
-                        .font(.system(size: 18, weight: .medium))
-                        .foregroundColor(OmiColors.textSecondary)
-                        .multilineTextAlignment(.center)
-                        .lineSpacing(4)
-                        .frame(maxWidth: 560)
+                    if !barActivated {
+                        Text("Press this shortcut to open Ask Omi.")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(OmiColors.textSecondary)
+                            .multilineTextAlignment(.center)
+                    } else {
+                        Text("Type “Which computer suits me best?”")
+                            .font(.system(size: 18, weight: .medium))
+                            .foregroundColor(OmiColors.textSecondary)
+                            .multilineTextAlignment(.center)
+                            .lineSpacing(4)
+                            .frame(maxWidth: 560)
+                    }
                 }
 
                 if !barActivated {
-                    // Keyboard shortcut hint
                     VStack(spacing: 12) {
-                        Text("Try it now")
-                            .font(.system(size: 13))
-                            .foregroundColor(OmiColors.textTertiary)
-
                         HStack(spacing: 6) {
                             ForEach(Array(shortcutSettings.askOmiKey.hintKeys.enumerated()), id: \.offset) { index, symbol in
                                 if index > 0 {
@@ -73,12 +72,21 @@ struct OnboardingFloatingBarDemoView: View {
                                 keyCap(symbol)
                             }
                         }
+
+                        Text("Ask Omi opens at the top of your screen.")
+                            .font(.system(size: 13))
+                            .foregroundColor(OmiColors.textTertiary)
                     }
                     .padding(.top, 4)
                     .transition(.opacity)
-                } else if !showContinue {
-                    // Waiting for user to type and get a response
-                    Text("Type a question in the floating bar above")
+                } else {
+                    MacLineupPreview()
+                        .frame(maxWidth: 980)
+                        .transition(.opacity.combined(with: .move(edge: .bottom)))
+                }
+
+                if barActivated && !showContinue {
+                    Text("Ask the question above, then wait for the answer.")
                         .font(.system(size: 13))
                         .foregroundColor(OmiColors.textTertiary)
                         .padding(.top, 4)
@@ -95,10 +103,10 @@ struct OnboardingFloatingBarDemoView: View {
                 Button(action: onComplete) {
                     Text("Continue")
                         .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(.white)
+                        .foregroundColor(.black)
                         .frame(maxWidth: 280)
                         .padding(.vertical, 12)
-                        .background(OmiColors.purplePrimary)
+                        .background(Color.white)
                         .cornerRadius(12)
                 }
                 .buttonStyle(.plain)

--- a/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
@@ -13,7 +13,8 @@ struct OnboardingFloatingBarShortcutStepView: View {
 
     @State private var shortcutDetected = false
     @State private var showContinue = false
-    @State private var keyMonitor: Any?
+    @State private var localKeyMonitor: Any?
+    @State private var globalKeyMonitor: Any?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -67,35 +68,20 @@ struct OnboardingFloatingBarShortcutStepView: View {
                     }
                 }
 
-                HStack(spacing: 14) {
-                    Button(action: cycleShortcut) {
-                        Text("Change shortcut")
+                if showContinue {
+                    Button(action: onComplete) {
+                        Text("Continue")
                             .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(OmiColors.textSecondary)
-                            .padding(.horizontal, 18)
+                            .foregroundColor(.black)
+                            .padding(.horizontal, 28)
                             .padding(.vertical, 12)
                             .background(
                                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                    .fill(OmiColors.backgroundSecondary)
+                                    .fill(Color.white)
                             )
                     }
                     .buttonStyle(.plain)
-
-                    if showContinue {
-                        Button(action: onComplete) {
-                            Text("Continue")
-                                .font(.system(size: 15, weight: .semibold))
-                                .foregroundColor(.white)
-                                .padding(.horizontal, 28)
-                                .padding(.vertical, 12)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                                        .fill(OmiColors.purplePrimary)
-                                )
-                        }
-                        .buttonStyle(.plain)
-                        .transition(.move(edge: .trailing).combined(with: .opacity))
-                    }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
                 }
             }
 
@@ -110,9 +96,13 @@ struct OnboardingFloatingBarShortcutStepView: View {
             installKeyMonitor()
         }
         .onDisappear {
-            if let monitor = keyMonitor {
+            if let monitor = localKeyMonitor {
                 NSEvent.removeMonitor(monitor)
-                keyMonitor = nil
+                localKeyMonitor = nil
+            }
+            if let monitor = globalKeyMonitor {
+                NSEvent.removeMonitor(monitor)
+                globalKeyMonitor = nil
             }
             // Re-register the global hotkey for the next step.
             GlobalShortcutManager.shared.registerShortcuts()
@@ -137,19 +127,19 @@ struct OnboardingFloatingBarShortcutStepView: View {
 
     private func keyCap(_ label: String) -> some View {
         RoundedRectangle(cornerRadius: 10, style: .continuous)
-            .fill(shortcutDetected ? OmiColors.purplePrimary : OmiColors.backgroundTertiary)
+            .fill(shortcutDetected ? Color.white : OmiColors.backgroundTertiary)
             .frame(width: 48, height: 48)
             .overlay(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .stroke(
-                        shortcutDetected ? OmiColors.purplePrimary : OmiColors.textTertiary.opacity(0.3),
+                        shortcutDetected ? Color.white : OmiColors.textTertiary.opacity(0.3),
                         lineWidth: 2
                     )
             )
             .overlay {
                 Text(label)
                     .font(.system(size: 18, weight: .semibold))
-                    .foregroundColor(shortcutDetected ? .white : OmiColors.textPrimary)
+                    .foregroundColor(shortcutDetected ? .black : OmiColors.textPrimary)
             }
     }
 
@@ -168,12 +158,12 @@ struct OnboardingFloatingBarShortcutStepView: View {
                         .font(.system(size: 13, weight: .medium))
                 }
             }
-            .foregroundColor(isSelected ? .white : OmiColors.textSecondary)
+            .foregroundColor(isSelected ? .black : OmiColors.textSecondary)
             .padding(.horizontal, 14)
             .padding(.vertical, 10)
             .background(
                 RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(isSelected ? OmiColors.purplePrimary : OmiColors.backgroundSecondary)
+                    .fill(isSelected ? Color.white : OmiColors.backgroundSecondary)
             )
         }
         .buttonStyle(.plain)
@@ -182,28 +172,26 @@ struct OnboardingFloatingBarShortcutStepView: View {
     // MARK: - Key Monitor
 
     private func installKeyMonitor() {
-        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            guard !shortcutDetected else { return event }
-            if shortcutSettings.askOmiKey.matches(event) {
-                shortcutDetected = true
-                withAnimation(.easeInOut(duration: 0.3)) {
-                    showContinue = true
-                }
-                return nil  // consume the event so the floating bar does not open
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            if handleShortcutEvent(event) {
+                return nil
             }
             return event
         }
+        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+            _ = handleShortcutEvent(event)
+        }
     }
 
-    // MARK: - Cycle Shortcut
-
-    private func cycleShortcut() {
-        let allKeys = ShortcutSettings.AskOmiKey.allCases
-        guard let currentIndex = allKeys.firstIndex(of: shortcutSettings.askOmiKey) else { return }
-        let nextIndex = allKeys.index(after: currentIndex)
-        shortcutSettings.askOmiKey =
-            nextIndex == allKeys.endIndex ? allKeys[allKeys.startIndex] : allKeys[nextIndex]
-        shortcutDetected = false
-        showContinue = false
+    private func handleShortcutEvent(_ event: NSEvent) -> Bool {
+        guard !shortcutDetected else { return false }
+        guard shortcutSettings.askOmiKey.matches(event) else { return false }
+        DispatchQueue.main.async {
+            shortcutDetected = true
+            withAnimation(.easeInOut(duration: 0.3)) {
+                showContinue = true
+            }
+        }
+        return true
     }
 }

--- a/desktop/Desktop/Sources/OnboardingGoalStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingGoalStepView.swift
@@ -116,13 +116,13 @@ private struct GoalChipGrid: View {
         Button(action: { onSelect(item) }) {
           Text(item)
             .font(.system(size: 13, weight: .semibold))
-            .foregroundColor(isSelected ? .white : OmiColors.textSecondary)
+            .foregroundColor(isSelected ? .black : OmiColors.textSecondary)
             .frame(maxWidth: .infinity)
             .padding(.horizontal, 14)
             .padding(.vertical, 12)
             .background(
               RoundedRectangle(cornerRadius: 14, style: .continuous)
-                .fill(isSelected ? OmiColors.purplePrimary : Color.white.opacity(0.05))
+                .fill(isSelected ? Color.white : Color.white.opacity(0.05))
                 .overlay(
                   RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .stroke(Color.white.opacity(isSelected ? 0 : 0.08), lineWidth: 1)

--- a/desktop/Desktop/Sources/OnboardingNotificationStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingNotificationStepView.swift
@@ -45,7 +45,7 @@ struct OnboardingNotificationStepView: View {
                 // Icon with glow
                 ZStack {
                     Circle()
-                        .fill(OmiColors.purplePrimary.opacity(0.15))
+                        .fill(Color.white.opacity(0.15))
                         .frame(width: 100, height: 100)
                         .blur(radius: 20)
                         .scaleEffect(pulseAnimation ? 1.2 : 1.0)
@@ -55,7 +55,7 @@ struct OnboardingNotificationStepView: View {
                         .font(.system(size: 44))
                         .foregroundStyle(
                             LinearGradient(
-                                colors: [OmiColors.purplePrimary, OmiColors.purpleSecondary],
+                                colors: [Color.white, Color.gray],
                                 startPoint: .topLeading,
                                 endPoint: .bottomTrailing
                             )
@@ -93,7 +93,7 @@ struct OnboardingNotificationStepView: View {
                 VStack(spacing: 12) {
                     HStack(spacing: 6) {
                         Image(systemName: "bell.badge.fill")
-                            .foregroundColor(OmiColors.purplePrimary)
+                            .foregroundColor(Color.white)
                             .font(.system(size: 12))
                         Text("Notification shown below Ask omi")
                             .font(.system(size: 12))
@@ -103,10 +103,10 @@ struct OnboardingNotificationStepView: View {
                     Button(action: onContinue) {
                         Text("Continue")
                             .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(.white)
+                            .foregroundColor(.black)
                             .frame(maxWidth: 280)
                             .padding(.vertical, 12)
-                            .background(OmiColors.purplePrimary)
+                            .background(Color.white)
                             .cornerRadius(12)
                     }
                     .buttonStyle(.plain)
@@ -153,7 +153,7 @@ struct OnboardingNotificationStepView: View {
                 RoundedRectangle(cornerRadius: 8)
                     .fill(
                         LinearGradient(
-                            colors: [OmiColors.purplePrimary, OmiColors.purpleAccent],
+                            colors: [Color.black, Color.gray],
                             startPoint: .topLeading,
                             endPoint: .bottomTrailing
                         )

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -217,6 +217,8 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     scanState = .scanning
     scanStatusText = "Scanning your projects and apps..."
 
+    Task { await startBackgroundInsightsIfNeeded() }
+
     let result = await executeTool(name: "scan_files", arguments: [:])
     if result.lowercased().hasPrefix("error") {
       scanState = .failed(result)
@@ -227,7 +229,6 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     await refreshSnapshotIfAvailable()
     scanState = .complete
     scanStatusText = "Your workspace is mapped."
-    await startBackgroundInsightsIfNeeded()
   }
 
   func refreshSnapshotIfAvailable() async {
@@ -655,6 +656,7 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
     let publicDomains: Set<String> = [
       "gmail.com", "googlemail.com", "icloud.com", "me.com", "mac.com", "yahoo.com",
       "outlook.com", "hotmail.com", "live.com", "proton.me", "protonmail.com",
+      "privaterelay.appleid.com", "privaterelay.icloud.com",
     ]
 
     guard !publicDomains.contains(domain) else { return nil }

--- a/desktop/Desktop/Sources/OnboardingPermissionStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingPermissionStepView.swift
@@ -48,7 +48,7 @@ struct OnboardingPermissionStepView: View {
 
               Image(systemName: icon)
                 .font(.system(size: 24, weight: .semibold))
-                .foregroundColor(OmiColors.purplePrimary)
+                .foregroundColor(OmiColors.textSecondary)
             }
 
             VStack(alignment: .leading, spacing: 4) {

--- a/desktop/Desktop/Sources/OnboardingStepScaffold.swift
+++ b/desktop/Desktop/Sources/OnboardingStepScaffold.swift
@@ -152,7 +152,7 @@ struct OnboardingStepScaffold<Content: View>: View {
     HStack(spacing: 8) {
       ForEach(0..<totalSteps, id: \.self) { index in
         Capsule()
-          .fill(index <= stepIndex ? OmiColors.purplePrimary : Color.white.opacity(0.1))
+          .fill(index <= stepIndex ? Color.white : Color.white.opacity(0.1))
           .frame(width: index == stepIndex ? 28 : 8, height: 6)
       }
     }
@@ -164,7 +164,7 @@ struct OnboardingStepScaffold<Content: View>: View {
       Text(eyebrow.uppercased())
         .font(.system(size: 12, weight: .semibold))
         .tracking(1.2)
-        .foregroundColor(OmiColors.purplePrimary)
+        .foregroundColor(OmiColors.textTertiary)
 
       Text(title)
         .font(.system(size: 40, weight: .bold))
@@ -288,12 +288,12 @@ struct OnboardingCardButtonStyle: ButtonStyle {
   func makeBody(configuration: Configuration) -> some View {
     configuration.label
       .font(.system(size: 15, weight: .semibold))
-      .foregroundColor(isPrimary ? .white : OmiColors.textPrimary)
+      .foregroundColor(isPrimary ? .black : OmiColors.textPrimary)
       .padding(.horizontal, 18)
       .padding(.vertical, 12)
       .background(
         RoundedRectangle(cornerRadius: 14, style: .continuous)
-          .fill(isPrimary ? OmiColors.purplePrimary : OmiColors.backgroundTertiary)
+          .fill(isPrimary ? Color.white : OmiColors.backgroundTertiary)
       )
       .overlay(
         RoundedRectangle(cornerRadius: 14, style: .continuous)
@@ -319,7 +319,7 @@ struct OnboardingInsightCard: View {
 
         Image(systemName: icon)
           .font(.system(size: 16, weight: .semibold))
-          .foregroundColor(OmiColors.purplePrimary)
+          .foregroundColor(OmiColors.textSecondary)
       }
 
       VStack(alignment: .leading, spacing: 6) {
@@ -356,12 +356,12 @@ struct OnboardingSelectableChip: View {
     Button(action: action) {
       Text(title)
         .font(.system(size: 14, weight: .semibold))
-        .foregroundColor(isSelected ? .white : OmiColors.textSecondary)
+        .foregroundColor(isSelected ? .black : OmiColors.textSecondary)
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
         .background(
           Capsule()
-            .fill(isSelected ? OmiColors.purplePrimary : OmiColors.backgroundSecondary)
+            .fill(isSelected ? Color.white : OmiColors.backgroundSecondary)
         )
         .overlay(
           Capsule()

--- a/desktop/Desktop/Sources/OnboardingTasksStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingTasksStepView.swift
@@ -35,7 +35,7 @@ struct OnboardingTasksStepView: View {
                 // Icon with glow
                 ZStack {
                     Circle()
-                        .fill(OmiColors.purplePrimary.opacity(0.15))
+                        .fill(Color.white.opacity(0.15))
                         .frame(width: 100, height: 100)
                         .blur(radius: 20)
                         .scaleEffect(pulseAnimation ? 1.2 : 1.0)
@@ -45,7 +45,7 @@ struct OnboardingTasksStepView: View {
                         .font(.system(size: 44))
                         .foregroundStyle(
                             LinearGradient(
-                                colors: [OmiColors.purplePrimary, OmiColors.purpleSecondary],
+                                colors: [Color.white, Color.gray],
                                 startPoint: .topLeading,
                                 endPoint: .bottomTrailing
                             )
@@ -87,10 +87,10 @@ struct OnboardingTasksStepView: View {
                 Button(action: onComplete) {
                     Text("Take me to my tasks")
                         .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(.white)
+                        .foregroundColor(.black)
                         .frame(maxWidth: 280)
                         .padding(.vertical, 12)
-                        .background(OmiColors.purplePrimary)
+                        .background(Color.white)
                         .cornerRadius(12)
                 }
                 .buttonStyle(.plain)

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -289,6 +289,7 @@ struct OnboardingView: View {
           requiresRestart: true,
           onContinue: {
             AnalyticsManager.shared.onboardingStepCompleted(step: 10, stepName: "ScreenRecording")
+            startMonitoringIfNeeded()
             currentStep = 11
           },
           onSkip: {
@@ -306,9 +307,7 @@ struct OnboardingView: View {
           totalSteps: OnboardingFlow.introStepCount,
           onContinue: {
             AnalyticsManager.shared.onboardingStepCompleted(step: 11, stepName: "Goal")
-            if !ProactiveAssistantsPlugin.shared.isMonitoring {
-              ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
-            }
+            startMonitoringIfNeeded()
             currentStep = 12
           }
         )
@@ -418,7 +417,7 @@ struct OnboardingView: View {
     if LaunchAtLoginManager.shared.setEnabled(true) {
       AnalyticsManager.shared.launchAtLoginChanged(enabled: true, source: "onboarding_complete")
     }
-    ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
+    startMonitoringIfNeeded()
     appState.startTranscription()
 
     // Create welcome task
@@ -433,6 +432,13 @@ struct OnboardingView: View {
           priority: "low"
         )
       }
+    }
+  }
+
+  private func startMonitoringIfNeeded() {
+    AssistantSettings.shared.screenAnalysisEnabled = true
+    if !ProactiveAssistantsPlugin.shared.isMonitoring {
+      ProactiveAssistantsPlugin.shared.startMonitoring { _, _ in }
     }
   }
 }
@@ -467,7 +473,7 @@ struct OnboardingTrustPreviewCard: View {
       HStack(spacing: 8) {
         Image(systemName: "shield.lefthalf.filled")
           .font(.system(size: 16, weight: .semibold))
-          .foregroundColor(OmiColors.purplePrimary.opacity(0.9))
+          .foregroundColor(OmiColors.textSecondary)
         Text("Trust & Privacy")
           .font(.system(size: 17, weight: .medium))
           .foregroundColor(OmiColors.textSecondary)
@@ -498,7 +504,7 @@ struct OnboardingTrustPreviewCard: View {
           .fill(OmiColors.backgroundTertiary.opacity(0.75))
           .overlay(
             RoundedRectangle(cornerRadius: 16)
-              .stroke(OmiColors.purplePrimary.opacity(0.25), lineWidth: 1)
+              .stroke(Color.white.opacity(0.08), lineWidth: 1)
           )
       )
     }
@@ -511,7 +517,7 @@ struct OnboardingTrustPreviewCard: View {
     HStack(alignment: .top, spacing: 10) {
       Image(systemName: icon)
         .font(.system(size: 14, weight: .semibold))
-        .foregroundColor(OmiColors.purplePrimary)
+        .foregroundColor(OmiColors.textSecondary)
         .frame(width: 20, height: 20)
 
       VStack(alignment: .leading, spacing: 2) {
@@ -524,7 +530,7 @@ struct OnboardingTrustPreviewCard: View {
               .foregroundColor(OmiColors.textSecondary)
             if let url = URL(string: "https://github.com/basedhardware/omi/") {
               Link("public", destination: url)
-                .foregroundColor(OmiColors.purpleSecondary)
+                .foregroundColor(OmiColors.textPrimary)
                 .underline()
             }
             Text(" and auditable.")
@@ -628,7 +634,7 @@ struct OnboardingPrivacySheet: View {
       HStack {
         Image(systemName: "shield.lefthalf.filled")
           .scaledFont(size: 16)
-          .foregroundColor(OmiColors.purplePrimary)
+          .foregroundColor(OmiColors.textSecondary)
 
         Text("Data & Privacy")
           .scaledFont(size: 16, weight: .semibold)

--- a/desktop/Desktop/Sources/OnboardingVoiceDemoView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceDemoView.swift
@@ -14,6 +14,7 @@ struct OnboardingVoiceDemoView: View {
     @State private var observedShortcutPress = false
     @State private var waitingForResponse = false
     @State private var showContinue = false
+    @State private var previousTranscriptionMode: ShortcutSettings.PTTTranscriptionMode?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -83,10 +84,10 @@ struct OnboardingVoiceDemoView: View {
                 Button(action: onComplete) {
                     Text("Continue")
                         .font(.system(size: 15, weight: .semibold))
-                        .foregroundColor(.white)
+                        .foregroundColor(.black)
                         .frame(maxWidth: 280)
                         .padding(.vertical, 12)
-                        .background(OmiColors.purplePrimary)
+                        .background(Color.white)
                         .cornerRadius(12)
                 }
                 .buttonStyle(.plain)
@@ -98,14 +99,20 @@ struct OnboardingVoiceDemoView: View {
         .background(OmiColors.backgroundPrimary)
         .onAppear {
             FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
+            resetFloatingBarConversation()
             if let barState = FloatingControlBarManager.shared.barState {
                 PushToTalkManager.shared.setup(barState: barState)
             }
+            previousTranscriptionMode = shortcutSettings.pttTranscriptionMode
+            shortcutSettings.pttTranscriptionMode = .live
+            Task {
+                await chatProvider.warmupBridge()
+            }
         }
         .onDisappear {
-            if FloatingControlBarManager.shared.barState?.showingAIConversation == true {
-                FloatingControlBarManager.shared.toggleAIInput()
-            }
+            shortcutSettings.pttTranscriptionMode = previousTranscriptionMode ?? .batch
+            resetFloatingBarConversation()
+            PushToTalkManager.shared.cleanup()
         }
         .onChange(of: pttManager.state) { _, newState in
             if newState != .idle {
@@ -127,12 +134,19 @@ struct OnboardingVoiceDemoView: View {
             showContinueNow()
             return
         }
-        // Poll every 0.5s for up to 60s
-        for _ in 0..<120 {
-            try? await Task.sleep(nanoseconds: 500_000_000)
-            if barState.showingAIResponse,
-               let msg = barState.currentAIMessage,
-               !msg.isStreaming {
+        // Poll every 0.25s for up to 20s. Unlock as soon as the send cycle finishes,
+        // even if the network or bridge failed, so onboarding does not get stuck here.
+        for _ in 0..<80 {
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            if let msg = barState.currentAIMessage,
+               !msg.isStreaming,
+               !msg.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                showContinueNow()
+                return
+            }
+            if !chatProvider.isSending,
+               observedShortcutPress,
+               (chatProvider.errorMessage != nil || barState.currentAIMessage != nil) {
                 showContinueNow()
                 return
             }
@@ -145,6 +159,17 @@ struct OnboardingVoiceDemoView: View {
         withAnimation(.easeInOut(duration: 0.3)) {
             showContinue = true
         }
+    }
+
+    private func resetFloatingBarConversation() {
+        guard let barState = FloatingControlBarManager.shared.barState else { return }
+        barState.showingAIConversation = false
+        barState.showingAIResponse = false
+        barState.aiInputText = ""
+        barState.currentAIMessage = nil
+        barState.chatHistory = []
+        barState.isVoiceFollowUp = false
+        barState.voiceFollowUpTranscript = ""
     }
 
     private func keyCap(_ label: String) -> some View {

--- a/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
@@ -1,18 +1,17 @@
 import SwiftUI
 
-/// Onboarding step: verify the push-to-talk shortcut and complete one voice query
-/// without pre-showing the floating bar.
+/// Onboarding step: verify the push-to-talk shortcut key without opening the voice bar.
 struct OnboardingVoiceShortcutStepView: View {
   @ObservedObject var appState: AppState
   @ObservedObject var chatProvider: ChatProvider
   var onComplete: () -> Void
   var onSkip: () -> Void
 
-  @ObservedObject private var pttManager = PushToTalkManager.shared
   @ObservedObject private var shortcutSettings = ShortcutSettings.shared
 
-  @State private var observedShortcutPress = false
+  @State private var shortcutDetected = false
   @State private var showContinue = false
+  @State private var keyMonitor: Any?
 
   var body: some View {
     VStack(spacing: 0) {
@@ -84,12 +83,12 @@ struct OnboardingVoiceShortcutStepView: View {
             Button(action: onComplete) {
               Text("Continue")
                 .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(.black)
                 .padding(.horizontal, 28)
                 .padding(.vertical, 12)
                 .background(
                   RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(OmiColors.purplePrimary)
+                    .fill(Color.white)
                 )
             }
             .buttonStyle(.plain)
@@ -104,55 +103,54 @@ struct OnboardingVoiceShortcutStepView: View {
     .background(OmiColors.backgroundPrimary)
     .onAppear {
       FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
-
-      if let barState = FloatingControlBarManager.shared.barState {
-        PushToTalkManager.shared.setup(barState: barState)
-      }
+      resetFloatingBarConversation()
+      FloatingControlBarManager.shared.hide()
+      PushToTalkManager.shared.cleanup()
+      installKeyMonitor()
     }
     .onDisappear {
-      if FloatingControlBarManager.shared.barState?.showingAIConversation == true {
-        FloatingControlBarManager.shared.toggleAIInput()
+      if let monitor = keyMonitor {
+        NSEvent.removeMonitor(monitor)
+        keyMonitor = nil
       }
     }
-    .onChange(of: pttManager.state) { _, newState in
-      if newState != .idle {
-        observedShortcutPress = true
-      }
-      if OnboardingFlow.shouldUnlockVoiceShortcutContinue(
-        observedShortcutPress: observedShortcutPress,
-        pttState: newState
-      ) {
-        withAnimation(.easeInOut(duration: 0.3)) {
-          showContinue = true
-        }
-      }
-    }
+  }
+
+  private func resetFloatingBarConversation() {
+    guard let barState = FloatingControlBarManager.shared.barState else { return }
+    barState.showingAIConversation = false
+    barState.showingAIResponse = false
+    barState.aiInputText = ""
+    barState.currentAIMessage = nil
+    barState.chatHistory = []
+    barState.isVoiceFollowUp = false
+    barState.voiceFollowUpTranscript = ""
   }
 
   private var shortcutKeyPreview: some View {
     VStack(spacing: 12) {
       RoundedRectangle(cornerRadius: 14, style: .continuous)
-        .fill(isShortcutActive ? OmiColors.purplePrimary : OmiColors.backgroundTertiary)
+        .fill(shortcutDetected ? Color.white : OmiColors.backgroundTertiary)
         .frame(width: 64, height: 64)
         .overlay(
           RoundedRectangle(cornerRadius: 14, style: .continuous)
             .stroke(
-              isShortcutActive ? OmiColors.purplePrimary : OmiColors.textTertiary.opacity(0.3),
+              shortcutDetected ? Color.white : OmiColors.textTertiary.opacity(0.3),
               lineWidth: 2)
         )
         .overlay {
           VStack(spacing: 6) {
             Text(shortcutLabelTop)
               .font(.system(size: 13, weight: .semibold))
-              .foregroundColor(isShortcutActive ? .white : OmiColors.textPrimary)
+              .foregroundColor(shortcutDetected ? .black : OmiColors.textPrimary)
 
             Text(shortcutLabelBottom)
               .font(.system(size: 14, weight: .medium))
-              .foregroundColor(isShortcutActive ? .white.opacity(0.95) : OmiColors.textSecondary)
+              .foregroundColor(shortcutDetected ? .black.opacity(0.7) : OmiColors.textSecondary)
           }
         }
 
-      Text(isShortcutActive ? "Shortcut detected" : "Press and hold to test")
+      Text(shortcutDetected ? "Shortcut detected" : "Press and hold to test")
         .font(.system(size: 13, weight: .medium))
         .foregroundColor(OmiColors.textTertiary)
     }
@@ -162,7 +160,7 @@ struct OnboardingVoiceShortcutStepView: View {
     let isSelected = shortcutSettings.pttKey == key
     return Button {
       shortcutSettings.pttKey = key
-      observedShortcutPress = false
+      shortcutDetected = false
       showContinue = false
     } label: {
       HStack(spacing: 6) {
@@ -171,24 +169,15 @@ struct OnboardingVoiceShortcutStepView: View {
         Text(pttChoiceTitle(for: key))
           .font(.system(size: 13, weight: .semibold))
       }
-      .foregroundColor(isSelected ? .white : OmiColors.textSecondary)
+      .foregroundColor(isSelected ? .black : OmiColors.textSecondary)
       .padding(.horizontal, 14)
       .padding(.vertical, 10)
       .background(
         RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .fill(isSelected ? OmiColors.purplePrimary : OmiColors.backgroundSecondary)
+          .fill(isSelected ? Color.white : OmiColors.backgroundSecondary)
       )
     }
     .buttonStyle(.plain)
-  }
-
-  private var isShortcutActive: Bool {
-    switch pttManager.state {
-    case .idle:
-      return false
-    case .listening, .lockedListening, .finalizing:
-      return true
-    }
   }
 
   private var shortcutLabelTop: String {
@@ -217,13 +206,39 @@ struct OnboardingVoiceShortcutStepView: View {
     }
   }
 
+  private func installKeyMonitor() {
+    keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
+      guard !shortcutDetected else { return event }
+      guard matchesCurrentPTTShortcut(event) else { return event }
+
+      shortcutDetected = true
+      withAnimation(.easeInOut(duration: 0.3)) {
+        showContinue = true
+      }
+      return nil
+    }
+  }
+
+  private func matchesCurrentPTTShortcut(_ event: NSEvent) -> Bool {
+    switch shortcutSettings.pttKey {
+    case .option:
+      let otherModifiers: NSEvent.ModifierFlags = [.command, .control, .shift]
+      return event.modifierFlags.intersection(otherModifiers) == []
+        && event.modifierFlags.contains(.option)
+    case .rightCommand:
+      return event.keyCode == 54 && event.modifierFlags.contains(.command)
+    case .fn:
+      return event.modifierFlags.contains(.function)
+    }
+  }
+
   private func cycleShortcut() {
     let allKeys = ShortcutSettings.PTTKey.allCases
     guard let currentIndex = allKeys.firstIndex(of: shortcutSettings.pttKey) else { return }
     let nextIndex = allKeys.index(after: currentIndex)
     shortcutSettings.pttKey =
       nextIndex == allKeys.endIndex ? allKeys[allKeys.startIndex] : allKeys[nextIndex]
-    observedShortcutPress = false
+    shortcutDetected = false
     showContinue = false
   }
 }


### PR DESCRIPTION
## Summary
- improve the second half of desktop onboarding by making the shortcut and voice follow-up steps less confusing
- start onboarding enrichment earlier after file access and keep the graph styling aligned with the newer black/white onboarding work
- start screen monitoring as soon as screen recording is granted so Rewind has content immediately after onboarding

## Verification
- swift build --package-path desktop/Desktop
- rebuilt and launched /Applications/onboarding-part2.app
- connected with agent-swift to confirm the app launched

## Notes
- checked the separate onboarding-fixes worktree before landing this
- pulled in the safe overlap from that worktree (earlier background enrichment, private-relay search fix, and style harmonization) without taking the unrelated chat-only settings change