### PR TITLE
fix(desktop): Rewind captures frontmost window instead of backmost in fallback (#6552)

### DIFF
--- a/desktop/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/Desktop/Sources/ScreenCaptureService.swift
@@ -530,11 +530,20 @@ final class ScreenCaptureService: Sendable {
       }
     }
 
-    guard let largest = appWindows.max(by: { $0.area < $1.area }) else {
+    guard !appWindows.isEmpty else {
       return (appName, nil, nil)
     }
 
-    return (appName, largest.title, largest.windowID)
+    // CGWindowListCopyWindowInfo returns windows in front-to-back z-order,
+    // so the first element for a given PID is the frontmost on screen.
+    // Among windows with the largest area, prefer the frontmost (first in the
+    // array) so we capture the window the user is looking at instead of the
+    // backmost equal-sized window (which is often the first one opened).
+    // Fixes: https://github.com/BasedHardware/omi/issues/6552
+    let maxArea = appWindows.map(\.area).max()!
+    let frontmost = appWindows.first(where: { $0.area == maxArea })!
+
+    return (appName, frontmost.title, frontmost.windowID)
   }
 
   /// Private API: get CGWindowID directly from an AXUIElement (avoids fragile position/size matching)


### PR DESCRIPTION
## Problem

When the Accessibility API is unavailable (e.g., certain app configurations, AX failures after threshold), `getActiveWindowInfo()` falls back to picking the largest window from `CGWindowListCopyWindowInfo`. However, when multiple windows of the same app have equal area (common with Safari, Finder, etc.), Swift's `max(by:)` returns the **last** element. Since CGWindowList is ordered front-to-back, this selects the **backmost** (first-opened) window instead of the frontmost focused one.

This caused Rewind to capture a background Reddit window while the user was actively working in a different Safari window, triggering incorrect productivity notifications.

## Fix

Among windows tied for largest area, prefer the **first** in z-order (frontmost on screen). Uses `first(where:)` on the max area instead of `max(by:)` directly.

- Surgical 1-file change in `ScreenCaptureService.swift`
- Only affects fallback heuristic (AX path unchanged)
- Build verified: `swift build` passes

Closes #6552