### PR TITLE
feat: Private Cloud Sync — list, play, share, and delete all audio files (#3215)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+  "name": "omi-fork-dev",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22-bookworm",
+  "hostRequirements": {
+    "cpus": 2,
+    "memory": "8gb",
+    "storage": "32gb"
+  },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/python:1": {
+      "version": "3.12"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "ms-python.python"
+      ]
+    },
+    "codespaces": {
+      "openFiles": [
+        "README.md",
+        "AGENTS.md"
+      ]
+    }
+  },
+  "postCreateCommand": "npm install || true"
+}

--- a/app/lib/backend/http/api/audio.dart
+++ b/app/lib/backend/http/api/audio.dart
@@ -82,3 +82,69 @@ Future<List<AudioFileUrlInfo>> getConversationAudioSignedUrls(String conversatio
     return [];
   }
 }
+
+class CloudAudioConversation {
+  final String id;
+  final String title;
+  final DateTime? createdAt;
+  final int audioFileCount;
+  final double totalDuration;
+
+  CloudAudioConversation({
+    required this.id,
+    required this.title,
+    this.createdAt,
+    required this.audioFileCount,
+    required this.totalDuration,
+  });
+
+  factory CloudAudioConversation.fromJson(Map<String, dynamic> json) {
+    return CloudAudioConversation(
+      id: json['id'] ?? '',
+      title: json['title'] ?? 'Untitled',
+      createdAt: json['created_at'] != null ? DateTime.parse(json['created_at']).toLocal() : null,
+      audioFileCount: json['audio_file_count'] ?? 0,
+      totalDuration: (json['total_duration'] ?? 0).toDouble(),
+    );
+  }
+}
+
+Future<List<CloudAudioConversation>> getCloudAudioConversations() async {
+  try {
+    final headers = await buildHeaders(requireAuthCheck: true);
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}v1/sync/audio/conversations',
+      headers: headers,
+      method: 'GET',
+      body: '',
+    );
+
+    if (response == null || response.statusCode != 200) {
+      return [];
+    }
+
+    final decoded = jsonDecode(response.body) as Map<String, dynamic>;
+    final conversations = decoded['conversations'] as List<dynamic>? ?? [];
+    return conversations.map((c) => CloudAudioConversation.fromJson(c as Map<String, dynamic>)).toList();
+  } catch (e) {
+    Logger.debug('Error getting cloud audio conversations: $e');
+    return [];
+  }
+}
+
+Future<bool> deleteAllCloudAudio() async {
+  try {
+    final headers = await buildHeaders(requireAuthCheck: true);
+    final response = await makeApiCall(
+      url: '${Env.apiBaseUrl}v1/sync/audio',
+      headers: headers,
+      method: 'DELETE',
+      body: '',
+    );
+
+    return response?.statusCode == 200;
+  } catch (e) {
+    Logger.debug('Error deleting all cloud audio: $e');
+    return false;
+  }
+}

--- a/app/lib/pages/conversations/private_cloud_sync_page.dart
+++ b/app/lib/pages/conversations/private_cloud_sync_page.dart
@@ -1,14 +1,30 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 import 'package:font_awesome_flutter/font_awesome_flutter.dart';
+import 'package:just_audio/just_audio.dart';
 import 'package:provider/provider.dart';
+import 'package:share_plus/share_plus.dart';
 
+import 'package:omi/backend/http/api/audio.dart';
 import 'package:omi/providers/user_provider.dart';
+import 'package:omi/services/audio_download_service.dart';
 import 'package:omi/utils/l10n_extensions.dart';
