### PR TITLE
chore: bump build number to 804

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.530+803
+version: 1.0.530+804
 
 environment:
   sdk: ">=3.0.0 <4.0.0"


### PR DESCRIPTION
Bump build number 803 → 804 for mobile release. Includes PR #6294 (audio safety WAL widget + auto-sync).

---
_by AI for @beastoin_