### PR TITLE
Fix: OCR crash on screen capture enable (array bounds failure)

### DIFF
--- a/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -174,13 +174,23 @@ actor RewindOCRService {
                     return
                 }
 
+                // Defensive copy — Vision framework results are bridged NSArray objects
+                // that can trigger EXC_BREAKPOINT / _objectAt assertion failures if the
+                // underlying buffer is mutated or released during enumeration (see #5891, #5151).
+                let safeObservations = Array(observations)
+
                 var blocks: [OCRTextBlock] = []
                 var fullTextLines: [String] = []
 
-                for observation in observations {
-                    guard let candidate = observation.topCandidates(1).first else { continue }
+                for observation in safeObservations {
+                    let candidates = observation.topCandidates(1)
+                    guard !candidates.isEmpty, let candidate = candidates.first else { continue }
 
                     let boundingBox = observation.boundingBox
+                    // Validate bounding box values are finite before using them
+                    guard boundingBox.origin.x.isFinite, boundingBox.origin.y.isFinite,
+                          boundingBox.width.isFinite, boundingBox.height.isFinite else { continue }
+
                     let block = OCRTextBlock(
                         text: candidate.string,
                         x: Double((boundingBox.origin.x * 1000).rounded()) / 1000,


### PR DESCRIPTION
## Problem
macOS app crashes with `EXC_BREAKPOINT` in `__SwiftNativeNSArrayWithContiguousStorage._objectAt` when Screen Capture is enabled. 100% reproducible on macOS 15.7+ and macOS Tahoe 26.4.

**Sentry:** 32+ affected users, 299 events ([OMI-COMPUTER-57](https://mediar-n5.sentry.io/issues/7240539156/))

## Root Cause
`VNRecognizeTextRequest` completion handler iterates a bridged `NSArray` that can have its backing store released mid-enumeration, causing a Swift runtime assertion failure.

## Fix
- **Defensive copy** of `observations` array before iteration (breaks NSArray bridging dependency)
- **Emptiness check** on `topCandidates()` before accessing `.first`  
- **Finite validation** on bounding box values before arithmetic

Minimal, surgical change — 12 lines added, 2 lines removed in a single file.

Fixes #5891
Fixes #5151