### PR TITLE
Bump build number to 809 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.530+808
+version: 1.0.530+809
 
 
 environment:


### PR DESCRIPTION
Version bump for mobile release v1.0.530 (809).

Deploys automatically via Codemagic auto-deploy on merge to main. No manual steps required.

---
_by AI for @beastoin_