### PR TITLE
Fix unhealthy health check in GCP ALB for pusher endpoints

### DIFF
--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -267,22 +267,28 @@ resources:
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: 8080
-  failureThreshold: 30
+  failureThreshold: 5
   periodSeconds: 10
+  timeoutSeconds: 5
 
 readinessProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: 8080
-  failureThreshold: 30
+  failureThreshold: 3
   periodSeconds: 10
+  timeoutSeconds: 5
 
 startupProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: 8080
-  failureThreshold: 30
+  failureThreshold: 60
   periodSeconds: 10
+  timeoutSeconds: 5
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -292,25 +292,28 @@ resources:
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 livenessProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: 8080
-  failureThreshold: 3
+  failureThreshold: 5
   periodSeconds: 10
-  timeoutSeconds: 1
+  timeoutSeconds: 5
 
 readinessProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: 8080
   failureThreshold: 3
   periodSeconds: 10
-  timeoutSeconds: 1
+  timeoutSeconds: 5
 
 startupProbe:
-  tcpSocket:
+  httpGet:
+    path: /health
     port: 8080
   failureThreshold: 60
   periodSeconds: 10
-  timeoutSeconds: 1
+  timeoutSeconds: 5
 
 # This section is for setting up autoscaling more information can be found here: https://kubernetes.io/docs/concepts/workloads/autoscaling/
 autoscaling:
@@ -391,26 +394,4 @@ affinity:
             - key: version
               operator: In
               values:
-                - v2
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        preference:
-          matchExpressions:
-            - key: topology.kubernetes.io/zone
-              operator: In
-              values:
-                - us-central1-a
-      - weight: 70
-        preference:
-          matchExpressions:
-            - key: topology.kubernetes.io/zone
-              operator: In
-              values:
-                - us-central1-b
-      - weight: 50
-        preference:
-          matchExpressions:
-            - key: topology.kubernetes.io/zone
-              operator: In
-              values:
-                - us-central1-c
+                - v3

--- a/backend/pusher/main.py
+++ b/backend/pusher/main.py
@@ -27,5 +27,5 @@ for path in paths:
 
 
 @app.get('/health')
-def health_check():
+async def health_check():
     return {"status": "healthy"}

--- a/backend/routers/pusher.py
+++ b/backend/routers/pusher.py
@@ -82,7 +82,9 @@ async def _process_conversation_task(uid: str, conversation_id: str, language: s
             geolocation = get_cached_user_geolocation(uid)
             if geolocation:
                 geolocation = Geolocation(**geolocation)
-                conversation.geolocation = get_google_maps_location(geolocation.latitude, geolocation.longitude)
+                conversation.geolocation = await asyncio.to_thread(
+                    get_google_maps_location, geolocation.latitude, geolocation.longitude
+                )
 
             # Run blocking operations in thread pool to avoid blocking event loop
             conversation = await asyncio.to_thread(process_conversation, uid, language, conversation)

--- a/backend/utils/app_integrations.py
+++ b/backend/utils/app_integrations.py
@@ -1,3 +1,4 @@
+import asyncio
 import threading
 from typing import List, Any
 from datetime import datetime
@@ -185,13 +186,13 @@ def trigger_external_integrations(uid: str, conversation: Conversation) -> list:
 async def trigger_realtime_integrations(uid: str, segments: list[dict], conversation_id: str | None):
     logger.info(f"trigger_realtime_integrations {uid}")
     """REALTIME STREAMING"""
-    _trigger_realtime_integrations(uid, segments, conversation_id)
+    await asyncio.to_thread(_trigger_realtime_integrations, uid, segments, conversation_id)
 
 
 async def trigger_realtime_audio_bytes(uid: str, sample_rate: int, data: bytearray):
     logger.info(f"trigger_realtime_audio_bytes {uid}")
     """REALTIME AUDIO STREAMING"""
-    _trigger_realtime_audio_bytes(uid, sample_rate, data)
+    await asyncio.to_thread(_trigger_realtime_audio_bytes, uid, sample_rate, data)
 
 
 # proactive notification

--- a/backend/utils/webhooks.py
+++ b/backend/utils/webhooks.py
@@ -117,7 +117,8 @@ async def realtime_transcript_webhook(uid, segments: List[dict]):
             return
         webhook_url += f'?uid={uid}'
         try:
-            response = requests.post(
+            response = await asyncio.to_thread(
+                requests.post,
                 webhook_url,
                 json={'segments': segments, 'session_id': uid},
                 headers={'Content-Type': 'application/json'},
@@ -165,8 +166,8 @@ async def send_audio_bytes_developer_webhook(uid: str, sample_rate: int, data: b
             return
         webhook_url += f'?sample_rate={sample_rate}&uid={uid}'
         try:
-            response = requests.post(
-                webhook_url, data=data, headers={'Content-Type': 'application/octet-stream'}, timeout=15
+            response = await asyncio.to_thread(
+                requests.post, webhook_url, data=data, headers={'Content-Type': 'application/octet-stream'}, timeout=15
             )
             logger.info(f'send_audio_bytes_developer_webhook: {webhook_url} {response.status_code}')
         except Exception as e:


### PR DESCRIPTION
- _pusher/main.py_ — Make **/health** endpoint async
- _router/pusher.py_ — Offload blocking **get_google_maps_location** HTTP call to thread pool in conversation task
- _utils/app_integrations.py_ — Wrap **trigger_realtime_integrations** and **trigger_realtime_audio_bytes** in **asyncio.to_thread()**
- _utils/webhooks.py_ — Wrap **requests.post()** in **realtime_transcript_webhook** with **asyncio.to_thread()**
- _utils/webhooks.py_ — Offload blocking **requests.post** in **send_audio_bytes_developer_webhook** to thread pool
- _charts/pusher/prod_omi_pusher_values.yaml_ — Switch K8s probes from **tcpSocket** to **httpGet /health**
- _charts/pusher/prod_omi_pusher_values.yaml_ — Migrate pusher to **n4-highmem-2** node pool for better price/performance