### PR TITLE
Fix floating bar voice interruption behavior

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -29,6 +29,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   private var playbackTask: Task<Void, Never>?
   private var fillerTask: Task<Void, Never>?
   private var currentMode: PlaybackMode?
+  private var currentResponseID: String?
+  private var interruptedResponseID: String?
+  private var shouldInterruptNextResponse = false
   private var streamedText = ""
   private var bufferedText = ""
   private var synthesisQueue: [String] = []
@@ -78,9 +81,23 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
   func updateStreamingResponseIfEnabled(_ message: ChatMessage?, isFinal: Bool) {
     guard ShortcutSettings.shared.hasAnyFloatingBarVoiceAnswersEnabled else { return }
+    guard let message else { return }
+
+    if currentResponseID != message.id {
+      resetPlaybackPipeline(clearMode: false)
+      currentResponseID = message.id
+      interruptedResponseID = shouldInterruptNextResponse ? message.id : nil
+      shouldInterruptNextResponse = false
+    }
 
     let text = Self.cleanedPlaybackText(from: message)
     guard !text.isEmpty, Self.shouldSpeak(text) else { return }
+
+    if interruptedResponseID == message.id {
+      streamedText = text
+      bufferedText = ""
+      return
+    }
 
     if currentMode == nil {
       currentMode = resolvePlaybackMode()
@@ -171,7 +188,21 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
           self.startSynthesisIfNeeded(mode: mode)
         }
       } catch is CancellationError {
+        await MainActor.run {
+          guard let self else { return }
+          self.isSynthesizing = false
+          self.startSynthesisIfNeeded(mode: mode)
+        }
       } catch {
+        if Self.isCancellation(error) {
+          await MainActor.run {
+            guard let self else { return }
+            self.isSynthesizing = false
+            self.startSynthesisIfNeeded(mode: mode)
+          }
+          return
+        }
+
         await MainActor.run {
           guard let self else { return }
           self.isSynthesizing = false
@@ -186,20 +217,20 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   }
 
   func stop() {
-    playbackTask?.cancel()
-    playbackTask = nil
-    fillerTask?.cancel()
-    fillerTask = nil
-    currentMode = nil
-    streamedText = ""
-    bufferedText = ""
-    synthesisQueue.removeAll()
-    audioQueue.removeAll()
-    isSynthesizing = false
-    hasStartedRealPlayback = false
-    audioPlayer?.stop()
-    audioPlayer = nil
-    speechSynthesizer.stopSpeaking(at: .immediate)
+    resetPlaybackPipeline(clearMode: true)
+    currentResponseID = nil
+    interruptedResponseID = nil
+    shouldInterruptNextResponse = false
+  }
+
+  func interruptCurrentResponse() {
+    if let currentResponseID {
+      interruptedResponseID = currentResponseID
+      shouldInterruptNextResponse = false
+    } else {
+      shouldInterruptNextResponse = true
+    }
+    resetPlaybackPipeline(clearMode: false)
   }
 
   private func startPlaybackIfNeeded() {
@@ -239,6 +270,25 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
       self.audioPlayer = nil
       self.startPlaybackIfNeeded()
     }
+  }
+
+  private func resetPlaybackPipeline(clearMode: Bool) {
+    playbackTask?.cancel()
+    playbackTask = nil
+    fillerTask?.cancel()
+    fillerTask = nil
+    if clearMode {
+      currentMode = nil
+    }
+    streamedText = ""
+    bufferedText = ""
+    synthesisQueue.removeAll()
+    audioQueue.removeAll()
+    isSynthesizing = false
+    hasStartedRealPlayback = false
+    audioPlayer?.stop()
+    audioPlayer = nil
+    speechSynthesizer.stopSpeaking(at: .immediate)
   }
 
   private func preferredSystemVoice() -> AVSpeechSynthesisVoice? {
@@ -364,6 +414,23 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     }
 
     return emergencyLimit
+  }
+
+  private nonisolated static func isCancellation(_ error: Error) -> Bool {
+    if error is CancellationError {
+      return true
+    }
+
+    let nsError = error as NSError
+    if nsError.domain == NSURLErrorDomain, nsError.code == NSURLErrorCancelled {
+      return true
+    }
+
+    if let urlError = error as? URLError, urlError.code == .cancelled {
+      return true
+    }
+
+    return false
   }
 }
 

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -108,7 +108,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
 
     func handleEscapeKey() {
         if FloatingBarVoicePlaybackService.shared.isSpeaking {
-            FloatingBarVoicePlaybackService.shared.stop()
+            FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
             return
         }
 
@@ -785,8 +785,21 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
     }
 
     func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
