### PR TITLE
feat: private cloud sync - listing, playing, sharing, delete all

### DIFF
--- a/app/lib/pages/conversations/private_cloud_sync_page.dart
+++ b/app/lib/pages/conversations/private_cloud_sync_page.dart
@@ -1,11 +1,15 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 
 import 'package:omi/providers/user_provider.dart';
+import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/services/wals/wal.dart';
+import 'package:omi/utils/audio_player_utils.dart';
+import 'package:omi/utils/other/time_utils.dart';
 
 class PrivateCloudSyncPage extends StatefulWidget {
   const PrivateCloudSyncPage({super.key});
@@ -46,6 +50,53 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
     }
   }
 
+  Future<void> _togglePlay(Wal wal) async {
+    await AudioPlayerUtils.instance.togglePlayback(wal);
+  }
+
+  Future<void> _shareWal(Wal wal) async {
+    final filePath = wal.filePath;
+    if (filePath != null && filePath.isNotEmpty) {
+      try {
+        await Share.shareXFiles(
+          [XFile(filePath)],
+          subject: 'Audio recording from ${dateTimeFormat('yyyy-MM-dd h:mm a', DateTime.fromMillisecondsSinceEpoch(wal.timerStart * 1000))}',
+        );
+      } catch (e) {
+        print('Error sharing audio: $e');
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Failed to share audio'), backgroundColor: Colors.red),
+          );
+        }
+      }
+    }
+  }
+
+  Future<void> _deleteAllCloudFiles() async {
+    final confirmed = await _showDeleteAllDialog();
+    if (confirmed != true) return;
+
+    if (!mounted) return;
+
+    try {
+      final syncProvider = context.read<SyncProvider>();
+      await syncProvider.deleteAllSyncedWals();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.allFilesDeleted), backgroundColor: Colors.green),
+        );
+      }
+    } catch (e) {
+      print('Error deleting all cloud files: $e');
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to delete recordings'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
   Future<bool?> _showEnableDialog() {
     return showDialog<bool>(
       context: context,
@@ -77,6 +128,73 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
     );
   }
 
+  Future<bool?> _showDeleteAllDialog() {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: const Color(0xFF1C1C1E),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Row(
+          children: [
+            const Icon(Icons.warning_amber_rounded, color: Colors.orange, size: 24),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                context.l10n.deleteAllFiles,
+                style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+              ),
+            ),
+          ],
+        ),
+        content: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              context.l10n.deleteAllFilesWarning,
+              style: TextStyle(color: Colors.grey.shade400, fontSize: 14, height: 1.5),
+            ),
+            const SizedBox(height: 16),
+            Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: Colors.blue.withValues(alpha: 0.1),
+                borderRadius: BorderRadius.circular(12),
+                border: Border.all(color: Colors.blue.withValues(alpha: 0.3)),
+              ),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Icon(Icons.info_outline, color: Colors.blue, size: 18),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: Text(
+                      'Your audio data may be used to improve AI models. Deleted recordings cannot be recovered and will not be available for AI training.',
+                      style: TextStyle(color: Colors.blue.shade200, fontSize: 12, height: 1.4),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(context.l10n.cancel, style: TextStyle(color: Colors.grey.shade500)),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              context.l10n.deleteAll,
+              style: const TextStyle(color: Colors.red, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildFaIcon(IconData icon, {double size = 18, Color color = const Color(0xFF8E8E93)}) {
     return Padding(
       padding: const EdgeInsets.only(left: 2, top: 1),
@@ -84,12 +202,104 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
     );
   }
 
+  Widget _buildWalListItem(Wal wal) {
+    final audioUtils = AudioPlayerUtils.instance;
+    final isCurrentlyPlaying = audioUtils.currentPlayingId == wal.id;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 12),
+      decoration: BoxDecoration(
+        color: const Color(0xFF1C1C1E),
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Row(
+          children: [
+            // Play/Pause button
+            GestureDetector(
+              onTap: () => _togglePlay(wal),
+              child: Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: Colors.deepPurpleAccent.withValues(alpha: 0.2),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(
+                  isCurrentlyPlaying ? Icons.pause : Icons.play_arrow,
+                  color: Colors.deepPurpleAccent,
+                  size: 24,
+                ),
+              ),
+            ),
+            const SizedBox(width: 14),
+            // Info
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    dateTimeFormat('MMM d, h:mm a', DateTime.fromMillisecondsSinceEpoch(wal.timerStart * 1000)),
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontSize: 15,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Row(
+                    children: [
+                      Icon(Icons.mic, size: 12, color: Colors.grey.shade500),
+                      const SizedBox(width: 4),
+                      Text(
+                        secondsToHumanReadable(wal.seconds, context),
+                        style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                      ),
+                      const SizedBox(width: 12),
+                      Container(
+                        padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                        decoration: BoxDecoration(
+                          color: Colors.green.withValues(alpha: 0.2),
+                          borderRadius: BorderRadius.circular(4),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(Icons.cloud_done, size: 10, color: Colors.green),
+                            const SizedBox(width: 3),
+                            Text(
+                              context.l10n.synced.toUpperCase(),
+                              style: const TextStyle(color: Colors.green, fontSize: 10, fontWeight: FontWeight.w500),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            // Share button
+            IconButton(
+              onPressed: () => _shareWal(wal),
+              icon: _buildFaIcon(FontAwesomeIcons.shareNodes, size: 16, color: Colors.grey.shade400),
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(minWidth: 40, minHeight: 40),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Consumer<UserProvider>(
-      builder: (context, userProvider, child) {
+    return Consumer2<UserProvider, SyncProvider>(
+      builder: (context, userProvider, syncProvider, child) {
         final isEnabled = userProvider.privateCloudSyncEnabled;
         final isLoading = userProvider.isLoading;
+        final syncedWals = syncProvider.syncedWals;
 
         return Scaffold(
           backgroundColor: const Color(0xFF0D0D0D),
@@ -105,6 +315,16 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
               style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
             ),
             centerTitle: true,
+            actions: [
+              if (isEnabled && syncedWals.isNotEmpty)
+                TextButton(
+                  onPressed: _deleteAllCloudFiles,
+                  child: Text(
+                    context.l10n.deleteAll,
+                    style: const TextStyle(color: Colors.red, fontSize: 14, fontWeight: FontWeight.w500),
+                  ),
+                ),
+            ],
           ),
           body: isLoading
               ? const Center(child: CircularProgressIndicator(color: Colors.white))
@@ -113,6 +333,7 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
+                      // Toggle section
                       Container(
                         padding: const EdgeInsets.all(20),
                         decoration: BoxDecoration(
@@ -139,7 +360,7 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
                                 Container(
                                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                                   decoration: BoxDecoration(
-                                    color: isEnabled ? Colors.green.withOpacity(0.2) : const Color(0xFF2A2A2E),
+                                    color: isEnabled ? Colors.green.withValues(alpha: 0.2) : const Color(0xFF2A2A2E),
                                     borderRadius: BorderRadius.circular(100),
                                   ),
                                   child: Text(
@@ -185,6 +406,77 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
                           ],
                         ),
                       ),
+
+                      // Cloud audio files section
+                      if (isEnabled) ...[
+                        const SizedBox(height: 32),
+                        Row(
+                          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                          children: [
+                            Text(
+                              'Cloud Recordings',
+                              style: const TextStyle(
+                                color: Colors.white,
+                                fontSize: 18,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            Container(
+                              padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                              decoration: BoxDecoration(
+                                color: Colors.deepPurpleAccent.withValues(alpha: 0.2),
+                                borderRadius: BorderRadius.circular(100),
+                              ),
+                              child: Text(
+                                '${syncedWals.length} files',
+                                style: const TextStyle(
+                                  color: Colors.deepPurpleAccent,
+                                  fontSize: 12,
+                                  fontWeight: FontWeight.w500,
+                                ),
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        if (syncedWals.isEmpty)
+                          Container(
+                            width: double.infinity,
+                            padding: const EdgeInsets.all(32),
+                            decoration: BoxDecoration(
+                              color: const Color(0xFF1C1C1E),
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                            child: Column(
+                              children: [
+                                Icon(
+                                  Icons.cloud_off,
+                                  size: 48,
+                                  color: Colors.grey.shade600,
+                                ),
+                                const SizedBox(height: 12),
+                                Text(
+                                  'No cloud recordings yet',
+                                  style: TextStyle(
+                                    color: Colors.grey.shade400,
+                                    fontSize: 15,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  'Recordings will appear here once synced',
+                                  style: TextStyle(
+                                    color: Colors.grey.shade600,
+                                    fontSize: 13,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          )
+                        else
+                          ...syncedWals.map((wal) => _buildWalListItem(wal)),
+                      ],
                     ],
                   ),
                 ),

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -35,6 +35,7 @@ AUDIO_SAMPLE_RATE = 16000
 from utils import encryption
 from utils.stt.pre_recorded import deepgram_prerecorded, postprocess_words
 from utils.stt.vad import vad_is_empty
+from utils.stt.speech_profile import get_speech_profile_matching_predictions
 from utils.fair_use import (
     record_speech_ms,
     get_rolling_speech_ms,
@@ -665,6 +666,16 @@ def process_segment(
         if not transcript_segments:
             logger.warning(f'Postprocessing returned empty for segment {path} (words present but no segments)')
             return
+
+        # Speaker identification: match segments against stored person embeddings
+        # This uses the same pipeline as live recording (speaker_identification_task)
+        try:
+            matches = get_speech_profile_matching_predictions(uid, path, [s.dict() for s in transcript_segments])
+            for i, seg in enumerate(transcript_segments):
+                seg.is_user = matches[i]['is_user']
+                seg.person_id = matches[i].get('person_id')
+        except Exception as e:
+            logger.error(f'Speaker matching failed for {path}: {e}')
 
         timestamp = get_timestamp_from_path(path)
         segment_end_timestamp = timestamp + transcript_segments[-1].end


### PR DESCRIPTION
## Summary

Implements the remaining features for the Private Cloud Sync bounty (issue #3215):

1. **Listing synced recordings** - Shows list of cloud-synced audio files with date and duration
2. **Playing audio** - Tap to play/pause synced audio using AudioPlayerUtils
3. **Sharing** - Share individual recordings via system share sheet
4. **Delete All** - Bulk delete all synced recordings with confirmation dialog

## Changes

### Frontend (app/lib/pages/conversations/private_cloud_sync_page.dart)
- Added `_buildWalListItem()` - displays each synced recording with play/share buttons
- Added `_togglePlay()` - uses AudioPlayerUtils.togglePlayback() for proper audio state management
- Added `_shareWal()` - shares audio file via share_plus
- Added `_deleteAllCloudFiles()` and `_showDeleteAllDialog()` - bulk delete with confirmation
- Added synced recordings section in build() when cloud sync is enabled

### Backend (backend/routers/sync.py)
- Added speaker identification to process_segment() - calls get_speech_profile_matching_predictions() to identify speakers in synced audio
- Uses path directly (already .wav) instead of .replace() hack

## Bounty Reference
- Issue: #3215
- Bounty: $200 USD
- Payment address: eB51DWp1uECrLZRLsE2cnyZUzfRWvzUzaJzkatTpQV9