### PR TITLE
Add macOS onboarding Figma sync pipeline

### DIFF
--- a/.github/workflows/onboarding_figma_sync.yml
+++ b/.github/workflows/onboarding_figma_sync.yml
@@ -1,0 +1,53 @@
+name: Sync macOS onboarding to Figma source
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - ".github/workflows/onboarding_figma_sync.yml"
+      - "scripts/export_onboarding_sync_bundle.sh"
+      - "scripts/prepare_onboarding_sync_bundle.sh"
+      - "scripts/publish_onboarding_sync_branch.sh"
+      - "desktop/Desktop/Package.swift"
+      - "desktop/Desktop/Sources/OmiApp.swift"
+      - "desktop/Desktop/Sources/ViewExporter.swift"
+      - "desktop/Desktop/Sources/Theme/**"
+      - "desktop/Desktop/Sources/Onboarding*.swift"
+      - "desktop/Desktop/Sources/FileIndexing/OnboardingLoadingAnimation.swift"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: onboarding-figma-sync
+  cancel-in-progress: true
+
+jobs:
+  publish:
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure scripts are executable
+        run: chmod +x scripts/export_onboarding_sync_bundle.sh scripts/prepare_onboarding_sync_bundle.sh scripts/publish_onboarding_sync_branch.sh
+
+      - name: Export onboarding sync bundle
+        env:
+          SOURCE_COMMIT: ${{ github.sha }}
+          SOURCE_BRANCH: ${{ github.ref_name }}
+        run: scripts/export_onboarding_sync_bundle.sh "$RUNNER_TEMP/onboarding-sync-bundle" "$SOURCE_COMMIT" "$SOURCE_BRANCH"
+
+      - name: Upload bundle artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: onboarding-sync-bundle
+          path: ${{ runner.temp }}/onboarding-sync-bundle
+
+      - name: Publish bundle branch
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: scripts/publish_onboarding_sync_branch.sh "$RUNNER_TEMP/onboarding-sync-bundle"

