### PR TITLE
Update CHANGELOG.json for v0.11.209 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Added copy and share buttons to floating bar AI responses for quick Q&A sharing"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.209",
+      "date": "2026-04-01",
+      "changes": [
+        "Added copy and share buttons to floating bar AI responses for quick Q&A sharing"
+      ]
+    },
     {
       "version": "0.11.208",
       "date": "2026-04-01",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.209 and clears the unreleased array.