+import 'package:omi/utils/logger.dart';
 
 class PrivateCloudSyncPage extends StatefulWidget {
-  const PrivateCloudSyncPage({super.key});
+  const PrivateCloudSyncPage({
+    super.key,
+    this.loadCloudAudioConversations,
+    this.deleteAllCloudAudio,
+    this.confirmDeleteOverride,
+  });
+
+  final Future<List<CloudAudioConversation>> Function()? loadCloudAudioConversations;
+  final Future<bool> Function()? deleteAllCloudAudio;
+  final Future<bool?> Function(BuildContext context)? confirmDeleteOverride;
 
   @override
   State<PrivateCloudSyncPage> createState() => _PrivateCloudSyncPageState();
@@ -16,33 +32,320 @@ class PrivateCloudSyncPage extends StatefulWidget {
 
 class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
   bool _isSaving = false;
+  bool _isLoadingAudio = false;
+  bool _isDeleting = false;
+  bool _isAudioLoading = false;
+  List<CloudAudioConversation> _conversations = [];
+  bool? _lastPrivateCloudSyncEnabled;
+  int _playbackGeneration = 0;
+  int _cloudAudioRequestGeneration = 0;
+
+  final AudioPlayer _audioPlayer = AudioPlayer();
+  StreamSubscription<PlayerState>? _playerStateSubscription;
+  String? _currentPlayingConversationId;
+
+  @override
+  void initState() {
+    super.initState();
+    _playerStateSubscription = _audioPlayer.playerStateStream.listen((playerState) async {
+      if (playerState.processingState == ProcessingState.completed) {
+        await _audioPlayer.seek(Duration.zero, index: 0);
+        if (!mounted) return;
+        setState(() {
+          _currentPlayingConversationId = null;
+          _isAudioLoading = false;
+        });
+        return;
+      }
+
+      if (mounted) {
+        setState(() {});
+      }
+    });
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    final isEnabled = context.watch<UserProvider>().privateCloudSyncEnabled;
+    if (_lastPrivateCloudSyncEnabled == isEnabled) return;
+    _lastPrivateCloudSyncEnabled = isEnabled;
+
+    if (isEnabled) {
+      unawaited(_loadCloudAudioConversations());
+      return;
+    }
+
+    _cancelPendingPlayback(clearConversations: true);
+  }
+
+  void _cancelPendingPlayback({bool clearConversations = false}) {
+    _playbackGeneration++;
+    unawaited(_audioPlayer.stop());
+    _currentPlayingConversationId = null;
+    _isAudioLoading = false;
+    if (clearConversations) {
+      _invalidateCloudAudioRequests(clearLoading: true);
+      _conversations = [];
+    }
+  }
+
+  void _invalidateCloudAudioRequests({bool clearLoading = false}) {
+    _cloudAudioRequestGeneration++;
+    if (clearLoading) {
+      _isLoadingAudio = false;
+    }
+  }
+
+  bool _shouldAbortPlaybackStart(String conversationId, int playbackGeneration) {
+    return !mounted ||
+        _isDeleting ||
+        !context.read<UserProvider>().privateCloudSyncEnabled ||
+        _currentPlayingConversationId != conversationId ||
+        _playbackGeneration != playbackGeneration;
+  }
+
+  @override
+  void dispose() {
+    _playerStateSubscription?.cancel();
+    _audioPlayer.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadCloudAudioConversations() async {
+    if (!mounted) return;
+    final requestGeneration = ++_cloudAudioRequestGeneration;
+    setState(() => _isLoadingAudio = true);
+    try {
+      final conversations = await (widget.loadCloudAudioConversations ?? getCloudAudioConversations)();
+      if (!mounted || requestGeneration != _cloudAudioRequestGeneration) return;
+      setState(() {
+        _conversations = conversations;
+        _isLoadingAudio = false;
+      });
+    } catch (e) {
+      Logger.debug('Error loading cloud audio conversations: $e');
+      if (!mounted || requestGeneration != _cloudAudioRequestGeneration) return;
+      setState(() => _isLoadingAudio = false);
+    }
+  }
 
   Future<void> _togglePrivateCloudSync(bool value) async {
+    final userProvider = context.read<UserProvider>();
+
     if (value) {
       final confirmed = await _showEnableDialog();
       if (confirmed != true) return;
     }
 
+    if (!value) {
+      setState(() => _cancelPendingPlayback());
+    }
+
     setState(() => _isSaving = true);
     try {
-      await context.read<UserProvider>().setPrivateCloudSync(value);
+      await userProvider.setPrivateCloudSync(value);
+      if (!mounted) return;
       setState(() => _isSaving = false);
-      if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(value ? context.l10n.cloudStorageEnabled : context.l10n.cloudStorageDisabled),
+          backgroundColor: Colors.green,
+        ),
+      );
+    } catch (e) {
+      Logger.debug('Error toggling cloud storage: $e');
+      if (!mounted) return;
+      setState(() => _isSaving = false);
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(context.l10n.failedToUpdateSettings(e.toString())), backgroundColor: Colors.red),
+      );
+    }
+  }
+
+  Future<void> _playConversationAudio(CloudAudioConversation conversation) async {
+    if (_isAudioLoading) {
+      return;
+    }
+
+    if (_currentPlayingConversationId == conversation.id) {
+      if (_audioPlayer.playing) {
+        await _audioPlayer.pause();
+      } else {
+        await _audioPlayer.play();
+      }
+      if (mounted) setState(() {});
+      return;
+    }
+
+    // Capture the generation token BEFORE the first await so that a
+    // concurrent cancel() that increments _playbackGeneration cannot
+    // sneak in between the stop() call and the token read.
+    final playbackGeneration = ++_playbackGeneration;
+    await _audioPlayer.stop();
+    if (!mounted) return;
+    setState(() {
+      _currentPlayingConversationId = conversation.id;
+      _isAudioLoading = true;
+    });
+
+    try {
+      final audioFileInfos = await getConversationAudioSignedUrls(conversation.id);
+      if (_shouldAbortPlaybackStart(conversation.id, playbackGeneration)) {
+        if (mounted) {
+          setState(() {
+            _currentPlayingConversationId = null;
+            _isAudioLoading = false;
+          });
+        }
+        return;
+      }
+      if (audioFileInfos.isEmpty) {
+        throw Exception('No audio files available to play');
+      }
+
+      if (audioFileInfos.any((af) => !af.isCached)) {
+        await precacheConversationAudio(conversation.id);
+        if (_shouldAbortPlaybackStart(conversation.id, playbackGeneration)) return;
+        setState(() {
+          _currentPlayingConversationId = null;
+          _isAudioLoading = false;
+        });
+        if (!mounted) return;
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(
-            content: Text(value ? context.l10n.cloudStorageEnabled : context.l10n.cloudStorageDisabled),
-            backgroundColor: Colors.green,
-          ),
+          SnackBar(content: Text(context.l10n.preparingCloudAudioTryAgain), backgroundColor: Colors.orange),
         );
+        return;
+      }
+
+      final headers = await getAudioHeaders();
+      final urls = getConversationAudioUrls(
+        conversationId: conversation.id,
+        audioFileIds: audioFileInfos.map((af) => af.id).toList(),
+        format: 'wav',
+      );
+
+      final playlist = ConcatenatingAudioSource(
+        useLazyPreparation: true,
+        children: urls.map((url) => AudioSource.uri(Uri.parse(url), headers: headers)).toList(),
+      );
+
+      await _audioPlayer.setAudioSource(playlist, preload: true);
+      if (_shouldAbortPlaybackStart(conversation.id, playbackGeneration)) {
+        await _audioPlayer.stop();
+        if (mounted) {
+          setState(() {
+            _currentPlayingConversationId = null;
+            _isAudioLoading = false;
+          });
+        }
+        return;
+      }
+      setState(() => _isAudioLoading = false);
+      await _audioPlayer.play();
+      if (_shouldAbortPlaybackStart(conversation.id, playbackGeneration)) {
+        await _audioPlayer.stop();
+        if (mounted) {
+          setState(() {
+            _currentPlayingConversationId = null;
+          });
+        }
       }
     } catch (e) {
-      print('Error toggling cloud storage: $e');
-      setState(() => _isSaving = false);
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(context.l10n.failedToUpdateSettings(e.toString())), backgroundColor: Colors.red),
-        );
+      Logger.debug('Error playing conversation audio: $e');
+      if (!mounted) return;
+      setState(() {
+        _currentPlayingConversationId = null;
+        _isAudioLoading = false;
+      });
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(context.l10n.failedToPlayCloudAudio), backgroundColor: Colors.red));
+    }
+  }
+
+  Future<void> _shareConversationAudio(CloudAudioConversation conversation) async {
+    AudioDownloadService? service;
+    try {
+      final audioFileInfos = await getConversationAudioSignedUrls(conversation.id);
+      if (audioFileInfos.isEmpty) {
+        throw Exception('No audio file available to share');
       }
+
+      if (audioFileInfos.any((af) => !af.isCached || af.signedUrl == null)) {
+        await precacheConversationAudio(conversation.id);
+        if (!mounted) return;
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(context.l10n.preparingCloudAudioTryAgain), backgroundColor: Colors.orange),
+        );
+        return;
+      }
+
+      service = AudioDownloadService();
+      final file = await service.downloadAndCombineCloudAudio(
+        conversation.title,
+        audioFileInfos.map((audio) => DownloadableCloudAudioFile(url: audio.signedUrl!)).toList(),
+      );
+
+      if (file == null) {
+        throw Exception('No audio file available to share');
+      }
+
+      await SharePlus.instance.share(ShareParams(files: [XFile(file.path, mimeType: 'audio/wav')]));
+      await service.cleanup();
+    } catch (e) {
+      Logger.debug('Error sharing cloud audio: $e');
+      if (!mounted) return;
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(context.l10n.failedToShareCloudAudio), backgroundColor: Colors.red));
+    } finally {
+      await service?.cleanup();
+      service?.dispose();
+    }
+  }
+
+  Future<void> _deleteAllAudio() async {
+    final confirmed = await (widget.confirmDeleteOverride?.call(context) ?? _showDeleteAllDialog());
+    if (confirmed != true) return;
+
+    setState(() {
+      _isDeleting = true;
+      _invalidateCloudAudioRequests(clearLoading: true);
+    });
+    _cancelPendingPlayback();
+
+    try {
+      final success = await (widget.deleteAllCloudAudio ?? deleteAllCloudAudio)();
+      if (!mounted) return;
+      setState(() => _isDeleting = false);
+      if (success) {
+        setState(() {
+          _conversations = [];
+        });
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(context.l10n.audioDeletedSuccessfully), backgroundColor: Colors.green));
+      } else {
+        // Backend may have partially deleted — reload to reconcile UI with
+        // actual server state rather than leaving stale rows.
+        unawaited(_loadCloudAudioConversations());
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text(context.l10n.failedToDeleteAudio), backgroundColor: Colors.red));
+      }
+    } catch (e) {
+      Logger.debug('Error deleting all audio: $e');
+      if (!mounted) return;
+      setState(() {
+        _isDeleting = false;
+      });
+      // Backend state is unknown after an exception — reload to reconcile.
+      unawaited(_loadCloudAudioConversations());
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(context.l10n.failedToDeleteAudio), backgroundColor: Colors.red));
     }
   }
 
