### PR TITLE
fix(app): fire Task Integration Enabled event for all integrations

### DIFF
--- a/app/lib/core/app_shell.dart
+++ b/app/lib/core/app_shell.dart
@@ -30,6 +30,7 @@ import 'package:omi/services/google_tasks_service.dart';
 import 'package:omi/services/notifications.dart';
 import 'package:omi/services/todoist_service.dart';
 import 'package:omi/utils/alerts/app_snackbar.dart';
+import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/l10n_extensions.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_manager.dart';
@@ -227,6 +228,7 @@ class _AppShellState extends State<AppShell> {
     if (!mounted) return;
 
     if (success) {
+      MixpanelManager().taskIntegrationEnabled(appName: 'todoist', success: true);
       Logger.debug('✓ Todoist authentication completed successfully');
       Logger.debug('✓ Task integration enabled: Todoist - authentication complete');
       AppSnackbar.showSnackbar(context.l10n.successfullyConnectedTodoist);
@@ -234,6 +236,7 @@ class _AppShellState extends State<AppShell> {
       // Notify task integration provider to refresh UI from Firebase
       context.read<TaskIntegrationProvider>().refresh();
     } else {
+      MixpanelManager().taskIntegrationAuthFailed(appName: 'todoist');
       Logger.debug('Failed to complete Todoist authentication');
       AppSnackbar.showSnackbarError(context.l10n.failedToConnectTodoistRetry);
     }
@@ -246,6 +249,7 @@ class _AppShellState extends State<AppShell> {
     if (!mounted) return;
 
     if (success) {
+      MixpanelManager().taskIntegrationEnabled(appName: 'asana', success: true);
       Logger.debug('✓ Asana authentication completed successfully');
       Logger.debug('✓ Task integration enabled: Asana - authentication complete');
       AppSnackbar.showSnackbar(context.l10n.successfullyConnectedAsana);
@@ -258,6 +262,7 @@ class _AppShellState extends State<AppShell> {
         Navigator.of(context).push(MaterialPageRoute(builder: (context) => const AsanaSettingsPage()));
       }
     } else {
+      MixpanelManager().taskIntegrationAuthFailed(appName: 'asana');
       Logger.debug('Failed to complete Asana authentication');
       AppSnackbar.showSnackbarError(context.l10n.failedToConnectAsanaRetry);
     }
@@ -270,6 +275,7 @@ class _AppShellState extends State<AppShell> {
     if (!mounted) return;
 
     if (success) {
+      MixpanelManager().taskIntegrationEnabled(appName: 'google_tasks', success: true);
       Logger.debug('✓ Google Tasks authentication completed successfully');
       Logger.debug('✓ Task integration enabled: Google Tasks - authentication complete');
       AppSnackbar.showSnackbar(context.l10n.successfullyConnectedGoogleTasks);
@@ -277,6 +283,7 @@ class _AppShellState extends State<AppShell> {
       // Notify task integration provider to refresh UI from Firebase
       context.read<TaskIntegrationProvider>().refresh();
     } else {
+      MixpanelManager().taskIntegrationAuthFailed(appName: 'google_tasks');
       Logger.debug('Failed to complete Google Tasks authentication');
       AppSnackbar.showSnackbarError(context.l10n.failedToConnectGoogleTasksRetry);
     }
@@ -289,6 +296,7 @@ class _AppShellState extends State<AppShell> {
     if (!mounted) return;
 
     if (success) {
+      MixpanelManager().taskIntegrationEnabled(appName: 'clickup', success: true);
       Logger.debug('✓ ClickUp authentication completed successfully');
       Logger.debug('✓ Task integration enabled: ClickUp - authentication complete');
       AppSnackbar.showSnackbar(context.l10n.successfullyConnectedClickUp);
@@ -301,6 +309,7 @@ class _AppShellState extends State<AppShell> {
         Navigator.of(context).push(MaterialPageRoute(builder: (context) => const ClickUpSettingsPage()));
       }
     } else {
+      MixpanelManager().taskIntegrationAuthFailed(appName: 'clickup');
       Logger.debug('Failed to complete ClickUp authentication');
       AppSnackbar.showSnackbarError(context.l10n.failedToConnectClickUpRetry);
     }

--- a/app/lib/pages/settings/task_integrations_page.dart
+++ b/app/lib/pages/settings/task_integrations_page.dart
@@ -170,8 +170,7 @@ class _TaskIntegrationsPageState extends State<TaskIntegrationsPage> with Widget
 
   bool _shouldShowSettingsIcon() {
     final selected = context.read<TaskIntegrationProvider>().selectedApp;
-    final hasSettings =
-        (selected == TaskIntegrationApp.asana && AsanaService().isAuthenticated) ||
+    final hasSettings = (selected == TaskIntegrationApp.asana && AsanaService().isAuthenticated) ||
         (selected == TaskIntegrationApp.clickup && ClickUpService().isAuthenticated) ||
         (selected == TaskIntegrationApp.todoist && TodoistService().isAuthenticated) ||
         (selected == TaskIntegrationApp.googleTasks && GoogleTasksService().isAuthenticated);
@@ -215,6 +214,7 @@ class _TaskIntegrationsPageState extends State<TaskIntegrationsPage> with Widget
           // Save connected status to backend so auto-sync works
           await provider.saveConnectionDetails(app.key, {'connected': true});
           await provider.setSelectedApp(app);
+          MixpanelManager().taskIntegrationEnabled(appName: app.key, success: true);
           Logger.debug('✓ Task integration enabled: ${app.displayName} (${app.key})');
         } else {
           if (mounted) {

--- a/app/lib/providers/task_integration_provider.dart
+++ b/app/lib/providers/task_integration_provider.dart
@@ -7,7 +7,6 @@ import 'package:omi/services/asana_service.dart';
 import 'package:omi/services/clickup_service.dart';
 import 'package:omi/services/google_tasks_service.dart';
 import 'package:omi/services/todoist_service.dart';
-import 'package:omi/utils/analytics/mixpanel.dart';
 import 'package:omi/utils/logger.dart';
 import 'package:omi/utils/platform/platform_service.dart';
 
@@ -20,7 +19,7 @@ class TaskIntegrationProvider extends ChangeNotifier {
   bool _appleRemindersPermissionManuallySet = false;
 
   TaskIntegrationProvider()
-    : _selectedApp = PlatformService.isApple ? TaskIntegrationApp.appleReminders : TaskIntegrationApp.googleTasks;
+      : _selectedApp = PlatformService.isApple ? TaskIntegrationApp.appleReminders : TaskIntegrationApp.googleTasks;
 
   TaskIntegrationApp get selectedApp => _selectedApp;
   Map<String, dynamic> get connectionDetails => _connectionDetails;
@@ -97,10 +96,6 @@ class TaskIntegrationProvider extends ChangeNotifier {
       final success = await saveTaskIntegration(appKey, details);
       if (success) {
         _connectionDetails[appKey] = details;
-
-        // Track successful integration connection
-        MixpanelManager().taskIntegrationEnabled(appName: appKey, success: true);
-
         notifyListeners();
         return true;
       }


### PR DESCRIPTION
## Summary
- Fire `Task Integration Enabled` on OAuth callback success for Todoist, Asana, Google Tasks, ClickUp (previously never fired for Todoist/Google Tasks).
- Fire `Task Integration Auth Failed` when the OAuth callback itself fails (previously only fired if launching the OAuth URL failed).
- Fire `Task Integration Enabled` for Apple Reminders after permission is granted.
- Stop firing `Task Integration Enabled` from `TaskIntegrationProvider.saveConnectionDetails` — it was firing on every workspace/project change in the Asana/ClickUp settings pages, producing duplicate/misleading events.

Net effect: the event now fires exactly once per integration at the true enable moment, for all 5 integrations.

Note: historical data is incomplete (Todoist/Google Tasks never tracked; Asana/ClickUp counts inflated by settings changes). Backfill will be handled separately — Firestore `users/{uid}/task_integrations/{app_key}` docs have a `created_at` timestamp suitable for Mixpanel `/import`.

## Test plan
- [ ] Connect Todoist via OAuth → verify `Task Integration Enabled` event with `app_name: todoist` in Mixpanel
- [ ] Connect Asana via OAuth → verify event with `app_name: asana`
- [ ] Connect Google Tasks via OAuth → verify event with `app_name: google_tasks`
- [ ] Connect ClickUp via OAuth → verify event with `app_name: clickup`
- [ ] Grant Apple Reminders permission on iOS → verify event with `app_name: apple_reminders`
- [ ] Change an Asana workspace/project in the settings page → verify NO `Task Integration Enabled` event is fired
- [ ] Fail an OAuth callback → verify `Task Integration Auth Failed` event fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)