### PR TITLE
fix: default chat ratings to Desktop + backfill platform tags

### DIFF
--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -1709,7 +1709,7 @@ interface ChatRatingsData {
 }
 
 function ChatRatingsChart({ token }: { token: string | null }) {
-  const [platform, setPlatform] = useState<"all" | "desktop" | "mobile">("all");
+  const [platform, setPlatform] = useState<"all" | "desktop" | "mobile">("desktop");
 
   const { data, isLoading } = useSWR<ChatRatingsData>(
     token ? [`/api/omi/chat-lab/ratings?platform=${platform}`, token] : null,


### PR DESCRIPTION
## Summary
- Default the analytics chart filter to "Desktop"
- Backfill running: tagging all existing analytics docs with platform='desktop' or 'mobile' by checking if the rated message has a chat_session_id (desktop-only field)

🤖 Generated with [Claude Code](https://claude.com/claude-code)