### PR TITLE
docs(mcp): restructure into comprehensive multi-page docs

### DIFF
--- a/docs/doc/developer/mcp/examples.mdx
+++ b/docs/doc/developer/mcp/examples.mdx
@@ -1,0 +1,76 @@
+---
+title: "Examples"
+icon: "code"
+description: "Example prompts and integrations with the Omi MCP server"
+---
+
+## Example Prompts
+
+Once connected, try these prompts with your AI assistant:
+
+<AccordionGroup>
+  <Accordion title="Search and recall" icon="magnifying-glass">
+    ```
+    "What do you know about my work projects?"
+    "Find conversations where I discussed travel plans"
+    "Search my memories for anything about fitness goals"
+    "What did I talk about last Tuesday?"
+    ```
+  </Accordion>
+  <Accordion title="Memory management" icon="brain">
+    ```
+    "Remember that I prefer morning meetings before 10am"
+    "Update my memory about my favorite restaurant — it's now Sushi Nakazawa"
+    "Delete the memory about my old phone number"
+    "What are all my memories in the 'work' category?"
+    ```
+  </Accordion>
+  <Accordion title="Conversation analysis" icon="chart-line">
+    ```
+    "Summarize my conversations from this week"
+    "Find the conversation where I brainstormed app ideas"
+    "What topics come up most in my recent conversations?"
+    "Show me the full transcript of my last meeting"
+    ```
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Integration Examples
+
+<CardGroup cols={3}>
+  <Card title="LangChain" icon="link" href="https://github.com/BasedHardware/omi/tree/main/mcp/examples">
+    Build chains with Omi data
+  </Card>
+  <Card title="OpenAI Agents" icon="robot" href="https://github.com/BasedHardware/omi/tree/main/mcp/examples">
+    Create AI agents using Omi
+  </Card>
+  <Card title="DSPy" icon="code" href="https://github.com/BasedHardware/omi/tree/main/mcp/examples">
+    Programmatic LLM pipelines
+  </Card>
+</CardGroup>
+
+---
+
+## Python SDK Example
+
+```python
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+async with MultiServerMCPClient({
+    "omi": {
+        "url": "https://api.omi.me/v1/mcp/sse",
+        "transport": "streamable_http",
+        "headers": {"Authorization": "Bearer omi_mcp_YOUR_KEY"},
+    }
+}) as client:
+    tools = client.get_tools()
+
+    # Search memories
+    result = await client.call_tool("omi", "search_memories", {
+        "query": "morning routine",
+        "limit": 5,
+    })
+    print(result)
+```

