### PR TITLE
fix(admin): move admin check server-side to bypass Firestore rules

### DIFF
--- a/web/admin/app/api/auth/check-admin/route.ts
+++ b/web/admin/app/api/auth/check-admin/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyFirebaseToken, getDb } from '@/lib/firebase/admin';
+
+export async function GET(request: NextRequest) {
+  const authorization = request.headers.get('Authorization');
+  if (!authorization || !authorization.startsWith('Bearer ')) {
+    return NextResponse.json({ isAdmin: false }, { status: 401 });
+  }
+
+  const token = authorization.split('Bearer ')[1];
+  try {
+    const decodedToken = await verifyFirebaseToken(token);
+    if (!decodedToken) {
+      return NextResponse.json({ isAdmin: false }, { status: 401 });
+    }
+
+    const db = getDb();
+    const adminDoc = await db.collection('adminData').doc(decodedToken.uid).get();
+    return NextResponse.json({ isAdmin: adminDoc.exists });
+  } catch (error) {
+    console.error('Error checking admin status:', error);
+    return NextResponse.json({ isAdmin: false }, { status: 500 });
+  }
+}

--- a/web/admin/components/auth-provider.tsx
+++ b/web/admin/components/auth-provider.tsx
@@ -2,8 +2,7 @@
 
 import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { User, onAuthStateChanged, signOut as firebaseSignOut } from 'firebase/auth';
-import { doc, getDoc } from 'firebase/firestore';
-import { getFirebaseAuth, getFirebaseDb } from '@/lib/firebase/client';
+import { getFirebaseAuth } from '@/lib/firebase/client';
 import { useRouter } from 'next/navigation'; // Use next/navigation for App Router
 
 interface AuthContextProps {
@@ -47,16 +46,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
 
     const auth = getFirebaseAuth();
-    const db = getFirebaseDb();
     const unsubscribe = onAuthStateChanged(auth, async (currentUser) => {
       setLoading(true);
       if (currentUser) {
         console.log('currentUser', currentUser);
-        // Check if user is an Omi admin by looking for their UID in the specific product path
-        const adminDocRef = doc(db, 'adminData', currentUser.uid);
+        // Check admin status via server-side API (Admin SDK bypasses Firestore security rules)
         try {
-          const adminDoc = await getDoc(adminDocRef);
-          if (adminDoc.exists()) {
+          const idToken = await currentUser.getIdToken();
+          const res = await fetch('/api/auth/check-admin', {
+            headers: { Authorization: `Bearer ${idToken}` },
+          });
+          const data = await res.json();
+          if (data.isAdmin) {
             setUser(currentUser);
             setIsAdmin(true);
             console.log(`Admin user ${currentUser.email} signed in.`);
@@ -65,14 +66,14 @@ export function AuthProvider({ children }: { children: ReactNode }) {
             await firebaseSignOut(auth);
             setUser(null);
             setIsAdmin(false);
-            router.push('/login?error=unauthorized'); // Redirect non-admin to login
+            router.push('/login?error=unauthorized');
           }
         } catch (error) {
           console.error('Error checking admin status:', error);
           await firebaseSignOut(auth);
           setUser(null);
           setIsAdmin(false);
-          router.push('/login?error=check_failed'); // Redirect on error
+          router.push('/login?error=check_failed');
         }
       } else {
         setUser(null);


### PR DESCRIPTION
## Summary
- Firestore security rules block **all** client-side reads: `allow read, write: if false`
- The auth-provider was trying to read `adminData/{uid}` client-side via `getDoc()`, which was denied by rules → login always failed with `check_failed` or `unauthorized`
- Created server-side `/api/auth/check-admin` endpoint that uses Firebase Admin SDK (bypasses security rules)
- Updated auth-provider to call this API instead of reading Firestore directly

## Root cause
```
rules_version = '2';
service cloud.firestore {
  match /databases/{database}/documents {
    match /{doc=**} { allow read, write: if false; }
  }
}
```
All client-side Firestore reads are denied. The Admin SDK (server-side) bypasses these rules.

## Test plan
- [ ] Sign in with Google on admin.omi.me → should redirect to dashboard
- [ ] Sign in with non-admin account → should show "unauthorized" error
- [ ] API routes should continue working (server-side auth unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)