### PR TITLE
Enable Omi Pro plan catalog on desktop

### DIFF
--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -245,9 +245,9 @@ env:
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvw3kDbWmjs"
   - name: STRIPE_PRO_MONTHLY_PRICE_ID
-    value: ""
+    value: "price_1TAznX1F8wnoWYvwyaSVQbZW"
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
-    value: ""
+    value: "price_1TAznX1F8wnoWYvwN8YmzbiC"
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: BUCKET_PRIVATE_CLOUD_SYNC

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -272,7 +272,7 @@ env:
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RtJQ71F8wnoWYvwKMPaGlGY"
   - name: STRIPE_PRO_MONTHLY_PRICE_ID
-    value: ""
+    value: "price_1TAfBB1F8wnoWYvw8XBFM1dX"
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
     value: ""
   - name: SUBSCRIPTION_LAUNCH_DATE

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -217,33 +217,32 @@ def get_available_plans_endpoint(uid: str = Depends(auth.get_current_user_uid)):
         for definition in get_paid_plan_definitions():
             monthly_price_id = definition["monthly_price_id"]
             annual_price_id = definition["annual_price_id"]
-            if not monthly_price_id or not annual_price_id:
-                continue
-
-            monthly_price = stripe.Price.retrieve(monthly_price_id)
-            annual_price = stripe.Price.retrieve(annual_price_id)
-            pricing_options.append(
-                PricingOption(
-                    id=monthly_price.id,
-                    title=f'{definition["title"]} Monthly',
-                    price_string=f"${monthly_price.unit_amount / 100:.2f}/mo",
-                    description=None,
-                    interval=monthly_price.recurring.interval,
-                    unit_amount=monthly_price.unit_amount,
-                    is_active=current_price_id == monthly_price.id or scheduled_price_id == monthly_price.id,
+            if monthly_price_id:
+                monthly_price = stripe.Price.retrieve(monthly_price_id)
+                pricing_options.append(
+                    PricingOption(
+                        id=monthly_price.id,
+                        title=f'{definition["title"]} Monthly',
+                        price_string=f"${monthly_price.unit_amount / 100:.2f}/mo",
+                        description=None,
+                        interval=monthly_price.recurring.interval,
+                        unit_amount=monthly_price.unit_amount,
+                        is_active=current_price_id == monthly_price.id or scheduled_price_id == monthly_price.id,
+                    )
                 )
-            )
-            pricing_options.append(
-                PricingOption(
-                    id=annual_price.id,
-                    title=f'{definition["title"]} Annual',
-                    price_string=f"${int(annual_price.unit_amount / 100 / 12)}/mo",
-                    description=definition["annual_description"],
-                    interval=annual_price.recurring.interval,
-                    unit_amount=annual_price.unit_amount,
-                    is_active=current_price_id == annual_price.id or scheduled_price_id == annual_price.id,
+            if annual_price_id:
+                annual_price = stripe.Price.retrieve(annual_price_id)
+                pricing_options.append(
+                    PricingOption(
+                        id=annual_price.id,
+                        title=f'{definition["title"]} Annual',
+                        price_string=f"${int(annual_price.unit_amount / 100 / 12)}/mo",
+                        description=definition["annual_description"],
+                        interval=annual_price.recurring.interval,
+                        unit_amount=annual_price.unit_amount,
+                        is_active=current_price_id == annual_price.id or scheduled_price_id == annual_price.id,
+                    )
                 )
-            )
 
         if not pricing_options:
             raise HTTPException(status_code=500, detail="Price configuration not found")

--- a/backend/tests/unit/test_payment_available_plans_source.py
+++ b/backend/tests/unit/test_payment_available_plans_source.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+PAYMENT_SOURCE_FILE = Path(__file__).resolve().parents[2] / "routers" / "payment.py"
+
+
+def test_available_plans_support_partial_billing_options():
+    source = PAYMENT_SOURCE_FILE.read_text()
+
+    assert 'if monthly_price_id:' in source
+    assert 'if annual_price_id:' in source
+    assert 'if not monthly_price_id or not annual_price_id:' not in source

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -6179,6 +6179,7 @@ struct SettingsContentView: View {
         let availablePlans = try? await APIClient.shared.getAvailablePlans()
         await MainActor.run {
           userSubscription = subscription
+          subscriptionError = nil
           fallbackPlanCatalog = availablePlans.map { planCatalog(from: $0.plans) } ?? []
           if let selectedPlanIdForCheckout,
             subscription.subscription.plan.rawValue == selectedPlanIdForCheckout
@@ -6349,11 +6350,27 @@ struct SettingsContentView: View {
   private func completeLocalTestSubscriptionIfNeeded() async {
     guard let expectedPriceId = pendingSubscriptionPriceId else { return }
     let checkoutSessionId = pendingCheckoutSessionId
-    let baseURL = await APIClient.shared.rustBackendURL
-    guard baseURL.hasPrefix("http://127.0.0.1:8787/") || baseURL.hasPrefix("http://localhost:8787/")
-    else {
+    let pythonBaseURL = await APIClient.shared.baseURL
+    let rustBaseURL = await APIClient.shared.rustBackendURL
+
+    if let checkoutSessionId, isLocalURL(pythonBaseURL) {
+      guard
+        let encodedSessionId = checkoutSessionId.addingPercentEncoding(
+          withAllowedCharacters: .urlQueryAllowed),
+        let url = URL(string: "\(pythonBaseURL)v1/payments/success?session_id=\(encodedSessionId)")
+      else {
+        return
+      }
+
+      do {
+        _ = try await URLSession.shared.data(from: url)
+      } catch {
+        logError("Failed to complete local python test subscription", error: error)
+      }
       return
     }
+
+    guard isLocalURL(rustBaseURL) else { return }
 
     guard
       let encodedPriceId = expectedPriceId.addingPercentEncoding(
@@ -6362,7 +6379,7 @@ struct SettingsContentView: View {
       return
     }
 
-    var urlString = "\(baseURL)test/complete-subscription?price_id=\(encodedPriceId)"
+    var urlString = "\(rustBaseURL)test/complete-subscription?price_id=\(encodedPriceId)"
     if let checkoutSessionId,
       let encodedSessionId = checkoutSessionId.addingPercentEncoding(
         withAllowedCharacters: .urlQueryAllowed)
@@ -6377,6 +6394,10 @@ struct SettingsContentView: View {
     } catch {
       logError("Failed to complete local test subscription", error: error)
     }
+  }
+
+  private func isLocalURL(_ url: String) -> Bool {
+    url.hasPrefix("http://127.0.0.1:") || url.hasPrefix("http://localhost:")
   }
 
   private func openURLInDefaultBrowser(_ url: URL) {


### PR DESCRIPTION
## Summary
- wire the configured Omi Pro Stripe price IDs into dev and prod backend values
- allow available-plans to expose plans when only one billing interval is configured
- clear stale subscription errors after successful refresh and support local python billing success callbacks
- add a unit regression test for partial billing-option support

## Verification
- `./backend/test-preflight.sh`
- `pytest backend/tests/unit/test_subscription_plans.py backend/tests/unit/test_payment_available_plans_source.py`
- rebuilt and relaunched `/Applications/payments.app`; verified via `lsappinfo` and `agent-swift`

## Notes
- `backend/test.sh` was started and advanced substantially, but local env hydration was still in progress because the repo venv was missing backend dependencies (`scipy`, then `langchain_core`) until requirements installation began. This was an environment issue, not a failure in the changed files.