### PR TITLE
Bump version to 1.0.531+810 for mobile release

### DIFF
--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.530+810
+version: 1.0.531+810
 
 
 environment:


### PR DESCRIPTION
Version name 1.0.530 already exists on stores, causing deployment failures. Bumping to 1.0.531 with build 810 for a clean release.

---
_by AI for @beastoin_