### PR TITLE
fix: Gracefully handle missing speech profiles bucket

### DIFF
--- a/backend/utils/other/storage.py
+++ b/backend/utils/other/storage.py
@@ -51,7 +51,7 @@ if os.environ.get('SERVICE_ACCOUNT_JSON'):
 else:
     storage_client = storage.Client()
 
-speech_profiles_bucket = os.getenv('BUCKET_SPEECH_PROFILES')
+speech_profiles_bucket = (os.getenv('BUCKET_SPEECH_PROFILES') or '').strip() or None
 postprocessing_audio_bucket = os.getenv('BUCKET_POSTPROCESSING')
 memories_recordings_bucket = os.getenv('BUCKET_MEMORIES_RECORDINGS')
 private_cloud_sync_bucket = os.getenv('BUCKET_PRIVATE_CLOUD_SYNC', 'omi-private-cloud-sync')
@@ -61,12 +61,30 @@ app_thumbnails_bucket = os.getenv('BUCKET_APP_THUMBNAILS')
 chat_files_bucket = os.getenv('BUCKET_CHAT_FILES')
 desktop_updates_bucket = os.getenv('BUCKET_DESKTOP_UPDATES')
 
+_did_warn_missing_speech_profiles_bucket = False
+
+
+def _get_speech_profiles_bucket(required: bool = False):
+    global _did_warn_missing_speech_profiles_bucket
+
+    if speech_profiles_bucket:
+        return storage_client.bucket(speech_profiles_bucket)
+
+    if not _did_warn_missing_speech_profiles_bucket:
+        logger.warning('BUCKET_SPEECH_PROFILES is not configured; speech profile storage is disabled')
+        _did_warn_missing_speech_profiles_bucket = True
+
+    if required:
+        raise RuntimeError('BUCKET_SPEECH_PROFILES is not configured')
+
+    return None
+
 
 # *******************************************
 # ************* SPEECH PROFILE **************
 # *******************************************
 def upload_profile_audio(file_path: str, uid: str):
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket(required=True)
     path = f'{uid}/speech_profile.wav'
     blob = bucket.blob(path)
     blob.upload_from_filename(file_path)
@@ -74,7 +92,10 @@ def upload_profile_audio(file_path: str, uid: str):
 
 
 def get_user_has_speech_profile(uid: str, max_age_days: int = None) -> bool:
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return False
+
     blob = bucket.blob(f'{uid}/speech_profile.wav')
     if not blob.exists():
         return False
@@ -91,7 +112,10 @@ def get_user_has_speech_profile(uid: str, max_age_days: int = None) -> bool:
 
 
 def get_profile_audio_if_exists(uid: str, download: bool = True) -> str:
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return None
+
     path = f'{uid}/speech_profile.wav'
     blob = bucket.blob(path)
     if blob.exists():
@@ -105,7 +129,10 @@ def get_profile_audio_if_exists(uid: str, download: bool = True) -> str:
 
 
 def delete_additional_profile_audio(uid: str, file_name: str) -> None:
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return
+
     blob = bucket.blob(f'{uid}/additional_profile_recordings/{file_name}')
     if blob.exists():
         logger.info(f'delete_additional_profile_audio deleting {file_name}')
@@ -113,7 +140,10 @@ def delete_additional_profile_audio(uid: str, file_name: str) -> None:
 
 
 def get_additional_profile_recordings(uid: str, download: bool = False) -> List[str]:
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return []
+
     blobs = bucket.list_blobs(prefix=f'{uid}/additional_profile_recordings/')
     if download:
         paths = []
