### PR TITLE
fix(desktop): crash in Plan & Usage settings + OCR array bounds (#6506, #5151)

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -62,13 +62,19 @@ struct SubscriptionPlanCatalogMerger {
     primary: [SubscriptionPlanOption],
     fallback: [SubscriptionPlanOption]
   ) -> [SubscriptionPlanOption] {
-    var mergedById: [String: SubscriptionPlanOption] = [:]
+    // Filter out plans with empty IDs — malformed API responses can cause
+    // dictionary assertion failures in Swift's optimized merge path (#6506).
+    let safePrimary = primary.filter { !$0.id.isEmpty }
+    let safeFallback = fallback.filter { !$0.id.isEmpty }
 
-    for plan in fallback {
+    var mergedById: [String: SubscriptionPlanOption] = [:]
+    mergedById.reserveCapacity(max(safePrimary.count, safeFallback.count))
+
+    for plan in safeFallback {
       mergedById[plan.id] = plan
     }
 
-    for plan in primary {
+    for plan in safePrimary {
       if let existing = mergedById[plan.id] {
         mergedById[plan.id] = SubscriptionPlanOption(
           id: plan.id,
@@ -88,13 +94,18 @@ struct SubscriptionPlanCatalogMerger {
     primary: [SubscriptionPriceOption],
     fallback: [SubscriptionPriceOption]
   ) -> [SubscriptionPriceOption] {
-    var mergedById: [String: SubscriptionPriceOption] = [:]
+    // Filter out prices with empty IDs to avoid dictionary assertion crashes.
+    let safePrimary = primary.filter { !$0.id.isEmpty }
+    let safeFallback = fallback.filter { !$0.id.isEmpty }
 
-    for price in fallback {
+    var mergedById: [String: SubscriptionPriceOption] = [:]
+    mergedById.reserveCapacity(max(safePrimary.count, safeFallback.count))
+
+    for price in safeFallback {
       mergedById[price.id] = price
     }
 
-    for price in primary {
+    for price in safePrimary {
       mergedById[price.id] = price
     }
 

--- a/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
+++ b/desktop/Desktop/Sources/Rewind/Core/RewindOCRService.swift
@@ -178,29 +178,48 @@ actor RewindOCRService {
                 // that can trigger EXC_BREAKPOINT / _objectAt assertion failures if the
                 // underlying buffer is mutated or released during enumeration (see #5891, #5151).
                 let safeObservations = Array(observations)
+                let count = safeObservations.count
+
+                // Pre-extract all data from bridged observations in one pass to
+                // minimise exposure to Vision's internal buffer lifecycle (#5151).
+                struct RawOCR {
+                    let text: String
+                    let confidence: Float
+                    let box: CGRect
+                }
+
+                var rawResults: [RawOCR] = []
+                rawResults.reserveCapacity(count)
+                for i in 0..<count {
+                    let observation = safeObservations[i]
+                    let candidates = observation.topCandidates(1)
+                    guard let candidate = candidates.first else { continue }
+                    let box = observation.boundingBox
+                    guard box.origin.x.isFinite, box.origin.y.isFinite,
+                          box.width.isFinite, box.height.isFinite else { continue }
+                    rawResults.append(RawOCR(
+                        text: String(candidate.string),
+                        confidence: candidate.confidence,
+                        box: box
+                    ))
+                }
 
                 var blocks: [OCRTextBlock] = []
+                blocks.reserveCapacity(rawResults.count)
                 var fullTextLines: [String] = []
+                fullTextLines.reserveCapacity(rawResults.count)
 
-                for observation in safeObservations {
-                    let candidates = observation.topCandidates(1)
-                    guard !candidates.isEmpty, let candidate = candidates.first else { continue }
-
-                    let boundingBox = observation.boundingBox
-                    // Validate bounding box values are finite before using them
-                    guard boundingBox.origin.x.isFinite, boundingBox.origin.y.isFinite,
-                          boundingBox.width.isFinite, boundingBox.height.isFinite else { continue }
-
+                for raw in rawResults {
                     let block = OCRTextBlock(
-                        text: candidate.string,
-                        x: Double((boundingBox.origin.x * 1000).rounded()) / 1000,
-                        y: Double((boundingBox.origin.y * 1000).rounded()) / 1000,
-                        width: Double((boundingBox.width * 1000).rounded()) / 1000,
-                        height: Double((boundingBox.height * 1000).rounded()) / 1000,
-                        confidence: (Double(candidate.confidence) * 1000).rounded() / 1000
+                        text: raw.text,
+                        x: Double((raw.box.origin.x * 1000).rounded()) / 1000,
+                        y: Double((raw.box.origin.y * 1000).rounded()) / 1000,
+                        width: Double((raw.box.width * 1000).rounded()) / 1000,
+                        height: Double((raw.box.height * 1000).rounded()) / 1000,
+                        confidence: (Double(raw.confidence) * 1000).rounded() / 1000
                     )
                     blocks.append(block)
-                    fullTextLines.append(candidate.string)
+                    fullTextLines.append(raw.text)
                 }
 
                 let result = OCRResult(


### PR DESCRIPTION
## What

Fixes two crashes in the macOS desktop app:

### Plan & Usage settings crash (#6506)
**Root cause:** `SubscriptionPlanCatalogMerger.merge` crashes with `EXC_BREAKPOINT` in `_NativeDictionary.merge` when the backend returns plans or prices with empty IDs, triggering a Swift dictionary precondition failure during body evaluation.

**Fix:**
- Filter out plans/prices with empty IDs before dictionary merge
- Reserve dictionary capacity to avoid reallocation during merge

**Crash trace:** Main thread → `SettingsContentView.mergePlanCatalog` → `_NativeDictionary.merge` assertion failure

### OCR array bounds crash (#5151)
**Root cause:** Vision framework's bridged `NSArray` storage for `VNRecognizedTextObservation` results can be invalidated during iteration, causing `_objectAt` assertion failures even with the existing `Array(observations)` defensive copy.

**Fix:**
- Eagerly snapshot all text, confidence, and bounding box data in a single pass using a lightweight `RawOCR` struct
- Copy `String` values out of bridged objects immediately via `String(candidate.string)`
- Build `OCRTextBlock` array from already-copied native Swift data
- Reserve array capacity

**Crash trace:** Thread 9 → `RewindOCRService.extractTextWithBounds` → `__SwiftNativeNSArrayWithContiguousStorage._objectAt` assertion failure

## Testing
- `swift build` passes ✅
- Both fixes are defensive/additive — no behavior change for valid data

Closes #6506
Relates to #5151