### PR TITLE
Pin sentry-cocoa to 8.58.0 to fix Codemagic build

### DIFF
--- a/desktop/Desktop/Package.swift
+++ b/desktop/Desktop/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     .package(url: "https://github.com/firebase/firebase-ios-sdk.git", from: "11.0.0"),
     .package(url: "https://github.com/mixpanel/mixpanel-swift.git", from: "4.0.0"),
     .package(url: "https://github.com/PostHog/posthog-ios.git", from: "3.0.0"),
-    .package(url: "https://github.com/getsentry/sentry-cocoa.git", from: "8.0.0"),
+    .package(url: "https://github.com/getsentry/sentry-cocoa.git", exact: "8.58.0"),
     .package(url: "https://github.com/groue/GRDB.swift.git", from: "6.24.0"),
     .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
     .package(url: "https://github.com/gonzalezreal/swift-markdown-ui", from: "2.4.0"),


### PR DESCRIPTION
## Summary
Codemagic builds have been failing since v0.11.276 because Sentry's new `Package@swift-6.1.swift` manifest has a broken `String(cString:encoding:)` call on Xcode 16.4.

Pin to 8.58.0 (last working version already in Package.resolved) until Sentry fixes upstream.

## Error
```
error: Invalid manifest
/Package@swift-6.1.swift:72:51: error: extra argument 'encoding' in call
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)