### PR TITLE
Fix PTT voice: switch from broken batch mode to live

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -391,7 +391,7 @@ class ShortcutSettings: ObservableObject {
            let mode = PTTTranscriptionMode(rawValue: saved) {
             self.pttTranscriptionMode = mode
         } else {
-            self.pttTranscriptionMode = .batch
+            self.pttTranscriptionMode = .live
         }
         self.draggableBarEnabled = UserDefaults.standard.object(forKey: "shortcut_draggableBarEnabled") as? Bool ?? false
         self.floatingBarVoiceAnswersEnabled = UserDefaults.standard.object(forKey: "shortcut_floatingBarVoiceAnswersEnabled") as? Bool ?? false


### PR DESCRIPTION
## Summary
- Batch mode PTT was re-introduced broken by the March 29 automated sync (912690653) which reverted the March 6 fix (e80ec706e)
- The IOProc captures audio but `batchAudioBuffer` stays empty, causing "no audio recorded" 100% of the time
- Changes default from `.batch` to `.live` which works correctly

## Test plan
- [ ] Press PTT shortcut, speak, release — should transcribe and send query
- [ ] Verify floating bar shows live transcript while speaking

🤖 Generated with [Claude Code](https://claude.com/claude-code)