### PR TITLE
Update CHANGELOG.json for v0.11.239 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,13 @@
 {
-  "unreleased": ["Migrated data APIs to production backend for improved reliability and feature parity"],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.239",
+      "date": "2026-04-07",
+      "changes": [
+        "Migrated data APIs to production backend for improved reliability and feature parity"
+      ]
+    },
     {
       "version": "0.11.238",
       "date": "2026-04-07",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.239 and clears the unreleased array.