### PR TITLE
fix(transcribe): remove all heavy processing from listen — Redis deferred queue (#6061)

### DIFF
--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -899,3 +899,46 @@ def try_acquire_conversation_goal_lock(uid: str, conversation_id: str, ttl: int 
     """Idempotency lock: one goal extraction per conversation. Returns True if acquired."""
     result = r.set(f'users:{uid}:conv_goal_lock:{conversation_id}', '1', ex=ttl, nx=True)
     return result is not None
+
+
+# ******************************************************
+# ********** DEFERRED CONVERSATION QUEUE ***************
+# ******************************************************
+
+DEFERRED_CONVERSATION_QUEUE_KEY = 'deferred_conversations'
+DEFERRED_CONVERSATION_TTL = 60 * 60 * 4  # 4 hours — stale items auto-expire
+
+
+@try_catch_decorator
+def enqueue_deferred_conversation(uid: str, conversation_id: str, language: str) -> bool:
+    """Enqueue a conversation for deferred processing by pusher.
+
+    Idempotent: uses conversation_id as dedup key so the same conversation
+    is never queued twice even if multiple sessions enqueue it.
+    Returns True if newly added, False if already queued.
+    """
+    item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
+    dedup_key = f'deferred_conv_lock:{conversation_id}'
+    # Atomic dedup: only add to queue if the lock doesn't exist
+    if not r.set(dedup_key, '1', ex=DEFERRED_CONVERSATION_TTL, nx=True):
+        return False
+    r.rpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
+    return True
+
+
+@try_catch_decorator
+def dequeue_deferred_conversation() -> dict:
+    """Pop the next deferred conversation from the queue.
+
+    Returns dict with {uid, conversation_id, language} or None if empty.
+    """
+    item = r.lpop(DEFERRED_CONVERSATION_QUEUE_KEY)
+    if not item:
+        return None
+    return json.loads(item)
+
+
+@try_catch_decorator
+def get_deferred_queue_length() -> int:
+    """Return the current length of the deferred conversation queue."""
+    return r.llen(DEFERRED_CONVERSATION_QUEUE_KEY) or 0

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -909,33 +909,81 @@ DEFERRED_CONVERSATION_QUEUE_KEY = 'deferred_conversations'
 DEFERRED_CONVERSATION_TTL = 60 * 60 * 4  # 4 hours — stale items auto-expire
 
 
+DEFERRED_CONVERSATION_PROCESSING_KEY = 'deferred_conversations_processing'
+
+
 @try_catch_decorator
 def enqueue_deferred_conversation(uid: str, conversation_id: str, language: str) -> bool:
     """Enqueue a conversation for deferred processing by pusher.
 
     Idempotent: uses conversation_id as dedup key so the same conversation
     is never queued twice even if multiple sessions enqueue it.
-    Returns True if newly added, False if already queued.
+    Atomic: dedup lock + queue push happen in a single Redis pipeline.
+    Returns True if newly added, False if already queued or on error.
     """
     item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
     dedup_key = f'deferred_conv_lock:{conversation_id}'
-    # Atomic dedup: only add to queue if the lock doesn't exist
-    if not r.set(dedup_key, '1', ex=DEFERRED_CONVERSATION_TTL, nx=True):
+    # Atomic pipeline: set dedup lock + push to queue in one round-trip
+    pipe = r.pipeline(True)
+    pipe.set(dedup_key, '1', ex=DEFERRED_CONVERSATION_TTL, nx=True)
+    pipe.rpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
+    results = pipe.execute()
+    lock_acquired = results[0]
+    if not lock_acquired:
+        # Already queued — remove the duplicate we just pushed
+        r.lrem(DEFERRED_CONVERSATION_QUEUE_KEY, 1, item)
         return False
-    r.rpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
     return True
 
 
 @try_catch_decorator
 def dequeue_deferred_conversation() -> dict:
-    """Pop the next deferred conversation from the queue.
+    """Move the next deferred conversation to the processing list (crash-safe).
 
+    Uses LMOVE (atomic pop+push) so the item stays in the processing list
+    until explicitly acknowledged. If the worker crashes, the item remains
+    in the processing list for recovery.
     Returns dict with {uid, conversation_id, language} or None if empty.
     """
-    item = r.lpop(DEFERRED_CONVERSATION_QUEUE_KEY)
+    item = r.lmove(DEFERRED_CONVERSATION_QUEUE_KEY, DEFERRED_CONVERSATION_PROCESSING_KEY, 'LEFT', 'RIGHT')
     if not item:
         return None
     return json.loads(item)
+
+
+@try_catch_decorator
+def ack_deferred_conversation(uid: str, conversation_id: str, language: str):
+    """Acknowledge successful processing — remove from the processing list."""
+    item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
+    r.lrem(DEFERRED_CONVERSATION_PROCESSING_KEY, 1, item)
+
+
+@try_catch_decorator
+def nack_deferred_conversation(uid: str, conversation_id: str, language: str):
+    """Return a failed item back to the main queue for retry."""
+    item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
+    r.lrem(DEFERRED_CONVERSATION_PROCESSING_KEY, 1, item)
+    r.lpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
+    # Clear dedup lock so it can be re-enqueued if needed
+    r.delete(f'deferred_conv_lock:{conversation_id}')
+
+
+@try_catch_decorator
+def recover_deferred_processing():
+    """Move any items stuck in the processing list back to the main queue.
+
+    Called on pusher startup to recover from crashes.
+    """
+    while True:
+        item = r.lpop(DEFERRED_CONVERSATION_PROCESSING_KEY)
+        if not item:
+            break
+        r.rpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
+        try:
+            data = json.loads(item)
+            r.delete(f'deferred_conv_lock:{data["conversation_id"]}')
+        except Exception:
+            pass
 
 
 @try_catch_decorator

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -1005,17 +1005,34 @@ def ack_deferred_conversation(uid: str, conversation_id: str, language: str):
     r.delete(f'deferred_conv_active:{conversation_id}')
 
 
-@try_catch_decorator
-def nack_deferred_conversation(uid: str, conversation_id: str, language: str):
-    """Return a failed item back to the main queue for retry.
+DEFERRED_CONVERSATION_MAX_RETRIES = 3
 
-    Clears the active processing lock and moves item back to queue.
-    Does NOT delete the dedup lock — it persists until TTL expiry or ack.
+
+@try_catch_decorator
+def nack_deferred_conversation(uid: str, conversation_id: str, language: str) -> bool:
+    """Return a failed item to the back of the queue for retry, or discard after max retries.
+
+    Clears the active processing lock. Uses RPUSH (back of queue) to prevent
+    poison-pill starvation. Tracks retry count; after DEFERRED_CONVERSATION_MAX_RETRIES
+    failures, the item is discarded (not re-queued).
+    Returns True if re-queued, False if discarded.
     """
     item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
     r.lrem(DEFERRED_CONVERSATION_PROCESSING_KEY, 1, item)
     r.delete(f'deferred_conv_active:{conversation_id}')
-    r.lpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
+    # Track retry count
+    retry_key = f'deferred_conv_retries:{conversation_id}'
+    retries = r.incr(retry_key)
+    r.expire(retry_key, DEFERRED_CONVERSATION_TTL)
+    if retries > DEFERRED_CONVERSATION_MAX_RETRIES:
+        logger.warning(
+            f"Deferred conversation {conversation_id} exceeded {DEFERRED_CONVERSATION_MAX_RETRIES} retries, discarding"
+        )
+        r.delete(retry_key)
+        r.delete(f'deferred_conv_lock:{conversation_id}')
+        return False
+    r.rpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
+    return True
 
 
 @try_catch_decorator

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -921,14 +921,20 @@ end
 return 0
 """
 
-# Lua script for atomic recovery: LPOP + RPUSH in one call
+DEFERRED_PROCESSING_LOCK_TTL = 300  # 5 min — active processing claim per conversation
+
+# Lua script for atomic recovery: only LPOP+RPUSH if the processing lock has expired
 _RECOVER_ONE_LUA = """
-local item = redis.call('LPOP', KEYS[1])
-if item then
-    redis.call('RPUSH', KEYS[2], item)
-    return item
+local item = redis.call('LINDEX', KEYS[1], 0)
+if not item then return nil end
+local data = cjson.decode(item)
+local lock_key = 'deferred_conv_active:' .. data['conversation_id']
+if redis.call('EXISTS', lock_key) == 1 then
+    return 'ACTIVE'
 end
-return nil
+redis.call('LPOP', KEYS[1])
+redis.call('RPUSH', KEYS[2], item)
+return item
 """
 
 
@@ -952,49 +958,58 @@ def dequeue_deferred_conversation() -> dict:
     """Move the next deferred conversation to the processing list (crash-safe).
 
     Uses LMOVE (atomic pop+push) so the item stays in the processing list
-    until explicitly acknowledged. If the worker crashes, the item remains
-    in the processing list for recovery.
+    until explicitly acknowledged. Sets a per-conversation processing lock
+    with TTL so recovery knows which items are actively being processed.
     Returns dict with {uid, conversation_id, language} or None if empty.
     """
     item = r.lmove(DEFERRED_CONVERSATION_QUEUE_KEY, DEFERRED_CONVERSATION_PROCESSING_KEY, 'LEFT', 'RIGHT')
     if not item:
         return None
-    return json.loads(item)
+    data = json.loads(item)
+    # Set active processing lock — recovery skips items with this lock
+    r.set(f'deferred_conv_active:{data["conversation_id"]}', '1', ex=DEFERRED_PROCESSING_LOCK_TTL)
+    return data
 
 
 @try_catch_decorator
 def ack_deferred_conversation(uid: str, conversation_id: str, language: str):
-    """Acknowledge successful processing — remove from the processing list."""
+    """Acknowledge successful processing — remove from processing list and clear active lock."""
     item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
     r.lrem(DEFERRED_CONVERSATION_PROCESSING_KEY, 1, item)
+    r.delete(f'deferred_conv_active:{conversation_id}')
 
 
 @try_catch_decorator
 def nack_deferred_conversation(uid: str, conversation_id: str, language: str):
     """Return a failed item back to the main queue for retry.
 
-    Does NOT delete the dedup lock — it persists until TTL expiry or ack,
-    preventing duplicate enqueue while the item is still queued for retry.
+    Clears the active processing lock and moves item back to queue.
+    Does NOT delete the dedup lock — it persists until TTL expiry or ack.
     """
     item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
     r.lrem(DEFERRED_CONVERSATION_PROCESSING_KEY, 1, item)
+    r.delete(f'deferred_conv_active:{conversation_id}')
     r.lpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
 
 
 @try_catch_decorator
 def recover_deferred_processing():
-    """Move any items stuck in the processing list back to the main queue.
+    """Re-queue items stuck in the processing list from prior crashes.
 
-    Called on pusher startup to recover from crashes.
-    Atomic per-item via Lua script: LPOP + RPUSH in a single server-side call.
-    Does NOT delete dedup locks — they persist until TTL expiry or ack,
-    preventing duplicate enqueue while recovery items are re-queued.
+    Called on pusher startup. Only re-queues items whose active processing
+    lock has expired (meaning the processing pod crashed). Items still being
+    actively processed by another pod are left in place.
+    Atomic per-item via Lua script.
     """
     count = 0
     while True:
-        item = r.eval(_RECOVER_ONE_LUA, 2, DEFERRED_CONVERSATION_PROCESSING_KEY, DEFERRED_CONVERSATION_QUEUE_KEY)
-        if not item:
+        result = r.eval(_RECOVER_ONE_LUA, 2, DEFERRED_CONVERSATION_PROCESSING_KEY, DEFERRED_CONVERSATION_QUEUE_KEY)
+        if result is None:
             break
+        if isinstance(result, bytes):
+            result = result.decode()
+        if result == 'ACTIVE':
+            break  # Hit an item still being processed — stop scanning
         count += 1
     if count:
         logger.info(f"Recovered {count} deferred conversation(s) from processing list")

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -911,6 +911,26 @@ DEFERRED_CONVERSATION_TTL = 60 * 60 * 4  # 4 hours — stale items auto-expire
 
 DEFERRED_CONVERSATION_PROCESSING_KEY = 'deferred_conversations_processing'
 
+# Lua script for atomic dedup+push: only RPUSH if SET NX succeeds
+_ENQUEUE_LUA = """
+local lock_acquired = redis.call('SET', KEYS[1], '1', 'EX', ARGV[1], 'NX')
+if lock_acquired then
+    redis.call('RPUSH', KEYS[2], ARGV[2])
+    return 1
+end
+return 0
+"""
+
+# Lua script for atomic recovery: LPOP + RPUSH in one call
+_RECOVER_ONE_LUA = """
+local item = redis.call('LPOP', KEYS[1])
+if item then
+    redis.call('RPUSH', KEYS[2], item)
+    return item
+end
+return nil
+"""
+
 
 @try_catch_decorator
 def enqueue_deferred_conversation(uid: str, conversation_id: str, language: str) -> bool:
@@ -918,22 +938,13 @@ def enqueue_deferred_conversation(uid: str, conversation_id: str, language: str)
 
     Idempotent: uses conversation_id as dedup key so the same conversation
     is never queued twice even if multiple sessions enqueue it.
-    Atomic: dedup lock + queue push happen in a single Redis pipeline.
+    Fully atomic via Lua script: RPUSH only executes if SET NX succeeds.
     Returns True if newly added, False if already queued or on error.
     """
     item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
     dedup_key = f'deferred_conv_lock:{conversation_id}'
-    # Atomic pipeline: set dedup lock + push to queue in one round-trip
-    pipe = r.pipeline(True)
-    pipe.set(dedup_key, '1', ex=DEFERRED_CONVERSATION_TTL, nx=True)
-    pipe.rpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
-    results = pipe.execute()
-    lock_acquired = results[0]
-    if not lock_acquired:
-        # Already queued — remove the duplicate we just pushed
-        r.lrem(DEFERRED_CONVERSATION_QUEUE_KEY, 1, item)
-        return False
-    return True
+    result = r.eval(_ENQUEUE_LUA, 2, dedup_key, DEFERRED_CONVERSATION_QUEUE_KEY, str(DEFERRED_CONVERSATION_TTL), item)
+    return result == 1
 
 
 @try_catch_decorator
@@ -973,12 +984,12 @@ def recover_deferred_processing():
     """Move any items stuck in the processing list back to the main queue.
 
     Called on pusher startup to recover from crashes.
+    Atomic per-item via Lua script: LPOP + RPUSH in a single server-side call.
     """
     while True:
-        item = r.lpop(DEFERRED_CONVERSATION_PROCESSING_KEY)
+        item = r.eval(_RECOVER_ONE_LUA, 2, DEFERRED_CONVERSATION_PROCESSING_KEY, DEFERRED_CONVERSATION_QUEUE_KEY)
         if not item:
             break
-        r.rpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
         try:
             data = json.loads(item)
             r.delete(f'deferred_conv_lock:{data["conversation_id"]}')

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -923,18 +923,42 @@ return 0
 
 DEFERRED_PROCESSING_LOCK_TTL = 300  # 5 min — active processing claim per conversation
 
-# Lua script for atomic recovery: only LPOP+RPUSH if the processing lock has expired
-_RECOVER_ONE_LUA = """
-local item = redis.call('LINDEX', KEYS[1], 0)
+# Lua script for atomic dequeue: LMOVE + SET active lock in one server-side call
+_DEQUEUE_LUA = """
+local item = redis.call('LMOVE', KEYS[1], KEYS[2], 'LEFT', 'RIGHT')
 if not item then return nil end
 local data = cjson.decode(item)
 local lock_key = 'deferred_conv_active:' .. data['conversation_id']
-if redis.call('EXISTS', lock_key) == 1 then
-    return 'ACTIVE'
-end
-redis.call('LPOP', KEYS[1])
-redis.call('RPUSH', KEYS[2], item)
+redis.call('SET', lock_key, '1', 'EX', ARGV[1])
 return item
+"""
+
+# Lua script for atomic recovery: scan ALL items, re-queue only those without active lock
+_RECOVER_ALL_LUA = """
+local processing_key = KEYS[1]
+local queue_key = KEYS[2]
+local count = 0
+local len = redis.call('LLEN', processing_key)
+local i = 0
+while i < len do
+    local item = redis.call('LINDEX', processing_key, i)
+    if not item then break end
+    local ok, data = pcall(cjson.decode, item)
+    if ok and data['conversation_id'] then
+        local lock_key = 'deferred_conv_active:' .. data['conversation_id']
+        if redis.call('EXISTS', lock_key) == 0 then
+            redis.call('LREM', processing_key, 1, item)
+            redis.call('RPUSH', queue_key, item)
+            count = count + 1
+            len = len - 1
+        else
+            i = i + 1
+        end
+    else
+        i = i + 1
+    end
+end
+return count
 """
 
 
@@ -957,18 +981,20 @@ def enqueue_deferred_conversation(uid: str, conversation_id: str, language: str)
 def dequeue_deferred_conversation() -> dict:
     """Move the next deferred conversation to the processing list (crash-safe).
 
-    Uses LMOVE (atomic pop+push) so the item stays in the processing list
-    until explicitly acknowledged. Sets a per-conversation processing lock
-    with TTL so recovery knows which items are actively being processed.
+    Fully atomic via Lua: LMOVE + SET active lock in a single server-side call.
+    No race window between move and lock acquisition.
     Returns dict with {uid, conversation_id, language} or None if empty.
     """
-    item = r.lmove(DEFERRED_CONVERSATION_QUEUE_KEY, DEFERRED_CONVERSATION_PROCESSING_KEY, 'LEFT', 'RIGHT')
-    if not item:
+    result = r.eval(
+        _DEQUEUE_LUA,
+        2,
+        DEFERRED_CONVERSATION_QUEUE_KEY,
+        DEFERRED_CONVERSATION_PROCESSING_KEY,
+        str(DEFERRED_PROCESSING_LOCK_TTL),
+    )
+    if not result:
         return None
-    data = json.loads(item)
-    # Set active processing lock — recovery skips items with this lock
-    r.set(f'deferred_conv_active:{data["conversation_id"]}', '1', ex=DEFERRED_PROCESSING_LOCK_TTL)
-    return data
+    return json.loads(result)
 
 
 @try_catch_decorator
@@ -996,22 +1022,14 @@ def nack_deferred_conversation(uid: str, conversation_id: str, language: str):
 def recover_deferred_processing():
     """Re-queue items stuck in the processing list from prior crashes.
 
-    Called on pusher startup. Only re-queues items whose active processing
-    lock has expired (meaning the processing pod crashed). Items still being
-    actively processed by another pod are left in place.
-    Atomic per-item via Lua script.
+    Called on pusher startup. Scans ALL items in the processing list and
+    only re-queues those whose active processing lock has expired (meaning
+    the processing pod crashed). Items still being actively processed by
+    another pod are left in place.
+    Fully atomic via Lua script — scans entire list in one call.
     """
-    count = 0
-    while True:
-        result = r.eval(_RECOVER_ONE_LUA, 2, DEFERRED_CONVERSATION_PROCESSING_KEY, DEFERRED_CONVERSATION_QUEUE_KEY)
-        if result is None:
-            break
-        if isinstance(result, bytes):
-            result = result.decode()
-        if result == 'ACTIVE':
-            break  # Hit an item still being processed — stop scanning
-        count += 1
-    if count:
+    count = r.eval(_RECOVER_ALL_LUA, 2, DEFERRED_CONVERSATION_PROCESSING_KEY, DEFERRED_CONVERSATION_QUEUE_KEY)
+    if count and count > 0:
         logger.info(f"Recovered {count} deferred conversation(s) from processing list")
 
 

--- a/backend/database/redis_db.py
+++ b/backend/database/redis_db.py
@@ -971,12 +971,14 @@ def ack_deferred_conversation(uid: str, conversation_id: str, language: str):
 
 @try_catch_decorator
 def nack_deferred_conversation(uid: str, conversation_id: str, language: str):
-    """Return a failed item back to the main queue for retry."""
+    """Return a failed item back to the main queue for retry.
+
+    Does NOT delete the dedup lock — it persists until TTL expiry or ack,
+    preventing duplicate enqueue while the item is still queued for retry.
+    """
     item = json.dumps({'uid': uid, 'conversation_id': conversation_id, 'language': language})
     r.lrem(DEFERRED_CONVERSATION_PROCESSING_KEY, 1, item)
     r.lpush(DEFERRED_CONVERSATION_QUEUE_KEY, item)
-    # Clear dedup lock so it can be re-enqueued if needed
-    r.delete(f'deferred_conv_lock:{conversation_id}')
 
 
 @try_catch_decorator
@@ -985,16 +987,17 @@ def recover_deferred_processing():
 
     Called on pusher startup to recover from crashes.
     Atomic per-item via Lua script: LPOP + RPUSH in a single server-side call.
+    Does NOT delete dedup locks — they persist until TTL expiry or ack,
+    preventing duplicate enqueue while recovery items are re-queued.
     """
+    count = 0
     while True:
         item = r.eval(_RECOVER_ONE_LUA, 2, DEFERRED_CONVERSATION_PROCESSING_KEY, DEFERRED_CONVERSATION_QUEUE_KEY)
         if not item:
             break
-        try:
-            data = json.loads(item)
-            r.delete(f'deferred_conv_lock:{data["conversation_id"]}')
-        except Exception:
-            pass
+        count += 1
+    if count:
+        logger.info(f"Recovered {count} deferred conversation(s) from processing list")
 
 
 @try_catch_decorator

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -20,6 +20,14 @@ app = FastAPI()
 app.include_router(pusher.router)
 app.include_router(metrics.router)
 
+
+@app.on_event("startup")
+async def start_deferred_queue_worker():
+    import asyncio
+
+    asyncio.create_task(pusher.deferred_queue_worker())
+
+
 paths = ['_temp', '_samples', '_segments', '_speech_profiles']
 for path in paths:
     if not os.path.exists(path):

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import logging
 import os
@@ -23,8 +24,6 @@ app.include_router(metrics.router)
 
 @app.on_event("startup")
 async def start_deferred_queue_worker():
-    import asyncio
-
     asyncio.create_task(pusher.deferred_queue_worker())
 
 

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -581,34 +581,36 @@ DEFERRED_QUEUE_POLL_INTERVAL = 5.0  # seconds between queue polls
 
 
 async def _process_deferred_conversation(uid: str, conversation_id: str, language: str):
-    """Process a single deferred conversation (same logic as _process_conversation_task without WS response)."""
+    """Process a single deferred conversation (same logic as _process_conversation_task without WS response).
+
+    Raises on unrecoverable errors so the caller can nack and re-queue.
+    Processing errors (LLM/integration failures) are handled by discarding
+    the conversation — these are terminal and should not be retried.
+    """
+    conversation_data = conversations_db.get_conversation(uid, conversation_id)
+    if not conversation_data:
+        logger.warning(f"Deferred conversation not found: {conversation_id} {uid}")
+        return
+
+    conversation = Conversation(**conversation_data)
+
+    if conversation.status != ConversationStatus.processing:
+        conversations_db.update_conversation_status(uid, conversation.id, ConversationStatus.processing)
+        conversation.status = ConversationStatus.processing
+
     try:
-        conversation_data = conversations_db.get_conversation(uid, conversation_id)
-        if not conversation_data:
-            logger.warning(f"Deferred conversation not found: {conversation_id} {uid}")
-            return
+        geolocation = get_cached_user_geolocation(uid)
+        if geolocation:
+            geolocation = Geolocation(**geolocation)
+            conversation.geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
 
-        conversation = Conversation(**conversation_data)
-
-        if conversation.status != ConversationStatus.processing:
-            conversations_db.update_conversation_status(uid, conversation.id, ConversationStatus.processing)
-            conversation.status = ConversationStatus.processing
-
-        try:
-            geolocation = get_cached_user_geolocation(uid)
-            if geolocation:
-                geolocation = Geolocation(**geolocation)
-                conversation.geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
-
-            conversation = await asyncio.to_thread(process_conversation, uid, language, conversation)
-            await asyncio.to_thread(trigger_external_integrations, uid, conversation)
-        except Exception as e:
-            logger.error(f"Error processing deferred conversation: {e} {uid} {conversation_id}")
-            conversations_db.set_conversation_as_discarded(uid, conversation.id)
-
-        logger.info(f"Deferred conversation processed: {conversation_id} {uid}")
+        conversation = await asyncio.to_thread(process_conversation, uid, language, conversation)
+        await asyncio.to_thread(trigger_external_integrations, uid, conversation)
     except Exception as e:
-        logger.error(f"Error in _process_deferred_conversation: {e} {uid} {conversation_id}")
+        logger.error(f"Error processing deferred conversation: {e} {uid} {conversation_id}")
+        conversations_db.set_conversation_as_discarded(uid, conversation.id)
+
+    logger.info(f"Deferred conversation processed: {conversation_id} {uid}")
 
 
 async def deferred_queue_worker():

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -617,8 +617,14 @@ async def deferred_queue_worker():
     Started on pusher startup. Polls Redis for conversations that backend-listen
     enqueued when pusher was unavailable, and processes them using the same
     pipeline as real-time requests.
+
+    Crash-safe: uses LMOVE to move items to a processing list before work.
+    On success, ack removes the item. On failure, nack returns it to the queue.
+    On startup, recover_deferred_processing re-queues any items stuck in processing.
     """
     logger.info("Deferred queue worker started")
+    # Recover any items left in the processing list from a prior crash
+    redis_db.recover_deferred_processing()
     while True:
         try:
             item = redis_db.dequeue_deferred_conversation()
@@ -630,7 +636,12 @@ async def deferred_queue_worker():
             conversation_id = item['conversation_id']
             language = item.get('language', 'en')
             logger.info(f"Deferred queue worker processing: {conversation_id} {uid}")
-            await _process_deferred_conversation(uid, conversation_id, language)
+            try:
+                await _process_deferred_conversation(uid, conversation_id, language)
+                redis_db.ack_deferred_conversation(uid, conversation_id, language)
+            except Exception as e:
+                logger.error(f"Deferred queue worker processing failed, re-queueing: {e} {uid} {conversation_id}")
+                redis_db.nack_deferred_conversation(uid, conversation_id, language)
 
         except Exception as e:
             logger.error(f"Deferred queue worker error: {e}")

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -11,6 +11,7 @@ from fastapi.websockets import WebSocketDisconnect, WebSocket
 from starlette.websockets import WebSocketState
 
 import database.conversations as conversations_db
+from database import redis_db
 from database import users as users_db
 from database.redis_db import get_cached_user_geolocation
 from models.conversation import Conversation, ConversationStatus, Geolocation
@@ -570,6 +571,70 @@ async def _websocket_util_trigger(
                 await websocket.close(code=websocket_close_code)
             except Exception as e:
                 logger.error(f"Error closing WebSocket: {e}")
+
+
+# ******************************************************
+# ********** DEFERRED CONVERSATION QUEUE WORKER ********
+# ******************************************************
+
+DEFERRED_QUEUE_POLL_INTERVAL = 5.0  # seconds between queue polls
+
+
+async def _process_deferred_conversation(uid: str, conversation_id: str, language: str):
+    """Process a single deferred conversation (same logic as _process_conversation_task without WS response)."""
+    try:
+        conversation_data = conversations_db.get_conversation(uid, conversation_id)
+        if not conversation_data:
+            logger.warning(f"Deferred conversation not found: {conversation_id} {uid}")
+            return
+
+        conversation = Conversation(**conversation_data)
+
+        if conversation.status != ConversationStatus.processing:
+            conversations_db.update_conversation_status(uid, conversation.id, ConversationStatus.processing)
+            conversation.status = ConversationStatus.processing
+
+        try:
+            geolocation = get_cached_user_geolocation(uid)
+            if geolocation:
+                geolocation = Geolocation(**geolocation)
+                conversation.geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
+
+            conversation = await asyncio.to_thread(process_conversation, uid, language, conversation)
+            await asyncio.to_thread(trigger_external_integrations, uid, conversation)
+        except Exception as e:
+            logger.error(f"Error processing deferred conversation: {e} {uid} {conversation_id}")
+            conversations_db.set_conversation_as_discarded(uid, conversation.id)
+
+        logger.info(f"Deferred conversation processed: {conversation_id} {uid}")
+    except Exception as e:
+        logger.error(f"Error in _process_deferred_conversation: {e} {uid} {conversation_id}")
+
+
+async def deferred_queue_worker():
+    """Background worker that drains the Redis deferred conversation queue.
+
+    Started on pusher startup. Polls Redis for conversations that backend-listen
+    enqueued when pusher was unavailable, and processes them using the same
+    pipeline as real-time requests.
+    """
+    logger.info("Deferred queue worker started")
+    while True:
+        try:
+            item = redis_db.dequeue_deferred_conversation()
+            if item is None:
+                await asyncio.sleep(DEFERRED_QUEUE_POLL_INTERVAL)
+                continue
+
+            uid = item['uid']
+            conversation_id = item['conversation_id']
+            language = item.get('language', 'en')
+            logger.info(f"Deferred queue worker processing: {conversation_id} {uid}")
+            await _process_deferred_conversation(uid, conversation_id, language)
+
+        except Exception as e:
+            logger.error(f"Deferred queue worker error: {e}")
+            await asyncio.sleep(DEFERRED_QUEUE_POLL_INTERVAL)
 
 
 @router.websocket("/v1/trigger/listen")

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -148,6 +148,25 @@ PUSHER_DEGRADED_COOLDOWN = 60.0  # seconds before probing from DEGRADED
 PUSHER_RECONNECT_BASE_DELAY = 1.0  # seconds
 PUSHER_RECONNECT_MAX_DELAY = 60.0  # seconds
 
+# Conversation fallback: cap concurrent heavy processing on the listen event loop (#6061)
+FALLBACK_PROCESS_MAX_CONCURRENCY = max(1, int(os.getenv("FALLBACK_PROCESS_MAX_CONCURRENCY", "2")))
+FALLBACK_PROCESS_SEMAPHORE = asyncio.Semaphore(FALLBACK_PROCESS_MAX_CONCURRENCY)
+
+
+def _process_fallback_sync(uid: str, language: str, conversation, session_id: str):
+    """Run heavy conversation processing in a thread — must never run on the event loop.
+
+    Called via asyncio.to_thread() from _create_conversation_fallback().
+    """
+    geolocation = get_cached_user_geolocation(uid)
+    if geolocation:
+        geo = Geolocation(**geolocation)
+        conversation.geolocation = get_google_maps_location(geo.latitude, geo.longitude)
+
+    conversation = process_conversation(uid, language, conversation)
+    messages = trigger_external_integrations(uid, conversation)
+    return conversation, messages
+
 
 # ---- Multi-channel support ----
 
@@ -707,6 +726,7 @@ async def _stream_handler(
             _send_message_event(ConversationEvent(event_type="memory_processing_started", memory=conversation))
 
     # Fallback for when pusher is not available
+    # Heavy work runs in a thread to avoid blocking the event loop (#6061)
     async def _create_conversation_fallback(conversation_data: dict):
         conversation = Conversation(**conversation_data)
         if conversation.status != ConversationStatus.processing:
@@ -715,14 +735,10 @@ async def _stream_handler(
             conversation.status = ConversationStatus.processing
 
         try:
-            # Geolocation
-            geolocation = get_cached_user_geolocation(uid)
-            if geolocation:
-                geolocation = Geolocation(**geolocation)
-                conversation.geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
-
-            conversation = process_conversation(uid, language, conversation)
-            messages = trigger_external_integrations(uid, conversation)
+            async with FALLBACK_PROCESS_SEMAPHORE:
+                conversation, messages = await asyncio.to_thread(
+                    _process_fallback_sync, uid, language, conversation, session_id
+                )
         except Exception as e:
             logger.error(f"Error processing conversation: {e} {uid} {session_id}")
             conversations_db.set_conversation_as_discarded(uid, conversation.id)

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -703,12 +703,19 @@ async def _stream_handler(
 
     # Deferred processing: enqueue to Redis for pusher to drain (#6061)
     # No heavy work on the listen event loop — pusher handles all processing.
-    def _enqueue_conversation_for_deferred_processing(conversation_id: str):
+    def _enqueue_conversation_for_deferred_processing(conversation_id: str) -> bool:
+        """Returns True if enqueued or already queued, False on Redis error."""
         enqueued = redis_db.enqueue_deferred_conversation(uid, conversation_id, language)
-        if enqueued:
+        if enqueued is True:
             logger.info(f"Enqueued conversation {conversation_id} for deferred processing {uid} {session_id}")
-        else:
+            return True
+        elif enqueued is False:
             logger.info(f"Conversation {conversation_id} already queued for deferred processing {uid} {session_id}")
+            return True
+        else:
+            # enqueued is None — Redis error (swallowed by try_catch_decorator)
+            logger.error(f"Failed to enqueue conversation {conversation_id} (Redis error) {uid} {session_id}")
+            return False
 
     async def cleanup_processing_conversations():
         processing = conversations_db.get_processing_conversations(uid)
@@ -1452,11 +1459,12 @@ async def _stream_handler(
                     f"Conversation {conversation_id} already enqueued via fallback, skipping {uid} {session_id}"
                 )
                 return
-            fallback_processed_ids.add(conversation_id)
             logger.info(
                 f"Enqueueing conversation {conversation_id} for deferred processing (degraded) {uid} {session_id}"
             )
-            _enqueue_conversation_for_deferred_processing(conversation_id)
+            success = _enqueue_conversation_for_deferred_processing(conversation_id)
+            if success:
+                fallback_processed_ids.add(conversation_id)
 
         async def _pusher_reconnect_loop():
             """Single reconnect loop per session — replaces 3 scattered auto-reconnect calls.

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -38,10 +38,7 @@ import database.calendar_meetings as calendar_db
 import database.users as user_db
 from database.users import get_user_transcription_preferences
 from database import redis_db
-from database.redis_db import (
-    check_credits_invalidation,
-    get_cached_user_geolocation,
-)
+from database.redis_db import check_credits_invalidation
 from models.conversation import (
     Conversation,
     ConversationPhoto,
@@ -67,10 +64,9 @@ from models.message_event import (
 from models.transcript_segment import Translation
 from models.users import PlanType
 from utils.analytics import record_usage
-from utils.app_integrations import trigger_external_integrations, trigger_realtime_integrations
+from utils.app_integrations import trigger_realtime_integrations
 from utils.apps import is_audio_bytes_app_enabled
-from utils.conversations.location import get_google_maps_location
-from utils.conversations.process_conversation import process_conversation, retrieve_in_progress_conversation
+from utils.conversations.process_conversation import retrieve_in_progress_conversation
 from utils.notifications import send_credit_limit_notification, send_silent_user_notification
 from utils.other import endpoints as auth
 from utils.other.storage import get_profile_audio_if_exists, get_user_has_speech_profile
@@ -147,26 +143,6 @@ PUSHER_MAX_RECONNECT_ATTEMPTS = 6
 PUSHER_DEGRADED_COOLDOWN = 60.0  # seconds before probing from DEGRADED
 PUSHER_RECONNECT_BASE_DELAY = 1.0  # seconds
 PUSHER_RECONNECT_MAX_DELAY = 60.0  # seconds
-
-# Conversation fallback: cap concurrent heavy processing on the listen event loop (#6061)
-FALLBACK_PROCESS_MAX_CONCURRENCY = max(1, int(os.getenv("FALLBACK_PROCESS_MAX_CONCURRENCY", "2")))
-FALLBACK_PROCESS_SEMAPHORE = asyncio.Semaphore(FALLBACK_PROCESS_MAX_CONCURRENCY)
-
-
-def _process_fallback_sync(uid: str, language: str, conversation, session_id: str):
-    """Run heavy conversation processing in a thread — must never run on the event loop.
-
-    Called via asyncio.to_thread() from _create_conversation_fallback().
-    """
-    geolocation = get_cached_user_geolocation(uid)
-    if geolocation:
-        geo = Geolocation(**geolocation)
-        conversation.geolocation = get_google_maps_location(geo.latitude, geo.longitude)
-
-    conversation = process_conversation(uid, language, conversation)
-    messages = trigger_external_integrations(uid, conversation)
-    return conversation, messages
-
 
 # ---- Multi-channel support ----
 
@@ -725,27 +701,14 @@ async def _stream_handler(
             conversation = Conversation(**conversation_data)
             _send_message_event(ConversationEvent(event_type="memory_processing_started", memory=conversation))
 
-    # Fallback for when pusher is not available
-    # Heavy work runs in a thread to avoid blocking the event loop (#6061)
-    async def _create_conversation_fallback(conversation_data: dict):
-        conversation = Conversation(**conversation_data)
-        if conversation.status != ConversationStatus.processing:
-            _send_message_event(ConversationEvent(event_type="memory_processing_started", memory=conversation))
-            conversations_db.update_conversation_status(uid, conversation.id, ConversationStatus.processing)
-            conversation.status = ConversationStatus.processing
-
-        try:
-            async with FALLBACK_PROCESS_SEMAPHORE:
-                conversation, messages = await asyncio.to_thread(
-                    _process_fallback_sync, uid, language, conversation, session_id
-                )
-        except Exception as e:
-            logger.error(f"Error processing conversation: {e} {uid} {session_id}")
-            conversations_db.set_conversation_as_discarded(uid, conversation.id)
-            conversation.discarded = True
-            messages = []
-
-        _send_message_event(ConversationEvent(event_type="memory_created", memory=conversation, messages=messages))
+    # Deferred processing: enqueue to Redis for pusher to drain (#6061)
+    # No heavy work on the listen event loop — pusher handles all processing.
+    def _enqueue_conversation_for_deferred_processing(conversation_id: str):
+        enqueued = redis_db.enqueue_deferred_conversation(uid, conversation_id, language)
+        if enqueued:
+            logger.info(f"Enqueued conversation {conversation_id} for deferred processing {uid} {session_id}")
+        else:
+            logger.info(f"Conversation {conversation_id} already queued for deferred processing {uid} {session_id}")
 
     async def cleanup_processing_conversations():
         processing = conversations_db.get_processing_conversations(uid)
@@ -757,9 +720,9 @@ async def _stream_handler(
             if PUSHER_ENABLED and pusher_is_connected is not None and pusher_is_connected():
                 await request_conversation_processing(conversation['id'])
             elif PUSHER_ENABLED and pusher_is_degraded is not None and pusher_is_degraded():
-                await _create_conversation_fallback(conversation)
+                _enqueue_conversation_for_deferred_processing(conversation['id'])
             elif not PUSHER_ENABLED:
-                await _create_conversation_fallback(conversation)
+                _enqueue_conversation_for_deferred_processing(conversation['id'])
             else:
                 # PUSHER_ENABLED but handler not yet initialized — try pusher
                 await request_conversation_processing(conversation['id'])
@@ -855,17 +818,17 @@ async def _stream_handler(
         if conversation:
             has_content = conversation.get('transcript_segments') or conversation.get('photos')
             if has_content:
-                # Use pusher if enabled AND connected, otherwise fallback
+                # Use pusher if enabled AND connected, otherwise enqueue for deferred processing
                 if PUSHER_ENABLED and pusher_is_connected is not None and pusher_is_connected():
                     on_conversation_processing_started(conversation_id)
                     await request_conversation_processing(conversation_id)
                 elif PUSHER_ENABLED and pusher_is_degraded is not None and pusher_is_degraded():
                     logger.info(
-                        f"Pusher degraded, using fallback for conversation {conversation_id} {uid} {session_id}"
+                        f"Pusher degraded, enqueueing conversation {conversation_id} for deferred processing {uid} {session_id}"
                     )
-                    await _create_conversation_fallback(conversation)
+                    _enqueue_conversation_for_deferred_processing(conversation_id)
                 elif not PUSHER_ENABLED:
-                    await _create_conversation_fallback(conversation)
+                    _enqueue_conversation_for_deferred_processing(conversation_id)
                 else:
                     # PUSHER_ENABLED but handler not yet initialized — try pusher
                     on_conversation_processing_started(conversation_id)
@@ -1455,7 +1418,7 @@ async def _stream_handler(
                         )
                         # Route to fallback if in degraded mode
                         if reconnect_state == PusherReconnectState.DEGRADED:
-                            await _fallback_process_conversation(cid)
+                            _fallback_enqueue_conversation(cid)
                         pending_conversation_requests.pop(cid, None)
                         continue
                     info['retries'] += 1
@@ -1481,19 +1444,19 @@ async def _stream_handler(
             if reconnect_task is None or reconnect_task.done():
                 reconnect_task = asyncio.create_task(_pusher_reconnect_loop())
 
-        async def _fallback_process_conversation(conversation_id: str):
-            """Route conversation to fallback processing (degraded mode)."""
+        def _fallback_enqueue_conversation(conversation_id: str):
+            """Enqueue conversation for deferred processing (degraded mode)."""
             nonlocal fallback_processed_ids
             if conversation_id in fallback_processed_ids:
                 logger.info(
-                    f"Conversation {conversation_id} already processed via fallback, skipping {uid} {session_id}"
+                    f"Conversation {conversation_id} already enqueued via fallback, skipping {uid} {session_id}"
                 )
                 return
-            conversation_data = conversations_db.get_conversation(uid, conversation_id)
-            if conversation_data:
-                fallback_processed_ids.add(conversation_id)
-                logger.info(f"Routing conversation {conversation_id} to fallback (degraded mode) {uid} {session_id}")
-                await _create_conversation_fallback(conversation_data)
+            fallback_processed_ids.add(conversation_id)
+            logger.info(
+                f"Enqueueing conversation {conversation_id} for deferred processing (degraded) {uid} {session_id}"
+            )
+            _enqueue_conversation_for_deferred_processing(conversation_id)
 
         async def _pusher_reconnect_loop():
             """Single reconnect loop per session — replaces 3 scattered auto-reconnect calls.
@@ -1519,7 +1482,7 @@ async def _stream_handler(
                             # Route pending conversations to fallback (pop each to avoid race)
                             for cid in list(pending_conversation_requests.keys()):
                                 pending_conversation_requests.pop(cid, None)
-                                await _fallback_process_conversation(cid)
+                                _fallback_enqueue_conversation(cid)
                             continue
 
                         # Exponential backoff: 1s, 2s, 4s, 8s, 16s, 32s (capped at 60s)
@@ -1553,7 +1516,7 @@ async def _stream_handler(
                             logger.warning(f"Circuit breaker open, skipping to DEGRADED {uid} {session_id}")
                             for cid in list(pending_conversation_requests.keys()):
                                 pending_conversation_requests.pop(cid, None)
-                                await _fallback_process_conversation(cid)
+                                _fallback_enqueue_conversation(cid)
                             continue
                         except Exception:
                             pass  # _connect already logged the error

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -60,6 +60,7 @@ pytest tests/unit/test_sync_fair_use_gate.py -v
 pytest tests/unit/test_sync_silent_failure.py -v
 pytest tests/unit/test_timeout_middleware.py -v
 pytest tests/unit/test_pusher_circuit_breaker.py -v
+pytest tests/unit/test_fallback_event_loop_blocking.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_fallback_event_loop_blocking.py
+++ b/backend/tests/unit/test_fallback_event_loop_blocking.py
@@ -380,3 +380,222 @@ def test_reconnect_loop_routes_to_enqueue():
     func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 3000]
     assert '_fallback_enqueue_conversation' in func_body
     assert '_fallback_process_conversation' not in func_body or '_fallback_enqueue_conversation' in func_body
+
+
+# ---------------------------------------------------------------------------
+# Behavioral Redis queue tests (requires running Redis)
+# ---------------------------------------------------------------------------
+
+_TEST_UID = 'test-uid-6061'
+_TEST_CONV_ID_PREFIX = 'test-conv-6061-'
+_TEST_LANGUAGE = 'en'
+
+
+def _cleanup_redis_keys(conv_id):
+    """Clean up Redis keys created during a test."""
+    from database.redis_db import r
+
+    r.delete(f'deferred_conv_lock:{conv_id}')
+    r.delete(f'deferred_conv_active:{conv_id}')
+    r.delete(f'deferred_conv_retries:{conv_id}')
+    # Clean queue entries that might contain this conversation
+    from database.redis_db import DEFERRED_CONVERSATION_QUEUE_KEY, DEFERRED_CONVERSATION_PROCESSING_KEY
+    import json
+
+    item = json.dumps({'uid': _TEST_UID, 'conversation_id': conv_id, 'language': _TEST_LANGUAGE})
+    r.lrem(DEFERRED_CONVERSATION_QUEUE_KEY, 0, item)
+    r.lrem(DEFERRED_CONVERSATION_PROCESSING_KEY, 0, item)
+
+
+def test_redis_enqueue_dequeue_round_trip():
+    """Enqueue → dequeue must return the same item."""
+    from database import redis_db
+
+    conv_id = f'{_TEST_CONV_ID_PREFIX}roundtrip'
+    try:
+        result = redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        assert result is True, "First enqueue must return True"
+
+        item = redis_db.dequeue_deferred_conversation()
+        assert item is not None
+        assert item['uid'] == _TEST_UID
+        assert item['conversation_id'] == conv_id
+        assert item['language'] == _TEST_LANGUAGE
+
+        # Ack to clean up
+        redis_db.ack_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+    finally:
+        _cleanup_redis_keys(conv_id)
+
+
+def test_redis_enqueue_idempotent():
+    """Second enqueue of same conversation_id must return False."""
+    from database import redis_db
+
+    conv_id = f'{_TEST_CONV_ID_PREFIX}idempotent'
+    try:
+        first = redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        assert first is True
+        second = redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        assert second is False
+
+        # Clean up: dequeue and ack
+        item = redis_db.dequeue_deferred_conversation()
+        if item:
+            redis_db.ack_deferred_conversation(item['uid'], item['conversation_id'], item['language'])
+    finally:
+        _cleanup_redis_keys(conv_id)
+
+
+def test_redis_dequeue_empty_returns_none():
+    """Dequeue from empty queue must return None."""
+    from database import redis_db
+
+    item = redis_db.dequeue_deferred_conversation()
+    # Queue might have items from other tests — just verify it doesn't crash
+    # and returns either None or a valid dict
+    assert item is None or isinstance(item, dict)
+
+
+def test_redis_ack_removes_from_processing():
+    """Ack must remove the item from the processing list."""
+    from database import redis_db
+    from database.redis_db import r, DEFERRED_CONVERSATION_PROCESSING_KEY
+    import json
+
+    conv_id = f'{_TEST_CONV_ID_PREFIX}ack'
+    try:
+        redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        item = redis_db.dequeue_deferred_conversation()
+        assert item is not None
+
+        # Item should be in processing list
+        item_json = json.dumps({'uid': _TEST_UID, 'conversation_id': conv_id, 'language': _TEST_LANGUAGE})
+        count_before = r.llen(DEFERRED_CONVERSATION_PROCESSING_KEY) or 0
+
+        redis_db.ack_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+
+        # Active lock should be cleared
+        assert not r.exists(f'deferred_conv_active:{conv_id}')
+    finally:
+        _cleanup_redis_keys(conv_id)
+
+
+def test_redis_nack_requeues_to_back():
+    """Nack must return item to the back of the queue."""
+    from database import redis_db
+    from database.redis_db import r, DEFERRED_CONVERSATION_QUEUE_KEY
+
+    conv_id = f'{_TEST_CONV_ID_PREFIX}nack'
+    try:
+        redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        redis_db.dequeue_deferred_conversation()
+
+        queue_len_before = r.llen(DEFERRED_CONVERSATION_QUEUE_KEY) or 0
+        redis_db.nack_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        queue_len_after = r.llen(DEFERRED_CONVERSATION_QUEUE_KEY) or 0
+
+        assert queue_len_after == queue_len_before + 1, "Nack must add item back to queue"
+        # Active lock should be cleared
+        assert not r.exists(f'deferred_conv_active:{conv_id}')
+
+        # Clean up
+        item = redis_db.dequeue_deferred_conversation()
+        if item:
+            redis_db.ack_deferred_conversation(item['uid'], item['conversation_id'], item['language'])
+    finally:
+        _cleanup_redis_keys(conv_id)
+
+
+def test_redis_nack_max_retries_discards():
+    """After DEFERRED_CONVERSATION_MAX_RETRIES nacks, item must be discarded."""
+    from database import redis_db
+    from database.redis_db import r, DEFERRED_CONVERSATION_MAX_RETRIES
+
+    conv_id = f'{_TEST_CONV_ID_PREFIX}maxretry'
+    try:
+        redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+
+        for i in range(DEFERRED_CONVERSATION_MAX_RETRIES):
+            item = redis_db.dequeue_deferred_conversation()
+            assert item is not None, f"Dequeue should succeed on retry {i + 1}"
+            result = redis_db.nack_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+            assert result is True, f"Nack should re-queue on retry {i + 1}"
+
+        # One more dequeue + nack should discard
+        item = redis_db.dequeue_deferred_conversation()
+        assert item is not None
+        result = redis_db.nack_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        assert result is False, "Nack should discard after max retries"
+    finally:
+        _cleanup_redis_keys(conv_id)
+
+
+def test_redis_dequeue_sets_active_lock():
+    """Dequeue must set an active processing lock."""
+    from database import redis_db
+    from database.redis_db import r
+
+    conv_id = f'{_TEST_CONV_ID_PREFIX}activelock'
+    try:
+        redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        redis_db.dequeue_deferred_conversation()
+
+        assert r.exists(f'deferred_conv_active:{conv_id}'), "Dequeue must set active processing lock"
+        ttl = r.ttl(f'deferred_conv_active:{conv_id}')
+        assert ttl > 0, "Active lock must have a TTL"
+
+        redis_db.ack_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+    finally:
+        _cleanup_redis_keys(conv_id)
+
+
+def test_redis_recover_skips_active_items():
+    """Recovery must skip items with an active processing lock."""
+    from database import redis_db
+    from database.redis_db import r, DEFERRED_CONVERSATION_PROCESSING_KEY
+    import json
+
+    conv_id = f'{_TEST_CONV_ID_PREFIX}recover-active'
+    try:
+        redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        redis_db.dequeue_deferred_conversation()
+
+        # Item is in processing with active lock — recovery should skip it
+        processing_count_before = r.llen(DEFERRED_CONVERSATION_PROCESSING_KEY) or 0
+        redis_db.recover_deferred_processing()
+        processing_count_after = r.llen(DEFERRED_CONVERSATION_PROCESSING_KEY) or 0
+
+        assert processing_count_after == processing_count_before, "Recovery must not re-queue items with active lock"
+
+        redis_db.ack_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+    finally:
+        _cleanup_redis_keys(conv_id)
+
+
+def test_redis_recover_requeues_stale_items():
+    """Recovery must re-queue items whose active lock has expired."""
+    from database import redis_db
+    from database.redis_db import r, DEFERRED_CONVERSATION_PROCESSING_KEY, DEFERRED_CONVERSATION_QUEUE_KEY
+    import json
+
+    conv_id = f'{_TEST_CONV_ID_PREFIX}recover-stale'
+    try:
+        redis_db.enqueue_deferred_conversation(_TEST_UID, conv_id, _TEST_LANGUAGE)
+        redis_db.dequeue_deferred_conversation()
+
+        # Simulate crash: delete the active lock (as if TTL expired)
+        r.delete(f'deferred_conv_active:{conv_id}')
+
+        queue_len_before = r.llen(DEFERRED_CONVERSATION_QUEUE_KEY) or 0
+        redis_db.recover_deferred_processing()
+        queue_len_after = r.llen(DEFERRED_CONVERSATION_QUEUE_KEY) or 0
+
+        assert queue_len_after > queue_len_before, "Recovery must re-queue items without active lock"
+
+        # Clean up
+        item = redis_db.dequeue_deferred_conversation()
+        if item:
+            redis_db.ack_deferred_conversation(item['uid'], item['conversation_id'], item['language'])
+    finally:
+        _cleanup_redis_keys(conv_id)

--- a/backend/tests/unit/test_fallback_event_loop_blocking.py
+++ b/backend/tests/unit/test_fallback_event_loop_blocking.py
@@ -138,8 +138,8 @@ def test_redis_queue_key_defined():
     assert redis_db.DEFERRED_CONVERSATION_PROCESSING_KEY == 'deferred_conversations_processing'
 
 
-def test_enqueue_uses_pipeline_for_atomicity():
-    """enqueue_deferred_conversation must use a Redis pipeline for atomic dedup+push."""
+def test_enqueue_uses_lua_for_atomicity():
+    """enqueue_deferred_conversation must use a Lua script for atomic dedup+push."""
     import pathlib
 
     src = pathlib.Path(__file__).resolve().parents[2] / 'database' / 'redis_db.py'
@@ -148,7 +148,17 @@ def test_enqueue_uses_pipeline_for_atomicity():
     assert pos > 0
     next_func = source.find('\ndef ', pos + 1)
     func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 1000]
-    assert 'pipeline' in func_body, "enqueue must use a Redis pipeline for atomic dedup+push"
+    assert 'eval' in func_body, "enqueue must use r.eval (Lua script) for atomic dedup+push"
+
+
+def test_enqueue_lua_script_defined():
+    """_ENQUEUE_LUA must be defined with SET NX + RPUSH logic."""
+    import pathlib
+
+    src = pathlib.Path(__file__).resolve().parents[2] / 'database' / 'redis_db.py'
+    source = src.read_text()
+    assert '_ENQUEUE_LUA' in source
+    assert 'SET' in source and 'NX' in source and 'RPUSH' in source
 
 
 def test_dequeue_uses_lmove():
@@ -162,6 +172,19 @@ def test_dequeue_uses_lmove():
     next_func = source.find('\ndef ', pos + 1)
     func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 500]
     assert 'lmove' in func_body, "dequeue must use LMOVE (atomic pop+push to processing list)"
+
+
+def test_recover_uses_lua_for_atomicity():
+    """recover_deferred_processing must use Lua for atomic LPOP+RPUSH."""
+    import pathlib
+
+    src = pathlib.Path(__file__).resolve().parents[2] / 'database' / 'redis_db.py'
+    source = src.read_text()
+    pos = source.find('def recover_deferred_processing')
+    assert pos > 0
+    next_func = source.find('\ndef ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 500]
+    assert 'eval' in func_body, "recover must use r.eval (Lua script) for atomic LPOP+RPUSH"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_fallback_event_loop_blocking.py
+++ b/backend/tests/unit/test_fallback_event_loop_blocking.py
@@ -1,18 +1,19 @@
-"""Tests for conversation fallback event loop blocking fix (#6061).
+"""Tests for conversation deferred processing via Redis queue (#6061).
 
-Verifies that _create_conversation_fallback offloads heavy processing to a thread
-via asyncio.to_thread() and that the pod-level semaphore caps concurrency.
+Verifies that backend-listen never runs heavy processing locally — instead,
+conversations are enqueued to Redis for the pusher deferred queue worker.
 """
 
 import asyncio
+import json
 import threading
 import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 # ---------------------------------------------------------------------------
-# Source-level regression tests
+# Source-level regression tests — ensure architecture constraints hold
 # ---------------------------------------------------------------------------
 
 
@@ -24,88 +25,178 @@ def _read_transcribe_source():
     return src.read_text()
 
 
-def test_fallback_uses_asyncio_to_thread():
-    """_create_conversation_fallback must use asyncio.to_thread to offload blocking work."""
+def _read_pusher_source():
+    """Read routers/pusher.py source code."""
+    import pathlib
+
+    src = pathlib.Path(__file__).resolve().parents[2] / 'routers' / 'pusher.py'
+    return src.read_text()
+
+
+def _read_pusher_main_source():
+    """Read pusher/main.py source code."""
+    import pathlib
+
+    src = pathlib.Path(__file__).resolve().parents[2] / 'pusher' / 'main.py'
+    return src.read_text()
+
+
+def test_no_process_conversation_import_in_transcribe():
+    """transcribe.py must NOT import process_conversation (all processing is in pusher)."""
     source = _read_transcribe_source()
-    fallback_pos = source.find('async def _create_conversation_fallback')
-    assert fallback_pos > 0, "Cannot find _create_conversation_fallback"
-    fallback_body = source[fallback_pos : fallback_pos + 800]
+    # It should only import retrieve_in_progress_conversation, NOT process_conversation
+    assert 'import process_conversation' not in source or 'retrieve_in_progress_conversation' in source
+    # The direct function call must never appear (except in string literals / comments)
+    # Check that process_conversation( is not called as a function
+    lines = source.split('\n')
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith('#') or stripped.startswith('"') or stripped.startswith("'"):
+            continue
+        assert (
+            'process_conversation(uid' not in stripped
+        ), f"transcribe.py must not call process_conversation() directly: {stripped}"
+
+
+def test_no_trigger_external_integrations_in_transcribe():
+    """transcribe.py must NOT import or call trigger_external_integrations."""
+    source = _read_transcribe_source()
     assert (
-        'asyncio.to_thread' in fallback_body
-    ), "_create_conversation_fallback must use asyncio.to_thread to avoid blocking the event loop"
+        'trigger_external_integrations' not in source
+    ), "transcribe.py must not import or call trigger_external_integrations — this belongs in pusher"
 
 
-def test_fallback_uses_semaphore():
-    """_create_conversation_fallback must use FALLBACK_PROCESS_SEMAPHORE to cap concurrency."""
+def test_no_create_conversation_fallback():
+    """_create_conversation_fallback must not exist — replaced by Redis enqueue."""
     source = _read_transcribe_source()
-    fallback_pos = source.find('async def _create_conversation_fallback')
-    assert fallback_pos > 0
-    fallback_body = source[fallback_pos : fallback_pos + 800]
     assert (
-        'FALLBACK_PROCESS_SEMAPHORE' in fallback_body
-    ), "_create_conversation_fallback must use FALLBACK_PROCESS_SEMAPHORE"
+        '_create_conversation_fallback' not in source
+    ), "_create_conversation_fallback must be removed — use _enqueue_conversation_for_deferred_processing"
 
 
-def test_process_fallback_sync_exists_at_module_level():
-    """_process_fallback_sync must be a module-level function (not nested in closure)."""
+def test_no_process_fallback_sync():
+    """_process_fallback_sync must not exist — no heavy processing on listen."""
     source = _read_transcribe_source()
-    pos = source.find('def _process_fallback_sync(')
-    assert pos > 0, "Missing _process_fallback_sync function"
-    # Must be at module level (no leading whitespace beyond 0)
-    line_start = source.rfind('\n', 0, pos) + 1
-    leading = source[line_start:pos]
-    assert leading.strip() == '', "_process_fallback_sync must be at module level (no indentation)"
+    assert (
+        '_process_fallback_sync' not in source
+    ), "_process_fallback_sync must be removed — no heavy processing on the listen event loop"
 
 
-def test_process_fallback_sync_calls_process_conversation():
-    """_process_fallback_sync must call process_conversation."""
+def test_no_fallback_semaphore():
+    """FALLBACK_PROCESS_SEMAPHORE must not exist — not needed with Redis queue."""
     source = _read_transcribe_source()
-    pos = source.find('def _process_fallback_sync(')
+    assert 'FALLBACK_PROCESS_SEMAPHORE' not in source
+    assert 'FALLBACK_PROCESS_MAX_CONCURRENCY' not in source
+
+
+def test_enqueue_function_exists_in_transcribe():
+    """_enqueue_conversation_for_deferred_processing must exist in transcribe.py."""
+    source = _read_transcribe_source()
+    assert '_enqueue_conversation_for_deferred_processing' in source
+
+
+def test_enqueue_calls_redis_enqueue():
+    """_enqueue_conversation_for_deferred_processing must call redis_db.enqueue_deferred_conversation."""
+    source = _read_transcribe_source()
+    # Find the function body
+    pos = source.find('_enqueue_conversation_for_deferred_processing')
     assert pos > 0
-    # Find the end of the function (next def at same or lower indent)
-    next_def = source.find('\ndef ', pos + 1)
-    func_body = source[pos:next_def] if next_def > 0 else source[pos : pos + 800]
-    assert 'process_conversation(' in func_body, "_process_fallback_sync must call process_conversation"
-    assert (
-        'trigger_external_integrations(' in func_body
-    ), "_process_fallback_sync must call trigger_external_integrations"
-
-
-def test_no_direct_process_conversation_in_fallback():
-    """_create_conversation_fallback must NOT call process_conversation directly (must use thread)."""
-    source = _read_transcribe_source()
-    fallback_pos = source.find('async def _create_conversation_fallback')
-    assert fallback_pos > 0
-    # Find next function definition to bound the search
-    next_func = source.find('\n    async def ', fallback_pos + 1)
-    if next_func < 0:
-        next_func = fallback_pos + 800
-    fallback_body = source[fallback_pos:next_func]
-    assert (
-        'process_conversation(uid' not in fallback_body
-    ), "_create_conversation_fallback must not call process_conversation directly — use asyncio.to_thread"
-
-
-def test_semaphore_constant_exists():
-    """FALLBACK_PROCESS_SEMAPHORE and FALLBACK_PROCESS_MAX_CONCURRENCY must be defined."""
-    source = _read_transcribe_source()
-    assert 'FALLBACK_PROCESS_MAX_CONCURRENCY' in source
-    assert 'FALLBACK_PROCESS_SEMAPHORE' in source
-
-
-def test_fallback_sync_handles_geolocation():
-    """_process_fallback_sync must handle geolocation before processing."""
-    source = _read_transcribe_source()
-    pos = source.find('def _process_fallback_sync(')
-    assert pos > 0
-    next_def = source.find('\ndef ', pos + 1)
-    func_body = source[pos:next_def] if next_def > 0 else source[pos : pos + 800]
-    assert 'get_cached_user_geolocation' in func_body, "_process_fallback_sync must call get_cached_user_geolocation"
-    assert 'get_google_maps_location' in func_body, "_process_fallback_sync must call get_google_maps_location"
+    func_body = source[pos : pos + 500]
+    assert 'enqueue_deferred_conversation' in func_body
 
 
 # ---------------------------------------------------------------------------
-# Behavioral tests — test the threading/semaphore patterns directly
+# Redis queue function tests
+# ---------------------------------------------------------------------------
+
+
+def test_redis_enqueue_deferred_conversation():
+    """enqueue_deferred_conversation must push to Redis list with dedup."""
+    from database import redis_db
+
+    assert hasattr(redis_db, 'enqueue_deferred_conversation')
+    assert hasattr(redis_db, 'dequeue_deferred_conversation')
+    assert hasattr(redis_db, 'get_deferred_queue_length')
+
+
+def test_redis_queue_key_defined():
+    """DEFERRED_CONVERSATION_QUEUE_KEY must be defined in redis_db."""
+    from database import redis_db
+
+    assert hasattr(redis_db, 'DEFERRED_CONVERSATION_QUEUE_KEY')
+    assert redis_db.DEFERRED_CONVERSATION_QUEUE_KEY == 'deferred_conversations'
+
+
+# ---------------------------------------------------------------------------
+# Pusher deferred queue worker tests
+# ---------------------------------------------------------------------------
+
+
+def test_deferred_queue_worker_exists_in_pusher():
+    """deferred_queue_worker must exist in routers/pusher.py."""
+    source = _read_pusher_source()
+    assert 'async def deferred_queue_worker' in source
+
+
+def test_process_deferred_conversation_exists():
+    """_process_deferred_conversation must exist in routers/pusher.py."""
+    source = _read_pusher_source()
+    assert 'async def _process_deferred_conversation' in source
+
+
+def test_deferred_worker_uses_to_thread():
+    """_process_deferred_conversation must use asyncio.to_thread for heavy work."""
+    source = _read_pusher_source()
+    pos = source.find('async def _process_deferred_conversation')
+    assert pos > 0
+    # Find end of function
+    next_func = source.find('\nasync def ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 1500]
+    assert (
+        'asyncio.to_thread' in func_body
+    ), "_process_deferred_conversation must use asyncio.to_thread for blocking operations"
+
+
+def test_deferred_worker_calls_process_conversation():
+    """_process_deferred_conversation must call process_conversation."""
+    source = _read_pusher_source()
+    pos = source.find('async def _process_deferred_conversation')
+    assert pos > 0
+    next_func = source.find('\nasync def ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 1500]
+    assert 'process_conversation' in func_body
+
+
+def test_deferred_worker_handles_geolocation():
+    """_process_deferred_conversation must handle geolocation."""
+    source = _read_pusher_source()
+    pos = source.find('async def _process_deferred_conversation')
+    assert pos > 0
+    next_func = source.find('\nasync def ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 1500]
+    assert 'get_cached_user_geolocation' in func_body
+    assert 'get_google_maps_location' in func_body
+
+
+def test_deferred_worker_discards_on_error():
+    """_process_deferred_conversation must discard conversation on error."""
+    source = _read_pusher_source()
+    pos = source.find('async def _process_deferred_conversation')
+    assert pos > 0
+    next_func = source.find('\nasync def ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 1500]
+    assert 'set_conversation_as_discarded' in func_body
+
+
+def test_pusher_main_starts_deferred_worker():
+    """pusher/main.py must start the deferred queue worker on startup."""
+    source = _read_pusher_main_source()
+    assert 'deferred_queue_worker' in source
+    assert 'startup' in source
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests — Redis queue patterns
 # ---------------------------------------------------------------------------
 
 
@@ -115,17 +206,17 @@ async def test_to_thread_offloads_blocking_work():
     event_loop_thread = threading.current_thread().ident
     worker_thread_id = None
 
-    def blocking_work(uid, language, conversation, session_id):
+    def blocking_work(uid, language, conversation):
         nonlocal worker_thread_id
         worker_thread_id = threading.current_thread().ident
-        time.sleep(0.05)  # Simulate blocking work
-        return conversation, []
+        time.sleep(0.05)
+        return conversation
 
     mock_conversation = MagicMock()
-    await asyncio.to_thread(blocking_work, 'uid', 'en', mock_conversation, 'sess')
+    await asyncio.to_thread(blocking_work, 'uid', 'en', mock_conversation)
 
-    assert worker_thread_id is not None, "Worker thread ID should be set"
-    assert worker_thread_id != event_loop_thread, "Blocking work must run in a different thread than the event loop"
+    assert worker_thread_id is not None
+    assert worker_thread_id != event_loop_thread
 
 
 @pytest.mark.asyncio
@@ -139,218 +230,68 @@ async def test_event_loop_remains_responsive_during_thread_offload():
             await asyncio.sleep(0.01)
             ticker_count += 1
 
-    def slow_sync(uid, language, conversation, session_id):
-        time.sleep(0.15)  # Simulate 150ms of blocking work
-        return conversation, []
+    def slow_sync(uid, language, conversation):
+        time.sleep(0.15)
+        return conversation
 
     mock_conversation = MagicMock()
 
-    async def run_fallback():
-        return await asyncio.to_thread(slow_sync, 'uid', 'en', mock_conversation, 'sess')
+    async def run_in_thread():
+        return await asyncio.to_thread(slow_sync, 'uid', 'en', mock_conversation)
 
-    # Run ticker and fallback concurrently
-    await asyncio.gather(ticker(), run_fallback())
-
-    assert ticker_count >= 10, f"Event loop ticker only ran {ticker_count}/20 times — event loop was blocked"
-
-
-@pytest.mark.asyncio
-async def test_semaphore_caps_concurrency():
-    """asyncio.Semaphore must limit concurrent thread executions."""
-    max_concurrent = 0
-    current_concurrent = 0
-    lock = threading.Lock()
-
-    def counting_sync(uid, language, conversation, session_id):
-        nonlocal max_concurrent, current_concurrent
-        with lock:
-            current_concurrent += 1
-            if current_concurrent > max_concurrent:
-                max_concurrent = current_concurrent
-        time.sleep(0.1)
-        with lock:
-            current_concurrent -= 1
-        return conversation, []
-
-    # Use a semaphore with max=1 for testing
-    test_semaphore = asyncio.Semaphore(1)
-
-    async def run_one():
-        async with test_semaphore:
-            return await asyncio.to_thread(counting_sync, 'uid', 'en', MagicMock(), 'sess')
-
-    # Launch 4 concurrent fallback tasks
-    await asyncio.gather(*[run_one() for _ in range(4)])
-
-    assert max_concurrent == 1, f"Max concurrent was {max_concurrent}, expected 1 with semaphore(1)"
-
-
-@pytest.mark.asyncio
-async def test_semaphore_2_allows_two_concurrent():
-    """Semaphore(2) should allow exactly 2 concurrent executions."""
-    max_concurrent = 0
-    current_concurrent = 0
-    lock = threading.Lock()
-
-    def counting_sync(uid, language, conversation, session_id):
-        nonlocal max_concurrent, current_concurrent
-        with lock:
-            current_concurrent += 1
-            if current_concurrent > max_concurrent:
-                max_concurrent = current_concurrent
-        time.sleep(0.1)
-        with lock:
-            current_concurrent -= 1
-        return conversation, []
-
-    test_semaphore = asyncio.Semaphore(2)
-
-    async def run_one():
-        async with test_semaphore:
-            return await asyncio.to_thread(counting_sync, 'uid', 'en', MagicMock(), 'sess')
-
-    await asyncio.gather(*[run_one() for _ in range(6)])
-
-    assert max_concurrent == 2, f"Max concurrent was {max_concurrent}, expected 2 with semaphore(2)"
+    await asyncio.gather(ticker(), run_in_thread())
+    assert ticker_count >= 10, f"Event loop ticker only ran {ticker_count}/20 — event loop was blocked"
 
 
 @pytest.mark.asyncio
 async def test_exception_propagates_from_thread():
-    """Exceptions from the thread worker must propagate to the caller for error handling."""
+    """Exceptions from the thread worker must propagate to the caller."""
 
-    def failing_sync(uid, language, conversation, session_id):
+    def failing_sync(uid, language, conversation):
         raise RuntimeError("OpenAI API unavailable")
 
     with pytest.raises(RuntimeError, match="OpenAI API unavailable"):
-        await asyncio.to_thread(failing_sync, 'uid', 'en', MagicMock(), 'sess')
-
-
-@pytest.mark.asyncio
-async def test_semaphore_releases_on_exception():
-    """Semaphore must be released even when the thread worker raises."""
-    test_semaphore = asyncio.Semaphore(1)
-    call_count = 0
-
-    def failing_sync(uid, language, conversation, session_id):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            raise RuntimeError("fail first time")
-        return conversation, []
-
-    # First call fails
-    with pytest.raises(RuntimeError):
-        async with test_semaphore:
-            await asyncio.to_thread(failing_sync, 'uid', 'en', MagicMock(), 'sess')
-
-    # Second call should succeed (semaphore released despite exception)
-    async with test_semaphore:
-        result = await asyncio.to_thread(failing_sync, 'uid', 'en', MagicMock(), 'sess')
-
-    assert result is not None, "Semaphore must be released after exception for retry"
-    assert call_count == 2
+        await asyncio.to_thread(failing_sync, 'uid', 'en', MagicMock())
 
 
 # ---------------------------------------------------------------------------
-# Status transition and cancellation tests
+# Degraded mode routing tests
 # ---------------------------------------------------------------------------
 
 
-def test_status_transition_skipped_when_already_processing():
-    """_create_conversation_fallback must NOT send memory_processing_started if already processing.
-
-    Source-level: the `if conversation.status != ConversationStatus.processing` guard
-    must exist in the fallback function.
-    """
+def test_degraded_mode_routes_to_enqueue():
+    """When pusher is degraded, _process_conversation must enqueue, not process locally."""
     source = _read_transcribe_source()
-    fallback_pos = source.find('async def _create_conversation_fallback')
-    assert fallback_pos > 0
-    next_func = source.find('\n    async def ', fallback_pos + 1)
-    fallback_body = source[fallback_pos:next_func] if next_func > 0 else source[fallback_pos : fallback_pos + 800]
+    # Find the _process_conversation function (the inner one, indented)
+    pos = source.find('async def _process_conversation(conversation_id')
+    assert pos > 0, "Cannot find _process_conversation"
+    next_func = source.find('\n    async def ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 1000]
     assert (
-        'ConversationStatus.processing' in fallback_body
-    ), "Fallback must check conversation.status before sending processing event"
+        '_enqueue_conversation_for_deferred_processing' in func_body
+    ), "Degraded mode must route to _enqueue_conversation_for_deferred_processing"
+    assert (
+        '_create_conversation_fallback' not in func_body
+    ), "_create_conversation_fallback must not be called — use Redis enqueue"
 
 
-def test_discard_path_on_exception():
-    """On exception, conversation must be discarded and memory_created still sent.
-
-    Source-level: set_conversation_as_discarded must appear in the except block.
-    """
+def test_cleanup_processing_routes_to_enqueue():
+    """cleanup_processing_conversations must enqueue when degraded, not process locally."""
     source = _read_transcribe_source()
-    fallback_pos = source.find('async def _create_conversation_fallback')
-    assert fallback_pos > 0
-    next_func = source.find('\n    async def ', fallback_pos + 1)
-    fallback_body = source[fallback_pos:next_func] if next_func > 0 else source[fallback_pos : fallback_pos + 800]
-    assert 'set_conversation_as_discarded' in fallback_body, "Exception path must discard the conversation"
-    assert 'memory_created' in fallback_body, "memory_created event must be sent even on error (with empty messages)"
+    pos = source.find('async def cleanup_processing_conversations')
+    assert pos > 0
+    next_func = source.find('\n    async def ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 800]
+    assert '_enqueue_conversation_for_deferred_processing' in func_body
+    assert '_create_conversation_fallback' not in func_body
 
 
-@pytest.mark.asyncio
-async def test_cancellation_during_semaphore_wait():
-    """Task cancelled while waiting on semaphore must raise CancelledError."""
-    semaphore = asyncio.Semaphore(1)
-    # Hold the semaphore so the second task has to wait
-    await semaphore.acquire()
-
-    async def wait_for_semaphore():
-        async with semaphore:
-            return "acquired"
-
-    task = asyncio.create_task(wait_for_semaphore())
-    await asyncio.sleep(0.01)  # Let it start waiting
-    task.cancel()
-
-    with pytest.raises(asyncio.CancelledError):
-        await task
-
-    # Release the semaphore — it should still be usable
-    semaphore.release()
-    async with semaphore:
-        pass  # Semaphore still functional after cancellation
-
-
-@pytest.mark.asyncio
-async def test_cancellation_during_to_thread():
-    """Task cancelled during to_thread — CancelledError propagates but thread keeps running.
-
-    This documents the known behavior: asyncio.to_thread work is not truly
-    cancellable, but CancelledError is raised to the awaiter.
-    """
-    started = threading.Event()
-    finished = threading.Event()
-
-    def long_work(uid, language, conversation, session_id):
-        started.set()
-        time.sleep(0.5)
-        finished.set()
-        return conversation, []
-
-    task = asyncio.create_task(asyncio.to_thread(long_work, 'uid', 'en', MagicMock(), 'sess'))
-    await asyncio.sleep(0.05)  # Let the thread start
-    assert started.is_set(), "Thread should have started"
-
-    task.cancel()
-    with pytest.raises(asyncio.CancelledError):
-        await task
-
-    # Thread continues running (expected behavior — to_thread is not cancellable)
-    finished.wait(timeout=2.0)
-    assert finished.is_set(), "Thread continues even after task cancel (expected)"
-
-
-@pytest.mark.asyncio
-async def test_fallback_return_value_shape():
-    """_process_fallback_sync must return (conversation, messages) tuple."""
-
-    def sync_impl(uid, language, conversation, session_id):
-        return conversation, ['msg1', 'msg2']
-
-    mock_conversation = MagicMock()
-    result = await asyncio.to_thread(sync_impl, 'uid', 'en', mock_conversation, 'sess')
-
-    assert isinstance(result, tuple), "Return value must be a tuple"
-    assert len(result) == 2, "Return value must be (conversation, messages)"
-    conversation, messages = result
-    assert conversation is mock_conversation
-    assert messages == ['msg1', 'msg2']
+def test_reconnect_loop_routes_to_enqueue():
+    """_pusher_reconnect_loop must enqueue when exhausted/CB open, not process locally."""
+    source = _read_transcribe_source()
+    pos = source.find('async def _pusher_reconnect_loop')
+    assert pos > 0
+    next_func = source.find('\n        async def ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 3000]
+    assert '_fallback_enqueue_conversation' in func_body
+    assert '_fallback_process_conversation' not in func_body or '_fallback_enqueue_conversation' in func_body

--- a/backend/tests/unit/test_fallback_event_loop_blocking.py
+++ b/backend/tests/unit/test_fallback_event_loop_blocking.py
@@ -161,17 +161,21 @@ def test_enqueue_lua_script_defined():
     assert 'SET' in source and 'NX' in source and 'RPUSH' in source
 
 
-def test_dequeue_uses_lmove():
-    """dequeue_deferred_conversation must use LMOVE for crash-safe dequeue."""
+def test_dequeue_uses_lua_with_lmove():
+    """dequeue_deferred_conversation must use Lua script with LMOVE + SET for atomicity."""
     import pathlib
 
     src = pathlib.Path(__file__).resolve().parents[2] / 'database' / 'redis_db.py'
     source = src.read_text()
+    # Check the Lua script contains LMOVE + SET
+    assert '_DEQUEUE_LUA' in source
+    assert 'LMOVE' in source
+    # Dequeue function must use eval (Lua)
     pos = source.find('def dequeue_deferred_conversation')
     assert pos > 0
     next_func = source.find('\ndef ', pos + 1)
     func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 500]
-    assert 'lmove' in func_body, "dequeue must use LMOVE (atomic pop+push to processing list)"
+    assert 'eval' in func_body, "dequeue must use r.eval (Lua script) for atomic LMOVE + SET lock"
 
 
 def test_recover_uses_lua_for_atomicity():

--- a/backend/tests/unit/test_fallback_event_loop_blocking.py
+++ b/backend/tests/unit/test_fallback_event_loop_blocking.py
@@ -119,12 +119,49 @@ def test_redis_enqueue_deferred_conversation():
     assert hasattr(redis_db, 'get_deferred_queue_length')
 
 
+def test_redis_ack_nack_recover_exist():
+    """ack, nack, and recover functions must exist for crash-safe processing."""
+    from database import redis_db
+
+    assert hasattr(redis_db, 'ack_deferred_conversation')
+    assert hasattr(redis_db, 'nack_deferred_conversation')
+    assert hasattr(redis_db, 'recover_deferred_processing')
+
+
 def test_redis_queue_key_defined():
-    """DEFERRED_CONVERSATION_QUEUE_KEY must be defined in redis_db."""
+    """DEFERRED_CONVERSATION_QUEUE_KEY and PROCESSING_KEY must be defined in redis_db."""
     from database import redis_db
 
     assert hasattr(redis_db, 'DEFERRED_CONVERSATION_QUEUE_KEY')
     assert redis_db.DEFERRED_CONVERSATION_QUEUE_KEY == 'deferred_conversations'
+    assert hasattr(redis_db, 'DEFERRED_CONVERSATION_PROCESSING_KEY')
+    assert redis_db.DEFERRED_CONVERSATION_PROCESSING_KEY == 'deferred_conversations_processing'
+
+
+def test_enqueue_uses_pipeline_for_atomicity():
+    """enqueue_deferred_conversation must use a Redis pipeline for atomic dedup+push."""
+    import pathlib
+
+    src = pathlib.Path(__file__).resolve().parents[2] / 'database' / 'redis_db.py'
+    source = src.read_text()
+    pos = source.find('def enqueue_deferred_conversation')
+    assert pos > 0
+    next_func = source.find('\ndef ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 1000]
+    assert 'pipeline' in func_body, "enqueue must use a Redis pipeline for atomic dedup+push"
+
+
+def test_dequeue_uses_lmove():
+    """dequeue_deferred_conversation must use LMOVE for crash-safe dequeue."""
+    import pathlib
+
+    src = pathlib.Path(__file__).resolve().parents[2] / 'database' / 'redis_db.py'
+    source = src.read_text()
+    pos = source.find('def dequeue_deferred_conversation')
+    assert pos > 0
+    next_func = source.find('\ndef ', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 500]
+    assert 'lmove' in func_body, "dequeue must use LMOVE (atomic pop+push to processing list)"
 
 
 # ---------------------------------------------------------------------------
@@ -193,6 +230,27 @@ def test_pusher_main_starts_deferred_worker():
     source = _read_pusher_main_source()
     assert 'deferred_queue_worker' in source
     assert 'startup' in source
+
+
+def test_deferred_worker_uses_ack_nack():
+    """deferred_queue_worker must use ack on success and nack on failure."""
+    source = _read_pusher_source()
+    pos = source.find('async def deferred_queue_worker')
+    assert pos > 0
+    next_func = source.find('\n@router', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 2000]
+    assert 'ack_deferred_conversation' in func_body, "Worker must ack on success"
+    assert 'nack_deferred_conversation' in func_body, "Worker must nack on failure for retry"
+
+
+def test_deferred_worker_recovers_on_startup():
+    """deferred_queue_worker must call recover_deferred_processing on startup."""
+    source = _read_pusher_source()
+    pos = source.find('async def deferred_queue_worker')
+    assert pos > 0
+    next_func = source.find('\n@router', pos + 1)
+    func_body = source[pos:next_func] if next_func > 0 else source[pos : pos + 2000]
+    assert 'recover_deferred_processing' in func_body, "Worker must recover stuck items on startup"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/unit/test_fallback_event_loop_blocking.py
+++ b/backend/tests/unit/test_fallback_event_loop_blocking.py
@@ -249,3 +249,108 @@ async def test_semaphore_releases_on_exception():
 
     assert result is not None, "Semaphore must be released after exception for retry"
     assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Status transition and cancellation tests
+# ---------------------------------------------------------------------------
+
+
+def test_status_transition_skipped_when_already_processing():
+    """_create_conversation_fallback must NOT send memory_processing_started if already processing.
+
+    Source-level: the `if conversation.status != ConversationStatus.processing` guard
+    must exist in the fallback function.
+    """
+    source = _read_transcribe_source()
+    fallback_pos = source.find('async def _create_conversation_fallback')
+    assert fallback_pos > 0
+    next_func = source.find('\n    async def ', fallback_pos + 1)
+    fallback_body = source[fallback_pos:next_func] if next_func > 0 else source[fallback_pos : fallback_pos + 800]
+    assert (
+        'ConversationStatus.processing' in fallback_body
+    ), "Fallback must check conversation.status before sending processing event"
+
+
+def test_discard_path_on_exception():
+    """On exception, conversation must be discarded and memory_created still sent.
+
+    Source-level: set_conversation_as_discarded must appear in the except block.
+    """
+    source = _read_transcribe_source()
+    fallback_pos = source.find('async def _create_conversation_fallback')
+    assert fallback_pos > 0
+    next_func = source.find('\n    async def ', fallback_pos + 1)
+    fallback_body = source[fallback_pos:next_func] if next_func > 0 else source[fallback_pos : fallback_pos + 800]
+    assert 'set_conversation_as_discarded' in fallback_body, "Exception path must discard the conversation"
+    assert 'memory_created' in fallback_body, "memory_created event must be sent even on error (with empty messages)"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_semaphore_wait():
+    """Task cancelled while waiting on semaphore must raise CancelledError."""
+    semaphore = asyncio.Semaphore(1)
+    # Hold the semaphore so the second task has to wait
+    await semaphore.acquire()
+
+    async def wait_for_semaphore():
+        async with semaphore:
+            return "acquired"
+
+    task = asyncio.create_task(wait_for_semaphore())
+    await asyncio.sleep(0.01)  # Let it start waiting
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Release the semaphore — it should still be usable
+    semaphore.release()
+    async with semaphore:
+        pass  # Semaphore still functional after cancellation
+
+
+@pytest.mark.asyncio
+async def test_cancellation_during_to_thread():
+    """Task cancelled during to_thread — CancelledError propagates but thread keeps running.
+
+    This documents the known behavior: asyncio.to_thread work is not truly
+    cancellable, but CancelledError is raised to the awaiter.
+    """
+    started = threading.Event()
+    finished = threading.Event()
+
+    def long_work(uid, language, conversation, session_id):
+        started.set()
+        time.sleep(0.5)
+        finished.set()
+        return conversation, []
+
+    task = asyncio.create_task(asyncio.to_thread(long_work, 'uid', 'en', MagicMock(), 'sess'))
+    await asyncio.sleep(0.05)  # Let the thread start
+    assert started.is_set(), "Thread should have started"
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Thread continues running (expected behavior — to_thread is not cancellable)
+    finished.wait(timeout=2.0)
+    assert finished.is_set(), "Thread continues even after task cancel (expected)"
+
+
+@pytest.mark.asyncio
+async def test_fallback_return_value_shape():
+    """_process_fallback_sync must return (conversation, messages) tuple."""
+
+    def sync_impl(uid, language, conversation, session_id):
+        return conversation, ['msg1', 'msg2']
+
+    mock_conversation = MagicMock()
+    result = await asyncio.to_thread(sync_impl, 'uid', 'en', mock_conversation, 'sess')
+
+    assert isinstance(result, tuple), "Return value must be a tuple"
+    assert len(result) == 2, "Return value must be (conversation, messages)"
+    conversation, messages = result
+    assert conversation is mock_conversation
+    assert messages == ['msg1', 'msg2']

--- a/backend/tests/unit/test_fallback_event_loop_blocking.py
+++ b/backend/tests/unit/test_fallback_event_loop_blocking.py
@@ -1,0 +1,251 @@
+"""Tests for conversation fallback event loop blocking fix (#6061).
+
+Verifies that _create_conversation_fallback offloads heavy processing to a thread
+via asyncio.to_thread() and that the pod-level semaphore caps concurrency.
+"""
+
+import asyncio
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Source-level regression tests
+# ---------------------------------------------------------------------------
+
+
+def _read_transcribe_source():
+    """Read routers/transcribe.py source code."""
+    import pathlib
+
+    src = pathlib.Path(__file__).resolve().parents[2] / 'routers' / 'transcribe.py'
+    return src.read_text()
+
+
+def test_fallback_uses_asyncio_to_thread():
+    """_create_conversation_fallback must use asyncio.to_thread to offload blocking work."""
+    source = _read_transcribe_source()
+    fallback_pos = source.find('async def _create_conversation_fallback')
+    assert fallback_pos > 0, "Cannot find _create_conversation_fallback"
+    fallback_body = source[fallback_pos : fallback_pos + 800]
+    assert (
+        'asyncio.to_thread' in fallback_body
+    ), "_create_conversation_fallback must use asyncio.to_thread to avoid blocking the event loop"
+
+
+def test_fallback_uses_semaphore():
+    """_create_conversation_fallback must use FALLBACK_PROCESS_SEMAPHORE to cap concurrency."""
+    source = _read_transcribe_source()
+    fallback_pos = source.find('async def _create_conversation_fallback')
+    assert fallback_pos > 0
+    fallback_body = source[fallback_pos : fallback_pos + 800]
+    assert (
+        'FALLBACK_PROCESS_SEMAPHORE' in fallback_body
+    ), "_create_conversation_fallback must use FALLBACK_PROCESS_SEMAPHORE"
+
+
+def test_process_fallback_sync_exists_at_module_level():
+    """_process_fallback_sync must be a module-level function (not nested in closure)."""
+    source = _read_transcribe_source()
+    pos = source.find('def _process_fallback_sync(')
+    assert pos > 0, "Missing _process_fallback_sync function"
+    # Must be at module level (no leading whitespace beyond 0)
+    line_start = source.rfind('\n', 0, pos) + 1
+    leading = source[line_start:pos]
+    assert leading.strip() == '', "_process_fallback_sync must be at module level (no indentation)"
+
+
+def test_process_fallback_sync_calls_process_conversation():
+    """_process_fallback_sync must call process_conversation."""
+    source = _read_transcribe_source()
+    pos = source.find('def _process_fallback_sync(')
+    assert pos > 0
+    # Find the end of the function (next def at same or lower indent)
+    next_def = source.find('\ndef ', pos + 1)
+    func_body = source[pos:next_def] if next_def > 0 else source[pos : pos + 800]
+    assert 'process_conversation(' in func_body, "_process_fallback_sync must call process_conversation"
+    assert (
+        'trigger_external_integrations(' in func_body
+    ), "_process_fallback_sync must call trigger_external_integrations"
+
+
+def test_no_direct_process_conversation_in_fallback():
+    """_create_conversation_fallback must NOT call process_conversation directly (must use thread)."""
+    source = _read_transcribe_source()
+    fallback_pos = source.find('async def _create_conversation_fallback')
+    assert fallback_pos > 0
+    # Find next function definition to bound the search
+    next_func = source.find('\n    async def ', fallback_pos + 1)
+    if next_func < 0:
+        next_func = fallback_pos + 800
+    fallback_body = source[fallback_pos:next_func]
+    assert (
+        'process_conversation(uid' not in fallback_body
+    ), "_create_conversation_fallback must not call process_conversation directly — use asyncio.to_thread"
+
+
+def test_semaphore_constant_exists():
+    """FALLBACK_PROCESS_SEMAPHORE and FALLBACK_PROCESS_MAX_CONCURRENCY must be defined."""
+    source = _read_transcribe_source()
+    assert 'FALLBACK_PROCESS_MAX_CONCURRENCY' in source
+    assert 'FALLBACK_PROCESS_SEMAPHORE' in source
+
+
+def test_fallback_sync_handles_geolocation():
+    """_process_fallback_sync must handle geolocation before processing."""
+    source = _read_transcribe_source()
+    pos = source.find('def _process_fallback_sync(')
+    assert pos > 0
+    next_def = source.find('\ndef ', pos + 1)
+    func_body = source[pos:next_def] if next_def > 0 else source[pos : pos + 800]
+    assert 'get_cached_user_geolocation' in func_body, "_process_fallback_sync must call get_cached_user_geolocation"
+    assert 'get_google_maps_location' in func_body, "_process_fallback_sync must call get_google_maps_location"
+
+
+# ---------------------------------------------------------------------------
+# Behavioral tests — test the threading/semaphore patterns directly
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_to_thread_offloads_blocking_work():
+    """asyncio.to_thread must run the sync function in a different thread than the event loop."""
+    event_loop_thread = threading.current_thread().ident
+    worker_thread_id = None
+
+    def blocking_work(uid, language, conversation, session_id):
+        nonlocal worker_thread_id
+        worker_thread_id = threading.current_thread().ident
+        time.sleep(0.05)  # Simulate blocking work
+        return conversation, []
+
+    mock_conversation = MagicMock()
+    await asyncio.to_thread(blocking_work, 'uid', 'en', mock_conversation, 'sess')
+
+    assert worker_thread_id is not None, "Worker thread ID should be set"
+    assert worker_thread_id != event_loop_thread, "Blocking work must run in a different thread than the event loop"
+
+
+@pytest.mark.asyncio
+async def test_event_loop_remains_responsive_during_thread_offload():
+    """The event loop must remain responsive while blocking work runs in a thread."""
+    ticker_count = 0
+
+    async def ticker():
+        nonlocal ticker_count
+        for _ in range(20):
+            await asyncio.sleep(0.01)
+            ticker_count += 1
+
+    def slow_sync(uid, language, conversation, session_id):
+        time.sleep(0.15)  # Simulate 150ms of blocking work
+        return conversation, []
+
+    mock_conversation = MagicMock()
+
+    async def run_fallback():
+        return await asyncio.to_thread(slow_sync, 'uid', 'en', mock_conversation, 'sess')
+
+    # Run ticker and fallback concurrently
+    await asyncio.gather(ticker(), run_fallback())
+
+    assert ticker_count >= 10, f"Event loop ticker only ran {ticker_count}/20 times — event loop was blocked"
+
+
+@pytest.mark.asyncio
+async def test_semaphore_caps_concurrency():
+    """asyncio.Semaphore must limit concurrent thread executions."""
+    max_concurrent = 0
+    current_concurrent = 0
+    lock = threading.Lock()
+
+    def counting_sync(uid, language, conversation, session_id):
+        nonlocal max_concurrent, current_concurrent
+        with lock:
+            current_concurrent += 1
+            if current_concurrent > max_concurrent:
+                max_concurrent = current_concurrent
+        time.sleep(0.1)
+        with lock:
+            current_concurrent -= 1
+        return conversation, []
+
+    # Use a semaphore with max=1 for testing
+    test_semaphore = asyncio.Semaphore(1)
+
+    async def run_one():
+        async with test_semaphore:
+            return await asyncio.to_thread(counting_sync, 'uid', 'en', MagicMock(), 'sess')
+
+    # Launch 4 concurrent fallback tasks
+    await asyncio.gather(*[run_one() for _ in range(4)])
+
+    assert max_concurrent == 1, f"Max concurrent was {max_concurrent}, expected 1 with semaphore(1)"
+
+
+@pytest.mark.asyncio
+async def test_semaphore_2_allows_two_concurrent():
+    """Semaphore(2) should allow exactly 2 concurrent executions."""
+    max_concurrent = 0
+    current_concurrent = 0
+    lock = threading.Lock()
+
+    def counting_sync(uid, language, conversation, session_id):
+        nonlocal max_concurrent, current_concurrent
+        with lock:
+            current_concurrent += 1
+            if current_concurrent > max_concurrent:
+                max_concurrent = current_concurrent
+        time.sleep(0.1)
+        with lock:
+            current_concurrent -= 1
+        return conversation, []
+
+    test_semaphore = asyncio.Semaphore(2)
+
+    async def run_one():
+        async with test_semaphore:
+            return await asyncio.to_thread(counting_sync, 'uid', 'en', MagicMock(), 'sess')
+
+    await asyncio.gather(*[run_one() for _ in range(6)])
+
+    assert max_concurrent == 2, f"Max concurrent was {max_concurrent}, expected 2 with semaphore(2)"
+
+
+@pytest.mark.asyncio
+async def test_exception_propagates_from_thread():
+    """Exceptions from the thread worker must propagate to the caller for error handling."""
+
+    def failing_sync(uid, language, conversation, session_id):
+        raise RuntimeError("OpenAI API unavailable")
+
+    with pytest.raises(RuntimeError, match="OpenAI API unavailable"):
+        await asyncio.to_thread(failing_sync, 'uid', 'en', MagicMock(), 'sess')
+
+
+@pytest.mark.asyncio
+async def test_semaphore_releases_on_exception():
+    """Semaphore must be released even when the thread worker raises."""
+    test_semaphore = asyncio.Semaphore(1)
+    call_count = 0
+
+    def failing_sync(uid, language, conversation, session_id):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise RuntimeError("fail first time")
+        return conversation, []
+
+    # First call fails
+    with pytest.raises(RuntimeError):
+        async with test_semaphore:
+            await asyncio.to_thread(failing_sync, 'uid', 'en', MagicMock(), 'sess')
+
+    # Second call should succeed (semaphore released despite exception)
+    async with test_semaphore:
+        result = await asyncio.to_thread(failing_sync, 'uid', 'en', MagicMock(), 'sess')
+
+    assert result is not None, "Semaphore must be released after exception for retry"
+    assert call_count == 2


### PR DESCRIPTION
Closes #6061.

Backend-listen pod ml9h7 was killed by its liveness probe while serving 22 WS connections because `_create_conversation_fallback` ran `process_conversation()` (LLM calls, embeddings, Firestore writes) directly on the event loop during pusher degradation.

**Fix:** Remove ALL heavy processing from backend-listen. When pusher is unavailable, enqueue conversations to a Redis deferred queue (`deferred_conversations` list). The pusher service drains this queue via a background worker (`deferred_queue_worker`) that polls Redis, processes conversations using `asyncio.to_thread`, and uses an ack/nack pattern with crash recovery.

### Key Changes
- **`database/redis_db.py`**: Redis deferred queue with Lua scripts for atomic enqueue (SET NX + RPUSH), dequeue (LMOVE + SET active lock), and recovery (full-scan, skip active items). Crash-safe via LMOVE to processing list + per-item active lock with 5min TTL. Poison-pill prevention: RPUSH (back of queue) + max 3 retries before discard.
- **`routers/transcribe.py`**: Removed `_create_conversation_fallback`, `_process_fallback_sync`, `FALLBACK_PROCESS_SEMAPHORE`, and all imports of `process_conversation`/`trigger_external_integrations`. Added `_enqueue_conversation_for_deferred_processing()`. All three degraded-mode paths (degraded mode, cleanup, reconnect loop) route to Redis enqueue.
- **`routers/pusher.py`**: Added `_process_deferred_conversation()` (uses `asyncio.to_thread` for process_conversation and trigger_external_integrations) and `deferred_queue_worker()` (poll + ack/nack + crash recovery on startup).
- **`pusher/main.py`**: Startup handler creates the deferred queue worker task.

### Testing
- 38 unit tests (14 source-level, 3 threading behavioral, 3 routing, 10 behavioral Redis, 8 originally from tester/reviewer cycles)
- L1 live test: pusher service startup + Redis queue ops (enqueue/dequeue/ack/nack/recover) + worker processing
- L2 integrated test: both services running, cross-service queue verified (enqueue on listen → process on pusher within 4s)
- 8 rounds of CODEx reviewer feedback addressed (atomicity, crash safety, multi-pod, poison-pill)
- CODEx tester approved (TESTS_APPROVED)

### Review Cycle Changes
- Rounds 1-2: Atomic Lua scripts replacing pipeline/LPOP
- Round 3: Preserve dedup lock on nack (only clear on ack/TTL)
- Round 4: Per-item active processing lock (multi-pod safety)
- Round 5: Full-scan recovery + atomic dequeue Lua
- Round 6: Distinguish enqueue True/False/None in wrapper
- Round 7: Let unrecoverable errors propagate for nack
- Round 8: RPUSH + max retry counter (poison-pill prevention)

---
_by AI for @beastoin_