### PR TITLE
Enable rate limit enforcement after 48h clean shadow mode

### DIFF
--- a/backend/tests/unit/test_rate_limiting.py
+++ b/backend/tests/unit/test_rate_limiting.py
@@ -118,15 +118,15 @@ class TestBoostFactor(unittest.TestCase):
 class TestShadowMode(unittest.TestCase):
     """Test shadow mode env var parsing."""
 
-    def test_shadow_mode_default_on(self):
-        """Shadow mode defaults to ON (safe rollout — set RATE_LIMIT_SHADOW_MODE=false to enforce)."""
+    def test_shadow_mode_default_off(self):
+        """Shadow mode defaults to OFF (enforcement active — set RATE_LIMIT_SHADOW_MODE=true for shadow)."""
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("RATE_LIMIT_SHADOW_MODE", None)
             import utils.rate_limit_config as rlc
 
             importlib.reload(rlc)
             self.assertIsInstance(rlc.RATE_LIMIT_SHADOW, bool)
-            self.assertTrue(rlc.RATE_LIMIT_SHADOW)
+            self.assertFalse(rlc.RATE_LIMIT_SHADOW)
         importlib.reload(rlc)
 
     def test_shadow_mode_env_true(self):

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -10,8 +10,8 @@ Tuning knobs:
         Set > 1.0 during events to relax limits, < 1.0 to tighten.
         Read from env var RATE_LIMIT_BOOST at startup.
 
-    RATE_LIMIT_SHADOW: defaults ON (shadow/log-only). Set env var
-        RATE_LIMIT_SHADOW_MODE=false to enable enforcement (429 rejections).
+    RATE_LIMIT_SHADOW: defaults OFF (enforcement/429 rejections). Set env var
+        RATE_LIMIT_SHADOW_MODE=true to revert to shadow/log-only mode.
 
 Redis efficiency:
     Each check = 1 Lua script call (atomic INCR + TTL check).
@@ -25,7 +25,7 @@ import os
 # ---------------------------------------------------------------------------
 
 RATE_LIMIT_BOOST: float = float(os.getenv("RATE_LIMIT_BOOST", "1.0"))
-RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "true").lower() != "false"
+RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "false").lower() != "false"
 
 # ---------------------------------------------------------------------------
 # Policies: "name" -> (max_requests, window_seconds)
@@ -36,7 +36,7 @@ RATE_LIMIT_SHADOW: bool = os.getenv("RATE_LIMIT_SHADOW_MODE", "true").lower() !=
 
 RATE_POLICIES: dict[str, tuple[int, int]] = {
     # Conversations — each triggers ~22 OpenAI calls
-    "conversations:create": (8, 3600),
+    "conversations:create": (10, 3600),
     "conversations:reprocess": (3, 3600),
     "conversations:merge": (5, 3600),
     # Chat — 2-6 LLM calls per message


### PR DESCRIPTION
## Summary
- Enable rate limit enforcement by default (shadow mode → active 429 rejections)
- Bump `conversations:create` limit from 8/hr → 10/hr to accommodate power users

## Context
PR #5836 deployed per-UID rate limiting in **shadow mode** (log-only, no blocking). After 48h of production monitoring:

- **297 total shadow events** across 24 policies — only 3 policies triggered
- **0 Redis errors**, atomic Lua scripts stable across 20 pods
- **45 unique UIDs** observed, 2 power users generated 60% of all events
- **21 of 24 policies** had zero shadow events (comfortable headroom)

### Shadow event breakdown
| Policy | Events | Users | Analysis |
|--------|--------|-------|----------|
| `conversations:reprocess` (3/hr) | 149 | 29 | 1 user = 102 hits (automated retry loop) |
| `conversations:create` (8→10/hr) | 126 | 18 | 1 user = 73 hits (automated creation) |
| `knowledge_graph:rebuild` (2/hr) | 22 | 16 | Evenly spread, 1-2 hits each |

### Why bump conversations:create to 10/hr
- 8/hr could catch legitimate batch import workflows
- 10/hr still blocks the abuser (73 hits/48h) while giving normal power users headroom
- All other limits validated by shadow data — no changes needed

## Safety
- **Revert to shadow:** Set `RATE_LIMIT_SHADOW_MODE=true` env var (no code change needed)
- **Emergency relax:** Set `RATE_LIMIT_BOOST=2.0` to instantly double all limits
- **Fail-open:** Redis errors allow requests through (no blocking on infra failure)

## Test plan
- [x] 50 unit tests pass (policy validation, boost, enforcement, shadow mode, router wiring)
- [x] Shadow mode default test updated to expect `False` (enforcement active)
- [ ] Post-deploy: monitor 429 response rate for first 24h
- [ ] Verify no spike in user-facing errors

Closes #5835

_by AI for @beastoin_