### PR TITLE
Improve macOS onboarding and post-onboarding prompts

### DIFF
--- a/desktop/Desktop/Sources/AppBuild.swift
+++ b/desktop/Desktop/Sources/AppBuild.swift
@@ -32,4 +32,27 @@ enum AppBuild {
     let raw = UserDefaults.standard.string(forKey: updateChannelDefaultsKey) ?? "stable"
     return raw == "staging" ? "beta" : raw
   }
+
+  static var inferredUpdateChannel: String {
+    let bundlePath = Bundle.main.bundleURL.path.lowercased()
+    let display = displayName.lowercased()
+    let bundle = bundleIdentifier.lowercased()
+
+    if bundle.contains("beta")
+      || display.contains("beta")
+      || bundlePath.contains("/beta")
+      || bundlePath.contains("omi beta")
+    {
+      return "beta"
+    }
+
+    return "stable"
+  }
+
+  static func syncUpdateChannelWithInstalledApp() {
+    let inferred = inferredUpdateChannel
+    if currentUpdateChannel != inferred {
+      UserDefaults.standard.set(inferred, forKey: updateChannelDefaultsKey)
+    }
+  }
 }

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -793,8 +793,19 @@ class AppState: ObservableObject {
   /// Check screen recording permission status
   func checkScreenRecordingPermission() {
     let tccGranted = CGPreflightScreenCaptureAccess()
+    let shouldForceActualTest = screenRecordingGrantAttempts > 0 || hasScreenRecordingPermission
 
     if !tccGranted {
+      let actualPermission = ScreenCaptureService.checkPermission(
+        forceActualTestIfPreflightDenied: shouldForceActualTest)
+      if actualPermission {
+        hasScreenRecordingPermission = true
+        isScreenCaptureKitBroken = false
+        isScreenRecordingStale = false
+        screenRecordingGrantAttempts = 0
+        return
+      }
+
       hasScreenRecordingPermission = false
       isScreenCaptureKitBroken = false
       // If user already tried Grant once and permission is still not granted,

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -188,12 +188,12 @@ struct FloatingControlBarView: View {
                     .transition(.opacity)
             } else if isHovering || state.showingAIConversation {
                 VStack(spacing: 1) {
-                    compactButton(title: "Ask omi / Collapse", keys: shortcutSettings.askOmiKey.hintKeys) {
+                    compactButton(title: "Ask omi / Collapse", keys: shortcutSettings.askOmiShortcut.displayTokens) {
                         onAskAI()
                     }
 
                     HStack(spacing: 6) {
-                        compactLabel("Push to talk", keys: [shortcutSettings.pttKey.symbol])
+                        compactLabel("Push to talk", keys: shortcutSettings.pttShortcut.displayTokens)
                     }
                 }
                 .padding(.horizontal, 6)
@@ -251,7 +251,8 @@ struct FloatingControlBarView: View {
                 Text(key)
                     .scaledFont(size: 9)
                     .foregroundColor(.white)
-                    .frame(width: 15, height: 15)
+                    .padding(.horizontal, key.count > 1 ? 4 : 0)
+                    .frame(minWidth: 15, minHeight: 15)
                     .background(Color.white.opacity(0.1))
                     .cornerRadius(3)
             }
@@ -288,7 +289,11 @@ struct FloatingControlBarView: View {
                     .lineLimit(1)
                     .truncationMode(.head)
             } else {
-                Text(state.isVoiceLocked ? "Tap \(shortcutSettings.pttKey.symbol) to send" : "Release \(shortcutSettings.pttKey.symbol) to send")
+                Text(
+                    state.isVoiceLocked
+                        ? "Tap \(shortcutSettings.pttShortcut.displayLabel) to send"
+                        : "Release \(shortcutSettings.pttShortcut.displayLabel) to send"
+                )
                     .scaledFont(size: 13)
                     .foregroundColor(.white.opacity(0.5))
             }

--- a/desktop/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
@@ -51,9 +51,13 @@ class GlobalShortcutManager {
         if let ref = hotKeyRefs.removeValue(forKey: .askOmi) {
             UnregisterEventHotKey(ref)
         }
-        let askOmiKey = MainActor.assumeIsolated { ShortcutSettings.shared.askOmiKey }
-        registerHotKey(keyCode: Int(askOmiKey.keyCode), modifiers: askOmiKey.carbonModifiers, id: .askOmi)
-        NSLog("GlobalShortcutManager: Registered Ask Omi shortcut: \(askOmiKey.rawValue)")
+        let askOmiShortcut = MainActor.assumeIsolated { ShortcutSettings.shared.askOmiShortcut }
+        guard askOmiShortcut.supportsGlobalHotKey, let keyCode = askOmiShortcut.keyCode else {
+            NSLog("GlobalShortcutManager: Ask Omi shortcut is not a registerable hotkey")
+            return
+        }
+        registerHotKey(keyCode: Int(keyCode), modifiers: askOmiShortcut.carbonModifiers, id: .askOmi)
+        NSLog("GlobalShortcutManager: Registered Ask Omi shortcut: \(askOmiShortcut.displayLabel)")
     }
 
     private func registerHotKey(keyCode: Int, modifiers: Int, id: HotKeyID) {

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -72,18 +72,20 @@ class PushToTalkManager: ObservableObject {
     // Remove any existing monitors to make setup() safely re-entrant
     removeEventMonitors()
 
+    let monitorMask: NSEvent.EventTypeMask = [.flagsChanged, .keyDown, .keyUp]
+
     // Global monitor — fires when OTHER apps are focused
-    globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) {
+    globalMonitor = NSEvent.addGlobalMonitorForEvents(matching: monitorMask) {
       [weak self] event in
       Task { @MainActor in
-        self?.handleFlagsChanged(event)
+        self?.handleShortcutEvent(event)
       }
     }
 
     // Local monitor — fires when THIS app is focused
-    localMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { [weak self] event in
+    localMonitor = NSEvent.addLocalMonitorForEvents(matching: monitorMask) { [weak self] event in
       Task { @MainActor in
-        self?.handleFlagsChanged(event)
+        self?.handleShortcutEvent(event)
       }
       return event
     }
@@ -102,25 +104,28 @@ class PushToTalkManager: ObservableObject {
     }
   }
 
-  // MARK: - Option Key Handling
+  // MARK: - Shortcut Handling
 
-  private func handleFlagsChanged(_ event: NSEvent) {
-    let settings = ShortcutSettings.shared
+  private func handleShortcutEvent(_ event: NSEvent) {
+    let shortcut = ShortcutSettings.shared.pttShortcut
 
     let pttActive: Bool
-    switch settings.pttKey {
-    case .option:
-      // Ignore if other modifiers are held (Cmd, Ctrl, Shift)
-      let otherModifiers: NSEvent.ModifierFlags = [.command, .control, .shift]
-      guard event.modifierFlags.intersection(otherModifiers) == [] else { return }
-      pttActive = event.modifierFlags.contains(.option)
-    case .rightCommand:
-      // Right Cmd: keyCode 54. flagsChanged fires for both left/right Cmd.
-      // Only trigger on right Cmd (keyCode 54), not left (55).
-      guard event.keyCode == 54 || event.keyCode == 55 else { return }
-      pttActive = event.modifierFlags.contains(.command) && event.keyCode == 54
-    case .fn:
-      pttActive = event.modifierFlags.contains(.function)
+    switch event.type {
+    case .flagsChanged:
+      guard shortcut.modifierOnly else { return }
+      pttActive = shortcut.matchesFlagsChanged(event)
+    case .keyDown:
+      guard !shortcut.modifierOnly, !event.isARepeat else { return }
+      pttActive = shortcut.matchesKeyDown(event)
+    case .keyUp:
+      guard !shortcut.modifierOnly else { return }
+      pttActive = false
+      if shortcut.matchesKeyUp(event) {
+        handleShortcutUp()
+      }
+      return
+    default:
+      return
     }
 
     // Let the first shortcut press reveal the compact bar instead of requiring it
@@ -133,13 +138,13 @@ class PushToTalkManager: ObservableObject {
     guard FloatingControlBarManager.shared.isVisible else { return }
 
     if pttActive {
-      handleOptionDown()
-    } else {
-      handleOptionUp()
+      handleShortcutDown()
+    } else if shortcut.modifierOnly {
+      handleShortcutUp()
     }
   }
 
-  private func handleOptionDown() {
+  private func handleShortcutDown() {
     let now = ProcessInfo.processInfo.systemUptime
 
     switch state {
@@ -165,7 +170,7 @@ class PushToTalkManager: ObservableObject {
     }
   }
 
-  private func handleOptionUp() {
+  private func handleShortcutUp() {
     let now = ProcessInfo.processInfo.systemUptime
 
     switch state {

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -9,81 +9,284 @@ class ShortcutSettings: ObservableObject {
     /// Notification posted when the Ask Omi shortcut changes so hotkeys can be re-registered.
     nonisolated static let askOmiShortcutChanged = Notification.Name("ShortcutSettings.askOmiShortcutChanged")
 
-    /// Available modifier keys for push-to-talk.
-    enum PTTKey: String, CaseIterable {
-        case option = "Option (⌥)"
-        case rightCommand = "Right Command (⌘)"
-        case fn = "Fn / Globe"
+    struct KeyboardShortcut: Codable, Hashable {
+        var keyCode: UInt16?
+        var keyDisplay: String?
+        var modifiersRawValue: UInt
+        var modifierOnly: Bool
+        var requiresRightCommand: Bool
 
-        var symbol: String {
-            switch self {
-            case .option: return "\u{2325}"
-            case .rightCommand: return "\u{2318}"
-            case .fn: return "\u{1F310}"
-            }
-        }
-    }
+        private static let supportedModifierMask: NSEvent.ModifierFlags = [.command, .shift, .option, .control, .function]
 
-    /// Available shortcut presets for Ask Omi.
-    enum AskOmiKey: String, CaseIterable {
-        case cmdEnter = "⌘ Enter"
-        case cmdShiftEnter = "⌘⇧ Enter"
-        case cmdJ = "⌘J"
-        case cmdO = "⌘O"
-
-        /// Display symbols for the floating bar hint.
-        var hintKeys: [String] {
-            switch self {
-            case .cmdEnter: return ["\u{2318}", "\u{21A9}\u{FE0E}"]
-            case .cmdShiftEnter: return ["\u{2318}", "\u{21E7}", "\u{21A9}\u{FE0E}"]
-            case .cmdJ: return ["\u{2318}", "J"]
-            case .cmdO: return ["\u{2318}", "O"]
-            }
+        init(keyCode: UInt16, keyDisplay: String, modifiers: NSEvent.ModifierFlags = []) {
+            self.keyCode = keyCode
+            self.keyDisplay = keyDisplay
+            self.modifiersRawValue = Self.normalizedModifiers(modifiers).rawValue
+            self.modifierOnly = false
+            self.requiresRightCommand = false
         }
 
-        /// macOS virtual key code for this shortcut.
-        var keyCode: UInt16 {
-            switch self {
-            case .cmdEnter, .cmdShiftEnter: return 36  // Return
-            case .cmdJ: return 38  // J
-            case .cmdO: return 31  // O
-            }
+        init(modifierOnly modifiers: NSEvent.ModifierFlags, requiresRightCommand: Bool = false) {
+            let normalized = Self.normalizedModifiers(modifiers)
+            self.keyCode = nil
+            self.keyDisplay = nil
+            self.modifiersRawValue = normalized.rawValue
+            self.modifierOnly = true
+            self.requiresRightCommand = requiresRightCommand && normalized == [.command]
         }
 
-        /// Required modifier flags for matching NSEvent.
-        var modifierFlags: NSEvent.ModifierFlags {
-            switch self {
-            case .cmdEnter: return .command
-            case .cmdShiftEnter: return [.command, .shift]
-            case .cmdJ: return .command
-            case .cmdO: return .command
-            }
+        var modifiers: NSEvent.ModifierFlags {
+            Self.normalizedModifiers(NSEvent.ModifierFlags(rawValue: modifiersRawValue))
         }
 
-        /// Carbon modifier flags for RegisterEventHotKey.
+        var supportsGlobalHotKey: Bool {
+            !modifierOnly && keyCode != nil
+        }
+
+        var displayTokens: [String] {
+            let modifierTokens = Self.modifierTokens(for: modifiers)
+            if modifierOnly {
+                return modifierTokens
+            }
+            if let keyDisplay {
+                return modifierTokens + [keyDisplay]
+            }
+            return modifierTokens
+        }
+
+        var displayLabel: String {
+            if modifierOnly {
+                if requiresRightCommand {
+                    return "Right Cmd"
+                }
+                switch modifiers {
+                case [.option]:
+                    return "Option"
+                case [.function]:
+                    return "Fn"
+                case [.command]:
+                    return "Command"
+                case [.control]:
+                    return "Control"
+                case [.shift]:
+                    return "Shift"
+                default:
+                    return displayTokens.joined(separator: " ")
+                }
+            }
+            return displayTokens.joined(separator: " ")
+        }
+
+        var promptLabel: String {
+            if modifierOnly {
+                if requiresRightCommand {
+                    return "right cmd"
+                }
+                switch modifiers {
+                case [.option]:
+                    return "option"
+                case [.function]:
+                    return "fn"
+                case [.command]:
+                    return "command"
+                case [.control]:
+                    return "control"
+                case [.shift]:
+                    return "shift"
+                default:
+                    return displayLabel.lowercased()
+                }
+            }
+            return displayLabel.lowercased()
+        }
+
         var carbonModifiers: Int {
-            switch self {
-            case .cmdEnter: return Int(cmdKey)
-            case .cmdShiftEnter: return Int(cmdKey) | Int(shiftKey)
-            case .cmdJ: return Int(cmdKey)
-            case .cmdO: return Int(cmdKey)
+            var value = 0
+            if modifiers.contains(.command) {
+                value |= Int(cmdKey)
+            }
+            if modifiers.contains(.shift) {
+                value |= Int(shiftKey)
+            }
+            if modifiers.contains(.option) {
+                value |= Int(optionKey)
+            }
+            if modifiers.contains(.control) {
+                value |= Int(controlKey)
+            }
+            if modifiers.contains(.function) {
+                value |= Int(kEventKeyModifierFnMask)
+            }
+            return value
+        }
+
+        func matchesKeyDown(_ event: NSEvent) -> Bool {
+            guard !modifierOnly, event.type == .keyDown, let keyCode else { return false }
+            return keyCode == event.keyCode && Self.normalizedModifiers(event.modifierFlags) == modifiers
+        }
+
+        func matchesKeyUp(_ event: NSEvent) -> Bool {
+            guard !modifierOnly, event.type == .keyUp, let keyCode else { return false }
+            return keyCode == event.keyCode && Self.normalizedModifiers(event.modifierFlags) == modifiers
+        }
+
+        func matchesFlagsChanged(_ event: NSEvent) -> Bool {
+            guard modifierOnly, event.type == .flagsChanged else { return false }
+            let activeModifiers = Self.normalizedModifiers(event.modifierFlags)
+            guard activeModifiers == modifiers else { return false }
+            if requiresRightCommand {
+                return event.keyCode == 54
+            }
+            return true
+        }
+
+        static func fromRecordingEvent(_ event: NSEvent, allowModifierOnly: Bool) -> KeyboardShortcut? {
+            switch event.type {
+            case .keyDown:
+                return KeyboardShortcut(
+                    keyCode: event.keyCode,
+                    keyDisplay: keyDisplay(for: event.keyCode, characters: event.charactersIgnoringModifiers),
+                    modifiers: normalizedModifiers(event.modifierFlags)
+                )
+            case .flagsChanged:
+                guard allowModifierOnly else { return nil }
+                let modifiers = normalizedModifiers(event.modifierFlags)
+                guard !modifiers.isEmpty else { return nil }
+                return KeyboardShortcut(
+                    modifierOnly: modifiers,
+                    requiresRightCommand: modifiers == [.command] && event.keyCode == 54
+                )
+            default:
+                return nil
             }
         }
 
-        /// Check whether an NSEvent matches this shortcut.
-        func matches(_ event: NSEvent) -> Bool {
-            let mods = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-            return mods == modifierFlags && event.keyCode == keyCode
+        static func normalizedModifiers(_ flags: NSEvent.ModifierFlags) -> NSEvent.ModifierFlags {
+            flags.intersection(supportedModifierMask)
+        }
+
+        static func modifierTokens(for flags: NSEvent.ModifierFlags) -> [String] {
+            var tokens: [String] = []
+            if flags.contains(.control) {
+                tokens.append("⌃")
+            }
+            if flags.contains(.option) {
+                tokens.append("⌥")
+            }
+            if flags.contains(.shift) {
+                tokens.append("⇧")
+            }
+            if flags.contains(.command) {
+                tokens.append("⌘")
+            }
+            if flags.contains(.function) {
+                tokens.append("fn")
+            }
+            return tokens
+        }
+
+        static func keyDisplay(for keyCode: UInt16, characters: String?) -> String {
+            switch keyCode {
+            case 36:
+                return "↩"
+            case 48:
+                return "Tab"
+            case 49:
+                return "Space"
+            case 51:
+                return "⌫"
+            case 53:
+                return "Esc"
+            case 71:
+                return "⌧"
+            case 76:
+                return "Enter"
+            case 96:
+                return "F5"
+            case 97:
+                return "F6"
+            case 98:
+                return "F7"
+            case 99:
+                return "F3"
+            case 100:
+                return "F8"
+            case 101:
+                return "F9"
+            case 103:
+                return "F11"
+            case 105:
+                return "F13"
+            case 106:
+                return "F16"
+            case 107:
+                return "F14"
+            case 109:
+                return "F10"
+            case 111:
+                return "F12"
+            case 113:
+                return "F15"
+            case 114:
+                return "Help"
+            case 115:
+                return "Home"
+            case 116:
+                return "PgUp"
+            case 117:
+                return "⌦"
+            case 118:
+                return "F4"
+            case 119:
+                return "End"
+            case 120:
+                return "F2"
+            case 121:
+                return "PgDn"
+            case 122:
+                return "F1"
+            case 123:
+                return "←"
+            case 124:
+                return "→"
+            case 125:
+                return "↓"
+            case 126:
+                return "↑"
+            default:
+                if let characters {
+                    let trimmed = characters.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        return trimmed.uppercased()
+                    }
+                }
+                return "Key \(keyCode)"
+            }
         }
     }
 
-    @Published var pttKey: PTTKey {
-        didSet { UserDefaults.standard.set(pttKey.rawValue, forKey: "shortcut_pttKey") }
+    static let askOmiPresets: [KeyboardShortcut] = [
+        KeyboardShortcut(keyCode: 36, keyDisplay: "↩", modifiers: .command),
+        KeyboardShortcut(keyCode: 36, keyDisplay: "↩", modifiers: [.command, .shift]),
+        KeyboardShortcut(keyCode: 38, keyDisplay: "J", modifiers: .command),
+        KeyboardShortcut(keyCode: 31, keyDisplay: "O", modifiers: .command),
+    ]
+
+    static let pttPresets: [KeyboardShortcut] = [
+        KeyboardShortcut(modifierOnly: .option),
+        KeyboardShortcut(modifierOnly: .command, requiresRightCommand: true),
+        KeyboardShortcut(modifierOnly: .function),
+    ]
+
+    @Published var pttShortcut: KeyboardShortcut {
+        didSet {
+            persistShortcut(pttShortcut, forKey: Self.pttShortcutDefaultsKey)
+        }
     }
 
-    @Published var askOmiKey: AskOmiKey {
+    @Published var askOmiShortcut: KeyboardShortcut {
         didSet {
-            UserDefaults.standard.set(askOmiKey.rawValue, forKey: "shortcut_askOmiKey")
+            persistShortcut(askOmiShortcut, forKey: Self.askOmiShortcutDefaultsKey)
             NotificationCenter.default.post(name: Self.askOmiShortcutChanged, object: nil)
         }
     }
@@ -135,19 +338,28 @@ class ShortcutSettings: ObservableObject {
         didSet { UserDefaults.standard.set(draggableBarEnabled, forKey: "shortcut_draggableBarEnabled") }
     }
 
+    var askOmiUsesCustomShortcut: Bool {
+        !Self.askOmiPresets.contains(askOmiShortcut)
+    }
+
+    var pttUsesCustomShortcut: Bool {
+        !Self.pttPresets.contains(pttShortcut)
+    }
+
+    private static let askOmiShortcutDefaultsKey = "shortcut_askOmiKey"
+    private static let pttShortcutDefaultsKey = "shortcut_pttKey"
+
     private init() {
-        if let saved = UserDefaults.standard.string(forKey: "shortcut_pttKey"),
-           let key = PTTKey(rawValue: saved) {
-            self.pttKey = key
-        } else {
-            self.pttKey = .option
-        }
-        if let saved = UserDefaults.standard.string(forKey: "shortcut_askOmiKey"),
-           let key = AskOmiKey(rawValue: saved) {
-            self.askOmiKey = key
-        } else {
-            self.askOmiKey = .cmdEnter
-        }
+        self.pttShortcut = Self.loadShortcut(
+            forKey: Self.pttShortcutDefaultsKey,
+            legacyMapper: Self.legacyPTTShortcut
+        ) ?? Self.pttPresets[0]
+
+        self.askOmiShortcut = Self.loadShortcut(
+            forKey: Self.askOmiShortcutDefaultsKey,
+            legacyMapper: Self.legacyAskOmiShortcut
+        ) ?? Self.askOmiPresets[0]
+
         self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
         self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? true
         self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
@@ -159,5 +371,55 @@ class ShortcutSettings: ObservableObject {
             self.pttTranscriptionMode = .batch
         }
         self.draggableBarEnabled = UserDefaults.standard.object(forKey: "shortcut_draggableBarEnabled") as? Bool ?? false
+    }
+
+    private func persistShortcut(_ shortcut: KeyboardShortcut, forKey key: String) {
+        let encoder = JSONEncoder()
+        guard let data = try? encoder.encode(shortcut) else { return }
+        UserDefaults.standard.set(data, forKey: key)
+    }
+
+    private static func loadShortcut(
+        forKey key: String,
+        legacyMapper: (String) -> KeyboardShortcut?
+    ) -> KeyboardShortcut? {
+        let defaults = UserDefaults.standard
+        if let data = defaults.data(forKey: key),
+           let decoded = try? JSONDecoder().decode(KeyboardShortcut.self, from: data) {
+            return decoded
+        }
+        if let legacyValue = defaults.string(forKey: key),
+           let migrated = legacyMapper(legacyValue) {
+            return migrated
+        }
+        return nil
+    }
+
+    private static func legacyAskOmiShortcut(_ value: String) -> KeyboardShortcut? {
+        switch value {
+        case "⌘ Enter":
+            return askOmiPresets[0]
+        case "⌘⇧ Enter":
+            return askOmiPresets[1]
+        case "⌘J":
+            return askOmiPresets[2]
+        case "⌘O":
+            return askOmiPresets[3]
+        default:
+            return nil
+        }
+    }
+
+    private static func legacyPTTShortcut(_ value: String) -> KeyboardShortcut? {
+        switch value {
+        case "Option (⌥)":
+            return pttPresets[0]
+        case "Right Command (⌘)":
+            return pttPresets[1]
+        case "Fn / Globe":
+            return pttPresets[2]
+        default:
+            return nil
+        }
     }
 }

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -94,8 +94,8 @@ struct DesktopHomeView: View {
             .onAppear {
               if UserDefaults.standard.bool(forKey: "onboardingJustCompleted") {
                 UserDefaults.standard.removeObject(forKey: "onboardingJustCompleted")
-                log("DesktopHomeView: Onboarding just completed — navigating to Tasks page")
-                selectedIndex = SidebarNavItem.tasks.rawValue
+                log("DesktopHomeView: Onboarding just completed — navigating to Dashboard")
+                selectedIndex = SidebarNavItem.dashboard.rawValue
               }
             }
           mainContent

--- a/desktop/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/DashboardPage.swift
@@ -198,6 +198,7 @@ struct DashboardPage: View {
     @ObservedObject var appState: AppState
     @Binding var selectedIndex: Int
     @State private var selectedConversation: ServerConversation? = nil
+    @State private var showPromptPopup = false
 
     var body: some View {
         Group {
@@ -216,6 +217,20 @@ struct DashboardPage: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(Color.clear)
+        .overlay {
+            if showPromptPopup, !postOnboardingSuggestions.isEmpty {
+                TryAskingPopupView(
+                    suggestions: postOnboardingSuggestions,
+                    onAsk: handleSuggestedPrompt,
+                    onDismiss: dismissPromptPopup
+                )
+            }
+        }
+        .onAppear {
+            if PostOnboardingPromptSuggestions.shouldShowPopup && !postOnboardingSuggestions.isEmpty {
+                showPromptPopup = true
+            }
+        }
         .onReceive(NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)) { _ in
             viewModel.refreshGoals()
         }
@@ -223,6 +238,15 @@ struct DashboardPage: View {
 
     private var dashboardWidgets: some View {
         VStack(alignment: .leading, spacing: 24) {
+            if shouldShowSuggestionBanner {
+                PromptSuggestionBanner(
+                    suggestions: postOnboardingSuggestions,
+                    onOpen: { showPromptPopup = true },
+                    onAsk: handleSuggestedPrompt,
+                    onDismiss: dismissSuggestionBanner
+                )
+            }
+
             Grid(horizontalSpacing: 16, verticalSpacing: 16) {
                 // Top row: Tasks + Goals
                 GridRow {
@@ -276,8 +300,32 @@ struct DashboardPage: View {
             }
         }
         .padding(.horizontal, 24)
-        .padding(.top, 24)
+        .padding(.top, 36)
         .padding(.bottom, 8)
+    }
+
+    private var postOnboardingSuggestions: [String] {
+        PostOnboardingPromptSuggestions.suggestions()
+    }
+
+    private var shouldShowSuggestionBanner: Bool {
+        !postOnboardingSuggestions.isEmpty && !PostOnboardingPromptSuggestions.isDismissed
+    }
+
+    private func dismissPromptPopup() {
+        showPromptPopup = false
+        PostOnboardingPromptSuggestions.shouldShowPopup = false
+    }
+
+    private func dismissSuggestionBanner() {
+        showPromptPopup = false
+        PostOnboardingPromptSuggestions.shouldShowPopup = false
+        PostOnboardingPromptSuggestions.isDismissed = true
+    }
+
+    private func handleSuggestedPrompt(_ suggestion: String) {
+        dismissPromptPopup()
+        FloatingControlBarManager.shared.openAIInputWithQuery(suggestion)
     }
 
 }

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -182,12 +182,7 @@ class MemoryGraphViewModel: ObservableObject {
         defer { isLoading = false }
 
         do {
-            // Try local SQLite first (populated during file exploration)
-            var response = await KnowledgeGraphStorage.shared.loadGraph()
-            if response.nodes.isEmpty {
-                // Fall back to API (user may have graph from mobile)
-                response = try await APIClient.shared.getKnowledgeGraph()
-            }
+            let response = try await fetchGraph()
 
             log("Knowledge graph: \(response.nodes.count) nodes, \(response.edges.count) edges")
             isEmpty = response.nodes.isEmpty
@@ -217,6 +212,35 @@ class MemoryGraphViewModel: ObservableObject {
         } catch {
             log("Failed to load knowledge graph: \(error.localizedDescription)")
         }
+    }
+
+    private func fetchGraph() async throws -> KnowledgeGraphResponse {
+        var response = await KnowledgeGraphStorage.shared.loadGraph()
+        if !response.nodes.isEmpty {
+            return response
+        }
+
+        for attempt in 0..<4 {
+            if AuthState.shared.isRestoringAuth {
+                try? await Task.sleep(nanoseconds: 500_000_000)
+                continue
+            }
+
+            do {
+                return try await APIClient.shared.getKnowledgeGraph()
+            } catch {
+                if case AuthError.notSignedIn = error,
+                   AuthState.shared.isSignedIn || AuthState.shared.isRestoringAuth,
+                   attempt < 3 {
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                    continue
+                }
+                throw error
+            }
+        }
+
+        response = await KnowledgeGraphStorage.shared.loadGraph()
+        return response
     }
 
     // MARK: - Rebuild Graph

--- a/desktop/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
@@ -4,9 +4,17 @@ import SwiftUI
 struct ShortcutsSettingsSection: View {
     @ObservedObject private var settings = ShortcutSettings.shared
     @Binding var highlightedSettingId: String?
+    @State private var recordingTarget: ShortcutTarget?
+    @State private var captureError: String?
+    @State private var localShortcutCaptureMonitor: Any?
 
     init(highlightedSettingId: Binding<String?> = .constant(nil)) {
         self._highlightedSettingId = highlightedSettingId
+    }
+
+    private enum ShortcutTarget {
+        case askOmi
+        case pushToTalk
     }
 
     var body: some View {
@@ -20,6 +28,9 @@ struct ShortcutsSettingsSection: View {
             doubleTapCard
             pttSoundsCard
             referenceCard
+        }
+        .onDisappear {
+            stopShortcutCapture()
         }
     }
 
@@ -139,10 +150,20 @@ struct ShortcutsSettingsSection: View {
             }
 
             HStack(spacing: 12) {
-                ForEach(ShortcutSettings.AskOmiKey.allCases, id: \.self) { key in
-                    askOmiKeyButton(key)
+                ForEach(ShortcutSettings.askOmiPresets, id: \.self) { shortcut in
+                    askOmiKeyButton(shortcut)
                 }
+                customShortcutButton(for: .askOmi, isSelected: settings.askOmiUsesCustomShortcut)
                 Spacer()
+            }
+
+            if recordingTarget == .askOmi || settings.askOmiUsesCustomShortcut || (captureError != nil && recordingTarget == .askOmi) {
+                shortcutRecorderCard(
+                    title: recordingTarget == .askOmi ? "Press your custom Ask omi shortcut now" : "Custom Ask omi shortcut",
+                    shortcut: settings.askOmiShortcut,
+                    action: { startShortcutCapture(.askOmi) },
+                    helperText: "Use at least one non-modifier key."
+                )
             }
         }
         .padding(20)
@@ -153,14 +174,19 @@ struct ShortcutsSettingsSection: View {
         .modifier(SettingHighlightModifier(settingId: "floatingbar.shortcut", highlightedSettingId: $highlightedSettingId))
     }
 
-    private func askOmiKeyButton(_ key: ShortcutSettings.AskOmiKey) -> some View {
-        let isSelected = settings.askOmiKey == key
+    private func askOmiKeyButton(_ shortcut: ShortcutSettings.KeyboardShortcut) -> some View {
+        let isSelected = settings.askOmiShortcut == shortcut && !settings.askOmiUsesCustomShortcut
         return Button {
-            settings.askOmiKey = key
+            stopShortcutCapture()
+            settings.askOmiShortcut = shortcut
         } label: {
-            Text(key.rawValue)
-                .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textPrimary)
+            HStack(spacing: 4) {
+                ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                    Text(token)
+                        .scaledFont(size: 13, weight: .medium)
+                }
+            }
+            .foregroundColor(OmiColors.textPrimary)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
                 .background(
@@ -189,10 +215,20 @@ struct ShortcutsSettingsSection: View {
             }
 
             HStack(spacing: 12) {
-                ForEach(ShortcutSettings.PTTKey.allCases, id: \.self) { key in
-                    pttKeyButton(key)
+                ForEach(ShortcutSettings.pttPresets, id: \.self) { shortcut in
+                    pttKeyButton(shortcut)
                 }
+                customShortcutButton(for: .pushToTalk, isSelected: settings.pttUsesCustomShortcut)
                 Spacer()
+            }
+
+            if recordingTarget == .pushToTalk || settings.pttUsesCustomShortcut || (captureError != nil && recordingTarget == .pushToTalk) {
+                shortcutRecorderCard(
+                    title: recordingTarget == .pushToTalk ? "Press your custom push-to-talk shortcut now" : "Custom push-to-talk shortcut",
+                    shortcut: settings.pttShortcut,
+                    action: { startShortcutCapture(.pushToTalk) },
+                    helperText: "One key or a key combination both work."
+                )
             }
         }
         .padding(20)
@@ -203,16 +239,17 @@ struct ShortcutsSettingsSection: View {
         .modifier(SettingHighlightModifier(settingId: "floatingbar.ptt", highlightedSettingId: $highlightedSettingId))
     }
 
-    private func pttKeyButton(_ key: ShortcutSettings.PTTKey) -> some View {
-        let isSelected = settings.pttKey == key
+    private func pttKeyButton(_ shortcut: ShortcutSettings.KeyboardShortcut) -> some View {
+        let isSelected = settings.pttShortcut == shortcut && !settings.pttUsesCustomShortcut
         return Button {
-            settings.pttKey = key
+            stopShortcutCapture()
+            settings.pttShortcut = shortcut
         } label: {
-            HStack(spacing: 8) {
-                Text(key.symbol)
-                    .scaledFont(size: 16)
-                Text(key.rawValue)
-                    .scaledFont(size: 13, weight: .medium)
+            HStack(spacing: 6) {
+                ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                    Text(token)
+                        .scaledFont(size: 13, weight: .medium)
+                }
             }
             .foregroundColor(OmiColors.textPrimary)
             .padding(.horizontal, 14)
@@ -333,11 +370,11 @@ struct ShortcutsSettingsSection: View {
                 .scaledFont(size: 16, weight: .semibold)
                 .foregroundColor(OmiColors.textPrimary)
 
-            shortcutRow(label: "Ask omi", keys: settings.askOmiKey.rawValue)
+            shortcutRow(label: "Ask omi", keys: settings.askOmiShortcut.displayLabel)
             shortcutRow(label: "Toggle floating bar", keys: "\u{2318}\\")
-            shortcutRow(label: "Push to talk", keys: settings.pttKey.symbol + " hold")
+            shortcutRow(label: "Push to talk", keys: settings.pttShortcut.displayLabel + " hold")
             if settings.doubleTapForLock {
-                shortcutRow(label: "Locked listening", keys: settings.pttKey.symbol + " \u{00D7}2")
+                shortcutRow(label: "Locked listening", keys: settings.pttShortcut.displayLabel + " \u{00D7}2")
             }
         }
         .padding(20)
@@ -361,5 +398,130 @@ struct ShortcutsSettingsSection: View {
                 .background(OmiColors.backgroundTertiary.opacity(0.8))
                 .cornerRadius(6)
         }
+    }
+
+    private func customShortcutButton(for target: ShortcutTarget, isSelected: Bool) -> some View {
+        Button {
+            startShortcutCapture(target)
+        } label: {
+            Text("Custom")
+                .scaledFont(size: 13, weight: .medium)
+                .foregroundColor(isSelected || recordingTarget == target ? .black : OmiColors.textPrimary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(isSelected || recordingTarget == target
+                              ? OmiColors.purplePrimary.opacity(0.3)
+                              : OmiColors.backgroundTertiary.opacity(0.5))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(isSelected || recordingTarget == target ? OmiColors.purplePrimary : Color.clear, lineWidth: 1.5)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func shortcutRecorderCard(
+        title: String,
+        shortcut: ShortcutSettings.KeyboardShortcut,
+        action: @escaping () -> Void,
+        helperText: String
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .scaledFont(size: 13, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+
+            HStack(spacing: 10) {
+                HStack(spacing: 6) {
+                    ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                        Text(token)
+                            .scaledFont(size: 13, weight: .semibold)
+                            .foregroundColor(OmiColors.textPrimary)
+                            .padding(.horizontal, token.count > 2 ? 10 : 8)
+                            .padding(.vertical, 7)
+                            .background(
+                                RoundedRectangle(cornerRadius: 8)
+                                    .fill(OmiColors.backgroundPrimary)
+                            )
+                    }
+                }
+
+                Spacer()
+
+                Button(action: action) {
+                    Text(recordingTarget != nil ? "Listening..." : "Change")
+                        .scaledFont(size: 12, weight: .semibold)
+                        .foregroundColor(OmiColors.textPrimary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10)
+                                .fill(OmiColors.backgroundPrimary)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+
+            Text(helperText)
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textSecondary)
+
+            if let captureError, recordingTarget != nil {
+                Text(captureError)
+                    .scaledFont(size: 12, weight: .medium)
+                    .foregroundColor(.red.opacity(0.9))
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(OmiColors.backgroundSecondary.opacity(0.85))
+        )
+    }
+
+    private func startShortcutCapture(_ target: ShortcutTarget) {
+        stopShortcutCapture()
+        recordingTarget = target
+        captureError = nil
+
+        localShortcutCaptureMonitor = NSEvent.addLocalMonitorForEvents(matching: [.flagsChanged, .keyDown]) { event in
+            handleShortcutCapture(event) ? nil : event
+        }
+    }
+
+    private func stopShortcutCapture() {
+        if let monitor = localShortcutCaptureMonitor {
+            NSEvent.removeMonitor(monitor)
+            localShortcutCaptureMonitor = nil
+        }
+        recordingTarget = nil
+        captureError = nil
+    }
+
+    private func handleShortcutCapture(_ event: NSEvent) -> Bool {
+        guard let target = recordingTarget else { return false }
+
+        switch target {
+        case .askOmi:
+            if event.type == .flagsChanged {
+                captureError = "Ask omi needs a non-modifier key."
+                return true
+            }
+            guard let shortcut = ShortcutSettings.KeyboardShortcut.fromRecordingEvent(event, allowModifierOnly: false) else {
+                return false
+            }
+            settings.askOmiShortcut = shortcut
+        case .pushToTalk:
+            guard let shortcut = ShortcutSettings.KeyboardShortcut.fromRecordingEvent(event, allowModifierOnly: true) else {
+                return false
+            }
+            settings.pttShortcut = shortcut
+        }
+
+        stopShortcutCapture()
+        return true
     }
 }

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -80,6 +80,10 @@ struct OMIApp: App {
   /// Launch mode determined at startup from command-line arguments
   static let launchMode = LaunchMode.fromCommandLine()
 
+  init() {
+    AppBuild.syncUpdateChannelWithInstalledApp()
+  }
+
   /// Window title with version number (different for rewind mode)
   private var windowTitle: String {
     // Keep a distinct title in non-production builds so custom test apps are easy to identify.
@@ -1085,16 +1089,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // Mark clean shutdown so next launch skips expensive DB integrity check
     RewindDatabase.markCleanShutdown()
-
-    // If terminated mid-onboarding (e.g. macOS "Quit & Reopen" after granting FDA),
-    // schedule a relaunch so the user doesn't have to manually reopen the app.
-    if OnboardingChatPersistence.isMidOnboarding {
-      let bundleURL = Bundle.main.bundleURL
-      let task = Process()
-      task.executableURL = URL(fileURLWithPath: "/bin/sh")
-      task.arguments = ["-c", "sleep 1 && open \"\(bundleURL.path)\""]
-      try? task.run()
-    }
 
     // Report final resources before termination
     ResourceMonitor.shared.reportResourcesNow(context: "app_terminating")

--- a/desktop/Desktop/Sources/OnboardingFloatingBarDemoView.swift
+++ b/desktop/Desktop/Sources/OnboardingFloatingBarDemoView.swift
@@ -65,7 +65,7 @@ struct OnboardingFloatingBarDemoView: View {
                 if !barActivated {
                     VStack(spacing: 12) {
                         HStack(spacing: 6) {
-                            ForEach(Array(shortcutSettings.askOmiKey.hintKeys.enumerated()), id: \.offset) { index, symbol in
+                            ForEach(Array(shortcutSettings.askOmiShortcut.displayTokens.enumerated()), id: \.offset) { index, symbol in
                                 if index > 0 {
                                     Text("+")
                                         .font(.system(size: 15, weight: .medium))

--- a/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
@@ -1,8 +1,7 @@
-import Combine
 import SwiftUI
 
-/// Onboarding step: configure and test the floating bar shortcut (Cmd+Enter by default).
-/// Only detects the keypress — does NOT open the floating bar, to avoid confusing the user.
+/// Onboarding step: configure and test the floating bar shortcut.
+/// Only detects the keypress and does not open the floating bar.
 struct OnboardingFloatingBarShortcutStepView: View {
     @ObservedObject var appState: AppState
     @ObservedObject var chatProvider: ChatProvider
@@ -13,12 +12,13 @@ struct OnboardingFloatingBarShortcutStepView: View {
 
     @State private var shortcutDetected = false
     @State private var showContinue = false
+    @State private var isRecordingCustomShortcut = false
+    @State private var captureError: String?
     @State private var localKeyMonitor: Any?
     @State private var globalKeyMonitor: Any?
 
     var body: some View {
         VStack(spacing: 0) {
-            // Header
             HStack {
                 Text("Set your keyboard shortcut")
                     .font(.system(size: 18, weight: .semibold))
@@ -41,7 +41,6 @@ struct OnboardingFloatingBarShortcutStepView: View {
 
             Spacer()
 
-            // Content
             VStack(spacing: 24) {
                 Text("Press this shortcut.\nDo the buttons light up?")
                     .font(.system(size: 22, weight: .semibold))
@@ -51,7 +50,7 @@ struct OnboardingFloatingBarShortcutStepView: View {
                 RoundedRectangle(cornerRadius: 16, style: .continuous)
                     .fill(OmiColors.backgroundSecondary)
                     .frame(height: 128)
-                    .frame(maxWidth: 400)
+                    .frame(maxWidth: 420)
                     .overlay {
                         shortcutKeyPreview
                     }
@@ -62,9 +61,14 @@ struct OnboardingFloatingBarShortcutStepView: View {
                         .foregroundColor(OmiColors.textSecondary)
 
                     HStack(spacing: 10) {
-                        ForEach(ShortcutSettings.AskOmiKey.allCases, id: \.self) { key in
-                            shortcutChoiceButton(key)
+                        ForEach(ShortcutSettings.askOmiPresets, id: \.self) { shortcut in
+                            shortcutChoiceButton(shortcut)
                         }
+                        customShortcutButton
+                    }
+
+                    if isRecordingCustomShortcut || shortcutSettings.askOmiUsesCustomShortcut || captureError != nil {
+                        customShortcutRecorder
                     }
                 }
 
@@ -90,31 +94,19 @@ struct OnboardingFloatingBarShortcutStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(OmiColors.backgroundPrimary)
         .onAppear {
-            // Unregister the global hotkey so the floating bar does NOT open.
-            // We detect the keypress ourselves via a local NSEvent monitor.
             GlobalShortcutManager.shared.unregisterShortcuts()
             installKeyMonitor()
         }
         .onDisappear {
-            if let monitor = localKeyMonitor {
-                NSEvent.removeMonitor(monitor)
-                localKeyMonitor = nil
-            }
-            if let monitor = globalKeyMonitor {
-                NSEvent.removeMonitor(monitor)
-                globalKeyMonitor = nil
-            }
-            // Re-register the global hotkey for the next step.
+            removeKeyMonitors()
             GlobalShortcutManager.shared.registerShortcuts()
         }
     }
 
-    // MARK: - Shortcut Key Preview
-
     private var shortcutKeyPreview: some View {
         VStack(spacing: 12) {
             HStack(spacing: 8) {
-                ForEach(Array(shortcutSettings.askOmiKey.hintKeys.enumerated()), id: \.offset) { _, symbol in
+                ForEach(Array(shortcutSettings.askOmiShortcut.displayTokens.enumerated()), id: \.offset) { _, symbol in
                     keyCap(symbol)
                 }
             }
@@ -125,10 +117,73 @@ struct OnboardingFloatingBarShortcutStepView: View {
         }
     }
 
+    private var customShortcutButton: some View {
+        let isSelected = shortcutSettings.askOmiUsesCustomShortcut || isRecordingCustomShortcut
+        return Button(action: beginCustomShortcutCapture) {
+            Text("Custom")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(isSelected ? .black : OmiColors.textSecondary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(isSelected ? Color.white : OmiColors.backgroundSecondary)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var customShortcutRecorder: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(isRecordingCustomShortcut ? "Press your custom shortcut now" : "Custom shortcut")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(OmiColors.textPrimary)
+
+            HStack(spacing: 10) {
+                HStack(spacing: 6) {
+                    ForEach(Array(shortcutSettings.askOmiShortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                        smallKeyCap(token, active: true)
+                    }
+                }
+
+                Spacer()
+
+                Button(action: beginCustomShortcutCapture) {
+                    Text(isRecordingCustomShortcut ? "Listening..." : "Save")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(OmiColors.textPrimary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(OmiColors.backgroundPrimary)
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+
+            Text("Use at least one non-modifier key, like J or Return.")
+                .font(.system(size: 12))
+                .foregroundColor(OmiColors.textTertiary)
+
+            if let captureError {
+                Text(captureError)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.red.opacity(0.9))
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: 420)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(OmiColors.backgroundSecondary)
+        )
+    }
+
     private func keyCap(_ label: String) -> some View {
         RoundedRectangle(cornerRadius: 10, style: .continuous)
             .fill(shortcutDetected ? Color.white : OmiColors.backgroundTertiary)
-            .frame(width: 48, height: 48)
+            .frame(minWidth: 48, minHeight: 48)
             .overlay(
                 RoundedRectangle(cornerRadius: 10, style: .continuous)
                     .stroke(
@@ -140,20 +195,34 @@ struct OnboardingFloatingBarShortcutStepView: View {
                 Text(label)
                     .font(.system(size: 18, weight: .semibold))
                     .foregroundColor(shortcutDetected ? .black : OmiColors.textPrimary)
+                    .padding(.horizontal, label.count > 2 ? 14 : 10)
             }
+            .fixedSize()
     }
 
-    // MARK: - Shortcut Choice Buttons
+    private func smallKeyCap(_ label: String, active: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(active ? Color.white : OmiColors.backgroundTertiary)
+            .frame(minWidth: 36, minHeight: 32)
+            .overlay {
+                Text(label)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(active ? .black : OmiColors.textPrimary)
+                    .padding(.horizontal, label.count > 2 ? 10 : 8)
+            }
+            .fixedSize()
+    }
 
-    private func shortcutChoiceButton(_ key: ShortcutSettings.AskOmiKey) -> some View {
-        let isSelected = shortcutSettings.askOmiKey == key
+    private func shortcutChoiceButton(_ shortcut: ShortcutSettings.KeyboardShortcut) -> some View {
+        let isSelected = shortcutSettings.askOmiShortcut == shortcut && !shortcutSettings.askOmiUsesCustomShortcut
         return Button {
-            shortcutSettings.askOmiKey = key
-            shortcutDetected = false
-            showContinue = false
+            shortcutSettings.askOmiShortcut = shortcut
+            isRecordingCustomShortcut = false
+            captureError = nil
+            resetDetectionState()
         } label: {
             HStack(spacing: 4) {
-                ForEach(Array(key.hintKeys.enumerated()), id: \.offset) { _, symbol in
+                ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, symbol in
                     Text(symbol)
                         .font(.system(size: 13, weight: .medium))
                 }
@@ -169,29 +238,68 @@ struct OnboardingFloatingBarShortcutStepView: View {
         .buttonStyle(.plain)
     }
 
-    // MARK: - Key Monitor
+    private func beginCustomShortcutCapture() {
+        isRecordingCustomShortcut = true
+        captureError = nil
+        resetDetectionState()
+    }
+
+    private func resetDetectionState() {
+        shortcutDetected = false
+        showContinue = false
+    }
 
     private func installKeyMonitor() {
-        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
-            if handleShortcutEvent(event) {
-                return nil
-            }
-            return event
+        let mask: NSEvent.EventTypeMask = [.keyDown, .flagsChanged]
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { event in
+            handleShortcutEvent(event) ? nil : event
         }
-        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { event in
+        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask) { event in
             _ = handleShortcutEvent(event)
         }
     }
 
+    private func removeKeyMonitors() {
+        if let monitor = localKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            localKeyMonitor = nil
+        }
+        if let monitor = globalKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalKeyMonitor = nil
+        }
+    }
+
     private func handleShortcutEvent(_ event: NSEvent) -> Bool {
+        if isRecordingCustomShortcut {
+            return captureCustomShortcut(from: event)
+        }
+
         guard !shortcutDetected else { return false }
-        guard shortcutSettings.askOmiKey.matches(event) else { return false }
+        guard shortcutSettings.askOmiShortcut.matchesKeyDown(event) else { return false }
+
         DispatchQueue.main.async {
             shortcutDetected = true
             withAnimation(.easeInOut(duration: 0.3)) {
                 showContinue = true
             }
         }
+        return true
+    }
+
+    private func captureCustomShortcut(from event: NSEvent) -> Bool {
+        if event.type == .flagsChanged {
+            captureError = "Ask omi needs a non-modifier key."
+            return true
+        }
+
+        guard let shortcut = ShortcutSettings.KeyboardShortcut.fromRecordingEvent(event, allowModifierOnly: false) else {
+            return false
+        }
+
+        shortcutSettings.askOmiShortcut = shortcut
+        isRecordingCustomShortcut = false
+        captureError = nil
         return true
     }
 }

--- a/desktop/Desktop/Sources/OnboardingFlow.swift
+++ b/desktop/Desktop/Sources/OnboardingFlow.swift
@@ -2,9 +2,9 @@ import Foundation
 
 enum OnboardingFlow {
   static let steps = [
-    "Trust",
     "Name",
     "Language",
+    "Trust",
     "ScreenRecording",
     "FullDiskAccess",
     "FileScan",
@@ -31,7 +31,8 @@ enum OnboardingFlow {
     hasMergedVoiceInputStep: Bool,
     hasRemovedNotificationStep: Bool,
     hasInsertedFloatingBarShortcutStep: Bool,
-    hasMigratedPagedIntro: Bool
+    hasMigratedPagedIntro: Bool,
+    hasReorderedTrustStep: Bool
   ) -> Int {
     var migratedStep = currentStep
 
@@ -59,6 +60,19 @@ enum OnboardingFlow {
 
     if !hasMigratedPagedIntro, migratedStep > 0 {
       migratedStep += legacyPostIntroOffset
+    }
+
+    if !hasReorderedTrustStep {
+      switch migratedStep {
+      case 0:
+        migratedStep = 2
+      case 1:
+        migratedStep = 0
+      case 2:
+        migratedStep = 1
+      default:
+        break
+      }
     }
 
     return min(max(0, migratedStep), lastStepIndex)

--- a/desktop/Desktop/Sources/OnboardingPermissionStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingPermissionStepView.swift
@@ -69,6 +69,13 @@ struct OnboardingPermissionStepView: View {
             .foregroundColor(OmiColors.textSecondary)
             .lineSpacing(4)
 
+          if permissionType == "screen_recording", appState.isScreenRecordingStale {
+            Text("macOS still isn’t granting screen capture to this build. In Screen & System Audio Recording, toggle Omi Dev off, then on again, then quit and reopen the app.")
+              .font(.system(size: 13, weight: .medium))
+              .foregroundColor(OmiColors.warning)
+              .fixedSize(horizontal: false, vertical: true)
+          }
+
           if permissionType == "full_disk_access", let email = coordinator.userEmail() {
             Text(email)
               .font(.system(size: 13, weight: .medium))
@@ -175,7 +182,7 @@ struct OnboardingPermissionStepView: View {
 
     screenRecordingRefreshTask = Task {
       let granted = await Task.detached(priority: .utility) {
-        ScreenCaptureService.checkPermission()
+        ScreenCaptureService.checkPermission(forceActualTestIfPreflightDenied: true)
       }.value
 
       guard !Task.isCancelled else { return }

--- a/desktop/Desktop/Sources/OnboardingPromptSuggestions.swift
+++ b/desktop/Desktop/Sources/OnboardingPromptSuggestions.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+@MainActor
+enum PostOnboardingPromptSuggestions {
+  private static let suggestionsKey = "postOnboardingPromptSuggestions"
+  private static let showPopupKey = "showPostOnboardingPromptPopup"
+  private static let dismissedKey = "dismissedPostOnboardingPromptSuggestions"
+
+  static func save(_ suggestions: [String]) {
+    let cleaned = Array(
+      NSOrderedSet(
+        array: suggestions
+          .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+          .filter { !$0.isEmpty }
+      ).array as? [String] ?? suggestions
+    )
+
+    UserDefaults.standard.set(cleaned, forKey: suggestionsKey)
+    UserDefaults.standard.set(true, forKey: showPopupKey)
+    UserDefaults.standard.set(false, forKey: dismissedKey)
+  }
+
+  static func suggestions() -> [String] {
+    UserDefaults.standard.stringArray(forKey: suggestionsKey) ?? []
+  }
+
+  static var shouldShowPopup: Bool {
+    get { UserDefaults.standard.bool(forKey: showPopupKey) }
+    set { UserDefaults.standard.set(newValue, forKey: showPopupKey) }
+  }
+
+  static var isDismissed: Bool {
+    get { UserDefaults.standard.bool(forKey: dismissedKey) }
+    set { UserDefaults.standard.set(newValue, forKey: dismissedKey) }
+  }
+}
+
+@MainActor
+enum OnboardingPromptSuggestionBuilder {
+  static func build(from coordinator: OnboardingPagedIntroCoordinator) -> [String] {
+    var suggestions: [String] = []
+
+    if let project = coordinator.scanSnapshot?.projectNames.first {
+      suggestions.append("What should I focus on today to ship \(project) faster?")
+    }
+
+    if let technology = coordinator.scanSnapshot?.technologies.first {
+      suggestions.append("Based on my recent work, what am I probably blocked on in \(technology)?")
+    }
+
+    if !coordinator.emailSummary.isEmpty {
+      suggestions.append("Which follow-ups from my recent emails matter most today?")
+    }
+
+    if !coordinator.calendarSummary.isEmpty {
+      suggestions.append("Where can I create more focus time in my calendar this week?")
+    }
+
+    if !coordinator.goalDraft.isEmpty {
+      suggestions.append("Help me break \"\(coordinator.goalDraft)\" into the next 3 steps.")
+    }
+
+    if !coordinator.webResearchSummary.isEmpty || coordinator.scanSnapshot != nil {
+      suggestions.append("What should I prioritize this week based on what you know about me?")
+    }
+
+    suggestions.append("What on my screen matters most right now?")
+    suggestions.append("What is the highest-leverage thing I can do in the next 30 minutes?")
+
+    let deduped = Array(NSOrderedSet(array: suggestions).array as? [String] ?? suggestions)
+    return Array(deduped.prefix(6))
+  }
+}

--- a/desktop/Desktop/Sources/OnboardingTrustStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingTrustStepView.swift
@@ -13,25 +13,35 @@ struct OnboardingTrustStepView: View {
       graphViewModel: graphViewModel,
       stepIndex: stepIndex,
       totalSteps: totalSteps,
-      eyebrow: "",
-      title: "Trust",
+      eyebrow: "Before we continue",
+      title: "I’m going to ask for a few permissions.",
       description:
-        "In onboarding, Omi needs to learn about you and access a few permissions to be useful. Without them, Omi cannot help much. Can we proceed?",
+        "Omi is open source and private by design. During setup, we’ll ask for these permissions to understand your work and help in the right places:",
       layoutMode: .centered
     ) {
       VStack(spacing: 18) {
+        VStack(alignment: .leading, spacing: 12) {
+          permissionRow(icon: "display", title: "Screen + files", detail: "Build context from what you’re working on.")
+          permissionRow(icon: "mic.fill", title: "Microphone", detail: "Capture voice notes and meeting context.")
+          permissionRow(icon: "sparkles", title: "Accessibility + automation", detail: "Know the active app and act when you ask.")
+          permissionRow(icon: "bell.badge.fill", title: "Notifications", detail: "Send useful reminders instead of generic noise.")
+        }
+        .frame(maxWidth: 560, alignment: .leading)
+
         HStack(spacing: 12) {
-          Button("Yes, let's go") {
+          Button("Continue") {
             coordinator.clearLastActionError()
             onContinue()
           }
           .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
 
-          Button("No, show the source code") {
+          Button("Read the source code") {
             guard let url = URL(string: "https://github.com/BasedHardware/omi") else { return }
             NSWorkspace.shared.open(url)
           }
-          .buttonStyle(OnboardingCardButtonStyle(isPrimary: false))
+          .buttonStyle(.plain)
+          .foregroundColor(OmiColors.textSecondary)
+          .font(.system(size: 13, weight: .medium))
         }
       }
       .frame(maxWidth: .infinity, alignment: .center)
@@ -39,5 +49,34 @@ struct OnboardingTrustStepView: View {
         coordinator.clearLastActionError()
       }
     }
+  }
+
+  private func permissionRow(icon: String, title: String, detail: String) -> some View {
+    HStack(alignment: .top, spacing: 12) {
+      Image(systemName: icon)
+        .font(.system(size: 14, weight: .semibold))
+        .foregroundColor(.white.opacity(0.85))
+        .frame(width: 28, height: 28)
+        .background(
+          RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(OmiColors.backgroundSecondary)
+        )
+
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundColor(OmiColors.textPrimary)
+        Text(detail)
+          .font(.system(size: 13))
+          .foregroundColor(OmiColors.textSecondary)
+      }
+
+      Spacer()
+    }
+    .padding(14)
+    .background(
+      RoundedRectangle(cornerRadius: 14, style: .continuous)
+        .fill(OmiColors.backgroundTertiary.opacity(0.55))
+    )
   }
 }

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -16,6 +16,7 @@ struct OnboardingView: View {
   @AppStorage("onboardingNotificationStepRemoved") private var hasRemovedNotificationStep = false
   @AppStorage("onboardingFloatingBarShortcutStepInserted") private
     var hasInsertedFloatingBarShortcutStep = false
+  @AppStorage("onboardingTrustStepReordered") private var hasReorderedTrustStep = false
   @StateObject private var introCoordinator = OnboardingPagedIntroCoordinator()
   @StateObject private var graphViewModel = MemoryGraphViewModel()
 
@@ -57,7 +58,8 @@ struct OnboardingView: View {
         hasMergedVoiceInputStep: hasMergedVoiceInputStep,
         hasRemovedNotificationStep: hasRemovedNotificationStep,
         hasInsertedFloatingBarShortcutStep: hasInsertedFloatingBarShortcutStep,
-        hasMigratedPagedIntro: hasMigratedPagedIntro
+        hasMigratedPagedIntro: hasMigratedPagedIntro,
+        hasReorderedTrustStep: hasReorderedTrustStep
       )
       hasMigratedPagedIntro = true
       hasMigratedOnboardingSteps = true
@@ -65,6 +67,7 @@ struct OnboardingView: View {
       hasMergedVoiceInputStep = true
       hasRemovedNotificationStep = true
       hasInsertedFloatingBarShortcutStep = true
+      hasReorderedTrustStep = true
       introCoordinator.prepare(appState: appState)
     }
     .task {
@@ -84,35 +87,35 @@ struct OnboardingView: View {
   private var onboardingContent: some View {
     Group {
       if currentStep == 0 {
-        OnboardingTrustStepView(
+        OnboardingWelcomeStepView(
           coordinator: introCoordinator,
           graphViewModel: graphViewModel,
           stepIndex: 0,
           totalSteps: OnboardingFlow.introStepCount,
           onContinue: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 0, stepName: "Trust")
+            AnalyticsManager.shared.onboardingStepCompleted(step: 0, stepName: "Name")
             currentStep = 1
           }
         )
       } else if currentStep == 1 {
-        OnboardingWelcomeStepView(
+        OnboardingLanguageStepView(
           coordinator: introCoordinator,
           graphViewModel: graphViewModel,
           stepIndex: 1,
           totalSteps: OnboardingFlow.introStepCount,
           onContinue: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "Name")
+            AnalyticsManager.shared.onboardingStepCompleted(step: 1, stepName: "Language")
             currentStep = 2
           }
         )
       } else if currentStep == 2 {
-        OnboardingLanguageStepView(
+        OnboardingTrustStepView(
           coordinator: introCoordinator,
           graphViewModel: graphViewModel,
           stepIndex: 2,
           totalSteps: OnboardingFlow.introStepCount,
           onContinue: {
-            AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "Language")
+            AnalyticsManager.shared.onboardingStepCompleted(step: 2, stepName: "Trust")
             currentStep = 3
           }
         )
@@ -396,6 +399,7 @@ struct OnboardingView: View {
     // Navigate to Tasks page after transition
     UserDefaults.standard.set(true, forKey: "onboardingJustCompleted")
     UserDefaults.standard.set(true, forKey: "hasCompletedFileIndexing")
+    PostOnboardingPromptSuggestions.save(OnboardingPromptSuggestionBuilder.build(from: introCoordinator))
 
     // Clean up onboarding state and persisted chat data
     chatProvider.isOnboarding = false

--- a/desktop/Desktop/Sources/OnboardingVoiceDemoView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceDemoView.swift
@@ -60,7 +60,9 @@ struct OnboardingVoiceDemoView: View {
                             .foregroundColor(OmiColors.textTertiary)
 
                         HStack(spacing: 6) {
-                            keyCap(shortcutSettings.pttKey.symbol)
+                            ForEach(Array(shortcutSettings.pttShortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                                keyCap(token)
+                            }
                             Text("hold")
                                 .font(.system(size: 13, weight: .medium))
                                 .foregroundColor(OmiColors.textTertiary)

--- a/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
@@ -1,244 +1,326 @@
 import SwiftUI
 
-/// Onboarding step: verify the push-to-talk shortcut key without opening the voice bar.
+/// Onboarding step: verify the push-to-talk shortcut without opening the voice bar.
 struct OnboardingVoiceShortcutStepView: View {
-  @ObservedObject var appState: AppState
-  @ObservedObject var chatProvider: ChatProvider
-  var onComplete: () -> Void
-  var onSkip: () -> Void
+    @ObservedObject var appState: AppState
+    @ObservedObject var chatProvider: ChatProvider
+    var onComplete: () -> Void
+    var onSkip: () -> Void
 
-  @ObservedObject private var shortcutSettings = ShortcutSettings.shared
+    @ObservedObject private var shortcutSettings = ShortcutSettings.shared
 
-  @State private var shortcutDetected = false
-  @State private var showContinue = false
-  @State private var keyMonitor: Any?
+    @State private var shortcutDetected = false
+    @State private var showContinue = false
+    @State private var isRecordingCustomShortcut = false
+    @State private var captureError: String?
+    @State private var localKeyMonitor: Any?
+    @State private var globalKeyMonitor: Any?
 
-  var body: some View {
-    VStack(spacing: 0) {
-      // Header
-      HStack {
-        Text("Set your voice shortcut")
-          .font(.system(size: 18, weight: .semibold))
-          .foregroundColor(OmiColors.textPrimary)
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Set your voice shortcut")
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(OmiColors.textPrimary)
 
-        Spacer()
+                Spacer()
 
-        Button(action: onSkip) {
-          Text("Skip")
-            .font(.system(size: 13))
-            .foregroundColor(OmiColors.textTertiary)
+                Button(action: onSkip) {
+                    Text("Skip")
+                        .font(.system(size: 13))
+                        .foregroundColor(OmiColors.textTertiary)
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.horizontal, 24)
+            .padding(.vertical, 16)
+
+            Divider()
+                .background(OmiColors.backgroundTertiary)
+
+            Spacer()
+
+            VStack(spacing: 24) {
+                Text("Press and hold to test.\nDoes the button light up?")
+                    .font(.system(size: 22, weight: .semibold))
+                    .foregroundColor(OmiColors.textPrimary)
+                    .multilineTextAlignment(.center)
+
+                RoundedRectangle(cornerRadius: 16, style: .continuous)
+                    .fill(OmiColors.backgroundSecondary)
+                    .frame(height: 128)
+                    .frame(maxWidth: 420)
+                    .overlay {
+                        shortcutKeyPreview
+                    }
+
+                VStack(spacing: 12) {
+                    Text("Try another shortcut if it doesn't react:")
+                        .font(.system(size: 14, weight: .medium))
+                        .foregroundColor(OmiColors.textSecondary)
+
+                    HStack(spacing: 10) {
+                        ForEach(ShortcutSettings.pttPresets, id: \.self) { shortcut in
+                            shortcutChoiceButton(shortcut)
+                        }
+                        customShortcutButton
+                    }
+
+                    if isRecordingCustomShortcut || shortcutSettings.pttUsesCustomShortcut || captureError != nil {
+                        customShortcutRecorder
+                    }
+                }
+
+                if showContinue {
+                    Button(action: onComplete) {
+                        Text("Continue")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(.black)
+                            .padding(.horizontal, 28)
+                            .padding(.vertical, 12)
+                            .background(
+                                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                                    .fill(Color.white)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .transition(.move(edge: .trailing).combined(with: .opacity))
+                }
+            }
+
+            Spacer()
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(OmiColors.backgroundPrimary)
+        .onAppear {
+            FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
+            resetFloatingBarConversation()
+            FloatingControlBarManager.shared.hide()
+            PushToTalkManager.shared.cleanup()
+            installKeyMonitor()
+        }
+        .onDisappear {
+            removeKeyMonitors()
+        }
+    }
+
+    private func resetFloatingBarConversation() {
+        guard let barState = FloatingControlBarManager.shared.barState else { return }
+        barState.showingAIConversation = false
+        barState.showingAIResponse = false
+        barState.aiInputText = ""
+        barState.currentAIMessage = nil
+        barState.chatHistory = []
+        barState.isVoiceFollowUp = false
+        barState.voiceFollowUpTranscript = ""
+    }
+
+    private var shortcutKeyPreview: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 8) {
+                ForEach(Array(shortcutSettings.pttShortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                    keyCap(token)
+                }
+            }
+
+            Text(shortcutDetected ? "Shortcut detected" : "Press and hold to test")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(OmiColors.textTertiary)
+        }
+    }
+
+    private var customShortcutButton: some View {
+        let isSelected = shortcutSettings.pttUsesCustomShortcut || isRecordingCustomShortcut
+        return Button(action: beginCustomShortcutCapture) {
+            Text("Custom")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(isSelected ? .black : OmiColors.textSecondary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .fill(isSelected ? Color.white : OmiColors.backgroundSecondary)
+                )
         }
         .buttonStyle(.plain)
-      }
-      .padding(.horizontal, 24)
-      .padding(.vertical, 16)
+    }
 
-      Divider()
-        .background(OmiColors.backgroundTertiary)
+    private var customShortcutRecorder: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(isRecordingCustomShortcut ? "Press and hold your custom shortcut now" : "Custom shortcut")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundColor(OmiColors.textPrimary)
 
-      Spacer()
+            HStack(spacing: 10) {
+                HStack(spacing: 6) {
+                    ForEach(Array(shortcutSettings.pttShortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                        smallKeyCap(token, active: true)
+                    }
+                }
 
-      // Content
-      VStack(spacing: 24) {
-        Text("Press and hold to test.\nDoes the button light up?")
-          .font(.system(size: 22, weight: .semibold))
-          .foregroundColor(OmiColors.textPrimary)
-          .multilineTextAlignment(.center)
+                Spacer()
 
-        RoundedRectangle(cornerRadius: 16, style: .continuous)
-          .fill(OmiColors.backgroundSecondary)
-          .frame(height: 128)
-          .frame(maxWidth: 400)
-          .overlay {
-            shortcutKeyPreview
-          }
-
-        VStack(spacing: 12) {
-          Text("Try another key if it doesn't react:")
-            .font(.system(size: 14, weight: .medium))
-            .foregroundColor(OmiColors.textSecondary)
-
-          HStack(spacing: 10) {
-            ForEach(ShortcutSettings.PTTKey.allCases, id: \.self) { key in
-              shortcutChoiceButton(key)
+                Button(action: beginCustomShortcutCapture) {
+                    Text(isRecordingCustomShortcut ? "Listening..." : "Save")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundColor(OmiColors.textPrimary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                .fill(OmiColors.backgroundPrimary)
+                        )
+                }
+                .buttonStyle(.plain)
             }
-          }
-        }
 
-        HStack(spacing: 14) {
-          Button(action: cycleShortcut) {
-            Text("Change shortcut")
-              .font(.system(size: 15, weight: .semibold))
-              .foregroundColor(OmiColors.textSecondary)
-              .padding(.horizontal, 18)
-              .padding(.vertical, 12)
-              .background(
-                RoundedRectangle(cornerRadius: 12, style: .continuous)
-                  .fill(OmiColors.backgroundSecondary)
-              )
-          }
-          .buttonStyle(.plain)
+            Text("You can use one key or a combination like ⌘ J.")
+                .font(.system(size: 12))
+                .foregroundColor(OmiColors.textTertiary)
 
-          if showContinue {
-            Button(action: onComplete) {
-              Text("Continue")
-                .font(.system(size: 15, weight: .semibold))
-                .foregroundColor(.black)
-                .padding(.horizontal, 28)
-                .padding(.vertical, 12)
-                .background(
-                  RoundedRectangle(cornerRadius: 12, style: .continuous)
-                    .fill(Color.white)
-                )
+            if let captureError {
+                Text(captureError)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(.red.opacity(0.9))
             }
-            .buttonStyle(.plain)
-            .transition(.move(edge: .trailing).combined(with: .opacity))
-          }
         }
-      }
-
-      Spacer()
-    }
-    .frame(maxWidth: .infinity, maxHeight: .infinity)
-    .background(OmiColors.backgroundPrimary)
-    .onAppear {
-      FloatingControlBarManager.shared.setup(appState: appState, chatProvider: chatProvider)
-      resetFloatingBarConversation()
-      FloatingControlBarManager.shared.hide()
-      PushToTalkManager.shared.cleanup()
-      installKeyMonitor()
-    }
-    .onDisappear {
-      if let monitor = keyMonitor {
-        NSEvent.removeMonitor(monitor)
-        keyMonitor = nil
-      }
-    }
-  }
-
-  private func resetFloatingBarConversation() {
-    guard let barState = FloatingControlBarManager.shared.barState else { return }
-    barState.showingAIConversation = false
-    barState.showingAIResponse = false
-    barState.aiInputText = ""
-    barState.currentAIMessage = nil
-    barState.chatHistory = []
-    barState.isVoiceFollowUp = false
-    barState.voiceFollowUpTranscript = ""
-  }
-
-  private var shortcutKeyPreview: some View {
-    VStack(spacing: 12) {
-      RoundedRectangle(cornerRadius: 14, style: .continuous)
-        .fill(shortcutDetected ? Color.white : OmiColors.backgroundTertiary)
-        .frame(width: 64, height: 64)
-        .overlay(
-          RoundedRectangle(cornerRadius: 14, style: .continuous)
-            .stroke(
-              shortcutDetected ? Color.white : OmiColors.textTertiary.opacity(0.3),
-              lineWidth: 2)
+        .padding(14)
+        .frame(maxWidth: 420)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(OmiColors.backgroundSecondary)
         )
-        .overlay {
-          VStack(spacing: 6) {
-            Text(shortcutLabelTop)
-              .font(.system(size: 13, weight: .semibold))
-              .foregroundColor(shortcutDetected ? .black : OmiColors.textPrimary)
+    }
 
-            Text(shortcutLabelBottom)
-              .font(.system(size: 14, weight: .medium))
-              .foregroundColor(shortcutDetected ? .black.opacity(0.7) : OmiColors.textSecondary)
-          }
+    private func keyCap(_ label: String) -> some View {
+        RoundedRectangle(cornerRadius: 10, style: .continuous)
+            .fill(shortcutDetected ? Color.white : OmiColors.backgroundTertiary)
+            .frame(minWidth: 48, minHeight: 48)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .stroke(
+                        shortcutDetected ? Color.white : OmiColors.textTertiary.opacity(0.3),
+                        lineWidth: 2
+                    )
+            )
+            .overlay {
+                Text(label)
+                    .font(.system(size: 18, weight: .semibold))
+                    .foregroundColor(shortcutDetected ? .black : OmiColors.textPrimary)
+                    .padding(.horizontal, label.count > 2 ? 14 : 10)
+            }
+            .fixedSize()
+    }
+
+    private func smallKeyCap(_ label: String, active: Bool) -> some View {
+        RoundedRectangle(cornerRadius: 8, style: .continuous)
+            .fill(active ? Color.white : OmiColors.backgroundTertiary)
+            .frame(minWidth: 36, minHeight: 32)
+            .overlay {
+                Text(label)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(active ? .black : OmiColors.textPrimary)
+                    .padding(.horizontal, label.count > 2 ? 10 : 8)
+            }
+            .fixedSize()
+    }
+
+    private func shortcutChoiceButton(_ shortcut: ShortcutSettings.KeyboardShortcut) -> some View {
+        let isSelected = shortcutSettings.pttShortcut == shortcut && !shortcutSettings.pttUsesCustomShortcut
+        return Button {
+            shortcutSettings.pttShortcut = shortcut
+            isRecordingCustomShortcut = false
+            captureError = nil
+            resetDetectionState()
+        } label: {
+            HStack(spacing: 6) {
+                ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, token in
+                    Text(token)
+                        .font(.system(size: 13, weight: .medium))
+                }
+            }
+            .foregroundColor(isSelected ? .black : OmiColors.textSecondary)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isSelected ? Color.white : OmiColors.backgroundSecondary)
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func beginCustomShortcutCapture() {
+        isRecordingCustomShortcut = true
+        captureError = nil
+        resetDetectionState()
+    }
+
+    private func resetDetectionState() {
+        shortcutDetected = false
+        showContinue = false
+    }
+
+    private func installKeyMonitor() {
+        let mask: NSEvent.EventTypeMask = [.flagsChanged, .keyDown, .keyUp]
+        localKeyMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { event in
+            handleShortcutEvent(event) ? nil : event
+        }
+        globalKeyMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask) { event in
+            _ = handleShortcutEvent(event)
+        }
+    }
+
+    private func removeKeyMonitors() {
+        if let monitor = localKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            localKeyMonitor = nil
+        }
+        if let monitor = globalKeyMonitor {
+            NSEvent.removeMonitor(monitor)
+            globalKeyMonitor = nil
+        }
+    }
+
+    private func handleShortcutEvent(_ event: NSEvent) -> Bool {
+        if isRecordingCustomShortcut {
+            return captureCustomShortcut(from: event)
         }
 
-      Text(shortcutDetected ? "Shortcut detected" : "Press and hold to test")
-        .font(.system(size: 13, weight: .medium))
-        .foregroundColor(OmiColors.textTertiary)
+        guard !shortcutDetected else { return false }
+
+        let shortcut = shortcutSettings.pttShortcut
+        let detected: Bool
+        switch event.type {
+        case .flagsChanged:
+            detected = shortcut.matchesFlagsChanged(event)
+        case .keyDown:
+            detected = !event.isARepeat && shortcut.matchesKeyDown(event)
+        default:
+            detected = false
+        }
+
+        guard detected else { return false }
+
+        shortcutDetected = true
+        withAnimation(.easeInOut(duration: 0.3)) {
+            showContinue = true
+        }
+        return true
     }
-  }
 
-  private func shortcutChoiceButton(_ key: ShortcutSettings.PTTKey) -> some View {
-    let isSelected = shortcutSettings.pttKey == key
-    return Button {
-      shortcutSettings.pttKey = key
-      shortcutDetected = false
-      showContinue = false
-    } label: {
-      HStack(spacing: 6) {
-        Text(key.symbol)
-          .font(.system(size: 14, weight: .medium))
-        Text(pttChoiceTitle(for: key))
-          .font(.system(size: 13, weight: .semibold))
-      }
-      .foregroundColor(isSelected ? .black : OmiColors.textSecondary)
-      .padding(.horizontal, 14)
-      .padding(.vertical, 10)
-      .background(
-        RoundedRectangle(cornerRadius: 12, style: .continuous)
-          .fill(isSelected ? Color.white : OmiColors.backgroundSecondary)
-      )
+    private func captureCustomShortcut(from event: NSEvent) -> Bool {
+        guard let shortcut = ShortcutSettings.KeyboardShortcut.fromRecordingEvent(event, allowModifierOnly: true) else {
+            if event.type == .flagsChanged, event.modifierFlags.intersection(.deviceIndependentFlagsMask).isEmpty {
+                return false
+            }
+            captureError = "Press the key combination you want to use."
+            return false
+        }
+
+        shortcutSettings.pttShortcut = shortcut
+        isRecordingCustomShortcut = false
+        captureError = nil
+        return true
     }
-    .buttonStyle(.plain)
-  }
-
-  private var shortcutLabelTop: String {
-    switch shortcutSettings.pttKey {
-    case .option:
-      return "option"
-    case .rightCommand:
-      return "right cmd"
-    case .fn:
-      return "fn"
-    }
-  }
-
-  private var shortcutLabelBottom: String {
-    shortcutSettings.pttKey.symbol
-  }
-
-  private func pttChoiceTitle(for key: ShortcutSettings.PTTKey) -> String {
-    switch key {
-    case .option:
-      return "Option"
-    case .rightCommand:
-      return "Right Cmd"
-    case .fn:
-      return "Fn"
-    }
-  }
-
-  private func installKeyMonitor() {
-    keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) { event in
-      guard !shortcutDetected else { return event }
-      guard matchesCurrentPTTShortcut(event) else { return event }
-
-      shortcutDetected = true
-      withAnimation(.easeInOut(duration: 0.3)) {
-        showContinue = true
-      }
-      return nil
-    }
-  }
-
-  private func matchesCurrentPTTShortcut(_ event: NSEvent) -> Bool {
-    switch shortcutSettings.pttKey {
-    case .option:
-      let otherModifiers: NSEvent.ModifierFlags = [.command, .control, .shift]
-      return event.modifierFlags.intersection(otherModifiers) == []
-        && event.modifierFlags.contains(.option)
-    case .rightCommand:
-      return event.keyCode == 54 && event.modifierFlags.contains(.command)
-    case .fn:
-      return event.modifierFlags.contains(.function)
-    }
-  }
-
-  private func cycleShortcut() {
-    let allKeys = ShortcutSettings.PTTKey.allCases
-    guard let currentIndex = allKeys.firstIndex(of: shortcutSettings.pttKey) else { return }
-    let nextIndex = allKeys.index(after: currentIndex)
-    shortcutSettings.pttKey =
-      nextIndex == allKeys.endIndex ? allKeys[allKeys.startIndex] : allKeys[nextIndex]
-    shortcutDetected = false
-    showContinue = false
-  }
 }

--- a/desktop/Desktop/Sources/PostOnboardingPromptViews.swift
+++ b/desktop/Desktop/Sources/PostOnboardingPromptViews.swift
@@ -1,0 +1,251 @@
+import SwiftUI
+
+struct TryAskingPopupView: View {
+  let suggestions: [String]
+  let onAsk: (String) -> Void
+  let onDismiss: () -> Void
+
+  private let calloutAmber = Color(hex: 0xE3BF63)
+
+  var body: some View {
+    GeometryReader { proxy in
+      let popupWidth = min(max(proxy.size.width - 72, 560), 660)
+      let popupHeight = min(max(proxy.size.height - 80, 360), 520)
+
+      ZStack {
+        Color.black.opacity(0.52)
+          .ignoresSafeArea()
+          .onTapGesture(perform: onDismiss)
+
+        VStack {
+          popupContent
+        }
+        .frame(width: popupWidth, height: popupHeight)
+        .padding(26)
+        .background(
+          RoundedRectangle(cornerRadius: 28, style: .continuous)
+            .fill(OmiColors.backgroundSecondary.opacity(0.98))
+        )
+        .overlay(
+          RoundedRectangle(cornerRadius: 28, style: .continuous)
+            .stroke(calloutAmber.opacity(0.18), lineWidth: 1)
+        )
+        .overlay(alignment: .topLeading) {
+          RoundedRectangle(cornerRadius: 28, style: .continuous)
+            .fill(
+              LinearGradient(
+                colors: [calloutAmber.opacity(0.12), .clear],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+            )
+            .allowsHitTesting(false)
+        }
+        .overlay(alignment: .topTrailing) {
+          Button(action: onDismiss) {
+            Image(systemName: "xmark")
+              .font(.system(size: 12, weight: .bold))
+              .foregroundColor(OmiColors.textTertiary)
+              .frame(width: 28, height: 28)
+              .background(
+                Circle()
+                  .fill(OmiColors.backgroundTertiary)
+              )
+          }
+          .buttonStyle(.plain)
+          .padding(18)
+        }
+        .shadow(color: .black.opacity(0.4), radius: 30, x: 0, y: 16)
+      }
+    }
+  }
+
+  private var popupContent: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      HStack(spacing: 8) {
+        Image(systemName: "sparkles")
+          .font(.system(size: 11, weight: .semibold))
+        Text("Suggested first ask")
+          .font(.system(size: 12, weight: .semibold))
+      }
+      .foregroundColor(calloutAmber)
+      .padding(.horizontal, 10)
+      .padding(.vertical, 6)
+      .background(
+        Capsule()
+          .fill(calloutAmber.opacity(0.14))
+      )
+
+      Text("What would you like to ask omi first?")
+        .font(.system(size: 32, weight: .semibold, design: .serif))
+        .foregroundColor(OmiColors.textPrimary)
+
+      Text("Pick one and we’ll run it through the floating bar with your real context.")
+        .font(.system(size: 15))
+        .foregroundColor(OmiColors.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      VStack(spacing: 14) {
+        ForEach(suggestions, id: \.self) { suggestion in
+          Button {
+            onAsk(suggestion)
+          } label: {
+            HStack(spacing: 10) {
+              Image(systemName: "sparkles")
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundColor(calloutAmber)
+
+              Text(suggestion)
+                .font(.system(size: 15, weight: .medium))
+                .multilineTextAlignment(.leading)
+
+              Spacer(minLength: 0)
+
+              Image(systemName: "arrow.up.right")
+                .font(.system(size: 11, weight: .bold))
+                .foregroundColor(OmiColors.textQuaternary)
+            }
+            .contentShape(Rectangle())
+            .foregroundColor(OmiColors.textPrimary)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+            .background(
+              RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(OmiColors.backgroundTertiary.opacity(0.82))
+            )
+            .overlay(
+              RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .stroke(OmiColors.backgroundQuaternary.opacity(0.9), lineWidth: 1)
+            )
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    .padding(12)
+  }
+}
+
+struct PromptSuggestionBanner: View {
+  let suggestions: [String]
+  let onOpen: () -> Void
+  let onAsk: (String) -> Void
+  let onDismiss: () -> Void
+
+  private let calloutAmber = Color(hex: 0xC9972D)
+  private let calloutCream = Color(hex: 0xF4E3AA)
+
+  private func compactLabel(for suggestion: String) -> String {
+    if suggestion.hasPrefix("What should I focus on today to ship ") {
+      return "What should I focus on today?"
+    }
+    if suggestion.hasPrefix("Based on my recent work, what am I probably blocked on in ") {
+      return "What am I probably blocked on?"
+    }
+    if suggestion == "Which follow-ups from my recent emails matter most today?" {
+      return "Which email follow-ups matter most?"
+    }
+    if suggestion == "Where can I create more focus time in my calendar this week?" {
+      return "Where can I create more focus time?"
+    }
+    if suggestion.hasPrefix("Help me break \"") {
+      return "What are the next 3 steps?"
+    }
+    if suggestion == "What should I prioritize this week based on what you know about me?" {
+      return "What should I prioritize this week?"
+    }
+    if suggestion == "What on my screen matters most right now?" {
+      return "What matters most on my screen?"
+    }
+    if suggestion == "What is the highest-leverage thing I can do in the next 30 minutes?" {
+      return "What should I do in the next 30 minutes?"
+    }
+    return suggestion
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      Button(action: onOpen) {
+        VStack(alignment: .leading, spacing: 14) {
+          HStack(spacing: 8) {
+            Image(systemName: "sparkles")
+              .font(.system(size: 11, weight: .semibold))
+            Text("Suggested first ask")
+              .font(.system(size: 12, weight: .semibold))
+          }
+          .foregroundColor(Color.black.opacity(0.68))
+
+          Text("Next step -> Ask omi")
+            .font(.system(size: 20, weight: .semibold, design: .serif))
+            .foregroundColor(Color.black.opacity(0.86))
+
+          Text("Use your real screen and your existing context to get value quickly. Tap to open a few suggested questions.")
+            .font(.system(size: 14, weight: .medium))
+            .foregroundColor(Color.black.opacity(0.72))
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+      }
+      .buttonStyle(.plain)
+
+      HStack(spacing: 8) {
+        ForEach(Array(suggestions.prefix(3)), id: \.self) { suggestion in
+          Button {
+            onAsk(suggestion)
+          } label: {
+            Text(compactLabel(for: suggestion))
+              .font(.system(size: 12, weight: .semibold))
+              .foregroundColor(Color.black.opacity(0.74))
+              .lineLimit(1)
+              .padding(.horizontal, 12)
+              .padding(.vertical, 9)
+              .background(
+                Capsule()
+                  .fill(Color.white.opacity(0.5))
+              )
+          }
+          .buttonStyle(.plain)
+        }
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .padding(22)
+    .background(
+      RoundedRectangle(cornerRadius: 20, style: .continuous)
+        .fill(
+          LinearGradient(
+            colors: [calloutCream, Color(hex: 0xEFD07A)],
+            startPoint: .topLeading,
+            endPoint: .bottomTrailing
+          )
+        )
+    )
+    .overlay(
+      RoundedRectangle(cornerRadius: 20, style: .continuous)
+        .stroke(calloutAmber.opacity(0.24), lineWidth: 1)
+    )
+    .overlay(alignment: .topTrailing) {
+      ZStack(alignment: .topTrailing) {
+        Circle()
+          .fill(Color.white.opacity(0.3))
+          .frame(width: 120, height: 120)
+          .blur(radius: 34)
+          .offset(x: 34, y: -42)
+          .allowsHitTesting(false)
+
+        Button(action: onDismiss) {
+          Image(systemName: "xmark")
+            .font(.system(size: 11, weight: .bold))
+            .foregroundColor(Color.black.opacity(0.58))
+            .frame(width: 24, height: 24)
+            .background(
+              Circle()
+                .fill(Color.white.opacity(0.45))
+            )
+        }
+        .buttonStyle(.plain)
+        .padding(14)
+      }
+    }
+  }
+}

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalGenerationService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Goals/GoalGenerationService.swift
@@ -65,7 +65,7 @@ class GoalGenerationService {
 
         if lastDate == nil {
             log("GoalGenerationService: First run, generating immediately")
-            await generateGoalIfNeeded()
+            _ = await generateGoalIfNeeded()
             return
         }
 
@@ -76,11 +76,11 @@ class GoalGenerationService {
         }
 
         log("GoalGenerationService: New day — last generation was \(lastDate), triggering generation")
-        await generateGoalIfNeeded()
+        _ = await generateGoalIfNeeded()
     }
 
     /// Generate a goal if the user has room for more
-    private func generateGoalIfNeeded() async {
+    private func generateGoalIfNeeded() async -> Bool {
         do {
             let goals = try await APIClient.shared.getGoals()
             let activeGoals = goals.filter { $0.isActive }
@@ -88,7 +88,7 @@ class GoalGenerationService {
             if activeGoals.count >= maxActiveGoals {
                 log("GoalGenerationService: User already has \(activeGoals.count) active goals (max \(maxActiveGoals)), skipping")
                 UserDefaults.standard.set(Date(), forKey: Self.kLastGenerationDate)
-                return
+                return true
             }
 
             log("GoalGenerationService: User has \(activeGoals.count)/\(maxActiveGoals) goals, generating one...")
@@ -105,16 +105,37 @@ class GoalGenerationService {
             )
 
             NotificationCenter.default.post(name: .goalAutoCreated, object: goal)
+            return true
 
         } catch {
             log("GoalGenerationService: Failed to generate goal: \(error.localizedDescription)")
+            return false
         }
     }
 
     /// Manual trigger that bypasses the daily check
     func generateNow() async {
         log("GoalGenerationService: Manual generation triggered")
+        await waitForPrerequisites()
         await removeStaleGoals()
-        await generateGoalIfNeeded()
+        for attempt in 0..<3 {
+            if await generateGoalIfNeeded() {
+                return
+            }
+            guard attempt < 2 else { return }
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+        }
+    }
+
+    private func waitForPrerequisites() async {
+        for _ in 0..<20 {
+            let authReady = await MainActor.run {
+                AuthState.shared.isSignedIn && !AuthState.shared.isRestoringAuth
+            }
+            if authReady && APIKeyService.keysAvailable {
+                return
+            }
+            try? await Task.sleep(nanoseconds: 500_000_000)
+        }
     }
 }

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -282,6 +282,8 @@ class ChatProvider: ObservableObject {
 🚨 FLOATING BAR MODE — READ THIS FIRST BEFORE ANYTHING ELSE 🚨
 ================================================================================
 If the question contains a product name, software name, or proper noun — search the web for it before answering, even if you think you know what it is.
+If a screenshot is attached and the user asks a deictic question like "which one", "which option", "which suits me", "what should I choose", or "what's on my screen", ground the answer in the visible options first and prefer what is actually on screen over unrelated context.
+If the screenshot already clearly shows the relevant options, do not ignore it just because the query is short or ambiguous.
 Respond in exactly 1 sentence. No lists. No headers. No follow-up questions.
 A screenshot may be attached — use it silently only if relevant. Never mention or acknowledge it.
 ================================================================================

--- a/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
+++ b/desktop/Desktop/Sources/Providers/ChatToolExecutor.swift
@@ -521,6 +521,7 @@ class ChatToolExecutor {
 
         switch type {
         case "screen_recording":
+            appState.screenRecordingGrantAttempts += 1
             appState.triggerScreenRecordingPermission()
             if let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture") {
                 NSWorkspace.shared.open(url)

--- a/desktop/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/Desktop/Sources/ScreenCaptureService.swift
@@ -40,11 +40,22 @@ final class ScreenCaptureService: Sendable {
 
   /// Check if we have screen recording permission by actually testing capture
   /// CGPreflightScreenCaptureAccess can return stale data after code signing changes
-  static func checkPermission() -> Bool {
-    // First quick check - if CGPreflight says no, definitely no permission
-    if !CGPreflightScreenCaptureAccess() {
+  static func checkPermission(forceActualTestIfPreflightDenied: Bool = false) -> Bool {
+    let preflightGranted = CGPreflightScreenCaptureAccess()
+
+    if !preflightGranted {
       log("Screen capture: CGPreflight says no permission")
-      return false
+
+      guard forceActualTestIfPreflightDenied else {
+        return false
+      }
+
+      log("Screen capture: running forced actual capture test despite denied preflight")
+      let actualPermission = testCapturePermission()
+      if actualPermission {
+        log("Screen capture: actual capture succeeded even though CGPreflight returned false")
+      }
+      return actualPermission
     }
 
     // CGPreflight can return stale data after rebuilds, so test actual capture


### PR DESCRIPTION
## Summary
- fix macOS onboarding shortcut testing and add custom shortcut support
- reorder and rewrite the trust step, improve prompt suggestions, and add post-onboarding ask surfaces
- harden permission handling, beta-channel defaults, and onboarding restart behavior

## Testing
- `cd desktop && OMI_APP_NAME="onboarding-v14" ./run.sh --yolo`
