### PR TITLE
Update CHANGELOG.json for v0.11.221 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,13 @@
 {
-  "unreleased": ["Fixed speaker diarization in Take Note by migrating live transcription to production backend"],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.221",
+      "date": "2026-04-02",
+      "changes": [
+        "Fixed speaker diarization in Take Note by migrating live transcription to production backend"
+      ]
+    },
     {
       "version": "0.11.220",
       "date": "2026-04-02",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.221 and clears the unreleased array.