### PR TITLE
Force Sloane for floating bar voice answers

### DIFF
--- a/desktop/Backend-Rust/charts/desktop-backend/dev_values.yaml
+++ b/desktop/Backend-Rust/charts/desktop-backend/dev_values.yaml
@@ -32,6 +32,11 @@ env:
       secretKeyRef:
         name: dev-omi-backend-secrets
         key: GEMINI_API_KEY
+  - name: ELEVENLABS_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: dev-omi-backend-secrets
+        key: ELEVENLABS_API_KEY
   - name: RESEND_API_KEY
     valueFrom:
       secretKeyRef:

--- a/desktop/Backend-Rust/charts/desktop-backend/prod_values.yaml
+++ b/desktop/Backend-Rust/charts/desktop-backend/prod_values.yaml
@@ -34,6 +34,11 @@ env:
       secretKeyRef:
         name: prod-omi-backend-secrets
         key: DEEPGRAM_API_KEY
+  - name: ELEVENLABS_API_KEY
+    valueFrom:
+      secretKeyRef:
+        name: prod-omi-backend-secrets
+        key: ELEVENLABS_API_KEY
   - name: ENCRYPTION_SECRET
     valueFrom:
       secretKeyRef:

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -69,6 +69,8 @@ pub struct Config {
     pub deepgram_api_key: Option<String>,
     /// Anthropic API key for chat (served to desktop clients)
     pub anthropic_api_key: Option<String>,
+    /// ElevenLabs API key for floating bar voice answers (served to desktop clients)
+    pub elevenlabs_api_key: Option<String>,
     /// Google Calendar API key (served to desktop clients)
     pub google_calendar_api_key: Option<String>,
 }
@@ -130,6 +132,7 @@ impl Config {
             agent_gcs_bucket: env::var("AGENT_GCS_BUCKET").ok(),
             deepgram_api_key: env::var("DEEPGRAM_API_KEY").ok(),
             anthropic_api_key: env::var("ANTHROPIC_API_KEY").ok(),
+            elevenlabs_api_key: env::var("ELEVENLABS_API_KEY").ok(),
             google_calendar_api_key: env::var("GOOGLE_CALENDAR_API_KEY").ok(),
         }
     }

