### PR TITLE
Update CHANGELOG.json for v0.11.214 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed 2s+ UI freezes caused by dock tile updates during chat polling"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.214",
+      "date": "2026-04-01",
+      "changes": [
+        "Fixed 2s+ UI freezes caused by dock tile updates during chat polling"
+      ]
+    },
     {
       "version": "0.11.213",
       "date": "2026-04-01",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.214 and clears the unreleased array.