--- a/docs/doc/developer/mcp/introduction.mdx
+++ b/docs/doc/developer/mcp/introduction.mdx
@@ -1,0 +1,74 @@
+---
+title: "Introduction"
+icon: "plug"
+description: "Connect AI assistants to your Omi data using the Model Context Protocol"
+---
+
+## What is MCP?
+
+The [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open standard that lets AI assistants like Claude, Cursor, and other tools interact with external data sources. Omi's MCP server gives these assistants direct access to your memories and conversations.
+
+<CardGroup cols={3}>
+  <Card title="Search & Retrieve" icon="magnifying-glass">
+    Semantic search across your memories and conversations
+  </Card>
+  <Card title="Manage Memories" icon="brain">
+    Create, edit, and delete memories
+  </Card>
+  <Card title="Access Conversations" icon="comments">
+    Browse and search full conversation transcripts
+  </Card>
+</CardGroup>
+
+---
+
+## How It Works
+
+```mermaid
+sequenceDiagram
+    participant A as AI Assistant (Claude, Cursor, etc.)
+    participant M as Omi MCP Server
+    participant D as Your Omi Data
+
+    A->>M: tools/list (discover available tools)
+    M-->>A: 8 tools available
+    A->>M: tools/call search_memories {query: "morning routine"}
+    M->>D: Semantic search via Pinecone
+    D-->>M: Ranked results
+    M-->>A: Memories with relevance scores
+```
+
+Your AI assistant connects to the Omi MCP server, discovers available tools, and calls them as needed during your conversations. All data stays within your Omi account — the MCP server authenticates via your personal API key.
+
+---
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `get_memories` | List memories with optional category filtering |
+| `search_memories` | Semantic search across memories |
+| `create_memory` | Create a new memory |
+| `edit_memory` | Edit an existing memory |
+| `delete_memory` | Delete a memory |
+| `get_conversations` | List conversations with date/category filters |
+| `search_conversations` | Semantic search across conversations |
+| `get_conversation_by_id` | Get full conversation with transcript |
+
+See the [Tools Reference](/doc/developer/mcp/tools) for full parameter documentation.
+
+---
+
+## Comparison with Developer API
+
+| Feature | MCP | Developer API |
+|---------|-----|---------------|
+| **Purpose** | AI assistant integration | Direct HTTP API access |
+| **Access** | Read/write with AI context | Read & write user data |
+| **Search** | Semantic search built-in | Filter-based queries |
+| **Use Case** | Claude Desktop, Cursor, AI agents | Custom apps, dashboards |
+| **Best For** | AI-powered workflows | Batch operations, integrations |
+
+<Info>
+For programmatic access without AI assistants, use the [Developer API](/doc/developer/api/overview) instead.
+</Info>

--- a/docs/doc/developer/mcp/setup.mdx
+++ b/docs/doc/developer/mcp/setup.mdx
@@ -1,0 +1,127 @@
+---
+title: "Setup"
+icon: "gear"
+description: "Connect your AI assistant to the Omi MCP server"
+---
+
+## Hosted Server (Recommended)
+
+The fastest way to get started — no installation required.
+
+<Steps>
+  <Step title="Generate an API Key" icon="key">
+    Open the Omi app and navigate to **Settings → Developer → MCP** to generate your API key.
+
+    Your key will look like: `omi_mcp_...`
+  </Step>
+  <Step title="Configure Your Client" icon="sliders">
+    Use the following connection details:
+
+    - **Server URL:** `https://api.omi.me/v1/mcp/sse`
+    - **Authorization:** `Bearer omi_mcp_...` (your generated key)
+    - **Transport:** Streamable HTTP (MCP 2025-03-26 spec)
+  </Step>
+</Steps>
+
+---
+
+## Client Configuration
+
+<Tabs>
+  <Tab title="Claude Desktop" icon="robot">
+    Add to your `claude_desktop_config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "omi": {
+          "url": "https://api.omi.me/v1/mcp/sse",
+          "headers": {
+            "Authorization": "Bearer omi_mcp_YOUR_KEY_HERE"
+          }
+        }
+      }
+    }
+    ```
+
+    **Config file location:**
+    - macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+    - Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+  </Tab>
+  <Tab title="Cursor" icon="i-cursor">
+    Go to **Cursor Settings → MCP** and add a new server:
+
+    - **Name:** Omi
+    - **Transport:** SSE
+    - **URL:** `https://api.omi.me/v1/mcp/sse`
+    - **Headers:** `Authorization: Bearer omi_mcp_YOUR_KEY_HERE`
+  </Tab>
+  <Tab title="Poke" icon="circle-play">
+    <img src="/images/poke-mcp-setup.png" alt="Poke MCP Setup" className="rounded-xl border border-gray-200 dark:border-gray-800" />
+
+    Enter the server URL and API key in Poke's MCP connection settings.
+  </Tab>
+  <Tab title="Custom Client" icon="code">
+    Any MCP client that supports the **Streamable HTTP** transport (2025-03-26 spec) will work:
+
+    ```bash
+    # Endpoint
+    POST https://api.omi.me/v1/mcp/sse
+
+    # Headers
+    Authorization: Bearer omi_mcp_YOUR_KEY_HERE
+    Content-Type: application/json
+    Accept: text/event-stream  # for SSE responses
+
+    # Body (JSON-RPC 2.0)
+    {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+## Docker (Self-Hosted)
+
+If you prefer to run the MCP server locally:
+
+<Steps>
+  <Step title="Generate an API Key" icon="key">
+    Open the Omi app → **Settings → Developer → MCP** to generate your key.
+  </Step>
+  <Step title="Install Docker" icon="docker">
+    Install Docker. We recommend [OrbStack](https://orbstack.dev/) for macOS.
+  </Step>
+  <Step title="Configure Claude Desktop" icon="gear">
+    Add to your `claude_desktop_config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "omi": {
+          "command": "docker",
+          "args": ["run", "--rm", "-i", "-e", "OMI_API_KEY=omi_mcp_YOUR_KEY_HERE", "omiai/mcp-server"]
+        }
+      }
+    }
+    ```
+  </Step>
+</Steps>
+
+<Tip>
+The API key can also be provided with each tool call. If not provided, the server uses the `OMI_API_KEY` environment variable as a fallback.
+</Tip>
+
+---
+
+## Custom Backend URL
+
+If you are self-hosting the Omi backend:
+
+```bash
+export OMI_API_BASE_URL="https://your-backend-url.com"
+```
+
+<Note>
+Only needed for self-hosted Omi instances. The default URL points to the official Omi API.
+</Note>

--- a/docs/doc/developer/mcp/tools.mdx
+++ b/docs/doc/developer/mcp/tools.mdx
@@ -1,0 +1,180 @@
+---
+title: "Tools Reference"
+icon: "wrench"
+description: "Complete reference for all Omi MCP tools"
+---
+
+## Memory Tools
+
+<AccordionGroup>
+  <Accordion title="get_memories" icon="brain">
+    Retrieve a list of user memories with optional filtering.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `categories` | array | No | Categories to filter by |
+    | `limit` | number | No | Maximum number of memories (default: 100) |
+    | `offset` | number | No | Offset for pagination (default: 0) |
+
+    **Returns:** `{ "memories": [...] }`
+
+    **Example:**
+    ```
+    "Search my memories" → get_memories with no filters
+    "What do you know about my hobbies?" → get_memories with categories: ["hobbies"]
+    ```
+
+    **Memory categories:** `interesting`, `core`, `hobbies`, `lifestyle`, `interests`, `habits`, `work`, `skills`, `learnings`, `other`
+  </Accordion>
+
+  <Accordion title="search_memories" icon="magnifying-glass">
+    Semantic search across memories. Returns results ranked by relevance using vector similarity.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `query` | string | Yes | Natural language search query |
+    | `limit` | number | No | Maximum number of results (default: 10) |
+
+    **Returns:** `{ "memories": [{ ..., "relevance_score": 0.92 }, ...] }`
+
+    Each result includes a `relevance_score` (0.0 to 1.0) indicating how well it matches the query.
+
+    **Example:**
+    ```
+    "What do I know about machine learning?" → search_memories with query: "machine learning"
+    "Find memories about my morning routine" → search_memories with query: "morning routine"
+    ```
+  </Accordion>
+
+  <Accordion title="create_memory" icon="plus">
+    Create a new memory. Category is auto-detected if not provided.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `content` | string | Yes | Content of the memory |
+    | `category` | string | No | Category (auto-detected if omitted) |
+
+    **Returns:** `{ "success": true, "memory": { ... } }`
+  </Accordion>
+
+  <Accordion title="edit_memory" icon="pen">
+    Edit an existing memory's content.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `memory_id` | string | Yes | ID of the memory to edit |
+    | `content` | string | Yes | New content for the memory |
+
+    **Returns:** `{ "success": true }`
+  </Accordion>
+
+  <Accordion title="delete_memory" icon="trash">
+    Delete a memory by ID.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `memory_id` | string | Yes | ID of the memory to delete |
+
+    **Returns:** `{ "success": true }`
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Conversation Tools
+
+<AccordionGroup>
+  <Accordion title="get_conversations" icon="comments">
+    Retrieve a list of conversations with optional date and category filtering.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `start_date` | string | No | Filter after this date (YYYY-MM-DD) |
+    | `end_date` | string | No | Filter before this date (YYYY-MM-DD) |
+    | `categories` | array | No | Categories to filter by |
+    | `limit` | number | No | Maximum number of conversations (default: 20) |
+    | `offset` | number | No | Offset for pagination (default: 0) |
+
+    **Returns:** `{ "conversations": [...] }` — metadata only. Use `get_conversation_by_id` for full transcripts.
+
+    **Example:**
+    ```
+    "What did I talk about last week?" → get_conversations with date range
+    "Show my work conversations" → get_conversations with categories: ["work"]
+    ```
+
+    **Conversation categories:** `personal`, `education`, `health`, `finance`, `technology`, `business`, `work`, `social`, `travel`, `entertainment`, `sports`, `family`, and more.
+  </Accordion>
+
+  <Accordion title="search_conversations" icon="magnifying-glass">
+    Semantic search across conversations. Returns results ranked by relevance using vector similarity.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `query` | string | Yes | Natural language search query |
+    | `start_date` | string | No | Filter after this date (YYYY-MM-DD) |
+    | `end_date` | string | No | Filter before this date (YYYY-MM-DD) |
+    | `limit` | number | No | Maximum number of results (default: 10) |
+
+    **Returns:** `{ "conversations": [...] }` — ranked by relevance to the query.
+
+    **Example:**
+    ```
+    "When did I discuss the product launch?" → search_conversations with query: "product launch"
+    "Find conversations about hiring from January" → search_conversations with query: "hiring", start_date: "2026-01-01", end_date: "2026-01-31"
+    ```
+  </Accordion>
+
+  <Accordion title="get_conversation_by_id" icon="file-lines">
+    Retrieve a single conversation by ID, including the full transcript with speaker segments.
+
+    **Parameters:**
+    | Name | Type | Required | Description |
+    |------|------|----------|-------------|
+    | `conversation_id` | string | Yes | The ID of the conversation |
+
+    **Returns:** Full conversation object with transcript segments, timestamps, structured summary, and metadata.
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Error Handling
+
+All tools return JSON-RPC 2.0 errors when something goes wrong:
+
+| Code | Meaning |
+|------|---------|
+| `-32602` | Invalid parameters (bad date format, unknown category) |
+| `-32001` | Resource not found (memory or conversation doesn't exist) |
+| `-32002` | Locked content (paid plan required) |
+| `-32601` | Unknown tool name |
+
+**Example error response:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32001,
+    "message": "Memory not found"
+  }
+}
+```
+
+---
+
+## Locked Content
+
+Memories and conversations behind the paid plan are handled gracefully:
+
+- **Memories:** Content is truncated to 70 characters with `...`
+- **Conversations:** Action items and events are hidden from the structured data
+- **Direct access:** Returns error `-32002` with a clear message

