### PR TITLE
Add floating bar sessions per user chart

### DIFF
--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -541,6 +541,55 @@ export default function AnalyticsPage() {
         </Card>
       </div>
 
+      {/* Floating Bar Sessions per User */}
+      <Card className="p-6">
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-lg font-semibold">Floating Bar Sessions per User</h2>
+          {fbSummary && (
+            <span className="text-sm text-muted-foreground">
+              Avg: <span className="font-medium text-foreground">{fbSummary.overallAvgSessionsPerUserPerDay ?? "—"}</span> sessions/user/day
+            </span>
+          )}
+        </div>
+        <p className="text-sm text-muted-foreground mb-4">
+          Times floating bar was opened and a question asked, per user per day (follow-ups don&apos;t count)
+        </p>
+        <div className="h-[300px]">
+          {fbUsageLoading ? (
+            <div className="h-full flex items-center justify-center">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : fbUsageData.length === 0 ? (
+            <div className="h-full flex items-center justify-center text-muted-foreground">
+              No usage data yet
+            </div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={fbUsageData}>
+                <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={(v) => {
+                    const d = new Date(v + "T00:00:00");
+                    return d.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+                  }}
+                  tick={{ fontSize: 11 }}
+                />
+                <YAxis tick={{ fontSize: 11 }} />
+                <Tooltip
+                  labelFormatter={(v) => {
+                    const d = new Date(v + "T00:00:00");
+                    return d.toLocaleDateString("en-US", { month: "long", day: "numeric", year: "numeric" });
+                  }}
+                />
+                <Legend />
+                <Line dataKey="avg_sessions_per_user" name="Sessions/User" stroke="#6366f1" strokeWidth={2} dot={false} />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </Card>
+
       {/* Message Ratings — macOS Floating Bar */}
       <Card className="p-6">
         <div className="flex items-center justify-between mb-1">

--- a/web/admin/app/api/omi/stats/floating-bar-usage/route.ts
+++ b/web/admin/app/api/omi/stats/floating-bar-usage/route.ts
@@ -57,7 +57,21 @@ export async function GET(request: NextRequest) {
       ORDER BY day
     `;
 
-    const [totalRes, voiceRes] = await Promise.all([
+    // Query 3: Daily sessions (unique floating bar opens, not follow-ups)
+    const sessionsQuery = `
+      SELECT
+        toDate(timestamp) as day,
+        count() as sessions,
+        count(DISTINCT distinct_id) as session_users
+      FROM events
+      WHERE event = 'floating_bar_ask_omi_opened'
+        AND properties.$os_name = 'macOS'
+        AND timestamp >= now() - interval ${days} day
+      GROUP BY day
+      ORDER BY day
+    `;
+
+    const [totalRes, voiceRes, sessionsRes] = await Promise.all([
       fetch(`${host}/api/projects/${projectId}/query/`, {
         method: "POST",
         headers: {
@@ -74,10 +88,19 @@ export async function GET(request: NextRequest) {
         },
         body: JSON.stringify({ query: { kind: "HogQLQuery", query: voiceQuery } }),
       }),
+      fetch(`${host}/api/projects/${projectId}/query/`, {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query: { kind: "HogQLQuery", query: sessionsQuery } }),
+      }),
     ]);
 
-    if (!totalRes.ok || !voiceRes.ok) {
-      const text = !totalRes.ok ? await totalRes.text() : await voiceRes.text();
+    if (!totalRes.ok || !voiceRes.ok || !sessionsRes.ok) {
+      const failedRes = !totalRes.ok ? totalRes : !voiceRes.ok ? voiceRes : sessionsRes;
+      const text = await failedRes.text();
       console.error("PostHog query error:", text);
       return NextResponse.json(
         { error: "PostHog API error" },
@@ -87,14 +110,20 @@ export async function GET(request: NextRequest) {
 
     const totalResult = await totalRes.json();
     const voiceResult = await voiceRes.json();
+    const sessionsResult = await sessionsRes.json();
 
     const totalRows: [string, number, number][] = totalResult?.results ?? [];
     const voiceRows: [string, number][] = voiceResult?.results ?? [];
+    const sessionsRows: [string, number, number][] = sessionsResult?.results ?? [];
 
-    // Build voice lookup by date
+    // Build lookups by date
     const voiceByDate: Record<string, number> = {};
     for (const [date, count] of voiceRows) {
       voiceByDate[date.slice(0, 10)] = count;
+    }
+    const sessionsByDate: Record<string, { sessions: number; users: number }> = {};
+    for (const [date, sessions, users] of sessionsRows) {
+      sessionsByDate[date.slice(0, 10)] = { sessions, users };
     }
 
     // Combine into daily data
@@ -103,6 +132,8 @@ export async function GET(request: NextRequest) {
       const voice = voiceByDate[d] || 0;
       const text = totalQueries - voice;
       const avgPerUser = uniqueUsers > 0 ? Math.round((totalQueries / uniqueUsers) * 10) / 10 : 0;
+      const sess = sessionsByDate[d] || { sessions: 0, users: 0 };
+      const avgSessionsPerUser = sess.users > 0 ? Math.round((sess.sessions / sess.users) * 10) / 10 : 0;
       return {
         date: d,
         total_queries: totalQueries,
@@ -110,6 +141,8 @@ export async function GET(request: NextRequest) {
         voice_queries: voice,
         unique_users: uniqueUsers,
         avg_per_user: avgPerUser,
+        sessions: sess.sessions,
+        avg_sessions_per_user: avgSessionsPerUser,
       };
     });
 
@@ -118,10 +151,8 @@ export async function GET(request: NextRequest) {
     const totalAllVoice = daily.reduce((s, d) => s + d.voice_queries, 0);
     const totalAllText = daily.reduce((s, d) => s + d.text_queries, 0);
     const totalAllUsers = daily.reduce((s, d) => s + d.unique_users, 0);
+    const totalAllSessions = daily.reduce((s, d) => s + d.sessions, 0);
     const activeDays = daily.filter((d) => d.total_queries > 0).length;
-    const overallAvgPerUser = activeDays > 0 && totalAllUsers > 0
-      ? Math.round((totalAllQueries / (totalAllUsers / activeDays)) * 10) / 10
-      : 0;
 
     const result = {
       data: daily,
@@ -130,7 +161,9 @@ export async function GET(request: NextRequest) {
         totalQueries: totalAllQueries,
         totalVoice: totalAllVoice,
         totalText: totalAllText,
-        overallAvgPerUserPerDay: activeDays > 0 ? Math.round((totalAllQueries / totalAllUsers) * 10) / 10 : 0,
+        totalSessions: totalAllSessions,
+        overallAvgPerUserPerDay: totalAllUsers > 0 ? Math.round((totalAllQueries / totalAllUsers) * 10) / 10 : 0,
+        overallAvgSessionsPerUserPerDay: totalAllUsers > 0 ? Math.round((totalAllSessions / totalAllUsers) * 10) / 10 : 0,
         activeDays,
       },
     };


### PR DESCRIPTION
## Summary
- Added sessions tracking to floating-bar-usage API (uses `floating_bar_ask_omi_opened` event — counts unique opens, not follow-up queries)
- Added "Floating Bar Sessions per User" line chart to analytics dashboard
- Shows avg sessions/user/day — one session = one floating bar open + question, follow-ups don't count

## Test plan
- [ ] Verify chart renders on analytics page
- [ ] Verify sessions count differs from total queries (should be lower)

🤖 Generated with [Claude Code](https://claude.com/claude-code)