### PR TITLE
Update CHANGELOG.json for v0.11.206 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed floating bar follow-up input not auto-focusing when restoring a conversation"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.206",
+      "date": "2026-04-01",
+      "changes": [
+        "Fixed floating bar follow-up input not auto-focusing when restoring a conversation"
+      ]
+    },
     {
       "version": "0.11.205",
       "date": "2026-03-31",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.206 and clears the unreleased array.