### PR TITLE
feat(plugins): add Google Calendar auto-sync to Omi memories

### DIFF
--- a/plugins/omi-google-calendar-app/main.py
+++ b/plugins/omi-google-calendar-app/main.py
@@ -4,9 +4,11 @@ Google Calendar Integration App for Omi
 This app provides Google Calendar integration through OAuth2 authentication
 and chat tools for managing calendar events.
 """
+import asyncio
 import os
 import sys
 import secrets
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 from typing import Optional, List
 from urllib.parse import urlencode
@@ -16,7 +18,7 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, Request, Query, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 
-from sync import start_auto_sync, stop_auto_sync, sync_user_calendar
+from sync import start_auto_sync, stop_auto_sync, sync_user_calendar, auto_sync_loop
 
 from db import (
     store_google_tokens,
@@ -59,10 +61,50 @@ GOOGLE_SCOPES = [
     "https://www.googleapis.com/auth/userinfo.profile",
 ]
 
+def _get_all_autosync_users():
+    """Return list of uids that have tokens stored (used by auto_sync_loop)."""
+    import os
+    from db import _ensure_data_dir
+    _ensure_data_dir()
+    data_dir = os.getenv("DATA_DIR", "./data")
+    try:
+        tokens_file = os.path.join(data_dir, "google_tokens.json")
+        if not os.path.exists(tokens_file):
+            return []
+        import json
+        with open(tokens_file) as f:
+            data = json.load(f)
+        return list(data.keys())
+    except Exception:
+        return []
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """FastAPI lifespan: start global auto-sync background task on startup."""
+    task = asyncio.create_task(
+        auto_sync_loop(
+            get_valid_access_token,
+            calendar_api_request,
+            get_default_calendar,
+            _get_all_autosync_users,
+        )
+    )
+    log("App: Auto-sync background loop started")
+    yield
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    log("App: Auto-sync background loop stopped")
+
+
 app = FastAPI(
     title="Google Calendar Omi Integration",
     description="Google Calendar integration for Omi - Manage your calendar with chat",
-    version="1.0.0"
+    version="1.0.0",
+    lifespan=lifespan,
 )
 
 
@@ -1317,12 +1359,7 @@ async def trigger_sync(request: Request):
         if not tokens:
             return JSONResponse({"error": "Google Calendar not connected"}, status_code=401)
 
-        # Run sync in thread pool to avoid blocking the event loop
-        import asyncio
-        loop = asyncio.get_event_loop()
-        result = await loop.run_in_executor(
-            None,
-            sync_user_calendar,
+        result = await sync_user_calendar(
             uid,
             get_valid_access_token,
             calendar_api_request,
@@ -1377,12 +1414,7 @@ async def toggle_auto_sync(request: Request):
                 calendar_api_request,
                 get_default_calendar,
             )
-            # Run initial sync in thread pool
-            import asyncio
-            loop = asyncio.get_event_loop()
-            sync_result = await loop.run_in_executor(
-                None,
-                sync_user_calendar,
+            sync_result = await sync_user_calendar(
                 uid,
                 get_valid_access_token,
                 calendar_api_request,

--- a/plugins/omi-google-calendar-app/main.py
+++ b/plugins/omi-google-calendar-app/main.py
@@ -1298,6 +1298,80 @@ def get_css() -> str:
 
 
 # ============================================
+# Calendar Sync Endpoints
+# ============================================
+
+from sync import sync_user_calendar
+
+
+@app.post("/sync", tags=["sync"])
+async def trigger_sync(request: Request):
+    """Manually trigger a calendar sync to push events as Omi memories."""
+    try:
+        body = await request.json()
+        uid = body.get("uid")
+        if not uid:
+            return JSONResponse({"error": "uid is required"}, status_code=400)
+
+        result = sync_user_calendar(
+            uid,
+            get_valid_access_token_fn=get_valid_access_token,
+            calendar_api_request_fn=calendar_api_request,
+            get_default_calendar_fn=get_default_calendar,
+        )
+        return result
+
+    except Exception as e:
+        log(f"Sync error: {e}")
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+@app.get("/sync/status", tags=["sync"])
+async def sync_status(uid: str = Query(...)):
+    """Get sync status for a user."""
+    last_sync = get_user_setting(uid, "last_sync_at")
+    auto_sync = get_user_setting(uid, "auto_sync_enabled")
+    synced_count = len(get_user_setting(uid, "synced_event_ids") or [])
+    return {
+        "last_sync_at": last_sync,
+        "auto_sync_enabled": auto_sync or False,
+        "synced_events": synced_count,
+    }
+
+
+@app.post("/sync/toggle", tags=["sync"])
+async def toggle_auto_sync(request: Request):
+    """Enable or disable automatic sync for a user."""
+    try:
+        body = await request.json()
+        uid = body.get("uid")
+        enabled = body.get("enabled", True)
+        if not uid:
+            return JSONResponse({"error": "uid is required"}, status_code=400)
+
+        store_user_setting(uid, "auto_sync_enabled", enabled)
+        status = "enabled" if enabled else "disabled"
+        log(f"Auto-sync {status} for {uid}")
+
+        result = {"message": f"Auto-sync {status}"}
+
+        if enabled:
+            sync_result = sync_user_calendar(
+                uid,
+                get_valid_access_token_fn=get_valid_access_token,
+                calendar_api_request_fn=calendar_api_request,
+                get_default_calendar_fn=get_default_calendar,
+            )
+            result["initial_sync"] = sync_result
+
+        return result
+
+    except Exception as e:
+        log(f"Toggle sync error: {e}")
+        return JSONResponse({"error": str(e)}, status_code=500)
+
+
+# ============================================
 # Main Entry Point
 # ============================================
 

--- a/plugins/omi-google-calendar-app/main.py
+++ b/plugins/omi-google-calendar-app/main.py
@@ -16,6 +16,8 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, Request, Query, HTTPException
 from fastapi.responses import HTMLResponse, RedirectResponse, JSONResponse
 
+from sync import start_auto_sync, stop_auto_sync, sync_user_calendar
+
 from db import (
     store_google_tokens,
     get_google_tokens,
@@ -1301,9 +1303,6 @@ def get_css() -> str:
 # Calendar Sync Endpoints
 # ============================================
 
-from sync import sync_user_calendar
-
-
 @app.post("/sync", tags=["sync"])
 async def trigger_sync(request: Request):
     """Manually trigger a calendar sync to push events as Omi memories."""
@@ -1313,11 +1312,21 @@ async def trigger_sync(request: Request):
         if not uid:
             return JSONResponse({"error": "uid is required"}, status_code=400)
 
-        result = sync_user_calendar(
+        # Auth check: verify user has connected Google Calendar
+        tokens = get_google_tokens(uid)
+        if not tokens:
+            return JSONResponse({"error": "Google Calendar not connected"}, status_code=401)
+
+        # Run sync in thread pool to avoid blocking the event loop
+        import asyncio
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(
+            None,
+            sync_user_calendar,
             uid,
-            get_valid_access_token_fn=get_valid_access_token,
-            calendar_api_request_fn=calendar_api_request,
-            get_default_calendar_fn=get_default_calendar,
+            get_valid_access_token,
+            calendar_api_request,
+            get_default_calendar,
         )
         return result
 
@@ -1329,6 +1338,11 @@ async def trigger_sync(request: Request):
 @app.get("/sync/status", tags=["sync"])
 async def sync_status(uid: str = Query(...)):
     """Get sync status for a user."""
+    # Auth check: only return status if user has connected
+    tokens = get_google_tokens(uid)
+    if not tokens:
+        return JSONResponse({"error": "Google Calendar not connected"}, status_code=401)
+
     last_sync = get_user_setting(uid, "last_sync_at")
     auto_sync = get_user_setting(uid, "auto_sync_enabled")
     synced_count = len(get_user_setting(uid, "synced_event_ids") or [])
@@ -1349,22 +1363,35 @@ async def toggle_auto_sync(request: Request):
         if not uid:
             return JSONResponse({"error": "uid is required"}, status_code=400)
 
-        store_user_setting(uid, "auto_sync_enabled", enabled)
-        status = "enabled" if enabled else "disabled"
-        log(f"Auto-sync {status} for {uid}")
+        # Auth check: verify user has connected Google Calendar
+        tokens = get_google_tokens(uid)
+        if not tokens:
+            return JSONResponse({"error": "Google Calendar not connected"}, status_code=401)
 
-        result = {"message": f"Auto-sync {status}"}
+        store_user_setting(uid, "auto_sync_enabled", enabled)
 
         if enabled:
-            sync_result = sync_user_calendar(
+            start_auto_sync(
                 uid,
-                get_valid_access_token_fn=get_valid_access_token,
-                calendar_api_request_fn=calendar_api_request,
-                get_default_calendar_fn=get_default_calendar,
+                get_valid_access_token,
+                calendar_api_request,
+                get_default_calendar,
             )
-            result["initial_sync"] = sync_result
-
-        return result
+            # Run initial sync in thread pool
+            import asyncio
+            loop = asyncio.get_event_loop()
+            sync_result = await loop.run_in_executor(
+                None,
+                sync_user_calendar,
+                uid,
+                get_valid_access_token,
+                calendar_api_request,
+                get_default_calendar,
+            )
+            return {"message": "Auto-sync enabled", "initial_sync": sync_result}
+        else:
+            stop_auto_sync(uid)
+            return {"message": "Auto-sync disabled"}
 
     except Exception as e:
         log(f"Toggle sync error: {e}")

--- a/plugins/omi-google-calendar-app/sync.py
+++ b/plugins/omi-google-calendar-app/sync.py
@@ -4,18 +4,12 @@ Google Calendar Auto-Sync Module for Omi.
 Provides automatic synchronization of Google Calendar events into Omi's
 memory system. Events are transformed into natural language memories and
 pushed via the Omi Facts API.
-
-Key features:
-- Periodic background sync (configurable interval)
-- Deduplication via event ID tracking
-- Natural language event formatting
-- Handles token refresh automatically
 """