@@ -132,14 +162,20 @@ def get_additional_profile_recordings(uid: str, download: bool = False) -> List[
 
 
 def delete_user_person_speech_sample(uid: str, person_id: str, file_name: str) -> None:
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return
+
     blob = bucket.blob(f'{uid}/people_profiles/{person_id}/{file_name}')
     if blob.exists():
         blob.delete()
 
 
 def delete_user_person_speech_samples(uid: str, person_id: str) -> None:
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return
+
     blobs = bucket.list_blobs(prefix=f'{uid}/people_profiles/{person_id}/')
     for blob in blobs:
         blob.delete()
@@ -161,7 +197,7 @@ def upload_person_speech_sample_from_bytes(
         wav_file.setframerate(sample_rate)
         wav_file.writeframes(audio_bytes)
 
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket(required=True)
     filename = f"{uuid_module.uuid4()}.wav"
     path = f'{uid}/people_profiles/{person_id}/{filename}'
     blob = bucket.blob(path)
@@ -171,13 +207,19 @@ def upload_person_speech_sample_from_bytes(
 
 
 def get_user_people_ids(uid: str) -> List[str]:
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return []
+
     blobs = bucket.list_blobs(prefix=f'{uid}/people_profiles/')
     return [blob.name.split("/")[-2] for blob in blobs]
 
 
 def get_user_person_speech_samples(uid: str, person_id: str, download: bool = False) -> List[str]:
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return []
+
     blobs = bucket.list_blobs(prefix=f'{uid}/people_profiles/{person_id}/')
     if download:
         paths = []
@@ -203,7 +245,10 @@ def get_speech_sample_signed_urls(paths: List[str]) -> List[str]:
     """
     if not paths:
         return []
-    bucket = storage_client.bucket(speech_profiles_bucket)
+    bucket = _get_speech_profiles_bucket()
+    if bucket is None:
+        return []
+
     signed_urls = []
     for path in paths:
         blob = bucket.blob(path)
@@ -1129,6 +1174,8 @@ def download_speech_profile_bytes(path: str) -> bytes:
     Raises:
         NotFound: If the sample doesn't exist
     """
+    if not speech_profiles_bucket:
+        raise BlobNotFound('Speech profile storage is not configured')
     return download_blob_bytes(speech_profiles_bucket, path)
 
 
@@ -1142,6 +1189,8 @@ def delete_speech_profile_blob(path: str) -> bool:
     Returns:
         True if deleted, False if not found
     """
+    if not speech_profiles_bucket:
+        return False
     return delete_blob(speech_profiles_bucket, path)
 
 


### PR DESCRIPTION
Fully tested e2e

<img width="995" height="77" alt="Bildschirmfoto 2026-04-01 um 02 18 58" src="https://github.com/user-attachments/assets/e2a08fa2-e789-40f5-aec4-c24950aa6d2e" />


This pull request improves the robustness and error handling of all speech profile storage operations in `backend/utils/other/storage.py`. It introduces a helper function to safely access the speech profiles bucket, adds warnings and explicit error messages when the bucket is not configured, and ensures that all relevant functions gracefully handle missing configuration instead of failing unexpectedly.

**Speech profile bucket access and error handling:**

* Added the `_get_speech_profiles_bucket` helper function to centralize logic for accessing the `speech_profiles_bucket`, including warning logging and raising errors when required. All speech profile functions now use this helper to prevent failures when the bucket is not configured.
* Updated all speech profile-related functions (such as `upload_profile_audio`, `get_user_has_speech_profile`, `get_profile_audio_if_exists`, etc.) to use `_get_speech_profiles_bucket` and handle missing bucket configuration gracefully by returning early or raising informative exceptions. [[1]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40R51-R85) [[2]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40L81-R105) [[3]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40L95-R140) [[4]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40L129-R179) [[5]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40L152-R191) [[6]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40L174-R213) [[7]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40L184-R235) [[8]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40L216-R264)
* Added explicit error raising in `download_speech_profile_bytes` and safe return in `delete_speech_profile_blob` if the speech profiles bucket is not configured, improving clarity and preventing silent failures. [[1]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40R1138-R1139) [[2]](diffhunk://#diff-d49776c1d9f6e82320c6294565513d519c8bee17c96afcfa863b8e0dc37a8d40R1153-R1154)

**Environment variable handling:**

* Improved the parsing of the `BUCKET_SPEECH_PROFILES` environment variable to correctly handle empty or whitespace-only values, ensuring the configuration is robust against misconfiguration.