### PR TITLE
Refine desktop shortcuts and dashboard widgets

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
@@ -51,7 +51,13 @@ class GlobalShortcutManager {
         if let ref = hotKeyRefs.removeValue(forKey: .askOmi) {
             UnregisterEventHotKey(ref)
         }
-        let askOmiShortcut = MainActor.assumeIsolated { ShortcutSettings.shared.askOmiShortcut }
+        let (askOmiEnabled, askOmiShortcut) = MainActor.assumeIsolated {
+            (ShortcutSettings.shared.askOmiEnabled, ShortcutSettings.shared.askOmiShortcut)
+        }
+        guard askOmiEnabled else {
+            NSLog("GlobalShortcutManager: Ask Omi shortcut is disabled")
+            return
+        }
         guard askOmiShortcut.supportsGlobalHotKey, let keyCode = askOmiShortcut.keyCode else {
             NSLog("GlobalShortcutManager: Ask Omi shortcut is not a registerable hotkey")
             return

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -107,6 +107,7 @@ class PushToTalkManager: ObservableObject {
   // MARK: - Shortcut Handling
 
   private func handleShortcutEvent(_ event: NSEvent) {
+    guard ShortcutSettings.shared.pttEnabled else { return }
     let shortcut = ShortcutSettings.shared.pttShortcut
 
     let pttActive: Bool

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -291,6 +291,17 @@ class ShortcutSettings: ObservableObject {
         }
     }
 
+    @Published var askOmiEnabled: Bool {
+        didSet {
+            UserDefaults.standard.set(askOmiEnabled, forKey: "shortcut_askOmiEnabled")
+            NotificationCenter.default.post(name: Self.askOmiShortcutChanged, object: nil)
+        }
+    }
+
+    @Published var pttEnabled: Bool {
+        didSet { UserDefaults.standard.set(pttEnabled, forKey: "shortcut_pttEnabled") }
+    }
+
     @Published var doubleTapForLock: Bool {
         didSet { UserDefaults.standard.set(doubleTapForLock, forKey: "shortcut_doubleTapForLock") }
     }
@@ -360,6 +371,8 @@ class ShortcutSettings: ObservableObject {
             legacyMapper: Self.legacyAskOmiShortcut
         ) ?? Self.askOmiPresets[0]
 
+        self.askOmiEnabled = UserDefaults.standard.object(forKey: "shortcut_askOmiEnabled") as? Bool ?? true
+        self.pttEnabled = UserDefaults.standard.object(forKey: "shortcut_pttEnabled") as? Bool ?? true
         self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
         self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? true
         self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true

--- a/desktop/Desktop/Sources/MainWindow/Components/GoalsWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/GoalsWidget.swift
@@ -27,18 +27,6 @@ struct GoalsWidget: View {
 
                 Spacer()
 
-                // History button
-                GoalHeaderButton(icon: "clock.arrow.circlepath", tooltip: "Goal history", color: OmiColors.textTertiary) {
-                    showingHistory = true
-                }
-
-                // AI goal generation button (when there are goals but room for more)
-                if goals.count > 0 && goals.count < 4 {
-                    GoalHeaderButton(icon: "sparkles", tooltip: "Generate AI goal", color: OmiColors.purplePrimary.opacity(0.8), isLoading: isGeneratingGoal) {
-                        triggerGoalGeneration()
-                    }
-                }
-
                 // Add goal button (only if less than 3 goals)
                 if goals.count < 4 {
                     GoalHeaderButton(icon: "plus", tooltip: "Add goal", color: OmiColors.textTertiary) {

--- a/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
+++ b/desktop/Desktop/Sources/MainWindow/Components/TodaysTasksWidget.swift
@@ -6,8 +6,6 @@ struct TasksWidget: View {
     let recentTasks: [TaskActionItem]
     let onToggleCompletion: (TaskActionItem) -> Void
 
-    @State private var showDailyTaskCreation = false
-
     private var totalTaskCount: Int {
         overdueTasks.count + todaysTasks.count + recentTasks.count
     }
@@ -29,74 +27,64 @@ struct TasksWidget: View {
                 Text("Tasks")
                     .scaledFont(size: 16, weight: .semibold)
                     .foregroundColor(OmiColors.textPrimary)
-
-                Spacer()
-
-                Button(action: {
-                    showDailyTaskCreation = true
-                }) {
-                    HStack(spacing: 4) {
-                        Image(systemName: "repeat.circle")
-                            .scaledFont(size: 12)
-                        Text("Daily")
-                            .scaledFont(size: 11, weight: .medium)
-                    }
-                    .foregroundColor(OmiColors.purplePrimary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 4)
-                    .background(
-                        RoundedRectangle(cornerRadius: 6)
-                            .fill(OmiColors.purplePrimary.opacity(0.1))
-                    )
-                }
-                .buttonStyle(.plain)
             }
 
             if totalTaskCount == 0 {
                 // Empty state
-                VStack(spacing: 8) {
-                    Image(systemName: "checkmark.circle")
-                        .scaledFont(size: 28)
-                        .foregroundColor(OmiColors.textQuaternary)
-                    Text("No incomplete tasks")
-                        .scaledFont(size: 13)
-                        .foregroundColor(OmiColors.textTertiary)
+                VStack {
+                    Spacer(minLength: 0)
+
+                    VStack(spacing: 8) {
+                        Image(systemName: "checkmark.circle")
+                            .scaledFont(size: 28)
+                            .foregroundColor(OmiColors.textQuaternary)
+                        Text("No incomplete tasks")
+                            .scaledFont(size: 13)
+                            .foregroundColor(OmiColors.textTertiary)
+                    }
+
+                    Spacer(minLength: 0)
                 }
                 .frame(maxWidth: .infinity)
-                .padding(.vertical, 20)
+                .frame(maxHeight: .infinity)
             } else {
                 let allTasks = (combinedTodayTasks + recentTasks).prefix(3)
 
-                VStack(spacing: 6) {
-                    ForEach(Array(allTasks)) { task in
-                        TaskRowView(
-                            task: task,
-                            onToggle: { onToggleCompletion(task) }
-                        )
-                    }
-                }
+                VStack(spacing: 0) {
+                    Spacer(minLength: 0)
 
-                // View all link
-                Button(action: {
-                    // Navigate to Tasks tab
-                    NotificationCenter.default.post(
-                        name: .navigateToTasks,
-                        object: nil
-                    )
-                }) {
-                    HStack {
-                        Spacer()
-                        Text("View all tasks")
-                            .scaledFont(size: 12, weight: .medium)
-                            .foregroundColor(OmiColors.textSecondary)
-                        Image(systemName: "chevron.right")
-                            .scaledFont(size: 10)
-                            .foregroundColor(OmiColors.textSecondary)
-                        Spacer()
+                    VStack(spacing: 6) {
+                        ForEach(Array(allTasks)) { task in
+                            TaskRowView(
+                                task: task,
+                                onToggle: { onToggleCompletion(task) }
+                            )
+                        }
                     }
+
+                    Button(action: {
+                        NotificationCenter.default.post(
+                            name: .navigateToTasks,
+                            object: nil
+                        )
+                    }) {
+                        HStack {
+                            Spacer()
+                            Text("View all tasks")
+                                .scaledFont(size: 12, weight: .medium)
+                                .foregroundColor(OmiColors.textSecondary)
+                            Image(systemName: "chevron.right")
+                                .scaledFont(size: 10)
+                                .foregroundColor(OmiColors.textSecondary)
+                            Spacer()
+                        }
+                    }
+                    .buttonStyle(.plain)
+                    .padding(.top, 8)
+
+                    Spacer(minLength: 0)
                 }
-                .buttonStyle(.plain)
-                .padding(.top, 4)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
         .padding(20)
@@ -109,16 +97,6 @@ struct TasksWidget: View {
                         .stroke(OmiColors.backgroundQuaternary.opacity(0.5), lineWidth: 1)
                 )
         )
-        .sheet(isPresented: $showDailyTaskCreation) {
-            DailyTaskCreationSheet { description, priority in
-                Task {
-                    await TasksStore.shared.createDailyRecurringTask(
-                        description: description,
-                        priority: priority
-                    )
-                }
-            }
-        }
     }
 }
 

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -67,6 +67,7 @@ struct SettingsContentView: View {
 
     // Updater view model
     @ObservedObject private var updaterViewModel = UpdaterViewModel.shared
+    @ObservedObject private var shortcutSettings = ShortcutSettings.shared
 
     // Master monitoring state (screen analysis)
     @State private var isMonitoring: Bool
@@ -244,6 +245,7 @@ struct SettingsContentView: View {
         case planUsage = "Plan and Usage"
         case aiChat = "AI Chat"
         case floatingBar = "Floating Bar"
+        case shortcuts = "Shortcuts"
         case advanced = "Advanced"
         case about = "About"
     }
@@ -389,6 +391,8 @@ struct SettingsContentView: View {
                     aiChatSection
                 case .floatingBar:
                     floatingBarSection
+                case .shortcuts:
+                    shortcutsSection
                 case .advanced:
                     advancedSection
                 case .about:
@@ -1730,7 +1734,6 @@ struct SettingsContentView: View {
 
     private var floatingBarSection: some View {
         VStack(spacing: 20) {
-            // Show floating bar toggle
             settingsCard(settingId: "floatingbar.show") {
                 HStack(spacing: 16) {
                     Circle()
@@ -1753,12 +1756,56 @@ struct SettingsContentView: View {
                             } else {
                                 FloatingControlBarManager.shared.hide()
                             }
-                        }
+                    }
                 }
             }
 
-            ShortcutsSettingsSection(highlightedSettingId: $highlightedSettingId)
+            settingsCard(settingId: "floatingbar.background") {
+                VStack(alignment: .leading, spacing: 16) {
+                    Text("Background Style")
+                        .scaledFont(size: 16, weight: .semibold)
+                        .foregroundColor(OmiColors.textPrimary)
+
+                    HStack(spacing: 16) {
+                        Text("Transparent")
+                            .scaledFont(size: 13, weight: shortcutSettings.solidBackground ? .regular : .semibold)
+                            .foregroundColor(shortcutSettings.solidBackground ? OmiColors.textTertiary : OmiColors.textPrimary)
+
+                        Toggle("", isOn: $shortcutSettings.solidBackground)
+                            .toggleStyle(.switch)
+                            .tint(OmiColors.purplePrimary)
+                            .labelsHidden()
+
+                        Text("Solid Dark")
+                            .scaledFont(size: 13, weight: shortcutSettings.solidBackground ? .semibold : .regular)
+                            .foregroundColor(shortcutSettings.solidBackground ? OmiColors.textPrimary : OmiColors.textTertiary)
+
+                        Spacer()
+                    }
+                }
+            }
+
+            settingsCard(settingId: "floatingbar.draggable") {
+                HStack(spacing: 16) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Draggable Floating Bar")
+                            .scaledFont(size: 16, weight: .semibold)
+                            .foregroundColor(OmiColors.textPrimary)
+                        Text("Allow repositioning the floating bar by dragging it.")
+                            .scaledFont(size: 13)
+                            .foregroundColor(OmiColors.textSecondary)
+                    }
+                    Spacer()
+                    Toggle("", isOn: $shortcutSettings.draggableBarEnabled)
+                        .toggleStyle(.switch)
+                        .tint(OmiColors.purplePrimary)
+                }
+            }
         }
+    }
+
+    private var shortcutsSection: some View {
+        ShortcutsSettingsSection(highlightedSettingId: $highlightedSettingId)
     }
 
     private var aiChatSection: some View {

--- a/desktop/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/ShortcutsSettingsSection.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 
-/// Settings section for keyboard shortcuts and push-to-talk configuration.
 struct ShortcutsSettingsSection: View {
     @ObservedObject private var settings = ShortcutSettings.shared
     @Binding var highlightedSettingId: String?
@@ -19,12 +18,8 @@ struct ShortcutsSettingsSection: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            aiModelCard
-            backgroundStyleCard
-            draggableBarCard
             askOmiKeyCard
             pttKeyCard
-            pttTranscriptionModeCard
             doubleTapCard
             pttSoundsCard
             referenceCard
@@ -32,110 +27,6 @@ struct ShortcutsSettingsSection: View {
         .onDisappear {
             stopShortcutCapture()
         }
-    }
-
-    private var aiModelCard: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("AI Model")
-                    .scaledFont(size: 16, weight: .semibold)
-                    .foregroundColor(OmiColors.textPrimary)
-                Text("Choose the AI model for Ask omi conversations.")
-                    .scaledFont(size: 13)
-                    .foregroundColor(OmiColors.textSecondary)
-            }
-
-            HStack(spacing: 12) {
-                ForEach(ShortcutSettings.availableModels, id: \.id) { model in
-                    aiModelButton(model)
-                }
-                Spacer()
-            }
-        }
-        .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(OmiColors.backgroundTertiary.opacity(0.5))
-        )
-        .modifier(SettingHighlightModifier(settingId: "floatingbar.model", highlightedSettingId: $highlightedSettingId))
-    }
-
-    private func aiModelButton(_ model: (id: String, label: String)) -> some View {
-        let isSelected = settings.selectedModel == model.id
-        return Button {
-            settings.selectedModel = model.id
-        } label: {
-            Text(model.label)
-                .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textPrimary)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(isSelected
-                              ? OmiColors.purplePrimary.opacity(0.3)
-                              : OmiColors.backgroundTertiary.opacity(0.5))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(isSelected ? OmiColors.purplePrimary : Color.clear, lineWidth: 1.5)
-                )
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var backgroundStyleCard: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text("Background Style")
-                .scaledFont(size: 16, weight: .semibold)
-                .foregroundColor(OmiColors.textPrimary)
-
-            HStack(spacing: 16) {
-                Text("Transparent")
-                    .scaledFont(size: 13, weight: settings.solidBackground ? .regular : .semibold)
-                    .foregroundColor(settings.solidBackground ? OmiColors.textTertiary : OmiColors.textPrimary)
-
-                Toggle("", isOn: $settings.solidBackground)
-                    .toggleStyle(.switch)
-                    .tint(OmiColors.purplePrimary)
-                    .labelsHidden()
-
-                Text("Solid Dark")
-                    .scaledFont(size: 13, weight: settings.solidBackground ? .semibold : .regular)
-                    .foregroundColor(settings.solidBackground ? OmiColors.textPrimary : OmiColors.textTertiary)
-
-                Spacer()
-            }
-        }
-        .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(OmiColors.backgroundTertiary.opacity(0.5))
-        )
-        .modifier(SettingHighlightModifier(settingId: "floatingbar.background", highlightedSettingId: $highlightedSettingId))
-    }
-
-    private var draggableBarCard: some View {
-        HStack(spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Draggable Floating Bar")
-                    .scaledFont(size: 16, weight: .semibold)
-                    .foregroundColor(OmiColors.textPrimary)
-                Text("Allow repositioning the floating bar by dragging it.")
-                    .scaledFont(size: 13)
-                    .foregroundColor(OmiColors.textSecondary)
-            }
-            Spacer()
-            Toggle("", isOn: $settings.draggableBarEnabled)
-                .toggleStyle(.switch)
-                .tint(OmiColors.purplePrimary)
-        }
-        .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(OmiColors.backgroundTertiary.opacity(0.5))
-        )
-        .modifier(SettingHighlightModifier(settingId: "floatingbar.draggable", highlightedSettingId: $highlightedSettingId))
     }
 
     private var askOmiKeyCard: some View {
@@ -153,14 +44,19 @@ struct ShortcutsSettingsSection: View {
                 ForEach(ShortcutSettings.askOmiPresets, id: \.self) { shortcut in
                     askOmiKeyButton(shortcut)
                 }
-                customShortcutButton(for: .askOmi, isSelected: settings.askOmiUsesCustomShortcut)
+                customShortcutButton(for: .askOmi, isSelected: settings.askOmiEnabled && settings.askOmiUsesCustomShortcut)
+                disableShortcutButton(isDisabled: !settings.askOmiEnabled) {
+                    stopShortcutCapture()
+                    settings.askOmiEnabled = false
+                }
                 Spacer()
             }
 
-            if recordingTarget == .askOmi || settings.askOmiUsesCustomShortcut || (captureError != nil && recordingTarget == .askOmi) {
+            if settings.askOmiEnabled && (recordingTarget == .askOmi || settings.askOmiUsesCustomShortcut || (captureError != nil && recordingTarget == .askOmi)) {
                 shortcutRecorderCard(
                     title: recordingTarget == .askOmi ? "Press your custom Ask omi shortcut now" : "Custom Ask omi shortcut",
                     shortcut: settings.askOmiShortcut,
+                    isRecording: recordingTarget == .askOmi,
                     action: { startShortcutCapture(.askOmi) },
                     helperText: "Use at least one non-modifier key."
                 )
@@ -175,30 +71,13 @@ struct ShortcutsSettingsSection: View {
     }
 
     private func askOmiKeyButton(_ shortcut: ShortcutSettings.KeyboardShortcut) -> some View {
-        let isSelected = settings.askOmiShortcut == shortcut && !settings.askOmiUsesCustomShortcut
+        let isSelected = settings.askOmiEnabled && settings.askOmiShortcut == shortcut && !settings.askOmiUsesCustomShortcut
         return Button {
             stopShortcutCapture()
+            settings.askOmiEnabled = true
             settings.askOmiShortcut = shortcut
         } label: {
-            HStack(spacing: 4) {
-                ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, token in
-                    Text(token)
-                        .scaledFont(size: 13, weight: .medium)
-                }
-            }
-            .foregroundColor(OmiColors.textPrimary)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(isSelected
-                              ? OmiColors.purplePrimary.opacity(0.3)
-                              : OmiColors.backgroundTertiary.opacity(0.5))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(isSelected ? OmiColors.purplePrimary : Color.clear, lineWidth: 1.5)
-                )
+            shortcutSelectionLabel(tokens: shortcut.displayTokens, isSelected: isSelected)
         }
         .buttonStyle(.plain)
     }
@@ -218,14 +97,19 @@ struct ShortcutsSettingsSection: View {
                 ForEach(ShortcutSettings.pttPresets, id: \.self) { shortcut in
                     pttKeyButton(shortcut)
                 }
-                customShortcutButton(for: .pushToTalk, isSelected: settings.pttUsesCustomShortcut)
+                customShortcutButton(for: .pushToTalk, isSelected: settings.pttEnabled && settings.pttUsesCustomShortcut)
+                disableShortcutButton(isDisabled: !settings.pttEnabled) {
+                    stopShortcutCapture()
+                    settings.pttEnabled = false
+                }
                 Spacer()
             }
 
-            if recordingTarget == .pushToTalk || settings.pttUsesCustomShortcut || (captureError != nil && recordingTarget == .pushToTalk) {
+            if settings.pttEnabled && (recordingTarget == .pushToTalk || settings.pttUsesCustomShortcut || (captureError != nil && recordingTarget == .pushToTalk)) {
                 shortcutRecorderCard(
                     title: recordingTarget == .pushToTalk ? "Press your custom push-to-talk shortcut now" : "Custom push-to-talk shortcut",
                     shortcut: settings.pttShortcut,
+                    isRecording: recordingTarget == .pushToTalk,
                     action: { startShortcutCapture(.pushToTalk) },
                     helperText: "One key or a key combination both work."
                 )
@@ -240,80 +124,13 @@ struct ShortcutsSettingsSection: View {
     }
 
     private func pttKeyButton(_ shortcut: ShortcutSettings.KeyboardShortcut) -> some View {
-        let isSelected = settings.pttShortcut == shortcut && !settings.pttUsesCustomShortcut
+        let isSelected = settings.pttEnabled && settings.pttShortcut == shortcut && !settings.pttUsesCustomShortcut
         return Button {
             stopShortcutCapture()
+            settings.pttEnabled = true
             settings.pttShortcut = shortcut
         } label: {
-            HStack(spacing: 6) {
-                ForEach(Array(shortcut.displayTokens.enumerated()), id: \.offset) { _, token in
-                    Text(token)
-                        .scaledFont(size: 13, weight: .medium)
-                }
-            }
-            .foregroundColor(OmiColors.textPrimary)
-            .padding(.horizontal, 14)
-            .padding(.vertical, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(isSelected
-                          ? OmiColors.purplePrimary.opacity(0.3)
-                          : OmiColors.backgroundTertiary.opacity(0.5))
-            )
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(isSelected ? OmiColors.purplePrimary : Color.clear, lineWidth: 1.5)
-            )
-        }
-        .buttonStyle(.plain)
-    }
-
-    private var pttTranscriptionModeCard: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            VStack(alignment: .leading, spacing: 4) {
-                Text("Transcription Mode")
-                    .scaledFont(size: 16, weight: .semibold)
-                    .foregroundColor(OmiColors.textPrimary)
-                Text(settings.pttTranscriptionMode.description)
-                    .scaledFont(size: 13)
-                    .foregroundColor(OmiColors.textSecondary)
-            }
-
-            HStack(spacing: 12) {
-                ForEach(ShortcutSettings.PTTTranscriptionMode.allCases, id: \.self) { mode in
-                    pttTranscriptionModeButton(mode)
-                }
-                Spacer()
-            }
-        }
-        .padding(20)
-        .background(
-            RoundedRectangle(cornerRadius: 12)
-                .fill(OmiColors.backgroundTertiary.opacity(0.5))
-        )
-        .modifier(SettingHighlightModifier(settingId: "floatingbar.transcriptionmode", highlightedSettingId: $highlightedSettingId))
-    }
-
-    private func pttTranscriptionModeButton(_ mode: ShortcutSettings.PTTTranscriptionMode) -> some View {
-        let isSelected = settings.pttTranscriptionMode == mode
-        return Button {
-            settings.pttTranscriptionMode = mode
-        } label: {
-            Text(mode.rawValue)
-                .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(OmiColors.textPrimary)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(isSelected
-                              ? OmiColors.purplePrimary.opacity(0.3)
-                              : OmiColors.backgroundTertiary.opacity(0.5))
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(isSelected ? OmiColors.purplePrimary : Color.clear, lineWidth: 1.5)
-                )
+            shortcutSelectionLabel(tokens: shortcut.displayTokens, isSelected: isSelected)
         }
         .buttonStyle(.plain)
     }
