### PR TITLE
Update CHANGELOG.json for v0.11.203 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed batch transcription failing on long speech (50s+) by splitting large audio chunks automatically"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.203",
+      "date": "2026-03-31",
+      "changes": [
+        "Fixed batch transcription failing on long speech (50s+) by splitting large audio chunks automatically"
+      ]
+    },
     {
       "version": "0.11.202",
       "date": "2026-03-31",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.203 and clears the unreleased array.