### PR TITLE
Fix crash in Settings on duplicate plan price IDs

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -5618,7 +5618,7 @@ struct SettingsContentView: View {
     for plan in primary {
       if let existing = mergedById[plan.id] {
         let mergedPrices = Array(
-          Dictionary(uniqueKeysWithValues: (existing.prices + plan.prices).map { ($0.id, $0) })
+          Dictionary((existing.prices + plan.prices).map { ($0.id, $0) }, uniquingKeysWith: { _, new in new })
             .values
         )
         .sorted { $0.title < $1.title }


### PR DESCRIPTION
## Summary
- `Dictionary(uniqueKeysWithValues:)` crashes with a fatal error when merging plan prices that share the same ID
- Replace with `uniquingKeysWith` to handle duplicates gracefully (keeps the primary plan's price)
- Deterministic crash reported by user on v0.11.276, macOS 26.3.1, Apple Silicon

## Stack trace
```
_assertionFailure → _NativeDictionary.merge →
mergePlanCatalog(primary:fallback:) → mergedPlanCatalog.getter →
currentPlanBillingDetail.getter → currentPlanSubtitle.getter →
planUsageSection.getter
```

## Test plan
- [ ] Open Settings page with a subscription that has overlapping price IDs in primary and fallback catalogs
- [ ] Verify no crash, plan details display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)