### PR TITLE
Add frosted floating bar background

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBackgroundModifier.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBackgroundModifier.swift
@@ -34,11 +34,14 @@ struct FloatingBackgroundModifier: ViewModifier {
                     if settings.solidBackground {
                         Color(nsColor: NSColor(white: 0.12, alpha: 1.0))
                     } else {
-                        VisualEffectView(material: .fullScreenUI, blendingMode: .behindWindow, alphaValue: 0.6)
+                        ZStack {
+                            VisualEffectView(material: .hudWindow, blendingMode: .behindWindow, alphaValue: 0.95)
+                            Color.black.opacity(0.18)
+                        }
                     }
                 }
             )
-            .cornerRadius(cornerRadius)
+            .clipShape(.rect(cornerRadius: cornerRadius))
             .overlay(
                 RoundedRectangle(cornerRadius: cornerRadius)
                     .strokeBorder(Color.black.opacity(0.5), lineWidth: 1)


### PR DESCRIPTION
## Summary
- make the floating bar background more frosted and less transparent by switching to a denser material
- add a subtle dark tint overlay so the bar reads more cleanly over busy content
- keep this in the shared floating background modifier so it becomes the default for the floating bar surfaces

## Verification
- launched a local manual test build: `/Applications/frosted-bar-test.app`
- connected with `agent-swift` to `com.omi.frosted-bar-test`