### PR TITLE
feat(mcp): add search_memories and search_conversations tools

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -22,6 +22,7 @@ from utils.other.endpoints import check_rate_limit_inline
 import database.memories as memories_db
 import database.conversations as conversations_db
 import database.mcp_api_key as mcp_api_key_db
+import database.vector_db as vector_db
 from models.memories import MemoryDB, Memory, MemoryCategory
 from models.conversation_enums import CategoryEnum
 from utils.llm.memories import identify_category_for_memory
@@ -142,6 +143,32 @@ MCP_TOOLS = [
                 "conversation_id": {"type": "string", "description": "The ID of the conversation to retrieve"}
             },
             "required": ["conversation_id"],
+        },
+    },
+    {
+        "name": "search_memories",
+        "description": "Semantic search across the user's memories. Returns memories ranked by relevance to the query.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Natural language search query"},
+                "limit": {"type": "integer", "description": "Maximum number of results to return", "default": 10},
+            },
+            "required": ["query"],
+        },
+    },
+    {
+        "name": "search_conversations",
+        "description": "Semantic search across the user's conversations. Returns conversations ranked by relevance to the query.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Natural language search query"},
+                "start_date": {"type": "string", "description": "Filter after this date (yyyy-mm-dd)"},
+                "end_date": {"type": "string", "description": "Filter before this date (yyyy-mm-dd)"},
+                "limit": {"type": "integer", "description": "Maximum number of results to return", "default": 10},
+            },
+            "required": ["query"],
         },
     },
 ]
@@ -298,6 +325,86 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
             raise ToolExecutionError("A paid plan is required to access this conversation.", code=-32002)
 
         return {"conversation": conversation}
+
+    elif tool_name == "search_memories":
+        query = arguments.get("query")
+        if not query:
+            raise ToolExecutionError("query is required")
+
+        limit = arguments.get("limit", 10)
+
+        matches = vector_db.find_similar_memories(user_id, query, threshold=0.0, limit=limit)
+        if not matches:
+            return {"memories": []}
+
+        memory_ids = [m['id'] for m in matches]
+        memories = memories_db.get_memories_by_ids(user_id, memory_ids)
+
+        # Build score lookup and filter locked
+        score_map = {m['id']: m.get('score', 0) for m in matches}
+        results = []
+        for mem in memories:
+            if mem.get('is_locked', False):
+                content = mem.get('content', '')
+                mem['content'] = (content[:70] + '...') if len(content) > 70 else content
+            mem['relevance_score'] = round(score_map.get(mem.get('id'), 0), 4)
+            results.append(mem)
+
+        # Sort by relevance
+        results.sort(key=lambda x: x.get('relevance_score', 0), reverse=True)
+
+        return {"memories": results}
+
+    elif tool_name == "search_conversations":
+        query = arguments.get("query")
+        if not query:
+            raise ToolExecutionError("query is required")
+
+        limit = arguments.get("limit", 10)
+        start_date = arguments.get("start_date")
+        end_date = arguments.get("end_date")
+
+        # Parse dates to epoch for vector search
+        starts_at = None
+        ends_at = None
+        if start_date:
+            try:
+                starts_at = int(datetime.strptime(start_date, "%Y-%m-%d").timestamp())
+            except ValueError:
+                raise ToolExecutionError(
+                    f"Invalid start_date format: '{start_date}'. Expected YYYY-MM-DD.", code=-32602
+                )
+        if end_date:
+            try:
+                ends_at = int(datetime.strptime(end_date, "%Y-%m-%d").timestamp())
+            except ValueError:
+                raise ToolExecutionError(f"Invalid end_date format: '{end_date}'. Expected YYYY-MM-DD.", code=-32602)
+
+        conversation_ids = vector_db.query_vectors(query, user_id, starts_at=starts_at, ends_at=ends_at, k=limit)
+        if not conversation_ids:
+            return {"conversations": []}
+
+        conversations = conversations_db.get_conversations_by_id(user_id, conversation_ids)
+
+        # Simplify and handle locked content
+        results = []
+        for conv in conversations:
+            structured = conv.get("structured")
+            if conv.get("is_locked", False) and structured:
+                structured = dict(structured)
+                structured['action_items'] = []
+                structured['events'] = []
+            results.append(
+                {
+                    "id": conv.get("id"),
+                    "started_at": conv.get("started_at"),
+                    "finished_at": conv.get("finished_at"),
+                    "structured": structured,
+                    "language": conv.get("language"),
+                }
+            )
+
+        return {"conversations": results}
 
     else:
         raise ToolExecutionError(f"Unknown tool: {tool_name}", code=-32601)

