### PR TITLE
Update CHANGELOG.json for v0.11.298 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,10 +1,15 @@
 {
-  "unreleased": [
-    "Minimized pauses when Omi reads long voice responses out loud",
-    "Fixed duplicate Screen Recording permission warnings flooding the floating bar after auto-update",
-    "Improved chat tool discoverability: richer database schema with column descriptions, table relationships, FTS search patterns, new search_tasks tool, and enriched daily recap with focus sessions, memories, and observations"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.298",
+      "date": "2026-04-13",
+      "changes": [
+        "Minimized pauses when Omi reads long voice responses out loud",
+        "Fixed duplicate Screen Recording permission warnings flooding the floating bar after auto-update",
+        "Improved chat tool discoverability: richer database schema with column descriptions, table relationships, FTS search patterns, new search_tasks tool, and enriched daily recap with focus sessions, memories, and observations"
+      ]
+    },
     {
       "version": "0.11.296",
       "date": "2026-04-13",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.298 and clears the unreleased array.