### PR TITLE
docs(onboarding): fix outdated button controls and LED indicators

### DIFF
--- a/docs/onboarding/omi.mdx
+++ b/docs/onboarding/omi.mdx
@@ -12,8 +12,8 @@ sidebarTitle: "Omi Setup"
   <Step title="Charge Your Device" icon="battery-full">
     Make sure your Omi device is charged. When you switch it on, there should be a light indicator.
 
-    - Turn on the device using the button in the center
-    - Look for the LED light to confirm it's powered on
+    - Press the button once to turn on the device
+    - Look for the LED light to confirm it's powered on (blue if connected, red if not yet paired)
   </Step>
   <Step title="Download the Omi App" icon="mobile">
     Download the official Omi app from your device's app store:
@@ -53,19 +53,21 @@ sidebarTitle: "Omi Setup"
 
 ## Button Controls
 
-<CardGroup cols={2}>
-  <Card title="Single Press" icon="hand-pointer">
-    **Turn On/Off**
+<CardGroup cols={3}>
+  <Card title="Single Tap" icon="hand-pointer">
+    **Notification Event**
 
-    Single press to power the device on or off
+    Quick tap (under 300ms) to trigger an action in the app
   </Card>
-  <Card title="Long Press" icon="hand">
-    **Voice Questions**
+  <Card title="Double Tap" icon="hand-peace">
+    **Notification Event**
 
-    1. Press and hold until you feel a vibration
-    2. Keep pressed and ask your question
-    3. Release when you're done speaking
-    4. Get your answer in Omi chat or as a notification
+    Two quick taps to trigger a second action in the app
+  </Card>
+  <Card title="Long Press (3s)" icon="hand">
+    **Power Off**
+
+    Press and hold for 3 seconds to turn the device off. Press the button once to turn it back on.
   </Card>
 </CardGroup>
 
@@ -77,10 +79,11 @@ Understanding your Omi's status through LED colors:
 
 | Color | Status |
 |-------|--------|
-| 🔴 **Red** | Device is on but disconnected from your phone |
-| 🔵 **Blue** | Device is on and connected to your phone |
-| 🟠 **Orange** | Device is charging and disconnected |
-| 🔵 **Teal** | Device is charging and connected |
+| 🔴 **Solid Red** | Device is on but disconnected from your phone |
+| 🔵 **Solid Blue** | Device is on and connected to your phone |
+| 🟢 **Blinking Green + Red** | Charging while disconnected |
+| 🟢 **Blinking Green + Blue** | Charging while connected |
+| 🟢 **Solid Green** | Fully charged (battery ≥ 98%) |
 
 ---
 


### PR DESCRIPTION
## Summary
- **Button controls were wrong**: single press doesn't power off (it's a tap event), long press (3s) powers off, double tap was missing
- **LED indicators were wrong**: orange/teal colors don't exist in current firmware; charging shows blinking green, fully charged shows solid green
- Updated to match current firmware (`omi/firmware/omi/src/lib/core/button.c` and `main.c`)

## Test plan
- [ ] Verify docs page renders correctly on docs.omi.me after merge
- [x] Cross-referenced with firmware source code

🤖 Generated with [Claude Code](https://claude.com/claude-code)