### PR TITLE
fix(web-admin): retention rate >100% when platform filter applied

### DIFF
--- a/web/admin/app/api/omi/stats/retention/mixpanel/__tests__/transformRetention.test.ts
+++ b/web/admin/app/api/omi/stats/retention/mixpanel/__tests__/transformRetention.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { transformRetention } from '../route';
+
+describe('transformRetention', () => {
+  it('caps per-cohort retention at 100% when counts[N] > counts[0]', () => {
+    const raw = {
+      '2026-03-27T00:00:00': { counts: [10, 12], first: 20 },
+    };
+    const result = transformRetention(raw);
+    expect(result.cohorts).toHaveLength(1);
+    expect(result.cohorts[0].users).toBe(10);
+    expect(result.cohorts[0].data[0].retention).toBe(100);
+    expect(result.cohorts[0].data[1].retention).toBe(100); // 120% capped to 100%
+  });
+
+  it('preserves retention values at or below 100%', () => {
+    const raw = {
+      '2026-03-27T00:00:00': { counts: [20, 10, 5], first: 30 },
+    };
+    const result = transformRetention(raw);
+    expect(result.cohorts[0].data[0].retention).toBe(100);
+    expect(result.cohorts[0].data[1].retention).toBe(50);
+    expect(result.cohorts[0].data[2].retention).toBe(25);
+  });
+
+  it('caps average retention when one cohort exceeds 100%', () => {
+    // Cohort A: counts[1]=12 > counts[0]=10 → 120% capped to 100%
+    // Cohort B: counts[1]=10 / counts[0]=20 → 50%
+    // Average: (100 + 50) / 2 = 75, not (120 + 50) / 2 = 85
+    const raw = {
+      '2026-03-27T00:00:00': { counts: [10, 12], first: 20 },
+      '2026-03-28T00:00:00': { counts: [20, 10], first: 30 },
+    };
+    const result = transformRetention(raw);
+    expect(result.data[1].retention).toBe(75);
+  });
+
+  it('skips cohorts with counts[0] === 0', () => {
+    const raw = {
+      '2026-03-27T00:00:00': { counts: [0, 5], first: 10 },
+      '2026-03-28T00:00:00': { counts: [10, 5], first: 10 },
+    };
+    const result = transformRetention(raw);
+    expect(result.cohorts).toHaveLength(1);
+    expect(result.cohorts[0].date).toBe('2026-03-28');
+    expect(result.totalUsers).toBe(10);
+  });
+
+  it('returns empty result for no cohort data', () => {
+    const raw = {};
+    const result = transformRetention(raw);
+    expect(result.data).toEqual([]);
+    expect(result.cohorts).toEqual([]);
+    expect(result.totalCohorts).toBe(0);
+    expect(result.totalUsers).toBe(0);
+  });
+
+  it('filters out non-cohort keys', () => {
+    const raw = {
+      '2026-03-27T00:00:00': { counts: [10, 5], first: 10 },
+      request: { something: 'else' } as any,
+    };
+    const result = transformRetention(raw);
+    expect(result.totalCohorts).toBe(1);
+    expect(result.cohorts).toHaveLength(1);
+  });
+
+  it('handles multiple days with mixed over/under 100%', () => {
+    // Real-world scenario: macOS filter causes some days >100%
+    const raw = {
+      '2026-03-27T00:00:00': { counts: [6, 9, 3, 8], first: 15 },
+    };
+    const result = transformRetention(raw);
+    const retentions = result.cohorts[0].data.map((d) => d.retention);
+    expect(retentions[0]).toBe(100);       // 100%
+    expect(retentions[1]).toBe(100);       // 150% capped
+    expect(retentions[2]).toBe(50);        // 50%
+    expect(retentions[3]).toBe(100);       // 133% capped
+  });
+});

