### PR TITLE
feat: platform filter for chat ratings (desktop/mobile)

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -532,7 +532,7 @@ def get_all_ratings(rating_type: str = 'memory_summary'):
     return [rating.to_dict() for rating in ratings]
 
 
-def set_chat_message_rating_score(uid: str, message_id: str, value: int, reason: str = None):
+def set_chat_message_rating_score(uid: str, message_id: str, value: int, reason: str = None, platform: str = None):
     """
     Store chat message rating/feedback.
 
@@ -542,6 +542,7 @@ def set_chat_message_rating_score(uid: str, message_id: str, value: int, reason:
         value: Rating value (1 = thumbs up, -1 = thumbs down, 0 = neutral/removed)
         reason: Optional reason for thumbs down (e.g. 'too_verbose', 'incorrect_or_hallucination',
                 'not_helpful_or_irrelevant', 'didnt_follow_instructions', 'other')
+        platform: 'desktop' or 'mobile' — identifies where the rating came from
     """
     doc_id = document_id_from_seed('chat_message' + message_id)
     data = {
@@ -554,6 +555,8 @@ def set_chat_message_rating_score(uid: str, message_id: str, value: int, reason:
     }
     if reason:
         data['reason'] = reason
+    if platform:
+        data['platform'] = platform
     db.collection('analytics').document(doc_id).set(data)
 
 

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -901,7 +901,7 @@ def rate_message(
 
     # Also store in analytics collection
     value = rating if rating is not None else 0
-    set_chat_message_rating_score(uid, message_id, value)
+    set_chat_message_rating_score(uid, message_id, value, platform='mobile')
 
     # Try to submit feedback to LangSmith
     try:

--- a/backend/routers/chat_sessions.py
+++ b/backend/routers/chat_sessions.py
@@ -177,7 +177,7 @@ def rate_message(
     # Also write to analytics collection (same as mobile endpoint) so ratings
     # appear in the admin dashboard chat ratings chart.
     value = request.rating if request.rating is not None else 0
-    set_chat_message_rating_score(uid, message_id, value)
+    set_chat_message_rating_score(uid, message_id, value, platform='desktop')
     return {'status': 'ok'}
 
 

--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -1709,8 +1709,10 @@ interface ChatRatingsData {
 }
 
 function ChatRatingsChart({ token }: { token: string | null }) {
+  const [platform, setPlatform] = useState<"all" | "desktop" | "mobile">("all");
+
   const { data, isLoading } = useSWR<ChatRatingsData>(
-    token ? ["/api/omi/chat-lab/ratings", token] : null,
+    token ? [`/api/omi/chat-lab/ratings?platform=${platform}`, token] : null,
     authenticatedFetcher
   );
 
@@ -1735,7 +1737,24 @@ function ChatRatingsChart({ token }: { token: string | null }) {
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center justify-between">
-          <span>Chat Response Ratings</span>
+          <div className="flex items-center gap-3">
+            <span>Chat Response Ratings</span>
+            <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
+              {(["all", "desktop", "mobile"] as const).map((p) => (
+                <button
+                  key={p}
+                  onClick={() => setPlatform(p)}
+                  className={`px-3 py-1 transition-colors ${
+                    platform === p
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-muted text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {p === "all" ? "All" : p === "desktop" ? "Desktop" : "Mobile"}
+                </button>
+              ))}
+            </div>
+          </div>
           {stats.total > 0 && (
             <div className="flex items-center gap-4 text-sm font-normal">
               <span className="text-green-500">{stats.up} 👍</span>

--- a/web/admin/app/api/omi/chat-lab/ratings/route.ts
+++ b/web/admin/app/api/omi/chat-lab/ratings/route.ts
@@ -17,15 +17,20 @@ export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request);
   if (authResult instanceof NextResponse) return authResult;
 
+  const { searchParams } = new URL(request.url);
+  // 'all' | 'desktop' | 'mobile' — filters by platform field on analytics docs
+  const platform = searchParams.get('platform') || 'all';
+
   try {
     const db = getDb();
 
-    // Ratings are stored in the `analytics` collection with type='chat_message'.
-    // Each doc has: value (1=up, -1=down), created_at, uid, message_id
+    // Ratings are in the `analytics` collection with type='chat_message'.
+    // Each doc has: value (1/-1), created_at, uid, message_id, platform ('desktop'/'mobile')
+    // Historical docs before the platform tag was added have no platform field.
     const snapshot = await db
       .collection('analytics')
       .where('type', '==', 'chat_message')
-      .limit(5000)
+      .limit(10000)
       .get();
 
     const weeklyStats = new Map<string, { thumbs_up: number; thumbs_down: number }>();
@@ -34,6 +39,13 @@ export async function GET(request: NextRequest) {
       const data = doc.data();
       const value = data.value;
       if (value !== 1 && value !== -1) continue;
+
+      // Platform filter
+      if (platform !== 'all') {
+        const docPlatform = data.platform;
+        if (platform === 'desktop' && docPlatform !== 'desktop') continue;
+        if (platform === 'mobile' && docPlatform !== 'mobile') continue;
+      }
 
       const createdAt = data.created_at;
       if (!createdAt) continue;
@@ -59,7 +71,7 @@ export async function GET(request: NextRequest) {
     const total_up = result.reduce((sum, w) => sum + w.thumbs_up, 0);
     const total_down = result.reduce((sum, w) => sum + w.thumbs_down, 0);
 
-    return NextResponse.json({ weeks: result, total_up, total_down });
+    return NextResponse.json({ weeks: result, total_up, total_down, platform });
   } catch (error) {
     console.error('[Chat Lab] Error fetching ratings:', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });


### PR DESCRIPTION
## Summary
- Tag analytics docs with `platform='desktop'` or `'mobile'` when ratings are written
- Admin ratings API supports `?platform=all|desktop|mobile` filter
- Analytics chart has All / Desktop / Mobile toggle (default All)

Historical ratings have no platform tag — they show under "All" only. New ratings going forward will be tagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)