### PR TITLE
feat: app_version on ratings + By Version chart

### DIFF
--- a/backend/database/users.py
+++ b/backend/database/users.py
@@ -532,7 +532,9 @@ def get_all_ratings(rating_type: str = 'memory_summary'):
     return [rating.to_dict() for rating in ratings]
 
 
-def set_chat_message_rating_score(uid: str, message_id: str, value: int, reason: str = None, platform: str = None):
+def set_chat_message_rating_score(
+    uid: str, message_id: str, value: int, reason: str = None, platform: str = None, app_version: str = None
+):
     """
     Store chat message rating/feedback.
 
@@ -543,6 +545,7 @@ def set_chat_message_rating_score(uid: str, message_id: str, value: int, reason:
         reason: Optional reason for thumbs down (e.g. 'too_verbose', 'incorrect_or_hallucination',
                 'not_helpful_or_irrelevant', 'didnt_follow_instructions', 'other')
         platform: 'desktop' or 'mobile' — identifies where the rating came from
+        app_version: App version string (e.g. '0.11.276') — maps to a specific prompt version
     """
     doc_id = document_id_from_seed('chat_message' + message_id)
     data = {
@@ -557,6 +560,8 @@ def set_chat_message_rating_score(uid: str, message_id: str, value: int, reason:
         data['reason'] = reason
     if platform:
         data['platform'] = platform
+    if app_version:
+        data['app_version'] = app_version
     db.collection('analytics').document(doc_id).set(data)
 
 

--- a/backend/routers/chat_sessions.py
+++ b/backend/routers/chat_sessions.py
@@ -48,6 +48,7 @@ class SaveMessageRequest(BaseModel):
 
 class RateMessageRequest(BaseModel):
     rating: int | None = Field(None, ge=-1, le=1)
+    app_version: str | None = None
 
 
 class InitialMessageRequest(BaseModel):
@@ -177,7 +178,7 @@ def rate_message(
     # Also write to analytics collection (same as mobile endpoint) so ratings
     # appear in the admin dashboard chat ratings chart.
     value = request.rating if request.rating is not None else 0
-    set_chat_message_rating_score(uid, message_id, value, platform='desktop')
+    set_chat_message_rating_score(uid, message_id, value, platform='desktop', app_version=request.app_version)
     return {'status': 'ok'}
 
 

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -4374,8 +4374,10 @@ extension APIClient {
   func rateMessage(messageId: String, rating: Int?) async throws {
     struct RateRequest: Encodable {
       let rating: Int?
+      let app_version: String?
     }
-    let body = RateRequest(rating: rating)
+    let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
+    let body = RateRequest(rating: rating, app_version: version)
     let _: MessageStatusResponse = try await patch(
       "v2/desktop/messages/\(messageId)/rating", body: body)
   }

--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -1696,42 +1696,50 @@ export default function AnalyticsPage() {
 
 // --- Chat Ratings Chart (Firebase analytics collection) ---
 
-interface RatingWeek {
-  week: string;
-  thumbs_up: number;
-  thumbs_down: number;
-}
-
-interface ChatRatingsData {
-  weeks: RatingWeek[];
-  total_up: number;
-  total_down: number;
-}
+interface RatingWeek { week: string; thumbs_up: number; thumbs_down: number }
+interface RatingVersion { version: string; thumbs_up: number; thumbs_down: number }
+interface ChatRatingsWeekData { weeks: RatingWeek[]; total_up: number; total_down: number }
+interface ChatRatingsVersionData { versions: RatingVersion[]; total_up: number; total_down: number }
 
 function ChatRatingsChart({ token }: { token: string | null }) {
   const [platform, setPlatform] = useState<"all" | "desktop" | "mobile">("desktop");
+  const [groupBy, setGroupBy] = useState<"week" | "version">("week");
 
-  const { data, isLoading } = useSWR<ChatRatingsData>(
-    token ? [`/api/omi/chat-lab/ratings?platform=${platform}`, token] : null,
+  const { data: weekData, isLoading: weekLoading } = useSWR<ChatRatingsWeekData>(
+    token && groupBy === "week" ? [`/api/omi/chat-lab/ratings?platform=${platform}&group_by=week`, token] : null,
+    authenticatedFetcher
+  );
+  const { data: versionData, isLoading: versionLoading } = useSWR<ChatRatingsVersionData>(
+    token && groupBy === "version" ? [`/api/omi/chat-lab/ratings?platform=${platform}&group_by=version`, token] : null,
     authenticatedFetcher
   );
 
+  const isLoading = groupBy === "week" ? weekLoading : versionLoading;
+
   const stats = useMemo(() => {
-    if (!data) return { total: 0, up: 0, down: 0, pct: 0 };
-    const { total_up: up, total_down: down } = data;
+    const d = groupBy === "week" ? weekData : versionData;
+    if (!d) return { total: 0, up: 0, down: 0, pct: 0 };
+    const { total_up: up, total_down: down } = d;
     const total = up + down;
     return { total, up, down, pct: total > 0 ? Math.round((up / total) * 100) : 0 };
-  }, [data]);
+  }, [weekData, versionData, groupBy]);
 
   const chartData = useMemo(() => {
-    if (!data?.weeks) return [];
-    return data.weeks.map((w) => ({
-      ...w,
-      satisfaction: w.thumbs_up + w.thumbs_down > 0
-        ? Math.round((w.thumbs_up / (w.thumbs_up + w.thumbs_down)) * 100)
-        : 0,
+    if (groupBy === "version") {
+      if (!versionData?.versions) return [];
+      return versionData.versions
+        .filter((v) => v.version !== "unknown")
+        .map((v) => ({
+          ...v, label: v.version.replace("0.11.", "v"),
+          satisfaction: v.thumbs_up + v.thumbs_down > 0 ? Math.round((v.thumbs_up / (v.thumbs_up + v.thumbs_down)) * 100) : 0,
+        }));
+    }
+    if (!weekData?.weeks) return [];
+    return weekData.weeks.map((w) => ({
+      ...w, label: w.week,
+      satisfaction: w.thumbs_up + w.thumbs_down > 0 ? Math.round((w.thumbs_up / (w.thumbs_up + w.thumbs_down)) * 100) : 0,
     }));
-  }, [data]);
+  }, [weekData, versionData, groupBy]);
 
   return (
     <Card>
@@ -1754,6 +1762,13 @@ function ChatRatingsChart({ token }: { token: string | null }) {
                 </button>
               ))}
             </div>
+            <div className="flex rounded-md overflow-hidden border border-border text-xs font-medium">
+              {(["week", "version"] as const).map((g) => (
+                <button key={g} onClick={() => setGroupBy(g)}
+                  className={`px-3 py-1 transition-colors ${groupBy === g ? "bg-primary text-primary-foreground" : "bg-muted text-muted-foreground hover:bg-accent"}`}
+                >{g === "week" ? "By Week" : "By Version"}</button>
+              ))}
+            </div>
           </div>
           {stats.total > 0 && (
             <div className="flex items-center gap-4 text-sm font-normal">
@@ -1773,13 +1788,15 @@ function ChatRatingsChart({ token }: { token: string | null }) {
           </div>
         ) : !chartData.length ? (
           <div className="text-center text-muted-foreground py-12">
-            No chat ratings data available
+            {groupBy === "version"
+              ? "No version-tagged ratings yet. Ratings will be tagged with app version after the next desktop release."
+              : "No chat ratings data available"}
           </div>
         ) : (
           <ResponsiveContainer width="100%" height={250}>
             <ComposedChart data={chartData}>
               <CartesianGrid strokeDasharray="3 3" opacity={0.1} />
-              <XAxis dataKey="week" tick={{ fontSize: 11 }} />
+              <XAxis dataKey="label" tick={{ fontSize: 11 }} />
               <YAxis yAxisId="count" tick={{ fontSize: 11 }} />
               <YAxis yAxisId="pct" orientation="right" tick={{ fontSize: 11 }} domain={[0, 100]} unit="%" />
               <Tooltip

--- a/web/admin/app/api/omi/chat-lab/ratings/route.ts
+++ b/web/admin/app/api/omi/chat-lab/ratings/route.ts
@@ -18,33 +18,62 @@ export async function GET(request: NextRequest) {
   if (authResult instanceof NextResponse) return authResult;
 
   const { searchParams } = new URL(request.url);
-  // 'all' | 'desktop' | 'mobile' — filters by platform field on analytics docs
   const platform = searchParams.get('platform') || 'all';
+  const groupBy = searchParams.get('group_by') || 'week'; // 'week' or 'version'
 
   try {
     const db = getDb();
 
-    // Ratings are in the `analytics` collection with type='chat_message'.
-    // Each doc has: value (1/-1), created_at, uid, message_id, platform ('desktop'/'mobile')
-    // Historical docs before the platform tag was added have no platform field.
     const snapshot = await db
       .collection('analytics')
       .where('type', '==', 'chat_message')
       .limit(10000)
       .get();
 
+    if (groupBy === 'version') {
+      // Group by app_version
+      const versionStats = new Map<string, { thumbs_up: number; thumbs_down: number }>();
+
+      for (const doc of snapshot.docs) {
+        const data = doc.data();
+        const value = data.value;
+        if (value !== 1 && value !== -1) continue;
+        if (platform !== 'all') {
+          if (platform === 'desktop' && data.platform !== 'desktop') continue;
+          if (platform === 'mobile' && data.platform !== 'mobile') continue;
+        }
+
+        const version = data.app_version || 'unknown';
+        const entry = versionStats.get(version) || { thumbs_up: 0, thumbs_down: 0 };
+        if (value === 1) entry.thumbs_up++;
+        else entry.thumbs_down++;
+        versionStats.set(version, entry);
+      }
+
+      const versions = Array.from(versionStats.entries())
+        .map(([version, stats]) => ({
+          version,
+          thumbs_up: stats.thumbs_up,
+          thumbs_down: stats.thumbs_down,
+        }))
+        .sort((a, b) => a.version.localeCompare(b.version, undefined, { numeric: true }));
+
+      const total_up = versions.reduce((s, v) => s + v.thumbs_up, 0);
+      const total_down = versions.reduce((s, v) => s + v.thumbs_down, 0);
+
+      return NextResponse.json({ versions, total_up, total_down, platform, group_by: 'version' });
+    }
+
+    // Default: group by week
     const weeklyStats = new Map<string, { thumbs_up: number; thumbs_down: number }>();
 
     for (const doc of snapshot.docs) {
       const data = doc.data();
       const value = data.value;
       if (value !== 1 && value !== -1) continue;
-
-      // Platform filter
       if (platform !== 'all') {
-        const docPlatform = data.platform;
-        if (platform === 'desktop' && docPlatform !== 'desktop') continue;
-        if (platform === 'mobile' && docPlatform !== 'mobile') continue;
+        if (platform === 'desktop' && data.platform !== 'desktop') continue;
+        if (platform === 'mobile' && data.platform !== 'mobile') continue;
       }
 
       const createdAt = data.created_at;
@@ -71,7 +100,7 @@ export async function GET(request: NextRequest) {
     const total_up = result.reduce((sum, w) => sum + w.thumbs_up, 0);
     const total_down = result.reduce((sum, w) => sum + w.thumbs_down, 0);
 
-    return NextResponse.json({ weeks: result, total_up, total_down, platform });
+    return NextResponse.json({ weeks: result, total_up, total_down, platform, group_by: 'week' });
   } catch (error) {
     console.error('[Chat Lab] Error fetching ratings:', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });


### PR DESCRIPTION
## Summary
- Desktop sends `app_version` with every thumbs up/down rating
- Backend stores `app_version` on analytics docs  
- Admin chart has "By Week" / "By Version" toggle — each version = a prompt iteration
- Platform filter (All/Desktop/Mobile) still works

Version data will populate after the next desktop release. Historical ratings tagged by backfill have no version yet (show as "unknown", filtered out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)