-        NSSize(
-            width: max(frameSize.width, FloatingControlBarWindow.minBarSize.width),
+        let minimumWidth: CGFloat
+        if state.showingAIConversation {
+            minimumWidth = FloatingControlBarWindow.expandedWidth
+        } else if state.currentNotification != nil {
+            minimumWidth = FloatingControlBarWindow.notificationWidth
+        } else if state.isVoiceListening {
+            minimumWidth = FloatingControlBarWindow.expandedWidth
+        } else if state.isHoveringBar {
+            minimumWidth = FloatingControlBarWindow.expandedBarSize.width
+        } else {
+            minimumWidth = FloatingControlBarWindow.minBarSize.width
+        }
+
+        return NSSize(
+            width: max(frameSize.width, minimumWidth),
             height: max(frameSize.height, FloatingControlBarWindow.minBarSize.height)
         )
     }
@@ -1374,7 +1387,7 @@ class FloatingControlBarManager {
         activeQueryGeneration += 1
         chatCancellable?.cancel()
         chatCancellable = nil
-        FloatingBarVoicePlaybackService.shared.stop()
+        FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
         barWindow.cancelInputHeightObserver()
         barWindow.state.currentQueryFromVoice = fromVoice
         barWindow.state.showingAIConversation = true
@@ -1415,7 +1428,7 @@ class FloatingControlBarManager {
         }
 
         limiter.recordQuery()
-        FloatingBarVoicePlaybackService.shared.stop()
+        FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
 
         let screenshotData = await Task.detached { () -> Data? in
             guard let url = ScreenCaptureManager.captureScreen() else { return nil }

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -6,7 +6,8 @@ import Combine
 ///
 /// State machine:
 ///   idle → [Option down] → listening → [Option up] → finalizing → sends query → idle
-///   idle → [Option tap+tap within 400ms] → lockedListening → [Option tap] → finalizing → idle
+///   idle → [Quick tap] → pendingLockDecision → [tap again within 400ms] → lockedListening
+///   pendingLockDecision → [timeout] → finalizing → sends query → idle
 @MainActor
 class PushToTalkManager: ObservableObject {
   static let shared = PushToTalkManager()
@@ -16,6 +17,7 @@ class PushToTalkManager: ObservableObject {
   enum PTTState {
     case idle
     case listening
+    case pendingLockDecision
     case lockedListening
     case finalizing
   }
@@ -32,6 +34,7 @@ class PushToTalkManager: ObservableObject {
   private var lastOptionDownTime: TimeInterval = 0
   private var lastOptionUpTime: TimeInterval = 0
   private let doubleTapThreshold: TimeInterval = 0.4
+  private let tapToLockMaxHoldDuration: TimeInterval = 0.22
 
   // Transcription
   private var transcriptionService: TranscriptionService?
@@ -40,6 +43,7 @@ class PushToTalkManager: ObservableObject {
   private var lastInterimText: String = ""
   private var finalizeWorkItem: DispatchWorkItem?
   private var hasMicPermission: Bool = false
+  private var isCurrentSessionFollowUp = false
 
   // Batch mode: accumulate raw audio for post-recording transcription
   private var batchAudioBuffer = Data()
@@ -152,6 +156,7 @@ class PushToTalkManager: ObservableObject {
     case .idle:
       // Check for double-tap: if last Option-up was recent, enter locked mode
       if ShortcutSettings.shared.doubleTapForLock && (now - lastOptionUpTime) < doubleTapThreshold {
+        lastOptionUpTime = 0
         enterLockedListening()
       } else {
         lastOptionDownTime = now
@@ -161,6 +166,10 @@ class PushToTalkManager: ObservableObject {
     case .listening:
       // Already listening (hold mode), ignore repeated flagsChanged
       break
+
+    case .pendingLockDecision:
+      stopListening()
+      enterLockedListening()
 
     case .lockedListening:
       // Tap while locked → finalize
@@ -177,37 +186,34 @@ class PushToTalkManager: ObservableObject {
     switch state {
     case .listening:
       let holdDuration = now - lastOptionDownTime
-      lastOptionUpTime = now
 
-      if ShortcutSettings.shared.doubleTapForLock && holdDuration < doubleTapThreshold {
-        // Short tap — delay briefly to allow double-tap detection
-        let workItem = DispatchWorkItem { [weak self] in
-          Task { @MainActor in
-            guard let self = self, self.state == .listening else { return }
-            self.finalize()
-          }
-        }
-        finalizeWorkItem = workItem
-        DispatchQueue.main.asyncAfter(deadline: .now() + doubleTapThreshold, execute: workItem)
+      if ShortcutSettings.shared.doubleTapForLock && holdDuration < tapToLockMaxHoldDuration {
+        lastOptionUpTime = now
+        enterPendingLockDecision()
       } else {
+        lastOptionUpTime = 0
         // Long hold released — finalize immediately
         finalize()
       }
 
+    case .pendingLockDecision:
+      break
+
     case .lockedListening:
       // In locked mode, Option-up is ignored (we finalize on next Option-down)
-      lastOptionUpTime = now
+      break
 
     case .idle, .finalizing:
-      lastOptionUpTime = now
+      break
     }
   }
 
   // MARK: - Listening Lifecycle
 
   private func startListening() {
-    FloatingBarVoicePlaybackService.shared.stop()
+    FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
     state = .listening
+    isCurrentSessionFollowUp = barState?.showingAIResponse == true
     transcriptSegments = []
     lastInterimText = ""
     finalizeWorkItem?.cancel()
@@ -220,13 +226,7 @@ class PushToTalkManager: ObservableObject {
       sound?.play()
     }
 
-    // Check if an AI conversation is already active — enter follow-up mode
-    let isFollowUp = barState?.showingAIResponse == true
-    if isFollowUp {
-      barState?.isVoiceFollowUp = true
-      barState?.voiceFollowUpTranscript = ""
-    }
-
+    let isFollowUp = isCurrentSessionFollowUp
     AnalyticsManager.shared.floatingBarPTTStarted(mode: isFollowUp ? "follow_up_hold" : "hold")
     updateBarState()
 
@@ -236,10 +236,11 @@ class PushToTalkManager: ObservableObject {
   }
 
   private func enterLockedListening() {
-    FloatingBarVoicePlaybackService.shared.stop()
+    FloatingBarVoicePlaybackService.shared.interruptCurrentResponse()
     finalizeWorkItem?.cancel()
     finalizeWorkItem = nil
     state = .lockedListening
+    isCurrentSessionFollowUp = barState?.showingAIResponse == true
 
     // Play start-of-PTT sound for locked mode
     if ShortcutSettings.shared.pttSoundsEnabled {
@@ -248,13 +249,7 @@ class PushToTalkManager: ObservableObject {
       sound?.play()
     }
 
-    // Check if an AI conversation is already active — enter follow-up mode
-    let isFollowUp = barState?.showingAIResponse == true
-    if isFollowUp {
-      barState?.isVoiceFollowUp = true
-      barState?.voiceFollowUpTranscript = ""
-    }
-
+    let isFollowUp = isCurrentSessionFollowUp
     AnalyticsManager.shared.floatingBarPTTStarted(mode: isFollowUp ? "follow_up_locked" : "locked")
 
     // If we were already listening from the first tap, keep going.
@@ -271,6 +266,23 @@ class PushToTalkManager: ObservableObject {
     log("PushToTalkManager: entered locked listening mode (followUp=\(isFollowUp))")
   }
 
+  private func enterPendingLockDecision() {
+    guard state == .listening else { return }
+
+    state = .pendingLockDecision
+    audioCaptureService?.stopCapture()
+    updateBarState()
+
+    let workItem = DispatchWorkItem { [weak self] in
+      Task { @MainActor in
+        guard let self, self.state == .pendingLockDecision else { return }
+        self.finalize()
+      }
+    }
+    finalizeWorkItem = workItem
+    DispatchQueue.main.asyncAfter(deadline: .now() + doubleTapThreshold, execute: workItem)
+  }
+
   private func stopListening() {
     finalizeWorkItem?.cancel()
     finalizeWorkItem = nil
@@ -283,6 +295,7 @@ class PushToTalkManager: ObservableObject {
     batchAudioLock.lock()
     batchAudioBuffer = Data()
     batchAudioLock.unlock()
+    isCurrentSessionFollowUp = false
     updateBarState()
   }
 
@@ -290,16 +303,15 @@ class PushToTalkManager: ObservableObject {
   func cancelListening() {
     guard state != .idle else { return }
     log("PushToTalkManager: cancelling listening")
-    barState?.isVoiceFollowUp = false
-    barState?.voiceFollowUpTranscript = ""
     stopListening()
   }
 
   private var finalizedMode: String = "hold"
 
   private func finalize() {
-    guard state == .listening || state == .lockedListening else { return }
+    guard state == .listening || state == .lockedListening || state == .pendingLockDecision else { return }
 
+    lastOptionUpTime = 0
     finalizedMode = state == .lockedListening ? "locked" : "hold"
     state = .finalizing
     finalizeWorkItem?.cancel()
@@ -405,7 +417,7 @@ class PushToTalkManager: ObservableObject {
       query = lastInterimText.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     let hasQuery = !query.isEmpty
-    let wasFollowUp = barState?.isVoiceFollowUp == true
+    let wasFollowUp = isCurrentSessionFollowUp
 
     AnalyticsManager.shared.floatingBarPTTEnded(
       mode: finalizedMode,
@@ -413,9 +425,7 @@ class PushToTalkManager: ObservableObject {
       transcriptLength: query.count
     )
 
-    // Clear follow-up state
-    barState?.isVoiceFollowUp = false
-    barState?.voiceFollowUpTranscript = ""
+    isCurrentSessionFollowUp = false
 
     // Reset state — skip PTT collapse resize when we have a query,
     // because openAIInputWithQuery will resize to the correct size.
@@ -543,20 +553,22 @@ class PushToTalkManager: ObservableObject {
   }
 
   private func handleTranscriptSegments(_ segments: [TranscriptionService.BackendSegment]) {
-    guard state == .listening || state == .lockedListening || state == .finalizing else { return }
+    guard
+      state == .listening || state == .lockedListening || state == .pendingLockDecision
+        || state == .finalizing
+    else { return }
 
     for segment in segments {
       transcriptSegments.append(segment.text)
     }
     lastInterimText = ""
 
-    // Update live transcript in the bar
-    let liveText = transcriptSegments.joined(separator: " ")
-    barState?.voiceTranscript = liveText
-
-    // Also update follow-up transcript if in follow-up mode
-    if barState?.isVoiceFollowUp == true {
-      barState?.voiceFollowUpTranscript = liveText
+    if state == .listening || state == .lockedListening {
+      let liveText = transcriptSegments.joined(separator: " ")
+      barState?.voiceTranscript = liveText
+      if isCurrentSessionFollowUp {
+        barState?.voiceFollowUpTranscript = liveText
+      }
     }
 
     // In finalizing state, segments mean backend is done — send immediately
@@ -573,11 +585,13 @@ class PushToTalkManager: ObservableObject {
   private func updateBarState(skipResize: Bool = false) {
     guard let barState = barState else { return }
     let wasListening = barState.isVoiceListening
-    barState.isVoiceListening =
-      (state == .listening || state == .lockedListening || state == .finalizing)
+    let isShowingVoiceUI = (state == .listening || state == .lockedListening)
+    barState.isVoiceListening = isShowingVoiceUI
     barState.isVoiceLocked = (state == .lockedListening)
-    if state == .idle {
+    barState.isVoiceFollowUp = isCurrentSessionFollowUp && isShowingVoiceUI
+    if !isShowingVoiceUI {
       barState.voiceTranscript = ""
+      barState.voiceFollowUpTranscript = ""
     }
 
     // Skip resize when in follow-up mode, expanded AI conversation, or during onboarding


### PR DESCRIPTION
## Summary
- stop spoken floating-bar replies for the current response when interrupted by Escape or push-to-talk
- prevent cancelled ElevenLabs synthesis from falling back into a second system voice
- tighten push-to-talk lock detection and keep the voice UI from lingering after release
- clamp floating bar resize so the AI conversation cannot collapse into a broken narrow layout

## Testing
- rebuilt and launched `/Applications/Audio Fix.app`
- manually verified build/run path locally; UI behavior to be smoke-tested from the PR build