### PR TITLE
fix(android): guard BLE scan permission and connectGatt null returns

### DIFF
--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -84,7 +84,7 @@ class OmiBleForegroundService : Service() {
                     BluetoothAdapter.STATE_OFF -> {
                         Log.d(TAG, "Bluetooth turned OFF, cleaning up GATT")
                         updateNotification("Bluetooth is off")
-                        OmiBleManager.instance.disconnectAllPeripherals()
+                        OmiBleManager.instance.handleBluetoothOff()
                     }
                 }
             }

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -286,6 +286,22 @@ class OmiBleManager private constructor(private val application: Application) {
         OmiBleForegroundService.stopService(application)
     }
 
+    /** Clean up all GATT connections because Bluetooth was turned off.
+     *  Unlike disconnectAllPeripherals(), this notifies Dart and does NOT
+     *  set appClosed/manuallyDisconnected so reconnect works when BT comes back. */
+    fun handleBluetoothOff() {
+        cancelPendingReconnect()
+        for ((addr, gatt) in connectedGatts) {
+            cleanupPeripheral(addr)
+            gatt.close()
+            mainHandler.post {
+                flutterApi?.onPeripheralDisconnected(addr, "bluetooth_off") {}
+            }
+        }
+        connectedGatts.clear()
+        connectingAddresses.clear()
+    }
+
     fun isManuallyDisconnected(address: String): Boolean {
         return manuallyDisconnected.contains(address.uppercase())
     }

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -137,7 +137,7 @@ class OmiBleManager private constructor(private val application: Application) {
             return
         }
 
-        if (ContextCompat.checkSelfPermission(application, "android.permission.BLUETOOTH_SCAN") != PackageManager.PERMISSION_GRANTED) {
+        if (ContextCompat.checkSelfPermission(application, android.Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
             Log.w(TAG, "BLUETOOTH_SCAN permission not granted, cannot scan")
             return
         }

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -137,7 +137,8 @@ class OmiBleManager private constructor(private val application: Application) {
             return
         }
 
-        if (ContextCompat.checkSelfPermission(application, android.Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.S &&
+            ContextCompat.checkSelfPermission(application, android.Manifest.permission.BLUETOOTH_SCAN) != PackageManager.PERMISSION_GRANTED) {
             Log.w(TAG, "BLUETOOTH_SCAN permission not granted, cannot scan")
             return
         }

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -314,6 +314,11 @@ class OmiBleManager private constructor(private val application: Application) {
         Log.i(TAG, "reconnectKnownPeripheral: $addr (autoConnect=true)")
         connectingAddresses.add(addr)
         val gatt = device.connectGatt(application, true, gattCallback, BluetoothDevice.TRANSPORT_LE)
+        if (gatt == null) {
+            Log.e(TAG, "connectGatt returned null for $addr in reconnectKnownPeripheral")
+            connectingAddresses.remove(addr)
+            return
+        }
         connectedGatts[addr] = gatt
     }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -8,10 +8,12 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.content.pm.PackageManager
 import android.os.Handler
 import android.os.Looper
 import android.os.ParcelUuid
 import android.util.Log
+import androidx.core.content.ContextCompat
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -135,6 +137,11 @@ class OmiBleManager private constructor(private val application: Application) {
             return
         }
 
+        if (ContextCompat.checkSelfPermission(application, "android.permission.BLUETOOTH_SCAN") != PackageManager.PERMISSION_GRANTED) {
+            Log.w(TAG, "BLUETOOTH_SCAN permission not granted, cannot scan")
+            return
+        }
+
         stopScan()
 
         val scanner = adapter.bluetoothLeScanner ?: return
@@ -245,6 +252,11 @@ class OmiBleManager private constructor(private val application: Application) {
         Log.i(TAG, "connectPeripheral($caller): $addr")
         connectingAddresses.add(addr)
         val gatt = device.connectGatt(application, false, gattCallback, BluetoothDevice.TRANSPORT_LE)
+        if (gatt == null) {
+            Log.e(TAG, "connectGatt returned null for $addr")
+            connectingAddresses.remove(addr)
+            return
+        }
         connectedGatts[addr] = gatt
     }
 
@@ -613,6 +625,11 @@ class OmiBleManager private constructor(private val application: Application) {
                                 val device = bluetoothAdapter?.getRemoteDevice(address) ?: return@Runnable
                                 connectingAddresses.add(address)
                                 val newGatt = device.connectGatt(application, true, this, BluetoothDevice.TRANSPORT_LE)
+                                if (newGatt == null) {
+                                    Log.e(TAG, "connectGatt returned null for $address during auth-failure retry")
+                                    connectingAddresses.remove(address)
+                                    return@Runnable
+                                }
                                 connectedGatts[address] = newGatt
                             }
                             pendingReconnectRunnable = runnable
@@ -628,6 +645,11 @@ class OmiBleManager private constructor(private val application: Application) {
                                 val device = bluetoothAdapter?.getRemoteDevice(address) ?: return@Runnable
                                 connectingAddresses.add(address)
                                 val newGatt = device.connectGatt(application, true, this, BluetoothDevice.TRANSPORT_LE)
+                                if (newGatt == null) {
+                                    Log.e(TAG, "connectGatt returned null for $address during auto-reconnect")
+                                    connectingAddresses.remove(address)
+                                    return@Runnable
+                                }
                                 connectedGatts[address] = newGatt
                             }
                             pendingReconnectRunnable = runnable


### PR DESCRIPTION
## Summary

- **BLUETOOTH_SCAN permission check** in `startScan()` — prevents `SecurityException` crash on Android 12+ when scan fires before the permission popup resolves
- **Null guard on `connectGatt()`** at all 3 call sites (initial connect, auth-failure retry, auto-reconnect) — `connectGatt` returns null when Bluetooth is off/unavailable, causing `ConcurrentHashMap` NPE since it doesn't allow null values. Also cleans up `connectingAddresses` so the address isn't permanently blocked from future connection attempts.

## Crashes fixed (from Crashlytics)

1. `SecurityException: Need android.permission.BLUETOOTH_SCAN permission` — during onboarding scan
2. `NullPointerException at ConcurrentHashMap.putVal` — during `connectPeripheral` via Pigeon

## Test plan

- [ ] Fresh install on Android 12+ — scan should not crash before permission is granted
- [ ] Toggle Bluetooth off while app is connected — reconnect attempt should not crash
- [ ] Normal connect/disconnect flow still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)