### PR TITLE
Start floating bar voice playback during streaming

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -2,201 +2,341 @@ import AVFoundation
 import Foundation
 
 @MainActor
-final class FloatingBarVoicePlaybackService: NSObject {
-    static let shared = FloatingBarVoicePlaybackService()
+final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
+  static let shared = FloatingBarVoicePlaybackService()
 
-    static let devAPIKeyDefaultsKey = "dev_elevenlabs_api_key"
-    static let devVoiceIDDefaultsKey = "dev_elevenlabs_voice_id"
+  static let devAPIKeyDefaultsKey = "dev_elevenlabs_api_key"
+  static let devVoiceIDDefaultsKey = "dev_elevenlabs_voice_id"
 
-    nonisolated private static let defaultVoiceID = "21m00Tcm4TlvDq8ikWAM"  // Rachel
-    nonisolated private static let defaultModelID = "eleven_multilingual_v2"
+  nonisolated private static let defaultVoiceID = "21m00Tcm4TlvDq8ikWAM"  // Rachel
+  nonisolated private static let defaultModelID = "eleven_multilingual_v2"
+  nonisolated private static let minimumChunkLength = 48
+  nonisolated private static let preferredChunkLength = 140
 
-    private var playbackTask: Task<Void, Never>?
-    private var audioPlayer: AVAudioPlayer?
-    private let speechSynthesizer = AVSpeechSynthesizer()
+  private var playbackTask: Task<Void, Never>?
+  private var currentMode: PlaybackMode?
+  private var streamedText = ""
+  private var bufferedText = ""
+  private var synthesisQueue: [String] = []
+  private var audioQueue: [Data] = []
+  private var isSynthesizing = false
+  private var audioPlayer: AVAudioPlayer?
+  private let speechSynthesizer = AVSpeechSynthesizer()
 
-    private override init() {}
+  private override init() {}
 
-    func playResponseIfEnabled(_ message: ChatMessage?) {
-        guard AnalyticsManager.isDevBuild else { return }
-        guard ShortcutSettings.shared.floatingBarVoiceAnswersEnabled else { return }
+  func playResponseIfEnabled(_ message: ChatMessage?) {
+    guard ShortcutSettings.shared.floatingBarVoiceAnswersEnabled else { return }
+    updateStreamingResponseIfEnabled(message, isFinal: true)
+  }
 
-        let text = Self.cleanedPlaybackText(from: message)
-        guard !text.isEmpty, Self.shouldSpeak(text) else { return }
+  func updateStreamingResponseIfEnabled(_ message: ChatMessage?, isFinal: Bool) {
+    guard ShortcutSettings.shared.floatingBarVoiceAnswersEnabled else { return }
 
-        let defaults = UserDefaults.standard
-        guard let apiKey = defaults.string(forKey: Self.devAPIKeyDefaultsKey)?.trimmingCharacters(in: .whitespacesAndNewlines),
-              !apiKey.isEmpty else {
-            playSystemFallback(text)
-            return
-        }
+    let text = Self.cleanedPlaybackText(from: message)
+    guard !text.isEmpty, Self.shouldSpeak(text) else { return }
 
-        let voiceID = defaults.string(forKey: Self.devVoiceIDDefaultsKey)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        let resolvedVoiceID = (voiceID?.isEmpty == false) ? voiceID! : Self.defaultVoiceID
-
-        stop()
-        playbackTask = Task { [weak self] in
-            do {
-                let audioData = try await Self.synthesizeSpeech(text: text, apiKey: apiKey, voiceID: resolvedVoiceID)
-                try Task.checkCancellation()
-                await MainActor.run {
-                    self?.startPlayback(audioData)
-                }
-            } catch is CancellationError {
-            } catch {
-                await MainActor.run {
-                    log("FloatingBarVoicePlaybackService: ElevenLabs playback failed, falling back to system voice: \(error.localizedDescription)")
-                    self?.playSystemFallback(text)
-                }
-            }
-        }
+    if currentMode == nil {
+      currentMode = resolvePlaybackMode()
     }
 
-    func stop() {
-        playbackTask?.cancel()
-        playbackTask = nil
-        audioPlayer?.stop()
-        audioPlayer = nil
-        speechSynthesizer.stopSpeaking(at: .immediate)
+    guard let mode = currentMode else {
+      return
     }
 
-    private func startPlayback(_ data: Data) {
-        do {
-            let player = try AVAudioPlayer(data: data)
-            player.prepareToPlay()
-            player.play()
-            audioPlayer = player
-        } catch {
-            log("FloatingBarVoicePlaybackService: could not start audio playback: \(error.localizedDescription)")
-        }
+    if !text.hasPrefix(streamedText) {
+      streamedText = ""
+      bufferedText = ""
+      synthesisQueue.removeAll()
+      audioQueue.removeAll()
     }
 
-    private func playSystemFallback(_ text: String) {
-        speechSynthesizer.stopSpeaking(at: .immediate)
-        let utterance = AVSpeechUtterance(string: text)
-        utterance.rate = 0.47
-        utterance.pitchMultiplier = 1.02
-        utterance.volume = 1.0
-        utterance.voice = preferredSystemVoice()
-        speechSynthesizer.speak(utterance)
+    if text.count > streamedText.count {
+      let newText = String(text.dropFirst(streamedText.count))
+      streamedText = text
+      bufferedText += newText
+      drainBufferedText(isFinal: isFinal, mode: mode)
+    } else if isFinal {
+      drainBufferedText(isFinal: true, mode: mode)
+    }
+  }
+
+  private func resolvePlaybackMode() -> PlaybackMode {
+    let defaults = UserDefaults.standard
+    guard
+      let apiKey = defaults.string(forKey: Self.devAPIKeyDefaultsKey)?.trimmingCharacters(
+        in: .whitespacesAndNewlines),
+      !apiKey.isEmpty
+    else {
+      return .systemFallback
     }
 
-    private func preferredSystemVoice() -> AVSpeechSynthesisVoice? {
-        let preferredNames = ["Samantha", "Karen", "Moira"]
-        for name in preferredNames {
-            if let voice = AVSpeechSynthesisVoice.speechVoices().first(where: { $0.name.localizedCaseInsensitiveContains(name) }) {
-                return voice
-            }
+    let voiceID = defaults.string(forKey: Self.devVoiceIDDefaultsKey)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    let resolvedVoiceID = (voiceID?.isEmpty == false) ? voiceID! : Self.defaultVoiceID
+    return .elevenLabs(apiKey: apiKey, voiceID: resolvedVoiceID)
+  }
+
+  private func drainBufferedText(isFinal: Bool, mode: PlaybackMode) {
+    while let boundary = Self.nextChunkBoundary(in: bufferedText, isFinal: isFinal) {
+      let chunk = String(bufferedText[..<boundary]).trimmingCharacters(in: .whitespacesAndNewlines)
+      bufferedText = String(bufferedText[boundary...]).trimmingCharacters(
+        in: .whitespacesAndNewlines)
+
+      guard !chunk.isEmpty, Self.shouldSpeak(chunk) else { continue }
+      enqueueChunk(chunk, mode: mode)
+    }
+  }
+
+  private func enqueueChunk(_ text: String, mode: PlaybackMode) {
+    switch mode {
+    case .systemFallback:
+      enqueueSystemSpeech(text)
+    case .elevenLabs:
+      synthesisQueue.append(text)
+      startSynthesisIfNeeded(mode: mode)
+    }
+  }
+
+  private func startSynthesisIfNeeded(mode: PlaybackMode) {
+    guard !isSynthesizing else { return }
+    guard case .elevenLabs(let apiKey, let voiceID) = mode else { return }
+    guard !synthesisQueue.isEmpty else { return }
+
+    let text = synthesisQueue.removeFirst()
+    isSynthesizing = true
+    playbackTask?.cancel()
+    playbackTask = Task { [weak self] in
+      do {
+        let audioData = try await Self.synthesizeSpeech(
+          text: text, apiKey: apiKey, voiceID: voiceID)
+        try Task.checkCancellation()
+        await MainActor.run {
+          guard let self else { return }
+          self.isSynthesizing = false
+          self.audioQueue.append(audioData)
+          self.startPlaybackIfNeeded()
+          self.startSynthesisIfNeeded(mode: mode)
         }
-        return AVSpeechSynthesisVoice(language: "en-US")
+      } catch is CancellationError {
+      } catch {
+        await MainActor.run {
+          guard let self else { return }
+          self.isSynthesizing = false
+          log(
+            "FloatingBarVoicePlaybackService: ElevenLabs chunk synthesis failed, falling back to system voice: \(error.localizedDescription)"
+          )
+          self.enqueueSystemSpeech(text)
+          self.startSynthesisIfNeeded(mode: mode)
+        }
+      }
+    }
+  }
+
+  func stop() {
+    playbackTask?.cancel()
+    playbackTask = nil
+    currentMode = nil
+    streamedText = ""
+    bufferedText = ""
+    synthesisQueue.removeAll()
+    audioQueue.removeAll()
+    isSynthesizing = false
+    audioPlayer?.stop()
+    audioPlayer = nil
+    speechSynthesizer.stopSpeaking(at: .immediate)
+  }
+
+  private func startPlaybackIfNeeded() {
+    guard audioPlayer == nil else { return }
+    guard !audioQueue.isEmpty else { return }
+    startPlayback(audioQueue.removeFirst())
+  }
+
+  private func startPlayback(_ data: Data) {
+    do {
+      let player = try AVAudioPlayer(data: data)
+      player.delegate = self
+      player.prepareToPlay()
+      player.play()
+      audioPlayer = player
+    } catch {
+      log(
+        "FloatingBarVoicePlaybackService: could not start audio playback: \(error.localizedDescription)"
+      )
+    }
+  }
+
+  private func enqueueSystemSpeech(_ text: String) {
+    let utterance = AVSpeechUtterance(string: text)
+    utterance.rate = 0.47
+    utterance.pitchMultiplier = 1.02
+    utterance.volume = 1.0
+    utterance.voice = preferredSystemVoice()
+    speechSynthesizer.speak(utterance)
+  }
+
+  nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+    Task { @MainActor [weak self] in
+      guard let self else { return }
+      self.audioPlayer = nil
+      self.startPlaybackIfNeeded()
+    }
+  }
+
+  private func preferredSystemVoice() -> AVSpeechSynthesisVoice? {
+    let preferredNames = ["Samantha", "Karen", "Moira"]
+    for name in preferredNames {
+      if let voice = AVSpeechSynthesisVoice.speechVoices().first(where: {
+        $0.name.localizedCaseInsensitiveContains(name)
+      }) {
+        return voice
+      }
+    }
+    return AVSpeechSynthesisVoice(language: "en-US")
+  }
+
+  private nonisolated static func synthesizeSpeech(text: String, apiKey: String, voiceID: String)
+    async throws -> Data
+  {
+    var request = URLRequest(
+      url: URL(string: "https://api.elevenlabs.io/v1/text-to-speech/\(voiceID)")!)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("audio/mpeg", forHTTPHeaderField: "Accept")
+    request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
+    request.timeoutInterval = 45
+
+    let body = ElevenLabsSpeechRequest(
+      text: text,
+      modelID: defaultModelID,
+      outputFormat: "mp3_44100_128",
+      voiceSettings: .init(
+        stability: 0.42,
+        similarityBoost: 0.82,
+        style: 0.22,
+        useSpeakerBoost: true
+      )
+    )
+    request.httpBody = try JSONEncoder().encode(body)
+
+    let (data, response) = try await URLSession.shared.data(for: request)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw FloatingBarVoicePlaybackError.invalidResponse
+    }
+    guard (200..<300).contains(httpResponse.statusCode) else {
+      let errorBody = String(data: data.prefix(300), encoding: .utf8) ?? "Unknown error"
+      throw FloatingBarVoicePlaybackError.requestFailed(
+        statusCode: httpResponse.statusCode, body: errorBody)
+    }
+    return data
+  }
+
+  private nonisolated static func cleanedPlaybackText(from message: ChatMessage?) -> String {
+    guard let message else { return "" }
+
+    let baseText: String
+    if !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      baseText = message.text
+    } else {
+      baseText = message.contentBlocks.compactMap { block in
+        switch block {
+        case .text(_, let text):
+          return text
+        case .discoveryCard(_, let title, let summary, _):
+          return "\(title). \(summary)"
+        case .toolCall, .thinking:
+          return nil
+        }
+      }.joined(separator: "\n\n")
     }
 
-    private nonisolated static func synthesizeSpeech(text: String, apiKey: String, voiceID: String) async throws -> Data {
-        var request = URLRequest(url: URL(string: "https://api.elevenlabs.io/v1/text-to-speech/\(voiceID)")!)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.setValue("audio/mpeg", forHTTPHeaderField: "Accept")
-        request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
-        request.timeoutInterval = 45
+    let collapsedWhitespace = baseText.replacingOccurrences(
+      of: "\\s+", with: " ", options: .regularExpression)
+    return collapsedWhitespace.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
 
-        let body = ElevenLabsSpeechRequest(
-            text: text,
-            modelID: defaultModelID,
-            outputFormat: "mp3_44100_128",
-            voiceSettings: .init(
-                stability: 0.42,
-                similarityBoost: 0.82,
-                style: 0.22,
-                useSpeakerBoost: true
-            )
-        )
-        request.httpBody = try JSONEncoder().encode(body)
+  private nonisolated static func shouldSpeak(_ text: String) -> Bool {
+    let lowercased = text.lowercased()
+    if lowercased == "failed to get a response. please try again." {
+      return false
+    }
+    if lowercased.hasPrefix("⚠️") || lowercased.hasPrefix("warning:") {
+      return false
+    }
+    return true
+  }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
-        guard let httpResponse = response as? HTTPURLResponse else {
-            throw FloatingBarVoicePlaybackError.invalidResponse
-        }
-        guard (200 ..< 300).contains(httpResponse.statusCode) else {
-            let errorBody = String(data: data.prefix(300), encoding: .utf8) ?? "Unknown error"
-            throw FloatingBarVoicePlaybackError.requestFailed(statusCode: httpResponse.statusCode, body: errorBody)
-        }
-        return data
+  private nonisolated static func nextChunkBoundary(in text: String, isFinal: Bool) -> String.Index?
+  {
+    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return nil }
+
+    if isFinal {
+      return text.endIndex
     }
 
-    private nonisolated static func cleanedPlaybackText(from message: ChatMessage?) -> String {
-        guard let message else { return "" }
+    guard text.count >= minimumChunkLength else { return nil }
 
-        let baseText: String
-        if !message.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            baseText = message.text
-        } else {
-            baseText = message.contentBlocks.compactMap { block in
-                switch block {
-                case .text(_, let text):
-                    return text
-                case .discoveryCard(_, let title, let summary, _):
-                    return "\(title). \(summary)"
-                case .toolCall, .thinking:
-                    return nil
-                }
-            }.joined(separator: "\n\n")
-        }
+    let searchLimit = text.index(text.startIndex, offsetBy: min(text.count, preferredChunkLength))
+    let searchSlice = text[..<searchLimit]
 
-        let collapsedWhitespace = baseText.replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
-        return collapsedWhitespace.trimmingCharacters(in: .whitespacesAndNewlines)
+    if let punctuationIndex = searchSlice.lastIndex(where: { ".!?\n".contains($0) }) {
+      return text.index(after: punctuationIndex)
     }
 
-    private nonisolated static func shouldSpeak(_ text: String) -> Bool {
-        let lowercased = text.lowercased()
-        if lowercased == "failed to get a response. please try again." {
-            return false
-        }
-        if lowercased.hasPrefix("⚠️") || lowercased.hasPrefix("warning:") {
-            return false
-        }
-        return true
+    guard text.count >= preferredChunkLength else { return nil }
+    if let whitespaceIndex = searchSlice.lastIndex(where: \.isWhitespace) {
+      return whitespaceIndex
     }
+
+    return searchLimit
+  }
+}
+
+private enum PlaybackMode {
+  case elevenLabs(apiKey: String, voiceID: String)
+  case systemFallback
 }
 
 private struct ElevenLabsSpeechRequest: Encodable {
-    let text: String
-    let modelID: String
-    let outputFormat: String
-    let voiceSettings: ElevenLabsVoiceSettings
+  let text: String
+  let modelID: String
+  let outputFormat: String
+  let voiceSettings: ElevenLabsVoiceSettings
 
-    enum CodingKeys: String, CodingKey {
-        case text
-        case modelID = "model_id"
-        case outputFormat = "output_format"
-        case voiceSettings = "voice_settings"
-    }
+  enum CodingKeys: String, CodingKey {
+    case text
+    case modelID = "model_id"
+    case outputFormat = "output_format"
+    case voiceSettings = "voice_settings"
+  }
 }
 
 private struct ElevenLabsVoiceSettings: Encodable {
-    let stability: Double
-    let similarityBoost: Double
-    let style: Double
-    let useSpeakerBoost: Bool
+  let stability: Double
+  let similarityBoost: Double
+  let style: Double
+  let useSpeakerBoost: Bool
 
-    enum CodingKeys: String, CodingKey {
-        case stability
-        case similarityBoost = "similarity_boost"
-        case style
-        case useSpeakerBoost = "use_speaker_boost"
-    }
+  enum CodingKeys: String, CodingKey {
+    case stability
+    case similarityBoost = "similarity_boost"
+    case style
+    case useSpeakerBoost = "use_speaker_boost"
+  }
 }
 
 private enum FloatingBarVoicePlaybackError: LocalizedError {
-    case invalidResponse
-    case requestFailed(statusCode: Int, body: String)
+  case invalidResponse
+  case requestFailed(statusCode: Int, body: String)
 
-    var errorDescription: String? {
-        switch self {
-        case .invalidResponse:
-            return "Invalid ElevenLabs response"
-        case .requestFailed(let statusCode, let body):
-            return "ElevenLabs request failed (\(statusCode)): \(body)"
-        }
+  var errorDescription: String? {
+    switch self {
+    case .invalidResponse:
+      return "Invalid ElevenLabs response"
+    case .requestFailed(let statusCode, let body):
+      return "ElevenLabs request failed (\(statusCode)): \(body)"
     }
+  }
 }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1221,6 +1221,10 @@ class FloatingControlBarManager {
 
                 // Store the full ChatMessage (preserves contentBlocks, tool calls, thinking)
                 barWindow?.state.currentAIMessage = aiMessage
+                FloatingBarVoicePlaybackService.shared.updateStreamingResponseIfEnabled(
+                    aiMessage,
+                    isFinal: !aiMessage.isStreaming
+                )
 
                 if aiMessage.isStreaming {
                     barWindow?.state.isAILoading = false
@@ -1273,7 +1277,10 @@ class FloatingControlBarManager {
             barWindow.resizeToResponseHeightPublic(animated: true)
         }
 
-        FloatingBarVoicePlaybackService.shared.playResponseIfEnabled(barWindow.state.currentAIMessage)
+        FloatingBarVoicePlaybackService.shared.updateStreamingResponseIfEnabled(
+            barWindow.state.currentAIMessage,
+            isFinal: true
+        )
     }
 }
 


### PR DESCRIPTION
## Summary
- remove the dev-build-only playback gate so shipped desktop builds can actually speak floating-bar answers
- start synthesizing and queueing voice chunks while the response is still streaming instead of waiting for the full answer
- keep interruption behavior by clearing queued playback when a new shortcut request starts

## Verification
- compiled the desktop app on the Mac mini from this branch with `swift build -c debug --package-path desktop/Desktop`
- launched an isolated Mac mini test app copy with the automation bridge and confirmed it reaches signed-in main state remotely
- confirmed the current release line is blocked without this change: `v0.11.205` predates voice answers entirely, and `v0.11.212` still has the `AnalyticsManager.isDevBuild` playback guard
