### PR TITLE
fix(desktop): stop screen recording permission notification flood after auto-update

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,6 +1,7 @@
 {
   "unreleased": [
-    "Minimized pauses when Omi reads long voice responses out loud"
+    "Minimized pauses when Omi reads long voice responses out loud",
+    "Fixed duplicate Screen Recording permission warnings flooding the floating bar after auto-update"
   ],
   "releases": [
     {

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -833,6 +833,7 @@ class AppState: ObservableObject {
         isScreenCaptureKitBroken = false
         isScreenRecordingStale = false
         screenRecordingGrantAttempts = 0
+        UserDefaults.standard.removeObject(forKey: NotificationService.screenCaptureResetShownKey)
         return
       }
 
@@ -877,6 +878,7 @@ class AppState: ObservableObject {
         // Permission recovered (user toggled off/on in System Settings)
         isScreenRecordingStale = false
         screenRecordingGrantAttempts = 0
+        UserDefaults.standard.removeObject(forKey: NotificationService.screenCaptureResetShownKey)
       }
 
       if isScreenCaptureKitBroken {
@@ -888,6 +890,7 @@ class AppState: ObservableObject {
               log("AppState: ScreenCaptureKit recovered — clearing broken flag")
               self.isScreenCaptureKitBroken = false
               self.hasScreenRecordingPermission = true
+              UserDefaults.standard.removeObject(forKey: NotificationService.screenCaptureResetShownKey)
             }
           }
         }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/NotificationService.swift
@@ -64,6 +64,12 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
     /// Title that identifies screen capture reset notifications
     static let screenCaptureResetTitle = "Screen Recording Needs Reset"
 
+    /// UserDefaults key that records whether the screen capture reset notification
+    /// has already been shown in the current broken-capture episode. Cleared by
+    /// `AppState.checkScreenRecordingPermission()` as soon as capture recovers,
+    /// so a new breakage re-notifies exactly once.
+    static let screenCaptureResetShownKey = "screenCaptureResetNotificationShown"
+
     /// Stores metadata for sent notifications so we can retrieve it in delegate callbacks
     /// Key: notification identifier, Value: (title, assistantId)
     private var notificationMetadata: [String: (title: String, assistantId: String)] = [:]
@@ -208,6 +214,19 @@ class NotificationService: NSObject, UNUserNotificationCenterDelegate {
         context: FloatingBarNotificationContext? = nil,
         screenshotData: Data? = nil
     ) {
+        // Rate-limit the screen-capture reset notification to one per broken-capture
+        // episode. The recovery loop in ProactiveAssistantsPlugin.attemptAutoReset
+        // re-fires this on every session (soft-recovery + app restart), which buried
+        // users in duplicate banners when a stale TCC csreq from an auto-update made
+        // the capture path unrecoverable without a manual toggle in System Settings.
+        if title == Self.screenCaptureResetTitle {
+            if UserDefaults.standard.bool(forKey: Self.screenCaptureResetShownKey) {
+                log("NotificationService: suppressing duplicate screen capture reset notification")
+                return
+            }
+            UserDefaults.standard.set(true, forKey: Self.screenCaptureResetShownKey)
+        }
+
         FloatingControlBarManager.shared.showNotification(
             title: title,
             message: message,


### PR DESCRIPTION
## Summary

- Dedupes the "Screen Recording Needs Reset" notification to once per broken-capture episode using a persistent `UserDefaults` flag
- Clears the flag the moment capture actually recovers (either `CGPreflight`/`ScreenCaptureService.checkPermission()` or the async SCK self-test returns true), so a brand-new breakage later still re-notifies exactly once

## Why

PostHog shows **9,975 \`Screen Capture Broken Detected\` events across 124 unique users in the last 72 h**, with only **9 \`Screen Capture Reset Clicked\` events / 7 users** — a 0.09 % resolution rate. Top user hit **577 events in 72 h** (~one every 7.5 min). Users are seeing a screenshot-worthy stack of identical _"Screen recording permission needs to be re-enabled. Click to open Settings."_ banners in the floating bar.

Root cause: after a Sparkle auto-update the new Omi.app binary has a different code signing hash, so the TCC `csreq` stored for the Screen Recording grant no longer matches. `CGPreflightScreenCaptureAccess()` still returns `true`, but actual ScreenCaptureKit capture fails silently. `ProactiveAssistantsPlugin.handleCaptureFailure` → `attemptAutoReset` → `softRecoveryAndRestart()` restarts the app. The new session hits the same stale csreq, walks the same failure ladder, and re-fires the same `NotificationService.sendNotification(title: screenCaptureResetTitle, …)`. The in-process `hasSoftRecoveryThisSession` / `hasAutoResetThisSession` gates only dedupe within one app launch, so they don't help across the restart loop.

PR BasedHardware/omi#6493 (commit 9d4c9db49) already removed the `tccutil reset` path that used to wipe the user's grant entirely. That stopped permission from being destroyed but made the warning loop unrecoverable — the stale csreq persists forever, so the notification kept firing forever.

## What this PR does

- `NotificationService.swift`: early-return when `title == screenCaptureResetTitle` and `UserDefaults[screenCaptureResetNotificationShown] == true`; otherwise flip the flag and proceed as before.
- `AppState.swift`: clear the flag at every point where screen capture state flips back to "working" — the `tccGranted == false` branch when `actualPermission` becomes true, the `realPermission` recovery branch, and the async SCK self-test recovery branch.
- `CHANGELOG.json`: one-line entry under `unreleased`.

Users stuck in the flood will see the current in-flight notification suppressed on their next app launch (the flag persists across restarts — which is exactly the point). A new real breakage will re-notify exactly once.

## Test plan

- [ ] Build with \`OMI_APP_NAME=\"flood-fix\" ./run.sh\` on the Mac mini
- [ ] Manually set \`UserDefaults.standard.set(true, forKey: \"screenCaptureResetNotificationShown\")\` and confirm `NotificationService.sendNotification(title: \"Screen Recording Needs Reset\", …)` early-returns
- [ ] Toggle Screen Recording permission OFF then ON in System Settings → Privacy & Security and confirm the flag is cleared (log \`AppState: ScreenCaptureKit recovered\` + flag gone via \`defaults read com.omi.flood-fix screenCaptureResetNotificationShown\`)
- [ ] Confirm the floating-bar notification fires exactly once on fresh breakage
- [ ] Check PostHog the next day: \`Screen Capture Broken Detected\` event count per user should drop to ≤ 1 per episode, not hundreds

🤖 Generated with [Claude Code](https://claude.com/claude-code)