### PR TITLE
Give Claude context about proactive notifications when user responds

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarState.swift
@@ -15,6 +15,19 @@ struct FloatingBarNotification: Identifiable, Equatable {
     let title: String
     let message: String
     let assistantId: String
+    /// Screenshot JPEG data from the moment the notification was generated (not shown in UI)
+    let screenshotData: Data?
+
+    init(title: String, message: String, assistantId: String, screenshotData: Data? = nil) {
+        self.title = title
+        self.message = message
+        self.assistantId = assistantId
+        self.screenshotData = screenshotData
+    }
+
+    static func == (lhs: FloatingBarNotification, rhs: FloatingBarNotification) -> Bool {
+        lhs.id == rhs.id
+    }
 }
 
 /// Observable object holding the state for the floating control bar.

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1015,8 +1015,8 @@ class FloatingControlBarManager {
         window?.makeKeyAndOrderFront(nil)
     }
 
-    func showNotification(title: String, message: String, assistantId: String, sound: NotificationSound) {
-        let notification = FloatingBarNotification(title: title, message: message, assistantId: assistantId)
+    func showNotification(title: String, message: String, assistantId: String, sound: NotificationSound, screenshotData: Data? = nil) {
+        let notification = FloatingBarNotification(title: title, message: message, assistantId: assistantId, screenshotData: screenshotData)
         guard let window else {
             log("FloatingControlBarManager: dropping notification because window is not set up")
             return
@@ -1281,7 +1281,22 @@ class FloatingControlBarManager {
 
         let bodyText = notification.message.trimmingCharacters(in: .whitespacesAndNewlines)
         let messageText = bodyText.isEmpty ? notification.title : bodyText
-        guard let message = provider.appendAssistantMessage(messageText) else { return }
+
+        let notificationContext = """
+<proactive_notification_context>
+The following message was a proactive notification you sent to the user based on their screen activity.
+The user did NOT ask for this — you observed their screen and proactively sent this tip/insight.
+If the user asks about it, answer as if you wrote it and explain the reasoning behind it.
+
+Your proactive message: \(messageText)
+Source: \(notification.assistantId) assistant
+</proactive_notification_context>
+"""
+        guard let message = provider.appendAssistantMessage(
+            messageText,
+            notificationContext: notificationContext,
+            notificationScreenshot: notification.screenshotData
+        ) else { return }
 
         storedNotificationMessages[notification.id] = StoredNotificationMessage(
             message: message,

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Insight/InsightAssistant.swift
@@ -194,6 +194,7 @@ actor InsightAssistant: ProactiveAssistant {
         _ adviceResult: InsightExtractionResult,
         screenshotId: Int64?,
         windowTitle: String? = nil,
+        screenshotData: Data? = nil,
         sendEvent: @escaping (String, [String: Any]) -> Void
     ) async {
         // Check if AI has new insight (should almost always be true now - only false for duplicates)
@@ -255,7 +256,7 @@ actor InsightAssistant: ProactiveAssistant {
             InsightAssistantSettings.shared.notificationsEnabled
         }
         if notificationsEnabled {
-            await sendInsightNotification(insight: extractedInsight)
+            await sendInsightNotification(insight: extractedInsight, screenshotData: screenshotData)
         }
 
         // Send event to Flutter
@@ -344,14 +345,15 @@ actor InsightAssistant: ProactiveAssistant {
     }
 
     /// Send a notification for the insight (uses short headline for notification body)
-    private func sendInsightNotification(insight: ExtractedInsight) async {
+    private func sendInsightNotification(insight: ExtractedInsight, screenshotData: Data? = nil) async {
         let message = insight.headline ?? insight.insight
 
         await MainActor.run {
             NotificationService.shared.sendNotification(
                 title: "Insight",
                 message: message,
-                assistantId: identifier
+                assistantId: identifier,
+                screenshotData: screenshotData
             )
         }
     }
@@ -444,7 +446,7 @@ actor InsightAssistant: ProactiveAssistant {
             }
 
             // Handle the result with screenshot ID for SQLite storage
-            await handleResultWithScreenshot(result, screenshotId: frame.screenshotId, windowTitle: frame.windowTitle) { type, data in
+            await handleResultWithScreenshot(result, screenshotId: frame.screenshotId, windowTitle: frame.windowTitle, screenshotData: frame.jpegData) { type, data in
                 Task { @MainActor in
                     AssistantCoordinator.shared.sendEvent(type: type, data: data)
                 }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -200,12 +200,13 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         ScreenCaptureService.resetScreenCapturePermissionAndRestart()
     }
 
-    func sendNotification(title: String, message: String, assistantId: String = "default", sound: NotificationSound = .default) {
+    func sendNotification(title: String, message: String, assistantId: String = "default", sound: NotificationSound = .default, screenshotData: Data? = nil) {
         FloatingControlBarManager.shared.showNotification(
             title: title,
             message: message,
             assistantId: assistantId,
-            sound: sound
+            sound: sound,
+            screenshotData: screenshotData
         )
 
         // Keep the floating-bar preview, but still deliver the real macOS

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -359,8 +359,12 @@ struct ChatMessage: Identifiable {
     var contentBlocks: [ChatContentBlock]
     /// Metadata about context used to generate this response (AI messages only)
     var metadata: MessageMetadata?
+    /// Context text for proactive notification messages (not shown to user, sent to Claude)
+    var notificationContext: String?
+    /// Screenshot JPEG data captured when a proactive notification was generated
+    var notificationScreenshot: Data?
 
-    init(id: String = UUID().uuidString, text: String, createdAt: Date = Date(), sender: ChatSender, isStreaming: Bool = false, rating: Int? = nil, isSynced: Bool = false, citations: [Citation] = [], contentBlocks: [ChatContentBlock] = [], metadata: MessageMetadata? = nil) {
+    init(id: String = UUID().uuidString, text: String, createdAt: Date = Date(), sender: ChatSender, isStreaming: Bool = false, rating: Int? = nil, isSynced: Bool = false, citations: [Citation] = [], contentBlocks: [ChatContentBlock] = [], metadata: MessageMetadata? = nil, notificationContext: String? = nil, notificationScreenshot: Data? = nil) {
         self.id = id
         self.text = text
         self.createdAt = createdAt
@@ -371,6 +375,8 @@ struct ChatMessage: Identifiable {
         self.citations = citations
         self.contentBlocks = contentBlocks
         self.metadata = metadata
+        self.notificationContext = notificationContext
+        self.notificationScreenshot = notificationScreenshot
     }
 }
 
@@ -1978,11 +1984,11 @@ A screenshot may be attached — use it silently only if relevant. Never mention
     }
 
     @discardableResult
-    func appendAssistantMessage(_ text: String) -> ChatMessage? {
+    func appendAssistantMessage(_ text: String, notificationContext: String? = nil, notificationScreenshot: Data? = nil) -> ChatMessage? {
         let trimmedText = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedText.isEmpty else { return nil }
 
-        let aiMessage = ChatMessage(text: trimmedText, sender: .ai)
+        let aiMessage = ChatMessage(text: trimmedText, sender: .ai, notificationContext: notificationContext, notificationScreenshot: notificationScreenshot)
         let localId = aiMessage.id
         let capturedSessionId = isInDefaultChat ? nil : currentSessionId
         let capturedAppId = overrideAppId ?? selectedAppId
@@ -2154,6 +2160,22 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 systemPrompt += "\n\n" + suffix
             }
 
+            // Auto-inject notification context: if the most recent AI message before
+            // the user's new message is a proactive notification, tell Claude about it
+            // so it can answer follow-up questions about the notification.
+            var effectiveImageData = imageData
+            if systemPromptSuffix == nil {
+                // Find the last AI message before the user's current message
+                let aiMessages = messages.filter { $0.sender == .ai && !$0.isStreaming }
+                if let lastAI = aiMessages.last, let ctx = lastAI.notificationContext {
+                    systemPrompt += "\n\n" + ctx
+                    // Attach the notification screenshot if no other image is provided
+                    if effectiveImageData == nil, let screenshotData = lastAI.notificationScreenshot {
+                        effectiveImageData = screenshotData
+                    }
+                }
+            }
+
             // Query the active bridge with streaming
             // Callbacks for ACP bridge
             let textDeltaHandler: ACPBridge.TextDeltaHandler = { [weak self] delta in
@@ -2237,7 +2259,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
                 mode: chatMode.rawValue,
                 model: model ?? modelOverride,
                 resume: resume,
-                imageData: imageData,
+                imageData: effectiveImageData,
                 onTextDelta: textDeltaHandler,
                 onToolCall: toolCallHandler,
                 onToolActivity: toolActivityHandler,


### PR DESCRIPTION
## Summary
- When a proactive notification (insight/focus/memory) is saved as a chat message, it now carries notification context and the screenshot that triggered it
- When the user responds to a notification (in either floating bar or main chat), Claude automatically receives the context explaining it was a proactive notification plus the original screenshot
- No UI changes — the notification still looks the same to the user

Fixes the issue where Claude had no idea what generated a proactive notification and couldn't explain its reasoning when the user asked about it (e.g., "Stop hunting for a 1099-SA" → "why?" → "No record of you hunting...")

## Test plan
- [ ] Trigger a proactive notification (insight assistant)
- [ ] Respond to the notification in the floating bar — Claude should understand it sent the message
- [ ] Let the notification persist to main chat, respond there — Claude should still have context
- [ ] Verify UI looks unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)