--- a/desktop/Backend-Rust/src/routes/config.rs
+++ b/desktop/Backend-Rust/src/routes/config.rs
@@ -15,6 +15,8 @@ struct ApiKeysResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     anthropic_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    elevenlabs_api_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     firebase_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     google_calendar_api_key: Option<String>,
@@ -25,6 +27,7 @@ struct ApiKeysResponse {
 async fn get_api_keys(State(state): State<AppState>, _user: AuthUser) -> Json<ApiKeysResponse> {
     Json(ApiKeysResponse {
         anthropic_api_key: state.config.anthropic_api_key.clone(),
+        elevenlabs_api_key: state.config.elevenlabs_api_key.clone(),
         firebase_api_key: state.config.firebase_api_key.clone(),
         google_calendar_api_key: state.config.google_calendar_api_key.clone(),
     })

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -4629,6 +4629,7 @@ extension APIClient {
         let deepgramApiKey: String?
         let geminiApiKey: String?
         let anthropicApiKey: String?
+        let elevenLabsApiKey: String?
         let firebaseApiKey: String?
         let googleCalendarApiKey: String?
 
@@ -4636,6 +4637,7 @@ extension APIClient {
             case deepgramApiKey = "deepgram_api_key"
             case geminiApiKey = "gemini_api_key"
             case anthropicApiKey = "anthropic_api_key"
+            case elevenLabsApiKey = "elevenlabs_api_key"
             case firebaseApiKey = "firebase_api_key"
             case googleCalendarApiKey = "google_calendar_api_key"
         }

--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -4,8 +4,8 @@ import Foundation
 /// Developer overrides (set in Settings) take precedence over backend-provided keys.
 ///
 /// NOTE: Deepgram and Gemini keys are NO LONGER fetched from the backend —
-/// they are proxied server-side (issue #5861). Only Anthropic, Firebase, and
-/// Calendar keys are still served via /v1/config/api-keys.
+/// they are proxied server-side (issue #5861). Anthropic, ElevenLabs, Firebase,
+/// and Calendar keys are still served via /v1/config/api-keys.
 @MainActor
 final class APIKeyService: ObservableObject {
     static let shared = APIKeyService()
@@ -14,6 +14,7 @@ final class APIKeyService: ObservableObject {
     @Published private(set) var deepgramApiKey: String?
     @Published private(set) var geminiApiKey: String?
     @Published private(set) var anthropicApiKey: String?
+    @Published private(set) var elevenLabsApiKey: String?
     @Published private(set) var firebaseApiKey: String?
     @Published private(set) var googleCalendarApiKey: String?
     @Published private(set) var isLoaded: Bool = false
@@ -51,6 +52,10 @@ final class APIKeyService: ObservableObject {
         nonEmpty(UserDefaults.standard.string(forKey: "dev_anthropic_api_key")) ?? anthropicApiKey
     }
 
+    var effectiveElevenLabsKey: String? {
+        nonEmpty(UserDefaults.standard.string(forKey: "dev_elevenlabs_api_key")) ?? elevenLabsApiKey
+    }
+
     var effectiveFirebaseApiKey: String? {
         firebaseApiKey
     }
@@ -70,6 +75,7 @@ final class APIKeyService: ObservableObject {
                 self.deepgramApiKey = keys.deepgramApiKey
                 self.geminiApiKey = keys.geminiApiKey
                 self.anthropicApiKey = keys.anthropicApiKey
+                self.elevenLabsApiKey = keys.elevenLabsApiKey
                 self.firebaseApiKey = keys.firebaseApiKey
                 self.googleCalendarApiKey = keys.googleCalendarApiKey
                 self.isLoaded = true
@@ -77,7 +83,7 @@ final class APIKeyService: ObservableObject {
                 // Set env vars so existing getenv() consumers keep working during transition
                 applyToEnvironment()
 
-                log("APIKeyService: Fetched keys from backend (deepgram=\(keys.deepgramApiKey != nil), gemini=\(keys.geminiApiKey != nil), anthropic=\(keys.anthropicApiKey != nil), firebase=\(keys.firebaseApiKey != nil), calendar=\(keys.googleCalendarApiKey != nil))")
+                log("APIKeyService: Fetched keys from backend (deepgram=\(keys.deepgramApiKey != nil), gemini=\(keys.geminiApiKey != nil), anthropic=\(keys.anthropicApiKey != nil), elevenlabs=\(keys.elevenLabsApiKey != nil), firebase=\(keys.firebaseApiKey != nil), calendar=\(keys.googleCalendarApiKey != nil))")
                 return
             } catch {
                 let delay = pow(2.0, Double(attempt - 1))
@@ -100,6 +106,7 @@ final class APIKeyService: ObservableObject {
         deepgramApiKey = nil
         geminiApiKey = nil
         anthropicApiKey = nil
+        elevenLabsApiKey = nil
         firebaseApiKey = nil
         googleCalendarApiKey = nil
         isLoaded = false
@@ -108,6 +115,7 @@ final class APIKeyService: ObservableObject {
         unsetenv("DEEPGRAM_API_KEY")
         unsetenv("GEMINI_API_KEY")
         unsetenv("ANTHROPIC_API_KEY")
+        unsetenv("ELEVENLABS_API_KEY")
         // NOTE: Do NOT unset FIREBASE_API_KEY — it's needed for the next sign-in
         // (auth bootstrap requires Firebase key before backend is reachable)
         unsetenv("GOOGLE_CALENDAR_API_KEY")
@@ -123,6 +131,9 @@ final class APIKeyService: ObservableObject {
         }
         if let key = effectiveAnthropicKey {
             setenv("ANTHROPIC_API_KEY", key, 1)
+        }
+        if let key = effectiveElevenLabsKey {
+            setenv("ELEVENLABS_API_KEY", key, 1)
         }
         if let key = effectiveFirebaseApiKey {
             setenv("FIREBASE_API_KEY", key, 1)
@@ -154,6 +165,11 @@ final class APIKeyService: ObservableObject {
     nonisolated static var currentAnthropicKey: String? {
         nonEmptyStatic(UserDefaults.standard.string(forKey: "dev_anthropic_api_key"))
             ?? (getenv("ANTHROPIC_API_KEY").flatMap { String(validatingUTF8: $0) })
+    }
+
+    nonisolated static var currentElevenLabsKey: String? {
+        nonEmptyStatic(UserDefaults.standard.string(forKey: "dev_elevenlabs_api_key"))
+            ?? (getenv("ELEVENLABS_API_KEY").flatMap { String(validatingUTF8: $0) })
     }
 
     /// True when the app has enough configuration to start transcription and screen analysis.

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -63,19 +63,15 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   }
 
   private func resolvePlaybackMode() -> PlaybackMode {
-    let defaults = UserDefaults.standard
     guard
-      let apiKey = defaults.string(forKey: Self.devAPIKeyDefaultsKey)?.trimmingCharacters(
+      let apiKey = APIKeyService.currentElevenLabsKey?.trimmingCharacters(
         in: .whitespacesAndNewlines),
       !apiKey.isEmpty
     else {
       return .systemFallback
     }
 
-    let voiceID = defaults.string(forKey: Self.devVoiceIDDefaultsKey)?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    let resolvedVoiceID = (voiceID?.isEmpty == false) ? voiceID! : Self.defaultVoiceID
-    return .elevenLabs(apiKey: apiKey, voiceID: resolvedVoiceID)
+    return .elevenLabs(apiKey: apiKey, voiceID: Self.defaultVoiceID)
   }
 
   private func drainBufferedText(isFinal: Bool, mode: PlaybackMode) {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -314,7 +314,6 @@ struct SettingsContentView: View {
     @AppStorage("dev_gemini_api_key") private var devGeminiKey: String = ""
     @AppStorage("dev_anthropic_api_key") private var devAnthropicKey: String = ""
     @AppStorage("dev_elevenlabs_api_key") private var devElevenLabsKey: String = ""
-    @AppStorage("dev_elevenlabs_voice_id") private var devElevenLabsVoiceID: String = ""
 
     init(
         appState: AppState,
@@ -4294,7 +4293,7 @@ struct SettingsContentView: View {
                             .scaledFont(size: 13)
                             .foregroundColor(OmiColors.textSecondary)
                         if devElevenLabsKey.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                            Text("No ElevenLabs key saved yet, so the app will use the local Samantha voice.")
+                            Text("No personal ElevenLabs key saved. The app will use Omi's default Sloane voice when available, otherwise it falls back to Samantha.")
                                 .scaledFont(size: 12)
                                 .foregroundColor(OmiColors.textTertiary)
                         }
@@ -4329,20 +4328,12 @@ struct SettingsContentView: View {
 
             developerKeyField(
                 title: "ElevenLabs API Key",
-                subtitle: "For experimental floating-bar voice answers",
+                subtitle: "For experimental floating-bar voice answers with the Sloane voice",
                 settingId: "advanced.devkeys.elevenlabs",
                 value: syncedElevenLabsKeyBinding
             )
 
-            developerTextField(
-                title: "ElevenLabs Voice ID",
-                subtitle: "Optional override. Leave blank to use the default Sloane voice.",
-                placeholder: "BAMYoBHLZM7lJgJAmFz0",
-                settingId: "advanced.devkeys.elevenlabsvoice",
-                value: syncedElevenLabsVoiceIDBinding
-            )
-
-            if !devDeepgramKey.isEmpty || !devGeminiKey.isEmpty || !devAnthropicKey.isEmpty || !devElevenLabsKey.isEmpty || !devElevenLabsVoiceID.isEmpty {
+            if !devDeepgramKey.isEmpty || !devGeminiKey.isEmpty || !devAnthropicKey.isEmpty || !devElevenLabsKey.isEmpty {
                 settingsCard(settingId: "advanced.devkeys.clear") {
                     HStack {
                         Spacer()
@@ -4351,7 +4342,6 @@ struct SettingsContentView: View {
                             devGeminiKey = ""
                             devAnthropicKey = ""
                             devElevenLabsKey = ""
-                            devElevenLabsVoiceID = ""
                             SettingsSyncManager.shared.pushPartialUpdate(
                                 AssistantSettingsResponse(
                                     floatingBar: FloatingBarSettingsResponse(
@@ -4389,22 +4379,6 @@ struct SettingsContentView: View {
         }
     }
 
-    private func developerTextField(title: String, subtitle: String, placeholder: String, settingId: String, value: Binding<String>) -> some View {
-        settingsCard(settingId: settingId) {
-            VStack(alignment: .leading, spacing: 8) {
-                Text(title)
-                    .scaledFont(size: 14, weight: .medium)
-                    .foregroundColor(OmiColors.textPrimary)
-                Text(subtitle)
-                    .scaledFont(size: 12)
-                    .foregroundColor(OmiColors.textTertiary)
-                TextField(placeholder, text: value)
-                    .textFieldStyle(.roundedBorder)
-                    .scaledFont(size: 13)
-            }
-        }
-    }
-
     private var floatingBarVoiceAnswersBinding: Binding<Bool> {
         Binding(
             get: { shortcutSettings.floatingBarVoiceAnswersEnabled },
@@ -4427,20 +4401,6 @@ struct SettingsContentView: View {
                 SettingsSyncManager.shared.pushPartialUpdate(
                     AssistantSettingsResponse(
                         floatingBar: FloatingBarSettingsResponse(elevenLabsApiKey: newValue)
-                    )
-                )
-            }
-        )
-    }
-
-    private var syncedElevenLabsVoiceIDBinding: Binding<String> {
-        Binding(
-            get: { devElevenLabsVoiceID },
-            set: { newValue in
-                devElevenLabsVoiceID = newValue
-                SettingsSyncManager.shared.pushPartialUpdate(
-                    AssistantSettingsResponse(
-                        floatingBar: FloatingBarSettingsResponse(elevenLabsVoiceID: newValue)
                     )
                 )
             }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
@@ -99,8 +99,14 @@ class SettingsSyncManager {
             if let v = floatingBar.elevenLabsApiKey {
                 UserDefaults.standard.set(v, forKey: FloatingBarVoicePlaybackService.devAPIKeyDefaultsKey)
             }
-            if let v = floatingBar.elevenLabsVoiceID {
-                UserDefaults.standard.set(v, forKey: FloatingBarVoicePlaybackService.devVoiceIDDefaultsKey)
+            UserDefaults.standard.removeObject(forKey: FloatingBarVoicePlaybackService.devVoiceIDDefaultsKey)
+            if let v = floatingBar.elevenLabsVoiceID?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !v.isEmpty {
+                pushPartialUpdate(
+                    AssistantSettingsResponse(
+                        floatingBar: FloatingBarSettingsResponse(elevenLabsVoiceID: "")
+                    )
+                )
             }
         }
 
@@ -163,7 +169,7 @@ class SettingsSyncManager {
         let floatingBar = FloatingBarSettingsResponse(
             voiceAnswersEnabled: ShortcutSettings.shared.floatingBarVoiceAnswersEnabled,
             elevenLabsApiKey: UserDefaults.standard.string(forKey: FloatingBarVoicePlaybackService.devAPIKeyDefaultsKey) ?? "",
-            elevenLabsVoiceID: UserDefaults.standard.string(forKey: FloatingBarVoicePlaybackService.devVoiceIDDefaultsKey) ?? ""
+            elevenLabsVoiceID: ""
         )
 
         return AssistantSettingsResponse(


### PR DESCRIPTION
## Summary
- force floating bar replies onto the Sloane ElevenLabs voice instead of honoring stale voice-id overrides
- fetch ElevenLabs from the desktop backend config key path so production can use ElevenLabs without relying on a locally seeded dev key
- clear deprecated saved voice-id overrides from settings sync and remove the user-facing voice-id field

## Testing
- swift build -c debug --package-path desktop/Desktop
- cargo check