### PR TITLE
fix(desktop): floating bar text, graph persistence on restart

### DIFF
--- a/desktop/Desktop/Sources/OnboardingFloatingBarDemoView.swift
+++ b/desktop/Desktop/Sources/OnboardingFloatingBarDemoView.swift
@@ -42,18 +42,18 @@ struct OnboardingFloatingBarDemoView: View {
             VStack(spacing: 28) {
                 VStack(spacing: 12) {
                     if !barActivated {
-                        Text(“Omi sees your screen and gives you hyper-personalized responses”)
+                        Text("Omi sees your screen and gives you hyper-personalized responses")
                             .font(.system(size: 20, weight: .bold))
                             .foregroundColor(OmiColors.textPrimary)
                             .multilineTextAlignment(.center)
                             .frame(maxWidth: 560)
 
-                        Text(“Press this shortcut to open Ask Omi.”)
+                        Text("Press this shortcut to open Ask Omi.")
                             .font(.system(size: 18, weight: .medium))
                             .foregroundColor(OmiColors.textSecondary)
                             .multilineTextAlignment(.center)
                     } else {
-                        Text(“Type “Which computer suits me best?””)
+                        Text("Type 'Which computer suits me best?'")
                             .font(.system(size: 24, weight: .bold))
                             .foregroundColor(OmiColors.textPrimary)
                             .multilineTextAlignment(.center)

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -79,11 +79,12 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
 
   func prepare(appState: AppState) {
     ChatToolExecutor.onboardingAppState = appState
-    OnboardingChatPersistence.saveMidOnboarding()
     appState.checkAllPermissions()
 
-    // Clear graph only on first onboarding start (step 0), not mid-onboarding restarts.
-    if !OnboardingChatPersistence.isMidOnboarding {
+    // Clear graph only on first onboarding start, not mid-onboarding restarts.
+    let isResuming = OnboardingChatPersistence.isMidOnboarding
+    OnboardingChatPersistence.saveMidOnboarding()
+    if !isResuming {
       Task { await KnowledgeGraphStorage.shared.clearAll() }
     }
 


### PR DESCRIPTION
## Summary
- Replace "The Floating Bar" heading with "Omi sees your screen and gives you hyper-personalized responses"
- Make type prompt bigger (24pt bold) so users see it immediately
- Remove "Ask the question above, then wait for the answer." text
- Fix graph clearing: was always clearing because `saveMidOnboarding()` ran before the check
- Graph now preserved across mid-onboarding restarts (fixes Kacper's empty graph issue)

## Test plan
- [ ] Floating bar demo step shows new text
- [ ] Graph persists after screen recording restart
- [ ] Graph clears on fresh onboarding start

🤖 Generated with [Claude Code](https://claude.com/claude-code)