@@ -338,6 +155,8 @@ struct ShortcutsSettingsSection: View {
             RoundedRectangle(cornerRadius: 12)
                 .fill(OmiColors.backgroundTertiary.opacity(0.5))
         )
+        .opacity(settings.pttEnabled ? 1 : 0.55)
+        .disabled(!settings.pttEnabled)
         .modifier(SettingHighlightModifier(settingId: "floatingbar.doubletap", highlightedSettingId: $highlightedSettingId))
     }
 
@@ -361,6 +180,8 @@ struct ShortcutsSettingsSection: View {
             RoundedRectangle(cornerRadius: 12)
                 .fill(OmiColors.backgroundTertiary.opacity(0.5))
         )
+        .opacity(settings.pttEnabled ? 1 : 0.55)
+        .disabled(!settings.pttEnabled)
         .modifier(SettingHighlightModifier(settingId: "floatingbar.pttsounds", highlightedSettingId: $highlightedSettingId))
     }
 
@@ -370,10 +191,10 @@ struct ShortcutsSettingsSection: View {
                 .scaledFont(size: 16, weight: .semibold)
                 .foregroundColor(OmiColors.textPrimary)
 
-            shortcutRow(label: "Ask omi", keys: settings.askOmiShortcut.displayLabel)
+            shortcutRow(label: "Ask omi", keys: settings.askOmiEnabled ? settings.askOmiShortcut.displayLabel : "Disabled")
             shortcutRow(label: "Toggle floating bar", keys: "\u{2318}\\")
-            shortcutRow(label: "Push to talk", keys: settings.pttShortcut.displayLabel + " hold")
-            if settings.doubleTapForLock {
+            shortcutRow(label: "Push to talk", keys: settings.pttEnabled ? settings.pttShortcut.displayLabel + " hold" : "Disabled")
+            if settings.pttEnabled && settings.doubleTapForLock {
                 shortcutRow(label: "Locked listening", keys: settings.pttShortcut.displayLabel + " \u{00D7}2")
             }
         }
@@ -402,16 +223,22 @@ struct ShortcutsSettingsSection: View {
 
     private func customShortcutButton(for target: ShortcutTarget, isSelected: Bool) -> some View {
         Button {
+            switch target {
+            case .askOmi:
+                settings.askOmiEnabled = true
+            case .pushToTalk:
+                settings.pttEnabled = true
+            }
             startShortcutCapture(target)
         } label: {
             Text("Custom")
                 .scaledFont(size: 13, weight: .medium)
-                .foregroundColor(isSelected || recordingTarget == target ? .black : OmiColors.textPrimary)
+                .foregroundColor(OmiColors.textPrimary)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
                 .background(
                     RoundedRectangle(cornerRadius: 10)
-                        .fill(isSelected || recordingTarget == target
+                        .fill((isSelected || recordingTarget == target)
                               ? OmiColors.purplePrimary.opacity(0.3)
                               : OmiColors.backgroundTertiary.opacity(0.5))
                 )
@@ -423,9 +250,53 @@ struct ShortcutsSettingsSection: View {
         .buttonStyle(.plain)
     }
 
+    private func disableShortcutButton(isDisabled: Bool, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text("Disable")
+                .scaledFont(size: 13, weight: .medium)
+                .foregroundColor(OmiColors.textPrimary)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(isDisabled
+                              ? OmiColors.purplePrimary.opacity(0.3)
+                              : OmiColors.backgroundTertiary.opacity(0.5))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(isDisabled ? OmiColors.purplePrimary : Color.clear, lineWidth: 1.5)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func shortcutSelectionLabel(tokens: [String], isSelected: Bool) -> some View {
+        HStack(spacing: 6) {
+            ForEach(Array(tokens.enumerated()), id: \.offset) { _, token in
+                Text(token)
+                    .scaledFont(size: 13, weight: .medium)
+            }
+        }
+        .foregroundColor(OmiColors.textPrimary)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(isSelected
+                      ? OmiColors.purplePrimary.opacity(0.3)
+                      : OmiColors.backgroundTertiary.opacity(0.5))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(isSelected ? OmiColors.purplePrimary : Color.clear, lineWidth: 1.5)
+        )
+    }
+
     private func shortcutRecorderCard(
         title: String,
         shortcut: ShortcutSettings.KeyboardShortcut,
+        isRecording: Bool,
         action: @escaping () -> Void,
         helperText: String
     ) -> some View {
@@ -452,7 +323,7 @@ struct ShortcutsSettingsSection: View {
                 Spacer()
 
                 Button(action: action) {
-                    Text(recordingTarget != nil ? "Listening..." : "Change")
+                    Text(isRecording ? "Listening..." : "Save")
                         .scaledFont(size: 12, weight: .semibold)
                         .foregroundColor(OmiColors.textPrimary)
                         .padding(.horizontal, 12)
@@ -469,7 +340,7 @@ struct ShortcutsSettingsSection: View {
                 .scaledFont(size: 12)
                 .foregroundColor(OmiColors.textSecondary)
 
-            if let captureError, recordingTarget != nil {
+            if let captureError, isRecording {
                 Text(captureError)
                     .scaledFont(size: 12, weight: .medium)
                     .foregroundColor(.red.opacity(0.9))
@@ -513,11 +384,13 @@ struct ShortcutsSettingsSection: View {
             guard let shortcut = ShortcutSettings.KeyboardShortcut.fromRecordingEvent(event, allowModifierOnly: false) else {
                 return false
             }
+            settings.askOmiEnabled = true
             settings.askOmiShortcut = shortcut
         case .pushToTalk:
             guard let shortcut = ShortcutSettings.KeyboardShortcut.fromRecordingEvent(event, allowModifierOnly: true) else {
                 return false
             }
+            settings.pttEnabled = true
             settings.pttShortcut = shortcut
         }
 

--- a/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -113,15 +113,14 @@ struct SettingsSearchItem: Identifiable {
         SettingsSearchItem(name: "Analysis Throttle", subtitle: "Wait before analyzing after switching apps", keywords: ["delay", "throttle", "app switch"], section: .advanced, icon: "clock.arrow.2.circlepath", settingId: "advanced.analysisthrottle"),
         SettingsSearchItem(name: "Goals", subtitle: "Track personal goals with AI-powered progress detection", keywords: ["goal", "target", "objective", "tracking"], section: .advanced, icon: "target", settingId: "advanced.goals"),
         SettingsSearchItem(name: "Auto-Generate Goals", subtitle: "Automatically suggest new goals daily based on your conversations and tasks", keywords: ["auto generate", "suggest goals", "daily goals"], section: .advanced, icon: "target", settingId: "advanced.goals.autogenerate"),
-        SettingsSearchItem(name: "Ask omi Floating Bar", subtitle: "Configure shortcuts and floating bar behavior", keywords: ["floating bar", "shortcuts", "push to talk"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.askomi"),
-        SettingsSearchItem(name: "AI Model", subtitle: "Choose the AI model for Ask omi conversations", keywords: ["model", "ai", "sonnet", "opus", "claude"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.model"),
+        SettingsSearchItem(name: "Ask omi Floating Bar", subtitle: "Configure the floating bar appearance and visibility", keywords: ["floating bar", "ask omi", "show bar"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.show"),
         SettingsSearchItem(name: "Background Style", subtitle: "Toggle between solid and transparent background", keywords: ["background", "solid", "transparent", "blur"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.background"),
         SettingsSearchItem(name: "Draggable Floating Bar", subtitle: "Allow repositioning the floating bar by dragging it", keywords: ["drag", "move", "reposition", "draggable"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.draggable"),
-        SettingsSearchItem(name: "Ask omi Shortcut", subtitle: "Global shortcut to open Ask omi from anywhere", keywords: ["shortcut", "hotkey", "keyboard", "global shortcut"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.shortcut"),
-        SettingsSearchItem(name: "Push to Talk", subtitle: "Hold a key to speak, release to send your question to AI", keywords: ["push to talk", "ptt", "hold to talk", "microphone key"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.ptt"),
-        SettingsSearchItem(name: "Transcription Mode", subtitle: "Choose how voice input is processed", keywords: ["transcription", "mode", "voice", "dictation"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.transcriptionmode"),
-        SettingsSearchItem(name: "Double-tap for Locked Mode", subtitle: "Double-tap the push-to-talk key to keep listening hands-free", keywords: ["double tap", "locked mode", "hands free", "listening"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.doubletap"),
-        SettingsSearchItem(name: "Push-to-Talk Sounds", subtitle: "Play audio feedback when starting and ending voice input", keywords: ["sounds", "audio feedback", "ptt sounds"], section: .floatingBar, icon: "sparkles", settingId: "floatingbar.pttsounds"),
+        SettingsSearchItem(name: "Shortcuts", subtitle: "Configure Ask omi and push-to-talk keyboard shortcuts", keywords: ["shortcuts", "keyboard", "hotkeys", "push to talk"], section: .shortcuts, icon: "keyboard", settingId: "floatingbar.shortcut"),
+        SettingsSearchItem(name: "Ask omi Shortcut", subtitle: "Global shortcut to open Ask omi from anywhere", keywords: ["shortcut", "hotkey", "keyboard", "global shortcut"], section: .shortcuts, icon: "keyboard", settingId: "floatingbar.shortcut"),
+        SettingsSearchItem(name: "Push to Talk", subtitle: "Hold a key to speak, release to send your question to AI", keywords: ["push to talk", "ptt", "hold to talk", "microphone key"], section: .shortcuts, icon: "keyboard", settingId: "floatingbar.ptt"),
+        SettingsSearchItem(name: "Double-tap for Locked Mode", subtitle: "Double-tap the push-to-talk key to keep listening hands-free", keywords: ["double tap", "locked mode", "hands free", "listening"], section: .shortcuts, icon: "keyboard", settingId: "floatingbar.doubletap"),
+        SettingsSearchItem(name: "Push-to-Talk Sounds", subtitle: "Play audio feedback when starting and ending voice input", keywords: ["sounds", "audio feedback", "ptt sounds"], section: .shortcuts, icon: "keyboard", settingId: "floatingbar.pttsounds"),
         SettingsSearchItem(name: "Multiple Chat Sessions", subtitle: "Create separate chat threads", keywords: ["multi chat", "threads"], section: .advanced, icon: "slider.horizontal.3", settingId: "advanced.preferences.multichat"),
         SettingsSearchItem(name: "Compact Conversations", subtitle: "Toggle between compact and expanded conversation list", keywords: ["conversation view", "list"], section: .advanced, icon: "slider.horizontal.3", settingId: "advanced.preferences.compact"),
         SettingsSearchItem(name: "Launch at Login", subtitle: "Start omi automatically when you log in", keywords: ["startup", "login", "boot"], section: .advanced, icon: "slider.horizontal.3", settingId: "advanced.preferences.launchatlogin"),
@@ -324,6 +323,7 @@ struct SettingsSidebarItem: View {
         case .planUsage: return "creditcard"
         case .aiChat: return "cpu"
         case .floatingBar: return "sparkles"
+        case .shortcuts: return "keyboard"
         case .advanced: return "chart.bar"
         case .about: return "info.circle"
         }


### PR DESCRIPTION
## Summary
- center the dashboard tasks widget and remove the extra dashboard header controls
- split keyboard shortcuts into a dedicated Settings section and remove model/transcription choices from that UI
- add disable states for Ask omi and Push to Talk shortcuts while preserving custom shortcut support

## Verification
- rebuilt and launched `/Applications/onboarding-v14.app` from this branch
- connected to the running app with `agent-swift` and verified the new `Shortcuts` settings section is present
- confirmed the old `AI Model` and `Transcription Mode` settings are no longer exposed in the shortcuts UI