--- a/docs/doc/developer/mcp/troubleshooting.mdx
+++ b/docs/doc/developer/mcp/troubleshooting.mdx
@@ -1,0 +1,106 @@
+---
+title: "Troubleshooting"
+icon: "bug"
+description: "Debug and fix common MCP connection issues"
+---
+
+## Common Issues
+
+<AccordionGroup>
+  <Accordion title="Connection refused or 401 Unauthorized" icon="lock">
+    - Verify your API key starts with `omi_mcp_`
+    - Check that the `Authorization` header uses `Bearer` prefix: `Bearer omi_mcp_...`
+    - Generate a new key in the Omi app: **Settings → Developer → MCP**
+    - Ensure the key hasn't been revoked
+  </Accordion>
+  <Accordion title="No tools showing up" icon="toolbox">
+    - Send an `initialize` request first — tools are only available after initialization
+    - Check that your client supports the Streamable HTTP transport (2025-03-26 spec)
+    - Try the `/v1/mcp/sse/info` endpoint to verify the server is reachable:
+      ```bash
+      curl https://api.omi.me/v1/mcp/sse/info
+      ```
+  </Accordion>
+  <Accordion title="Search returns empty results" icon="magnifying-glass">
+    - Semantic search requires conversations/memories to be indexed in the vector database
+    - New data may take a few minutes to be indexed after creation
+    - Try broader queries — very specific queries may not match if phrased differently than the original
+    - Use `get_memories` or `get_conversations` with filters as a fallback
+  </Accordion>
+  <Accordion title="Rate limit errors (429)" icon="gauge-high">
+    - The MCP server has per-user rate limits to prevent abuse
+    - Wait a moment and retry
+    - Reduce the frequency of tool calls in automated workflows
+  </Accordion>
+  <Accordion title="Locked content errors (-32002)" icon="lock">
+    - Some memories and conversations are behind the paid plan
+    - Upgrade your plan to access all content
+    - Locked memories still appear in list/search results with truncated content
+  </Accordion>
+</AccordionGroup>
+
+---
+
+## Debugging Tools
+
+<Tabs>
+  <Tab title="MCP Inspector" icon="magnifying-glass">
+    Use the MCP inspector to test tools interactively:
+
+    ```bash
+    npx @modelcontextprotocol/inspector uvx mcp-server-omi
+    ```
+
+    For local development:
+
+    ```bash
+    cd path/to/servers/src/omi
+    npx @modelcontextprotocol/inspector uv run mcp-server-omi
+    ```
+  </Tab>
+  <Tab title="curl" icon="terminal">
+    Test the server directly:
+
+    ```bash
+    # Check server info
+    curl https://api.omi.me/v1/mcp/sse/info
+
+    # Initialize a session
+    curl -X POST https://api.omi.me/v1/mcp/sse \
+      -H "Authorization: Bearer omi_mcp_YOUR_KEY" \
+      -H "Content-Type: application/json" \
+      -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+
+    # List tools (use the Mcp-Session-Id from the initialize response)
+    curl -X POST https://api.omi.me/v1/mcp/sse \
+      -H "Authorization: Bearer omi_mcp_YOUR_KEY" \
+      -H "Content-Type: application/json" \
+      -H "Mcp-Session-Id: SESSION_ID_HERE" \
+      -d '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}'
+    ```
+  </Tab>
+  <Tab title="Log Files" icon="file-lines">
+    View Claude Desktop MCP logs:
+
+    ```bash
+    # macOS
+    tail -n 20 -f ~/Library/Logs/Claude/mcp-server-omi.log
+
+    # Windows
+    type %APPDATA%\Claude\logs\mcp-server-omi.log
+    ```
+  </Tab>
+</Tabs>
+
+---
+
+## Need Help?
+
+<CardGroup cols={2}>
+  <Card title="Discord Community" icon="discord" href="http://discord.omi.me">
+    Get help from the community and team
+  </Card>
+  <Card title="GitHub Issues" icon="github" href="https://github.com/BasedHardware/omi/issues">
+    Report bugs or request features
+  </Card>
+</CardGroup>