--- a/web/admin/app/api/omi/stats/retention/mixpanel/__tests__/transformRetention.test.ts
+++ b/web/admin/app/api/omi/stats/retention/mixpanel/__tests__/transformRetention.test.ts
@@ -2,42 +2,56 @@ import { describe, it, expect } from 'vitest';
 import { transformRetention } from '../route';
 
 describe('transformRetention', () => {
-  it('caps per-cohort retention at 100% when counts[N] > counts[0]', () => {
+  it('uses cohort.first as denominator for retention calculation', () => {
     const raw = {
-      '2026-03-27T00:00:00': { counts: [10, 12], first: 20 },
+      '2026-03-27T00:00:00': { counts: [7, 9], first: 12 },
     };
     const result = transformRetention(raw);
     expect(result.cohorts).toHaveLength(1);
-    expect(result.cohorts[0].users).toBe(10);
-    expect(result.cohorts[0].data[0].retention).toBe(100);
-    expect(result.cohorts[0].data[1].retention).toBe(100); // 120% capped to 100%
+    expect(result.cohorts[0].users).toBe(12); // first, not counts[0]
+    expect(result.cohorts[0].data[0].retention).toBe(58.33); // 7/12 * 100
+    expect(result.cohorts[0].data[1].retention).toBe(75); // 9/12 * 100
   });
 
-  it('preserves retention values at or below 100%', () => {
+  it('never produces >100% when counts[N] < first', () => {
+    // Even though counts[1] > counts[0], retention stays ≤100% because denominator is first
     const raw = {
-      '2026-03-27T00:00:00': { counts: [20, 10, 5], first: 30 },
+      '2026-03-27T00:00:00': { counts: [6, 9, 3], first: 10 },
     };
     const result = transformRetention(raw);
+    const retentions = result.cohorts[0].data.map((d) => d.retention);
+    expect(retentions[0]).toBe(60); // 6/10
+    expect(retentions[1]).toBe(90); // 9/10
+    expect(retentions[2]).toBe(30); // 3/10
+    expect(retentions.every((r) => r <= 100)).toBe(true);
+  });
+
+  it('falls back to counts[0] when first is not provided', () => {
+    const raw = {
+      '2026-03-27T00:00:00': { counts: [20, 10, 5] },
+    };
+    const result = transformRetention(raw);
+    expect(result.cohorts[0].users).toBe(20);
     expect(result.cohorts[0].data[0].retention).toBe(100);
     expect(result.cohorts[0].data[1].retention).toBe(50);
     expect(result.cohorts[0].data[2].retention).toBe(25);
   });
 
-  it('caps average retention when one cohort exceeds 100%', () => {
-    // Cohort A: counts[1]=12 > counts[0]=10 → 120% capped to 100%
-    // Cohort B: counts[1]=10 / counts[0]=20 → 50%
-    // Average: (100 + 50) / 2 = 75, not (120 + 50) / 2 = 85
+  it('computes average retention using first as denominator', () => {
+    // Cohort A: first=12, counts[1]=9 → 75%
+    // Cohort B: first=20, counts[1]=10 → 50%
+    // Average: (75 + 50) / 2 = 62.5
     const raw = {
-      '2026-03-27T00:00:00': { counts: [10, 12], first: 20 },
-      '2026-03-28T00:00:00': { counts: [20, 10], first: 30 },
+      '2026-03-27T00:00:00': { counts: [7, 9], first: 12 },
+      '2026-03-28T00:00:00': { counts: [20, 10], first: 20 },
     };
     const result = transformRetention(raw);
-    expect(result.data[1].retention).toBe(75);
+    expect(result.data[1].retention).toBe(62.5);
   });
 
-  it('skips cohorts with counts[0] === 0', () => {
+  it('skips cohorts with first === 0', () => {
     const raw = {
-      '2026-03-27T00:00:00': { counts: [0, 5], first: 10 },
+      '2026-03-27T00:00:00': { counts: [0, 5], first: 0 },
       '2026-03-28T00:00:00': { counts: [10, 5], first: 10 },
     };
     const result = transformRetention(raw);
@@ -65,16 +79,12 @@ describe('transformRetention', () => {
     expect(result.cohorts).toHaveLength(1);
   });
 
-  it('handles multiple days with mixed over/under 100%', () => {
-    // Real-world scenario: macOS filter causes some days >100%
+  it('totalUsers sums cohort.first values', () => {
     const raw = {
-      '2026-03-27T00:00:00': { counts: [6, 9, 3, 8], first: 15 },
+      '2026-03-27T00:00:00': { counts: [7, 3], first: 12 },
+      '2026-03-28T00:00:00': { counts: [6, 2], first: 7 },
     };
     const result = transformRetention(raw);
-    const retentions = result.cohorts[0].data.map((d) => d.retention);
-    expect(retentions[0]).toBe(100);       // 100%
-    expect(retentions[1]).toBe(100);       // 150% capped
-    expect(retentions[2]).toBe(50);        // 50%
-    expect(retentions[3]).toBe(100);       // 133% capped
+    expect(result.totalUsers).toBe(19); // 12 + 7
   });
 });

--- a/web/admin/app/api/omi/stats/retention/mixpanel/route.ts
+++ b/web/admin/app/api/omi/stats/retention/mixpanel/route.ts
@@ -49,25 +49,24 @@ export function transformRetention(raw: Record<string, RawCohort>): RetentionRes
     const cohort = raw[date];
     if (!cohort || !Array.isArray(cohort.counts)) continue;
 
-    // Use counts[0] as denominator so "Users" reflects the filtered platform.
-    // Cap at 100% because Mixpanel's where-filter applies per-day independently:
-    // a user might match on day N but not day 0, making counts[N] > counts[0].
-    const first = cohort.counts[0] || 0;
-    if (first === 0) continue;
+    // Use cohort.first as denominator — the true cohort size.
+    // With born_where, first = users whose birth event matched the platform filter.
+    // counts[N] can never exceed first, so retention is always ≤ 100%.
+    const denominator = cohort.first ?? cohort.counts[0] ?? 0;
+    if (denominator === 0) continue;
 
-    totalUsers += first;
+    totalUsers += denominator;
     const label = date.split('T')[0]; // "YYYY-MM-DD"
     const curve: { day: number; retention: number }[] = [];
 
     for (let dayIdx = 0; dayIdx < cohort.counts.length; dayIdx++) {
-      const pct = (cohort.counts[dayIdx] / first) * 100;
       curve.push({
         day: dayIdx,
-        retention: Math.round(Math.min(pct, 100) * 100) / 100,
+        retention: Math.round((cohort.counts[dayIdx] / denominator) * 100 * 100) / 100,
       });
     }
 
-    cohorts.push({ date: label, users: first, data: curve });
+    cohorts.push({ date: label, users: denominator, data: curve });
   }
 
   for (let dayIdx = 0; dayIdx < maxDays; dayIdx++) {
@@ -78,11 +77,11 @@ export function transformRetention(raw: Record<string, RawCohort>): RetentionRes
       const cohort = raw[date];
       if (!cohort || !Array.isArray(cohort.counts)) continue;
 
-      const first = cohort.counts[0] || 0;
-      if (first === 0) continue;
+      const denominator = cohort.first ?? cohort.counts[0] ?? 0;
+      if (denominator === 0) continue;
       if (dayIdx >= cohort.counts.length) continue;
 
-      sumPct += Math.min((cohort.counts[dayIdx] / first) * 100, 100);
+      sumPct += (cohort.counts[dayIdx] / denominator) * 100;
       cohortCount++;
     }
 
@@ -131,7 +130,11 @@ export async function GET(request: NextRequest) {
     });
 
     if (platform === 'macos') {
-      params.set('where', 'properties["$os"]=="macOS"');
+      // Use born_where to define the cohort as "users whose first session was on macOS".
+      // This makes cohort.first = macOS-born users, so retention never exceeds 100%.
+      // Using `where` instead would filter events per-day independently, allowing
+      // counts[N] > counts[0] and producing >100% retention.
+      params.set('born_where', 'properties["$os"]=="macOS"');
     }
 
     const url = `${apiBase.replace(/\/$/, '')}/retention?${params.toString()}`;

--- a/web/admin/app/api/omi/stats/retention/mixpanel/route.ts
+++ b/web/admin/app/api/omi/stats/retention/mixpanel/route.ts
@@ -2,6 +2,101 @@ import { NextRequest, NextResponse } from 'next/server';
 import { verifyAdmin } from '@/lib/auth';
 export const dynamic = 'force-dynamic';
 
+interface RawCohort {
+  counts: number[];
+  first?: number;
+}
+
+interface CohortResult {
+  date: string;
+  users: number;
+  data: { day: number; retention: number }[];
+}
+
+interface RetentionResult {
+  data: { day: number; retention: number }[];
+  cohorts: CohortResult[];
+  totalCohorts: number;
+  totalUsers: number;
+}
+
+/**
+ * Transform raw Mixpanel retention data into capped retention percentages.
+ * Exported for unit testing.
+ */
+export function transformRetention(raw: Record<string, RawCohort>): RetentionResult {
+  const cohortDates = Object.keys(raw)
+    .filter((k) => typeof raw[k] === 'object' && raw[k] !== null && 'counts' in raw[k])
+    .sort();
+
+  if (cohortDates.length === 0) {
+    return { data: [], cohorts: [], totalCohorts: 0, totalUsers: 0 };
+  }
+
+  let maxDays = 0;
+  for (const date of cohortDates) {
+    const counts = raw[date]?.counts;
+    if (Array.isArray(counts) && counts.length > maxDays) {
+      maxDays = counts.length;
+    }
+  }
+
+  const data: { day: number; retention: number }[] = [];
+  let totalUsers = 0;
+  const cohorts: CohortResult[] = [];
+
+  for (const date of cohortDates) {
+    const cohort = raw[date];
+    if (!cohort || !Array.isArray(cohort.counts)) continue;
+
+    // Use counts[0] as denominator so "Users" reflects the filtered platform.
+    // Cap at 100% because Mixpanel's where-filter applies per-day independently:
+    // a user might match on day N but not day 0, making counts[N] > counts[0].
+    const first = cohort.counts[0] || 0;
+    if (first === 0) continue;
+
+    totalUsers += first;
+    const label = date.split('T')[0]; // "YYYY-MM-DD"
+    const curve: { day: number; retention: number }[] = [];
+
+    for (let dayIdx = 0; dayIdx < cohort.counts.length; dayIdx++) {
+      const pct = (cohort.counts[dayIdx] / first) * 100;
+      curve.push({
+        day: dayIdx,
+        retention: Math.round(Math.min(pct, 100) * 100) / 100,
+      });
+    }
+
+    cohorts.push({ date: label, users: first, data: curve });
+  }
+
+  for (let dayIdx = 0; dayIdx < maxDays; dayIdx++) {
+    let sumPct = 0;
+    let cohortCount = 0;
+
+    for (const date of cohortDates) {
+      const cohort = raw[date];
+      if (!cohort || !Array.isArray(cohort.counts)) continue;
+
+      const first = cohort.counts[0] || 0;
+      if (first === 0) continue;
+      if (dayIdx >= cohort.counts.length) continue;
+
+      sumPct += Math.min((cohort.counts[dayIdx] / first) * 100, 100);
+      cohortCount++;
+    }
+
+    if (cohortCount > 0) {
+      data.push({
+        day: dayIdx,
+        retention: Math.round((sumPct / cohortCount) * 100) / 100,
+      });
+    }
+  }
+
+  return { data, cohorts, totalCohorts: cohortDates.length, totalUsers };
+}
+
 export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
@@ -69,86 +164,8 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // raw format: { "YYYY-MM-DDTHH:MM:SS": { counts: [n0, n1, ...], first: N }, ... }
-    // Filter out non-cohort keys like "request", "error"
-    const cohortDates = Object.keys(raw)
-      .filter((k) => typeof raw[k] === 'object' && raw[k] !== null && 'counts' in raw[k])
-      .sort();
-    if (cohortDates.length === 0) {
-      return NextResponse.json({ data: [], totalCohorts: 0, totalUsers: 0 });
-    }
-
-    // Find max retention days across all cohorts
-    let maxDays = 0;
-    for (const date of cohortDates) {
-      const counts = raw[date]?.counts;
-      if (Array.isArray(counts) && counts.length > maxDays) {
-        maxDays = counts.length;
-      }
-    }
-
-    // Average retention across all cohorts for each day
-    const data: { day: number; retention: number }[] = [];
-    let totalUsers = 0;
-
-    // Per-cohort retention curves
-    const cohorts: { date: string; users: number; data: { day: number; retention: number }[] }[] = [];
-
-    for (const date of cohortDates) {
-      const cohort = raw[date];
-      if (!cohort || !Array.isArray(cohort.counts)) continue;
-
-      // Use counts[0] as denominator so "Users" reflects the filtered platform.
-      // Cap at 100% because Mixpanel's where-filter applies per-day independently:
-      // a user might match on day N but not day 0, making counts[N] > counts[0].
-      const first = cohort.counts[0] || 0;
-      if (first === 0) continue;
-
-      totalUsers += first;
-      const label = date.split('T')[0]; // "YYYY-MM-DD"
-      const curve: { day: number; retention: number }[] = [];
-
-      for (let dayIdx = 0; dayIdx < cohort.counts.length; dayIdx++) {
-        const pct = (cohort.counts[dayIdx] / first) * 100;
-        curve.push({
-          day: dayIdx,
-          retention: Math.round(Math.min(pct, 100) * 100) / 100,
-        });
-      }
-
-      cohorts.push({ date: label, users: first, data: curve });
-    }
-
-    for (let dayIdx = 0; dayIdx < maxDays; dayIdx++) {
-      let sumPct = 0;
-      let cohortCount = 0;
-
-      for (const date of cohortDates) {
-        const cohort = raw[date];
-        if (!cohort || !Array.isArray(cohort.counts)) continue;
-
-        const first = cohort.counts[0] || 0;
-        if (first === 0) continue;
-        if (dayIdx >= cohort.counts.length) continue;
-
-        sumPct += Math.min((cohort.counts[dayIdx] / first) * 100, 100);
-        cohortCount++;
-      }
-
-      if (cohortCount > 0) {
-        data.push({
-          day: dayIdx,
-          retention: Math.round((sumPct / cohortCount) * 100) / 100,
-        });
-      }
-    }
-
-    return NextResponse.json({
-      data,
-      cohorts,
-      totalCohorts: cohortDates.length,
-      totalUsers,
-    });
+    const result = transformRetention(raw);
+    return NextResponse.json(result);
   } catch (error) {
     console.error('Error fetching Mixpanel retention:', error);
     return NextResponse.json(

--- a/web/admin/app/api/omi/stats/retention/mixpanel/route.ts
+++ b/web/admin/app/api/omi/stats/retention/mixpanel/route.ts
@@ -98,7 +98,11 @@ export async function GET(request: NextRequest) {
       const cohort = raw[date];
       if (!cohort || !Array.isArray(cohort.counts)) continue;
 
-      const first = cohort.counts[0] || 0;
+      // Use cohort.first (unfiltered cohort size) as denominator, not counts[0].
+      // When a platform filter is applied, counts[0] only includes users matching
+      // the filter on day 0, while counts[N] includes different users matching on
+      // day N — making counts[N] > counts[0] possible, giving >100% retention.
+      const first = cohort.first ?? cohort.counts[0] ?? 0;
       if (first === 0) continue;
 
       totalUsers += first;
@@ -123,8 +127,7 @@ export async function GET(request: NextRequest) {
         const cohort = raw[date];
         if (!cohort || !Array.isArray(cohort.counts)) continue;
 
-        // Use counts[0] as base when filtering, since `first` may be unfiltered
-        const first = cohort.counts[0] || 0;
+        const first = cohort.first ?? cohort.counts[0] ?? 0;
         if (first === 0) continue;
         if (dayIdx >= cohort.counts.length) continue;
 

--- a/web/admin/app/api/omi/stats/retention/mixpanel/route.ts
+++ b/web/admin/app/api/omi/stats/retention/mixpanel/route.ts
@@ -98,11 +98,10 @@ export async function GET(request: NextRequest) {
       const cohort = raw[date];
       if (!cohort || !Array.isArray(cohort.counts)) continue;
 
-      // Use cohort.first (unfiltered cohort size) as denominator, not counts[0].
-      // When a platform filter is applied, counts[0] only includes users matching
-      // the filter on day 0, while counts[N] includes different users matching on
-      // day N — making counts[N] > counts[0] possible, giving >100% retention.
-      const first = cohort.first ?? cohort.counts[0] ?? 0;
+      // Use counts[0] as denominator so "Users" reflects the filtered platform.
+      // Cap at 100% because Mixpanel's where-filter applies per-day independently:
+      // a user might match on day N but not day 0, making counts[N] > counts[0].
+      const first = cohort.counts[0] || 0;
       if (first === 0) continue;
 
       totalUsers += first;
@@ -110,9 +109,10 @@ export async function GET(request: NextRequest) {
       const curve: { day: number; retention: number }[] = [];
 
       for (let dayIdx = 0; dayIdx < cohort.counts.length; dayIdx++) {
+        const pct = (cohort.counts[dayIdx] / first) * 100;
         curve.push({
           day: dayIdx,
-          retention: Math.round((cohort.counts[dayIdx] / first) * 100 * 100) / 100,
+          retention: Math.round(Math.min(pct, 100) * 100) / 100,
         });
       }
 
@@ -127,11 +127,11 @@ export async function GET(request: NextRequest) {
         const cohort = raw[date];
         if (!cohort || !Array.isArray(cohort.counts)) continue;
 
-        const first = cohort.first ?? cohort.counts[0] ?? 0;
+        const first = cohort.counts[0] || 0;
         if (first === 0) continue;
         if (dayIdx >= cohort.counts.length) continue;
 
-        sumPct += (cohort.counts[dayIdx] / first) * 100;
+        sumPct += Math.min((cohort.counts[dayIdx] / first) * 100, 100);
         cohortCount++;
       }
 


### PR DESCRIPTION
## Summary

Fix cohort retention rates exceeding 100% in admin dashboard analytics when filtering by platform (e.g. macOS).

**Root cause:** The API used Mixpanel's `where` filter which applies per-day independently — a user could match on day N but not day 0, making `counts[N] > counts[0]`. Combined with using `counts[0]` as denominator, this produced retention >100%.

**Fix (proper):** Two changes that eliminate >100% at the source:
1. **`born_where` instead of `where`** — defines the cohort as "users whose first session was on macOS" rather than filtering events per-day. This means `cohort.first` = macOS-born users.
2. **`cohort.first` as denominator** — the true cohort size. `counts[N]` can never exceed `first`, so retention is mathematically bounded at ≤100%.

Users column shows macOS-born cohort size (e.g. 25, 11, 9) — meaningful platform-specific numbers.

## Changes

1. **`route.ts`** — Switch `where` → `born_where`, use `cohort.first` as denominator via extracted `transformRetention()`
2. **`transformRetention.test.ts`** — 8 unit tests covering denominator logic, edge cases

## Testing evidence

- **Unit tests**: 8 tests, all passing (vitest)
- **Live dev server**: Real Mixpanel API data, macOS, 30 days
  - BEFORE: 26 cells exceeded 100% (max 166.7%)
  - AFTER (born_where): 0 cells >100%, max 88.89%
  - Users column: 25, 27, 11, 9... (macOS-born cohort sizes)
- Before/after screenshots in PR comments

## Risks / Edge cases

- `born_where` changes the cohort definition: "users born on macOS" vs "all users filtered by macOS per-day". This is analytically more correct but shows different numbers.
- Falls back to `counts[0]` if `cohort.first` is not provided (backward compat).

---
_by AI for @beastoin_