### PR TITLE
Update CHANGELOG.json for v0.11.292 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed floating bar close button requiring multiple clicks by enlarging the hit area"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.292",
+      "date": "2026-04-11",
+      "changes": [
+        "Fixed floating bar close button requiring multiple clicks by enlarging the hit area"
+      ]
+    },
     {
       "version": "0.11.289",
       "date": "2026-04-11",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.292 and clears the unreleased array.