@@ -77,10 +380,247 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
     );
   }
 
+  Future<bool?> _showDeleteAllDialog() {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        backgroundColor: const Color(0xFF1C1C1E),
+        shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+        title: Row(
+          children: [
+            const Icon(Icons.warning_amber_rounded, color: Colors.red, size: 24),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                context.l10n.deleteAllAudioTitle,
+                style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+              ),
+            ),
+          ],
+        ),
+        content: Text(
+          context.l10n.deleteAllAudioMessage,
+          style: TextStyle(color: Colors.grey.shade400, fontSize: 14, height: 1.4),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(context.l10n.cancel, style: TextStyle(color: Colors.grey.shade500)),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              context.l10n.deleteAll,
+              style: const TextStyle(color: Colors.red, fontWeight: FontWeight.w600),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
   Widget _buildFaIcon(IconData icon, {double size = 18, Color color = const Color(0xFF8E8E93)}) {
     return Padding(
       padding: const EdgeInsets.only(left: 2, top: 1),
       child: FaIcon(icon, size: size, color: color),
+    );
+  }
+
+  String _formatDuration(double seconds) {
+    final duration = Duration(milliseconds: (seconds * 1000).round());
+    final hours = duration.inHours;
+    final minutes = duration.inMinutes.remainder(60).toString().padLeft(2, '0');
+    final secs = duration.inSeconds.remainder(60).toString().padLeft(2, '0');
+
+    if (hours > 0) {
+      return '$hours:$minutes:$secs';
+    }
+    return '$minutes:$secs';
+  }
+
+  String _formatDate(DateTime? date) {
+    if (date == null) return '';
+
+    final localizations = MaterialLocalizations.of(context);
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final target = DateTime(date.year, date.month, date.day);
+    final diff = today.difference(target).inDays;
+
+    if (diff == 0) return context.l10n.today;
+    if (diff == 1) return context.l10n.yesterday;
+    return localizations.formatMediumDate(date);
+  }
+
+  Widget _buildConversationTile(CloudAudioConversation conversation) {
+    final isSelected = _currentPlayingConversationId == conversation.id;
+    final isPlaying = isSelected && _audioPlayer.playing;
+    final isLoading = _isAudioLoading;
+    final isSelectedLoading = isSelected && _isAudioLoading;
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(14),
+      decoration: BoxDecoration(
+        color: isSelected ? const Color(0xFF2A2A2E).withValues(alpha: 0.8) : const Color(0xFF1C1C1E),
+        borderRadius: BorderRadius.circular(14),
+        border: isSelected ? Border.all(color: Colors.deepPurpleAccent.withValues(alpha: 0.4)) : null,
+      ),
+      child: Row(
+        children: [
+          GestureDetector(
+            onTap: isLoading ? null : () => _playConversationAudio(conversation),
+            child: Container(
+              width: 44,
+              height: 44,
+              decoration: BoxDecoration(
+                color: isSelected ? Colors.deepPurpleAccent : const Color(0xFF2A2A2E),
+                shape: BoxShape.circle,
+              ),
+              child: Center(
+                child: isSelectedLoading
+                    ? const SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(color: Colors.white, strokeWidth: 2),
+                      )
+                    : Icon(isPlaying ? Icons.pause : Icons.play_arrow, color: Colors.white, size: 22),
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  conversation.title,
+                  style: const TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w500),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+                const SizedBox(height: 4),
+                Wrap(
+                  crossAxisAlignment: WrapCrossAlignment.center,
+                  spacing: 8,
+                  children: [
+                    Text(
+                      context.l10n.nAudioFiles(conversation.audioFileCount),
+                      style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                    ),
+                    Text(
+                      _formatDuration(conversation.totalDuration),
+                      style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                    ),
+                    if (conversation.createdAt != null)
+                      Text(
+                        _formatDate(conversation.createdAt),
+                        style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                      ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          IconButton(
+            onPressed: () => _shareConversationAudio(conversation),
+            icon: const Icon(Icons.share_outlined, color: Color(0xFF8E8E93), size: 20),
+            splashRadius: 20,
+            tooltip: context.l10n.shareAudio,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAudioFilesSection(bool isEnabled) {
+    if (!isEnabled) return const SizedBox.shrink();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const SizedBox(height: 24),
+        Container(
+          padding: const EdgeInsets.all(20),
+          decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(20)),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                children: [
+                  _buildFaIcon(FontAwesomeIcons.fileAudio, size: 18, color: Colors.deepPurpleAccent),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text(
+                      context.l10n.cloudAudioFiles,
+                      style: const TextStyle(color: Colors.white, fontSize: 18, fontWeight: FontWeight.w600),
+                    ),
+                  ),
+                  if (!_isDeleting)
+                    TextButton.icon(
+                      onPressed: _deleteAllAudio,
+                      icon: const Icon(Icons.delete_outline, size: 16, color: Colors.red),
+                      label: Text(context.l10n.deleteAllAudio, style: const TextStyle(color: Colors.red, fontSize: 13)),
+                      style: TextButton.styleFrom(
+                        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+                        minimumSize: Size.zero,
+                        tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                      ),
+                    ),
+                ],
+              ),
+              const SizedBox(height: 16),
+              if (_isLoadingAudio || _isDeleting)
+                Center(
+                  child: Padding(
+                    padding: const EdgeInsets.all(20),
+                    child: Column(
+                      children: [
+                        const CircularProgressIndicator(color: Colors.deepPurpleAccent),
+                        if (_isDeleting) ...[
+                          const SizedBox(height: 12),
+                          Text(context.l10n.deletingAudio, style: TextStyle(color: Colors.grey.shade400, fontSize: 14)),
+                        ],
+                      ],
+                    ),
+                  ),
+                )
+              else if (_conversations.isEmpty)
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 24),
+                  child: Center(
+                    child: Column(
+                      children: [
+                        Icon(Icons.cloud_off_outlined, color: Colors.grey.shade600, size: 40),
+                        const SizedBox(height: 12),
+                        Text(
+                          context.l10n.noCloudAudioFiles,
+                          style: TextStyle(color: Colors.grey.shade400, fontSize: 15, fontWeight: FontWeight.w500),
+                        ),
+                        const SizedBox(height: 6),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 24),
+                          child: Text(
+                            context.l10n.noCloudAudioDescription,
+                            style: TextStyle(color: Colors.grey.shade600, fontSize: 13),
+                            textAlign: TextAlign.center,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                )
+              else
+                ListView.builder(
+                  shrinkWrap: true,
+                  physics: const NeverScrollableScrollPhysics(),
+                  itemCount: _conversations.length,
+                  itemBuilder: (context, index) => _buildConversationTile(_conversations[index]),
+                ),
+            ],
+          ),
+        ),
+      ],
     );
   }
 
@@ -139,7 +679,7 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
                                 Container(
                                   padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                                   decoration: BoxDecoration(
-                                    color: isEnabled ? Colors.green.withOpacity(0.2) : const Color(0xFF2A2A2E),
+                                    color: isEnabled ? Colors.green.withValues(alpha: 0.2) : const Color(0xFF2A2A2E),
                                     borderRadius: BorderRadius.circular(100),
                                   ),
                                   child: Text(
@@ -185,6 +725,7 @@ class _PrivateCloudSyncPageState extends State<PrivateCloudSyncPage> {
                           ],
                         ),
                       ),
+                      _buildAudioFilesSection(isEnabled),
                     ],
                   ),
                 ),

