### PR TITLE
Add crash rate tracking to PostHog and analytics dashboard

### DIFF
--- a/desktop/Desktop/Sources/AnalyticsManager.swift
+++ b/desktop/Desktop/Sources/AnalyticsManager.swift
@@ -278,6 +278,35 @@ class AnalyticsManager {
     )
   }
 
+  // MARK: - Crash Detection
+
+  /// Detect if the previous session crashed (no clean exit) and report to PostHog.
+  /// Must be called AFTER analytics initialization but BEFORE appLaunched().
+  func detectAndReportCrash() {
+    guard !Self.isDevBuild else { return }
+
+    let cleanExitKey = "lastSessionCleanExit"
+    let hasLaunchedBeforeKey = "crashDetection_hasLaunchedBefore"
+
+    let hadPreviousSession = UserDefaults.standard.bool(forKey: hasLaunchedBeforeKey)
+    let lastCleanExit = UserDefaults.standard.bool(forKey: cleanExitKey)
+
+    // Mark that we've launched at least once (skip crash report on very first launch)
+    UserDefaults.standard.set(true, forKey: hasLaunchedBeforeKey)
+
+    // Clear the flag — will be set back to true only on clean exit
+    UserDefaults.standard.set(false, forKey: cleanExitKey)
+
+    if hadPreviousSession && !lastCleanExit {
+      log("Analytics: Previous session did not exit cleanly — reporting crash")
+      let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
+      PostHogManager.shared.track("App Crash Detected", properties: [
+        "app_version": version,
+        "os_version": ProcessInfo.processInfo.operatingSystemVersionString,
+      ])
+    }
+  }
+
   // MARK: - App Lifecycle Events
 
   func appLaunched() {

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -342,6 +342,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     // Initialize analytics (MixPanel + PostHog)
     AnalyticsManager.shared.initialize()
+    AnalyticsManager.shared.detectAndReportCrash()
     AnalyticsManager.shared.appLaunched()
     AnalyticsManager.shared.trackDisplayInfo()
 
@@ -1057,6 +1058,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
   }
 
   func applicationWillTerminate(_ notification: Notification) {
+    // Mark clean exit so crash detection works on next launch
+    UserDefaults.standard.set(true, forKey: "lastSessionCleanExit")
+
     // Remove window observers
     for observer in windowObservers {
       NotificationCenter.default.removeObserver(observer)

--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -184,6 +184,11 @@ interface DauTrendsData {
   days: number;
 }
 
+interface CrashRateData {
+  data: { date: string; crashes: number; users: number; crashFreeRate: number }[];
+  days: number;
+}
+
 interface ViralMetrics {
   growthAccounting: {
     week: string;
@@ -358,6 +363,9 @@ export default function AnalyticsPage() {
 
   const { data: macosVersionStats, isLoading: macosVersionStatsLoading } =
     useSWR<MacosVersionStatsData>(token ? ["/api/omi/stats/macos-versions", token] : null, authFetcher, swrOpts);
+
+  const { data: crashRate, isLoading: crashRateLoading } =
+    useSWR<CrashRateData>(token ? ["/api/omi/stats/crash-rate?days=30", token] : null, authFetcher, swrOpts);
 
   const retentionPlatformParam = retentionPlatform ? `&platform=${retentionPlatform}` : '';
 
@@ -1339,6 +1347,58 @@ export default function AnalyticsPage() {
           </div>
         </Card>
       </div>
+
+      {/* Crash Rate */}
+      <Card className="p-6">
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-lg font-semibold">App Stability</h2>
+          {crashRate?.data && (() => {
+            const recent = crashRate.data.slice(-7);
+            const totalCrashes = recent.reduce((s, d) => s + d.crashes, 0);
+            const totalUsers = recent.reduce((s, d) => s + d.users, 0);
+            const rate = totalUsers > 0 ? ((1 - totalCrashes / totalUsers) * 100).toFixed(1) : "100.0";
+            return (
+              <span className="text-sm text-muted-foreground">
+                {rate}% crash-free (7d) · {totalCrashes} crashes
+              </span>
+            );
+          })()}
+        </div>
+        <p className="text-sm text-muted-foreground mb-4">Daily crashes vs active users (last 30 days)</p>
+        <div className="h-[300px]">
+          {crashRateLoading ? (
+            <div className="flex items-center justify-center h-full">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : (crashRate?.data?.length ?? 0) > 0 ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <ComposedChart data={crashRate!.data}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                <YAxis yAxisId="left" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <YAxis yAxisId="right" orientation="right" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={(v) => `${v}%`} domain={[90, 100]} />
+                <Tooltip
+                  formatter={(value: number, name: string) => {
+                    if (name === "crashFreeRate") return [`${value}%`, "Crash-Free Rate"];
+                    if (name === "crashes") return [value.toLocaleString(), "Crashes"];
+                    return [value.toLocaleString(), "Active Users"];
+                  }}
+                  labelFormatter={fullDate}
+                  contentStyle={tooltipStyle}
+                />
+                <Legend />
+                <Bar yAxisId="left" dataKey="crashes" name="Crashes" fill="#ef4444" radius={[2, 2, 0, 0]} />
+                <Bar yAxisId="left" dataKey="users" name="Active Users" fill="#6366f1" radius={[2, 2, 0, 0]} opacity={0.3} />
+                <Line yAxisId="right" type="monotone" dataKey="crashFreeRate" name="Crash-Free Rate" stroke="#22c55e" strokeWidth={2} dot={false} activeDot={{ r: 4 }} />
+              </ComposedChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex items-center justify-center h-full text-muted-foreground">
+              No crash data yet — events will appear after v0.11.277+
+            </div>
+          )}
+        </div>
+      </Card>
 
       {/* Daily New Users + Rolling Avg */}
       <Card className="p-6">

--- a/web/admin/app/api/omi/stats/crash-rate/route.ts
+++ b/web/admin/app/api/omi/stats/crash-rate/route.ts
@@ -1,0 +1,178 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAdmin } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+let cache: { data: CrashRatePoint[]; days: number; timestamp: number } | null =
+  null;
+const CACHE_TTL = 30 * 60 * 1000;
+
+interface CrashRatePoint {
+  date: string;
+  crashes: number;
+  users: number;
+  crashFreeRate: number;
+}
+
+export async function GET(request: NextRequest) {
+  const authResult = await verifyAdmin(request);
+  if (authResult instanceof NextResponse) return authResult;
+
+  try {
+    const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+    const projectId = process.env.POSTHOG_PROJECT_ID;
+    const host = process.env.POSTHOG_HOST || "https://us.posthog.com";
+
+    if (!apiKey || !projectId) {
+      return NextResponse.json(
+        { error: "PostHog credentials not configured" },
+        { status: 500 }
+      );
+    }
+
+    const searchParams = request.nextUrl.searchParams;
+    const days = Math.min(parseInt(searchParams.get("days") || "30", 10), 90);
+
+    if (cache && cache.days === days && Date.now() - cache.timestamp < CACHE_TTL) {
+      return NextResponse.json({ data: cache.data, days });
+    }
+
+    // Query crashes and active users per day in a single HogQL query
+    const hogql = `
+      SELECT
+        toDate(timestamp) as day,
+        countIf(event = 'App Crash Detected') as crashes,
+        countIf(DISTINCT distinct_id, event = 'App Became Active') as users
+      FROM events
+      WHERE (event = 'App Crash Detected' OR event = 'App Became Active')
+        AND properties.$os_name = 'macOS'
+        AND timestamp >= now() - interval ${days} day
+      GROUP BY day
+      ORDER BY day
+    `;
+
+    const response = await fetch(`${host}/api/projects/${projectId}/query/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: { kind: "HogQLQuery", query: hogql },
+      }),
+    });
+
+    if (!response.ok) {
+      // HogQL countIf with DISTINCT might not be supported — fall back to two queries
+      const [crashRes, dauRes] = await Promise.allSettled([
+        fetch(`${host}/api/projects/${projectId}/query/`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            query: {
+              kind: "HogQLQuery",
+              query: `
+                SELECT toDate(timestamp) as day, count() as crashes
+                FROM events
+                WHERE event = 'App Crash Detected'
+                  AND properties.$os_name = 'macOS'
+                  AND timestamp >= now() - interval ${days} day
+                GROUP BY day ORDER BY day
+              `,
+            },
+          }),
+        }),
+        fetch(`${host}/api/projects/${projectId}/query/`, {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            query: {
+              kind: "HogQLQuery",
+              query: `
+                SELECT toDate(timestamp) as day, count(DISTINCT distinct_id) as users
+                FROM events
+                WHERE event = 'App Became Active'
+                  AND properties.$os_name = 'macOS'
+                  AND timestamp >= now() - interval ${days} day
+                GROUP BY day ORDER BY day
+              `,
+            },
+          }),
+        }),
+      ]);
+
+      const crashMap: Record<string, number> = {};
+      const dauMap: Record<string, number> = {};
+
+      if (crashRes.status === "fulfilled" && crashRes.value.ok) {
+        const raw = await crashRes.value.json();
+        for (const [date, count] of raw.results || []) {
+          crashMap[date] = count;
+        }
+      }
+
+      if (dauRes.status === "fulfilled" && dauRes.value.ok) {
+        const raw = await dauRes.value.json();
+        for (const [date, count] of raw.results || []) {
+          dauMap[date] = count;
+        }
+      }
+
+      const data = buildDateSeries(days, crashMap, dauMap);
+      cache = { data, days, timestamp: Date.now() };
+      return NextResponse.json({ data, days });
+    }
+
+    // Single-query path succeeded
+    const raw = await response.json();
+    const results: [string, number, number][] = raw.results || [];
+
+    const crashMap: Record<string, number> = {};
+    const dauMap: Record<string, number> = {};
+    for (const [date, crashes, users] of results) {
+      crashMap[date] = crashes;
+      dauMap[date] = users;
+    }
+
+    const data = buildDateSeries(days, crashMap, dauMap);
+    cache = { data, days, timestamp: Date.now() };
+    return NextResponse.json({ data, days });
+  } catch (error: any) {
+    console.error("Crash rate error:", error);
+    return NextResponse.json(
+      { error: error.message || "Failed to fetch crash rate" },
+      { status: 500 }
+    );
+  }
+}
+
+function buildDateSeries(
+  days: number,
+  crashMap: Record<string, number>,
+  dauMap: Record<string, number>
+): CrashRatePoint[] {
+  const toDate = new Date();
+  const fromDate = new Date();
+  fromDate.setDate(fromDate.getDate() - days);
+
+  const formatDate = (d: Date) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+  const data: CrashRatePoint[] = [];
+  const current = new Date(fromDate);
+  while (current <= toDate) {
+    const dateStr = formatDate(current);
+    const crashes = crashMap[dateStr] ?? 0;
+    const users = dauMap[dateStr] ?? 0;
+    const crashFreeRate = users > 0 ? Math.round((1 - crashes / users) * 1000) / 10 : 100;
+    data.push({ date: dateStr, crashes, users, crashFreeRate });
+    current.setDate(current.getDate() + 1);
+  }
+  return data;
+}


### PR DESCRIPTION
## Summary
- **Swift**: Detect crashes via clean-exit flag in `UserDefaults`. On launch, if previous session didn't call `applicationWillTerminate`, send `App Crash Detected` event to PostHog
- **API**: New `/api/omi/stats/crash-rate` endpoint querying PostHog for daily crashes vs active users
- **Dashboard**: New "App Stability" chart showing crashes per day, active users, and crash-free rate percentage

## How it works
1. `applicationWillTerminate` sets `lastSessionCleanExit = true`
2. On next launch, `detectAndReportCrash()` checks the flag — if false, previous session crashed
3. Sends `App Crash Detected` event with app version and OS version
4. Dashboard queries both `App Crash Detected` and `App Became Active` events via HogQL
5. Chart shows red bars (crashes), purple bars (users), green line (crash-free %)

## Notes
- Skips first-ever launch (no previous session to check)
- Skips dev builds (no analytics pollution)
- Dashboard shows "No crash data yet" until v0.11.277+ users start reporting
- API has 30-min cache and fallback to two separate queries if combined HogQL fails

## Test plan
- [ ] Verify crash detection works: force-kill app, relaunch, check PostHog for event
- [ ] Verify clean exit doesn't trigger: quit app normally, relaunch, no crash event
- [ ] Verify dashboard chart renders with crash data
- [ ] Verify dashboard shows placeholder when no data exists yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)