### PR TITLE
Revert floating bar response context summary layout

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -620,23 +620,15 @@ struct MessageMetadataPopover: View {
 
                 Divider()
 
-                // Context fed into the prompt — dynamically discovered sections
+                // Context fed into the prompt
                 Text("Context in Prompt")
                     .scaledFont(size: 11, weight: .semibold)
                     .foregroundColor(.primary)
-                let sections = metadata.promptSections
-                if sections.isEmpty {
-                    Text("No tagged sections found")
-                        .scaledFont(size: 11)
-                        .foregroundColor(.secondary)
-                } else {
-                    ForEach(sections, id: \.tag) { section in
-                        metadataRow(
-                            label: section.label,
-                            value: "\(section.itemCount) items (\(section.charCount) chars)"
-                        )
-                    }
-                }
+                metadataRow(label: "User memories/facts", value: "\(metadata.memoriesCount)")
+                metadataRow(label: "Conversation history turns", value: "\(metadata.conversationTurns)")
+                metadataRow(label: "Tasks", value: "\(metadata.tasksCount)")
+                metadataRow(label: "Goals", value: "\(metadata.goalsCount)")
+                metadataRow(label: "Available tools", value: "\(metadata.availableToolsCount)")
 
                 // Tool calls
                 if !metadata.toolNames.isEmpty {


### PR DESCRIPTION
## Summary
- revert the Response Context popover to the previous fixed summary rows
- keep later additions like screenshot size details and SQL query stats intact

## Testing
- not run (UI text-only change)