### PR TITLE
Route device info sync to AutoSyncPage for new firmware

### DIFF
--- a/app/lib/pages/home/device.dart
+++ b/app/lib/pages/home/device.dart
@@ -18,6 +18,7 @@ import 'package:omi/utils/other/time_utils.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/widgets/device_widget.dart';
 import 'package:omi/widgets/dialog.dart';
+import 'package:omi/pages/conversations/auto_sync_page.dart';
 import 'package:omi/pages/conversations/sync_page.dart';
 import 'firmware_update.dart';
 import 'omiglass_ota_update.dart';
@@ -213,14 +214,13 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
             chipValue: provider.connectedDevice == null
                 ? context.l10n.offline
                 : provider.havingNewFirmware
-                ? context.l10n.available
-                : null,
+                    ? context.l10n.available
+                    : null,
             onTap: provider.connectedDevice != null
                 ? () {
                     // Route to OmiGlass OTA page for openglass devices
                     final deviceName = provider.connectedDevice?.name?.toLowerCase() ?? '';
-                    final isOpenGlass =
-                        provider.connectedDevice?.type == DeviceType.openglass ||
+                    final isOpenGlass = provider.connectedDevice?.type == DeviceType.openglass ||
                         deviceName.contains('openglass') ||
                         deviceName.contains('omiglass') ||
                         deviceName.contains('glass');
@@ -258,7 +258,9 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
               chipColor: pendingSeconds > 0 ? const Color(0xFF3D3520) : null,
               chipTextColor: pendingSeconds > 0 ? const Color(0xFFFFD060) : null,
               onTap: () {
-                Navigator.of(context).push(MaterialPageRoute(builder: (context) => const SyncPage()));
+                final page =
+                    context.read<DeviceProvider>().supportsMultiFileSync ? const AutoSyncPage() : const SyncPage();
+                Navigator.of(context).push(MaterialPageRoute(builder: (context) => page));
               },
             ),
           ],
@@ -417,8 +419,7 @@ class _ConnectedDeviceState extends State<ConnectedDevice> {
     final manufacturer = provider.pairedDevice?.manufacturerName ?? context.l10n.unknown;
     final firmware = provider.pairedDevice?.firmwareRevision ?? context.l10n.unknown;
     final deviceId = provider.pairedDevice?.id ?? context.l10n.unknown;
-    final serialNumber =
-        provider.pairedDevice?.serialNumber ??
+    final serialNumber = provider.pairedDevice?.serialNumber ??
         provider.pairedDevice?.id.replaceAll(':', '').replaceAll('-', '').toUpperCase() ??
         context.l10n.unknown;
 


### PR DESCRIPTION
## Summary
- Device info screen SD card sync button was always routing to the old `SyncPage`, even for devices with firmware >= 3.0.17 that support the new multi-file protocol
- Now checks `DeviceProvider.supportsMultiFileSync` (firmware version based) to route to `AutoSyncPage` for new firmware

## Test plan
- [ ] Connect device with firmware >= 3.0.17, tap SD Card Sync in device info → should open AutoSyncPage
- [ ] Connect device with old firmware, tap SD Card Sync → should open old SyncPage

🤖 Generated with [Claude Code](https://claude.com/claude-code)