### PR TITLE
Fix speaker profile extraction: conv_id race on rollover + chunk misroute

### DIFF
--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -406,9 +406,9 @@ async def _websocket_util_trigger(
                     res = json.loads(bytes(data[4:]).decode("utf-8"))
                     segments = res.get('segments')
                     memory_id = res.get('memory_id')
-                    # Update conversation_id from transcript if provided
-                    if memory_id:
-                        current_conversation_id = memory_id
+                    # Do NOT overwrite current_conversation_id from memory_id here —
+                    # the authoritative source is header_type 103. Overwriting corrupts
+                    # private cloud sync chunk paths (#6190 Bug 2).
                     if len(transcript_queue) >= TRANSCRIPT_QUEUE_WARN_SIZE:
                         logger.warning(f"Warning: transcript_queue size {len(transcript_queue)} {uid}")
                     # Use memory_id if available, otherwise use current_conversation_id for conversations

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -29,6 +29,7 @@ from utils.webhooks import (
 )
 from utils.other.storage import upload_audio_chunk, upload_audio_chunks_batch
 from utils.metrics import PUSHER_ACTIVE_WS_CONNECTIONS
+from utils.speaker_assignment import resolve_transcript_conversation_id
 from utils.speaker_identification import extract_speaker_samples
 import logging
 
@@ -411,8 +412,7 @@ async def _websocket_util_trigger(
                     # private cloud sync chunk paths (#6190 Bug 2).
                     if len(transcript_queue) >= TRANSCRIPT_QUEUE_WARN_SIZE:
                         logger.warning(f"Warning: transcript_queue size {len(transcript_queue)} {uid}")
-                    # Use memory_id if available, otherwise use current_conversation_id for conversations
-                    conversation_or_memory_id = memory_id or current_conversation_id
+                    conversation_or_memory_id = resolve_transcript_conversation_id(memory_id, current_conversation_id)
                     transcript_queue.append({'segments': segments, 'memory_id': conversation_or_memory_id})
                     continue
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -30,6 +30,7 @@ from firebase_admin.auth import InvalidIdTokenError
 
 from utils.speaker_assignment import (
     process_speaker_assigned_segments,
+    resolve_conversation_for_segments,
     update_speaker_assignment_maps,
     should_update_speaker_to_person_map,
 )
@@ -2518,15 +2519,9 @@ async def _stream_handler(
                                 # Forward to pusher for speech sample extraction (non-blocking)
                                 # Only for real people (not 'user') and when private cloud sync is enabled
                                 # Only when can_assign is true (has speech_profile_processed segment)
-                                # Use segment_conversation_map to resolve the conversation the segments
-                                # actually belong to — current_conversation_id may have advanced on rollover.
-                                # Iterate all segment_ids to find a mapped conv — first ID may be unknown/stale.
-                                sample_conv_id = current_conversation_id
-                                for sid in segment_ids:
-                                    mapped = segment_conversation_map.get(sid)
-                                    if mapped:
-                                        sample_conv_id = mapped
-                                        break
+                                sample_conv_id = resolve_conversation_for_segments(
+                                    segment_ids, segment_conversation_map, current_conversation_id
+                                )
                                 if (
                                     can_assign
                                     and person_id

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2520,11 +2520,13 @@ async def _stream_handler(
                                 # Only when can_assign is true (has speech_profile_processed segment)
                                 # Use segment_conversation_map to resolve the conversation the segments
                                 # actually belong to — current_conversation_id may have advanced on rollover.
-                                sample_conv_id = (
-                                    segment_conversation_map.get(segment_ids[0], current_conversation_id)
-                                    if segment_ids
-                                    else current_conversation_id
-                                )
+                                # Iterate all segment_ids to find a mapped conv — first ID may be unknown/stale.
+                                sample_conv_id = current_conversation_id
+                                for sid in segment_ids:
+                                    mapped = segment_conversation_map.get(sid)
+                                    if mapped:
+                                        sample_conv_id = mapped
+                                        break
                                 if (
                                     can_assign
                                     and person_id

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -402,6 +402,7 @@ async def _stream_handler(
     speaker_to_person_map: Dict[int, Tuple[str, str]] = {}
     segment_person_assignment_map: Dict[str, str] = {}
     current_session_segments: Dict[str, bool] = {}  # Store only speech_profile_processed status
+    segment_conversation_map: Dict[str, str] = {}  # segment_id → conversation_id snapshot (prevents race on rollover)
     suggested_segments: Set[str] = set()
     first_audio_byte_timestamp: Optional[float] = None
     last_usage_record_timestamp: Optional[float] = None
@@ -2079,6 +2080,7 @@ async def _stream_handler(
 
                 for seg in newly_processed_segments:
                     current_session_segments[seg.id] = seg.speech_profile_processed
+                    segment_conversation_map[seg.id] = current_conversation_id
                 transcript_segments, _, _ = TranscriptSegment.combine_segments([], newly_processed_segments)
 
             # Update transcript segments
@@ -2516,18 +2518,25 @@ async def _stream_handler(
                                 # Forward to pusher for speech sample extraction (non-blocking)
                                 # Only for real people (not 'user') and when private cloud sync is enabled
                                 # Only when can_assign is true (has speech_profile_processed segment)
+                                # Use segment_conversation_map to resolve the conversation the segments
+                                # actually belong to — current_conversation_id may have advanced on rollover.
+                                sample_conv_id = (
+                                    segment_conversation_map.get(segment_ids[0], current_conversation_id)
+                                    if segment_ids
+                                    else current_conversation_id
+                                )
                                 if (
                                     can_assign
                                     and person_id
                                     and person_id != 'user'
                                     and private_cloud_sync_enabled
                                     and send_speaker_sample_request is not None
-                                    and current_conversation_id
+                                    and sample_conv_id
                                 ):
                                     spawn(
                                         send_speaker_sample_request(
                                             person_id=person_id,
-                                            conv_id=current_conversation_id,
+                                            conv_id=sample_conv_id,
                                             segment_ids=segment_ids,
                                         )
                                     )

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -1826,6 +1826,14 @@ async def _stream_handler(
 
             buffer_start_ts, buffer_end_ts = time_range
 
+            # Log timing inputs for clock-source alignment analysis (#6190)
+            logger.info(
+                f"Speaker ID timing: seg_abs=[{seg_start:.3f},{seg_end:.3f}] "
+                f"buf=[{buffer_start_ts:.3f},{buffer_end_ts:.3f}] "
+                f"drift_start={seg_start - buffer_start_ts:.3f}s drift_end={seg_end - buffer_end_ts:.3f}s "
+                f"duration={duration:.2f}s {uid} {session_id}"
+            )
+
             # Calculate extraction range - stay within segment bounds, max 10 seconds from center
             MAX_EXTRACT_DURATION = 10.0
 
@@ -1841,18 +1849,26 @@ async def _stream_handler(
                 extract_end = center + half_duration
 
             # Clamp to buffer availability
+            pre_clamp_duration = extract_end - extract_start
             extract_start = max(buffer_start_ts, extract_start)
             extract_end = min(buffer_end_ts, extract_end)
 
             if extract_end <= extract_start:
-                logger.info(f"Speaker ID: no audio to extract {uid} {session_id}")
+                logger.info(
+                    f"Speaker ID: no audio to extract "
+                    f"(pre_clamp={pre_clamp_duration:.2f}s, clamped_range=[{extract_start:.3f},{extract_end:.3f}]) "
+                    f"{uid} {session_id}"
+                )
                 return
 
             # Reject clips too short for speaker embedding (issue #4572)
             extracted_duration = extract_end - extract_start
             if extracted_duration < SPEAKER_ID_MIN_AUDIO:
                 logger.info(
-                    f"Speaker ID: extracted audio too short ({extracted_duration:.2f}s < {SPEAKER_ID_MIN_AUDIO}s) after buffer clamping {uid} {session_id}"
+                    f"Speaker ID: extracted audio too short ({extracted_duration:.2f}s < {SPEAKER_ID_MIN_AUDIO}s) "
+                    f"after buffer clamping (pre_clamp={pre_clamp_duration:.2f}s, "
+                    f"start_clipped={seg_start < buffer_start_ts}, end_clipped={seg_end > buffer_end_ts}) "
+                    f"{uid} {session_id}"
                 )
                 return
 

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -2093,6 +2093,8 @@ async def _stream_handler(
 
             if removed_ids:
                 _send_message_event(SegmentsDeletedEvent(segment_ids=removed_ids))
+                for rid in removed_ids:
+                    segment_conversation_map.pop(rid, None)
 
             if transcript_segments:
                 await websocket.send_json([segment.dict() for segment in updated_segments])
@@ -2746,6 +2748,7 @@ async def _stream_handler(
             speaker_to_person_map.clear()
             segment_person_assignment_map.clear()
             current_session_segments.clear()
+            segment_conversation_map.clear()
             suggested_segments.clear()
             realtime_segment_buffers.clear()
             realtime_photo_buffers.clear()

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -16,6 +16,7 @@ pytest tests/unit/test_users_add_sample_transaction.py -v
 pytest tests/unit/test_voice_message_language.py -v
 pytest tests/unit/test_speaker_assignment.py -v
 pytest tests/unit/test_speaker_id_pipeline.py -v
+pytest tests/unit/test_conv_id_race.py -v
 pytest tests/unit/test_user_speaker_embedding.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v

--- a/backend/tests/unit/test_conv_id_race.py
+++ b/backend/tests/unit/test_conv_id_race.py
@@ -71,6 +71,35 @@ class TestSegmentConversationMap:
         assert segment_conversation_map.get('seg-1', current_conversation_id) == 'conv-A'
         assert segment_conversation_map.get('seg-3', current_conversation_id) == 'conv-B'
 
+    def test_mixed_segment_ids_first_unknown_resolves_from_later(self):
+        """If first segment_id is unknown but later ones are in the map, resolve correctly."""
+        segment_conversation_map = {'seg-2': 'conv-A', 'seg-3': 'conv-A'}
+        current_conversation_id = 'conv-B'
+
+        segment_ids = ['unknown-seg', 'seg-2', 'seg-3']
+        # Iterate all segment_ids to find a mapped conv (mirrors fix in transcribe.py)
+        sample_conv_id = current_conversation_id
+        for sid in segment_ids:
+            mapped = segment_conversation_map.get(sid)
+            if mapped:
+                sample_conv_id = mapped
+                break
+        assert sample_conv_id == 'conv-A'
+
+    def test_all_unknown_segments_fall_back_to_current(self):
+        """If no segment_ids are in the map, fall back to current_conversation_id."""
+        segment_conversation_map = {'seg-1': 'conv-A'}
+        current_conversation_id = 'conv-B'
+
+        segment_ids = ['unknown-1', 'unknown-2']
+        sample_conv_id = current_conversation_id
+        for sid in segment_ids:
+            mapped = segment_conversation_map.get(sid)
+            if mapped:
+                sample_conv_id = mapped
+                break
+        assert sample_conv_id == 'conv-B'
+
     def test_map_populated_at_segment_creation(self):
         """Verify the map is populated when segments are first processed, not later."""
         segment_conversation_map = {}

--- a/backend/tests/unit/test_conv_id_race.py
+++ b/backend/tests/unit/test_conv_id_race.py
@@ -9,7 +9,7 @@ Bug 2: Pusher header_type 102 must not overwrite current_conversation_id
 import json
 import struct
 
-from utils.speaker_assignment import resolve_conversation_for_segments
+from utils.speaker_assignment import resolve_conversation_for_segments, resolve_transcript_conversation_id
 
 
 class TestResolveConversationForSegments:
@@ -103,54 +103,74 @@ class TestSegmentConversationMapPopulation:
         assert resolve_conversation_for_segments(['seg-1'], segment_conversation_map, 'conv-B') == 'conv-A'
         assert resolve_conversation_for_segments(['seg-3'], segment_conversation_map, 'conv-B') == 'conv-B'
 
+    def test_removed_ids_pruned_from_map(self):
+        """Merged/removed segment IDs should be pruned from the map."""
+        segment_conversation_map = {'seg-1': 'conv-A', 'seg-2': 'conv-A', 'seg-3': 'conv-A'}
+        removed_ids = ['seg-1', 'seg-2']
+        for rid in removed_ids:
+            segment_conversation_map.pop(rid, None)
+        assert segment_conversation_map == {'seg-3': 'conv-A'}
 
-class TestPusherMemoryIdOverwrite:
-    """Tests that header_type 102 no longer overwrites current_conversation_id."""
 
-    def _parse_header_102(self, data):
-        """Parse a header_type 102 message."""
-        header_type = struct.unpack('<I', data[:4])[0]
-        assert header_type == 102
-        return json.loads(bytes(data[4:]).decode('utf-8'))
+class TestResolveTranscriptConversationId:
+    """Tests for the production resolve_transcript_conversation_id function (Bug 2)."""
 
-    def test_header_102_does_not_overwrite_conversation_id(self):
-        """memory_id in transcript should NOT change current_conversation_id."""
+    def test_memory_id_returned_when_present(self):
+        """memory_id should be used for transcript queue, not current_conversation_id."""
+        result = resolve_transcript_conversation_id('conv-B', 'conv-A')
+        assert result == 'conv-B'
+
+    def test_current_used_when_memory_id_none(self):
+        """Without memory_id, should fall back to current_conversation_id."""
+        result = resolve_transcript_conversation_id(None, 'conv-A')
+        assert result == 'conv-A'
+
+    def test_current_used_when_memory_id_empty(self):
+        """Empty string memory_id should fall back to current_conversation_id."""
+        result = resolve_transcript_conversation_id('', 'conv-A')
+        assert result == 'conv-A'
+
+    def test_does_not_mutate_current_conversation_id(self):
+        """Calling resolve_transcript_conversation_id must not change the caller's state.
+
+        This tests the contract: header_type 102 must not overwrite
+        current_conversation_id. The function returns the resolved value
+        without side effects."""
+        current_conversation_id = 'conv-A'
+        conversation_or_memory_id = resolve_transcript_conversation_id('conv-B', current_conversation_id)
+        assert current_conversation_id == 'conv-A'
+        assert conversation_or_memory_id == 'conv-B'
+
+    def test_both_none(self):
+        """When both are None, returns None."""
+        result = resolve_transcript_conversation_id(None, None)
+        assert result is None
+
+    def test_header_103_is_only_authority(self):
+        """header_type 103 is the only way to change current_conversation_id.
+
+        resolve_transcript_conversation_id never mutates the caller's ID."""
         current_conversation_id = 'conv-A'
 
-        # Build a 102 message with memory_id
-        payload = json.dumps({'segments': [], 'memory_id': 'conv-B'}).encode('utf-8')
-        data = struct.pack('<I', 102) + payload
-        res = self._parse_header_102(data)
+        # header_type 102 arrives with memory_id 'conv-B'
+        transcript_conv = resolve_transcript_conversation_id('conv-B', current_conversation_id)
+        assert transcript_conv == 'conv-B'
+        assert current_conversation_id == 'conv-A'  # unchanged
 
-        memory_id = res.get('memory_id')
-        # The fix: we do NOT overwrite current_conversation_id
-        # (removed: if memory_id: current_conversation_id = memory_id)
-        conversation_or_memory_id = memory_id or current_conversation_id
-        assert current_conversation_id == 'conv-A'  # must stay unchanged
-        assert conversation_or_memory_id == 'conv-B'  # transcript queue uses memory_id
-
-    def test_header_102_without_memory_id_uses_current(self):
-        """Without memory_id, transcript queue should use current_conversation_id."""
-        current_conversation_id = 'conv-A'
-
-        payload = json.dumps({'segments': [{'text': 'hello'}]}).encode('utf-8')
-        data = struct.pack('<I', 102) + payload
-        res = self._parse_header_102(data)
-
-        memory_id = res.get('memory_id')
-        conversation_or_memory_id = memory_id or current_conversation_id
-        assert conversation_or_memory_id == 'conv-A'
+        # header_type 103 is the only authority (done by caller)
+        current_conversation_id = 'conv-C'
+        assert current_conversation_id == 'conv-C'
 
     def test_private_cloud_chunks_use_authoritative_conv_id(self):
-        """Private cloud sync chunks must always use the header_type 103 conversation ID."""
+        """Private cloud sync chunks must use the header_type 103 conversation ID,
+        not the memory_id from 102."""
         current_conversation_id = 'conv-A'
         private_cloud_queue = []
 
-        # Simulate header_type 102 with different memory_id
-        memory_id = 'conv-B'
-        # Fix: we do NOT overwrite current_conversation_id
+        # header_type 102 arrives but does NOT change current_conversation_id
+        resolve_transcript_conversation_id('conv-B', current_conversation_id)
 
-        # Simulate header_type 101 audio chunk queuing
+        # Private cloud chunk uses current_conversation_id (from 103)
         private_cloud_queue.append(
             {
                 'data': b'\x00' * 100,
@@ -159,23 +179,4 @@ class TestPusherMemoryIdOverwrite:
                 'retries': 0,
             }
         )
-
         assert private_cloud_queue[0]['conversation_id'] == 'conv-A'
-
-    def test_header_103_is_authoritative(self):
-        """header_type 103 should be the only way to change current_conversation_id."""
-        current_conversation_id = None
-
-        # Header 103 sets it
-        new_conversation_id = 'conv-A'
-        current_conversation_id = new_conversation_id
-        assert current_conversation_id == 'conv-A'
-
-        # Header 102 with memory_id must NOT change it
-        memory_id = 'conv-B'
-        # (no overwrite)
-        assert current_conversation_id == 'conv-A'
-
-        # Header 103 with new ID changes it
-        current_conversation_id = 'conv-C'
-        assert current_conversation_id == 'conv-C'

--- a/backend/tests/unit/test_conv_id_race.py
+++ b/backend/tests/unit/test_conv_id_race.py
@@ -9,96 +9,65 @@ Bug 2: Pusher header_type 102 must not overwrite current_conversation_id
 import json
 import struct
 
+from utils.speaker_assignment import resolve_conversation_for_segments
 
-class TestSegmentConversationMap:
-    """Tests that segment_conversation_map resolves the correct conversation
-    for speaker sample requests, even after conversation rollover."""
+
+class TestResolveConversationForSegments:
+    """Tests for the production resolve_conversation_for_segments function."""
 
     def test_segment_maps_to_original_conversation(self):
         """Segments created in conv-A should map to conv-A even after rollover to conv-B."""
-        segment_conversation_map = {}
-        current_conversation_id = 'conv-A'
-
-        # Simulate segment creation in conv-A
-        segments = [{'id': 'seg-1'}, {'id': 'seg-2'}, {'id': 'seg-3'}]
-        for seg in segments:
-            segment_conversation_map[seg['id']] = current_conversation_id
-
-        # Simulate rollover
-        current_conversation_id = 'conv-B'
-
-        # speaker_assigned comes back — should resolve to conv-A, not conv-B
-        segment_ids = ['seg-1', 'seg-2']
-        sample_conv_id = segment_conversation_map.get(segment_ids[0], current_conversation_id)
-        assert sample_conv_id == 'conv-A'
+        segment_conversation_map = {'seg-1': 'conv-A', 'seg-2': 'conv-A', 'seg-3': 'conv-A'}
+        result = resolve_conversation_for_segments(['seg-1', 'seg-2'], segment_conversation_map, 'conv-B')
+        assert result == 'conv-A'
 
     def test_fallback_to_current_when_segment_unknown(self):
         """If segment not in map (edge case), fall back to current_conversation_id."""
-        segment_conversation_map = {}
-        current_conversation_id = 'conv-B'
-
-        segment_ids = ['unknown-seg']
-        sample_conv_id = segment_conversation_map.get(segment_ids[0], current_conversation_id)
-        assert sample_conv_id == 'conv-B'
+        result = resolve_conversation_for_segments(['unknown-seg'], {}, 'conv-B')
+        assert result == 'conv-B'
 
     def test_empty_segment_ids_uses_current(self):
         """Empty segment_ids should use current_conversation_id."""
-        segment_conversation_map = {'seg-1': 'conv-A'}
-        current_conversation_id = 'conv-B'
-
-        segment_ids = []
-        sample_conv_id = (
-            segment_conversation_map.get(segment_ids[0], current_conversation_id)
-            if segment_ids
-            else current_conversation_id
-        )
-        assert sample_conv_id == 'conv-B'
+        result = resolve_conversation_for_segments([], {'seg-1': 'conv-A'}, 'conv-B')
+        assert result == 'conv-B'
 
     def test_segments_across_two_conversations(self):
         """Segments from different conversations should each resolve correctly."""
-        segment_conversation_map = {}
-
-        # Conv-A segments
-        current_conversation_id = 'conv-A'
-        for sid in ['seg-1', 'seg-2']:
-            segment_conversation_map[sid] = current_conversation_id
-
-        # Rollover
-        current_conversation_id = 'conv-B'
-        for sid in ['seg-3', 'seg-4']:
-            segment_conversation_map[sid] = current_conversation_id
-
-        assert segment_conversation_map.get('seg-1', current_conversation_id) == 'conv-A'
-        assert segment_conversation_map.get('seg-3', current_conversation_id) == 'conv-B'
+        segment_conversation_map = {
+            'seg-1': 'conv-A',
+            'seg-2': 'conv-A',
+            'seg-3': 'conv-B',
+            'seg-4': 'conv-B',
+        }
+        assert resolve_conversation_for_segments(['seg-1'], segment_conversation_map, 'conv-B') == 'conv-A'
+        assert resolve_conversation_for_segments(['seg-3'], segment_conversation_map, 'conv-B') == 'conv-B'
 
     def test_mixed_segment_ids_first_unknown_resolves_from_later(self):
         """If first segment_id is unknown but later ones are in the map, resolve correctly."""
         segment_conversation_map = {'seg-2': 'conv-A', 'seg-3': 'conv-A'}
-        current_conversation_id = 'conv-B'
-
-        segment_ids = ['unknown-seg', 'seg-2', 'seg-3']
-        # Iterate all segment_ids to find a mapped conv (mirrors fix in transcribe.py)
-        sample_conv_id = current_conversation_id
-        for sid in segment_ids:
-            mapped = segment_conversation_map.get(sid)
-            if mapped:
-                sample_conv_id = mapped
-                break
-        assert sample_conv_id == 'conv-A'
+        result = resolve_conversation_for_segments(
+            ['unknown-seg', 'seg-2', 'seg-3'], segment_conversation_map, 'conv-B'
+        )
+        assert result == 'conv-A'
 
     def test_all_unknown_segments_fall_back_to_current(self):
         """If no segment_ids are in the map, fall back to current_conversation_id."""
-        segment_conversation_map = {'seg-1': 'conv-A'}
-        current_conversation_id = 'conv-B'
+        result = resolve_conversation_for_segments(['unknown-1', 'unknown-2'], {'seg-1': 'conv-A'}, 'conv-B')
+        assert result == 'conv-B'
 
-        segment_ids = ['unknown-1', 'unknown-2']
-        sample_conv_id = current_conversation_id
-        for sid in segment_ids:
-            mapped = segment_conversation_map.get(sid)
-            if mapped:
-                sample_conv_id = mapped
-                break
-        assert sample_conv_id == 'conv-B'
+    def test_none_current_conversation_id(self):
+        """When current_conversation_id is None and no match, returns None."""
+        result = resolve_conversation_for_segments(['unknown'], {}, None)
+        assert result is None
+
+    def test_none_current_but_mapped(self):
+        """When current_conversation_id is None but segment is mapped, returns mapped value."""
+        result = resolve_conversation_for_segments(['seg-1'], {'seg-1': 'conv-A'}, None)
+        assert result == 'conv-A'
+
+
+class TestSegmentConversationMapPopulation:
+    """Tests that segment_conversation_map is populated correctly at segment creation."""
 
     def test_map_populated_at_segment_creation(self):
         """Verify the map is populated when segments are first processed, not later."""
@@ -117,6 +86,22 @@ class TestSegmentConversationMap:
 
         assert segment_conversation_map == {'seg-1': 'conv-A', 'seg-2': 'conv-A'}
         assert current_session_segments == {'seg-1': True, 'seg-2': False}
+
+    def test_map_snapshots_correct_conv_across_rollover(self):
+        """Segments populated before and after rollover map to their respective conversations."""
+        segment_conversation_map = {}
+
+        current_conversation_id = 'conv-A'
+        for sid in ['seg-1', 'seg-2']:
+            segment_conversation_map[sid] = current_conversation_id
+
+        current_conversation_id = 'conv-B'
+        for sid in ['seg-3', 'seg-4']:
+            segment_conversation_map[sid] = current_conversation_id
+
+        # Now use the production function to resolve
+        assert resolve_conversation_for_segments(['seg-1'], segment_conversation_map, 'conv-B') == 'conv-A'
+        assert resolve_conversation_for_segments(['seg-3'], segment_conversation_map, 'conv-B') == 'conv-B'
 
 
 class TestPusherMemoryIdOverwrite:

--- a/backend/tests/unit/test_conv_id_race.py
+++ b/backend/tests/unit/test_conv_id_race.py
@@ -1,0 +1,167 @@
+"""Unit tests for conversation_id race condition fixes (#6190).
+
+Bug 1: segment_conversation_map prevents stale current_conversation_id
+        from being used in speaker_assigned handler after rollover.
+Bug 2: Pusher header_type 102 must not overwrite current_conversation_id
+        from memory_id — only header_type 103 is authoritative.
+"""
+
+import json
+import struct
+
+
+class TestSegmentConversationMap:
+    """Tests that segment_conversation_map resolves the correct conversation
+    for speaker sample requests, even after conversation rollover."""
+
+    def test_segment_maps_to_original_conversation(self):
+        """Segments created in conv-A should map to conv-A even after rollover to conv-B."""
+        segment_conversation_map = {}
+        current_conversation_id = 'conv-A'
+
+        # Simulate segment creation in conv-A
+        segments = [{'id': 'seg-1'}, {'id': 'seg-2'}, {'id': 'seg-3'}]
+        for seg in segments:
+            segment_conversation_map[seg['id']] = current_conversation_id
+
+        # Simulate rollover
+        current_conversation_id = 'conv-B'
+
+        # speaker_assigned comes back — should resolve to conv-A, not conv-B
+        segment_ids = ['seg-1', 'seg-2']
+        sample_conv_id = segment_conversation_map.get(segment_ids[0], current_conversation_id)
+        assert sample_conv_id == 'conv-A'
+
+    def test_fallback_to_current_when_segment_unknown(self):
+        """If segment not in map (edge case), fall back to current_conversation_id."""
+        segment_conversation_map = {}
+        current_conversation_id = 'conv-B'
+
+        segment_ids = ['unknown-seg']
+        sample_conv_id = segment_conversation_map.get(segment_ids[0], current_conversation_id)
+        assert sample_conv_id == 'conv-B'
+
+    def test_empty_segment_ids_uses_current(self):
+        """Empty segment_ids should use current_conversation_id."""
+        segment_conversation_map = {'seg-1': 'conv-A'}
+        current_conversation_id = 'conv-B'
+
+        segment_ids = []
+        sample_conv_id = (
+            segment_conversation_map.get(segment_ids[0], current_conversation_id)
+            if segment_ids
+            else current_conversation_id
+        )
+        assert sample_conv_id == 'conv-B'
+
+    def test_segments_across_two_conversations(self):
+        """Segments from different conversations should each resolve correctly."""
+        segment_conversation_map = {}
+
+        # Conv-A segments
+        current_conversation_id = 'conv-A'
+        for sid in ['seg-1', 'seg-2']:
+            segment_conversation_map[sid] = current_conversation_id
+
+        # Rollover
+        current_conversation_id = 'conv-B'
+        for sid in ['seg-3', 'seg-4']:
+            segment_conversation_map[sid] = current_conversation_id
+
+        assert segment_conversation_map.get('seg-1', current_conversation_id) == 'conv-A'
+        assert segment_conversation_map.get('seg-3', current_conversation_id) == 'conv-B'
+
+    def test_map_populated_at_segment_creation(self):
+        """Verify the map is populated when segments are first processed, not later."""
+        segment_conversation_map = {}
+        current_session_segments = {}
+        current_conversation_id = 'conv-A'
+
+        # Simulate newly_processed_segments loop (mirrors transcribe.py)
+        segments = [
+            type('Seg', (), {'id': 'seg-1', 'speech_profile_processed': True})(),
+            type('Seg', (), {'id': 'seg-2', 'speech_profile_processed': False})(),
+        ]
+        for seg in segments:
+            current_session_segments[seg.id] = seg.speech_profile_processed
+            segment_conversation_map[seg.id] = current_conversation_id
+
+        assert segment_conversation_map == {'seg-1': 'conv-A', 'seg-2': 'conv-A'}
+        assert current_session_segments == {'seg-1': True, 'seg-2': False}
+
+
+class TestPusherMemoryIdOverwrite:
+    """Tests that header_type 102 no longer overwrites current_conversation_id."""
+
+    def _parse_header_102(self, data):
+        """Parse a header_type 102 message."""
+        header_type = struct.unpack('<I', data[:4])[0]
+        assert header_type == 102
+        return json.loads(bytes(data[4:]).decode('utf-8'))
+
+    def test_header_102_does_not_overwrite_conversation_id(self):
+        """memory_id in transcript should NOT change current_conversation_id."""
+        current_conversation_id = 'conv-A'
+
+        # Build a 102 message with memory_id
+        payload = json.dumps({'segments': [], 'memory_id': 'conv-B'}).encode('utf-8')
+        data = struct.pack('<I', 102) + payload
+        res = self._parse_header_102(data)
+
+        memory_id = res.get('memory_id')
+        # The fix: we do NOT overwrite current_conversation_id
+        # (removed: if memory_id: current_conversation_id = memory_id)
+        conversation_or_memory_id = memory_id or current_conversation_id
+        assert current_conversation_id == 'conv-A'  # must stay unchanged
+        assert conversation_or_memory_id == 'conv-B'  # transcript queue uses memory_id
+
+    def test_header_102_without_memory_id_uses_current(self):
+        """Without memory_id, transcript queue should use current_conversation_id."""
+        current_conversation_id = 'conv-A'
+
+        payload = json.dumps({'segments': [{'text': 'hello'}]}).encode('utf-8')
+        data = struct.pack('<I', 102) + payload
+        res = self._parse_header_102(data)
+
+        memory_id = res.get('memory_id')
+        conversation_or_memory_id = memory_id or current_conversation_id
+        assert conversation_or_memory_id == 'conv-A'
+
+    def test_private_cloud_chunks_use_authoritative_conv_id(self):
+        """Private cloud sync chunks must always use the header_type 103 conversation ID."""
+        current_conversation_id = 'conv-A'
+        private_cloud_queue = []
+
+        # Simulate header_type 102 with different memory_id
+        memory_id = 'conv-B'
+        # Fix: we do NOT overwrite current_conversation_id
+
+        # Simulate header_type 101 audio chunk queuing
+        private_cloud_queue.append(
+            {
+                'data': b'\x00' * 100,
+                'conversation_id': current_conversation_id,
+                'timestamp': 1234567890.0,
+                'retries': 0,
+            }
+        )
+
+        assert private_cloud_queue[0]['conversation_id'] == 'conv-A'
+
+    def test_header_103_is_authoritative(self):
+        """header_type 103 should be the only way to change current_conversation_id."""
+        current_conversation_id = None
+
+        # Header 103 sets it
+        new_conversation_id = 'conv-A'
+        current_conversation_id = new_conversation_id
+        assert current_conversation_id == 'conv-A'
+
+        # Header 102 with memory_id must NOT change it
+        memory_id = 'conv-B'
+        # (no overwrite)
+        assert current_conversation_id == 'conv-A'
+
+        # Header 103 with new ID changes it
+        current_conversation_id = 'conv-C'
+        assert current_conversation_id == 'conv-C'

--- a/backend/tests/unit/test_listen_pipeline.py
+++ b/backend/tests/unit/test_listen_pipeline.py
@@ -636,13 +636,10 @@ class TestPusherHeaderDemux:
     def test_header_102_memory_id_does_not_overwrite_conversation_id(self):
         """header_type 102 must NOT overwrite current_conversation_id (#6190 Bug 2).
         Only header_type 103 is authoritative for conversation tracking."""
+        from utils.speaker_assignment import resolve_transcript_conversation_id
+
         current_conversation_id = 'old-conv'
-        payload = {'segments': [], 'memory_id': 'new-conv-from-memory'}
-        res = payload
-        memory_id = res.get('memory_id')
-        # Fix: do NOT overwrite current_conversation_id from memory_id
-        # Transcript queue uses memory_id independently via conversation_or_memory_id
-        conversation_or_memory_id = memory_id or current_conversation_id
+        conversation_or_memory_id = resolve_transcript_conversation_id('new-conv-from-memory', current_conversation_id)
         assert current_conversation_id == 'old-conv'  # must stay unchanged
         assert conversation_or_memory_id == 'new-conv-from-memory'  # transcript queue uses memory_id
 

--- a/backend/tests/unit/test_listen_pipeline.py
+++ b/backend/tests/unit/test_listen_pipeline.py
@@ -633,15 +633,18 @@ class TestPusherHeaderDemux:
         assert len(private_cloud_queue[0]['data']) == 500
         assert len(private_cloud_sync_buffer) == 0
 
-    def test_flaw_header_102_memory_id_updates_conversation_id(self):
-        """FLAW TEST: memory_id in transcript should update current_conversation_id."""
+    def test_header_102_memory_id_does_not_overwrite_conversation_id(self):
+        """header_type 102 must NOT overwrite current_conversation_id (#6190 Bug 2).
+        Only header_type 103 is authoritative for conversation tracking."""
         current_conversation_id = 'old-conv'
         payload = {'segments': [], 'memory_id': 'new-conv-from-memory'}
         res = payload
         memory_id = res.get('memory_id')
-        if memory_id:
-            current_conversation_id = memory_id
-        assert current_conversation_id == 'new-conv-from-memory'
+        # Fix: do NOT overwrite current_conversation_id from memory_id
+        # Transcript queue uses memory_id independently via conversation_or_memory_id
+        conversation_or_memory_id = memory_id or current_conversation_id
+        assert current_conversation_id == 'old-conv'  # must stay unchanged
+        assert conversation_or_memory_id == 'new-conv-from-memory'  # transcript queue uses memory_id
 
 
 # ===================================================================

--- a/backend/utils/speaker_assignment.py
+++ b/backend/utils/speaker_assignment.py
@@ -76,6 +76,36 @@ def update_speaker_assignment_maps(
     return True
 
 
+def resolve_conversation_for_segments(
+    segment_ids: List[str],
+    segment_conversation_map: Dict[str, str],
+    current_conversation_id: Optional[str],
+) -> Optional[str]:
+    """Resolve which conversation a set of segments belongs to.
+
+    After conversation rollover, current_conversation_id points to the NEW
+    conversation, but speaker_assigned responses may reference segments from
+    the PREVIOUS conversation.  segment_conversation_map snapshots which
+    conversation each segment was created in.
+
+    Iterates all segment_ids (not just the first) because the first ID may
+    be unknown/stale.
+
+    Args:
+        segment_ids: Segment IDs from the speaker_assigned event.
+        segment_conversation_map: segment_id → conversation_id snapshot.
+        current_conversation_id: Fallback when no segment is in the map.
+
+    Returns:
+        The resolved conversation ID, or current_conversation_id as fallback.
+    """
+    for sid in segment_ids:
+        mapped = segment_conversation_map.get(sid)
+        if mapped:
+            return mapped
+    return current_conversation_id
+
+
 def should_update_speaker_to_person_map(speaker_id: Optional[int]) -> bool:
     """Check if speaker_to_person_map should be updated for text detection.
 

--- a/backend/utils/speaker_assignment.py
+++ b/backend/utils/speaker_assignment.py
@@ -106,6 +106,26 @@ def resolve_conversation_for_segments(
     return current_conversation_id
 
 
+def resolve_transcript_conversation_id(
+    memory_id: Optional[str],
+    current_conversation_id: Optional[str],
+) -> Optional[str]:
+    """Resolve the conversation ID for a transcript queue entry.
+
+    header_type 102 carries an optional memory_id that identifies which
+    conversation the transcript belongs to.  This must NOT overwrite
+    current_conversation_id (which is set only by header_type 103).
+
+    Args:
+        memory_id: The memory_id from the 102 payload (may be None).
+        current_conversation_id: The authoritative conversation ID from 103.
+
+    Returns:
+        memory_id if present, otherwise current_conversation_id.
+    """
+    return memory_id or current_conversation_id
+
+
 def should_update_speaker_to_person_map(speaker_id: Optional[int]) -> bool:
     """Check if speaker_to_person_map should be updated for text detection.
 

--- a/backend/utils/speaker_identification.py
+++ b/backend/utils/speaker_identification.py
@@ -360,6 +360,17 @@ async def extract_speaker_samples(
             abs_start = started_at_ts + sample_start
             abs_end = started_at_ts + sample_end
 
+            # Log timing inputs for clock-source alignment analysis (#6190)
+            chunk_ts_range = (
+                (min(c['timestamp'] for c in chunks), max(c['timestamp'] for c in chunks)) if chunks else (0, 0)
+            )
+            logger.info(
+                f"Speaker sample timing: seg_rel=[{segment_start:.3f},{segment_end:.3f}] "
+                f"abs=[{abs_start:.3f},{abs_end:.3f}] started_at_ts={started_at_ts:.3f} "
+                f"chunk_range=[{chunk_ts_range[0]:.3f},{chunk_ts_range[1]:.3f}] "
+                f"n_chunks={len(chunks)} {uid} {conversation_id}"
+            )
+
             # Find relevant chunks
             sorted_chunks = sorted(chunks, key=lambda c: c['timestamp'])
 
@@ -381,7 +392,8 @@ async def extract_speaker_samples(
 
             if not relevant_timestamps:
                 logger.info(
-                    f"No relevant chunks for segment {segment_start:.1f}-{segment_end:.1f}s {uid} {conversation_id}"
+                    f"No relevant chunks for segment {segment_start:.1f}-{segment_end:.1f}s "
+                    f"abs=[{abs_start:.3f},{abs_end:.3f}] {uid} {conversation_id}"
                 )
                 continue
 
@@ -399,7 +411,15 @@ async def extract_speaker_samples(
             # Use av for sample-accurate trimming
             trim_start = abs_start - buffer_start
             trim_end = abs_end - buffer_start
+            merged_duration = len(merged) / (sample_rate * 2) if merged else 0
             sample_audio = _trim_pcm_audio(merged, sample_rate, trim_start, trim_end)
+            sample_duration = len(sample_audio) / (sample_rate * 2) if sample_audio else 0
+
+            logger.info(
+                f"Speaker sample trim: merged={merged_duration:.2f}s "
+                f"trim=[{trim_start:.3f},{trim_end:.3f}] result={sample_duration:.2f}s "
+                f"buffer_start={buffer_start:.3f} {uid} {conversation_id}"
+            )
 
             # Ensure minimum sample length (8 seconds)
             min_sample_seconds = 8.0


### PR DESCRIPTION
Fixes #6190.

**Scope change**: Original issue diagnosed conv_id race + memory_id overwrite as root cause. Prod evidence (from mon) shows the symptom (containment=0.23, audio too short 1.39s) is real but the root cause is a timestamp alignment bug — three different clock sources for the same audio. This PR now includes:

1. **Observability logging** (new) — adds timing telemetry to both extraction paths to confirm the clock-source misalignment hypothesis before attempting a behavioral fix:
   - `transcribe.py`: logs segment abs_start/abs_end, ring buffer range, drift, and clamp details
   - `speaker_identification.py`: logs abs timestamps, GCS chunk range, trim window, and extracted duration

2. **Defensive hardening** (original) — conv_id race fix and memory_id overwrite removal are still included as correct code hardening, but are not the prod root cause:
   - `resolve_conversation_for_segments()` in `utils/speaker_assignment.py`
   - `resolve_transcript_conversation_id()` in `utils/speaker_assignment.py`
   - `segment_conversation_map` lifecycle management in `transcribe.py`

**Next step**: Deploy logging to dev, reproduce the extraction failure, confirm the drift values, then file a targeted fix for the timestamp alignment.

---
_by AI for @beastoin_