### PR TITLE
Fix invisible buttons on Memories empty state

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -1579,15 +1579,11 @@ struct MemoriesPage: View {
                     Text("Add Your First Memory")
                 }
                 .scaledFont(size: 14, weight: .medium)
-                .foregroundColor(OmiColors.textPrimary)
+                .foregroundColor(.white)
                 .padding(.horizontal, 20)
                 .padding(.vertical, 10)
-                .background(Color.white)
+                .background(OmiColors.purplePrimary)
                 .cornerRadius(8)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(OmiColors.border, lineWidth: 1)
-                )
             }
             .buttonStyle(.plain)
             .padding(.top, 8)
@@ -1658,15 +1654,11 @@ struct MemoriesPage: View {
                     Text("Retry")
                 }
                 .scaledFont(size: 14, weight: .medium)
-                .foregroundColor(OmiColors.textPrimary)
+                .foregroundColor(.white)
                 .padding(.horizontal, 20)
                 .padding(.vertical, 10)
-                .background(Color.white)
+                .background(OmiColors.purplePrimary)
                 .cornerRadius(8)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 8)
-                        .stroke(OmiColors.border, lineWidth: 1)
-                )
             }
             .buttonStyle(.plain)
         }


### PR DESCRIPTION
## Summary
- White text + white background made buttons invisible in dark mode on the Memories page
- "Add Your First Memory" and "Retry" buttons were completely hidden
- Fixed by using purple background with white text (matches other CTAs in the app)

## Test plan
- [ ] Open Memories page with no memories — "Add Your First Memory" button should be visible (purple)
- [ ] Trigger error state — "Retry" button should be visible (purple)

🤖 Generated with [Claude Code](https://claude.com/claude-code)