--- a/app/lib/services/audio_download_service.dart
+++ b/app/lib/services/audio_download_service.dart
@@ -10,6 +10,12 @@ import 'package:omi/utils/logger.dart';
 
 enum AudioDownloadStage { preparing, downloading, processing }
 
+class DownloadableCloudAudioFile {
+  final String url;
+
+  const DownloadableCloudAudioFile({required this.url});
+}
+
 class AudioDownloadService {
   final http.Client _client = http.Client();
   final List<File> _tempFiles = [];
@@ -90,6 +96,67 @@ class AudioDownloadService {
     }
   }
 
+  Future<File?> downloadAndCombineCloudAudio(
+    String conversationTitle,
+    List<DownloadableCloudAudioFile> audioFiles, {
+    void Function(double)? onProgress,
+    void Function(AudioDownloadStage)? onStageChange,
+  }) async {
+    try {
+      if (audioFiles.isEmpty) {
+        Logger.debug('No downloadable cloud audio files available');
+        return null;
+      }
+
+      onStageChange?.call(AudioDownloadStage.preparing);
+
+      final tempDir = await getTemporaryDirectory();
+      final downloadedFiles = <File>[];
+      var totalProgress = 0.0;
+
+      onStageChange?.call(AudioDownloadStage.downloading);
+
+      for (var i = 0; i < audioFiles.length; i++) {
+        final audioInfo = audioFiles[i];
+        final filename = 'cloud_audio_part_${i + 1}_${DateTime.now().millisecondsSinceEpoch}.wav';
+        final filePath = '${tempDir.path}/$filename';
+
+        final file = await _downloadFile(
+          audioInfo.url,
+          filePath,
+          onProgress: (progress) {
+            totalProgress = (i + progress) / audioFiles.length;
+            onProgress?.call(totalProgress);
+          },
+        );
+
+        downloadedFiles.add(file);
+        _tempFiles.add(file);
+      }
+
+      if (downloadedFiles.isEmpty) {
+        Logger.debug('No cloud audio files were downloaded');
+        return null;
+      }
+
+      if (downloadedFiles.length == 1) {
+        return downloadedFiles.first;
+      }
+
+      onStageChange?.call(AudioDownloadStage.processing);
+
+      final combinedFilename = _generateSafeFilenameFromTitle(conversationTitle);
+      final combinedPath = '${tempDir.path}/$combinedFilename';
+      final combinedFile = await WavCombiner.combineWavFiles(downloadedFiles, combinedPath);
+      _tempFiles.add(combinedFile);
+
+      return combinedFile;
+    } catch (e) {
+      Logger.debug('Error in downloadAndCombineCloudAudio: $e');
+      rethrow;
+    }
+  }
+
   Future<File> _downloadFile(String url, String path, {void Function(double)? onProgress}) async {
     final request = http.Request('GET', Uri.parse(url));
     final response = await _client.send(request);
@@ -122,10 +189,21 @@ class AudioDownloadService {
   }
 
   String _generateSafeFilename(ServerConversation conversation) {
+    return _generateSafeFilenameFromTitle(conversation.structured.title);
+  }
+
+  String _generateSafeFilenameFromTitle(String title) {
     final now = DateTime.now();
     final timestamp =
         '${now.year}${now.month.toString().padLeft(2, '0')}${now.day.toString().padLeft(2, '0')}_${now.hour.toString().padLeft(2, '0')}${now.minute.toString().padLeft(2, '0')}${now.second.toString().padLeft(2, '0')}';
-    return 'omi_$timestamp.wav';
+    final sanitizedTitle = title
+        .trim()
+        .replaceAll(RegExp(r'[^a-zA-Z0-9]+'), '_')
+        .replaceAll(RegExp(r'_+'), '_')
+        .replaceAll(RegExp(r'^_|_$'), '');
+    final boundedTitle = sanitizedTitle.length > 80 ? sanitizedTitle.substring(0, 80) : sanitizedTitle;
+    final prefix = boundedTitle.isEmpty ? 'omi' : boundedTitle.toLowerCase();
+    return '${prefix}_$timestamp.wav';
   }
 
   Future<void> cleanup() async {

--- a/app/test/widgets/private_cloud_sync_page_test.dart
+++ b/app/test/widgets/private_cloud_sync_page_test.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:omi/backend/preferences.dart';
+import 'package:omi/backend/http/api/audio.dart';
+import 'package:omi/l10n/app_localizations.dart';
+import 'package:omi/pages/conversations/private_cloud_sync_page.dart';
+import 'package:omi/providers/user_provider.dart';
+
+class _StubUserProvider extends UserProvider {
+  _StubUserProvider({required this.enabled, this.loading = false});
+
+  final bool enabled;
+  final bool loading;
+
+  @override
+  bool get privateCloudSyncEnabled => enabled;
+
+  @override
+  bool get isLoading => loading;
+}
+
+void main() {
+  setUpAll(() async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    SharedPreferences.setMockInitialValues({});
+    await SharedPreferencesUtil.init();
+  });
+
+  Future<void> _pumpPage(
+    WidgetTester tester,
+    UserProvider userProvider, {
+    Future<List<CloudAudioConversation>> Function()? loadCloudAudioConversations,
+    Future<bool> Function()? deleteAllCloudAudioOverride,
+    Future<bool?> Function(BuildContext context)? confirmDeleteOverride,
+  }) async {
+    await tester.pumpWidget(
+      ChangeNotifierProvider<UserProvider>.value(
+        value: userProvider,
+        child: MaterialApp(
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          home: PrivateCloudSyncPage(
+            loadCloudAudioConversations: loadCloudAudioConversations ?? getCloudAudioConversations,
+            deleteAllCloudAudio: deleteAllCloudAudioOverride ?? deleteAllCloudAudio,
+            confirmDeleteOverride: confirmDeleteOverride,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+  }
+
+  testWidgets('keeps delete-all action visible when cloud sync is enabled and list is empty', (tester) async {
+    final userProvider = _StubUserProvider(enabled: true);
+    addTearDown(userProvider.dispose);
+
+    await _pumpPage(tester, userProvider);
+
+    final context = tester.element(find.byType(PrivateCloudSyncPage));
+    final l10n = AppLocalizations.of(context);
+
+    expect(find.text(l10n.deleteAllAudio), findsOneWidget);
+    expect(find.text(l10n.noCloudAudioFiles), findsOneWidget);
+  });
+
+  testWidgets('ignores stale cloud-audio fetches after delete all succeeds', (tester) async {
+    final userProvider = _StubUserProvider(enabled: true);
+    final loadCompleter = Completer<List<CloudAudioConversation>>();
+    addTearDown(userProvider.dispose);
+
+    await _pumpPage(
+      tester,
+      userProvider,
+      loadCloudAudioConversations: () => loadCompleter.future,
+      deleteAllCloudAudioOverride: () async => true,
+      confirmDeleteOverride: (_) async => true,
+    );
+
+    final context = tester.element(find.byType(PrivateCloudSyncPage));
+    final l10n = AppLocalizations.of(context);
+
+    await tester.tap(find.text(l10n.deleteAllAudio));
+    await tester.pump();
+    await tester.pump();
+
+    loadCompleter.complete([
+      CloudAudioConversation(
+        id: 'conv-1',
+        title: 'Phantom conversation',
+        audioFileCount: 1,
+        totalDuration: 42,
+      ),
+    ]);
+    await tester.pump();
+    await tester.pump();
+
+    expect(find.text('Phantom conversation'), findsNothing);
+    expect(find.text(l10n.noCloudAudioFiles), findsOneWidget);
+  });
+}

--- a/backend/database/conversations.py
+++ b/backend/database/conversations.py
@@ -294,6 +294,27 @@ def iter_all_conversations(uid: str, batch_size: int = 400, include_discarded: b
         offset += batch_size
 
 
+def iter_audio_metadata_conversations(uid: str, batch_size: int = 400, include_discarded: bool = False):
+    """Yield lightweight conversation metadata without hydrating transcript payloads."""
+    conversations_ref = db.collection('users').document(uid).collection(conversations_collection)
+    if not include_discarded:
+        conversations_ref = conversations_ref.where(filter=FieldFilter('discarded', '==', False))
+    conversations_ref = conversations_ref.select(['id', 'created_at', 'audio_files', 'structured.title', 'is_locked'])
+    conversations_ref = conversations_ref.order_by('created_at', direction=firestore.Query.DESCENDING)
+    offset = 0
+    while True:
+        batch_ref = conversations_ref.limit(batch_size).offset(offset)
+        batch = []
+        for doc in batch_ref.stream():
+            conv = doc.to_dict() or {}
+            conv.setdefault('id', doc.id)
+            batch.append(conv)
+        yield from batch
+        if len(batch) < batch_size:
+            break
+        offset += batch_size
+
+
 def update_conversation(uid: str, conversation_id: str, update_data: dict):
     doc_ref = db.collection('users').document(uid).collection(conversations_collection).document(conversation_id)
     doc_snapshot = doc_ref.get()

--- a/backend/routers/sync.py
+++ b/backend/routers/sync.py
@@ -43,6 +43,7 @@ from utils.other.storage import (
     download_audio_chunks_and_merge,
     get_or_create_merged_audio,
     get_merged_audio_signed_url,
+    delete_all_user_cloud_audio,
 )
 
 from utils import encryption
@@ -165,6 +166,95 @@ def _precache_audio_file(uid: str, conversation_id: str, audio_file: dict, fill_
         logger.info(f"Pre-cached audio file: {audio_file_id}")
     except Exception as e:
         logger.error(f"Error pre-caching audio file {audio_file.get('id')}: {e}")
+
+
+@router.get("/v1/sync/audio/conversations", tags=['v1'])
+def list_conversations_with_audio(
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """
+    List all conversations that have cloud-synced audio files.
+    Returns lightweight conversation info (id, title, date, audio file count, total duration).
+    """
+    result = []
+    for conv in conversations_db.iter_audio_metadata_conversations(uid, include_discarded=False):
+        audio_files = conv.get('audio_files') or []
+        if not audio_files or conv.get('is_locked', False):
+            continue
+
+        result.append(
+            {
+                'id': conv.get('id'),
+                'title': (conv.get('structured') or {}).get('title') or 'Untitled',
+                'created_at': conv.get('created_at'),
+                'audio_file_count': len(audio_files),
+                'total_duration': sum((af.get('duration') or 0) for af in audio_files),
+            }
+        )
+
+    result.sort(key=lambda conv: conv.get('created_at') or datetime.min.replace(tzinfo=timezone.utc), reverse=True)
+
+    return {'conversations': result}
+
+
+@router.delete("/v1/sync/audio", tags=['v1'])
+def delete_all_cloud_audio(
+    uid: str = Depends(auth.get_current_user_uid),
+):
+    """
+    Delete all cloud-synced audio files for the current user.
+    This removes audio chunks, merged files, and cached files from cloud storage,
+    and clears the audio_files array from each conversation document.
+    """
+    conversations_to_clear = []
+    cleared_conversations = 0
+    for conv in conversations_db.iter_audio_metadata_conversations(uid, include_discarded=True):
+        if not conv.get('audio_files'):
+            continue
+        conversations_to_clear.append(conv['id'])
+
+    metadata_failures: list[str] = []
+    for conversation_id in conversations_to_clear:
+        try:
+            conversations_db.update_conversation(uid, conversation_id, {'audio_files': []})
+            cleared_conversations += 1
+        except Exception as e:
+            logger.error(f"Failed to clear audio_files for conversation {conversation_id}: {e}")
+            metadata_failures.append(conversation_id)
+
+    # Always attempt blob cleanup even if some metadata clears failed.
+    # Skipping blob deletion on partial metadata failure leaves orphaned blobs in
+    # storage while metadata is already gone — a privacy and cost leak with no
+    # self-healing path.
+    delete_result = delete_all_user_cloud_audio(uid)
+    deleted_count = delete_result['deleted_blobs']
+    failed_blob_count = delete_result['failed_blobs']
+
+    if metadata_failures or failed_blob_count:
+        logger.error(
+            f"delete-all-audio partial failure for user {uid}: "
+            f"metadata_failures={len(metadata_failures)} conversation(s), "
+            f"failed_blobs={failed_blob_count}, deleted_blobs={deleted_count}, "
+            f"cleared_conversations={cleared_conversations}"
+        )
+        raise HTTPException(
+            status_code=503,
+            detail={
+                'message': 'Partial failure during cloud audio deletion.',
+                'deleted_blobs': deleted_count,
+                'failed_blobs': failed_blob_count,
+                'cleared_conversations': cleared_conversations,
+                'failed_metadata_conversations': len(metadata_failures),
+            },
+        )
+
+    logger.info(
+        f"Deleted {deleted_count} cloud audio blobs and cleared {cleared_conversations} conversations for user {uid}"
+    )
+    return {
+        'deleted_blobs': deleted_count,
+        'cleared_conversations': cleared_conversations,
+    }
 
 
 @router.post("/v1/sync/audio/{conversation_id}/precache", tags=['v1'])

--- a/backend/tests/unit/test_private_cloud_sync_audio_management.py
+++ b/backend/tests/unit/test_private_cloud_sync_audio_management.py
@@ -1,0 +1,156 @@
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+from routers import sync
+
+
+def _conversation(idx: int, *, audio_files=None, discarded=False):
+    return {
+        'id': f'conv-{idx}',
+        'structured': {'title': f'Title {idx}'},
+        'created_at': datetime(2026, 1, 1, tzinfo=timezone.utc) + timedelta(minutes=idx),
+        'audio_files': audio_files or [],
+        'discarded': discarded,
+    }
+
+
+def test_list_conversations_with_audio_iterates_all_batches(monkeypatch):
+    conversations = [_conversation(1, audio_files=[])]
+    conversations.extend(_conversation(i, audio_files=[{'duration': 1.5}, {'duration': 2.5}]) for i in range(2, 505))
+
+    iter_mock = MagicMock(return_value=iter(conversations))
+    monkeypatch.setattr(sync.conversations_db, 'iter_audio_metadata_conversations', iter_mock)
+
+    result = sync.list_conversations_with_audio(uid='user-1')
+
+    iter_mock.assert_called_once_with('user-1', include_discarded=False)
+    assert len(result['conversations']) == 503
+    assert result['conversations'][0]['id'] == 'conv-504'
+    assert result['conversations'][0]['audio_file_count'] == 2
+    assert result['conversations'][0]['total_duration'] == 4.0
+    assert result['conversations'][-1]['id'] == 'conv-2'
+
+
+def test_list_conversations_with_audio_skips_locked_conversations(monkeypatch):
+    conversations = [
+        _conversation(1, audio_files=[{'duration': 1.0}], discarded=False),
+        {**_conversation(2, audio_files=[{'duration': 2.0}], discarded=False), 'is_locked': True},
+    ]
+
+    monkeypatch.setattr(
+        sync.conversations_db, 'iter_audio_metadata_conversations', MagicMock(return_value=iter(conversations))
+    )
+
+    result = sync.list_conversations_with_audio(uid='user-1')
+
+    assert [conversation['id'] for conversation in result['conversations']] == ['conv-1']
+
+
+def test_delete_all_cloud_audio_clears_every_matching_conversation(monkeypatch):
+    conversations = [_conversation(i, audio_files=[{'duration': 1.0}]) for i in range(1, 505)]
+    conversations.append(_conversation(999, audio_files=[]))
+
+    iter_mock = MagicMock(return_value=iter(conversations))
+    update_mock = MagicMock()
+    delete_mock = MagicMock(return_value={'deleted_blobs': 77, 'failed_blobs': 0})
+
+    monkeypatch.setattr(sync.conversations_db, 'iter_audio_metadata_conversations', iter_mock)
+    monkeypatch.setattr(sync.conversations_db, 'update_conversation', update_mock)
+    monkeypatch.setattr(sync, 'delete_all_user_cloud_audio', delete_mock)
+
+    result = sync.delete_all_cloud_audio(uid='user-1')
+
+    delete_mock.assert_called_once_with('user-1')
+    iter_mock.assert_called_once_with('user-1', include_discarded=True)
+    assert update_mock.call_count == 504
+    update_mock.assert_any_call('user-1', 'conv-1', {'audio_files': []})
+    update_mock.assert_any_call('user-1', 'conv-504', {'audio_files': []})
+    assert result == {'deleted_blobs': 77, 'cleared_conversations': 504}
+
+
+def test_delete_all_cloud_audio_still_runs_blob_cleanup_when_metadata_clear_fails(monkeypatch):
+    # Blob cleanup must run even when metadata clears fail — skipping it leaves
+    # orphaned blobs after metadata is already gone (privacy + cost leak).
+    conversations = [_conversation(1, audio_files=[{'duration': 1.0}])]
+    iter_mock = MagicMock(return_value=iter(conversations))
+    update_mock = MagicMock(side_effect=RuntimeError('firestore down'))
+    delete_mock = MagicMock(return_value={'deleted_blobs': 0, 'failed_blobs': 0})
+
+    monkeypatch.setattr(sync.conversations_db, 'iter_audio_metadata_conversations', iter_mock)
+    monkeypatch.setattr(sync.conversations_db, 'update_conversation', update_mock)
+    monkeypatch.setattr(sync, 'delete_all_user_cloud_audio', delete_mock)
+
+    with pytest.raises(sync.HTTPException) as exc_info:
+        sync.delete_all_cloud_audio(uid='user-1')
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail['failed_metadata_conversations'] == 1
+    assert exc_info.value.detail['cleared_conversations'] == 0
+    # Blob cleanup must have been attempted despite metadata failure
+    delete_mock.assert_called_once_with('user-1')
+
+
+def test_delete_all_cloud_audio_returns_error_when_blob_delete_partially_fails(monkeypatch):
+    conversations = [_conversation(1, audio_files=[{'duration': 1.0}])]
+
+    monkeypatch.setattr(
+        sync.conversations_db,
+        'iter_audio_metadata_conversations',
+        MagicMock(return_value=iter(conversations)),
+    )
+    monkeypatch.setattr(sync.conversations_db, 'update_conversation', MagicMock())
+    monkeypatch.setattr(
+        sync,
+        'delete_all_user_cloud_audio',
+        MagicMock(return_value={'deleted_blobs': 4, 'failed_blobs': 1}),
+    )
+
+    with pytest.raises(sync.HTTPException) as exc_info:
+        sync.delete_all_cloud_audio(uid='user-1')
+
+    assert exc_info.value.status_code == 503
+    assert exc_info.value.detail == {
+        'message': 'Partial failure during cloud audio deletion.',
+        'deleted_blobs': 4,
+        'failed_blobs': 1,
+        'cleared_conversations': 1,
+        'failed_metadata_conversations': 0,
+    }
+
+
+def test_delete_all_cloud_audio_returns_error_combining_metadata_and_blob_failures(monkeypatch):
+    # 2 conversations: first fails metadata clear, second succeeds.
+    # Blob cleanup runs and also partially fails.
+    # Response must include both failure counts.
+    conversations = [
+        _conversation(1, audio_files=[{'duration': 1.0}]),
+        _conversation(2, audio_files=[{'duration': 2.0}]),
+    ]
+
+    def update_side_effect(uid, conv_id, patch):
+        if conv_id == 'conv-1':
+            raise RuntimeError('firestore timeout')
+
+    monkeypatch.setattr(
+        sync.conversations_db,
+        'iter_audio_metadata_conversations',
+        MagicMock(return_value=iter(conversations)),
+    )
+    monkeypatch.setattr(sync.conversations_db, 'update_conversation', MagicMock(side_effect=update_side_effect))
+    monkeypatch.setattr(
+        sync,
+        'delete_all_user_cloud_audio',
+        MagicMock(return_value={'deleted_blobs': 3, 'failed_blobs': 2}),
+    )
+
+    with pytest.raises(sync.HTTPException) as exc_info:
+        sync.delete_all_cloud_audio(uid='user-1')
+
+    assert exc_info.value.status_code == 503
+    detail = exc_info.value.detail
+    assert detail['failed_metadata_conversations'] == 1
+    assert detail['cleared_conversations'] == 1
+    assert detail['failed_blobs'] == 2
+    assert detail['deleted_blobs'] == 3

--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -649,6 +649,39 @@ def delete_conversation_audio_files(uid: str, conversation_id: str) -> None:
         blob.delete()
 
 
+def delete_all_user_cloud_audio(uid: str) -> dict[str, int]:
+    """Delete all cloud-synced audio blobs for a user.
+
+    Removes raw chunks, per-conversation merged audio, and cached merged assets.
+    Returns the total number of deleted and failed blobs.
+    """
+    bucket = storage_client.bucket(private_cloud_sync_bucket)
+    deleted = 0
+    failed = 0
+
+    for prefix in (f'chunks/{uid}/', f'audio/{uid}/', f'merged/{uid}/'):
+        try:
+            blobs = bucket.list_blobs(prefix=prefix)
+            for blob in blobs:
+                try:
+                    blob.delete()
+                    deleted += 1
+                except Exception as e:
+                    failed += 1
+                    logger.error(f'Failed to delete cloud audio blob {blob.name}: {e}')
+        except Exception as e:
+            failed += 1
+            logger.error(f'Failed to list cloud audio blobs for prefix {prefix}: {e}')
+
+    if failed:
+        logger.warning(f'Failed to delete {failed} cloud audio blobs for user {uid}')
+
+    return {
+        'deleted_blobs': deleted,
+        'failed_blobs': failed,
+    }
+
+
 def download_audio_chunks_and_merge(
     uid: str,
     conversation_id: str,


### PR DESCRIPTION

## Summary

- **Problem:** Private Cloud Sync has no way to list, play, share, or delete cloud audio files, so users cannot manage their stored recordings.
- **What changed:** Added backend endpoints for cloud-audio listing and bulk deletion plus a full management UI in the Private Cloud Sync page. Follow-up fixes guarantee temp-file cleanup during share, block concurrent play dispatch while audio is loading, require all cloud-audio parts to be cached before play/share continues, avoid loading the cloud-audio list when Private Cloud Sync is off, exclude locked conversations from the listing, and clear Firestore metadata before blob deletion.
- **What did NOT change (scope boundary):** No changes to the sync upload flow, no changes to local audio handling, and no changes to the conversation processing pipeline.

## Risk

- **Large diff (+4252 −210):** Mostly l10n auto-regeneration. True code delta is ~9 files / +1139 −13 lines. Reviewers: focus on backend endpoints and the management UI flow.
- **Backend state changes:** DELETE endpoints remove GCS blobs and Firestore metadata. Both operations are idempotent-sequent (delete on non-existent resources is a no-op).
- **Concurrency:** Playback token captured before first `await` to prevent race conditions; delete-all acquires no locks but sequences Firestore → GCS in order.
- **Performance:** Cloud-audio list is paginated server-side; UI loads with skeleton then streams results.

## Testing

- [x] Unit tests pass (`pytest backend/tests/unit/test_private_cloud_sync_audio_management.py`)
- [x] Widget tests pass (`flutter test app/test/widgets/private_cloud_sync_page_test.dart`)
- [x] Lint & format checks pass

## Changes

### Backend
- **`backend/routers/sync.py`** — New endpoints: `GET /cloud-audio` (list all cloud audio with playback URLs) and `DELETE /cloud-audio` (bulk delete by IDs)
- **`backend/database/conversations.py`** — Firestore queries for cloud-audio listing, scoped to non-locked conversations
- **`backend/utils/other/storage.py`** — GCS blob deletion helpers

### Frontend
- **`app/lib/pages/conversations/private_cloud_sync_page.dart`** — Full management UI: audio list, inline player, share action, delete with confirmation
- **`app/lib/services/audio_download_service.dart`** — Handles cloud-audio download and blob URL management
- **`app/lib/backend/http/api/audio.dart`** — HTTP client for new cloud-audio endpoints

### Tests & Dev Experience
- **`backend/tests/unit/test_private_cloud_sync_audio_management.py`** — Unit tests for list and bulk-delete endpoints
- **`app/test/widgets/private_cloud_sync_page_test.dart`** — Widget tests for the management UI
- **`.devcontainer/devcontainer.json`** — Codespaces devcontainer for easy contributor onboarding

## Related

- Closes #3215