+import asyncio
 import os
 import sys
-import time
 from datetime import datetime, timedelta
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional, Set
 
 import requests
 
@@ -28,7 +22,7 @@ OMI_API_KEY = os.getenv("OMI_API_KEY", "")
 
 # Sync defaults
 DEFAULT_SYNC_INTERVAL_MINUTES = 30
-MAX_EVENTS_PER_SYNC = 20
+MAX_EVENTS_PER_SYNC = 50
 SYNC_LOOKFORWARD_DAYS = 7
 
 
@@ -104,7 +98,7 @@ def push_memory_to_omi(uid: str, memory_text: str) -> bool:
         response = requests.post(
             url, headers=headers, json=payload, params={"uid": uid}, timeout=10
         )
-        if response.status_code == 200:
+        if response.status_code in (200, 201):
             log(f"Sync: Pushed memory for {uid}: {memory_text[:80]}...")
             return True
         else:
@@ -117,21 +111,15 @@ def push_memory_to_omi(uid: str, memory_text: str) -> bool:
 
 def sync_user_calendar(
     uid: str,
-    get_valid_access_token_fn,
-    calendar_api_request_fn,
-    get_default_calendar_fn,
+    get_valid_access_token_fn: Callable,
+    calendar_api_request_fn: Callable,
+    get_default_calendar_fn: Callable,
 ) -> Dict:
     """
     Sync a user's upcoming Google Calendar events to Omi memories.
 
-    Args:
-        uid: User ID
-        get_valid_access_token_fn: Function to get valid OAuth token
-        calendar_api_request_fn: Function to make Calendar API requests
-        get_default_calendar_fn: Function to get user's default calendar
-
-    Returns:
-        Dict with sync results (success, synced count, skipped count, etc.)
+    Merges new event IDs into the cumulative set of already-synced IDs
+    to prevent duplicate memories across runs.
     """
     log(f"Sync: Starting for user {uid}")
 
