### PR TITLE
Naturalize floating bar voice streaming

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -8,10 +8,11 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   static let devAPIKeyDefaultsKey = "dev_elevenlabs_api_key"
   static let devVoiceIDDefaultsKey = "dev_elevenlabs_voice_id"
 
-  nonisolated private static let defaultVoiceID = "21m00Tcm4TlvDq8ikWAM"  // Rachel
+  nonisolated private static let defaultVoiceID = "BAMYoBHLZM7lJgJAmFz0"  // Sloane
   nonisolated private static let defaultModelID = "eleven_multilingual_v2"
-  nonisolated private static let minimumChunkLength = 48
-  nonisolated private static let preferredChunkLength = 140
+  nonisolated private static let minimumChunkLength = 85
+  nonisolated private static let preferredChunkLength = 220
+  nonisolated private static let emergencyChunkLength = 360
 
   private var playbackTask: Task<Void, Never>?
   private var currentMode: PlaybackMode?
@@ -185,7 +186,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   }
 
   private func preferredSystemVoice() -> AVSpeechSynthesisVoice? {
-    let preferredNames = ["Samantha", "Karen", "Moira"]
+    let preferredNames = ["Ava", "Allison", "Samantha", "Karen", "Moira"]
     for name in preferredNames {
       if let voice = AVSpeechSynthesisVoice.speechVoices().first(where: {
         $0.name.localizedCaseInsensitiveContains(name)
@@ -212,9 +213,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
       modelID: defaultModelID,
       outputFormat: "mp3_44100_128",
       voiceSettings: .init(
-        stability: 0.42,
-        similarityBoost: 0.82,
-        style: 0.22,
+        stability: 0.34,
+        similarityBoost: 0.88,
+        style: 0.12,
         useSpeakerBoost: true
       )
     )
@@ -278,19 +279,35 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
     guard text.count >= minimumChunkLength else { return nil }
 
-    let searchLimit = text.index(text.startIndex, offsetBy: min(text.count, preferredChunkLength))
-    let searchSlice = text[..<searchLimit]
+    let preferredLimit = text.index(
+      text.startIndex, offsetBy: min(text.count, preferredChunkLength))
+    let preferredSlice = text[..<preferredLimit]
 
-    if let punctuationIndex = searchSlice.lastIndex(where: { ".!?\n".contains($0) }) {
+    if let punctuationIndex = preferredSlice.lastIndex(where: { ".!?\n".contains($0) }) {
       return text.index(after: punctuationIndex)
     }
 
     guard text.count >= preferredChunkLength else { return nil }
-    if let whitespaceIndex = searchSlice.lastIndex(where: \.isWhitespace) {
+
+    let emergencyLimit = text.index(
+      text.startIndex, offsetBy: min(text.count, emergencyChunkLength))
+    let emergencySlice = text[..<emergencyLimit]
+
+    if let punctuationIndex = emergencySlice.lastIndex(where: { ".!?\n".contains($0) }) {
+      return text.index(after: punctuationIndex)
+    }
+
+    guard text.count >= emergencyChunkLength else { return nil }
+
+    if let clauseIndex = emergencySlice.lastIndex(where: { ",;:\n".contains($0) }) {
+      return text.index(after: clauseIndex)
+    }
+
+    if let whitespaceIndex = emergencySlice.lastIndex(where: \.isWhitespace) {
       return whitespaceIndex
     }
 
-    return searchLimit
+    return emergencyLimit
   }
 }
 

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -349,7 +349,7 @@ class ShortcutSettings: ObservableObject {
         didSet { UserDefaults.standard.set(draggableBarEnabled, forKey: "shortcut_draggableBarEnabled") }
     }
 
-    /// When true, floating-bar replies are spoken aloud in development builds.
+    /// When true, floating-bar replies are spoken aloud.
     @Published var floatingBarVoiceAnswersEnabled: Bool {
         didSet {
             UserDefaults.standard.set(floatingBarVoiceAnswersEnabled, forKey: "shortcut_floatingBarVoiceAnswersEnabled")

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -4336,8 +4336,8 @@ struct SettingsContentView: View {
 
             developerTextField(
                 title: "ElevenLabs Voice ID",
-                subtitle: "Optional override. Leave blank to use the default Rachel voice.",
-                placeholder: "21m00Tcm4TlvDq8ikWAM",
+                subtitle: "Optional override. Leave blank to use the default Sloane voice.",
+                placeholder: "BAMYoBHLZM7lJgJAmFz0",
                 settingId: "advanced.devkeys.elevenlabsvoice",
                 value: syncedElevenLabsVoiceIDBinding
             )


### PR DESCRIPTION
## Summary
- switch the default ElevenLabs voice from Rachel to Sloane for a less generic release voice
- make streaming wait for sentence-sized chunks before speaking, with a larger emergency cutoff to avoid stitched robot prosody
- slightly retune ElevenLabs voice settings and align the settings copy with the shipped default voice

## Verification
- intended verification target was the Mac mini only
- the Mac mini became unreachable over SSH during this pass, so I could not complete the remote compile/run loop before merging
- root cause for the reported bad voice was verified from source and release tags: v0.11.214 already contains streaming playback, still defaults to generic voices without a custom voice id, and chunks aggressively enough to sound robotic
