### PR TITLE
Show 'Right ⌘' for right command PTT preset

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -46,6 +46,9 @@ class ShortcutSettings: ObservableObject {
         var displayTokens: [String] {
             let modifierTokens = Self.modifierTokens(for: modifiers)
             if modifierOnly {
+                if requiresRightCommand {
+                    return ["Right ⌘"]
+                }
                 return modifierTokens
             }
             if let keyDisplay {


### PR DESCRIPTION
## Summary
- PTT preset for right command now displays as "Right ⌘" instead of just "⌘" in settings and onboarding

## Test plan
- [ ] Settings → Shortcuts → Push to Talk shows "Right ⌘" for the second preset
- [ ] Onboarding voice demo title shows "Hold Right Cmd and Ask" when right command is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)