### PR TITLE
Bump build number to 798 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.528+797
+version: 1.0.528+798
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Version bump for mobile release: `1.0.528+797` → `1.0.528+798`.

Triggers Codemagic auto-deploy to TestFlight + Google Play internal on merge.

---
_by AI for @beastoin_