### PR TITLE
Fix onboarding skip alert and empty name bypass

### DIFF
--- a/desktop/Desktop/Sources/OnboardingChatView.swift
+++ b/desktop/Desktop/Sources/OnboardingChatView.swift
@@ -169,12 +169,6 @@ struct OnboardingChatView: View {
             .foregroundColor(OmiColors.textTertiary)
         }
         .buttonStyle(.plain)
-        .alert("Are you sure?", isPresented: $showSkipConfirmation) {
-          Button("Skip anyway", role: .destructive) { onSkip() }
-          Button("Continue setup", role: .cancel) {}
-        } message: {
-          Text("Omi won't be useful for you if it doesn't know enough about you.")
-        }
       }
       .padding(.horizontal, 24)
       .padding(.vertical, 16)
@@ -440,6 +434,12 @@ struct OnboardingChatView: View {
       }
       .padding(.horizontal, 20)
       .padding(.vertical, 16)
+    }
+    .alert("Are you sure?", isPresented: $showSkipConfirmation) {
+      Button("Skip anyway", role: .destructive) { onSkip() }
+      Button("Continue setup", role: .cancel) {}
+    } message: {
+      Text("Omi won't be useful for you if it doesn't know enough about you.")
     }
     .onAppear {
       startChat()
@@ -776,6 +776,7 @@ struct OnboardingChatView: View {
     guard canSend else { return }
 
     let text = inputText.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !text.isEmpty else { return }
     inputText = ""
 
     // Clear quick replies and unblock any pending ask_followup


### PR DESCRIPTION
## Summary
- Move `.alert()` modifier from Skip button to top-level VStack so the skip confirmation dialog renders above the 3D brain graph ZStack (fixes #6069)
- Add empty text guard in `sendMessage()` to prevent whitespace-only input from bypassing the name entry step (fixes #6071)

## Context
Found via chaos engineering on the desktop onboarding flow using agent-swift. The skip confirmation alert was invisible because SwiftUI rendered it behind the brain graph's ZStack. Empty/whitespace sends could bypass the chat name entry step.

## Test plan
- [ ] Click "Skip" during onboarding — confirmation dialog should appear above all content
- [ ] Press Enter/Cmd+Enter with empty input — nothing should be sent
- [ ] Normal onboarding flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)