### PR TITLE
Fix voice answers: deploy ElevenLabs API key to Cloud Run

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -84,6 +84,7 @@ jobs:
             DEEPGRAM_API_KEY=DESKTOP_DEEPGRAM_API_KEY:latest
             ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest
             GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
+            ELEVENLABS_API_KEY=DESKTOP_ELEVENLABS_API_KEY:latest
 
   deploy-desktop-backend-prod:
     needs: deploy-desktop-backend
@@ -147,6 +148,7 @@ jobs:
             DEEPGRAM_API_KEY=DESKTOP_DEEPGRAM_API_KEY:latest
             ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest
             GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
+            ELEVENLABS_API_KEY=DESKTOP_ELEVENLABS_API_KEY:latest
 
   tag-release:
     needs: [deploy-desktop-backend, deploy-desktop-backend-prod]

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -73,6 +73,7 @@ jobs:
             DEEPGRAM_API_KEY=DESKTOP_DEEPGRAM_API_KEY:latest
             ANTHROPIC_API_KEY=DESKTOP_ANTHROPIC_API_KEY:latest
             GOOGLE_CALENDAR_API_KEY=DESKTOP_GOOGLE_CALENDAR_API_KEY:latest
+            ELEVENLABS_API_KEY=DESKTOP_ELEVENLABS_API_KEY:latest
 
       - name: Show Output
         run: echo "Desktop backend deployed to development environment"


### PR DESCRIPTION
## Summary
- The ElevenLabs TTS code was already added to the Rust backend and Swift app by previous PRs, but the **GitHub workflow never passed `ELEVENLABS_API_KEY`** to the Cloud Run deployment
- This meant the env var was always empty in production, so `APIKeyService` returned nil, and every user fell back to the macOS `AVSpeechSynthesizer` robot voice
- Adds `ELEVENLABS_API_KEY=DESKTOP_ELEVENLABS_API_KEY:latest` to all 3 Cloud Run deploy steps (dev, staging, prod)
- Created the `DESKTOP_ELEVENLABS_API_KEY` secret in GCP Secret Manager

## Test plan
- [ ] Deploy backend with this change
- [ ] Verify `/v1/config/api-keys` returns `elevenlabs_api_key`
- [ ] Trigger a floating bar voice reply and confirm ElevenLabs voice plays (not the macOS robot)

🤖 Generated with [Claude Code](https://claude.com/claude-code)