### PR TITLE
fix(desktop): align API response keys with Python backend

### DIFF
--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -1453,7 +1453,7 @@ struct ActionItemsListResponse: Codable {
     let hasMore: Bool
 
     enum CodingKeys: String, CodingKey {
-        case items
+        case items = "action_items"
         case hasMore = "has_more"
     }
 }
@@ -1945,10 +1945,10 @@ extension APIClient {
         if let cache = goalsCache, let time = goalsCacheTime, Date().timeIntervalSince(time) < 5 {
             return cache
         }
-        let response: GoalsListResponse = try await get("v1/goals/all")
-        goalsCache = response.goals
+        let goals: [Goal] = try await get("v1/goals/all")
+        goalsCache = goals
         goalsCacheTime = Date()
-        return response.goals
+        return goals
     }
 
     /// Creates a new goal
@@ -2046,8 +2046,8 @@ extension APIClient {
 
     /// Gets completed goals for history
     func getCompletedGoals() async throws -> [Goal] {
-        let response: GoalsListResponse = try await get("v1/goals/completed")
-        return response.goals
+        let goals: [Goal] = try await get("v1/goals/completed")
+        return goals
     }
 
     /// Completes a goal (marks as inactive with completed_at)
@@ -3020,7 +3020,7 @@ extension APIClient {
 
     /// Fetches apps grouped by capability (v2 API - matches Flutter/Python backend)
     /// Returns groups: Featured, Integrations, Chat Assistants, Summary Apps, Realtime Notifications
-    func getAppsV2(offset: Int = 0, limit: Int = 100) async throws -> OmiAppsV2Response {
+    func getAppsV2(offset: Int = 0, limit: Int = 50) async throws -> OmiAppsV2Response {
         let endpoint = "v2/apps?offset=\(offset)&limit=\(limit)"
         return try await get(endpoint)
     }


### PR DESCRIPTION
## Summary
- **ActionItemsListResponse**: backend returns `action_items` key but Swift decoded `items` → all task loading failed with "key 'items' not found"
- **Goals API**: `/v1/goals/all` and `/v1/goals/completed` return plain JSON arrays, not `{"goals": [...]}` wrapper → "Expected Dictionary but found array" error
- **Apps v2**: reduce default `limit` from 100 to 50 to match backend validation max (was returning 422)

These are response format mismatches introduced by the desktop → Python backend migration (#6174).

## Test plan
- [ ] Tasks load in the Tasks page (no more "key 'items' not found" errors)
- [ ] Goals widget loads on Dashboard (no more "Expected Dictionary" errors)
- [ ] Apps page loads without 422 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)