### PR TITLE
Increase brain map size and remove subtitle

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoryGraph/MemoryGraphPage.swift
@@ -74,15 +74,9 @@ struct MemoryGraphInlineCard: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       HStack(alignment: .center, spacing: 12) {
-        VStack(alignment: .leading, spacing: 4) {
-          Text("Brain Map")
-            .scaledFont(size: 15, weight: .semibold)
-            .foregroundColor(OmiColors.textPrimary)
-
-          Text("How people, projects, and ideas connect across your recent memories.")
-            .scaledFont(size: 12)
-            .foregroundColor(OmiColors.textSecondary)
-        }
+        Text("Brain Map")
+          .scaledFont(size: 15, weight: .semibold)
+          .foregroundColor(OmiColors.textPrimary)
 
         Spacer()
 
@@ -129,7 +123,7 @@ struct MemoryGraphInlineCard: View {
           .padding(18)
         }
       }
-      .frame(height: 186)
+      .frame(height: 350)
       .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
     }
     .padding(16)


### PR DESCRIPTION
## Summary
- Increased brain map visualization height from 186pt to 350pt for better visibility
- Removed subtitle text "How people, projects, and ideas connect across your recent memories."
- Brain map now takes ~50% of visible area on memories page

🤖 Generated with [Claude Code](https://claude.com/claude-code)