### PR TITLE
fix(desktop): prevent account usage crash

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -57,6 +57,56 @@ struct SettingsPage: View {
   }
 }
 
+struct SubscriptionPlanCatalogMerger {
+  static func merge(
+    primary: [SubscriptionPlanOption],
+    fallback: [SubscriptionPlanOption]
+  ) -> [SubscriptionPlanOption] {
+    var mergedById: [String: SubscriptionPlanOption] = [:]
+
+    for plan in fallback {
+      mergedById[plan.id] = plan
+    }
+
+    for plan in primary {
+      if let existing = mergedById[plan.id] {
+        mergedById[plan.id] = SubscriptionPlanOption(
+          id: plan.id,
+          title: plan.title.isEmpty ? existing.title : plan.title,
+          features: plan.features.isEmpty ? existing.features : plan.features,
+          prices: mergePrices(primary: plan.prices, fallback: existing.prices)
+        )
+      } else {
+        mergedById[plan.id] = plan
+      }
+    }
+
+    return Array(mergedById.values)
+  }
+
+  private static func mergePrices(
+    primary: [SubscriptionPriceOption],
+    fallback: [SubscriptionPriceOption]
+  ) -> [SubscriptionPriceOption] {
+    var mergedById: [String: SubscriptionPriceOption] = [:]
+
+    for price in fallback {
+      mergedById[price.id] = price
+    }
+
+    for price in primary {
+      mergedById[price.id] = price
+    }
+
+    return Array(mergedById.values).sorted { lhs, rhs in
+      if lhs.title != rhs.title {
+        return lhs.title < rhs.title
+      }
+      return lhs.id < rhs.id
+    }
+  }
+}
+
 /// Dark-themed settings content matching the main window style
 struct SettingsContentView: View {
   // AppState for transcription control
@@ -5609,32 +5659,7 @@ struct SettingsContentView: View {
     primary: [SubscriptionPlanOption],
     fallback: [SubscriptionPlanOption]
   ) -> [SubscriptionPlanOption] {
-    var mergedById: [String: SubscriptionPlanOption] = [:]
-
-    for plan in fallback {
-      mergedById[plan.id] = plan
-    }
-
-    for plan in primary {
-      if let existing = mergedById[plan.id] {
-        let mergedPrices = Array(
-          Dictionary(uniqueKeysWithValues: (existing.prices + plan.prices).map { ($0.id, $0) })
-            .values
-        )
-        .sorted { $0.title < $1.title }
-
-        mergedById[plan.id] = SubscriptionPlanOption(
-          id: plan.id,
-          title: plan.title.isEmpty ? existing.title : plan.title,
-          features: plan.features.isEmpty ? existing.features : plan.features,
-          prices: mergedPrices
-        )
-      } else {
-        mergedById[plan.id] = plan
-      }
-    }
-
-    return Array(mergedById.values)
+    SubscriptionPlanCatalogMerger.merge(primary: primary, fallback: fallback)
   }
 
   private func fallbackFeatures(for planId: String) -> [String] {

--- a/desktop/Desktop/Tests/SubscriptionPlanCatalogMergerTests.swift
+++ b/desktop/Desktop/Tests/SubscriptionPlanCatalogMergerTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SubscriptionPlanCatalogMergerTests: XCTestCase {
+
+  func testMergeDeduplicatesDuplicatePriceIDsWithoutCrashing() {
+    let fallback = [
+      SubscriptionPlanOption(
+        id: "pro",
+        title: "Omi Pro",
+        features: ["Fallback Feature"],
+        prices: [
+          SubscriptionPriceOption(
+            id: "price_monthly",
+            title: "Monthly",
+            description: "Fallback monthly",
+            priceString: "$20"
+          ),
+          SubscriptionPriceOption(
+            id: "price_annual",
+            title: "Annual",
+            description: "Fallback annual",
+            priceString: "$200"
+          ),
+        ]
+      )
+    ]
+
+    let primary = [
+      SubscriptionPlanOption(
+        id: "pro",
+        title: "Omi Pro",
+        features: ["Primary Feature"],
+        prices: [
+          SubscriptionPriceOption(
+            id: "price_monthly",
+            title: "Monthly",
+            description: "Primary monthly",
+            priceString: "$19"
+          )
+        ]
+      )
+    ]
+
+    let merged = SubscriptionPlanCatalogMerger.merge(primary: primary, fallback: fallback)
+
+    XCTAssertEqual(merged.count, 1)
+    XCTAssertEqual(merged[0].features, ["Primary Feature"])
+    XCTAssertEqual(merged[0].prices.count, 2)
+
+    let monthly = try XCTUnwrap(merged[0].prices.first(where: { $0.id == "price_monthly" }))
+    XCTAssertEqual(monthly.priceString, "$19")
+
+    let annual = try XCTUnwrap(merged[0].prices.first(where: { $0.id == "price_annual" }))
+    XCTAssertEqual(annual.priceString, "$200")
+  }
+}


### PR DESCRIPTION
## Summary
- replace the plan catalog dictionary merge with safe ID-based deduping
- prevent duplicate Stripe price IDs from crashing Settings -> Plan and Usage
- add a regression test for duplicate price IDs across primary and fallback plan data

## Verification
- Mac mini desktop build path compiled successfully with the patched SettingsPage
- Full Mac mini launch verification was blocked by a missing Apple Development signing identity
- Clean remote SwiftPM test execution was blocked by that machine's broken Homebrew git/pcre2 linkage