### PR TITLE
Fix floating bar close button first click

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarView.swift
@@ -63,11 +63,17 @@ struct FloatingControlBarView: View {
                 Button {
                     onCloseAI()
                 } label: {
-                    Image(systemName: "xmark")
-                        .font(.system(size: 8))
-                        .foregroundColor(.secondary)
-                        .frame(width: 16, height: 16)
-                        .overlay(Circle().strokeBorder(Color.white.opacity(0.2), lineWidth: 0.5))
+                    ZStack {
+                        Circle()
+                            .strokeBorder(Color.white.opacity(0.2), lineWidth: 0.5)
+                            .frame(width: 16, height: 16)
+
+                        Image(systemName: "xmark")
+                            .font(.system(size: 8))
+                            .foregroundColor(.secondary)
+                    }
+                    .frame(width: 20, height: 20)
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .padding(6)

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -2,6 +2,12 @@ import Cocoa
 import Combine
 import SwiftUI
 
+private final class FloatingBarHostingView<Content: View>: NSHostingView<Content> {
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+}
+
 /// NSPanel subclass for the floating control bar.
 ///
 /// Using a non-activating panel lets the Ask Omi shortcut focus the floating bar
@@ -135,7 +141,7 @@ class FloatingControlBarWindow: NSPanel, NSWindowDelegate {
             onShareLink: { [weak self] in await self?.onShareLink?() }
         ).environmentObject(state)
 
-        hostingView = NSHostingView(rootView: AnyView(
+        hostingView = FloatingBarHostingView(rootView: AnyView(
             swiftUIView
                 .withFontScaling()
                 .preferredColorScheme(.dark)


### PR DESCRIPTION
## Summary
- enlarge the floating bar close button hit target without changing the visible icon
- make the floating bar hosting view accept first-mouse events so the first exact click is not consumed activating the non-activating panel

## Verification
- `git diff --check`
- macOS build/run verification on the Mac mini was blocked by machine state: broken Homebrew git path, `xcodebuild` requiring `xcodebuild -runFirstLaunch`, and SwiftPM/Xcode environment instability on that host