### PR TITLE
Update CHANGELOG.json for v0.11.202 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,9 +1,14 @@
 {
-  "unreleased": [
-    "Fixed WebSocket transcription disconnects: proper handshake detection, audio buffering during reconnection, unlimited retry with backoff, and thread-safe connection state",
-    "Fixed UI freezes caused by dock tile updates when receiving support messages"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.202",
+      "date": "2026-03-31",
+      "changes": [
+        "Fixed WebSocket transcription disconnects: proper handshake detection, audio buffering during reconnection, unlimited retry with backoff, and thread-safe connection state",
+        "Fixed UI freezes caused by dock tile updates when receiving support messages"
+      ]
+    },
     {
       "version": "0.11.200",
       "date": "2026-03-31",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.202 and clears the unreleased array.