### PR TITLE
Update CHANGELOG.json for v0.11.274 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed call recordings being labeled as a single speaker by re-enabling system audio capture (now with drift compensation, no more crackling)"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.274",
+      "date": "2026-04-09",
+      "changes": [
+        "Fixed call recordings being labeled as a single speaker by re-enabling system audio capture (now with drift compensation, no more crackling)"
+      ]
+    },
     {
       "version": "0.11.272",
       "date": "2026-04-09",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.274 and clears the unreleased array.