### PR TITLE
Update CHANGELOG.json for v0.11.223 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,13 @@
 {
-  "unreleased": ["Fixed speaker diarization in Take Note by migrating live transcription to production backend"],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.223",
+      "date": "2026-04-04",
+      "changes": [
+        "Fixed speaker diarization in Take Note by migrating live transcription to production backend"
+      ]
+    },
     {
       "version": "0.11.222",
       "date": "2026-04-03",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.223 and clears the unreleased array.