### PR TITLE
chore: bump build number to 797

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.528+796
+version: 1.0.528+797
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
## Summary
Bump build number 796 → 797 to trigger Codemagic build with PR #6157 (v2 async sync-local-files) app changes.

- Backend already deployed (revision backend-00880-wdc, 09:40 UTC)
- This triggers iOS TestFlight + Android internal builds via Codemagic auto-deploy

## Changes
- `app/pubspec.yaml`: `1.0.528+796` → `1.0.528+797`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_