### PR TITLE
Fix speaker extraction clock-source divergence (#6190)

### DIFF
--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -175,6 +175,8 @@ class TranscriptSegment(BaseModel):
                         return a, b
                     if _can_backward_merge_single_sentence(first_sentence, last_incomplete):
                         a.text = f'{a.text} {first_sentence}'.strip()
+                        if b.stt_end is not None:
+                            a.stt_end = b.stt_end
                         return a, None
                 if last_incomplete and len(last_incomplete) < len(b.text.strip()):
                     b.text = f'{last_incomplete} {b.text}'.strip()

--- a/backend/models/transcript_segment.py
+++ b/backend/models/transcript_segment.py
@@ -35,6 +35,11 @@ class TranscriptSegment(BaseModel):
     translations: Optional[List[Translation]] = []
     speech_profile_processed: bool = True
     stt_provider: Optional[str] = None
+    # Raw STT audio-time coordinates — position in the audio stream the STT provider received.
+    # Used for exact audio extraction (e.g., speaker embedding). Excluded from serialization
+    # so they never reach Firestore or the client. See #6190.
+    stt_start: Optional[float] = Field(default=None, exclude=True, repr=False)
+    stt_end: Optional[float] = Field(default=None, exclude=True, repr=False)
 
     def __init__(self, **data):
         super().__init__(**data)
@@ -176,17 +181,23 @@ class TranscriptSegment(BaseModel):
                     if prefix:
                         a.text = prefix
                         a.end = min(a.end, b.start)
+                        if a.stt_end is not None and b.stt_start is not None:
+                            a.stt_end = min(a.stt_end, b.stt_start)
                         return a, b
                     a.text = ""
                     return None, b
             if _should_merge_same_speaker(a, b):
                 a.text += f' {b.text}'
                 a.end = b.end
+                if b.stt_end is not None:
+                    a.stt_end = b.stt_end
                 return a, None
 
             if _should_merge_lowercase_continuation(a, b):
                 a.text += f' {b.text}'
                 a.end = b.end
+                if b.stt_end is not None:
+                    a.stt_end = b.stt_end
                 return a, None
 
             return a, b

--- a/backend/routers/transcribe.py
+++ b/backend/routers/transcribe.py
@@ -101,7 +101,6 @@ from utils.webhooks import get_audio_bytes_webhook_seconds
 from utils.onboarding import OnboardingHandler
 
 from utils.aac import AACDecoder
-from utils.audio import AudioRingBuffer
 from utils.metrics import (
     BACKEND_LISTEN_ACTIVE_WS_CONNECTIONS,
     PUSHER_CIRCUIT_BREAKER_REJECTIONS,
@@ -347,11 +346,8 @@ async def _stream_handler(
     realtime_photo_buffers: deque[ConversationPhoto] = deque(maxlen=MAX_PHOTO_BUFFER_SIZE)
 
     # === Speaker Identification State ===
-    RING_BUFFER_DURATION = 60.0  # seconds
     SPEAKER_ID_MIN_AUDIO = 2.0
     SPEAKER_ID_TARGET_AUDIO = 4.0
-
-    audio_ring_buffer: Optional[AudioRingBuffer] = None
     speaker_id_segment_queue: asyncio.Queue[dict] = asyncio.Queue(maxsize=100)
     person_embeddings_cache: Dict[str, dict] = {}  # person_id -> {embedding, name}
     speaker_id_enabled = False  # Will be set after private_cloud_sync_enabled is known
@@ -690,8 +686,6 @@ async def _stream_handler(
     if not use_custom_stt and not is_multi_channel and include_speech_profile:
         has_speech_profile = get_user_has_speech_profile(uid)
     speaker_id_enabled = not use_custom_stt and (private_cloud_sync_enabled or has_speech_profile)
-    if speaker_id_enabled:
-        audio_ring_buffer = AudioRingBuffer(RING_BUFFER_DURATION, sample_rate)
 
     # Conversation timeout (to process the conversation after x seconds of silence)
     # Max: 4h, min 2m
@@ -1707,7 +1701,7 @@ async def _stream_handler(
     async def speaker_identification_task():
         """Consume segment queue, accumulate per speaker, trigger match when ready."""
         nonlocal websocket_active, speaker_to_person_map
-        nonlocal person_embeddings_cache, audio_ring_buffer
+        nonlocal person_embeddings_cache
 
         if not speaker_id_enabled:
             speaker_id_done.set()
@@ -1806,20 +1800,30 @@ async def _stream_handler(
         speaker_id_done.set()
 
     async def _match_speaker_embedding(speaker_id: int, segment: dict):
-        """Extract audio from ring buffer and match against stored embeddings."""
-        nonlocal speaker_to_person_map, segment_person_assignment_map, audio_ring_buffer, speaker_map_dirty
+        """Extract audio from STT audio ring buffer and match against stored embeddings.
+
+        Uses stt_start/stt_end (raw STT audio-time coordinates) to index into
+        deepgram_socket.stt_audio_ring, which stores exactly the bytes Deepgram
+        received. This eliminates wall-clock/STT-time drift (#6190).
+        """
+        nonlocal speaker_to_person_map, segment_person_assignment_map, speaker_map_dirty
 
         try:
-            seg_start = segment['abs_start']
-            seg_end = segment['abs_end']
+            seg_start = segment['stt_start']
+            seg_end = segment['stt_end']
             duration = segment['duration']
 
             if duration < SPEAKER_ID_MIN_AUDIO:
                 logger.info(f"Speaker ID: segment too short ({duration:.1f}s) {uid} {session_id}")
                 return
 
+            stt_ring = deepgram_socket.stt_audio_ring if deepgram_socket else None
+            if stt_ring is None:
+                logger.info(f"Speaker ID: no STT audio ring {uid} {session_id}")
+                return
+
             # Get buffer time range
-            time_range = audio_ring_buffer.get_time_range()
+            time_range = stt_ring.get_time_range()
             if time_range is None:
                 logger.info(f"Speaker ID: buffer empty {uid} {session_id}")
                 return
@@ -1856,8 +1860,8 @@ async def _stream_handler(
                 )
                 return
 
-            # Extract only the needed bytes directly from ring buffer
-            pcm_data = audio_ring_buffer.extract(extract_start, extract_end)
+            # Extract only the needed bytes directly from STT audio ring buffer
+            pcm_data = stt_ring.extract(extract_start, extract_end)
             if not pcm_data:
                 logger.error(f"Speaker ID: failed to extract audio {uid} {session_id}")
                 return
@@ -2138,26 +2142,25 @@ async def _stream_handler(
                         suggested_segments.add(segment.id)
                         continue
 
-                    # Embeding id speaker indentification
+                    # Embedding-based speaker identification (#6190: use STT audio-time)
                     if speaker_id_enabled and person_embeddings_cache:
-                        started_at_ts = conversation.started_at.timestamp()
                         if (
                             segment.speaker_id is not None
                             and not segment.person_id
                             and not segment.is_user
                             and segment.speaker_id not in speaker_to_person_map
+                            and segment.stt_start is not None
+                            and segment.stt_end is not None
                         ):
                             try:
                                 speaker_id_segment_queue.put_nowait(
                                     {
                                         'id': segment.id,
                                         'speaker_id': segment.speaker_id,
-                                        'abs_start': first_audio_byte_timestamp
-                                        + segment.start
-                                        - time_offset,  # raw start/end
-                                        'abs_end': first_audio_byte_timestamp + segment.end - time_offset,
-                                        'duration': segment.end - segment.start,
-                                        'text': segment.text,  # TODO: remove
+                                        'stt_start': segment.stt_start,
+                                        'stt_end': segment.stt_end,
+                                        'duration': segment.stt_end - segment.stt_start,
+                                        'text': segment.text,
                                     }
                                 )
                             except asyncio.QueueFull:
@@ -2302,7 +2305,7 @@ async def _stream_handler(
     async def receive_data(dg_socket):
         nonlocal websocket_active, websocket_close_code, last_audio_received_time, last_activity_time, current_conversation_id
         nonlocal realtime_photo_buffers, speaker_to_person_map, first_audio_byte_timestamp, last_usage_record_timestamp
-        nonlocal audio_ring_buffer, dg_usage_ms_pending
+        nonlocal dg_usage_ms_pending
         timer_start = time.time()
         last_audio_received_time = timer_start
         last_activity_time = timer_start
@@ -2456,10 +2459,6 @@ async def _stream_handler(
                                     f"Sample rate: {sample_rate}Hz {uid} {session_id}"
                                 )
                                 continue
-
-                        # Feed ring buffer for speaker identification (always, with wall-clock time)
-                        if audio_ring_buffer is not None:
-                            audio_ring_buffer.write(data, last_audio_received_time)
 
                         if not use_custom_stt:
                             # VAD gating is handled inside GatedDeepgramSocket.send()

--- a/backend/tests/unit/test_streaming_deepgram_backoff.py
+++ b/backend/tests/unit/test_streaming_deepgram_backoff.py
@@ -298,9 +298,10 @@ def test_deepgram_options_no_keepalive():
 
 
 @pytest.mark.asyncio
-async def test_process_audio_dg_returns_safe_socket_no_gate():
-    """process_audio_dg returns SafeDeepgramSocket when no VAD gate provided (#5870)."""
+async def test_process_audio_dg_returns_gated_socket_no_gate():
+    """process_audio_dg always returns GatedDeepgramSocket, even without VAD gate (#6190)."""
     from utils.stt.safe_socket import SafeDeepgramSocket
+    from utils.stt.vad_gate import GatedDeepgramSocket
 
     mock_dg_conn = MagicMock()
     with patch(
@@ -312,7 +313,8 @@ async def test_process_audio_dg_returns_safe_socket_no_gate():
             sample_rate=16000,
             channels=1,
         )
-    assert isinstance(result, SafeDeepgramSocket)
+    assert isinstance(result, GatedDeepgramSocket)
+    assert isinstance(result._conn, SafeDeepgramSocket)
     assert result.is_connection_dead is False
     result.finish()
 
@@ -867,7 +869,7 @@ def test_close_reason_preserved_when_keepalive_raises_after():
 @pytest.mark.asyncio
 async def test_process_audio_dg_registers_close_error_handlers():
     """process_audio_dg registers Close and Error handlers on dg_connection (#6036)."""
-    from utils.stt.safe_socket import SafeDeepgramSocket
+    from utils.stt.vad_gate import GatedDeepgramSocket
 
     mock_dg_conn = MagicMock()
     with patch(
@@ -879,7 +881,7 @@ async def test_process_audio_dg_registers_close_error_handlers():
             sample_rate=16000,
             channels=1,
         )
-    assert isinstance(result, SafeDeepgramSocket)
+    assert isinstance(result, GatedDeepgramSocket)
 
     # Verify .on() was called for Close and Error events
     on_calls = mock_dg_conn.on.call_args_list
@@ -888,7 +890,7 @@ async def test_process_audio_dg_registers_close_error_handlers():
     assert LiveTranscriptionEvents.Close in registered_events
     assert LiveTranscriptionEvents.Error in registered_events
 
-    # Invoke the close handler and verify it sets death_reason
+    # Invoke the close handler and verify it sets death_reason via delegation
     for call in on_calls:
         event, handler = call[0][0], call[0][1]
         if event == LiveTranscriptionEvents.Close:
@@ -901,7 +903,7 @@ async def test_process_audio_dg_registers_close_error_handlers():
 @pytest.mark.asyncio
 async def test_process_audio_dg_error_handler_sets_death_reason():
     """process_audio_dg Error handler feeds into set_close_reason (#6036)."""
-    from utils.stt.safe_socket import SafeDeepgramSocket
+    from utils.stt.vad_gate import GatedDeepgramSocket
 
     mock_dg_conn = MagicMock()
     with patch(
@@ -913,7 +915,7 @@ async def test_process_audio_dg_error_handler_sets_death_reason():
             sample_rate=16000,
             channels=1,
         )
-    assert isinstance(result, SafeDeepgramSocket)
+    assert isinstance(result, GatedDeepgramSocket)
 
     on_calls = mock_dg_conn.on.call_args_list
     LiveTranscriptionEvents = sys.modules['deepgram'].LiveTranscriptionEvents

--- a/backend/tests/unit/test_streaming_deepgram_backoff.py
+++ b/backend/tests/unit/test_streaming_deepgram_backoff.py
@@ -929,6 +929,113 @@ async def test_process_audio_dg_error_handler_sets_death_reason():
 
 
 # ---------------------------------------------------------------------------
+# stream_transcript callback contract tests (#6190)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_stream_transcript_injects_stt_start_stt_end():
+    """process_audio_dg wrapper should inject stt_start/stt_end into forwarded segments (#6190).
+
+    Captures the on_message callback from process_audio_dg, fires it with a mock
+    DG result, and verifies the original stream_transcript receives segments with
+    stt_start/stt_end set to the raw DG timestamps.
+    """
+    received = []
+    original_transcript = lambda segs: received.extend(segs)
+
+    mock_dg_conn = MagicMock()
+    captured_on_message = None
+
+    async def capture_backoff(on_message, on_error, *args, **kwargs):
+        nonlocal captured_on_message
+        captured_on_message = on_message
+        return mock_dg_conn
+
+    with patch('utils.stt.streaming.connect_to_deepgram_with_backoff', new=capture_backoff):
+        await process_audio_dg(
+            stream_transcript=original_transcript,
+            language='en',
+            sample_rate=16000,
+            channels=1,
+        )
+
+    assert captured_on_message is not None, "on_message should have been captured"
+
+    # Build a mock DG result with one word
+    mock_word = MagicMock()
+    mock_word.speaker = 0
+    mock_word.start = 1.5
+    mock_word.end = 2.3
+    mock_word.punctuated_word = "Hello"
+
+    mock_result = MagicMock()
+    mock_result.channel.alternatives = [MagicMock()]
+    mock_result.channel.alternatives[0].transcript = "Hello"
+    mock_result.channel.alternatives[0].words = [mock_word]
+
+    # Fire the callback
+    captured_on_message(None, mock_result)
+
+    assert len(received) == 1
+    seg = received[0]
+    assert seg['stt_start'] == 1.5, "stt_start should equal raw DG start"
+    assert seg['stt_end'] == 2.3, "stt_end should equal raw DG end"
+    assert seg['start'] == 1.5, "start should be unmodified (no gate)"
+    assert seg['end'] == 2.3, "end should be unmodified (no gate)"
+
+
+@pytest.mark.asyncio
+async def test_stream_transcript_stt_preserved_before_remap():
+    """With VAD gate, stt_start/stt_end should be preserved before wall-clock remapping (#6190)."""
+    from utils.stt.vad_gate import VADStreamingGate
+
+    received = []
+    original_transcript = lambda segs: received.extend(segs)
+
+    mock_dg_conn = MagicMock()
+    captured_on_message = None
+
+    async def capture_backoff(on_message, on_error, *args, **kwargs):
+        nonlocal captured_on_message
+        captured_on_message = on_message
+        return mock_dg_conn
+
+    mock_gate = VADStreamingGate(sample_rate=16000, channels=1, mode='active', uid='test', session_id='test')
+    # Seed mapper with offset so remap changes start/end
+    mock_gate.dg_wall_mapper.on_audio_sent(chunk_duration_sec=5.0, chunk_wall_rel_sec=100.0)
+
+    with patch('utils.stt.streaming.connect_to_deepgram_with_backoff', new=capture_backoff):
+        await process_audio_dg(
+            stream_transcript=original_transcript,
+            language='en',
+            sample_rate=16000,
+            channels=1,
+            vad_gate=mock_gate,
+        )
+
+    mock_word = MagicMock()
+    mock_word.speaker = 0
+    mock_word.start = 1.0
+    mock_word.end = 2.0
+    mock_word.punctuated_word = "Test"
+
+    mock_result = MagicMock()
+    mock_result.channel.alternatives = [MagicMock()]
+    mock_result.channel.alternatives[0].transcript = "Test"
+    mock_result.channel.alternatives[0].words = [mock_word]
+
+    captured_on_message(None, mock_result)
+
+    assert len(received) == 1
+    seg = received[0]
+    assert seg['stt_start'] == 1.0, "stt_start should preserve raw DG time"
+    assert seg['stt_end'] == 2.0, "stt_end should preserve raw DG time"
+    # start/end should be remapped to wall-clock
+    assert seg['start'] != 1.0, "start should have been remapped by gate"
+
+
+# ---------------------------------------------------------------------------
 # GatedDeepgramSocket death_reason delegation tests
 # ---------------------------------------------------------------------------
 

--- a/backend/tests/unit/test_transcript_segment.py
+++ b/backend/tests/unit/test_transcript_segment.py
@@ -508,3 +508,111 @@ def test_mixed_english_cjk_sentence_splitting():
     assert len(segments) == 2
     assert segments[0].text.endswith("。")
     assert segments[1].text == "Next part."
+
+
+# --- stt_start / stt_end field tests (#6190) ---
+
+
+def _segment_with_stt(text, speaker="SPEAKER_00", is_user=False, start=0.0, end=1.0, stt_start=None, stt_end=None):
+    return TranscriptSegment(
+        text=text, speaker=speaker, is_user=is_user, start=start, end=end, stt_start=stt_start, stt_end=stt_end
+    )
+
+
+class TestSttTimestampFields:
+    """Tests for stt_start/stt_end — raw STT audio-time coordinates (#6190)."""
+
+    def test_stt_fields_survive_construction(self):
+        """stt_start/stt_end should be accessible on the object after construction."""
+        seg = _segment_with_stt("hello", stt_start=1.5, stt_end=3.0)
+        assert seg.stt_start == 1.5
+        assert seg.stt_end == 3.0
+
+    def test_stt_fields_excluded_from_dict(self):
+        """stt_start/stt_end must NOT appear in .dict() / .model_dump() output."""
+        seg = _segment_with_stt("hello", stt_start=1.5, stt_end=3.0)
+        d = seg.dict()
+        assert 'stt_start' not in d
+        assert 'stt_end' not in d
+
+    def test_stt_fields_excluded_from_model_dump(self):
+        """stt_start/stt_end must NOT appear in .model_dump() output (Pydantic v2)."""
+        seg = _segment_with_stt("hello", stt_start=1.5, stt_end=3.0)
+        d = seg.model_dump()
+        assert 'stt_start' not in d
+        assert 'stt_end' not in d
+
+    def test_stt_fields_default_none(self):
+        """stt_start/stt_end default to None when not provided."""
+        seg = _segment("hello")
+        assert seg.stt_start is None
+        assert seg.stt_end is None
+
+    def test_stt_fields_survive_model_copy(self):
+        """stt_start/stt_end should survive model_copy(deep=True)."""
+        seg = _segment_with_stt("hello", stt_start=1.5, stt_end=3.0)
+        copy = seg.model_copy(deep=True)
+        assert copy.stt_start == 1.5
+        assert copy.stt_end == 3.0
+
+    def test_stt_fields_from_dict_kwargs(self):
+        """stt_start/stt_end should work when passed via **dict (streaming.py flow)."""
+        data = {
+            'text': 'hello',
+            'speaker': 'SPEAKER_00',
+            'is_user': False,
+            'start': 0.0,
+            'end': 1.0,
+            'stt_start': 2.0,
+            'stt_end': 3.0,
+        }
+        seg = TranscriptSegment(**data, speech_profile_processed=True)
+        assert seg.stt_start == 2.0
+        assert seg.stt_end == 3.0
+
+
+class TestSttTimestampMerge:
+    """Tests that stt_end propagates correctly during segment merges (#6190)."""
+
+    def test_same_speaker_merge_carries_stt_end(self):
+        """Same-speaker merge should update stt_end to the last segment's value."""
+        a = _segment_with_stt("Hello there", speaker="SPEAKER_00", start=0.0, end=2.0, stt_start=0.0, stt_end=1.5)
+        b = _segment_with_stt("my friend.", speaker="SPEAKER_00", start=2.0, end=4.0, stt_start=1.5, stt_end=3.5)
+        segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+        assert len(segments) == 1
+        assert segments[0].stt_start == 0.0
+        assert segments[0].stt_end == 3.5
+
+    def test_different_speaker_preserves_stt(self):
+        """Different speaker segments with complete sentences keep their own stt times."""
+        a = _segment_with_stt(
+            "Hello there, how are you doing today?",
+            speaker="SPEAKER_00",
+            start=0.0,
+            end=2.0,
+            stt_start=0.0,
+            stt_end=1.5,
+        )
+        b = _segment_with_stt(
+            "I am doing great, thanks for asking.",
+            speaker="SPEAKER_01",
+            start=2.0,
+            end=4.0,
+            stt_start=1.5,
+            stt_end=3.5,
+        )
+        segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+        assert len(segments) == 2
+        assert segments[0].stt_start == 0.0
+        assert segments[0].stt_end == 1.5
+        assert segments[1].stt_start == 1.5
+        assert segments[1].stt_end == 3.5
+
+    def test_merge_with_none_stt_fields(self):
+        """Merging segments where stt fields are None should not crash."""
+        a = _segment("Hello there", speaker="SPEAKER_00", start=0.0, end=2.0)
+        b = _segment("my friend.", speaker="SPEAKER_00", start=2.0, end=4.0)
+        segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+        assert len(segments) == 1
+        assert segments[0].stt_start is None
+        assert segments[0].stt_end is None

--- a/backend/tests/unit/test_transcript_segment.py
+++ b/backend/tests/unit/test_transcript_segment.py
@@ -608,6 +608,77 @@ class TestSttTimestampMerge:
         assert segments[1].stt_start == 1.5
         assert segments[1].stt_end == 3.5
 
+    def test_backward_single_sentence_merge_carries_stt_end(self):
+        """When b is fully absorbed into a (backward single-sentence), a.stt_end should extend."""
+        # a has incomplete sentence, b is a short incomplete continuation from different speaker
+        a = _segment_with_stt(
+            "Maybe it is a 20 degree field and we read faster than we can",
+            speaker="SPEAKER_00",
+            start=0.0,
+            end=2.0,
+            stt_start=0.0,
+            stt_end=1.5,
+        )
+        b = _segment_with_stt(
+            "listen.",
+            speaker="SPEAKER_01",
+            start=2.0,
+            end=2.2,
+            stt_start=1.5,
+            stt_end=1.7,
+        )
+        segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+        # b should be absorbed into a (single sentence backward merge)
+        assert len(segments) == 1
+        assert "listen" in segments[0].text
+        assert segments[0].stt_start == 0.0
+        assert segments[0].stt_end == 1.7, "stt_end should extend to cover absorbed b"
+
+    def test_forward_merge_clamps_stt_end(self):
+        """When incomplete text moves from a to b (forward merge), a.stt_end should clamp."""
+        a = _segment_with_stt(
+            "Complete sentence. and then",
+            speaker="SPEAKER_00",
+            start=0.0,
+            end=3.0,
+            stt_start=0.0,
+            stt_end=2.5,
+        )
+        b = _segment_with_stt(
+            "we keep going with a much longer sentence that makes this the dominant text.",
+            speaker="SPEAKER_01",
+            start=3.0,
+            end=6.0,
+            stt_start=2.5,
+            stt_end=5.5,
+        )
+        segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+        assert len(segments) == 2
+        # a.stt_end should be clamped to b.stt_start or below
+        assert segments[0].stt_end <= segments[1].stt_start
+
+    def test_lowercase_continuation_merge_carries_stt_end(self):
+        """Lowercase continuation merge should extend stt_end."""
+        a = _segment_with_stt(
+            "Hello there my",
+            speaker="SPEAKER_00",
+            start=0.0,
+            end=2.0,
+            stt_start=0.0,
+            stt_end=1.5,
+        )
+        b = _segment_with_stt(
+            "friend.",
+            speaker="SPEAKER_00",
+            start=2.0,
+            end=3.0,
+            stt_start=1.5,
+            stt_end=2.5,
+        )
+        segments, _, _ = TranscriptSegment.combine_segments([], [a, b])
+        assert len(segments) == 1
+        assert segments[0].stt_end == 2.5
+
     def test_merge_with_none_stt_fields(self):
         """Merging segments where stt fields are None should not crash."""
         a = _segment("Hello there", speaker="SPEAKER_00", start=0.0, end=2.0)

--- a/backend/tests/unit/test_vad_gate.py
+++ b/backend/tests/unit/test_vad_gate.py
@@ -2217,6 +2217,25 @@ class TestSttAudioRingBuffer:
             assert sock._stt_cursor_sec > prev
             prev = sock._stt_cursor_sec
 
+    def test_gate_fallback_still_tracks_ring_buffer(self):
+        """After gate process error and fallback, audio should still go to stt_audio_ring."""
+        # Create a gate that will raise on process_audio
+        gate = VADStreamingGate(sample_rate=8000, channels=1, mode='active', uid='u', session_id='s')
+        mock_conn = MagicMock()
+        sock = GatedDeepgramSocket(mock_conn, gate=gate, sample_rate=8000)
+
+        # Make gate.process_audio raise to trigger fallback
+        gate.process_audio = MagicMock(side_effect=RuntimeError("VAD crash"))
+
+        chunk = _make_pcm(20, sample_rate=8000)
+        sock.send(chunk, wall_time=time.time())
+
+        # After fallback, gate should be disabled
+        assert sock._gate is None
+        # But audio should still be tracked in ring buffer
+        assert sock._stt_cursor_sec > 0.0, "Fallback path should still track STT audio"
+        assert sock.stt_audio_ring.total_bytes_written == len(chunk)
+
 
 class TestRemapPreservesSttTimes:
     """Verify remap_segments preserves stt_start/stt_end (#6190)."""

--- a/backend/tests/unit/test_vad_gate.py
+++ b/backend/tests/unit/test_vad_gate.py
@@ -2146,3 +2146,128 @@ class TestDG1011KeepaliveGap:
             )
         finally:
             safe.finish()
+
+
+# ---------------------------------------------------------------------------
+# STT audio ring buffer tests (#6190)
+# ---------------------------------------------------------------------------
+
+
+class TestSttAudioRingBuffer:
+    """Verify that GatedDeepgramSocket tracks audio sent to DG in stt_audio_ring."""
+
+    def test_no_gate_tracks_all_bytes(self):
+        """Without a gate, all sent audio ends up in stt_audio_ring."""
+        mock_conn = MagicMock()
+        sock = GatedDeepgramSocket(mock_conn, gate=None, sample_rate=8000)
+
+        chunk = _make_pcm(20, sample_rate=8000)  # 20ms @ 8kHz = 320 bytes
+        sock.send(chunk)
+
+        assert sock._stt_cursor_sec == pytest.approx(len(chunk) / (8000 * 2), abs=1e-9)
+        extracted = sock.stt_audio_ring.extract(0.0, sock._stt_cursor_sec)
+        assert extracted == chunk
+
+    def test_gated_tracks_only_speech_bytes(self):
+        """With an active gate, only speech audio goes into stt_audio_ring."""
+        gate = VADStreamingGate(sample_rate=8000, channels=1, mode='active', uid='u', session_id='s')
+        mock_conn = MagicMock()
+        sock = GatedDeepgramSocket(mock_conn, gate=gate, sample_rate=8000)
+
+        t = time.time()
+        # Silence: no audio should reach DG or ring buffer
+        _set_vad_speech(False)
+        for i in range(5):
+            sock.send(_make_pcm(30, sample_rate=8000), wall_time=t + i * 0.03)
+
+        assert sock._stt_cursor_sec == 0.0, "Silence should not advance STT cursor"
+
+        # Speech: audio should reach both DG and ring buffer
+        _set_vad_speech(True)
+        speech_chunk = _make_pcm(30, sample_rate=8000)
+        sock.send(speech_chunk, wall_time=t + 0.2)
+
+        assert sock._stt_cursor_sec > 0.0, "Speech should advance STT cursor"
+        assert sock.stt_audio_ring.total_bytes_written > 0
+
+    def test_extract_matches_sent_audio(self):
+        """Ring buffer extract for full range should return exactly what was sent."""
+        mock_conn = MagicMock()
+        sock = GatedDeepgramSocket(mock_conn, gate=None, sample_rate=8000)
+
+        chunks = []
+        for i in range(50):
+            chunk = _make_pcm(20, sample_rate=8000)
+            chunks.append(chunk)
+            sock.send(chunk)
+
+        all_audio = b''.join(chunks)
+        extracted = sock.stt_audio_ring.extract(0.0, sock._stt_cursor_sec)
+        # Allow ±4 byte tolerance for floating-point cursor accumulation
+        assert abs(len(extracted) - len(all_audio)) <= 4
+
+    def test_cursor_advances_monotonically(self):
+        """STT cursor should advance monotonically with each send."""
+        mock_conn = MagicMock()
+        sock = GatedDeepgramSocket(mock_conn, gate=None, sample_rate=16000)
+
+        prev = 0.0
+        for _ in range(10):
+            sock.send(_make_pcm(20, sample_rate=16000))
+            assert sock._stt_cursor_sec > prev
+            prev = sock._stt_cursor_sec
+
+
+class TestRemapPreservesSttTimes:
+    """Verify remap_segments preserves stt_start/stt_end (#6190)."""
+
+    def test_remap_sets_stt_fields(self):
+        """remap_segments should copy start/end to stt_start/stt_end before overwriting."""
+        gate = VADStreamingGate(sample_rate=8000, channels=1, mode='active', uid='u', session_id='s')
+        # Seed the DG→wall mapper with a checkpoint that has a wall-time offset
+        # so we can verify start/end get remapped to different values
+        gate.dg_wall_mapper.on_audio_sent(chunk_duration_sec=5.0, chunk_wall_rel_sec=100.0)
+
+        segments = [
+            {'start': 1.0, 'end': 2.0, 'text': 'hello', 'speaker': 'SPEAKER_00', 'is_user': False, 'person_id': None},
+        ]
+        gate.remap_segments(segments)
+
+        assert segments[0]['stt_start'] == 1.0, "Raw STT start should be preserved"
+        assert segments[0]['stt_end'] == 2.0, "Raw STT end should be preserved"
+        # start/end should now be wall-clock-relative (different from raw STT times)
+        assert segments[0]['start'] != 1.0, "start should have been remapped"
+
+    def test_remap_does_not_overwrite_existing_stt(self):
+        """If stt_start/stt_end are already set, remap should not overwrite them."""
+        gate = VADStreamingGate(sample_rate=8000, channels=1, mode='active', uid='u', session_id='s')
+        gate.dg_wall_mapper.on_audio_sent(chunk_duration_sec=5.0, chunk_wall_rel_sec=100.0)
+
+        segments = [
+            {
+                'start': 1.0,
+                'end': 2.0,
+                'stt_start': 0.5,
+                'stt_end': 1.5,
+                'text': 'hello',
+                'speaker': 'SPEAKER_00',
+                'is_user': False,
+                'person_id': None,
+            },
+        ]
+        gate.remap_segments(segments)
+
+        assert segments[0]['stt_start'] == 0.5, "Pre-existing stt_start should not be overwritten"
+        assert segments[0]['stt_end'] == 1.5, "Pre-existing stt_end should not be overwritten"
+
+    def test_remap_noop_when_shadow(self):
+        """In shadow mode, remap_segments should not touch any timestamps."""
+        gate = VADStreamingGate(sample_rate=8000, channels=1, mode='shadow', uid='u', session_id='s')
+        segments = [
+            {'start': 1.0, 'end': 2.0, 'text': 'hello', 'speaker': 'SPEAKER_00', 'is_user': False, 'person_id': None},
+        ]
+        gate.remap_segments(segments)
+
+        assert segments[0]['start'] == 1.0
+        assert segments[0]['end'] == 2.0
+        assert 'stt_start' not in segments[0], "Shadow mode should not add stt fields"

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -183,13 +183,18 @@ async def process_audio_dg(
     """
     logger.info(f'process_audio_dg {language} {sample_rate} {channels}')
 
-    # If gate provided, wrap stream_transcript to remap DG timestamps
-    if vad_gate is not None:
-        _original_stream_transcript = stream_transcript
+    # Wrap stream_transcript to:
+    # 1. Always preserve raw STT audio-time as stt_start/stt_end (#6190)
+    # 2. Remap start/end to wall-clock-relative when VAD gate is active
+    _original_stream_transcript = stream_transcript
 
-        def stream_transcript(segments):
+    def stream_transcript(segments):
+        for seg in segments:
+            seg['stt_start'] = seg['start']
+            seg['stt_end'] = seg['end']
+        if vad_gate is not None:
             vad_gate.remap_segments(segments)
-            _original_stream_transcript(segments)
+        _original_stream_transcript(segments)
 
     def on_message(self, result, **kwargs):
         sentence = result.channel.alternatives[0].transcript
@@ -255,10 +260,9 @@ async def process_audio_dg(
     dg_connection.on(LiveTranscriptionEvents.Close, on_dg_close)
     dg_connection.on(LiveTranscriptionEvents.Error, on_dg_error)
 
-    # Wrap with VAD gate if provided
-    if vad_gate is not None:
-        return GatedDeepgramSocket(safe_conn, gate=vad_gate)
-    return safe_conn
+    # Always wrap with GatedDeepgramSocket for STT audio ring buffer (#6190)
+    # + optional VAD gating
+    return GatedDeepgramSocket(safe_conn, gate=vad_gate, sample_rate=sample_rate)
 
 
 # Calculate backoff with jitter

--- a/backend/utils/stt/vad_gate.py
+++ b/backend/utils/stt/vad_gate.py
@@ -28,6 +28,8 @@ from typing import Any, Dict, List, Optional, Tuple
 import numpy as np
 import torch
 
+from utils.audio import AudioRingBuffer
+
 logger = logging.getLogger('vad_gate')
 
 # ---------------------------------------------------------------------------
@@ -673,9 +675,18 @@ class VADStreamingGate:
         }
 
     def remap_segments(self, segments: list) -> None:
-        """Remap DG timestamps to wall-clock-relative if gate is active."""
+        """Remap DG timestamps to wall-clock-relative if gate is active.
+
+        Preserves raw STT audio-time coordinates as ``stt_start``/``stt_end``
+        before overwriting ``start``/``end`` so speaker-extraction can use them
+        to index into the STT audio ring buffer. See #6190.
+        """
         if self.mode == 'active':
             for seg in segments:
+                if 'stt_start' not in seg:
+                    seg['stt_start'] = seg['start']
+                if 'stt_end' not in seg:
+                    seg['stt_end'] = seg['end']
                 seg['start'] = self.dg_wall_mapper.dg_to_wall_rel(seg['start'])
                 seg['end'] = self.dg_wall_mapper.dg_to_wall_rel(seg['end'])
 
@@ -701,9 +712,14 @@ class GatedDeepgramSocket:
     This keeps all VAD logic out of transcribe.py.
     """
 
-    def __init__(self, dg_connection, gate: Optional['VADStreamingGate'] = None):
+    def __init__(self, dg_connection, gate: Optional['VADStreamingGate'] = None, sample_rate: int = 8000):
         self._conn = dg_connection
         self._gate = gate
+        # STT audio ring buffer — stores exactly the bytes DG receives, indexed
+        # by cumulative STT audio-time. Used for speaker-extraction (#6190).
+        self._bytes_per_sec = sample_rate * 2  # PCM16 mono
+        self._stt_cursor_sec = 0.0
+        self.stt_audio_ring = AudioRingBuffer(duration_seconds=120, sample_rate=sample_rate)
         # Audio capture for transcript quality validation (off by default)
         self._capture_dir = os.getenv('VAD_GATE_AUDIO_CAPTURE_DIR', '')
         self._raw_file = None
@@ -726,11 +742,18 @@ class GatedDeepgramSocket:
         """Why the DG connection died. Delegates to SafeDeepgramSocket."""
         return self._conn.death_reason
 
+    def _track_stt_audio(self, data: bytes) -> None:
+        """Write *data* to the STT audio ring buffer, advancing the cursor."""
+        duration = len(data) / self._bytes_per_sec
+        self._stt_cursor_sec += duration
+        self.stt_audio_ring.write(data, self._stt_cursor_sec)
+
     def send(self, data: bytes, wall_time: Optional[float] = None) -> None:
         """Send audio through VAD gate (if active), then to DG."""
         if self.is_connection_dead:
             return
         if self._gate is None:
+            self._track_stt_audio(data)
             return self._conn.send(data)
 
         now = wall_time or time.time()
@@ -740,12 +763,14 @@ class GatedDeepgramSocket:
             logger.exception('VAD gate process error, falling back to direct send uid=%s', self._gate.uid)
             self._gate.mode = 'off'  # Disable timestamp remapping in stream_transcript wrapper
             self._gate = None  # Disable gate for rest of session
+            self._track_stt_audio(data)
             return self._conn.send(data)
         if self._raw_file:
             self._raw_file.write(data)
         if self._gated_file and gate_out.audio_to_send:
             self._gated_file.write(gate_out.audio_to_send)
         if gate_out.audio_to_send:
+            self._track_stt_audio(gate_out.audio_to_send)
             # SafeDeepgramSocket.send() handles dead detection internally
             self._conn.send(gate_out.audio_to_send)
         # Keepalive is handled automatically by SafeDeepgramSocket's background thread.


### PR DESCRIPTION
Fixes #6190.

Speaker profile extraction was failing because the audio ring buffer used wall-clock timestamps while DG segment timestamps are STT-audio-relative. When VAD gate skips silence, these clocks diverge, causing "audio too short" failures. This PR adds `stt_start`/`stt_end` fields to `TranscriptSegment` that preserve raw STT audio-time coordinates, creates an STT audio ring buffer inside `GatedDeepgramSocket` that stores exactly the bytes Deepgram receives (indexed by cumulative STT audio-time), and wires speaker extraction to use these matched coordinates — eliminating the clock-source mismatch entirely.

**Review cycle changes:**
- Propagated `stt_end` through backward-merge single-sentence path
- Updated streaming tests for always-GatedDeepgramSocket wrapping
- Added merge propagation tests for all 4 stt_end paths (same-speaker, backward single-sentence, forward prefix-split, lowercase-continuation)
- Added gate fallback ring buffer tracking test

**Test results:** 201 passed across test_transcript_segment.py, test_vad_gate.py, test_streaming_deepgram_backoff.py.

---
_by AI for @beastoin_