### PR TITLE
feat: Apple Reminders two-way sync with calendarItemIdentifier storage

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -231,15 +231,15 @@ extension FlutterError: Error {}
           return
       }
 
-      let exportedIds = appleRemindersService.syncBatchFromJSON(itemsJson)
+      let exportedMappings = appleRemindersService.syncBatchFromJSON(itemsJson)
 
-      if !exportedIds.isEmpty {
+      if !exportedMappings.isEmpty {
           DispatchQueue.main.async {
-              self.appleRemindersChannel?.invokeMethod("markExportedBatch", arguments: ["action_item_ids": exportedIds])
+              self.appleRemindersChannel?.invokeMethod("markExportedBatch", arguments: ["mappings": exportedMappings])
           }
       }
 
-      completionHandler(exportedIds.isEmpty ? .noData : .newData)
+      completionHandler(exportedMappings.isEmpty ? .noData : .newData)
   }
 
   override func applicationWillTerminate(_ application: UIApplication) {

--- a/app/ios/Runner/AppleRemindersService.swift
+++ b/app/ios/Runner/AppleRemindersService.swift
@@ -256,9 +256,14 @@ class AppleRemindersService {
                     "exists": true,
                     "completed": reminder.isCompleted,
                     "title": reminder.title ?? "",
+                    "notes": reminder.notes ?? "",
                 ]
                 if let completionDate = reminder.completionDate {
                     status["completionDate"] = AppleRemindersService.iso8601DateFormatter.string(from: completionDate)
+                }
+                if let dueDateComponents = reminder.dueDateComponents,
+                   let dueDate = Calendar.current.date(from: dueDateComponents) {
+                    status["dueDate"] = AppleRemindersService.iso8601DateFormatter.string(from: dueDate)
                 }
                 statuses[actionItemId] = status
             } else {
@@ -266,6 +271,7 @@ class AppleRemindersService {
                     "exists": false,
                     "completed": false,
                     "title": "",
+                    "notes": "",
                 ]
             }
         }

--- a/app/ios/Runner/AppleRemindersService.swift
+++ b/app/ios/Runner/AppleRemindersService.swift
@@ -28,18 +28,25 @@ class AppleRemindersService {
             completeReminder(call: call, result: result)
         case "syncFromFCM":
             syncFromFCM(call: call, result: result)
+        case "getRemindersStatus":
+            getRemindersStatus(call: call, result: result)
+        case "updateReminder":
+            updateReminder(call: call, result: result)
+        case "deleteReminder":
+            deleteReminder(call: call, result: result)
         default:
             result(FlutterMethodNotImplemented)
         }
     }
 
-    static let syncedItemsKey = "omi_synced_action_items"
     static let iso8601DateFormatter = ISO8601DateFormatter()
+
+    // MARK: - Batch Sync
 
     /// Core batch sync logic shared by both the foreground MethodChannel path
     /// and the background silent-push path (called from AppDelegate).
