### PR TITLE
fix(desktop): reduce API polling frequency (#6500)

### DIFF
--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -3067,6 +3067,8 @@ extension Notification.Name {
   static let navigateToTasks = Notification.Name("navigateToTasks")
   /// Posted by keyboard shortcuts to navigate sidebar. userInfo: ["rawValue": Int]
   static let navigateToSidebarItem = Notification.Name("navigateToSidebarItem")
+  /// Posted by Cmd+R to refresh all data (conversations, chat, tasks, memories)
+  static let refreshAllData = Notification.Name("refreshAllData")
   /// Posted by the local desktop automation bridge to request semantic navigation.
   static let desktopAutomationNavigateRequested = Notification.Name(
     "desktopAutomationNavigateRequested")

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -1997,7 +1997,7 @@ class AppState: ObservableObject {
 
   /// Refresh conversations silently (for auto-refresh timer and app-activate).
   /// Fetches from API only, merges in-place, and only triggers @Published if data actually changed.
-  func refreshConversations() async {
+  func refreshConversations(skipCount: Bool = false) async {
     // Skip if user is signed out (tokens are cleared)
     guard AuthState.shared.isSignedIn else { return }
     // Skip if in auth backoff period (recent 401 errors)
@@ -2057,14 +2057,16 @@ class AppState: ObservableObject {
       }
     }
 
-    // Update total count
-    do {
-      let count = try await APIClient.shared.getConversationsCount(includeDiscarded: false)
-      if totalConversationsCount != count {
-        totalConversationsCount = count
+    // Update total count (skipped during periodic background refreshes to halve traffic)
+    if !skipCount {
+      do {
+        let count = try await APIClient.shared.getConversationsCount(includeDiscarded: false)
+        if totalConversationsCount != count {
+          totalConversationsCount = count
+        }
+      } catch {
+        // Keep existing count
       }
-    } catch {
-      // Keep existing count
     }
   }
 

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -1995,9 +1995,9 @@ class AppState: ObservableObject {
     NotificationCenter.default.post(name: .conversationsPageDidLoad, object: nil)
   }
 
-  /// Refresh conversations silently (for auto-refresh timer and app-activate).
+  /// Refresh conversations silently (for app-activation and Cmd+R event-driven refreshes).
   /// Fetches from API only, merges in-place, and only triggers @Published if data actually changed.
-  func refreshConversations(skipCount: Bool = false) async {
+  func refreshConversations() async {
     // Skip if user is signed out (tokens are cleared)
     guard AuthState.shared.isSignedIn else { return }
     // Skip if in auth backoff period (recent 401 errors)
@@ -2057,16 +2057,13 @@ class AppState: ObservableObject {
       }
     }
 
-    // Update total count (skipped during periodic background refreshes to halve traffic)
-    if !skipCount {
-      do {
-        let count = try await APIClient.shared.getConversationsCount(includeDiscarded: false)
-        if totalConversationsCount != count {
-          totalConversationsCount = count
-        }
-      } catch {
-        // Keep existing count
+    do {
+      let count = try await APIClient.shared.getConversationsCount(includeDiscarded: false)
+      if totalConversationsCount != count {
+        totalConversationsCount = count
       }
+    } catch {
+      // Keep existing count
     }
   }
 

--- a/desktop/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/Desktop/Sources/MainWindow/CrispManager.swift
@@ -54,7 +54,11 @@ class CrispManager: ObservableObject {
     /// posting `didBecomeActive` / `.refreshAllData` actually reaches the poll
     /// method — if an observer subscribes to the wrong notification name or a
     /// future edit drops the wiring, the counter stays flat and the test fails.
-    @Published private(set) var pollInvocations: Int = 0
+    /// Deliberately **not** `@Published` — publishing on every activation/Cmd+R
+    /// refresh would emit `objectWillChange` and invalidate any SwiftUI view
+    /// observing `CrispManager`, which is a pure production cost for a value
+    /// nothing drives UI from.
+    private(set) var pollInvocations: Int = 0
 
     /// Call once after sign-in to fetch Crisp messages and listen for activation/Cmd+R.
     ///

--- a/desktop/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/Desktop/Sources/MainWindow/CrispManager.swift
@@ -24,14 +24,16 @@ class CrispManager: ObservableObject {
     /// Timestamp of the most recent operator message we've already notified about.
     /// Persisted to UserDefaults so unread messages survive app restarts.
     /// Stored as Double because UserDefaults can't round-trip UInt64.
-    private var lastSeenTimestamp: UInt64 {
+    /// Non-`private` so `CrispManagerLifecycleTests` can assert `markAsRead()` advances it.
+    var lastSeenTimestamp: UInt64 {
         get { UInt64(UserDefaults.standard.double(forKey: "crisp_lastSeenTimestamp")) }
         set { UserDefaults.standard.set(Double(newValue), forKey: "crisp_lastSeenTimestamp") }
     }
 
     /// Track the latest operator message timestamp from any poll.
     /// Persisted to UserDefaults so we don't re-notify after restart.
-    private var latestOperatorTimestamp: UInt64 {
+    /// Non-`private` so `CrispManagerLifecycleTests` can seed it before `markAsRead()`.
+    var latestOperatorTimestamp: UInt64 {
         get { UInt64(UserDefaults.standard.double(forKey: "crisp_latestOperatorTimestamp")) }
         set { UserDefaults.standard.set(Double(newValue), forKey: "crisp_latestOperatorTimestamp") }
     }
@@ -39,11 +41,13 @@ class CrispManager: ObservableObject {
     /// Track message texts we've already sent notifications for (to avoid duplicates)
     private var notifiedMessages = Set<String>()
 
-    /// Whether start() has been called
-    private var isStarted = false
+    /// Whether start() has been called. Non-`private` so lifecycle tests can
+    /// assert idempotency after calling `start()` twice.
+    var isStarted = false
 
-    private var activationObserver: NSObjectProtocol?
-    private var refreshAllObserver: NSObjectProtocol?
+    /// Non-`private` so lifecycle tests can assert `stop()` clears both observers.
+    var activationObserver: NSObjectProtocol?
+    var refreshAllObserver: NSObjectProtocol?
 
     private init() {}
 

--- a/desktop/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/Desktop/Sources/MainWindow/CrispManager.swift
@@ -49,7 +49,12 @@ class CrispManager: ObservableObject {
     var activationObserver: NSObjectProtocol?
     var refreshAllObserver: NSObjectProtocol?
 
-    private init() {}
+    /// Counter bumped at the top of `pollForMessages()`, before the auth-backoff
+    /// guard and the network task. Lets `CrispManagerLifecycleTests` prove that
+    /// posting `didBecomeActive` / `.refreshAllData` actually reaches the poll
+    /// method — if an observer subscribes to the wrong notification name or a
+    /// future edit drops the wiring, the counter stays flat and the test fails.
+    @Published private(set) var pollInvocations: Int = 0
 
     /// Call once after sign-in to fetch Crisp messages and listen for activation/Cmd+R.
     ///
@@ -107,6 +112,7 @@ class CrispManager: ObservableObject {
     // MARK: - Private
 
     private func pollForMessages() {
+        pollInvocations += 1
         Task {
             // Skip if in auth backoff period (recent 401 errors)
             guard !AuthBackoffTracker.shared.shouldSkipRequest() else { return }

--- a/desktop/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/Desktop/Sources/MainWindow/CrispManager.swift
@@ -1,6 +1,7 @@
+import AppKit
 import Foundation
 
-/// Polls the backend Crisp API endpoint for unread operator messages,
+/// Fetches Crisp operator messages on app activation and Cmd+R,
 /// fires macOS notifications, and tracks unread count for the sidebar badge.
 @MainActor
 class CrispManager: ObservableObject {
@@ -38,15 +39,15 @@ class CrispManager: ObservableObject {
     /// Track message texts we've already sent notifications for (to avoid duplicates)
     private var notifiedMessages = Set<String>()
 
-    /// Polling timer
-    private var pollTimer: Timer?
-
-    /// Whether polling has started
+    /// Whether start() has been called
     private var isStarted = false
+
+    private var activationObserver: NSObjectProtocol?
+    private var refreshAllObserver: NSObjectProtocol?
 
     private init() {}
 
-    /// Call once after sign-in to start polling for Crisp messages
+    /// Call once after sign-in to fetch Crisp messages and listen for activation/Cmd+R
     func start() {
         guard !isStarted else { return }
         isStarted = true
@@ -58,15 +59,19 @@ class CrispManager: ObservableObject {
             lastSeenTimestamp = UInt64(Date().timeIntervalSince1970)
         }
 
-        // Poll immediately, then every 2 minutes
+        // Fetch immediately on start
         pollForMessages()
-        pollTimer = Timer.scheduledTimer(withTimeInterval: 120, repeats: true) { [weak self] _ in
-            Task { @MainActor in
-                self?.pollForMessages()
-            }
-        }
 
-        log("CrispManager: started polling for operator messages")
+        // Refresh on app activation and Cmd+R (no periodic timer)
+        activationObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification, object: nil, queue: .main
+        ) { [weak self] _ in Task { @MainActor in self?.pollForMessages() } }
+
+        refreshAllObserver = NotificationCenter.default.addObserver(
+            forName: .refreshAllData, object: nil, queue: .main
+        ) { [weak self] _ in Task { @MainActor in self?.pollForMessages() } }
+
+        log("CrispManager: started (event-driven, no polling timer)")
     }
 
     /// Mark messages as read (called when user opens Help tab)
@@ -75,10 +80,12 @@ class CrispManager: ObservableObject {
         lastSeenTimestamp = latestOperatorTimestamp
     }
 
-    /// Stop polling (called on sign-out)
+    /// Stop observing (called on sign-out)
     func stop() {
-        pollTimer?.invalidate()
-        pollTimer = nil
+        if let obs = activationObserver { NotificationCenter.default.removeObserver(obs) }
+        if let obs = refreshAllObserver { NotificationCenter.default.removeObserver(obs) }
+        activationObserver = nil
+        refreshAllObserver = nil
         isStarted = false
         unreadCount = 0
         // Clear persisted timestamps so next sign-in starts fresh

--- a/desktop/Desktop/Sources/MainWindow/CrispManager.swift
+++ b/desktop/Desktop/Sources/MainWindow/CrispManager.swift
@@ -51,8 +51,13 @@ class CrispManager: ObservableObject {
 
     private init() {}
 
-    /// Call once after sign-in to fetch Crisp messages and listen for activation/Cmd+R
-    func start() {
+    /// Call once after sign-in to fetch Crisp messages and listen for activation/Cmd+R.
+    ///
+    /// - Parameter performInitialPoll: If `true` (default), kicks off an immediate
+    ///   `pollForMessages()` call that hits `APIClient.shared`. Pass `false` only
+    ///   from lifecycle unit tests that want to exercise observer registration
+    ///   without touching the network, auth state, or firing real notifications.
+    func start(performInitialPoll: Bool = true) {
         guard !isStarted else { return }
         isStarted = true
 
@@ -63,8 +68,9 @@ class CrispManager: ObservableObject {
             lastSeenTimestamp = UInt64(Date().timeIntervalSince1970)
         }
 
-        // Fetch immediately on start
-        pollForMessages()
+        if performInitialPoll {
+            pollForMessages()
+        }
 
         // Refresh on app activation and Cmd+R (no periodic timer)
         activationObserver = NotificationCenter.default.addObserver(

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -202,7 +202,7 @@ struct DesktopHomeView: View {
               NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             ) { _ in
               let now = Date()
-              guard now.timeIntervalSince(lastActivationRefresh) >= 60 else { return }
+              guard now.timeIntervalSince(lastActivationRefresh) >= PollingConfig.activationCooldown else { return }
               lastActivationRefresh = now
               Task { await appState.refreshConversations() }
               // Auto-start monitoring when returning to app if screen analysis is enabled
@@ -239,8 +239,8 @@ struct DesktopHomeView: View {
                 }
               }
             }
-            // Periodic refresh every 120s to pick up conversations from other devices (e.g. Omi Glass)
-            .onReceive(Timer.publish(every: 120, on: .main, in: .common).autoconnect()) { _ in
+            // Periodic refresh to pick up conversations from other devices (e.g. Omi Glass)
+            .onReceive(Timer.publish(every: PollingConfig.conversationsPollInterval, on: .main, in: .common).autoconnect()) { _ in
               Task { await appState.refreshConversations(skipCount: true) }
             }
             // On sign-out: reset @AppStorage-backed onboarding flag and stop transcription.

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -202,7 +202,7 @@ struct DesktopHomeView: View {
             ) { _ in
               // Cooldown: only refresh conversations if last activation was 60+ seconds ago
               let now = Date()
-              if now.timeIntervalSince(lastActivationRefresh) >= PollingConfig.activationCooldown {
+              if PollingConfig.shouldAllowActivationRefresh(now: now, lastRefresh: lastActivationRefresh) {
                 lastActivationRefresh = now
                 Task { await appState.refreshConversations() }
               }

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -32,6 +32,7 @@ struct DesktopHomeView: View {
   @State private var showTryAskingPopup = false
   @State private var previousIndexBeforeSettings: Int = 0
   @State private var logoPulse = false
+  @State private var lastActivationRefresh = Date.distantPast
 
   // Pre-loaded hero logo to avoid NSImage init crashes during SwiftUI body evaluation
   private static let heroLogoImage: NSImage? = {
@@ -196,9 +197,13 @@ struct DesktopHomeView: View {
               await AgentVMService.shared.ensureProvisioned()
             }
             // Refresh conversations when app becomes active (e.g. switching back from another app)
+            // Cooldown: skip if last activation refresh was less than 60 seconds ago
             .onReceive(
               NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             ) { _ in
+              let now = Date()
+              guard now.timeIntervalSince(lastActivationRefresh) >= 60 else { return }
+              lastActivationRefresh = now
               Task { await appState.refreshConversations() }
               // Auto-start monitoring when returning to app if screen analysis is enabled
               // but monitoring is not running. Handles the case where the user granted
@@ -234,9 +239,9 @@ struct DesktopHomeView: View {
                 }
               }
             }
-            // Periodic refresh every 30s to pick up conversations from other devices (e.g. Omi Glass)
-            .onReceive(Timer.publish(every: 30, on: .main, in: .common).autoconnect()) { _ in
-              Task { await appState.refreshConversations() }
+            // Periodic refresh every 120s to pick up conversations from other devices (e.g. Omi Glass)
+            .onReceive(Timer.publish(every: 120, on: .main, in: .common).autoconnect()) { _ in
+              Task { await appState.refreshConversations(skipCount: true) }
             }
             // On sign-out: reset @AppStorage-backed onboarding flag and stop transcription.
             // hasCompletedOnboarding must be set here (in a View) because @AppStorage

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -240,9 +240,9 @@ struct DesktopHomeView: View {
                 }
               }
             }
-            // Periodic refresh to pick up conversations from other devices (e.g. Omi Glass)
-            .onReceive(Timer.publish(every: PollingConfig.conversationsPollInterval, on: .main, in: .common).autoconnect()) { _ in
-              Task { await appState.refreshConversations(skipCount: true) }
+            // Cmd+R: refresh all data (conversations, chat, tasks, memories)
+            .onReceive(NotificationCenter.default.publisher(for: .refreshAllData)) { _ in
+              Task { await appState.refreshConversations() }
             }
             // On sign-out: reset @AppStorage-backed onboarding flag and stop transcription.
             // hasCompletedOnboarding must be set here (in a View) because @AppStorage

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -197,14 +197,15 @@ struct DesktopHomeView: View {
               await AgentVMService.shared.ensureProvisioned()
             }
             // Refresh conversations when app becomes active (e.g. switching back from another app)
-            // Cooldown: skip if last activation refresh was less than 60 seconds ago
             .onReceive(
               NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             ) { _ in
+              // Cooldown: only refresh conversations if last activation was 60+ seconds ago
               let now = Date()
-              guard now.timeIntervalSince(lastActivationRefresh) >= PollingConfig.activationCooldown else { return }
-              lastActivationRefresh = now
-              Task { await appState.refreshConversations() }
+              if now.timeIntervalSince(lastActivationRefresh) >= PollingConfig.activationCooldown {
+                lastActivationRefresh = now
+                Task { await appState.refreshConversations() }
+              }
               // Auto-start monitoring when returning to app if screen analysis is enabled
               // but monitoring is not running. Handles the case where the user granted
               // screen recording permission in System Settings and switched back.

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -206,8 +206,8 @@ class MemoriesViewModel: ObservableObject {
   // MARK: - Initialization
 
   init() {
-    // Auto-refresh memories every 120 seconds
-    Timer.publish(every: 120.0, on: .main, in: .common)
+    // Auto-refresh memories periodically
+    Timer.publish(every: PollingConfig.memoriesPollInterval, on: .main, in: .common)
       .autoconnect()
       .sink { [weak self] _ in
         Task { await self?.refreshMemoriesIfNeeded() }

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -139,6 +139,13 @@ class MemoriesViewModel: ObservableObject {
   /// Memories loaded from SQLite with filters applied
   @Published private(set) var filteredFromDatabase: [ServerMemory] = []
   @Published private(set) var isLoadingFiltered = false
+
+  /// Counter bumped at the top of `refreshMemoriesIfNeeded()`, before any of
+  /// the early-exit guards. Lets `MemoriesViewModelObserverTests` prove that
+  /// posting `didBecomeActive` / `.refreshAllData` actually reaches the refresh
+  /// method — if the observer rewire regresses, the counter stays flat and the
+  /// test fails.
+  @Published private(set) var refreshInvocations: Int = 0
   @Published var showingAddMemory = false
   @Published var newMemoryText = ""
   @Published var editingMemory: ServerMemory? = nil
@@ -223,6 +230,7 @@ class MemoriesViewModel: ObservableObject {
 
   /// Refresh memories if already loaded (for auto-refresh)
   private func refreshMemoriesIfNeeded() async {
+    refreshInvocations += 1
     // Skip if user is signed out (tokens are cleared)
     guard AuthState.shared.isSignedIn else { return }
     // Skip if in auth backoff period (recent 401 errors)

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -206,8 +206,8 @@ class MemoriesViewModel: ObservableObject {
   // MARK: - Initialization
 
   init() {
-    // Auto-refresh memories every 30 seconds
-    Timer.publish(every: 30.0, on: .main, in: .common)
+    // Auto-refresh memories every 120 seconds
+    Timer.publish(every: 120.0, on: .main, in: .common)
       .autoconnect()
       .sink { [weak self] _ in
         Task { await self?.refreshMemoriesIfNeeded() }

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -206,9 +206,15 @@ class MemoriesViewModel: ObservableObject {
   // MARK: - Initialization
 
   init() {
-    // Auto-refresh memories periodically
-    Timer.publish(every: PollingConfig.memoriesPollInterval, on: .main, in: .common)
-      .autoconnect()
+    // Refresh memories when app becomes active
+    NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+      .sink { [weak self] _ in
+        Task { await self?.refreshMemoriesIfNeeded() }
+      }
+      .store(in: &cancellables)
+
+    // Cmd+R: refresh memories on demand
+    NotificationCenter.default.publisher(for: .refreshAllData)
       .sink { [weak self] _ in
         Task { await self?.refreshMemoriesIfNeeded() }
       }

--- a/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/MemoriesPage.swift
@@ -145,7 +145,11 @@ class MemoriesViewModel: ObservableObject {
   /// posting `didBecomeActive` / `.refreshAllData` actually reaches the refresh
   /// method — if the observer rewire regresses, the counter stays flat and the
   /// test fails.
-  @Published private(set) var refreshInvocations: Int = 0
+  /// Deliberately **not** `@Published` — publishing on every activation/Cmd+R
+  /// refresh would emit `objectWillChange` and invalidate any SwiftUI view
+  /// observing `MemoriesViewModel`, which is a pure production cost for a
+  /// value nothing drives UI from.
+  private(set) var refreshInvocations: Int = 0
   @Published var showingAddMemory = false
   @Published var newMemoryText = ""
   @Published var editingMemory: ServerMemory? = nil

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -191,6 +191,13 @@ struct OMIApp: App {
         }
         .keyboardShortcut(",", modifiers: .command)
       }
+
+      CommandGroup(after: .toolbar) {
+        Button("Refresh") {
+          NotificationCenter.default.post(name: .refreshAllData, object: nil)
+        }
+        .keyboardShortcut("r", modifiers: .command)
+      }
     }
 
     // Note: Menu bar is now handled by NSStatusBar in AppDelegate.setupMenuBar()

--- a/desktop/Desktop/Sources/PollingConfig.swift
+++ b/desktop/Desktop/Sources/PollingConfig.swift
@@ -7,4 +7,12 @@ enum PollingConfig {
     /// Minimum time between app-activation conversation refreshes (seconds).
     /// Prevents cmd-tab spam from flooding the API.
     static let activationCooldown: TimeInterval = 60.0
+
+    /// Returns `true` when enough time has passed since `lastRefresh` to allow
+    /// another activation-triggered refresh. Used by DesktopHomeView to throttle
+    /// didBecomeActiveNotification bursts. Shared between production and tests
+    /// so a regression (e.g. `>=` → `>`) is caught by the unit tests.
+    static func shouldAllowActivationRefresh(now: Date = Date(), lastRefresh: Date) -> Bool {
+        now.timeIntervalSince(lastRefresh) >= activationCooldown
+    }
 }

--- a/desktop/Desktop/Sources/PollingConfig.swift
+++ b/desktop/Desktop/Sources/PollingConfig.swift
@@ -1,20 +1,10 @@
 import Foundation
 
-/// Centralized polling interval constants for all desktop auto-refresh timers.
-/// Changing values here updates every timer that references them.
+/// Centralized configuration for event-driven data refresh.
+/// All periodic polling timers have been removed — data refreshes on
+/// app activation (didBecomeActiveNotification) and manual Cmd+R.
 enum PollingConfig {
-    /// Chat message polling interval (seconds). Syncs messages from other platforms.
-    static let chatPollInterval: TimeInterval = 120.0
-
-    /// Tasks auto-refresh interval (seconds). Guarded by page visibility.
-    static let tasksPollInterval: TimeInterval = 120.0
-
-    /// Memories auto-refresh interval (seconds). Guarded by page visibility.
-    static let memoriesPollInterval: TimeInterval = 120.0
-
-    /// Conversations auto-refresh interval (seconds).
-    static let conversationsPollInterval: TimeInterval = 120.0
-
     /// Minimum time between app-activation conversation refreshes (seconds).
+    /// Prevents cmd-tab spam from flooding the API.
     static let activationCooldown: TimeInterval = 60.0
 }

--- a/desktop/Desktop/Sources/PollingConfig.swift
+++ b/desktop/Desktop/Sources/PollingConfig.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Centralized polling interval constants for all desktop auto-refresh timers.
+/// Changing values here updates every timer that references them.
+enum PollingConfig {
+    /// Chat message polling interval (seconds). Syncs messages from other platforms.
+    static let chatPollInterval: TimeInterval = 120.0
+
+    /// Tasks auto-refresh interval (seconds). Guarded by page visibility.
+    static let tasksPollInterval: TimeInterval = 120.0
+
+    /// Memories auto-refresh interval (seconds). Guarded by page visibility.
+    static let memoriesPollInterval: TimeInterval = 120.0
+
+    /// Conversations auto-refresh interval (seconds).
+    static let conversationsPollInterval: TimeInterval = 120.0
+
+    /// Minimum time between app-activation conversation refreshes (seconds).
+    static let activationCooldown: TimeInterval = 60.0
+}

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -539,10 +539,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
     private var sessionGroupingObserver: AnyCancellable?
     private var activationObserver: AnyCancellable?
 
-    // MARK: - Cross-Platform Message Polling
-    /// Polls for new messages from other platforms (mobile) every 120 seconds.
-    private var messagePollTimer: AnyCancellable?
-    private static let messagePollInterval: TimeInterval = PollingConfig.chatPollInterval
+    private var refreshAllObserver: AnyCancellable?
 
     // MARK: - Streaming Buffer
     /// Accumulates text deltas during streaming and flushes them to the published
@@ -638,17 +635,16 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 }
             }
 
-        // Poll for new messages from other platforms (mobile) every 120 seconds
-        messagePollTimer = Timer.publish(every: Self.messagePollInterval, on: .main, in: .common)
-            .autoconnect()
+        // Refresh messages when app becomes active
+        activationObserver = NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
                 Task { @MainActor in
                     await self?.pollForNewMessages()
                 }
             }
 
-        // Refresh messages when app becomes active (compensates for longer poll interval)
-        activationObserver = NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+        // Cmd+R: refresh messages on demand
+        refreshAllObserver = NotificationCenter.default.publisher(for: .refreshAllData)
             .sink { [weak self] _ in
                 Task { @MainActor in
                     await self?.pollForNewMessages()

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -542,7 +542,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
     // MARK: - Cross-Platform Message Polling
     /// Polls for new messages from other platforms (mobile) every 120 seconds.
     private var messagePollTimer: AnyCancellable?
-    private static let messagePollInterval: TimeInterval = 120.0
+    private static let messagePollInterval: TimeInterval = PollingConfig.chatPollInterval
 
     // MARK: - Streaming Buffer
     /// Accumulates text deltas during streaming and flushes them to the published

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -1926,14 +1926,15 @@ A screenshot may be attached — use it silently only if relevant. Never mention
 
     // MARK: - Cross-Platform Message Sync
 
-    /// Whether a poll is currently in-flight (prevents overlapping fetches)
-    private var isPolling = false
+    /// Prevents overlapping fetches when activation + Cmd+R fire back-to-back.
+    private let pollGate = ReentrancyGate()
 
     /// Fetch new messages from other platforms (e.g. mobile).
     /// Merges new messages into the existing array without disrupting the UI.
     private func pollForNewMessages() async {
         // Prevent overlapping fetches from activation + Cmd+R firing together
-        guard !isPolling else { return }
+        guard pollGate.tryEnter() else { return }
+        defer { pollGate.exit() }
         // Skip if user is signed out (tokens are cleared)
         guard AuthState.shared.isSignedIn else { return }
         // Skip if in auth backoff period (recent 401 errors)
@@ -1946,9 +1947,6 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         guard !messages.isEmpty || sessionsLoadError != nil else { return }
         // Skip if there's an active streaming message
         guard !messages.contains(where: { $0.isStreaming }) else { return }
-
-        isPolling = true
-        defer { isPolling = false }
 
         do {
             let persistedMessages: [ChatMessageDB]

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -539,10 +539,9 @@ A screenshot may be attached — use it silently only if relevant. Never mention
     private var sessionGroupingObserver: AnyCancellable?
 
     // MARK: - Cross-Platform Message Polling
-    /// Polls for new messages from other platforms (mobile) every 15 seconds.
-    /// Similar to TasksStore's 30-second polling pattern.
+    /// Polls for new messages from other platforms (mobile) every 120 seconds.
     private var messagePollTimer: AnyCancellable?
-    private static let messagePollInterval: TimeInterval = 15.0
+    private static let messagePollInterval: TimeInterval = 120.0
 
     // MARK: - Streaming Buffer
     /// Accumulates text deltas during streaming and flushes them to the published
@@ -638,7 +637,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 }
             }
 
-        // Poll for new messages from other platforms (mobile) every 15 seconds
+        // Poll for new messages from other platforms (mobile) every 120 seconds
         messagePollTimer = Timer.publish(every: Self.messagePollInterval, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -1924,11 +1924,16 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         isLoading = false
     }
 
-    // MARK: - Cross-Platform Message Polling
+    // MARK: - Cross-Platform Message Sync
 
-    /// Poll for new messages from other platforms (e.g. mobile).
+    /// Whether a poll is currently in-flight (prevents overlapping fetches)
+    private var isPolling = false
+
+    /// Fetch new messages from other platforms (e.g. mobile).
     /// Merges new messages into the existing array without disrupting the UI.
     private func pollForNewMessages() async {
+        // Prevent overlapping fetches from activation + Cmd+R firing together
+        guard !isPolling else { return }
         // Skip if user is signed out (tokens are cleared)
         guard AuthState.shared.isSignedIn else { return }
         // Skip if in auth backoff period (recent 401 errors)
@@ -1941,6 +1946,9 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         guard !messages.isEmpty || sessionsLoadError != nil else { return }
         // Skip if there's an active streaming message
         guard !messages.contains(where: { $0.isStreaming }) else { return }
+
+        isPolling = true
+        defer { isPolling = false }
 
         do {
             let persistedMessages: [ChatMessageDB]

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -537,6 +537,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
     private var multiChatObserver: AnyCancellable?
     private var playwrightExtensionObserver: AnyCancellable?
     private var sessionGroupingObserver: AnyCancellable?
+    private var activationObserver: AnyCancellable?
 
     // MARK: - Cross-Platform Message Polling
     /// Polls for new messages from other platforms (mobile) every 120 seconds.
@@ -640,6 +641,14 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         // Poll for new messages from other platforms (mobile) every 120 seconds
         messagePollTimer = Timer.publish(every: Self.messagePollInterval, on: .main, in: .common)
             .autoconnect()
+            .sink { [weak self] _ in
+                Task { @MainActor in
+                    await self?.pollForNewMessages()
+                }
+            }
+
+        // Refresh messages when app becomes active (compensates for longer poll interval)
+        activationObserver = NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
             .sink { [weak self] _ in
                 Task { @MainActor in
                     await self?.pollForNewMessages()

--- a/desktop/Desktop/Sources/ReentrancyGate.swift
+++ b/desktop/Desktop/Sources/ReentrancyGate.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Single-entry reentrancy gate for preventing overlapping async operations.
+///
+/// Use when two independent triggers (e.g. `didBecomeActive` + Cmd+R) can fire
+/// back-to-back and would otherwise cause duplicate fetches/inserts. Call
+/// `tryEnter()` at the start of the critical section — if it returns `false`,
+/// another caller is already in-flight and the current caller should bail out.
+/// Always pair `tryEnter()` with `exit()` via `defer` so the gate reopens even
+/// on thrown errors or early returns.
+///
+/// Tested in `ReentrancyGateTests`.
+@MainActor
+final class ReentrancyGate {
+    private var isInFlight = false
+
+    /// Attempts to enter the critical section.
+    /// - Returns: `true` if the caller acquired the gate (must call `exit()` when done),
+    ///   `false` if another operation is already in-flight (caller should skip its work).
+    func tryEnter() -> Bool {
+        guard !isInFlight else { return false }
+        isInFlight = true
+        return true
+    }
+
+    /// Releases the gate. Safe to call even if `tryEnter()` returned `false`
+    /// (no-op in that case — but callers should only `exit()` when their matching
+    /// `tryEnter()` returned `true`).
+    func exit() {
+        isInFlight = false
+    }
+}

--- a/desktop/Desktop/Sources/ReentrancyGate.swift
+++ b/desktop/Desktop/Sources/ReentrancyGate.swift
@@ -5,9 +5,22 @@ import Foundation
 /// Use when two independent triggers (e.g. `didBecomeActive` + Cmd+R) can fire
 /// back-to-back and would otherwise cause duplicate fetches/inserts. Call
 /// `tryEnter()` at the start of the critical section — if it returns `false`,
-/// another caller is already in-flight and the current caller should bail out.
-/// Always pair `tryEnter()` with `exit()` via `defer` so the gate reopens even
-/// on thrown errors or early returns.
+/// another caller is already in-flight and the current caller should bail out
+/// **without** calling `exit()`. Only the caller that got `true` from
+/// `tryEnter()` owns the gate and must release it.
+///
+/// The canonical usage is a `guard` + `defer` pair, which ensures `exit()` is
+/// only scheduled once the guard has admitted the caller:
+///
+/// ```swift
+/// guard gate.tryEnter() else { return }  // non-owners return here, no exit()
+/// defer { gate.exit() }                  // only the owner reaches this line
+/// // … critical section …
+/// ```
+///
+/// `exit()` does not validate ownership — a stray call will reopen the gate
+/// while another caller is still inside the critical section. Follow the
+/// `guard`/`defer` pattern above and the contract holds.
 ///
 /// Tested in `ReentrancyGateTests`.
 @MainActor
@@ -16,16 +29,16 @@ final class ReentrancyGate {
 
     /// Attempts to enter the critical section.
     /// - Returns: `true` if the caller acquired the gate (must call `exit()` when done),
-    ///   `false` if another operation is already in-flight (caller should skip its work).
+    ///   `false` if another operation is already in-flight (caller must **not** call `exit()`).
     func tryEnter() -> Bool {
         guard !isInFlight else { return false }
         isInFlight = true
         return true
     }
 
-    /// Releases the gate. Safe to call even if `tryEnter()` returned `false`
-    /// (no-op in that case — but callers should only `exit()` when their matching
-    /// `tryEnter()` returned `true`).
+    /// Releases the gate. **Caller contract:** only call this after a matching
+    /// `tryEnter()` returned `true`. Calling `exit()` without ownership will
+    /// reopen the gate while another caller is still inside the critical section.
     func exit() {
         isInFlight = false
     }

--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -33,7 +33,11 @@ class TasksStore: ObservableObject {
     /// `didBecomeActive` / `.refreshAllData` actually reaches the refresh method
     /// — if the observer rewire regresses (wrong notification name, dropped
     /// subscription), the counter stays flat and the test fails.
-    @Published private(set) var refreshInvocations: Int = 0
+    /// Deliberately **not** `@Published` — publishing on every activation/Cmd+R
+    /// refresh would emit `objectWillChange` and invalidate SwiftUI views
+    /// observing `TasksStore`, which is a pure production cost for a value
+    /// nothing drives UI from.
+    private(set) var refreshInvocations: Int = 0
 
     // Legacy compatibility - combines both lists
     var tasks: [TaskActionItem] {

--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -161,8 +161,8 @@ class TasksStore: ObservableObject {
     // MARK: - Initialization
 
     private init() {
-        // Auto-refresh tasks every 30 seconds
-        Timer.publish(every: 30.0, on: .main, in: .common)
+        // Auto-refresh tasks every 120 seconds
+        Timer.publish(every: 120.0, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 Task { await self?.refreshTasksIfNeeded() }

--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -161,9 +161,15 @@ class TasksStore: ObservableObject {
     // MARK: - Initialization
 
     private init() {
-        // Auto-refresh tasks periodically
-        Timer.publish(every: PollingConfig.tasksPollInterval, on: .main, in: .common)
-            .autoconnect()
+        // Refresh tasks when app becomes active
+        NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+            .sink { [weak self] _ in
+                Task { await self?.refreshTasksIfNeeded() }
+            }
+            .store(in: &cancellables)
+
+        // Cmd+R: refresh tasks on demand
+        NotificationCenter.default.publisher(for: .refreshAllData)
             .sink { [weak self] _ in
                 Task { await self?.refreshTasksIfNeeded() }
             }

--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -161,8 +161,8 @@ class TasksStore: ObservableObject {
     // MARK: - Initialization
 
     private init() {
-        // Auto-refresh tasks every 120 seconds
-        Timer.publish(every: 120.0, on: .main, in: .common)
+        // Auto-refresh tasks periodically
+        Timer.publish(every: PollingConfig.tasksPollInterval, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 Task { await self?.refreshTasksIfNeeded() }

--- a/desktop/Desktop/Sources/Stores/TasksStore.swift
+++ b/desktop/Desktop/Sources/Stores/TasksStore.swift
@@ -28,6 +28,13 @@ class TasksStore: ObservableObject {
     @Published var hasMoreDeletedTasks = true
     @Published var error: String?
 
+    /// Counter bumped at the top of `refreshTasksIfNeeded()`, before any of the
+    /// early-exit guards. Lets `TasksStoreObserverTests` prove that posting
+    /// `didBecomeActive` / `.refreshAllData` actually reaches the refresh method
+    /// — if the observer rewire regresses (wrong notification name, dropped
+    /// subscription), the counter stays flat and the test fails.
+    @Published private(set) var refreshInvocations: Int = 0
+
     // Legacy compatibility - combines both lists
     var tasks: [TaskActionItem] {
         incompleteTasks + completedTasks
@@ -181,6 +188,7 @@ class TasksStore: ObservableObject {
     /// Uses local-first pattern: sync API to cache, then reload from cache
     /// Merges changes in-place to avoid wholesale array replacement (which kills SwiftUI gestures)
     private func refreshTasksIfNeeded() async {
+        refreshInvocations += 1
         // Skip if not signed in
         guard AuthService.shared.isSignedIn else { return }
         // Skip if in auth backoff period (recent 401 errors)

--- a/desktop/Desktop/Tests/CrispManagerLifecycleTests.swift
+++ b/desktop/Desktop/Tests/CrispManagerLifecycleTests.swift
@@ -35,7 +35,7 @@ final class CrispManagerLifecycleTests: XCTestCase {
         let manager = CrispManager.shared
         XCTAssertFalse(manager.isStarted, "Manager must be stopped after setUp()")
 
-        manager.start()
+        manager.start(performInitialPoll: false)
         XCTAssertTrue(manager.isStarted, "start() must set isStarted true")
         let firstActivationObs = manager.activationObserver
         let firstRefreshObs = manager.refreshAllObserver
@@ -44,7 +44,7 @@ final class CrispManagerLifecycleTests: XCTestCase {
 
         // Second start() call must be a no-op — observers must NOT be replaced.
         // A new token would mean we leaked the first registration.
-        manager.start()
+        manager.start(performInitialPoll: false)
         XCTAssertTrue(manager.isStarted)
         XCTAssertTrue(
             manager.activationObserver === firstActivationObs as AnyObject,
@@ -58,7 +58,7 @@ final class CrispManagerLifecycleTests: XCTestCase {
 
     func testStopRemovesBothObservers() {
         let manager = CrispManager.shared
-        manager.start()
+        manager.start(performInitialPoll: false)
         XCTAssertNotNil(manager.activationObserver)
         XCTAssertNotNil(manager.refreshAllObserver)
         XCTAssertTrue(manager.isStarted)
@@ -69,7 +69,7 @@ final class CrispManagerLifecycleTests: XCTestCase {
         XCTAssertFalse(manager.isStarted, "stop() must clear isStarted so start() can run again")
 
         // After stop(), a subsequent start() must succeed (observer lifecycle reusable).
-        manager.start()
+        manager.start(performInitialPoll: false)
         XCTAssertTrue(manager.isStarted, "start() after stop() must re-register observers")
         XCTAssertNotNil(manager.activationObserver)
         XCTAssertNotNil(manager.refreshAllObserver)
@@ -77,7 +77,7 @@ final class CrispManagerLifecycleTests: XCTestCase {
 
     func testStopIsIdempotent() {
         let manager = CrispManager.shared
-        manager.start()
+        manager.start(performInitialPoll: false)
         manager.stop()
         // Second stop() must not crash or change state
         manager.stop()

--- a/desktop/Desktop/Tests/CrispManagerLifecycleTests.swift
+++ b/desktop/Desktop/Tests/CrispManagerLifecycleTests.swift
@@ -110,4 +110,56 @@ final class CrispManagerLifecycleTests: XCTestCase {
         XCTAssertEqual(manager.lastSeenTimestamp, 0)
         XCTAssertEqual(manager.unreadCount, 0)
     }
+
+    func testDidBecomeActiveNotificationTriggersPoll() async {
+        let manager = CrispManager.shared
+        manager.start(performInitialPoll: false)
+        let baseline = manager.pollInvocations
+
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification, object: nil
+        )
+        // Observer posts on main queue; yield so the block runs.
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            manager.pollInvocations, baseline + 1,
+            "didBecomeActive must route to pollForMessages() via the activation observer"
+        )
+    }
+
+    func testRefreshAllDataNotificationTriggersPoll() async {
+        let manager = CrispManager.shared
+        manager.start(performInitialPoll: false)
+        let baseline = manager.pollInvocations
+
+        NotificationCenter.default.post(name: .refreshAllData, object: nil)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            manager.pollInvocations, baseline + 1,
+            ".refreshAllData (Cmd+R) must route to pollForMessages() via the refresh observer"
+        )
+    }
+
+    func testStoppedManagerDoesNotRespondToNotifications() async {
+        let manager = CrispManager.shared
+        manager.start(performInitialPoll: false)
+        manager.stop()
+        let baseline = manager.pollInvocations
+
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification, object: nil
+        )
+        NotificationCenter.default.post(name: .refreshAllData, object: nil)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            manager.pollInvocations, baseline,
+            "After stop(), neither notification should reach pollForMessages()"
+        )
+    }
 }

--- a/desktop/Desktop/Tests/CrispManagerLifecycleTests.swift
+++ b/desktop/Desktop/Tests/CrispManagerLifecycleTests.swift
@@ -1,0 +1,113 @@
+import AppKit
+import XCTest
+@testable import Omi_Computer
+
+/// Tests for `CrispManager` event-driven lifecycle (#6500).
+///
+/// After removing the 120s polling timer, `CrispManager` relies entirely on
+/// `start()`/`stop()` registering/unregistering `didBecomeActive` + `.refreshAllData`
+/// observers. These tests cover the highest-risk branch: the observer lifecycle
+/// and `markAsRead()` timestamp advancement.
+@MainActor
+final class CrispManagerLifecycleTests: XCTestCase {
+
+    // Save and restore the UserDefaults-backed timestamps so each test runs
+    // against a known state without clobbering real app data.
+    private var savedLastSeen: Double = 0
+    private var savedLatestOperator: Double = 0
+
+    override func setUp() async throws {
+        try await super.setUp()
+        savedLastSeen = UserDefaults.standard.double(forKey: "crisp_lastSeenTimestamp")
+        savedLatestOperator = UserDefaults.standard.double(forKey: "crisp_latestOperatorTimestamp")
+        // Reset the singleton to a clean state — previous tests may have called start()
+        CrispManager.shared.stop()
+    }
+
+    override func tearDown() async throws {
+        CrispManager.shared.stop()
+        UserDefaults.standard.set(savedLastSeen, forKey: "crisp_lastSeenTimestamp")
+        UserDefaults.standard.set(savedLatestOperator, forKey: "crisp_latestOperatorTimestamp")
+        try await super.tearDown()
+    }
+
+    func testStartIsIdempotent() {
+        let manager = CrispManager.shared
+        XCTAssertFalse(manager.isStarted, "Manager must be stopped after setUp()")
+
+        manager.start()
+        XCTAssertTrue(manager.isStarted, "start() must set isStarted true")
+        let firstActivationObs = manager.activationObserver
+        let firstRefreshObs = manager.refreshAllObserver
+        XCTAssertNotNil(firstActivationObs, "start() must register activation observer")
+        XCTAssertNotNil(firstRefreshObs, "start() must register refreshAllData observer")
+
+        // Second start() call must be a no-op — observers must NOT be replaced.
+        // A new token would mean we leaked the first registration.
+        manager.start()
+        XCTAssertTrue(manager.isStarted)
+        XCTAssertTrue(
+            manager.activationObserver === firstActivationObs as AnyObject,
+            "Second start() must not replace the activation observer (leak guard)"
+        )
+        XCTAssertTrue(
+            manager.refreshAllObserver === firstRefreshObs as AnyObject,
+            "Second start() must not replace the refreshAllData observer (leak guard)"
+        )
+    }
+
+    func testStopRemovesBothObservers() {
+        let manager = CrispManager.shared
+        manager.start()
+        XCTAssertNotNil(manager.activationObserver)
+        XCTAssertNotNil(manager.refreshAllObserver)
+        XCTAssertTrue(manager.isStarted)
+
+        manager.stop()
+        XCTAssertNil(manager.activationObserver, "stop() must nil the activation observer")
+        XCTAssertNil(manager.refreshAllObserver, "stop() must nil the refreshAllData observer")
+        XCTAssertFalse(manager.isStarted, "stop() must clear isStarted so start() can run again")
+
+        // After stop(), a subsequent start() must succeed (observer lifecycle reusable).
+        manager.start()
+        XCTAssertTrue(manager.isStarted, "start() after stop() must re-register observers")
+        XCTAssertNotNil(manager.activationObserver)
+        XCTAssertNotNil(manager.refreshAllObserver)
+    }
+
+    func testStopIsIdempotent() {
+        let manager = CrispManager.shared
+        manager.start()
+        manager.stop()
+        // Second stop() must not crash or change state
+        manager.stop()
+        XCTAssertFalse(manager.isStarted)
+        XCTAssertNil(manager.activationObserver)
+        XCTAssertNil(manager.refreshAllObserver)
+    }
+
+    func testMarkAsReadAdvancesPersistedTimestamp() {
+        let manager = CrispManager.shared
+        manager.latestOperatorTimestamp = 999_999
+        manager.lastSeenTimestamp = 111_111
+
+        manager.markAsRead()
+
+        XCTAssertEqual(
+            manager.lastSeenTimestamp, 999_999,
+            "markAsRead() must advance lastSeenTimestamp to latestOperatorTimestamp"
+        )
+        XCTAssertEqual(manager.unreadCount, 0, "markAsRead() must clear unreadCount")
+    }
+
+    func testMarkAsReadIsSafeWhenNoNewMessages() {
+        let manager = CrispManager.shared
+        manager.latestOperatorTimestamp = 0
+        manager.lastSeenTimestamp = 0
+
+        manager.markAsRead()
+
+        XCTAssertEqual(manager.lastSeenTimestamp, 0)
+        XCTAssertEqual(manager.unreadCount, 0)
+    }
+}

--- a/desktop/Desktop/Tests/MemoriesViewModelObserverTests.swift
+++ b/desktop/Desktop/Tests/MemoriesViewModelObserverTests.swift
@@ -1,0 +1,62 @@
+import AppKit
+import XCTest
+@testable import Omi_Computer
+
+/// Tests for `MemoriesViewModel` auto-refresh observer wiring (#6500).
+///
+/// After replacing the 30-second `Timer.publish` with `didBecomeActive` +
+/// `.refreshAllData` subscribers, the view model must still refresh when
+/// those notifications fire. Because `MemoriesViewModel` is not a singleton,
+/// each test constructs a fresh instance (triggering `init()` which registers
+/// the two subscribers into its private `cancellables`) and asserts that
+/// posting each notification advances `refreshInvocations` by one.
+@MainActor
+final class MemoriesViewModelObserverTests: XCTestCase {
+
+    func testDidBecomeActiveNotificationTriggersRefresh() async {
+        let viewModel = MemoriesViewModel()
+        XCTAssertEqual(viewModel.refreshInvocations, 0, "Fresh instance must start at zero")
+
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification, object: nil
+        )
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            viewModel.refreshInvocations, 1,
+            "didBecomeActive must route to refreshMemoriesIfNeeded() via the activation subscriber"
+        )
+    }
+
+    func testRefreshAllDataNotificationTriggersRefresh() async {
+        let viewModel = MemoriesViewModel()
+
+        NotificationCenter.default.post(name: .refreshAllData, object: nil)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            viewModel.refreshInvocations, 1,
+            ".refreshAllData (Cmd+R) must route to refreshMemoriesIfNeeded() via the refresh subscriber"
+        )
+    }
+
+    func testDeallocatedViewModelDoesNotLeakObservers() async {
+        // Ensures the `[weak self]` capture in the Combine sinks lets the
+        // view model deallocate cleanly — no crash when the notifications
+        // fire after the instance is gone.
+        do {
+            let viewModel = MemoriesViewModel()
+            XCTAssertEqual(viewModel.refreshInvocations, 0)
+        }
+        // viewModel is out of scope and should be deallocated.
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification, object: nil
+        )
+        NotificationCenter.default.post(name: .refreshAllData, object: nil)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        // If the weak capture misbehaved we'd crash above; reaching here is the assertion.
+    }
+}

--- a/desktop/Desktop/Tests/PollingFrequencyTests.swift
+++ b/desktop/Desktop/Tests/PollingFrequencyTests.swift
@@ -20,43 +20,128 @@ final class PollingFrequencyTests: XCTestCase {
         XCTAssertEqual(PollingConfig.activationCooldown, 60.0, "Activation cooldown should be 60s")
     }
 
+    /// Uses the same comparison as production code in DesktopHomeView:
+    /// `now.timeIntervalSince(lastActivationRefresh) >= PollingConfig.activationCooldown`
     func testFirstActivationAlwaysAllowed() {
-        // distantPast means no previous activation — should always be allowed
         let lastRefresh = Date.distantPast
         let now = Date()
-        let elapsed = now.timeIntervalSince(lastRefresh)
-        XCTAssertGreaterThanOrEqual(elapsed, PollingConfig.activationCooldown)
+        // Mirror production: elapsed >= cooldown → refresh allowed
+        XCTAssertTrue(
+            now.timeIntervalSince(lastRefresh) >= PollingConfig.activationCooldown,
+            "First activation (distantPast) must always pass cooldown check"
+        )
     }
 
     func testActivationWithinCooldownIsBlocked() {
         let lastRefresh = Date()
-        // 30 seconds later — within cooldown
-        let now = lastRefresh.addingTimeInterval(30)
-        let elapsed = now.timeIntervalSince(lastRefresh)
-        XCTAssertLessThan(elapsed, PollingConfig.activationCooldown)
+        let now = lastRefresh.addingTimeInterval(PollingConfig.activationCooldown - 30)
+        XCTAssertFalse(
+            now.timeIntervalSince(lastRefresh) >= PollingConfig.activationCooldown,
+            "Activation 30s before cooldown expires must be blocked"
+        )
     }
 
-    func testActivationAtCooldownBoundaryIsAllowed() {
+    func testActivationAtExactCooldownBoundaryIsAllowed() {
         let lastRefresh = Date()
-        // Exactly 60 seconds later — at boundary
-        let now = lastRefresh.addingTimeInterval(60)
-        let elapsed = now.timeIntervalSince(lastRefresh)
-        XCTAssertGreaterThanOrEqual(elapsed, PollingConfig.activationCooldown)
+        let now = lastRefresh.addingTimeInterval(PollingConfig.activationCooldown)
+        // Production uses >= so exactly at boundary is allowed
+        XCTAssertTrue(
+            now.timeIntervalSince(lastRefresh) >= PollingConfig.activationCooldown,
+            "Activation at exactly cooldown boundary must be allowed (>= comparison)"
+        )
     }
 
     func testActivationAfterCooldownIsAllowed() {
         let lastRefresh = Date()
-        // 90 seconds later — past cooldown
-        let now = lastRefresh.addingTimeInterval(90)
-        let elapsed = now.timeIntervalSince(lastRefresh)
-        XCTAssertGreaterThanOrEqual(elapsed, PollingConfig.activationCooldown)
+        let now = lastRefresh.addingTimeInterval(PollingConfig.activationCooldown + 30)
+        XCTAssertTrue(
+            now.timeIntervalSince(lastRefresh) >= PollingConfig.activationCooldown,
+            "Activation 30s past cooldown must be allowed"
+        )
+    }
+
+    func testRapidActivationsAreThrottled() {
+        // Simulate rapid cmd-tab: 10 activations 1 second apart
+        let start = Date()
+        var lastAllowed = Date.distantPast
+        var allowedCount = 0
+        for i in 0..<10 {
+            let activation = start.addingTimeInterval(Double(i))
+            if activation.timeIntervalSince(lastAllowed) >= PollingConfig.activationCooldown {
+                allowedCount += 1
+                lastAllowed = activation
+            }
+        }
+        // Only the first activation should pass (subsequent ones are within 60s)
+        XCTAssertEqual(allowedCount, 1, "Rapid activations (1s apart) should only allow 1 refresh")
+    }
+
+    func testCooldownResetsAfterExpiry() {
+        // First activation allowed, second blocked, third allowed after cooldown
+        let start = Date()
+        var lastAllowed = Date.distantPast
+        var results: [Bool] = []
+
+        let activations = [
+            start,                                                     // t=0s: should be allowed
+            start.addingTimeInterval(30),                              // t=30s: within cooldown
+            start.addingTimeInterval(PollingConfig.activationCooldown + 1)  // t=61s: past cooldown
+        ]
+
+        for activation in activations {
+            let allowed = activation.timeIntervalSince(lastAllowed) >= PollingConfig.activationCooldown
+            results.append(allowed)
+            if allowed { lastAllowed = activation }
+        }
+
+        XCTAssertEqual(results, [true, false, true], "Expected: allowed, blocked, allowed after cooldown")
     }
 
     // MARK: - Refresh All Notification
 
     func testRefreshAllDataNotificationNameExists() {
-        // Verify the notification name is defined (Cmd+R triggers this)
         let name = Notification.Name.refreshAllData
         XCTAssertEqual(name.rawValue, "refreshAllData")
+    }
+
+    func testRefreshAllDataNotificationIsReceivable() {
+        let expectation = XCTestExpectation(description: "Notification received")
+        let observer = NotificationCenter.default.addObserver(
+            forName: .refreshAllData, object: nil, queue: .main
+        ) { _ in expectation.fulfill() }
+
+        NotificationCenter.default.post(name: .refreshAllData, object: nil)
+        wait(for: [expectation], timeout: 1.0)
+        NotificationCenter.default.removeObserver(observer)
+    }
+
+    // MARK: - CrispManager Lifecycle
+
+    @MainActor
+    func testCrispManagerStartIsIdempotent() {
+        let manager = CrispManager.shared
+        // start() has a guard — calling twice should not double-register observers
+        manager.start()
+        manager.start()  // Second call is a no-op
+        manager.stop()   // Clean up
+        XCTAssertEqual(manager.unreadCount, 0, "unreadCount should be 0 after stop")
+    }
+
+    @MainActor
+    func testCrispManagerStopClearsState() {
+        let manager = CrispManager.shared
+        manager.start()
+        manager.stop()
+        XCTAssertEqual(manager.unreadCount, 0, "unreadCount should be 0 after stop")
+        XCTAssertFalse(manager.isViewingHelp, "isViewingHelp should be false after stop")
+    }
+
+    @MainActor
+    func testCrispManagerMarkAsReadResetsCount() {
+        let manager = CrispManager.shared
+        manager.start()
+        manager.markAsRead()
+        XCTAssertEqual(manager.unreadCount, 0, "unreadCount should be 0 after markAsRead")
+        manager.stop()
     }
 }

--- a/desktop/Desktop/Tests/PollingFrequencyTests.swift
+++ b/desktop/Desktop/Tests/PollingFrequencyTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Tests for polling frequency reduction (#6500).
+/// Verifies that polling intervals are at their target values (120s)
+/// and that the activation cooldown logic works correctly.
+final class PollingFrequencyTests: XCTestCase {
+
+    // MARK: - Polling Interval Constants
+
+    func testChatPollIntervalIs120Seconds() {
+        // ChatProvider.messagePollInterval is private, so verify via the config constant
+        XCTAssertEqual(PollingConfig.chatPollInterval, 120.0, "Chat poll interval should be 120s")
+    }
+
+    func testTasksPollIntervalIs120Seconds() {
+        XCTAssertEqual(PollingConfig.tasksPollInterval, 120.0, "Tasks poll interval should be 120s")
+    }
+
+    func testMemoriesPollIntervalIs120Seconds() {
+        XCTAssertEqual(PollingConfig.memoriesPollInterval, 120.0, "Memories poll interval should be 120s")
+    }
+
+    func testConversationsPollIntervalIs120Seconds() {
+        XCTAssertEqual(PollingConfig.conversationsPollInterval, 120.0, "Conversations poll interval should be 120s")
+    }
+
+    // MARK: - Activation Cooldown
+
+    func testActivationCooldownIs60Seconds() {
+        XCTAssertEqual(PollingConfig.activationCooldown, 60.0, "Activation cooldown should be 60s")
+    }
+
+    func testFirstActivationAlwaysAllowed() {
+        // distantPast means no previous activation — should always be allowed
+        let lastRefresh = Date.distantPast
+        let now = Date()
+        let elapsed = now.timeIntervalSince(lastRefresh)
+        XCTAssertGreaterThanOrEqual(elapsed, PollingConfig.activationCooldown)
+    }
+
+    func testActivationWithinCooldownIsBlocked() {
+        let lastRefresh = Date()
+        // 30 seconds later — within cooldown
+        let now = lastRefresh.addingTimeInterval(30)
+        let elapsed = now.timeIntervalSince(lastRefresh)
+        XCTAssertLessThan(elapsed, PollingConfig.activationCooldown)
+    }
+
+    func testActivationAtCooldownBoundaryIsAllowed() {
+        let lastRefresh = Date()
+        // Exactly 60 seconds later — at boundary
+        let now = lastRefresh.addingTimeInterval(60)
+        let elapsed = now.timeIntervalSince(lastRefresh)
+        XCTAssertGreaterThanOrEqual(elapsed, PollingConfig.activationCooldown)
+    }
+
+    func testActivationAfterCooldownIsAllowed() {
+        let lastRefresh = Date()
+        // 90 seconds later — past cooldown
+        let now = lastRefresh.addingTimeInterval(90)
+        let elapsed = now.timeIntervalSince(lastRefresh)
+        XCTAssertGreaterThanOrEqual(elapsed, PollingConfig.activationCooldown)
+    }
+}

--- a/desktop/Desktop/Tests/PollingFrequencyTests.swift
+++ b/desktop/Desktop/Tests/PollingFrequencyTests.swift
@@ -2,51 +2,47 @@ import XCTest
 @testable import Omi_Computer
 
 /// Tests for event-driven refresh architecture (#6500).
-/// Verifies that all periodic polling timers have been removed and
-/// that activation cooldown logic works correctly.
+/// All polling timers are removed — refreshes happen on app activation
+/// (didBecomeActiveNotification) and manual Cmd+R (.refreshAllData).
+///
+/// Tests call `PollingConfig.shouldAllowActivationRefresh(now:lastRefresh:)`,
+/// which is the same function used by DesktopHomeView's activation handler.
+/// A regression in that predicate (e.g. `>=` → `>`) is caught here.
 final class PollingFrequencyTests: XCTestCase {
 
     // MARK: - No Polling Timers
 
     func testPollingConfigHasNoPollIntervals() {
-        // PollingConfig should only contain activationCooldown — no poll intervals.
-        // If someone adds a poll interval constant, this test must be updated.
-        XCTAssertEqual(PollingConfig.activationCooldown, 60.0, "Activation cooldown should be 60s")
+        // PollingConfig only exposes activationCooldown + the shared predicate.
+        // If someone reintroduces a poll interval constant, update this test.
+        XCTAssertEqual(PollingConfig.activationCooldown, 60.0)
     }
 
-    // MARK: - Activation Cooldown
+    // MARK: - Activation Cooldown (shared predicate)
 
-    func testActivationCooldownIs60Seconds() {
-        XCTAssertEqual(PollingConfig.activationCooldown, 60.0, "Activation cooldown should be 60s")
-    }
-
-    /// Uses the same comparison as production code in DesktopHomeView:
-    /// `now.timeIntervalSince(lastActivationRefresh) >= PollingConfig.activationCooldown`
     func testFirstActivationAlwaysAllowed() {
-        let lastRefresh = Date.distantPast
         let now = Date()
-        // Mirror production: elapsed >= cooldown → refresh allowed
         XCTAssertTrue(
-            now.timeIntervalSince(lastRefresh) >= PollingConfig.activationCooldown,
-            "First activation (distantPast) must always pass cooldown check"
+            PollingConfig.shouldAllowActivationRefresh(now: now, lastRefresh: .distantPast),
+            "First activation (distantPast) must always be allowed"
         )
     }
 
     func testActivationWithinCooldownIsBlocked() {
         let lastRefresh = Date()
-        let now = lastRefresh.addingTimeInterval(PollingConfig.activationCooldown - 30)
+        let now = lastRefresh.addingTimeInterval(PollingConfig.activationCooldown - 0.001)
         XCTAssertFalse(
-            now.timeIntervalSince(lastRefresh) >= PollingConfig.activationCooldown,
-            "Activation 30s before cooldown expires must be blocked"
+            PollingConfig.shouldAllowActivationRefresh(now: now, lastRefresh: lastRefresh),
+            "Activation just under cooldown must be blocked"
         )
     }
 
     func testActivationAtExactCooldownBoundaryIsAllowed() {
         let lastRefresh = Date()
         let now = lastRefresh.addingTimeInterval(PollingConfig.activationCooldown)
-        // Production uses >= so exactly at boundary is allowed
+        // Production uses >= — boundary must be inclusive. Guards against >= → > regressions.
         XCTAssertTrue(
-            now.timeIntervalSince(lastRefresh) >= PollingConfig.activationCooldown,
+            PollingConfig.shouldAllowActivationRefresh(now: now, lastRefresh: lastRefresh),
             "Activation at exactly cooldown boundary must be allowed (>= comparison)"
         )
     }
@@ -55,53 +51,66 @@ final class PollingFrequencyTests: XCTestCase {
         let lastRefresh = Date()
         let now = lastRefresh.addingTimeInterval(PollingConfig.activationCooldown + 30)
         XCTAssertTrue(
-            now.timeIntervalSince(lastRefresh) >= PollingConfig.activationCooldown,
+            PollingConfig.shouldAllowActivationRefresh(now: now, lastRefresh: lastRefresh),
             "Activation 30s past cooldown must be allowed"
         )
     }
 
+    func testBackwardClockSkewIsAllowed() {
+        // If system clock jumps backward, elapsed is negative < cooldown.
+        // Predicate returns false (blocked). This documents current behavior —
+        // a user with clock skew just won't get an auto-refresh that cycle.
+        let lastRefresh = Date()
+        let now = lastRefresh.addingTimeInterval(-10)
+        XCTAssertFalse(
+            PollingConfig.shouldAllowActivationRefresh(now: now, lastRefresh: lastRefresh),
+            "Negative elapsed (backward clock skew) must be treated as within cooldown"
+        )
+    }
+
     func testRapidActivationsAreThrottled() {
-        // Simulate rapid cmd-tab: 10 activations 1 second apart
+        // Simulate cmd-tab spam: 10 activations 1 second apart.
+        // Driven by the same predicate as production.
         let start = Date()
         var lastAllowed = Date.distantPast
         var allowedCount = 0
         for i in 0..<10 {
             let activation = start.addingTimeInterval(Double(i))
-            if activation.timeIntervalSince(lastAllowed) >= PollingConfig.activationCooldown {
+            if PollingConfig.shouldAllowActivationRefresh(now: activation, lastRefresh: lastAllowed) {
                 allowedCount += 1
                 lastAllowed = activation
             }
         }
-        // Only the first activation should pass (subsequent ones are within 60s)
         XCTAssertEqual(allowedCount, 1, "Rapid activations (1s apart) should only allow 1 refresh")
     }
 
     func testCooldownResetsAfterExpiry() {
-        // First activation allowed, second blocked, third allowed after cooldown
+        // Sequence [allowed, blocked, allowed] — the third activation is past cooldown.
         let start = Date()
         var lastAllowed = Date.distantPast
         var results: [Bool] = []
 
         let activations = [
-            start,                                                     // t=0s: should be allowed
-            start.addingTimeInterval(30),                              // t=30s: within cooldown
-            start.addingTimeInterval(PollingConfig.activationCooldown + 1)  // t=61s: past cooldown
+            start,                                                          // t=0: allowed (first)
+            start.addingTimeInterval(30),                                   // t=30: blocked
+            start.addingTimeInterval(PollingConfig.activationCooldown + 1)  // t=61: allowed
         ]
 
         for activation in activations {
-            let allowed = activation.timeIntervalSince(lastAllowed) >= PollingConfig.activationCooldown
+            let allowed = PollingConfig.shouldAllowActivationRefresh(
+                now: activation, lastRefresh: lastAllowed
+            )
             results.append(allowed)
             if allowed { lastAllowed = activation }
         }
 
-        XCTAssertEqual(results, [true, false, true], "Expected: allowed, blocked, allowed after cooldown")
+        XCTAssertEqual(results, [true, false, true])
     }
 
     // MARK: - Refresh All Notification
 
     func testRefreshAllDataNotificationNameExists() {
-        let name = Notification.Name.refreshAllData
-        XCTAssertEqual(name.rawValue, "refreshAllData")
+        XCTAssertEqual(Notification.Name.refreshAllData.rawValue, "refreshAllData")
     }
 
     func testRefreshAllDataNotificationIsReceivable() {
@@ -109,39 +118,9 @@ final class PollingFrequencyTests: XCTestCase {
         let observer = NotificationCenter.default.addObserver(
             forName: .refreshAllData, object: nil, queue: .main
         ) { _ in expectation.fulfill() }
+        defer { NotificationCenter.default.removeObserver(observer) }
 
         NotificationCenter.default.post(name: .refreshAllData, object: nil)
         wait(for: [expectation], timeout: 1.0)
-        NotificationCenter.default.removeObserver(observer)
-    }
-
-    // MARK: - CrispManager Lifecycle
-
-    @MainActor
-    func testCrispManagerStartIsIdempotent() {
-        let manager = CrispManager.shared
-        // start() has a guard — calling twice should not double-register observers
-        manager.start()
-        manager.start()  // Second call is a no-op
-        manager.stop()   // Clean up
-        XCTAssertEqual(manager.unreadCount, 0, "unreadCount should be 0 after stop")
-    }
-
-    @MainActor
-    func testCrispManagerStopClearsState() {
-        let manager = CrispManager.shared
-        manager.start()
-        manager.stop()
-        XCTAssertEqual(manager.unreadCount, 0, "unreadCount should be 0 after stop")
-        XCTAssertFalse(manager.isViewingHelp, "isViewingHelp should be false after stop")
-    }
-
-    @MainActor
-    func testCrispManagerMarkAsReadResetsCount() {
-        let manager = CrispManager.shared
-        manager.start()
-        manager.markAsRead()
-        XCTAssertEqual(manager.unreadCount, 0, "unreadCount should be 0 after markAsRead")
-        manager.stop()
     }
 }

--- a/desktop/Desktop/Tests/PollingFrequencyTests.swift
+++ b/desktop/Desktop/Tests/PollingFrequencyTests.swift
@@ -1,28 +1,17 @@
 import XCTest
 @testable import Omi_Computer
 
-/// Tests for polling frequency reduction (#6500).
-/// Verifies that polling intervals are at their target values (120s)
-/// and that the activation cooldown logic works correctly.
+/// Tests for event-driven refresh architecture (#6500).
+/// Verifies that all periodic polling timers have been removed and
+/// that activation cooldown logic works correctly.
 final class PollingFrequencyTests: XCTestCase {
 
-    // MARK: - Polling Interval Constants
+    // MARK: - No Polling Timers
 
-    func testChatPollIntervalIs120Seconds() {
-        // ChatProvider.messagePollInterval is private, so verify via the config constant
-        XCTAssertEqual(PollingConfig.chatPollInterval, 120.0, "Chat poll interval should be 120s")
-    }
-
-    func testTasksPollIntervalIs120Seconds() {
-        XCTAssertEqual(PollingConfig.tasksPollInterval, 120.0, "Tasks poll interval should be 120s")
-    }
-
-    func testMemoriesPollIntervalIs120Seconds() {
-        XCTAssertEqual(PollingConfig.memoriesPollInterval, 120.0, "Memories poll interval should be 120s")
-    }
-
-    func testConversationsPollIntervalIs120Seconds() {
-        XCTAssertEqual(PollingConfig.conversationsPollInterval, 120.0, "Conversations poll interval should be 120s")
+    func testPollingConfigHasNoPollIntervals() {
+        // PollingConfig should only contain activationCooldown — no poll intervals.
+        // If someone adds a poll interval constant, this test must be updated.
+        XCTAssertEqual(PollingConfig.activationCooldown, 60.0, "Activation cooldown should be 60s")
     }
 
     // MARK: - Activation Cooldown
@@ -61,5 +50,13 @@ final class PollingFrequencyTests: XCTestCase {
         let now = lastRefresh.addingTimeInterval(90)
         let elapsed = now.timeIntervalSince(lastRefresh)
         XCTAssertGreaterThanOrEqual(elapsed, PollingConfig.activationCooldown)
+    }
+
+    // MARK: - Refresh All Notification
+
+    func testRefreshAllDataNotificationNameExists() {
+        // Verify the notification name is defined (Cmd+R triggers this)
+        let name = Notification.Name.refreshAllData
+        XCTAssertEqual(name.rawValue, "refreshAllData")
     }
 }

--- a/desktop/Desktop/Tests/ReentrancyGateTests.swift
+++ b/desktop/Desktop/Tests/ReentrancyGateTests.swift
@@ -68,12 +68,17 @@ final class ReentrancyGateTests: XCTestCase {
         gate.exit()
     }
 
-    func testGuardDeferPatternOnlyExitsWhenOwnerEntered() {
+    func testGuardDeferPatternNonOwnerDoesNotCallExit() {
         // Models the canonical ChatProvider.pollForNewMessages() usage:
         //   guard gate.tryEnter() else { return }
         //   defer { gate.exit() }
-        // Non-owners return before the defer is registered, so exit() is
-        // never called from a non-owning caller — the contract holds.
+        //
+        // Regression guard: if a future edit swapped `defer` above `guard`, a
+        // non-owning caller would still fire `exit()` and reopen the gate while
+        // the owner was still inside the critical section. This test forces an
+        // overlap — caller A holds the gate, caller B invokes the critical
+        // section while A is still in-flight — and asserts B neither enters
+        // nor reopens the gate.
         let gate = ReentrancyGate()
         var exitCalls = 0
 
@@ -83,16 +88,26 @@ final class ReentrancyGateTests: XCTestCase {
                 gate.exit()
                 exitCalls += 1
             }
-            // simulated critical work — the second concurrent call below runs
-            // before this defer fires because Swift closures run synchronously.
         }
 
-        // First caller acquires + releases via defer.
-        criticalSection()
-        XCTAssertEqual(exitCalls, 1)
+        // Caller A (the test itself) acquires the gate directly.
+        XCTAssertTrue(gate.tryEnter(), "Precondition: caller A must acquire the gate")
 
-        // Second sequential caller also acquires cleanly after the first exited.
+        // Caller B invokes the critical section while A is still in-flight.
+        // Under guard/defer, B's guard short-circuits and no `defer` is registered,
+        // so exit() must not fire.
         criticalSection()
-        XCTAssertEqual(exitCalls, 2)
+        XCTAssertEqual(exitCalls, 0, "Non-owner caller B must not register an exit")
+
+        // Gate must still be owned by A — B must not have reopened it.
+        XCTAssertFalse(
+            gate.tryEnter(),
+            "Gate must still be held by A; a regressed guard/defer order would have reopened it"
+        )
+
+        // A releases; caller C can now run through the critical section normally.
+        gate.exit()
+        criticalSection()
+        XCTAssertEqual(exitCalls, 1, "Owner caller C must register exactly one exit")
     }
 }

--- a/desktop/Desktop/Tests/ReentrancyGateTests.swift
+++ b/desktop/Desktop/Tests/ReentrancyGateTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+@testable import Omi_Computer
+
+/// Tests for `ReentrancyGate`, the single-entry gate that prevents overlapping
+/// `ChatProvider.pollForNewMessages()` fetches when `didBecomeActive` and
+/// `.refreshAllData` fire back-to-back.
+@MainActor
+final class ReentrancyGateTests: XCTestCase {
+
+    func testFirstEnterSucceeds() {
+        let gate = ReentrancyGate()
+        XCTAssertTrue(gate.tryEnter(), "First enter on a fresh gate must succeed")
+    }
+
+    func testSecondEnterWithoutExitIsBlocked() {
+        let gate = ReentrancyGate()
+        XCTAssertTrue(gate.tryEnter())
+        XCTAssertFalse(
+            gate.tryEnter(),
+            "Second enter without matching exit must be blocked (in-flight)"
+        )
+    }
+
+    func testEnterAfterExitSucceeds() {
+        let gate = ReentrancyGate()
+        XCTAssertTrue(gate.tryEnter())
+        gate.exit()
+        XCTAssertTrue(
+            gate.tryEnter(),
+            "Enter after exit must succeed — gate should be reopened"
+        )
+    }
+
+    func testRepeatedEnterExitCyclesAllSucceed() {
+        // Simulates activation + Cmd+R firing sequentially (not overlapping) —
+        // every cycle should complete cleanly.
+        let gate = ReentrancyGate()
+        for cycle in 0..<5 {
+            XCTAssertTrue(
+                gate.tryEnter(),
+                "Cycle \(cycle): enter should succeed after prior exit"
+            )
+            gate.exit()
+        }
+    }
+
+    func testOverlappingTriggersResultInOneEntry() {
+        // Simulates the exact race `ChatProvider.pollGate` guards against:
+        // activation + Cmd+R fire while a fetch is in flight — only one caller
+        // may enter, the rest must bail out until the in-flight caller exits.
+        let gate = ReentrancyGate()
+        var enteredCount = 0
+
+        // Caller A starts the fetch
+        if gate.tryEnter() { enteredCount += 1 }
+        // Caller B (overlapping) tries while A is still in flight
+        if gate.tryEnter() { enteredCount += 1 }
+        // Caller C (overlapping) tries while A is still in flight
+        if gate.tryEnter() { enteredCount += 1 }
+
+        XCTAssertEqual(enteredCount, 1, "Only one of 3 overlapping callers may enter")
+
+        // Caller A completes
+        gate.exit()
+
+        // Caller D arrives after A exited — should be allowed
+        XCTAssertTrue(gate.tryEnter(), "New caller after exit must be allowed")
+        gate.exit()
+    }
+
+    func testExitWithoutEnterIsSafe() {
+        // Defensive: exit() when no prior enter() is a no-op. This matches the
+        // `defer { gate.exit() }` pattern — exit runs even when the guard bails.
+        // Subsequent enter should still succeed.
+        let gate = ReentrancyGate()
+        gate.exit()
+        XCTAssertTrue(gate.tryEnter(), "Enter after spurious exit must still succeed")
+    }
+}

--- a/desktop/Desktop/Tests/ReentrancyGateTests.swift
+++ b/desktop/Desktop/Tests/ReentrancyGateTests.swift
@@ -68,12 +68,31 @@ final class ReentrancyGateTests: XCTestCase {
         gate.exit()
     }
 
-    func testExitWithoutEnterIsSafe() {
-        // Defensive: exit() when no prior enter() is a no-op. This matches the
-        // `defer { gate.exit() }` pattern — exit runs even when the guard bails.
-        // Subsequent enter should still succeed.
+    func testGuardDeferPatternOnlyExitsWhenOwnerEntered() {
+        // Models the canonical ChatProvider.pollForNewMessages() usage:
+        //   guard gate.tryEnter() else { return }
+        //   defer { gate.exit() }
+        // Non-owners return before the defer is registered, so exit() is
+        // never called from a non-owning caller — the contract holds.
         let gate = ReentrancyGate()
-        gate.exit()
-        XCTAssertTrue(gate.tryEnter(), "Enter after spurious exit must still succeed")
+        var exitCalls = 0
+
+        func criticalSection() {
+            guard gate.tryEnter() else { return }
+            defer {
+                gate.exit()
+                exitCalls += 1
+            }
+            // simulated critical work — the second concurrent call below runs
+            // before this defer fires because Swift closures run synchronously.
+        }
+
+        // First caller acquires + releases via defer.
+        criticalSection()
+        XCTAssertEqual(exitCalls, 1)
+
+        // Second sequential caller also acquires cleanly after the first exited.
+        criticalSection()
+        XCTAssertEqual(exitCalls, 2)
     }
 }

--- a/desktop/Desktop/Tests/TasksStoreObserverTests.swift
+++ b/desktop/Desktop/Tests/TasksStoreObserverTests.swift
@@ -1,0 +1,64 @@
+import AppKit
+import XCTest
+@testable import Omi_Computer
+
+/// Tests for `TasksStore` auto-refresh observer wiring (#6500).
+///
+/// After replacing the 30-second `Timer.publish` with `didBecomeActive` +
+/// `.refreshAllData` subscribers, the store must still refresh when those
+/// notifications fire. These tests post each notification and assert the
+/// baseline-diffed `refreshInvocations` counter advances by one, proving the
+/// observer reaches `refreshTasksIfNeeded()` — the early-exit guards inside
+/// that method run after the counter bumps, so tests don't need local auth
+/// or any prior `loadTasks()` call.
+@MainActor
+final class TasksStoreObserverTests: XCTestCase {
+
+    func testDidBecomeActiveNotificationTriggersRefresh() async {
+        let store = TasksStore.shared
+        let baseline = store.refreshInvocations
+
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification, object: nil
+        )
+        // Sink runs on the main queue; yield so the task enqueues and fires.
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            store.refreshInvocations, baseline + 1,
+            "didBecomeActive must route to refreshTasksIfNeeded() via the activation observer"
+        )
+    }
+
+    func testRefreshAllDataNotificationTriggersRefresh() async {
+        let store = TasksStore.shared
+        let baseline = store.refreshInvocations
+
+        NotificationCenter.default.post(name: .refreshAllData, object: nil)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(
+            store.refreshInvocations, baseline + 1,
+            ".refreshAllData (Cmd+R) must route to refreshTasksIfNeeded() via the refresh observer"
+        )
+    }
+
+    func testBothNotificationsTriggerIndependentRefreshes() async {
+        let store = TasksStore.shared
+        let baseline = store.refreshInvocations
+
+        NotificationCenter.default.post(
+            name: NSApplication.didBecomeActiveNotification, object: nil
+        )
+        NotificationCenter.default.post(name: .refreshAllData, object: nil)
+        await Task.yield()
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        XCTAssertEqual(
+            store.refreshInvocations, baseline + 2,
+            "Both observers must fire independently — posting both notifications yields two refresh calls"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

**Eliminates all data-sync polling timers** from the desktop app, replacing with event-driven refresh (app activation + Cmd+R). Instead of polling every 15-120s whether data changed or not, the app only fetches data when the user actually needs it.

### Architecture: Polling → Event-Driven

| Data type | Before | Now |
|-----------|--------|-----|
| Chat messages | 15s timer | **No timer.** Refresh on app activation + Cmd+R |
| Conversations | 30s timer | **No timer.** Refresh on app activation (60s cooldown) + Cmd+R |
| Tasks | 30s timer | **No timer.** Refresh on page visible + app activation + Cmd+R |
| Memories | 30s timer | **No timer.** Refresh on page visible + app activation + Cmd+R |
| Crisp (support chat) | 120s timer | **No timer.** Refresh on app activation + Cmd+R |

### What triggers data refresh now

1. **App activation (`didBecomeActiveNotification`)** — user switches to the app, all visible data refreshes immediately
2. **Cmd+R** — global shortcut (new `CommandGroup` in `OmiApp.swift`) broadcasts `.refreshAllData` to all subscribers
3. **Page navigation** — tasks/memories refresh when their page becomes visible (existing `isActive` guards)
4. **User actions** — pull-to-refresh, sending messages, creating items, etc. (unchanged)

### Expected impact
- **Before**: ~4,275 req/user/day → 2.15M total/day
- **After**: ~20-50 req/user/day → ~10-25K total/day (event-driven only)
- **~99% traffic reduction** vs original polling
- 504 timeouts should drop to near-zero

## Testing

### Unit tests (37 tests across 6 new test files)
- `PollingFrequencyTests` — 10 tests (cooldown predicate, notification name, receivable)
- `PollingConfigTests` — cooldown constants + `shouldAllowActivationRefresh` predicate
- `ReentrancyGateTests` — 6 tests (acquire/release/overlap/ownership/reset)
- `CrispManagerLifecycleTests` — 8 tests (start/stop/observer wiring, didBecomeActive fires pollForMessages, .refreshAllData fires pollForMessages, performInitialPoll flag)
- `MemoriesViewModelObserverTests` — 3 tests (init wiring, both observer firings)
- `TasksStoreObserverTests` — 3 tests (init wiring, both observer firings)
- `ChatProviderPollGateRegressionTests` — re-entrancy regression coverage

### Live testing — CP9A/CP9B (all 22 changed paths verified)

Built `polling-6512.app` via `OMI_APP_NAME=polling-6512 ./run.sh --yolo` against the dev Cloud Run backend (`https://desktop-backend-hhibjajaja-uc.a.run.app`). Signed in via auth-inject tool. Exercised 4 event types against the running bundle:

1. **Launch activation** (`05:21:23`) — app startup in signed-in main content
2. **Cmd+R broadcast** (`05:22:07`) — CGEvent keyboard injection via Quartz
3. **App-switch activation** (`05:22:40`) — Safari → polling-6512
4. **Rapid re-activation within cooldown** (`05:23:02`, +22s) — non-happy path for `DesktopHomeView` cooldown

**All 22 changed paths L1 + L2 PASS.** Key live-observed behaviors matching design intent:
- `CrispManager: started (event-driven, no polling timer)` — literal log of the new behavior (replaces the old 120s `Timer.publish`)
- 4 live `CrispManager: fetching .../v1/crisp/unread` calls — one per event
- `refreshTasksIfNeeded invoked (count=1..4, signedIn=true)` → `ActionItemStorage: Synced 8 task action items from backend`
- `MemoriesViewModel: Fetched 173 memories from API`
- `Conversations: Auto-refresh updated (43 items)` after Cmd+R (`05:22:08`) and after app-switch at +77s (`05:22:42`)
- **ABSENCE of `Conversations: Auto-refresh updated` line after rapid second activation at +22s** — `PollingConfig.shouldAllowActivationRefresh` correctly blocked `refreshConversations` because 22s < 60s cooldown (the absence is the proof of the non-happy path)
- Cmd+R broadcast reached 4 independent subscribers (`TasksStore`, `ChatProvider`, `CrispManager`, `DesktopHomeView`) — post-path verified end-to-end

**Behavioral contrast**: Omi Dev (main branch, same shared `/tmp/omi-dev.log`) shows 2-minute `CrispManager: fetching` cadence confirming the old 120s timer. polling-6512 fetches ONLY on activation/broadcast events — timer removal live-verified. Timer grep: main has 6 `Timer.publish` lines across the changed files; this PR has 0.

**Untested live (unit-test backed)**: `CrispManager.stop()` on signout cycle; `AuthBackoffTracker` skip branch; `CrispManager` backoff skip branch.

**L3 (CP9C)**: `level3_required=false` — single-process desktop PR, no cluster/Helm changes. Skipped.

Full per-path checklist and CP9 evidence in comments:
- [CP9A/CP9B evidence summary](https://github.com/BasedHardware/omi/pull/6512#issuecomment-4249487645)
- [Ready for merge](https://github.com/BasedHardware/omi/pull/6512#issuecomment-4249489345)

## Risks / edge cases

- **Stale-data perception** — if the user stares at the app without interacting and data changes on another device, they won't see it until Cmd+R or app-switch. Mitigated by the `didBecomeActive` observer (refreshes on every window-focus) and the global Cmd+R shortcut. Acceptable trade-off because the old model caused ~800 daily 504s.
- **Rapid re-activation storm** — `DesktopHomeView` has a 60s cooldown (`PollingConfig.shouldAllowActivationRefresh`) to prevent activation floods from triggering excess conversation fetches. Live-verified with a 22s rapid re-activation that correctly blocked the refresh.
- **Chat re-entrancy** — `ChatProvider.pollForNewMessages` uses a `ReentrancyGate` (`pollGate`) with deferred release to prevent overlapping fetches. Regression test `ChatProviderPollGateRegressionTests` asserts overlapping calls don't double-fetch.
- **Signout cycle** — `CrispManager.stop()` removes both observers and clears persisted timestamp. Unit-test backed (`CrispManagerLifecycleTests.testStopRemovesBothObservers`).
- **Out of scope (intentional)**: `TranscriptionRetryService` (60s timer) — this is a retry/reconciliation queue for failed transcription uploads, not a data-sync timer. Removing it would cause lost transcriptions.

## Review cycle

- **Round 1**: Added chat activation observer (reviewer — chat had no activation path)
- **Round 2**: Extracted `PollingConfig`, added tests (tester — constants needed coverage)
- **Round 3 (rework)**: Removed all timers, added Cmd+R, event-driven architecture
- **Round 4**: Fixed `CrispManager` timer, added chat in-flight guard (reviewer R1 feedback)
- **CP7 re-run**: Reviewer loop re-executed after post-approval commits → `PR_APPROVED_LGTM`
- **CP8**: Tester loop re-executed, coverage gaps addressed (added `CrispManagerLifecycleTests`, `MemoriesViewModelObserverTests`, `TasksStoreObserverTests`, `ChatProviderPollGateRegressionTests`, `PollingFrequencyTests`) → `TESTS_APPROVED`
- **CP9A/CP9B**: Live tested against signed-in polling-6512 bundle + dev Cloud Run backend — all 22 changed paths PASS

Closes #6500 (Phase 1)

_by AI for @beastoin_
