### PR TITLE
Bump build number to 810 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.530+809
+version: 1.0.530+810
 
 
 environment:


### PR DESCRIPTION
Previous build 809 had Android auto-deploy cancelled on Codemagic. Fresh build number ensures clean deployment to both platforms.

---
_by AI for @beastoin_