@@ -139,9 +127,9 @@ def sync_user_calendar(
     if not access_token:
         return {"success": False, "error": "Not authenticated with Google Calendar"}
 
-    # Load previously synced event IDs for deduplication
+    # Load cumulative set of previously synced event IDs
     stored_ids_raw = get_user_setting(uid, "synced_event_ids")
-    synced_ids = set(stored_ids_raw) if stored_ids_raw else set()
+    synced_ids: Set[str] = set(stored_ids_raw) if stored_ids_raw else set()
 
     calendar_id = get_default_calendar_fn(uid)
     now = datetime.utcnow()
@@ -171,11 +159,9 @@ def sync_user_calendar(
 
     synced = 0
     skipped = 0
-    new_ids: set = set()
 
     for event in events:
         event_id = event.get("id", "")
-        new_ids.add(event_id)
 
         if event_id in synced_ids:
             skipped += 1
@@ -184,13 +170,13 @@ def sync_user_calendar(
         memory_text = format_event_as_memory(event)
         if push_memory_to_omi(uid, memory_text):
             synced += 1
+            synced_ids.add(event_id)
         else:
             log(f"Sync: Failed to push event {event_id}")
 
-        time.sleep(0.3)
-
+    # Persist the merged cumulative set
     store_user_setting(uid, "last_sync_at", datetime.utcnow().isoformat())
-    store_user_setting(uid, "synced_event_ids", list(new_ids))
+    store_user_setting(uid, "synced_event_ids", list(synced_ids))
 
     summary = f"Synced {synced} new events, skipped {skipped} already synced"
     log(f"Sync: Completed for {uid} — {summary}")
@@ -202,3 +188,67 @@ def sync_user_calendar(
         "total_events": len(events),
         "message": summary,
     }
+
+
+# ============================================
+# Background scheduler for auto-sync
+# ============================================
+
+_scheduler_tasks: Dict[str, asyncio.Task] = {}
+
+
+async def _run_periodic_sync(
+    uid: str,
+    interval_minutes: int,
+    get_valid_access_token_fn: Callable,
+    calendar_api_request_fn: Callable,
+    get_default_calendar_fn: Callable,
+):
+    """Background coroutine that syncs a user's calendar on a fixed interval."""
+    log(f"Scheduler: Started periodic sync for {uid} every {interval_minutes}m")
+    while True:
+        await asyncio.sleep(interval_minutes * 60)
+        enabled = get_user_setting(uid, "auto_sync_enabled")
+        if not enabled:
+            log(f"Scheduler: Auto-sync disabled for {uid}, stopping")
+            break
+        try:
+            sync_user_calendar(
+                uid,
+                get_valid_access_token_fn,
+                calendar_api_request_fn,
+                get_default_calendar_fn,
+            )
+        except Exception as e:
+            log(f"Scheduler: Error during periodic sync for {uid}: {e}")
+
+
+def start_auto_sync(
+    uid: str,
+    get_valid_access_token_fn: Callable,
+    calendar_api_request_fn: Callable,
+    get_default_calendar_fn: Callable,
+    interval_minutes: int = DEFAULT_SYNC_INTERVAL_MINUTES,
+):
+    """Start a background auto-sync task for a user."""
+    stop_auto_sync(uid)
+    loop = asyncio.get_event_loop()
+    task = loop.create_task(
+        _run_periodic_sync(
+            uid,
+            interval_minutes,
+            get_valid_access_token_fn,
+            calendar_api_request_fn,
+            get_default_calendar_fn,
+        )
+    )
+    _scheduler_tasks[uid] = task
+    log(f"Scheduler: Auto-sync task created for {uid}")
+
+
+def stop_auto_sync(uid: str):
+    """Cancel a user's background auto-sync task if running."""
+    task = _scheduler_tasks.pop(uid, None)
+    if task and not task.done():
+        task.cancel()
+        log(f"Scheduler: Cancelled auto-sync for {uid}")

--- a/plugins/omi-google-calendar-app/sync.py
+++ b/plugins/omi-google-calendar-app/sync.py
@@ -109,7 +109,7 @@ def push_memory_to_omi(uid: str, memory_text: str) -> bool:
         return False
 
 
-def sync_user_calendar(
+async def sync_user_calendar(
     uid: str,
     get_valid_access_token_fn: Callable,
     calendar_api_request_fn: Callable,
@@ -213,7 +213,7 @@ async def _run_periodic_sync(
             log(f"Scheduler: Auto-sync disabled for {uid}, stopping")
             break
         try:
-            sync_user_calendar(
+            await sync_user_calendar(
                 uid,
                 get_valid_access_token_fn,
                 calendar_api_request_fn,
@@ -252,3 +252,34 @@ def stop_auto_sync(uid: str):
     if task and not task.done():
         task.cancel()
         log(f"Scheduler: Cancelled auto-sync for {uid}")
+
+
+async def auto_sync_loop(
+    get_valid_access_token_fn: Callable,
+    calendar_api_request_fn: Callable,
+    get_default_calendar_fn: Callable,
+    get_all_users_fn: Callable,
+):
+    """
+    Global background task that periodically syncs all users with auto_sync_enabled=True.
+    Register this in the FastAPI app lifespan.
+    """
+    log("AutoSyncLoop: Started global auto-sync background task")
+    while True:
+        await asyncio.sleep(DEFAULT_SYNC_INTERVAL_MINUTES * 60)
+        try:
+            users = get_all_users_fn()
+            for uid in users:
+                enabled = get_user_setting(uid, "auto_sync_enabled")
+                if enabled:
+                    try:
+                        await sync_user_calendar(
+                            uid,
+                            get_valid_access_token_fn,
+                            calendar_api_request_fn,
+                            get_default_calendar_fn,
+                        )
+                    except Exception as e:
+                        log(f"AutoSyncLoop: Error syncing {uid}: {e}")
+        except Exception as e:
+            log(f"AutoSyncLoop: Error during loop iteration: {e}")

--- a/plugins/omi-google-calendar-app/sync.py
+++ b/plugins/omi-google-calendar-app/sync.py
@@ -1,0 +1,204 @@
+"""
+Google Calendar Auto-Sync Module for Omi.
+
+Provides automatic synchronization of Google Calendar events into Omi's
+memory system. Events are transformed into natural language memories and
+pushed via the Omi Facts API.
+
+Key features:
+- Periodic background sync (configurable interval)
+- Deduplication via event ID tracking
+- Natural language event formatting
+- Handles token refresh automatically
+"""
+import os
+import sys
+import time
+from datetime import datetime, timedelta
+from typing import Dict, List, Optional
+
+import requests
+
+from db import get_user_setting, store_user_setting
+
+# Omi Facts API configuration
+OMI_API_BASE = os.getenv("OMI_API_BASE", "https://api.omi.me/v2")
+OMI_APP_ID = os.getenv("OMI_APP_ID", "")
+OMI_API_KEY = os.getenv("OMI_API_KEY", "")
+
+# Sync defaults
+DEFAULT_SYNC_INTERVAL_MINUTES = 30
+MAX_EVENTS_PER_SYNC = 20
+SYNC_LOOKFORWARD_DAYS = 7
+
+
+def log(msg: str):
+    """Print and flush for Railway/production logging."""
+    print(msg)
+    sys.stdout.flush()
+
+
+def format_event_as_memory(event: dict) -> str:
+    """
+    Transform a Google Calendar event into a natural language memory string
+    suitable for Omi's memory system.
+    """
+    summary = event.get("summary", "Untitled event")
+    start = event.get("start", {})
+    end = event.get("end", {})
+    location = event.get("location", "")
+    description = event.get("description", "")
+    attendees = event.get("attendees", [])
+
+    if "date" in start:
+        time_str = f"all day on {start['date']}"
+    else:
+        start_dt_str = start.get("dateTime", "")
+        end_dt_str = end.get("dateTime", "")
+        try:
+            start_parsed = datetime.fromisoformat(start_dt_str.replace("Z", "+00:00"))
+            end_parsed = datetime.fromisoformat(end_dt_str.replace("Z", "+00:00"))
+            date_str = start_parsed.strftime("%B %d, %Y")
+            start_time = start_parsed.strftime("%I:%M %p")
+            end_time = end_parsed.strftime("%I:%M %p")
+            time_str = f"on {date_str} from {start_time} to {end_time}"
+        except Exception:
+            time_str = f"at {start_dt_str}"
+
+    parts = [f"Calendar event: {summary} {time_str}"]
+
+    if location:
+        parts.append(f"Location: {location}")
+
+    if attendees:
+        emails = [a.get("email", "") for a in attendees[:5] if a.get("email")]
+        if emails:
+            parts.append(f"With: {', '.join(emails)}")
+
+    if description:
+        desc_clean = description[:200].strip().replace("\n", " ")
+        if desc_clean:
+            parts.append(f"Notes: {desc_clean}")
+
+    return ". ".join(parts)
+
+
+def push_memory_to_omi(uid: str, memory_text: str) -> bool:
+    """Push a single memory to the Omi Facts API."""
+    if not OMI_APP_ID or not OMI_API_KEY:
+        log("Sync: OMI_APP_ID or OMI_API_KEY not configured, skipping push")
+        return False
+
+    url = f"{OMI_API_BASE}/integrations/{OMI_APP_ID}/user/facts"
+    headers = {
+        "Authorization": f"Bearer {OMI_API_KEY}",
+        "Content-Type": "application/json",
+    }
+    payload = {
+        "text": memory_text,
+        "text_source": "integration",
+        "text_source_spec": "google_calendar_sync",
+    }
+
+    try:
+        response = requests.post(
+            url, headers=headers, json=payload, params={"uid": uid}, timeout=10
+        )
+        if response.status_code == 200:
+            log(f"Sync: Pushed memory for {uid}: {memory_text[:80]}...")
+            return True
+        else:
+            log(f"Sync: Push failed {response.status_code}: {response.text[:200]}")
+            return False
+    except Exception as e:
+        log(f"Sync: Error pushing memory: {e}")
+        return False
+
+
+def sync_user_calendar(
+    uid: str,
+    get_valid_access_token_fn,
+    calendar_api_request_fn,
+    get_default_calendar_fn,
+) -> Dict:
+    """
+    Sync a user's upcoming Google Calendar events to Omi memories.
+
+    Args:
+        uid: User ID
+        get_valid_access_token_fn: Function to get valid OAuth token
+        calendar_api_request_fn: Function to make Calendar API requests
+        get_default_calendar_fn: Function to get user's default calendar
+
+    Returns:
+        Dict with sync results (success, synced count, skipped count, etc.)
+    """
+    log(f"Sync: Starting for user {uid}")
+
+    access_token = get_valid_access_token_fn(uid)
+    if not access_token:
+        return {"success": False, "error": "Not authenticated with Google Calendar"}
+
+    # Load previously synced event IDs for deduplication
+    stored_ids_raw = get_user_setting(uid, "synced_event_ids")
+    synced_ids = set(stored_ids_raw) if stored_ids_raw else set()
+
+    calendar_id = get_default_calendar_fn(uid)
+    now = datetime.utcnow()
+    time_min = now.isoformat() + "Z"
+    time_max = (now + timedelta(days=SYNC_LOOKFORWARD_DAYS)).isoformat() + "Z"
+
+    result = calendar_api_request_fn(
+        uid,
+        "GET",
+        f"/calendars/{calendar_id}/events",
+        params={
+            "timeMin": time_min,
+            "timeMax": time_max,
+            "maxResults": MAX_EVENTS_PER_SYNC,
+            "singleEvents": True,
+            "orderBy": "startTime",
+        },
+    )
+
+    if not result or "error" in result:
+        error_msg = result.get("error", "Unknown error") if result else "No response"
+        return {"success": False, "error": f"Failed to fetch events: {error_msg}"}
+
+    events = result.get("items", [])
+    if not events:
+        return {"success": True, "synced": 0, "skipped": 0, "message": "No upcoming events"}
+
+    synced = 0
+    skipped = 0
+    new_ids: set = set()
+
+    for event in events:
+        event_id = event.get("id", "")
+        new_ids.add(event_id)
+
+        if event_id in synced_ids:
+            skipped += 1
+            continue
+
+        memory_text = format_event_as_memory(event)
+        if push_memory_to_omi(uid, memory_text):
+            synced += 1
+        else:
+            log(f"Sync: Failed to push event {event_id}")
+
+        time.sleep(0.3)
+
+    store_user_setting(uid, "last_sync_at", datetime.utcnow().isoformat())
+    store_user_setting(uid, "synced_event_ids", list(new_ids))
+
+    summary = f"Synced {synced} new events, skipped {skipped} already synced"
+    log(f"Sync: Completed for {uid} — {summary}")
+
+    return {
+        "success": True,
+        "synced": synced,
+        "skipped": skipped,
+        "total_events": len(events),
+        "message": summary,
+    }


### PR DESCRIPTION
## Google Calendar Auto-Sync for Omi

/claim #1980

### What this PR does

Adds **automatic synchronization** of Google Calendar events into Omi's memory system. Unlike the previous manual-import attempts (#2131, #2654), this implementation provides continuous, hands-free sync.

### Changes

**New file: `plugins/omi-google-calendar-app/sync.py`**
- Background sync module that fetches upcoming calendar events
- Transforms events into natural language memories (e.g., "Calendar event: Team standup on March 31, 2026 from 09:00 AM to 09:30 AM. With: alice@company.com, bob@company.com")
- Pushes memories to Omi's Facts API (`/v2/integrations/{app_id}/user/facts`)
- Deduplication via event ID tracking — won't re-sync events already pushed
- Configurable: sync interval, lookforward window, max events per sync

**Modified: `plugins/omi-google-calendar-app/main.py`**
- Added `POST /sync` — manually trigger a sync
- Added `GET /sync/status` — check last sync time and status
- Added `POST /sync/toggle` — enable/disable auto-sync (triggers initial sync on enable)

### Why previous PRs failed

- **#2131**: Rejected because it was a one-time manual import. @beastoin specifically asked for automatic sync, not manual.
- **#2654**: Abandoned — incomplete implementation, no demo video.

This PR addresses both issues: it's automatic (not manual) and the sync module is cleanly separated for easy review.

### How it works

1. User connects Google Calendar via existing OAuth flow (already built)
2. User enables auto-sync via `POST /sync/toggle` or triggers manual sync via `POST /sync`
3. Sync fetches upcoming events (next 7 days by default)
4. Each new event is transformed into a natural language memory string
5. Memories are pushed to Omi via the Facts API
6. Event IDs are tracked to prevent duplicates on next sync

### Environment variables needed

- `OMI_APP_ID` — App ID from Omi developer console
- `OMI_API_KEY` — API key for the Omi Facts API

### Demo

Demo video will be provided shortly — setting up OAuth credentials for a live test.
