### PR TITLE
feat(auth): compile-time DEV_AUTH_BYPASS for local dev

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -22,7 +22,15 @@ class ApiClient {
   }
 }
 
+const _devAuthBypassEnabled = bool.fromEnvironment('DEV_AUTH_BYPASS_ENABLED');
+const _devAdminKey = String.fromEnvironment('DEV_ADMIN_KEY');
+const _devAuthBypassUid = String.fromEnvironment('DEV_AUTH_BYPASS_UID');
+
 Future<String> getAuthHeader() async {
+  if (_devAuthBypassEnabled && _devAdminKey.isNotEmpty) {
+    return 'Bearer $_devAdminKey$_devAuthBypassUid';
+  }
+
   DateTime? expiry = DateTime.fromMillisecondsSinceEpoch(SharedPreferencesUtil().tokenExpirationTime);
   bool hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
 

--- a/app/lib/providers/auth_provider.dart
+++ b/app/lib/providers/auth_provider.dart
@@ -18,6 +18,9 @@ import 'package:omi/utils/platform/platform_manager.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 
 class AuthenticationProvider extends BaseProvider {
+  static const _devAuthBypassEnabled = bool.fromEnvironment('DEV_AUTH_BYPASS_ENABLED');
+  static const _devAuthBypassUid = String.fromEnvironment('DEV_AUTH_BYPASS_UID');
+
   FirebaseAuth get _auth => FirebaseAuth.instance;
 
   User? user;
@@ -28,6 +31,16 @@ class AuthenticationProvider extends BaseProvider {
 
   AuthenticationProvider() {
     _initializeAuthListeners();
+    if (_devAuthBypassEnabled) {
+      _initDevAuthBypass();
+    }
+  }
+
+  Future<void> _initDevAuthBypass() async {
+    if (_auth.currentUser == null) {
+      Logger.debug('DEV_AUTH_BYPASS: signing in anonymously as $_devAuthBypassUid');
+      await _auth.signInAnonymously();
+    }
   }
 
   void _initializeAuthListeners() {
@@ -74,6 +87,9 @@ class AuthenticationProvider extends BaseProvider {
   }
 
   bool isSignedIn() {
+    if (_devAuthBypassEnabled) {
+      return _auth.currentUser != null;
+    }
     return _auth.currentUser != null && !_auth.currentUser!.isAnonymous;
   }
 

--- a/app/lib/services/auth_service.dart
+++ b/app/lib/services/auth_service.dart
@@ -23,9 +23,16 @@ class AuthService {
   static final AuthService _instance = AuthService._internal();
   static AuthService get instance => _instance;
 
+  static const _devAuthBypassEnabled = bool.fromEnvironment('DEV_AUTH_BYPASS_ENABLED');
+
   AuthService._internal();
 
-  bool isSignedIn() => FirebaseAuth.instance.currentUser != null && !FirebaseAuth.instance.currentUser!.isAnonymous;
+  bool isSignedIn() {
+    if (_devAuthBypassEnabled) {
+      return FirebaseAuth.instance.currentUser != null;
+    }
+    return FirebaseAuth.instance.currentUser != null && !FirebaseAuth.instance.currentUser!.isAnonymous;
+  }
 
   getFirebaseUser() {
     return FirebaseAuth.instance.currentUser;
@@ -224,8 +231,7 @@ class AuthService {
 
       Logger.debug('Starting OAuth flow for provider: $provider');
 
-      final authUrl =
-          '${Env.apiBaseUrl}v1/auth/authorize'
+      final authUrl = '${Env.apiBaseUrl}v1/auth/authorize'
           '?provider=$provider'
           '&redirect_uri=${Uri.encodeComponent(redirectUri)}'
           '&state=$state';
@@ -511,15 +517,13 @@ class AuthService {
           Logger.debug('Web platform detected - attempting updateProfile with caution');
 
           // Try with a timeout to prevent hanging
-          await user
-              .updateProfile(displayName: fullName)
-              .timeout(
-                const Duration(seconds: 5),
-                onTimeout: () {
-                  Logger.debug('updateProfile timed out on web platform');
-                  throw TimeoutException('updateProfile timed out', const Duration(seconds: 5));
-                },
-              );
+          await user.updateProfile(displayName: fullName).timeout(
+            const Duration(seconds: 5),
+            onTimeout: () {
+              Logger.debug('updateProfile timed out on web platform');
+              throw TimeoutException('updateProfile timed out', const Duration(seconds: 5));
+            },
+          );
         } else {
           await user.updateProfile(displayName: fullName);
         }
@@ -565,8 +569,7 @@ class AuthService {
 
       Logger.debug('Starting OAuth linking flow for provider: $provider');
 
-      final authUrl =
-          '${Env.apiBaseUrl}v1/auth/authorize'
+      final authUrl = '${Env.apiBaseUrl}v1/auth/authorize'
           '?provider=$provider'
           '&redirect_uri=${Uri.encodeComponent(redirectUri)}'
           '&state=$state';


### PR DESCRIPTION
Add compile-time auth bypass for local development, enabling the `omi` CLI to build and run the Flutter app without OAuth. When `DEV_AUTH_BYPASS_ENABLED=true` is passed via `--dart-define`, the app signs in anonymously and uses an ADMIN_KEY token for all API requests — matching the backend's existing `LOCAL_DEVELOPMENT=true` mode.

Three `--dart-define` flags control the bypass:
- `DEV_AUTH_BYPASS_ENABLED=true` — enables the bypass (default: false, dead code eliminated in prod)
- `DEV_AUTH_BYPASS_UID=dev-<name>` — per-agent UID for Firestore data isolation
- `DEV_ADMIN_KEY=123` — must match backend's ADMIN_KEY

Changes across 3 files (~40 lines):
- `auth_service.dart` — `isSignedIn()` accepts anonymous users when bypass enabled
- `auth_provider.dart` — auto `signInAnonymously()` on init, relaxed `isSignedIn()` gate
- `shared.dart` — `getAuthHeader()` returns `Bearer <ADMIN_KEY><UID>` directly, skipping Firebase token refresh

Safety: all bypass code uses `const bool.fromEnvironment` which defaults to `false` — Dart compiler eliminates dead branches in release/prod builds. Zero risk to production.

Context: agents waste 1-3 hours per PR debugging Firebase project mismatch (`based-hardware-dev` app configs vs `based-hardware` prod backend). This bypass eliminates that friction entirely for local dev. Part of the `omi` CLI tooling initiative.

---
_This pr was drafted by AI on behalf of @beastoin_