-    /// Returns the list of action item IDs that were successfully created as reminders.
-    func syncBatchFromJSON(_ itemsJson: String) -> [String] {
+    /// Returns an array of mappings: [{"actionItemId": "...", "calendarItemIdentifier": "..."}]
+    func syncBatchFromJSON(_ itemsJson: String) -> [[String: String]] {
         guard let data = itemsJson.data(using: .utf8),
               let items = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
               !items.isEmpty else {
@@ -49,16 +56,13 @@ class AppleRemindersService {
         guard hasRemindersAccess() else { return [] }
         guard let calendar = eventStore.defaultCalendarForNewReminders() else { return [] }
 
-        var syncedIds = Set(UserDefaults.standard.stringArray(forKey: AppleRemindersService.syncedItemsKey) ?? [])
-        var exportedIds: [String] = []
+        var savedPairs: [(String, EKReminder)] = []
 
         for item in items {
             guard let actionItemId = item["id"] as? String,
                   let reminderTitle = item["description"] as? String else {
                 continue
             }
-
-            if syncedIds.contains(actionItemId) { continue }
 
             let dueDate: Date? = {
                 if let dueDateStr = item["due_at"] as? String, !dueDateStr.isEmpty {
@@ -80,30 +84,28 @@ class AppleRemindersService {
 
             do {
                 try eventStore.save(reminder, commit: false)
-                syncedIds.insert(actionItemId)
-                exportedIds.append(actionItemId)
+                savedPairs.append((actionItemId, reminder))
             } catch {
                 continue
             }
         }
 
         // Single commit for all reminders
-        if !exportedIds.isEmpty {
-            do {
-                try eventStore.commit()
-            } catch {
-                return []
-            }
+        guard !savedPairs.isEmpty else { return [] }
+
+        do {
+            try eventStore.commit()
+        } catch {
+            return []
         }
 
-        // Persist dedup set
-        var syncedArray = Array(syncedIds)
-        if syncedArray.count > 100 {
-            syncedArray = Array(syncedArray.suffix(100))
+        // Read calendarItemIdentifier from each saved reminder after commit
+        return savedPairs.map { (actionItemId, reminder) in
+            [
+                "actionItemId": actionItemId,
+                "calendarItemIdentifier": reminder.calendarItemIdentifier
+            ]
         }
-        UserDefaults.standard.set(syncedArray, forKey: AppleRemindersService.syncedItemsKey)
-
-        return exportedIds
     }
 
     /// Handle sync triggered from Flutter foreground FCM handler via MethodChannel.
@@ -115,6 +117,8 @@ class AppleRemindersService {
         }
         result(syncBatchFromJSON(itemsJson))
     }
+
+    // MARK: - Permissions
 
     private func hasRemindersPermission(result: @escaping FlutterResult) {
         result(hasRemindersAccess())
@@ -146,6 +150,8 @@ class AppleRemindersService {
             }
         }
     }
+
+    // MARK: - Add Reminder (returns calendarItemIdentifier)
 
     private func addReminder(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let args = call.arguments as? [String: Any] else {
@@ -180,16 +186,13 @@ class AppleRemindersService {
         let calendars = eventStore.calendars(for: .reminder)
         targetCalendar = calendars.first { $0.title == listName }
 
-        // If not found, create a new calendar
+        // If not found, create a new calendar using the default source (respects iCloud)
         if targetCalendar == nil {
             targetCalendar = EKCalendar(for: .reminder, eventStore: eventStore)
             targetCalendar?.title = listName
             targetCalendar?.cgColor = UIColor.systemBlue.cgColor
 
-            // Set the source (usually the local source)
-            if let localSource = eventStore.sources.first(where: { $0.sourceType == .local }) {
-                targetCalendar?.source = localSource
-            } else if let defaultSource = eventStore.defaultCalendarForNewReminders()?.source {
+            if let defaultSource = eventStore.defaultCalendarForNewReminders()?.source {
                 targetCalendar?.source = defaultSource
             }
 
@@ -217,14 +220,132 @@ class AppleRemindersService {
             reminder.dueDateComponents = dueDateComponents
         }
 
-        // Save the reminder
+        // Save the reminder and return its calendarItemIdentifier
         do {
             try eventStore.save(reminder, commit: true)
-            result(true)
+            result(reminder.calendarItemIdentifier)
         } catch {
             result(FlutterError(code: "SAVE_FAILED", message: "Failed to save reminder: \(error.localizedDescription)", details: nil))
         }
     }
+
+    // MARK: - Get Reminders Status (two-way sync)
+
+    /// Look up reminders by their calendarItemIdentifier and return current status.
+    /// Input: {"mappings": {"actionItemId": "calendarItemIdentifier", ...}}
+    /// Output: {"actionItemId": {"exists": true, "completed": true, "title": "...", "completionDate": "ISO8601"}, ...}
+    private func getRemindersStatus(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let mappings = args["mappings"] as? [String: String] else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "Expected dict with 'mappings' key", details: nil))
+            return
+        }
+
+        guard hasRemindersAccess() else {
+            result(FlutterError(code: "PERMISSION_DENIED", message: "Reminders permission not granted", details: nil))
+            return
+        }
+
+        var statuses: [String: [String: Any]] = [:]
+
+        for (actionItemId, calendarItemId) in mappings {
+            let calendarItem = eventStore.calendarItem(withIdentifier: calendarItemId)
+
+            if let reminder = calendarItem as? EKReminder {
+                var status: [String: Any] = [
+                    "exists": true,
+                    "completed": reminder.isCompleted,
+                    "title": reminder.title ?? "",
+                ]
+                if let completionDate = reminder.completionDate {
+                    status["completionDate"] = AppleRemindersService.iso8601DateFormatter.string(from: completionDate)
+                }
+                statuses[actionItemId] = status
+            } else {
+                statuses[actionItemId] = [
+                    "exists": false,
+                    "completed": false,
+                    "title": "",
+                ]
+            }
+        }
+
+        result(statuses)
+    }
+
+    // MARK: - Update Reminder by Identifier
+
+    /// Update properties of an existing reminder by its calendarItemIdentifier.
+    private func updateReminder(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let calendarItemId = args["calendarItemIdentifier"] as? String else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "calendarItemIdentifier is required", details: nil))
+            return
+        }
+
+        guard hasRemindersAccess() else {
+            result(FlutterError(code: "PERMISSION_DENIED", message: "Reminders permission not granted", details: nil))
+            return
+        }
+
+        guard let reminder = eventStore.calendarItem(withIdentifier: calendarItemId) as? EKReminder else {
+            result(["success": false, "exists": false])
+            return
+        }
+
+        if let title = args["title"] as? String {
+            reminder.title = title
+        }
+        if let notes = args["notes"] as? String {
+            reminder.notes = notes
+        }
+        if let dueDateMs = args["dueDate"] as? Int64 {
+            let dueDate = Date(timeIntervalSince1970: TimeInterval(dueDateMs) / 1000.0)
+            reminder.dueDateComponents = Calendar.current.dateComponents(
+                [.year, .month, .day, .hour, .minute], from: dueDate)
+        }
+        if let completed = args["completed"] as? Bool {
+            reminder.isCompleted = completed
+        }
+
+        do {
+            try eventStore.save(reminder, commit: true)
+            result(["success": true, "exists": true])
+        } catch {
+            result(["success": false, "exists": true, "error": error.localizedDescription])
+        }
+    }
+
+    // MARK: - Delete Reminder by Identifier
+
+    /// Delete an existing reminder by its calendarItemIdentifier. Idempotent.
+    private func deleteReminder(call: FlutterMethodCall, result: @escaping FlutterResult) {
+        guard let args = call.arguments as? [String: Any],
+              let calendarItemId = args["calendarItemIdentifier"] as? String else {
+            result(FlutterError(code: "INVALID_ARGUMENTS", message: "calendarItemIdentifier is required", details: nil))
+            return
+        }
+
+        guard hasRemindersAccess() else {
+            result(FlutterError(code: "PERMISSION_DENIED", message: "Reminders permission not granted", details: nil))
+            return
+        }
+
+        guard let reminder = eventStore.calendarItem(withIdentifier: calendarItemId) as? EKReminder else {
+            // Already deleted — treat as success (idempotent)
+            result(["success": true, "existed": false])
+            return
+        }
+
+        do {
+            try eventStore.remove(reminder, commit: true)
+            result(["success": true, "existed": true])
+        } catch {
+            result(["success": false, "existed": true, "error": error.localizedDescription])
+        }
+    }
+
+    // MARK: - Legacy Methods (kept for backward compatibility)
 
     private func getReminders(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let args = call.arguments as? [String: Any] else {
@@ -234,13 +355,11 @@ class AppleRemindersService {
 
         let listName = args["listName"] as? String ?? "Reminders"
 
-        // Check permission
         guard hasRemindersAccess() else {
             result([])
             return
         }
 
-        // Find the calendar
         let calendars = eventStore.calendars(for: .reminder)
         guard let targetCalendar = calendars.first(where: { $0.title == listName }) else {
             result([])
@@ -257,6 +376,7 @@ class AppleRemindersService {
         }
     }
 
+    /// Legacy: complete by title match. Prefer updateReminder with calendarItemIdentifier.
     private func completeReminder(call: FlutterMethodCall, result: @escaping FlutterResult) {
         guard let args = call.arguments as? [String: Any] else {
             result(FlutterError(code: "INVALID_ARGUMENTS", message: "Invalid arguments", details: nil))
@@ -270,13 +390,11 @@ class AppleRemindersService {
 
         let listName = args["listName"] as? String ?? "Reminders"
 
-        // Check permission
         guard hasRemindersAccess() else {
             result(false)
             return
         }
 
-        // Find the calendar
         let calendars = eventStore.calendars(for: .reminder)
         guard let targetCalendar = calendars.first(where: { $0.title == listName }) else {
             result(false)

--- a/app/lib/backend/http/api/action_items.dart
+++ b/app/lib/backend/http/api/action_items.dart
@@ -104,6 +104,7 @@ Future<ActionItemWithMetadata?> updateActionItem(
   String? exportPlatform,
   int? sortOrder,
   int? indentLevel,
+  String? appleReminderId,
 }) async {
   var requestBody = <String, dynamic>{};
 
@@ -133,6 +134,9 @@ Future<ActionItemWithMetadata?> updateActionItem(
   }
   if (indentLevel != null) {
     requestBody['indent_level'] = indentLevel;
+  }
+  if (appleReminderId != null) {
+    requestBody['apple_reminder_id'] = appleReminderId;
   }
 
   var response = await makeApiCall(
@@ -319,5 +323,36 @@ Future<List<ActionItemWithMetadata>> createActionItemsBatch(List<Map<String, dyn
   } else {
     Logger.debug('createActionItemsBatch error ${response.statusCode}');
     return [];
+  }
+}
+
+// Apple Reminders sync
+class PendingSyncResponse {
+  final List<Map<String, dynamic>> pendingExport;
+  final List<Map<String, dynamic>> syncedItems;
+
+  PendingSyncResponse({required this.pendingExport, required this.syncedItems});
+}
+
+Future<PendingSyncResponse?> getPendingSyncItems({String platform = 'apple_reminders'}) async {
+  var response = await makeApiCall(
+    url: '${Env.apiBaseUrl}v1/action-items/pending-sync?platform=$platform',
+    headers: {},
+    method: 'GET',
+    body: '',
+  );
+
+  if (response == null) return null;
+
+  if (response.statusCode == 200) {
+    var body = utf8.decode(response.bodyBytes);
+    var data = jsonDecode(body);
+    return PendingSyncResponse(
+      pendingExport: (data['pending_export'] as List<dynamic>).cast<Map<String, dynamic>>(),
+      syncedItems: (data['synced_items'] as List<dynamic>).cast<Map<String, dynamic>>(),
+    );
+  } else {
+    Logger.debug('getPendingSyncItems error ${response.statusCode}');
+    return null;
   }
 }

--- a/app/lib/backend/schema/action_item.dart
+++ b/app/lib/backend/schema/action_item.dart
@@ -13,6 +13,7 @@ class ActionItemWithMetadata {
   final String? exportPlatform;
   final int sortOrder;
   final int indentLevel;
+  final String? appleReminderId;
 
   ActionItemWithMetadata({
     required this.id,
@@ -29,6 +30,7 @@ class ActionItemWithMetadata {
     this.exportPlatform,
     this.sortOrder = 0,
     this.indentLevel = 0,
+    this.appleReminderId,
   });
 
   factory ActionItemWithMetadata.fromJson(Map<String, dynamic> json) {
@@ -47,6 +49,7 @@ class ActionItemWithMetadata {
       exportPlatform: json['export_platform'],
       sortOrder: json['sort_order'] as int? ?? 0,
       indentLevel: json['indent_level'] as int? ?? 0,
+      appleReminderId: json['apple_reminder_id'],
     );
   }
 
@@ -66,6 +69,7 @@ class ActionItemWithMetadata {
       'export_platform': exportPlatform,
       'sort_order': sortOrder,
       'indent_level': indentLevel,
+      'apple_reminder_id': appleReminderId,
     };
   }
 
@@ -84,6 +88,7 @@ class ActionItemWithMetadata {
     String? exportPlatform,
     int? sortOrder,
     int? indentLevel,
+    String? appleReminderId,
   }) {
     return ActionItemWithMetadata(
       id: id ?? this.id,
@@ -100,6 +105,7 @@ class ActionItemWithMetadata {
       exportPlatform: exportPlatform ?? this.exportPlatform,
       sortOrder: sortOrder ?? this.sortOrder,
       indentLevel: indentLevel ?? this.indentLevel,
+      appleReminderId: appleReminderId ?? this.appleReminderId,
     );
   }
 }

--- a/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
+++ b/app/lib/pages/action_items/widgets/action_item_tile_widget.dart
@@ -842,13 +842,15 @@ class _ActionItemTileWidgetState extends State<ActionItemTileWidget> {
       );
     }
 
-    // Add to Apple Reminders
-    final success = await service.addReminder(
+    // Add to Apple Reminders — returns calendarItemIdentifier on success
+    final calendarItemId = await service.addReminder(
       title: widget.actionItem.description,
       notes: 'From Omi',
       dueDate: widget.actionItem.dueAt,
       listName: 'Reminders',
     );
+
+    final success = calendarItemId != null;
 
     if (context.mounted) {
       // Clear the loading snackbar
@@ -873,7 +875,7 @@ class _ActionItemTileWidgetState extends State<ActionItemTileWidget> {
         ),
       );
 
-      // If successful, update the action item with export metadata
+      // If successful, update the action item with export metadata + apple_reminder_id
       if (success) {
         final exportTime = DateTime.now();
         await updateActionItem(
@@ -881,6 +883,7 @@ class _ActionItemTileWidgetState extends State<ActionItemTileWidget> {
           exported: true,
           exportDate: exportTime,
           exportPlatform: 'apple_reminders',
+          appleReminderId: calendarItemId,
         );
 
         // Track action item export

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -52,7 +52,9 @@ import 'package:omi/providers/home_provider.dart';
 import 'package:omi/providers/message_provider.dart';
 import 'package:omi/providers/sync_provider.dart';
 import 'package:omi/services/announcement_service.dart';
+import 'package:omi/services/apple_reminders_sync_service.dart';
 import 'package:omi/services/notifications.dart';
+import 'package:omi/utils/platform/platform_service.dart';
 import 'package:omi/services/notifications/daily_reflection_notification.dart';
 import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/audio/foreground.dart';
@@ -202,6 +204,15 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
       if (mounted && SharedPreferencesUtil().claudeAgentEnabled) {
         ensureAgentVm();
         Provider.of<MessageProvider>(context, listen: false).startVmKeepalive();
+      }
+
+      // Sync Apple Reminders on foreground resume (non-blocking, debounced)
+      if (mounted && PlatformService.isApple) {
+        AppleRemindersSyncService().syncOnForegroundResume().then((_) {
+          if (mounted) {
+            Provider.of<ActionItemsProvider>(context, listen: false).forceRefreshActionItems();
+          }
+        });
       }
     } else if (state == AppLifecycleState.hidden) {
       event = 'App is hidden';
@@ -814,8 +825,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurple.withValues(alpha: 0.2)
                               : hasPendingOnDevice
-                                  ? Colors.orange.withValues(alpha: 0.15)
-                                  : const Color(0xFF1F1F25),
+                              ? Colors.orange.withValues(alpha: 0.15)
+                              : const Color(0xFF1F1F25),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -824,8 +835,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurpleAccent
                               : hasPendingOnDevice
-                                  ? Colors.orangeAccent
-                                  : Colors.white70,
+                              ? Colors.orangeAccent
+                              : Colors.white70,
                         ),
                       ),
                     );

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -42,6 +42,7 @@ import 'package:omi/pages/settings/settings_drawer.dart';
 import 'package:omi/pages/settings/task_integrations_page.dart';
 import 'package:omi/pages/settings/wrapped_2025_page.dart';
 import 'package:omi/providers/action_items_provider.dart';
+import 'package:omi/providers/task_integration_provider.dart';
 import 'package:omi/providers/app_provider.dart';
 import 'package:omi/providers/capture_provider.dart';
 import 'package:omi/providers/connectivity_provider.dart';
@@ -208,11 +209,14 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
 
       // Sync Apple Reminders on foreground resume (non-blocking, debounced)
       if (mounted && PlatformService.isApple) {
-        AppleRemindersSyncService().syncOnForegroundResume().then((_) {
-          if (mounted) {
-            Provider.of<ActionItemsProvider>(context, listen: false).forceRefreshActionItems();
-          }
-        });
+        final taskProvider = Provider.of<TaskIntegrationProvider>(context, listen: false);
+        if (taskProvider.selectedApp == TaskIntegrationApp.appleReminders) {
+          AppleRemindersSyncService().syncOnForegroundResume().then((_) {
+            if (mounted) {
+              Provider.of<ActionItemsProvider>(context, listen: false).forceRefreshActionItems();
+            }
+          });
+        }
       }
     } else if (state == AppLifecycleState.hidden) {
       event = 'App is hidden';
@@ -825,8 +829,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurple.withValues(alpha: 0.2)
                               : hasPendingOnDevice
-                              ? Colors.orange.withValues(alpha: 0.15)
-                              : const Color(0xFF1F1F25),
+                                  ? Colors.orange.withValues(alpha: 0.15)
+                                  : const Color(0xFF1F1F25),
                           shape: BoxShape.circle,
                         ),
                         child: Icon(
@@ -835,8 +839,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                           color: isSyncing
                               ? Colors.deepPurpleAccent
                               : hasPendingOnDevice
-                              ? Colors.orangeAccent
-                              : Colors.white70,
+                                  ? Colors.orangeAccent
+                                  : Colors.white70,
                         ),
                       ),
                     );

--- a/app/lib/services/apple_reminders_service.dart
+++ b/app/lib/services/apple_reminders_service.dart
@@ -16,21 +16,36 @@ class AppleRemindersService {
   void _initBackgroundSyncHandler() {
     _channel.setMethodCallHandler((call) async {
       if (call.method == 'markExportedBatch') {
-        final ids = (call.arguments['action_item_ids'] as List?)?.cast<String>() ?? [];
-        await Future.wait(ids.map(_markActionItemExported));
+        // New format: mappings with calendarItemIdentifier
+        final mappings = (call.arguments['mappings'] as List?)?.cast<Map<Object?, Object?>>() ?? [];
+        await Future.wait(
+          mappings.map((m) {
+            final actionItemId = m['actionItemId'] as String?;
+            final calendarItemId = m['calendarItemIdentifier'] as String?;
+            if (actionItemId != null) {
+              return _markActionItemExported(actionItemId, calendarItemId);
+            }
+            return Future.value();
+          }),
+        );
       } else if (call.method == 'markExported') {
         final actionItemId = call.arguments['action_item_id'] as String?;
         if (actionItemId != null) {
-          await _markActionItemExported(actionItemId);
+          await _markActionItemExported(actionItemId, null);
         }
       }
     });
   }
 
   /// Mark an action item as exported after successful Apple Reminders sync
-  Future<void> _markActionItemExported(String actionItemId) async {
+  Future<void> _markActionItemExported(String actionItemId, String? calendarItemIdentifier) async {
     try {
-      await updateActionItem(actionItemId, exported: true, exportPlatform: 'apple_reminders');
+      await updateActionItem(
+        actionItemId,
+        exported: true,
+        exportPlatform: 'apple_reminders',
+        appleReminderId: calendarItemIdentifier,
+      );
     } catch (e) {
       Logger.debug('Error marking action item as exported: $e');
     }
@@ -43,8 +58,18 @@ class AppleRemindersService {
     if (!isAvailable) return;
     try {
       final result = await _channel.invokeMethod('syncFromFCM', data);
-      final exportedIds = (result as List?)?.cast<String>() ?? [];
-      await Future.wait(exportedIds.map(_markActionItemExported));
+      // New format: list of {"actionItemId": "...", "calendarItemIdentifier": "..."}
+      final mappings = (result as List?)?.cast<Map<Object?, Object?>>() ?? [];
+      await Future.wait(
+        mappings.map((m) {
+          final actionItemId = m['actionItemId'] as String?;
+          final calendarItemId = m['calendarItemIdentifier'] as String?;
+          if (actionItemId != null) {
+            return _markActionItemExported(actionItemId, calendarItemId);
+          }
+          return Future.value();
+        }),
+      );
     } catch (e) {
       Logger.debug('Error triggering sync from FCM: $e');
     }
@@ -53,9 +78,9 @@ class AppleRemindersService {
   /// Check if Apple Reminders is available on this platform
   bool get isAvailable => PlatformService.isApple;
 
-  /// Add a task to Apple Reminders
-  /// Returns true if successful, false if failed or permission denied
-  Future<bool> addReminder({required String title, String? notes, DateTime? dueDate, String? listName}) async {
+  /// Add a task to Apple Reminders.
+  /// Returns the calendarItemIdentifier on success, null on failure.
+  Future<String?> addReminder({required String title, String? notes, DateTime? dueDate, String? listName}) async {
     if (!isAvailable) {
       throw UnsupportedError('Apple Reminders is only available on iOS and macOS');
     }
@@ -68,13 +93,14 @@ class AppleRemindersService {
         'listName': listName ?? 'Reminders',
       });
 
-      return result == true;
+      // result is now the calendarItemIdentifier string (or null on failure)
+      return result as String?;
     } on PlatformException catch (e) {
       Logger.debug('Error adding reminder: ${e.message}');
-      return false;
+      return null;
     } catch (e) {
       Logger.debug('Unexpected error adding reminder: $e');
-      return false;
+      return null;
     }
   }
 
@@ -127,7 +153,7 @@ class AppleRemindersService {
     return existingReminders.contains(title);
   }
 
-  /// Mark a reminder as completed in Apple Reminders
+  /// Mark a reminder as completed in Apple Reminders (legacy: by title match)
   Future<bool> completeReminder(String title, {String? listName}) async {
     if (!isAvailable) return false;
 
@@ -144,7 +170,70 @@ class AppleRemindersService {
     }
   }
 
-  /// Add an action item to Apple Reminders with automatic permission handling
+  /// Get completion status of reminders by their calendarItemIdentifier.
+  /// Input: map of {actionItemId: calendarItemIdentifier}
+  /// Output: map of {actionItemId: {exists: bool, completed: bool, title: String, completionDate: String?}}
+  Future<Map<String, Map<String, dynamic>>> getRemindersStatus(Map<String, String> mappings) async {
+    if (!isAvailable || mappings.isEmpty) return {};
+
+    try {
+      final result = await _channel.invokeMethod('getRemindersStatus', {'mappings': mappings});
+      if (result is Map) {
+        return result.map((key, value) => MapEntry(key.toString(), (value as Map).cast<String, dynamic>()));
+      }
+      return {};
+    } catch (e) {
+      Logger.debug('Error getting reminders status: $e');
+      return {};
+    }
+  }
+
+  /// Update a reminder by its calendarItemIdentifier
+  Future<Map<String, dynamic>> updateReminderById(
+    String calendarItemIdentifier, {
+    String? title,
+    String? notes,
+    DateTime? dueDate,
+    bool? completed,
+  }) async {
+    if (!isAvailable) return {'success': false, 'exists': false};
+
+    try {
+      final args = <String, dynamic>{'calendarItemIdentifier': calendarItemIdentifier};
+      if (title != null) args['title'] = title;
+      if (notes != null) args['notes'] = notes;
+      if (dueDate != null) args['dueDate'] = dueDate.millisecondsSinceEpoch;
+      if (completed != null) args['completed'] = completed;
+
+      final result = await _channel.invokeMethod('updateReminder', args);
+      if (result is Map) {
+        return result.cast<String, dynamic>();
+      }
+      return {'success': false, 'exists': false};
+    } catch (e) {
+      Logger.debug('Error updating reminder: $e');
+      return {'success': false, 'exists': false};
+    }
+  }
+
+  /// Delete a reminder by its calendarItemIdentifier
+  Future<Map<String, dynamic>> deleteReminderById(String calendarItemIdentifier) async {
+    if (!isAvailable) return {'success': false, 'existed': false};
+
+    try {
+      final result = await _channel.invokeMethod('deleteReminder', {'calendarItemIdentifier': calendarItemIdentifier});
+      if (result is Map) {
+        return result.cast<String, dynamic>();
+      }
+      return {'success': false, 'existed': false};
+    } catch (e) {
+      Logger.debug('Error deleting reminder: $e');
+      return {'success': false, 'existed': false};
+    }
+  }
+
+  /// Add an action item to Apple Reminders with automatic permission handling.
+  /// Returns the calendarItemIdentifier on success.
   Future<AppleRemindersResult> addActionItem(String actionItemDescription) async {
     if (!isAvailable) {
       return AppleRemindersResult.unsupported;
@@ -160,9 +249,9 @@ class AppleRemindersService {
     }
 
     // Add the reminder
-    final success = await addReminder(title: actionItemDescription, notes: 'From Omi', listName: 'Reminders');
+    final calendarItemId = await addReminder(title: actionItemDescription, notes: 'From Omi', listName: 'Reminders');
 
-    return success ? AppleRemindersResult.success : AppleRemindersResult.failed;
+    return calendarItemId != null ? AppleRemindersResult.success : AppleRemindersResult.failed;
   }
 }
 

--- a/app/lib/services/apple_reminders_sync_service.dart
+++ b/app/lib/services/apple_reminders_sync_service.dart
@@ -1,0 +1,142 @@
+import 'package:omi/backend/http/api/action_items.dart';
+import 'package:omi/services/apple_reminders_service.dart';
+import 'package:omi/utils/logger.dart';
+
+/// Orchestrates two-way sync between Omi action items and Apple Reminders.
+///
+/// Called on app foreground resume. Handles:
+/// - Outbound sync: creates reminders for unexported action items
+/// - Inbound sync: detects completion status changes in Apple Reminders
+class AppleRemindersSyncService {
+  static final AppleRemindersSyncService _instance = AppleRemindersSyncService._internal();
+  factory AppleRemindersSyncService() => _instance;
+  AppleRemindersSyncService._internal();
+
+  final _remindersService = AppleRemindersService();
+
+  DateTime? _lastSyncTime;
+  bool _isSyncing = false;
+  static const Duration _syncCooldown = Duration(seconds: 30);
+
+  /// Called on foreground resume. Debounced to avoid spamming EventKit.
+  Future<void> syncOnForegroundResume() async {
+    if (!_remindersService.isAvailable) return;
+    if (_isSyncing) return;
+
+    // Debounce: don't sync more than once per 30 seconds
+    if (_lastSyncTime != null && DateTime.now().difference(_lastSyncTime!) < _syncCooldown) {
+      return;
+    }
+
+    // Check permission
+    final hasPermission = await _remindersService.hasPermission();
+    if (!hasPermission) return;
+
+    _isSyncing = true;
+    try {
+      final syncData = await getPendingSyncItems(platform: 'apple_reminders');
+      if (syncData == null) return;
+
+      await _performOutboundSync(syncData.pendingExport);
+      await _performInboundSync(syncData.syncedItems);
+      _lastSyncTime = DateTime.now();
+    } catch (e) {
+      Logger.debug('Apple Reminders sync error: $e');
+    } finally {
+      _isSyncing = false;
+    }
+  }
+
+  /// Outbound: create reminders for unexported action items
+  Future<void> _performOutboundSync(List<Map<String, dynamic>> pendingExport) async {
+    if (pendingExport.isEmpty) return;
+
+    for (final item in pendingExport) {
+      final id = item['id'] as String?;
+      final description = item['description'] as String?;
+      if (id == null || description == null) continue;
+
+      final dueDateStr = item['due_at'] as String?;
+      final dueDate = dueDateStr != null ? DateTime.tryParse(dueDateStr) : null;
+
+      try {
+        final calendarItemId = await _remindersService.addReminder(
+          title: description,
+          notes: 'From Omi',
+          dueDate: dueDate,
+          listName: 'Reminders',
+        );
+
+        if (calendarItemId != null) {
+          await updateActionItem(
+            id,
+            exported: true,
+            exportPlatform: 'apple_reminders',
+            exportDate: DateTime.now(),
+            appleReminderId: calendarItemId,
+          );
+        }
+      } catch (e) {
+        Logger.debug('Outbound sync failed for item $id: $e');
+      }
+    }
+  }
+
+  /// Inbound: check completion status of synced reminders
+  Future<void> _performInboundSync(List<Map<String, dynamic>> syncedItems) async {
+    if (syncedItems.isEmpty) return;
+
+    // Build mapping: {actionItemId: calendarItemIdentifier}
+    final mappings = <String, String>{};
+    final itemStateMap = <String, Map<String, dynamic>>{};
+
+    for (final item in syncedItems) {
+      final id = item['id'] as String?;
+      final reminderId = item['apple_reminder_id'] as String?;
+      if (id == null || reminderId == null || reminderId.isEmpty) continue;
+      mappings[id] = reminderId;
+      itemStateMap[id] = item;
+    }
+
+    if (mappings.isEmpty) return;
+
+    // Get current status from EventKit
+    final statuses = await _remindersService.getRemindersStatus(mappings);
+
+    for (final entry in statuses.entries) {
+      final actionItemId = entry.key;
+      final status = entry.value;
+      final itemState = itemStateMap[actionItemId];
+      if (itemState == null) continue;
+
+      final exists = status['exists'] as bool? ?? false;
+      final reminderCompleted = status['completed'] as bool? ?? false;
+      final omiCompleted = itemState['completed'] as bool? ?? false;
+
+      if (!exists) {
+        // Reminder was deleted from Apple Reminders — clear the mapping
+        try {
+          await updateActionItem(actionItemId, appleReminderId: '');
+        } catch (e) {
+          Logger.debug('Failed to clear apple_reminder_id for $actionItemId: $e');
+        }
+        continue;
+      }
+
+      if (reminderCompleted && !omiCompleted) {
+        // Completed in Apple Reminders but not in Omi — sync completion to Omi
+        try {
+          await updateActionItem(actionItemId, completed: true);
+        } catch (e) {
+          Logger.debug('Failed to sync completion for $actionItemId: $e');
+        }
+      } else if (omiCompleted && !reminderCompleted) {
+        // Completed in Omi but not in Apple Reminders — sync completion to reminder
+        final reminderId = mappings[actionItemId];
+        if (reminderId != null) {
+          await _remindersService.updateReminderById(reminderId, completed: true);
+        }
+      }
+    }
+  }
+}

--- a/app/lib/services/apple_reminders_sync_service.dart
+++ b/app/lib/services/apple_reminders_sync_service.dart
@@ -5,8 +5,10 @@ import 'package:omi/utils/logger.dart';
 /// Orchestrates two-way sync between Omi action items and Apple Reminders.
 ///
 /// Called on app foreground resume. Handles:
-/// - Outbound sync: creates reminders for unexported action items
-/// - Inbound sync: detects completion status changes in Apple Reminders
+/// - Outbound sync: creates reminders for unexported action items (only items
+///   created after the user connected Apple Reminders)
+/// - Bidirectional sync: syncs all fields (title, due date, completion) both ways
+///   for items that already have an apple_reminder_id
 class AppleRemindersSyncService {
   static final AppleRemindersSyncService _instance = AppleRemindersSyncService._internal();
   factory AppleRemindersSyncService() => _instance;
@@ -23,12 +25,10 @@ class AppleRemindersSyncService {
     if (!_remindersService.isAvailable) return;
     if (_isSyncing) return;
 
-    // Debounce: don't sync more than once per 30 seconds
     if (_lastSyncTime != null && DateTime.now().difference(_lastSyncTime!) < _syncCooldown) {
       return;
     }
 
-    // Check permission
     final hasPermission = await _remindersService.hasPermission();
     if (!hasPermission) return;
 
@@ -38,7 +38,7 @@ class AppleRemindersSyncService {
       if (syncData == null) return;
 
       await _performOutboundSync(syncData.pendingExport);
-      await _performInboundSync(syncData.syncedItems);
+      await _performBidirectionalSync(syncData.syncedItems);
       _lastSyncTime = DateTime.now();
     } catch (e) {
       Logger.debug('Apple Reminders sync error: $e');
@@ -47,7 +47,9 @@ class AppleRemindersSyncService {
     }
   }
 
-  /// Outbound: create reminders for unexported action items
+  /// Outbound: create reminders for unexported action items.
+  /// The backend only returns items created after the user connected Apple Reminders,
+  /// so this won't dump old items when the integration is first enabled.
   Future<void> _performOutboundSync(List<Map<String, dynamic>> pendingExport) async {
     if (pendingExport.isEmpty) return;
 
@@ -82,11 +84,16 @@ class AppleRemindersSyncService {
     }
   }
 
-  /// Inbound: check completion status of synced reminders
-  Future<void> _performInboundSync(List<Map<String, dynamic>> syncedItems) async {
+  /// Bidirectional sync for items that already have an apple_reminder_id.
+  ///
+  /// Compares EventKit reminder state with Omi state and pushes diffs both ways.
+  /// Uses Omi's updated_at vs _lastSyncTime to determine direction:
+  /// - If Omi was updated since last sync → push all Omi fields to reminder
+  /// - Otherwise → pull all reminder fields to Omi
+  /// - Completion is always merged: if either side completed, both become completed
+  Future<void> _performBidirectionalSync(List<Map<String, dynamic>> syncedItems) async {
     if (syncedItems.isEmpty) return;
 
-    // Build mapping: {actionItemId: calendarItemIdentifier}
     final mappings = <String, String>{};
     final itemStateMap = <String, Map<String, dynamic>>{};
 
@@ -100,7 +107,6 @@ class AppleRemindersSyncService {
 
     if (mappings.isEmpty) return;
 
-    // Get current status from EventKit
     final statuses = await _remindersService.getRemindersStatus(mappings);
 
     for (final entry in statuses.entries) {
@@ -110,8 +116,6 @@ class AppleRemindersSyncService {
       if (itemState == null) continue;
 
       final exists = status['exists'] as bool? ?? false;
-      final reminderCompleted = status['completed'] as bool? ?? false;
-      final omiCompleted = itemState['completed'] as bool? ?? false;
 
       if (!exists) {
         // Reminder was deleted from Apple Reminders — clear the mapping
@@ -123,20 +127,128 @@ class AppleRemindersSyncService {
         continue;
       }
 
-      if (reminderCompleted && !omiCompleted) {
-        // Completed in Apple Reminders but not in Omi — sync completion to Omi
-        try {
-          await updateActionItem(actionItemId, completed: true);
-        } catch (e) {
-          Logger.debug('Failed to sync completion for $actionItemId: $e');
-        }
-      } else if (omiCompleted && !reminderCompleted) {
-        // Completed in Omi but not in Apple Reminders — sync completion to reminder
-        final reminderId = mappings[actionItemId];
-        if (reminderId != null) {
-          await _remindersService.updateReminderById(reminderId, completed: true);
-        }
+      final reminderId = mappings[actionItemId]!;
+
+      // Current state on both sides
+      final reminderCompleted = status['completed'] as bool? ?? false;
+      final omiCompleted = itemState['completed'] as bool? ?? false;
+      final reminderTitle = status['title'] as String? ?? '';
+      final omiDescription = itemState['description'] as String? ?? '';
+      final reminderDueDateStr = status['dueDate'] as String?;
+      final omiDueDateStr = itemState['due_at'] as String?;
+      final reminderDueDate = reminderDueDateStr != null ? DateTime.tryParse(reminderDueDateStr) : null;
+      final omiDueDate = omiDueDateStr != null ? DateTime.tryParse(omiDueDateStr) : null;
+
+      final titleDiffers = reminderTitle.isNotEmpty && reminderTitle != omiDescription;
+      final dueDateDiffers = _dueDatesAreDifferent(reminderDueDate, omiDueDate);
+      final completionDiffers = reminderCompleted != omiCompleted;
+
+      if (!titleDiffers && !dueDateDiffers && !completionDiffers) continue;
+
+      // Determine direction: did Omi change since last sync?
+      final omiUpdatedAtStr = itemState['updated_at'] as String?;
+      final omiUpdatedAt = omiUpdatedAtStr != null ? DateTime.tryParse(omiUpdatedAtStr) : null;
+      final omiChangedSinceLastSync =
+          _lastSyncTime != null && omiUpdatedAt != null && omiUpdatedAt.isAfter(_lastSyncTime!);
+
+      if (omiChangedSinceLastSync) {
+        // Omi was edited since last sync → push Omi state to reminder
+        await _pushOmiToReminder(reminderId, omiDescription, omiDueDate, omiCompleted, reminderCompleted);
+      } else {
+        // Reminder may have changed → pull reminder state to Omi
+        await _pullReminderToOmi(
+          actionItemId,
+          reminderId,
+          reminderTitle,
+          reminderDueDate,
+          reminderCompleted,
+          omiDescription,
+          omiDueDate,
+          omiCompleted,
+        );
       }
     }
+  }
+
+  /// Push Omi fields to Apple Reminder (Omi is the source of truth for this item)
+  Future<void> _pushOmiToReminder(
+    String reminderId,
+    String omiTitle,
+    DateTime? omiDueDate,
+    bool omiCompleted,
+    bool reminderCompleted,
+  ) async {
+    await _remindersService.updateReminderById(
+      reminderId,
+      title: omiTitle,
+      dueDate: omiDueDate,
+      completed: omiCompleted || reminderCompleted, // if either completed, mark completed
+    );
+  }
+
+  /// Pull Apple Reminder fields to Omi (Reminder is the source of truth for this item).
+  /// Collects all diffs into a single PATCH call.
+  Future<void> _pullReminderToOmi(
+    String actionItemId,
+    String reminderId,
+    String reminderTitle,
+    DateTime? reminderDueDate,
+    bool reminderCompleted,
+    String omiDescription,
+    DateTime? omiDueDate,
+    bool omiCompleted,
+  ) async {
+    bool? patchCompleted;
+    String? patchDescription;
+    DateTime? patchDueAt;
+    bool patchClearDueAt = false;
+    bool needsOmiUpdate = false;
+
+    // Completion: merge — if either side completed, both become completed
+    if (reminderCompleted && !omiCompleted) {
+      patchCompleted = true;
+      needsOmiUpdate = true;
+    } else if (omiCompleted && !reminderCompleted) {
+      // Omi completed but reminder not → push completion to reminder
+      await _remindersService.updateReminderById(reminderId, completed: true);
+    }
+
+    // Title: pull from reminder
+    if (reminderTitle.isNotEmpty && reminderTitle != omiDescription) {
+      patchDescription = reminderTitle;
+      needsOmiUpdate = true;
+    }
+
+    // Due date: pull from reminder
+    if (_dueDatesAreDifferent(reminderDueDate, omiDueDate)) {
+      if (reminderDueDate != null) {
+        patchDueAt = reminderDueDate;
+      } else {
+        patchClearDueAt = true;
+      }
+      needsOmiUpdate = true;
+    }
+
+    if (needsOmiUpdate) {
+      try {
+        await updateActionItem(
+          actionItemId,
+          completed: patchCompleted,
+          description: patchDescription,
+          dueAt: patchDueAt,
+          clearDueAt: patchClearDueAt,
+        );
+      } catch (e) {
+        Logger.debug('Failed to sync reminder→Omi for $actionItemId: $e');
+      }
+    }
+  }
+
+  /// Check if two due dates are meaningfully different (ignoring seconds/milliseconds).
+  /// EventKit only stores year/month/day/hour/minute in dueDateComponents.
+  bool _dueDatesAreDifferent(DateTime? a, DateTime? b) {
+    if (a == null && b == null) return false;
+    if (a == null || b == null) return true;
+    return a.year != b.year || a.month != b.month || a.day != b.day || a.hour != b.hour || a.minute != b.minute;
   }
 }

--- a/backend/database/action_items.py
+++ b/backend/database/action_items.py
@@ -246,6 +246,67 @@ def get_action_items(
     return action_items
 
 
+def get_unexported_action_items(uid: str, limit: int = 50) -> List[dict]:
+    """
+    Get action items that haven't been exported yet (for outbound sync).
+
+    Args:
+        uid: User ID
+        limit: Maximum number of items to return
+
+    Returns:
+        List of unexported action items
+    """
+    user_ref = db.collection('users').document(uid)
+    query = user_ref.collection(action_items_collection)
+    query = query.where(filter=FieldFilter('completed', '==', False))
+    query = query.order_by('created_at', direction=firestore.Query.DESCENDING)
+    query = query.limit(limit)
+
+    docs = query.stream()
+    action_items = []
+    for doc in docs:
+        data = doc.to_dict()
+        data['id'] = doc.id
+        data = _prepare_action_item_for_read(data)
+        # Filter in application code: exported != True (handles both False and missing field)
+        if data.get('exported') is True:
+            continue
+        action_items.append(data)
+
+    return action_items
+
+
+def get_action_items_with_reminder_id(uid: str, limit: int = 50) -> List[dict]:
+    """
+    Get action items that have an apple_reminder_id set (for inbound completion sync).
+
+    Args:
+        uid: User ID
+        limit: Maximum number of items to return
+
+    Returns:
+        List of action items with apple_reminder_id
+    """
+    user_ref = db.collection('users').document(uid)
+    query = user_ref.collection(action_items_collection)
+    query = query.where(filter=FieldFilter('export_platform', '==', 'apple_reminders'))
+    query = query.where(filter=FieldFilter('exported', '==', True))
+    query = query.order_by('updated_at', direction=firestore.Query.DESCENDING)
+    query = query.limit(limit)
+
+    docs = query.stream()
+    action_items = []
+    for doc in docs:
+        data = doc.to_dict()
+        data['id'] = doc.id
+        data = _prepare_action_item_for_read(data)
+        if data.get('apple_reminder_id'):
+            action_items.append(data)
+
+    return action_items
+
+
 def get_action_items_by_conversation(uid: str, conversation_id: str) -> List[dict]:
     """
     Get all action items for a specific conversation.

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -122,6 +122,11 @@ def get_pending_sync_items(
     if default_app != 'apple_reminders':
         return {"pending_export": [], "synced_items": []}
 
+    # Only export items created after the user connected Apple Reminders.
+    # This prevents dumping all existing action items when the integration is first enabled.
+    integration = users_db.get_task_integration(uid, 'apple_reminders')
+    connected_at = integration.get('created_at') if integration else None
+
     pending_export = action_items_db.get_unexported_action_items(uid, limit=50)
     synced_items = action_items_db.get_action_items_with_reminder_id(uid, limit=50)
 
@@ -133,6 +138,7 @@ def get_pending_sync_items(
             "completed": item.get("completed", False),
         }
         for item in pending_export
+        if connected_at is None or (item.get("created_at") and item["created_at"] >= connected_at)
     ]
 
     synced_items_response = [
@@ -141,6 +147,7 @@ def get_pending_sync_items(
             "description": item.get("description", ""),
             "apple_reminder_id": item.get("apple_reminder_id", ""),
             "completed": item.get("completed", False),
+            "due_at": item["due_at"].isoformat() if item.get("due_at") else None,
             "updated_at": item["updated_at"].isoformat() if item.get("updated_at") else None,
         }
         for item in synced_items

--- a/backend/routers/action_items.py
+++ b/backend/routers/action_items.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 import database.action_items as action_items_db
 import database.conversations as conversations_db
 import database.redis_db as redis_db
+import database.users as users_db
 from utils.users import get_user_display_name
 from utils.other import endpoints as auth
 from utils.notifications import (
@@ -42,6 +43,9 @@ class UpdateActionItemRequest(BaseModel):
     export_platform: Optional[str] = Field(default=None, description="Platform the item was exported to")
     sort_order: Optional[int] = Field(default=None, description="Manual sort order within category")
     indent_level: Optional[int] = Field(default=None, ge=0, le=3, description="Indentation level (0-3)")
+    apple_reminder_id: Optional[str] = Field(
+        default=None, description="EventKit calendarItemIdentifier for Apple Reminders two-way sync"
+    )
 
 
 class ActionItemResponse(BaseModel):
@@ -59,6 +63,7 @@ class ActionItemResponse(BaseModel):
     export_platform: Optional[str] = None
     sort_order: int = 0
     indent_level: int = 0
+    apple_reminder_id: Optional[str] = None
 
 
 def _get_valid_action_item(uid: str, action_item_id: str) -> dict:
@@ -92,6 +97,56 @@ def batch_update_action_items(request: BatchUpdateActionItemsRequest, uid: str =
     """Batch update sort_order and indent_level for multiple action items."""
     action_items_db.batch_update_action_items(uid, request.items)
     return {"status": "ok", "updated_count": len(request.items)}
+
+
+# *****************************
+# ****** SYNC ROUTES *********
+# *****************************
+
+
+@router.get("/v1/action-items/pending-sync", tags=['action-items'])
+def get_pending_sync_items(
+    platform: str = Query(description="Target sync platform, e.g. 'apple_reminders'"),
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """
+    Returns action items that need syncing to the specified platform.
+
+    - pending_export: items not yet exported (need outbound sync — create reminders)
+    - synced_items: items with apple_reminder_id set (need inbound sync — check completion)
+    """
+    if platform != 'apple_reminders':
+        return {"pending_export": [], "synced_items": []}
+
+    default_app = users_db.get_default_task_integration(uid)
+    if default_app != 'apple_reminders':
+        return {"pending_export": [], "synced_items": []}
+
+    pending_export = action_items_db.get_unexported_action_items(uid, limit=50)
+    synced_items = action_items_db.get_action_items_with_reminder_id(uid, limit=50)
+
+    pending_export_response = [
+        {
+            "id": item["id"],
+            "description": item.get("description", ""),
+            "due_at": item["due_at"].isoformat() if item.get("due_at") else None,
+            "completed": item.get("completed", False),
+        }
+        for item in pending_export
+    ]
+
+    synced_items_response = [
+        {
+            "id": item["id"],
+            "description": item.get("description", ""),
+            "apple_reminder_id": item.get("apple_reminder_id", ""),
+            "completed": item.get("completed", False),
+            "updated_at": item["updated_at"].isoformat() if item.get("updated_at") else None,
+        }
+        for item in synced_items
+    ]
+
+    return {"pending_export": pending_export_response, "synced_items": synced_items_response}
 
 
 # *****************************
@@ -231,6 +286,8 @@ def update_action_item(
         update_data['sort_order'] = request.sort_order
     if request.indent_level is not None:
         update_data['indent_level'] = request.indent_level
+    if request.apple_reminder_id is not None:
+        update_data['apple_reminder_id'] = request.apple_reminder_id
 
     # Update the action item
     success = action_items_db.update_action_item(uid, action_item_id, update_data)


### PR DESCRIPTION
## Summary

- **Store `calendarItemIdentifier`** — Every Apple Reminder we create now returns its stable EventKit UUID, which is stored on the backend alongside the action item. This enables lookup, update, delete, and completion detection.
- **Client-pull sync on foreground resume** — New `AppleRemindersSyncService` runs on every app foreground (30s debounce). Fetches unexported items from backend, creates reminders locally, stores identifiers back. No longer solely dependent on FCM silent push (which iOS throttles to ~2-3/hour).
- **Two-way completion sync** — Detects when reminders are completed in Apple Reminders app and marks corresponding Omi action items as complete. Also syncs Omi completions back to Apple Reminders.
- **Fix iCloud calendar source** — `addReminder` now uses `defaultCalendarForNewReminders()` instead of preferring `.local` source, so reminders sync across devices via iCloud.
- **Remove 100-item dedup cap** — Old `UserDefaults` dedup mechanism replaced by backend identifier mapping.

## Changes

### Backend (2 files)
- `apple_reminder_id` field on `UpdateActionItemRequest` and `ActionItemResponse`
- New `GET /v1/action-items/pending-sync?platform=apple_reminders` endpoint
- New Firestore query functions for unexported and synced items

### iOS Native (2 files)
- `addReminder` returns `calendarItemIdentifier` string instead of `true/false`
- `syncBatchFromJSON` returns `[{actionItemId, calendarItemIdentifier}]` mappings
- 3 new methods: `getRemindersStatus`, `updateReminder`, `deleteReminder`
- Fixed calendar source, removed UserDefaults dedup

### Dart (6 files modified, 1 new)
- `appleReminderId` field on `ActionItemWithMetadata`
- Updated `AppleRemindersService` with new return types and methods
- New `AppleRemindersSyncService` orchestrator (outbound + inbound sync)
- Lifecycle hook on `AppLifecycleState.resumed` in `HomePage`

## Test plan

- [ ] Set Apple Reminders as default task integration
- [ ] Create action items in Omi → verify reminders appear in Apple Reminders after backgrounding/foregrounding
- [ ] Complete a reminder in Apple Reminders → switch back to Omi → verify action item is marked complete
- [ ] Delete a reminder in Apple Reminders → switch back to Omi → verify action item remains but loses export badge
- [ ] Kill app, create action items via another device, reopen → verify reminders are created on foreground
- [ ] Manually export via tile icon → verify calendarItemIdentifier is stored
- [ ] Test with iCloud Reminders enabled → verify reminders sync across devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)