--- a/docs/doc/integrations.mdx
+++ b/docs/doc/integrations.mdx
@@ -1,5 +1,6 @@
 ---
-title: "Integrating Third-Party Wearables"
+title: "Integrate 3P Wearables"
+sidebarTitle: "Integrate 3P Wearables"
 icon: "puzzle-piece"
 description: "A guide to integrating any wearable device, like Plaud, Limitless, or your own custom hardware, with the Omi open-source ecosystem."
 ---

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -214,9 +214,23 @@
         "icon": "robot",
         "groups": [
           {
-            "group": "MCP Integration",
+            "group": "Getting Started",
             "pages": [
-              "doc/developer/MCP"
+              "doc/developer/mcp/introduction",
+              "doc/developer/mcp/setup"
+            ]
+          },
+          {
+            "group": "Reference",
+            "pages": [
+              "doc/developer/mcp/tools"
+            ]
+          },
+          {
+            "group": "Resources",
+            "pages": [
+              "doc/developer/mcp/examples",
+              "doc/developer/mcp/troubleshooting"
             ]
           }
         ]


### PR DESCRIPTION
## Summary
- Split the single MCP page into 5 focused pages with proper sidebar navigation
- MCP tab now has 3 sidebar groups: **Getting Started**, **Reference**, **Resources**
- Each page has icons, structured content, and follows the same patterns as Build Apps / API Reference tabs
- Also fixed "Integrating Third-Party Wearables" sidebar title → "Integrate 3P Wearables"

### New pages:
| Page | Content |
|------|---------|
| Introduction | What MCP is, how it works, tool summary table, comparison with Dev API |
| Setup | Hosted server, Claude Desktop/Cursor/Poke/custom client config tabs, Docker setup |
| Tools Reference | All 8 tools with full params, return types, examples, error codes, locked content handling |
| Examples | Prompt examples, integration cards, Python SDK code |
| Troubleshooting | Common issues accordion, debugging with curl/inspector/logs |

## Test plan
- [ ] Verify all 5 pages render correctly on docs.omi.me
- [ ] Verify sidebar shows 3 groups with proper icons
- [ ] Verify old `/doc/developer/MCP` URL still works (page still exists, just not in nav)

🤖 Generated with [Claude Code](https://claude.com/claude-code)