--- a/docs/doc/developer/MCP.mdx
+++ b/docs/doc/developer/MCP.mdx
@@ -81,24 +81,36 @@ The API key can also be provided with each tool call. If not provided, the serve
 
 <AccordionGroup>
   <Accordion title="get_memories" icon="brain">
-    Retrieve a list of user memories.
+    Retrieve a list of user memories with optional filtering.
 
     **Parameters:**
     | Name | Type | Required | Description |
     |------|------|----------|-------------|
-    | `limit` | number | No | Maximum number of memories to retrieve (default: 100) |
-    | `categories` | array | No | Categories to filter by (default: []) |
+    | `categories` | array | No | Categories to filter by |
+    | `limit` | number | No | Maximum number of memories (default: 100) |
+    | `offset` | number | No | Offset for pagination (default: 0) |
 
     **Returns:** JSON object containing list of memories
   </Accordion>
+  <Accordion title="search_memories" icon="magnifying-glass">
+    Semantic search across memories. Returns results ranked by relevance.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `query` | string | Yes | Natural language search query |
+    | `limit` | number | No | Maximum number of results (default: 10) |
+
+    **Returns:** List of memories with `relevance_score` field
+  </Accordion>
   <Accordion title="create_memory" icon="plus">
-    Create a new memory.
+    Create a new memory. Category is auto-detected if not provided.
 
     **Parameters:**
     | Name | Type | Required | Description |
     |------|------|----------|-------------|
     | `content` | string | Yes | Content of the memory |
-    | `category` | MemoryFilterOptions | Yes | Category of the memory |
+    | `category` | string | No | Category of the memory |
 
     **Returns:** Created memory object
   </Accordion>
@@ -124,15 +136,41 @@ The API key can also be provided with each tool call. If not provided, the serve
     **Returns:** Status of the operation
   </Accordion>
   <Accordion title="get_conversations" icon="comments">
-    Retrieve a list of user conversations.
+    Retrieve a list of conversations with optional date and category filtering.
 
     **Parameters:**
     | Name | Type | Required | Description |
     |------|------|----------|-------------|
-    | `include_discarded` | boolean | No | Include discarded conversations (default: false) |
-    | `limit` | number | No | Maximum number of conversations (default: 25) |
+    | `start_date` | string | No | Filter after this date (YYYY-MM-DD) |
+    | `end_date` | string | No | Filter before this date (YYYY-MM-DD) |
+    | `categories` | array | No | Categories to filter by |
+    | `limit` | number | No | Maximum number of conversations (default: 20) |
+    | `offset` | number | No | Offset for pagination (default: 0) |
 
-    **Returns:** List of conversation objects containing transcripts, timestamps, geolocation, and structured summaries
+    **Returns:** List of conversation metadata (use `get_conversation_by_id` for full transcripts)
+  </Accordion>
+  <Accordion title="search_conversations" icon="magnifying-glass">
+    Semantic search across conversations. Returns results ranked by relevance.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `query` | string | Yes | Natural language search query |
+    | `start_date` | string | No | Filter after this date (YYYY-MM-DD) |
+    | `end_date` | string | No | Filter before this date (YYYY-MM-DD) |
+    | `limit` | number | No | Maximum number of results (default: 10) |
+
+    **Returns:** List of matching conversations ranked by relevance
+  </Accordion>
+  <Accordion title="get_conversation_by_id" icon="file-lines">
+    Retrieve a single conversation by ID, including the full transcript.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `conversation_id` | string | Yes | The ID of the conversation |
+
+    **Returns:** Full conversation object with transcript segments
   </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
## Summary
- Adds `search_memories` tool — semantic search via Pinecone vectors, returns results ranked by `relevance_score`
- Adds `search_conversations` tool — semantic search with optional date range filtering
- Updates MCP docs with all 8 tools (was missing `search_*`, `get_conversation_by_id`, and several parameters)

Closes #6555

## Changes
- `backend/routers/mcp_sse.py`: 2 new tool definitions + execution handlers using `vector_db.find_similar_memories()` and `vector_db.query_vectors()`
- `docs/doc/developer/MCP.mdx`: Updated Available Tools section

## Test plan
- [x] Syntax check passes
- [x] Unit tests pass (prompt cache tests)
- [ ] Test `search_memories` via MCP client with a query
- [ ] Test `search_conversations` via MCP client with query + date range
- [ ] Verify locked content truncation works on search results

🤖 Generated with [Claude Code](https://claude.com/claude-code)