### PR TITLE
fix(ci): route Cloud Run traffic to latest revision on admin deploy

### DIFF
--- a/.github/workflows/gcp_admin.yml
+++ b/.github/workflows/gcp_admin.yml
@@ -73,6 +73,7 @@ jobs:
           service: ${{ env.SERVICE }}
           region: ${{ env.REGION }}
           image: gcr.io/${{ vars.GCP_PROJECT_ID }}/${{ env.SERVICE }}
+          revision_traffic: LATEST=100
           secrets: |
             FIREBASE_PROJECT_ID=WEB_ADMIN_FIREBASE_PROJECT_ID:latest
             FIREBASE_CLIENT_EMAIL=WEB_ADMIN_FIREBASE_CLIENT_EMAIL:latest


### PR DESCRIPTION
## Summary
- Adds `revision_traffic: LATEST=100` to the deploy-cloudrun step in `gcp_admin.yml`
- Fixes traffic being pinned to old revision (00042 from private repo deploy) while new monorepo revisions deploy but don't serve

## Context
The previous private repo deployment pinned traffic to revision 00042. When the monorepo workflow deploys new revisions, `deploy-cloudrun@v2` doesn't override the existing traffic routing — so the old code keeps serving. This one-line fix ensures each deploy automatically routes 100% traffic to the newly deployed revision.

## Test plan
- [ ] Merge this PR — triggers `gcp_admin.yml` workflow
- [ ] Verify workflow completes successfully
- [ ] Verify `admin.omi.me` serves from the latest revision (check `/dashboard/fair-use` exists)

🤖 Generated with [Claude Code](https://claude.com/claude-code)