### PR TITLE
Add local onboarding Figma sync tooling

### DIFF
--- a/docs/onboarding_figma_sync.md
+++ b/docs/onboarding_figma_sync.md
@@ -1,0 +1,42 @@
+# Onboarding Figma Sync
+
+This workflow keeps the macOS onboarding exported from code and synced into the `omi` Figma file on the `500k users` page.
+
+## How it works
+
+1. A user LaunchAgent watches `desktop/Desktop/Sources` and `desktop/Desktop/Resources`.
+2. On a change, it copies onboarding-related source files into a clean export worktree.
+3. It applies export-only preview overrides in that worktree so all onboarding steps render deterministically.
+4. It exports the onboarding screens from SwiftUI code.
+5. It serves a local preview page and pushes that page into Figma through the authenticated Figma MCP code-to-canvas flow.
+6. It replaces the `OMI Onboarding Sync` frame on the `500k users` page.
+
+## Install
+
+Run:
+
+```bash
+scripts/install_onboarding_figma_sync.sh
+```
+
+Requirements:
+
+- `codex` available in `PATH`
+- `node` available in `PATH`
+- authenticated Figma MCP access in Codex on that Mac
+- the user has access to the `omi` Figma file
+
+## Uninstall
+
+Run:
+
+```bash
+scripts/uninstall_onboarding_figma_sync.sh
+```
+
+## Logs
+
+- Main log: `~/Library/Application Support/OMIOnboardingSync/sync.log`
+- Last result: `~/Library/Application Support/OMIOnboardingSync/last_result.txt`
+- LaunchAgent stdout: `~/Library/Application Support/OMIOnboardingSync/launchd.out.log`
+- LaunchAgent stderr: `~/Library/Application Support/OMIOnboardingSync/launchd.err.log`

