### PR TITLE
Fix 4 failing TestDownloadEndpoint tests

### DIFF
--- a/backend/tests/unit/test_desktop_updates.py
+++ b/backend/tests/unit/test_desktop_updates.py
@@ -470,16 +470,15 @@ class TestDownloadEndpoint:
         mock_releases = [
             {
                 "channel": "stable",
+                "version_info": {"version": "1.0.0+100", "build": "100"},
                 "release": {"assets": [_dmg_asset("https://example.com/Omi-stable.dmg")]},
             },
         ]
         with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
-            async with AsyncClient(
-                transport=ASGITransport(app=_test_app), base_url="http://test", follow_redirects=False
-            ) as client:
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
                 resp = await client.get("/v2/desktop/download/latest?channel=stable")
-        assert resp.status_code == 302
-        assert resp.headers["location"] == "https://example.com/Omi-stable.dmg"
+        assert resp.status_code == 200
+        assert "https://example.com/Omi-stable.dmg" in resp.text
 
     @pytest.mark.asyncio
     async def test_404_no_releases(self):
@@ -493,50 +492,50 @@ class TestDownloadEndpoint:
         mock_releases = [
             {
                 "channel": "beta",
+                "version_info": {"version": "1.0.0+100", "build": "100"},
                 "release": {"assets": [_dmg_asset("https://example.com/beta.dmg")]},
             },
         ]
         with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
-            async with AsyncClient(
-                transport=ASGITransport(app=_test_app), base_url="http://test", follow_redirects=False
-            ) as client:
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
                 resp = await client.get("/v2/desktop/download/latest?channel=stable")
-        assert resp.status_code == 302
-        assert "beta.dmg" in resp.headers["location"]
+        assert resp.status_code == 200
+        assert "beta.dmg" in resp.text
 
     @pytest.mark.asyncio
     async def test_beta_no_fallback(self):
         mock_releases = [
             {
                 "channel": "stable",
+                "version_info": {"version": "1.0.0+100", "build": "100"},
                 "release": {"assets": [_dmg_asset("https://example.com/stable.dmg")]},
             },
         ]
         with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
             async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
                 resp = await client.get("/v2/desktop/download/latest?channel=beta")
-        assert resp.status_code == 302
-        assert resp.headers["location"] == "https://example.com/stable.dmg"
+        assert resp.status_code == 200
+        assert "https://example.com/stable.dmg" in resp.text
 
     @pytest.mark.asyncio
     async def test_beta_uses_latest_release_even_if_marked_stable(self):
         mock_releases = [
             {
                 "channel": "stable",
+                "version_info": {"version": "2.0.0+200", "build": "200"},
                 "release": {"assets": [_dmg_asset("https://example.com/latest.dmg")]},
             },
             {
                 "channel": "beta",
+                "version_info": {"version": "1.0.0+100", "build": "100"},
                 "release": {"assets": [_dmg_asset("https://example.com/older-beta.dmg")]},
             },
         ]
         with patch("routers.updates._get_live_desktop_releases", new_callable=AsyncMock, return_value=mock_releases):
-            async with AsyncClient(
-                transport=ASGITransport(app=_test_app), base_url="http://test", follow_redirects=False
-            ) as client:
+            async with AsyncClient(transport=ASGITransport(app=_test_app), base_url="http://test") as client:
                 resp = await client.get("/v2/desktop/download/latest?channel=beta")
-        assert resp.status_code == 302
-        assert resp.headers["location"] == "https://example.com/latest.dmg"
+        assert resp.status_code == 200
+        assert "https://example.com/latest.dmg" in resp.text
 
     @pytest.mark.asyncio
     async def test_404_when_no_dmg_asset(self):


### PR DESCRIPTION
Fixes 4 pre-existing test failures in `test_desktop_updates.py` that broke after the download endpoint was changed from 302 redirects to HTML landing pages (commit 7dcbd3222e). The `TestDownloadEndpoint` mocks were missing the `version_info` field (causing `KeyError`) and assertions expected 302 + `Location` header instead of 200 + HTML content with the DMG URL.

---
_This pr was drafted by AI on behalf of @beastoin_