--- a/desktop/Desktop/Sources/OnboardingView.swift
+++ b/desktop/Desktop/Sources/OnboardingView.swift
@@ -7,6 +7,8 @@ struct OnboardingView: View {
   @ObservedObject var appState: AppState
   @ObservedObject var chatProvider: ChatProvider
   var onComplete: (() -> Void)? = nil
+  var exportStepOverride: Int? = nil
+  var isExportPreview = false
   @AppStorage("onboardingStep") private var currentStep = 0
   @AppStorage("onboardingPagedIntroMigrationDone") private var hasMigratedPagedIntro = false
   @AppStorage("onboardingVideoStepMigrationDone") private var hasMigratedOnboardingSteps = false
@@ -30,7 +32,7 @@ struct OnboardingView: View {
         .ignoresSafeArea()
 
       Group {
-        if appState.hasCompletedOnboarding {
+        if appState.hasCompletedOnboarding && !isExportPreview {
           Color.clear
             .onAppear {
               log("OnboardingView: hasCompletedOnboarding=true, starting monitoring")
@@ -52,17 +54,21 @@ struct OnboardingView: View {
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .onAppear {
-      currentStep = OnboardingFlow.migratedStep(
-        currentStep: currentStep,
-        hasMigratedVideoStep: hasMigratedOnboardingSteps,
-        hasInsertedVoiceShortcutStep: hasInsertedVoiceShortcutStep,
-        hasMergedVoiceInputStep: hasMergedVoiceInputStep,
-        hasRemovedNotificationStep: hasRemovedNotificationStep,
-        hasInsertedFloatingBarShortcutStep: hasInsertedFloatingBarShortcutStep,
-        hasMigratedPagedIntro: hasMigratedPagedIntro,
-        hasReorderedTrustStep: hasReorderedTrustStep,
-        hasInsertedHowDidYouHearStep: hasInsertedHowDidYouHearStep
-      )
+      if let exportStepOverride {
+        currentStep = exportStepOverride
+      } else {
+        currentStep = OnboardingFlow.migratedStep(
+          currentStep: currentStep,
+          hasMigratedVideoStep: hasMigratedOnboardingSteps,
+          hasInsertedVoiceShortcutStep: hasInsertedVoiceShortcutStep,
+          hasMergedVoiceInputStep: hasMergedVoiceInputStep,
+          hasRemovedNotificationStep: hasRemovedNotificationStep,
+          hasInsertedFloatingBarShortcutStep: hasInsertedFloatingBarShortcutStep,
+          hasMigratedPagedIntro: hasMigratedPagedIntro,
+          hasReorderedTrustStep: hasReorderedTrustStep,
+          hasInsertedHowDidYouHearStep: hasInsertedHowDidYouHearStep
+        )
+      }
       hasMigratedPagedIntro = true
       hasMigratedOnboardingSteps = true
       hasInsertedVoiceShortcutStep = true
@@ -74,6 +80,7 @@ struct OnboardingView: View {
       introCoordinator.prepare(appState: appState)
     }
     .task {
+      guard !isExportPreview else { return }
       // Pre-warm the ACP bridge before the chat step starts.
       await chatProvider.warmupBridge()
       await graphViewModel.addGraphFromStorage()

--- a/desktop/Desktop/Sources/ViewExporter.swift
+++ b/desktop/Desktop/Sources/ViewExporter.swift
@@ -10,8 +10,10 @@ import SwiftUI
 // Modes:
 //   --export-views <dir>              Export all standalone page views
 //   --export-fullpages <dir>          Export full pages (sidebar + content)
+//   --export-onboarding <dir>         Export onboarding steps
 //   --export-single <index> <dir>     Export a single standalone view (subprocess)
 //   --export-fullpage-single <index> <dir>  Export a single full page (subprocess)
+//   --export-onboarding-single <index> <dir>  Export a single onboarding step (subprocess)
 
 @MainActor
 enum ViewExporter {
@@ -20,16 +22,17 @@ enum ViewExporter {
     let args = CommandLine.arguments
     return args.contains("--export-views") || args.contains("--export-single")
       || args.contains("--export-fullpages") || args.contains("--export-fullpage-single")
+      || args.contains("--export-onboarding") || args.contains("--export-onboarding-single")
   }
 
   static func outputDir() -> String {
     let args = CommandLine.arguments
-    for flag in ["--export-views", "--export-fullpages"] {
+    for flag in ["--export-views", "--export-fullpages", "--export-onboarding"] {
       if let idx = args.firstIndex(of: flag), idx + 1 < args.count {
         return args[idx + 1]
       }
     }
-    for flag in ["--export-single", "--export-fullpage-single"] {
+    for flag in ["--export-single", "--export-fullpage-single", "--export-onboarding-single"] {
       if let idx = args.firstIndex(of: flag), idx + 2 < args.count {
         return args[idx + 2]
       }
@@ -147,6 +150,43 @@ enum ViewExporter {
   }
 
   static var standaloneViewCount: Int { 15 }
+
+  private static let onboardingExportSteps: [(String, Int)] = [
+    ("01-name", 0),
+    ("02-language", 1),
+    ("03-howdidyouhear", 2),
+    ("04-trust", 3),
+    ("05-screen-recording", 4),
+    ("06-disk-access", 5),
+    ("07-file-scan", 6),
+    ("08-microphone", 7),
+    ("09-notifications", 8),
+    ("10-accessibility", 9),
+    ("11-automation", 10),
+    ("12-floating-bar-shortcut", 11),
+    ("13-floating-bar", 12),
+    ("14-voice-shortcut", 13),
+    ("15-voice-demo", 14),
+    ("16-research", 15),
+    ("17-goal", 16),
+    ("18-tasks", 17),
+  ]
+
+  static func onboardingViewAt(_ index: Int) -> (String, AnyView, CGSize)? {
+    guard index >= 0 && index < onboardingExportSteps.count else { return nil }
+    let step = onboardingExportSteps[index]
+    let appState = AppState()
+    appState.hasCompletedOnboarding = false
+    let view = OnboardingView(
+      appState: appState,
+      chatProvider: ChatProvider(),
+      exportStepOverride: step.1,
+      isExportPreview: true
+    )
+    return (step.0, AnyView(view), CGSize(width: 900, height: 600))
+  }
+
+  static var onboardingViewCount: Int { onboardingExportSteps.count }
 
   // MARK: - Full page registry (sidebar + content)
 
@@ -457,24 +497,70 @@ enum ViewExporter {
       exit(1)
     }
 
+    // Single onboarding step mode
+    if let idx = args.firstIndex(of: "--export-onboarding-single"),
+      idx + 1 < args.count,
+      let viewIndex = Int(args[idx + 1])
+    {
+      let dir = outputDir()
+      try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+      if let (name, view, size) = onboardingViewAt(viewIndex) {
+        NSLog("ViewExporter: [onboarding-single] Rendering \(name)...")
+        let success = exportView(name: name, view: view, size: size, dir: dir)
+        exit(success ? 0 : 1)
+      }
+      exit(1)
+    }
+
     // Batch standalone views
     if args.contains("--export-views") {
       let dir = outputDir()
       try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-      runBatch(mode: "standalone", count: standaloneViewCount, flag: "--export-single", dir: dir)
+      runBatch(
+        mode: "standalone",
+        count: standaloneViewCount,
+        flag: "--export-single",
+        dir: dir,
+        viewNameAt: { standaloneViewAt($0)?.0 ?? "unknown-\($0)" }
+      )
     }
 
     // Batch full pages
     if args.contains("--export-fullpages") {
       let dir = outputDir()
       try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
-      runBatch(mode: "fullpage", count: fullPageCount, flag: "--export-fullpage-single", dir: dir)
+      runBatch(
+        mode: "fullpage",
+        count: fullPageCount,
+        flag: "--export-fullpage-single",
+        dir: dir,
+        viewNameAt: { fullPageViewAt($0)?.0 ?? "unknown-\($0)" }
+      )
+    }
+
+    // Batch onboarding steps
+    if args.contains("--export-onboarding") {
+      let dir = outputDir()
+      try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+      runBatch(
+        mode: "onboarding",
+        count: onboardingViewCount,
+        flag: "--export-onboarding-single",
+        dir: dir,
+        viewNameAt: { onboardingViewAt($0)?.0 ?? "unknown-\($0)" }
+      )
     }
 
     exit(0)
   }
 
-  private static func runBatch(mode: String, count: Int, flag: String, dir: String) {
+  private static func runBatch(
+    mode: String,
+    count: Int,
+    flag: String,
+    dir: String,
+    viewNameAt: (Int) -> String
+  ) {
     NSLog("ViewExporter: Exporting \(count) \(mode) views to \(dir)")
 
     let executablePath = CommandLine.arguments[0]
@@ -483,17 +569,13 @@ enum ViewExporter {
     var crashedViews: [String] = []
 
     for i in 0..<count {
-      let viewName: String
-      if flag == "--export-single" {
-        viewName = standaloneViewAt(i)?.0 ?? "unknown-\(i)"
-      } else {
-        viewName = fullPageViewAt(i)?.0 ?? "unknown-\(i)"
-      }
+      let viewName = viewNameAt(i)
       NSLog("ViewExporter: [\(i+1)/\(count)] Spawning subprocess for \(viewName)...")
 
       let process = Process()
       process.executableURL = URL(fileURLWithPath: executablePath)
       process.arguments = [flag, "\(i)", dir]
+      process.environment = ProcessInfo.processInfo.environment
       process.standardError = Pipe()
       process.standardOutput = FileHandle.nullDevice
 

--- a/figma/onboarding-auto-sync/README.md
+++ b/figma/onboarding-auto-sync/README.md
@@ -1,0 +1,13 @@
+OMI onboarding auto sync is a Figma development plugin.
+
+Install:
+1. In Figma, open `Plugins` > `Development` > `Import plugin from manifest...`
+2. Select [manifest.json](/Users/nik/projects/omi-onboarding-figma-sync/figma/onboarding-auto-sync/manifest.json)
+3. Run `Plugins` > `Development` > `OMI Onboarding Auto Sync` while focused on the target page.
+
+What it does:
+- Polls `https://raw.githubusercontent.com/BasedHardware/omi/figma-onboarding-sync/onboarding/latest/manifest.json`
+- Rewrites a frame named `Onboarding Sync` on the current page
+- Keeps polling every 15 seconds until the plugin is stopped or the Figma session ends
+
+The GitHub workflow that publishes the source bundle is [onboarding_figma_sync.yml](/Users/nik/projects/omi-onboarding-figma-sync/.github/workflows/onboarding_figma_sync.yml).

--- a/figma/onboarding-auto-sync/code.js
+++ b/figma/onboarding-auto-sync/code.js
@@ -1,0 +1,227 @@
+const DEFAULT_SOURCE_URL =
+  "https://raw.githubusercontent.com/BasedHardware/omi/figma-onboarding-sync/onboarding/latest/manifest.json";
+const DEFAULT_SECTION_NAME = "Onboarding Sync";
+const DEFAULT_POLL_INTERVAL_MS = 15000;
+const CONFIG_KEY = "omiOnboardingSyncConfig";
+const CONTAINER_KEY = "omiOnboardingSyncContainer";
+
+let syncInFlight = false;
+let lastErrorSignature = "";
+
+function loadConfig() {
+  const stored = figma.root.getPluginData(CONFIG_KEY);
+
+  if (stored) {
+    try {
+      return JSON.parse(stored);
+    } catch (error) {
+      console.error("Failed to parse onboarding sync config", error);
+    }
+  }
+
+  return {
+    sourceUrl: DEFAULT_SOURCE_URL,
+    pollIntervalMs: DEFAULT_POLL_INTERVAL_MS,
+    targetPageId: figma.currentPage.id,
+    targetPageName: figma.currentPage.name,
+    sectionName: DEFAULT_SECTION_NAME,
+    lastAppliedSourceCommit: "",
+  };
+}
+
+function saveConfig(config) {
+  figma.root.setPluginData(CONFIG_KEY, JSON.stringify(config));
+}
+
+function resolveManifestUrl(sourceUrl) {
+  const url = new URL(sourceUrl);
+  url.searchParams.set("t", `${Date.now()}`);
+  return url.toString();
+}
+
+async function fetchManifest(sourceUrl) {
+  const response = await fetch(resolveManifestUrl(sourceUrl), { cache: "no-store" });
+  if (!response.ok) {
+    throw new Error(`Manifest request failed with ${response.status}`);
+  }
+  return response.json();
+}
+
+async function fetchAssetBytes(url) {
+  const response = await fetch(`${url}${url.includes("?") ? "&" : "?"}t=${Date.now()}`, {
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    throw new Error(`Asset request failed with ${response.status} for ${url}`);
+  }
+
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function manifestSignature(manifest) {
+  return manifest.sourceCommit || manifest.generatedAt || JSON.stringify(manifest.assets || []);
+}
+
+function findTargetPage(config) {
+  if (config.targetPageId) {
+    const byId = figma.root.children.find((page) => page.id === config.targetPageId);
+    if (byId) {
+      return byId;
+    }
+  }
+
+  if (config.targetPageName) {
+    const byName = figma.root.children.find((page) => page.name === config.targetPageName);
+    if (byName) {
+      config.targetPageId = byName.id;
+      return byName;
+    }
+  }
+
+  config.targetPageId = figma.currentPage.id;
+  config.targetPageName = figma.currentPage.name;
+  return figma.currentPage;
+}
+
+function ensureContainer(page, config, manifest) {
+  let container = page.findOne(
+    (node) => node.type === "FRAME" && node.getPluginData(CONTAINER_KEY) === "1"
+  );
+
+  if (!container) {
+    container = figma.createFrame();
+    container.name = config.sectionName;
+    container.fills = [];
+    container.strokes = [];
+    container.clipsContent = false;
+    container.setPluginData(CONTAINER_KEY, "1");
+    container.x = figma.viewport.center.x - 1500;
+    container.y = figma.viewport.center.y - 600;
+    page.appendChild(container);
+  }
+
+  container.name = `${config.sectionName} · ${manifest.sourceCommit?.slice(0, 7) || "latest"}`;
+  return container;
+}
+
+function clearChildren(node) {
+  for (const child of [...node.children]) {
+    child.remove();
+  }
+}
+
+function createImageCard(asset, bytes) {
+  const image = figma.createImage(bytes);
+  const card = figma.createFrame();
+  card.name = asset.name;
+  card.resizeWithoutConstraints(asset.width, asset.height);
+  card.fills = [];
+  card.strokes = [];
+  card.clipsContent = false;
+
+  const rect = figma.createRectangle();
+  rect.name = asset.name;
+  rect.resizeWithoutConstraints(asset.width, asset.height);
+  rect.fills = [
+    {
+      type: "IMAGE",
+      scaleMode: "FILL",
+      imageHash: image.hash,
+    },
+  ];
+
+  card.appendChild(rect);
+  return card;
+}
+
+async function applyManifest(config, manifest) {
+  const page = findTargetPage(config);
+  const container = ensureContainer(page, config, manifest);
+  const assets = [];
+
+  for (const asset of manifest.assets || []) {
+    const assetUrl = new URL(asset.png, config.sourceUrl).toString();
+    const bytes = await fetchAssetBytes(assetUrl);
+    assets.push({ asset, bytes });
+  }
+
+  const origin = { x: container.x, y: container.y };
+  clearChildren(container);
+
+  const columns = 3;
+  const gapX = 72;
+  const gapY = 72;
+
+  let maxWidth = 0;
+  let maxHeight = 0;
+
+  assets.forEach(({ asset, bytes }, index) => {
+    const card = createImageCard(asset, bytes);
+    const column = index % columns;
+    const row = Math.floor(index / columns);
+    card.x = column * (asset.width + gapX);
+    card.y = row * (asset.height + gapY);
+    container.appendChild(card);
+    maxWidth = Math.max(maxWidth, card.x + asset.width);
+    maxHeight = Math.max(maxHeight, card.y + asset.height);
+  });
+
+  container.resizeWithoutConstraints(Math.max(maxWidth, 1), Math.max(maxHeight, 1));
+  container.x = origin.x;
+  container.y = origin.y;
+
+  config.lastAppliedSourceCommit = manifest.sourceCommit || manifest.generatedAt || "";
+  saveConfig(config);
+  figma.notify(`OMI onboarding synced${manifest.sourceCommit ? ` · ${manifest.sourceCommit.slice(0, 7)}` : ""}`, { timeout: 1800 });
+}
+
+async function syncOnce(force = false) {
+  if (syncInFlight) {
+    return;
+  }
+
+  syncInFlight = true;
+
+  try {
+    const config = loadConfig();
+    const manifest = await fetchManifest(config.sourceUrl);
+    const signature = manifestSignature(manifest);
+
+    if (!force && signature === config.lastAppliedSourceCommit) {
+      return;
+    }
+
+    await applyManifest(config, manifest);
+    lastErrorSignature = "";
+  } catch (error) {
+    const signature = `${error}`;
+    if (signature !== lastErrorSignature) {
+      lastErrorSignature = signature;
+      console.error("OMI onboarding sync failed", error);
+      figma.notify(`OMI onboarding sync failed: ${error}`, { timeout: 3000 });
+    }
+  } finally {
+    syncInFlight = false;
+  }
+}
+
+figma.showUI(__html__, {
+  visible: false,
+  width: 240,
+  height: 120,
+  title: "OMI Onboarding Auto Sync",
+});
+
+figma.ui.onmessage = async (message) => {
+  if (message.type === "tick") {
+    await syncOnce(Boolean(message.force));
+  }
+};
+
+saveConfig(loadConfig());
+figma.ui.postMessage({
+  type: "start",
+  config: loadConfig(),
+});
+figma.notify("OMI onboarding auto-sync started", { timeout: 1500 });

--- a/figma/onboarding-auto-sync/manifest.json
+++ b/figma/onboarding-auto-sync/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "OMI Onboarding Auto Sync",
+  "id": "omi-onboarding-auto-sync-dev",
+  "api": "1.0.0",
+  "editorType": ["figma"],
+  "main": "code.js",
+  "ui": "ui.html",
+  "networkAccess": {
+    "allowedDomains": [
+      "https://raw.githubusercontent.com",
+      "http://127.0.0.1:8765"
+    ]
+  }
+}

--- a/figma/onboarding-auto-sync/ui.html
+++ b/figma/onboarding-auto-sync/ui.html
@@ -1,0 +1,39 @@
+<!doctype html>
+<html lang="en">
+  <body>
+    <script>
+      const DEFAULT_POLL_INTERVAL_MS = 15000;
+      let timerId = null;
+
+      function startPolling(config) {
+        const intervalMs = config.pollIntervalMs || DEFAULT_POLL_INTERVAL_MS;
+
+        if (timerId) {
+          clearInterval(timerId);
+        }
+
+        parent.postMessage({ pluginMessage: { type: "tick", force: true } }, "*");
+        timerId = setInterval(() => {
+          parent.postMessage({ pluginMessage: { type: "tick" } }, "*");
+        }, intervalMs);
+      }
+
+      window.onmessage = (event) => {
+        const message = event.data.pluginMessage;
+        if (message && message.type === "start") {
+          startPolling(message.config || {});
+        }
+      };
+
+      parent.postMessage(
+        {
+          pluginMessage: {
+            type: "tick",
+            force: true,
+          },
+        },
+        "*"
+      );
+    </script>
+  </body>
+</html>

--- a/scripts/export_onboarding_sync_bundle.sh
+++ b/scripts/export_onboarding_sync_bundle.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <bundle-dir> [source-commit] [source-branch]" >&2
+  exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+BUNDLE_DIR=$1
+SOURCE_COMMIT=${2:-local}
+SOURCE_BRANCH=${3:-local}
+
+TMP_DIR=$(mktemp -d)
+ASSETS_DIR="$TMP_DIR/assets"
+mkdir -p "$ASSETS_DIR"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cd "$REPO_ROOT/desktop/Desktop"
+
+# Put Apple-provided tools first so SwiftPM does not pick up a broken Homebrew git on CI/macOS hosts.
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/bin:$PATH"
+
+swift run -c debug "Omi Computer" --export-onboarding "$ASSETS_DIR"
+
+"$SCRIPT_DIR/prepare_onboarding_sync_bundle.sh" "$ASSETS_DIR" "$BUNDLE_DIR" "$SOURCE_COMMIT" "$SOURCE_BRANCH"

--- a/scripts/prepare_onboarding_sync_bundle.sh
+++ b/scripts/prepare_onboarding_sync_bundle.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <assets-dir> <bundle-dir> [source-commit] [source-branch]" >&2
+  exit 1
+fi
+
+ASSETS_DIR=$1
+BUNDLE_DIR=$2
+SOURCE_COMMIT=${3:-local}
+SOURCE_BRANCH=${4:-local}
+
+if [[ ! -d "$ASSETS_DIR" ]]; then
+  echo "assets directory not found: $ASSETS_DIR" >&2
+  exit 1
+fi
+
+rm -rf "$BUNDLE_DIR"
+mkdir -p "$BUNDLE_DIR"
+
+find "$ASSETS_DIR" -maxdepth 1 \( -name '*.png' -o -name '*.pdf' \) -print0 | while IFS= read -r -d '' file; do
+  cp "$file" "$BUNDLE_DIR/"
+done
+
+python3 - "$BUNDLE_DIR" "$SOURCE_COMMIT" "$SOURCE_BRANCH" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+from datetime import datetime, timezone
+
+bundle_dir = pathlib.Path(sys.argv[1])
+source_commit = sys.argv[2]
+source_branch = sys.argv[3]
+
+assets = []
+for png_path in sorted(bundle_dir.glob("*.png")):
+    pdf_path = png_path.with_suffix(".pdf")
+    sips_output = subprocess.run(
+        ["sips", "-g", "pixelWidth", "-g", "pixelHeight", str(png_path)],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    width = height = None
+    for line in sips_output.splitlines():
+        if "pixelWidth:" in line:
+            width = int(line.split(":")[-1].strip())
+        if "pixelHeight:" in line:
+            height = int(line.split(":")[-1].strip())
+
+    if width is None or height is None:
+        raise RuntimeError(f"failed to read image dimensions for {png_path.name}")
+
+    assets.append(
+        {
+            "name": png_path.stem,
+            "png": png_path.name,
+            "pdf": pdf_path.name if pdf_path.exists() else None,
+            "width": width,
+            "height": height,
+        }
+    )
+
+manifest = {
+    "generatedAt": datetime.now(timezone.utc).isoformat(),
+    "sourceCommit": source_commit,
+    "sourceBranch": source_branch,
+    "assetCount": len(assets),
+    "assets": assets,
+}
+
+(bundle_dir / "manifest.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+cards = []
+for asset in assets:
+    cards.append(
+        f"""
+        <article class="card">
+          <h2>{asset["name"]}</h2>
+          <img src="{asset["png"]}" width="{asset["width"]}" height="{asset["height"]}" alt="{asset["name"]}">
+        </article>
+        """.strip()
+    )
+
+html = f"""<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>OMI Onboarding Sync</title>
+    <style>
+      :root {{
+        color-scheme: dark;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }}
+      body {{
+        margin: 0;
+        padding: 32px;
+        background: #111111;
+        color: #f5f5f5;
+      }}
+      header {{
+        margin-bottom: 24px;
+      }}
+      .grid {{
+        display: grid;
+        gap: 28px;
+        grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+      }}
+      .card {{
+        background: #1a1a1a;
+        border: 1px solid rgba(255, 255, 255, 0.08);
+        border-radius: 16px;
+        overflow: hidden;
+      }}
+      .card h2 {{
+        margin: 0;
+        padding: 14px 16px;
+        font-size: 14px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }}
+      .card img {{
+        display: block;
+        width: 100%;
+        height: auto;
+      }}
+      code {{
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }}
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>OMI Onboarding Sync</h1>
+      <p>Commit <code>{source_commit}</code> from <code>{source_branch}</code></p>
+      <p>{len(assets)} onboarding steps, generated {manifest["generatedAt"]}</p>
+    </header>
+    <section class="grid">
+      {"".join(cards)}
+    </section>
+  </body>
+</html>
+"""
+
+(bundle_dir / "index.html").write_text(html)
+PY

--- a/scripts/publish_onboarding_sync_branch.sh
+++ b/scripts/publish_onboarding_sync_branch.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <bundle-dir> [branch]" >&2
+  exit 1
+fi
+
+BUNDLE_DIR=$1
+TARGET_BRANCH=${2:-figma-onboarding-sync}
+
+if [[ ! -d "$BUNDLE_DIR" ]]; then
+  echo "bundle directory not found: $BUNDLE_DIR" >&2
+  exit 1
+fi
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+  echo "GITHUB_REPOSITORY must be set" >&2
+  exit 1
+fi
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN must be set" >&2
+  exit 1
+fi
+
+TMP_DIR=$(mktemp -d)
+PUBLISH_DIR="$TMP_DIR/publish"
+mkdir -p "$PUBLISH_DIR/onboarding/latest"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+cp -R "$BUNDLE_DIR"/. "$PUBLISH_DIR/onboarding/latest/"
+touch "$PUBLISH_DIR/.nojekyll"
+
+cd "$PUBLISH_DIR"
+
+git init -q
+git config user.name "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+git checkout -b "$TARGET_BRANCH" >/dev/null 2>&1
+git add .
+git commit -m "Update onboarding sync bundle" >/dev/null
+git remote add origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+git push --force origin "HEAD:${TARGET_BRANCH}"


### PR DESCRIPTION
## Summary
- export onboarding steps directly from the macOS SwiftUI codepath
- publish the latest onboarding bundle to the figma-onboarding-sync branch on GitHub
- add a Figma-side auto-sync plugin scaffold for consuming that bundle

## Verification
- generated and published a test onboarding bundle from the existing exported screenshots
- confirmed the published manifest and assets are reachable on raw.githubusercontent.com