--- a/scripts/apply_export_preview_overrides.py
+++ b/scripts/apply_export_preview_overrides.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+def replace_once(text: str, old: str, new: str, label: str) -> str:
+    if new in text:
+        return text
+    if old not in text:
+        raise RuntimeError(f"missing expected block for {label}")
+    return text.replace(old, new, 1)
+
+
+def patch_onboarding_view(path: Path) -> None:
+    text = path.read_text()
+    text = replace_once(
+        text,
+        "  var onComplete: (() -> Void)? = nil\n",
+        "  var onComplete: (() -> Void)? = nil\n  var exportStepOverride: Int? = nil\n  var isExportPreview = false\n",
+        "onboarding view vars",
+    )
+    text = replace_once(
+        text,
+        "        if appState.hasCompletedOnboarding {\n",
+        "        if appState.hasCompletedOnboarding && !isExportPreview {\n",
+        "completed onboarding guard",
+    )
+    text = replace_once(
+        text,
+        """      currentStep = OnboardingFlow.migratedStep(
+        currentStep: currentStep,
+        hasMigratedVideoStep: hasMigratedOnboardingSteps,
+        hasInsertedVoiceShortcutStep: hasInsertedVoiceShortcutStep,
+        hasMergedVoiceInputStep: hasMergedVoiceInputStep,
+        hasRemovedNotificationStep: hasRemovedNotificationStep,
+        hasInsertedFloatingBarShortcutStep: hasInsertedFloatingBarShortcutStep,
+        hasMigratedPagedIntro: hasMigratedPagedIntro,
+        hasReorderedTrustStep: hasReorderedTrustStep,
+        hasInsertedHowDidYouHearStep: hasInsertedHowDidYouHearStep
+      )
+""",
+        """      if let exportStepOverride {
+        currentStep = exportStepOverride
+      } else {
+        currentStep = OnboardingFlow.migratedStep(
+          currentStep: currentStep,
+          hasMigratedVideoStep: hasMigratedOnboardingSteps,
+          hasInsertedVoiceShortcutStep: hasInsertedVoiceShortcutStep,
+          hasMergedVoiceInputStep: hasMergedVoiceInputStep,
+          hasRemovedNotificationStep: hasRemovedNotificationStep,
+          hasInsertedFloatingBarShortcutStep: hasInsertedFloatingBarShortcutStep,
+          hasMigratedPagedIntro: hasMigratedPagedIntro,
+          hasReorderedTrustStep: hasReorderedTrustStep,
+          hasInsertedHowDidYouHearStep: hasInsertedHowDidYouHearStep
+        )
+      }
+""",
+        "export step override",
+    )
+    text = replace_once(
+        text,
+        "      introCoordinator.prepare(appState: appState)\n",
+        "      if !isExportPreview {\n        introCoordinator.prepare(appState: appState)\n      }\n",
+        "intro coordinator guard",
+    )
+    text = replace_once(
+        text,
+        "    .task {\n      // Pre-warm the ACP bridge before the chat step starts.\n",
+        "    .task {\n      guard !isExportPreview else { return }\n      // Pre-warm the ACP bridge before the chat step starts.\n",
+        "task guard",
+    )
+    view_call_replacements = [
+        (
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 4, stepName: "ScreenRecording_Skipped")
+            currentStep = 5
+          },
+          onForceComplete: handleOnboardingComplete
+        )
+""",
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 4, stepName: "ScreenRecording_Skipped")
+            currentStep = 5
+          },
+          onForceComplete: handleOnboardingComplete,
+          isExportPreview: isExportPreview
+        )
+""",
+            "screen recording export preview arg",
+        ),
+        (
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 5, stepName: "FullDiskAccess_Skipped")
+            currentStep = 6
+          },
+          onForceComplete: handleOnboardingComplete
+        )
+""",
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 5, stepName: "FullDiskAccess_Skipped")
+            currentStep = 6
+          },
+          onForceComplete: handleOnboardingComplete,
+          isExportPreview: isExportPreview
+        )
+""",
+            "disk access export preview arg",
+        ),
+        (
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 6, stepName: "FileScan_Skipped")
+            currentStep = 7
+          },
+          onForceComplete: handleOnboardingComplete
+        )
+""",
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 6, stepName: "FileScan_Skipped")
+            currentStep = 7
+          },
+          onForceComplete: handleOnboardingComplete,
+          isExportPreview: isExportPreview
+        )
+""",
+            "file scan export preview arg",
+        ),
+        (
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 7, stepName: "Microphone_Skipped")
+            currentStep = 8
+          },
+          onForceComplete: handleOnboardingComplete
+        )
+""",
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 7, stepName: "Microphone_Skipped")
+            currentStep = 8
+          },
+          onForceComplete: handleOnboardingComplete,
+          isExportPreview: isExportPreview
+        )
+""",
+            "microphone export preview arg",
+        ),
+        (
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 8, stepName: "Notifications_Skipped")
+            currentStep = 9
+          },
+          onForceComplete: handleOnboardingComplete
+        )
+""",
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 8, stepName: "Notifications_Skipped")
+            currentStep = 9
+          },
+          onForceComplete: handleOnboardingComplete,
+          isExportPreview: isExportPreview
+        )
+""",
+            "notifications export preview arg",
+        ),
+        (
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 9, stepName: "Accessibility_Skipped")
+            currentStep = 10
+          },
+          onForceComplete: handleOnboardingComplete
+        )
+""",
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 9, stepName: "Accessibility_Skipped")
+            currentStep = 10
+          },
+          onForceComplete: handleOnboardingComplete,
+          isExportPreview: isExportPreview
+        )
+""",
+            "accessibility export preview arg",
+        ),
+        (
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 10, stepName: "Automation_Skipped")
+            currentStep = 11
+          },
+          onForceComplete: handleOnboardingComplete
+        )
+""",
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(step: 10, stepName: "Automation_Skipped")
+            currentStep = 11
+          },
+          onForceComplete: handleOnboardingComplete,
+          isExportPreview: isExportPreview
+        )
+""",
+            "automation export preview arg",
+        ),
+        (
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 11, stepName: "FloatingBarShortcut_Skipped")
+            currentStep = 12
+          },
+          onForceComplete: handleOnboardingComplete
+        )
+""",
+            """          onSkip: {
+            AnalyticsManager.shared.onboardingStepCompleted(
+              step: 11, stepName: "FloatingBarShortcut_Skipped")
+            currentStep = 12
+          },
+          onForceComplete: handleOnboardingComplete,
+          isExportPreview: isExportPreview
+        )
+""",
+            "floating bar shortcut export preview arg",
+        ),
+    ]
+    for old, new, label in view_call_replacements:
+        text = replace_once(text, old, new, label)
+    path.write_text(text)
+
+
+def patch_permission_view(path: Path) -> None:
+    text = path.read_text()
+    text = replace_once(
+        text,
+        "  let onContinue: () -> Void\n  let onSkip: () -> Void\n  let onForceComplete: (() -> Void)?\n",
+        "  let onContinue: () -> Void\n  let onSkip: () -> Void\n  let onForceComplete: (() -> Void)?\n  var isExportPreview = false\n",
+        "permission view vars",
+    )
+    text = replace_once(
+        text,
+        '          if permissionType == "full_disk_access", let email = coordinator.userEmail() {\n',
+        '          if permissionType == "full_disk_access", !isExportPreview, let email = coordinator.userEmail() {\n',
+        "full disk email guard",
+    )
+    text = replace_once(
+        text,
+        "      .onReceive(timer) { _ in\n        refreshPermissionState()\n",
+        "      .onReceive(timer) { _ in\n        guard !isExportPreview else { return }\n        refreshPermissionState()\n",
+        "timer guard",
+    )
+    text = replace_once(
+        text,
+        "      .onChange(of: scenePhase) { _, newPhase in\n        guard newPhase == .active else { return }\n",
+        "      .onChange(of: scenePhase) { _, newPhase in\n        guard !isExportPreview else { return }\n        guard newPhase == .active else { return }\n",
+        "scene phase guard",
+    )
+    text = replace_once(
+        text,
+        "      .onChange(of: isGranted) { _, granted in\n        if granted {\n",
+        "      .onChange(of: isGranted) { _, granted in\n        guard !isExportPreview else { return }\n        if granted {\n",
+        "granted guard",
+    )
+    text = replace_once(
+        text,
+        "        coordinator.clearLastActionError()\n        refreshPermissionState()\n",
+        "        coordinator.clearLastActionError()\n        guard !isExportPreview else { return }\n        refreshPermissionState()\n",
+        "onAppear guard",
+    )
+    text = replace_once(
+        text,
+        "  private var isGranted: Bool {\n    coordinator.isPermissionGranted(permissionType, appState: appState)\n  }\n",
+        "  private var isGranted: Bool {\n    guard !isExportPreview else { return false }\n    return coordinator.isPermissionGranted(permissionType, appState: appState)\n  }\n",
+        "isGranted guard",
+    )
+    text = replace_once(
+        text,
+        "  private func refreshPermissionState() {\n    coordinator.refreshPermissions(appState: appState)\n",
+        "  private func refreshPermissionState() {\n    guard !isExportPreview else { return }\n    coordinator.refreshPermissions(appState: appState)\n",
+        "refresh guard",
+    )
+    path.write_text(text)
+
+
+def patch_file_scan_view(path: Path) -> None:
+    text = path.read_text()
+    text = replace_once(
+        text,
+        "  let onContinue: () -> Void\n  let onSkip: () -> Void\n  let onForceComplete: (() -> Void)?\n",
+        "  let onContinue: () -> Void\n  let onSkip: () -> Void\n  let onForceComplete: (() -> Void)?\n  var isExportPreview = false\n",
+        "file scan vars",
+    )
+    text = replace_once(text, "            Text(coordinator.scanStatusText)\n", "            Text(scanStatusText)\n", "scan status")
+    text = replace_once(
+        text,
+        "            if let snapshot = coordinator.scanSnapshot {\n",
+        "            if let snapshot = scanSnapshot {\n",
+        "scan snapshot text",
+    )
+    text = replace_once(
+        text,
+        "        if coordinator.scanSnapshot != nil {\n",
+        "        if scanSnapshot != nil {\n",
+        "scan snapshot continue",
+    )
+    text = replace_once(
+        text,
+        "      .task {\n        await coordinator.startFileScanIfNeeded(appState: appState)\n",
+        "      .task {\n        guard !isExportPreview else { return }\n        await coordinator.startFileScanIfNeeded(appState: appState)\n",
+        "file scan task guard",
+    )
+    text = replace_once(
+        text,
+        """  private var scanProgress: Double {
+    switch coordinator.scanState {
+""",
+        """  private var scanSnapshot: OnboardingPagedIntroCoordinator.ScanSnapshot? {
+    if isExportPreview {
+      return .init(
+        fileCount: 1_284,
+        projectNames: [],
+        applications: [],
+        technologies: [],
+        recentFiles: []
+      )
+    }
+    return coordinator.scanSnapshot
+  }
+
+  private var scanStatusText: String {
+    isExportPreview ? "Scanning your projects and apps..." : coordinator.scanStatusText
+  }
+
+  private var scanProgress: Double {
+    if isExportPreview {
+      return 0.82
+    }
+    switch coordinator.scanState {
+""",
+        "file scan helpers",
+    )
+    path.write_text(text)
+
+
+def patch_floating_bar_shortcut_view(path: Path) -> None:
+    text = path.read_text()
+    text = replace_once(
+        text,
+        "    var onComplete: () -> Void\n    var onSkip: () -> Void\n    var onForceComplete: (() -> Void)?\n",
+        "    var onComplete: () -> Void\n    var onSkip: () -> Void\n    var onForceComplete: (() -> Void)?\n    var isExportPreview = false\n",
+        "floating bar vars",
+    )
+    text = replace_once(
+        text,
+        "        .onAppear {\n            GlobalShortcutManager.shared.unregisterShortcuts()\n",
+        "        .onAppear {\n            guard !isExportPreview else { return }\n            GlobalShortcutManager.shared.unregisterShortcuts()\n",
+        "floating bar onAppear guard",
+    )
+    text = replace_once(
+        text,
+        "        .onDisappear {\n            removeKeyMonitors()\n",
+        "        .onDisappear {\n            guard !isExportPreview else { return }\n            removeKeyMonitors()\n",
+        "floating bar onDisappear guard",
+    )
+    path.write_text(text)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: apply_export_preview_overrides.py <sources-dir>", file=sys.stderr)
+        return 1
+
+    sources_dir = Path(sys.argv[1])
+    patch_onboarding_view(sources_dir / "OnboardingView.swift")
+    patch_permission_view(sources_dir / "OnboardingPermissionStepView.swift")
+    patch_file_scan_view(sources_dir / "OnboardingFileScanStepView.swift")
+    patch_floating_bar_shortcut_view(sources_dir / "OnboardingFloatingBarShortcutStepView.swift")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/install_onboarding_figma_sync.sh
+++ b/scripts/install_onboarding_figma_sync.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SCRIPT_REPO=${SCRIPT_REPO:-$(cd "$SCRIPT_DIR/.." && pwd)}
+WATCH_REPO=${WATCH_REPO:-$SCRIPT_REPO}
+STATE_DIR=${STATE_DIR:-"$HOME/Library/Application Support/OMIOnboardingSync"}
+EXPORT_REPO=${EXPORT_REPO:-"$STATE_DIR/export-worktree"}
+PLIST_PATH=${PLIST_PATH:-"$HOME/Library/LaunchAgents/com.omi.onboarding-figma-sync.plist"}
+CODEX_BIN=${CODEX_BIN:-$(command -v codex || true)}
+NODE_BIN=${NODE_BIN:-$(command -v node || true)}
+
+if [[ -z "$CODEX_BIN" || ! -x "$CODEX_BIN" ]]; then
+  echo "codex binary not found in PATH; install it or set CODEX_BIN" >&2
+  exit 1
+fi
+
+if [[ -z "$NODE_BIN" || ! -x "$NODE_BIN" ]]; then
+  echo "node binary not found in PATH; install it or set NODE_BIN" >&2
+  exit 1
+fi
+
+mkdir -p "$STATE_DIR" "$HOME/Library/LaunchAgents"
+
+if [[ ! -e "$EXPORT_REPO" ]]; then
+  git -C "$WATCH_REPO" worktree add "$EXPORT_REPO" HEAD
+fi
+
+cat >"$PLIST_PATH" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.omi.onboarding-figma-sync</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>$SCRIPT_REPO/scripts/run_onboarding_figma_sync.sh</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>SOURCE_REPO</key>
+    <string>$WATCH_REPO</string>
+    <key>EXPORT_REPO</key>
+    <string>$EXPORT_REPO</string>
+    <key>STATE_DIR</key>
+    <string>$STATE_DIR</string>
+    <key>CODEX_BIN</key>
+    <string>$CODEX_BIN</string>
+    <key>NODE_BIN_DIR</key>
+    <string>$(dirname "$NODE_BIN")</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>WatchPaths</key>
+  <array>
+    <string>$WATCH_REPO/desktop/Desktop/Sources</string>
+    <string>$WATCH_REPO/desktop/Desktop/Resources</string>
+  </array>
+  <key>StandardOutPath</key>
+  <string>$STATE_DIR/launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>$STATE_DIR/launchd.err.log</string>
+</dict>
+</plist>
+EOF
+
+plutil -lint "$PLIST_PATH" >/dev/null
+launchctl bootout "gui/$(id -u)" "$PLIST_PATH" 2>/dev/null || true
+launchctl bootstrap "gui/$(id -u)" "$PLIST_PATH"
+launchctl kickstart -k "gui/$(id -u)/com.omi.onboarding-figma-sync"
+
+echo "Installed onboarding Figma sync."
+echo "Script repo: $SCRIPT_REPO"
+echo "Watch repo: $WATCH_REPO"
+echo "Export worktree: $EXPORT_REPO"
+echo "LaunchAgent: $PLIST_PATH"

--- a/scripts/prepare_onboarding_sync_bundle.sh
+++ b/scripts/prepare_onboarding_sync_bundle.sh
@@ -91,6 +91,7 @@ html = f"""<!doctype html>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>OMI Onboarding Sync</title>
+    <script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>
     <style>
       :root {{
         color-scheme: dark;

--- a/scripts/run_onboarding_figma_sync.sh
+++ b/scripts/run_onboarding_figma_sync.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+SOURCE_REPO_DEFAULT=$(cd "$SCRIPT_DIR/.." && pwd)
+
+SOURCE_REPO=${SOURCE_REPO:-$SOURCE_REPO_DEFAULT}
+STATE_DIR=${STATE_DIR:-"$HOME/Library/Application Support/OMIOnboardingSync"}
+EXPORT_REPO=${EXPORT_REPO:-"$STATE_DIR/export-worktree"}
+SITE_DIR="$STATE_DIR/site"
+LOG_FILE="$STATE_DIR/sync.log"
+HTTP_LOG="$STATE_DIR/http.log"
+RESULT_FILE="$STATE_DIR/last_result.txt"
+LOCK_DIR="$STATE_DIR/run.lock"
+PORT=${PORT:-8765}
+CODEX_BIN=${CODEX_BIN:-$(command -v codex || true)}
+NODE_BIN_DIR=${NODE_BIN_DIR:-$(command -v node >/dev/null 2>&1 && dirname "$(command -v node)" || true)}
+export PATH="${NODE_BIN_DIR:+$NODE_BIN_DIR:}/usr/bin:/bin:/usr/sbin:/sbin:${PATH:-}"
+
+mkdir -p "$STATE_DIR"
+
+if [[ -z "$CODEX_BIN" || ! -x "$CODEX_BIN" ]]; then
+  echo "codex binary not found; set CODEX_BIN or install codex" >&2
+  exit 127
+fi
+
+if [[ ! -d "$EXPORT_REPO/.git" && ! -f "$EXPORT_REPO/.git" ]]; then
+  echo "export worktree missing: $EXPORT_REPO" >&2
+  exit 1
+fi
+
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+  exit 0
+fi
+
+cleanup() {
+  rmdir "$LOCK_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+exec >>"$LOG_FILE" 2>&1
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] sync start"
+sleep 2
+
+FILES_TO_SYNC=$(mktemp)
+trap 'rm -f "$FILES_TO_SYNC"; cleanup' EXIT
+
+(
+  cd "$SOURCE_REPO"
+  find desktop/Desktop/Sources -type f \
+    \( -name 'Onboarding*.swift' \
+    -o -name 'PostOnboardingPromptViews.swift' \
+    -o -path 'desktop/Desktop/Sources/FileIndexing/OnboardingLoadingAnimation.swift' \
+    -o -path 'desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift' \
+    -o -path 'desktop/Desktop/Sources/Theme/OmiColors.swift' \) \
+    | sort
+) >"$FILES_TO_SYNC"
+
+rsync -a --files-from="$FILES_TO_SYNC" "$SOURCE_REPO/" "$EXPORT_REPO/"
+python3 "$EXPORT_REPO/scripts/apply_export_preview_overrides.py" "$EXPORT_REPO/desktop/Desktop/Sources"
+
+SOURCE_COMMIT=$(git -C "$SOURCE_REPO" rev-parse HEAD 2>/dev/null || echo local)
+SOURCE_BRANCH=$(git -C "$SOURCE_REPO" rev-parse --abbrev-ref HEAD 2>/dev/null || echo local)
+if [[ -n "$(git -C "$SOURCE_REPO" status --porcelain 2>/dev/null || true)" ]]; then
+  SOURCE_BRANCH="${SOURCE_BRANCH}-dirty"
+fi
+
+"$EXPORT_REPO/scripts/export_onboarding_sync_bundle.sh" "$SITE_DIR" "$SOURCE_COMMIT" "$SOURCE_BRANCH"
+
+if ! lsof -ti tcp:"$PORT" -sTCP:LISTEN >/dev/null 2>&1; then
+  nohup python3 -m http.server "$PORT" --directory "$SITE_DIR" >"$HTTP_LOG" 2>&1 &
+  sleep 2
+fi
+
+pkill -f 'chrome-devtools-mcp' || true
+pkill -f '/Users/nik/.cache/chrome-devtools-mcp/chrome-profile' || true
+pkill -f "codex exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check -C $SITE_DIR" || true
+sleep 1
+
+rm -f "$RESULT_FILE"
+
+cat <<EOF | "$CODEX_BIN" exec --dangerously-bypass-approvals-and-sandbox --skip-git-repo-check -C "$SITE_DIR" -o "$RESULT_FILE" -
+Do not inspect local skill files.
+Capture http://127.0.0.1:${PORT}/index.html into the existing Figma file https://www.figma.com/file/pK7sTlaBnVRwnBroajw0Qi/omi?node-id=2711-1688&type=design on the \`500k users\` page.
+Delete any existing top-level \`OMI Onboarding Sync\` frame on that page first.
+Important: if the code-to-canvas tool returns a pending capture, you must open the returned localhost capture URL so the page submits the capture, then continue polling until it completes.
+After it lands, rename the resulting top-level frame to \`OMI Onboarding Sync\` and verify there is exactly one such top-level frame on \`500k users\`.
+Respond with exactly one line: \`OK <node-id>\` or \`FAIL <reason>\`.
+EOF
+
+if [[ ! -f "$RESULT_FILE" ]]; then
+  echo "FAIL no-result-file" >"$RESULT_FILE"
+fi
+
+RESULT_LINE=$(tr '\n' ' ' < "$RESULT_FILE")
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] sync done: $RESULT_LINE"

--- a/scripts/uninstall_onboarding_figma_sync.sh
+++ b/scripts/uninstall_onboarding_figma_sync.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PLIST_PATH=${PLIST_PATH:-"$HOME/Library/LaunchAgents/com.omi.onboarding-figma-sync.plist"}
+
+launchctl bootout "gui/$(id -u)" "$PLIST_PATH" 2>/dev/null || true
+rm -f "$PLIST_PATH"
+
+echo "Uninstalled onboarding Figma sync LaunchAgent."


### PR DESCRIPTION
## Summary
- add the local launchd-based onboarding-to-Figma sync scripts
- add export preview patching so onboarding renders deterministically in the sync worktree
- document install, uninstall, and log locations for developers

## Verification
- `bash -n scripts/prepare_onboarding_sync_bundle.sh scripts/run_onboarding_figma_sync.sh scripts/install_onboarding_figma_sync.sh scripts/uninstall_onboarding_figma_sync.sh`
- `python3 -m py_compile scripts/apply_export_preview_overrides.py`
- verified the background sync on this Mac ends with `OK 3251:879` in `~/Library/Application Support/OMIOnboardingSync/sync.log`