### PR TITLE
fix(app): persist auto-sync clear/delete to device storage

### DIFF
--- a/app/lib/services/wals/storage_sync.dart
+++ b/app/lib/services/wals/storage_sync.dart
@@ -218,17 +218,56 @@ class StorageSyncImpl implements StorageSync {
 
   @override
   Future deleteWal(Wal wal) async {
+    await _deleteWalsOnDevice([wal]);
     _wals = _wals.where((w) => w.id != wal.id).toList();
+    listener.onWalUpdated();
   }
 
   @override
   Future<void> deleteAllSyncedWals() async {
+    final toDelete = _wals.where((w) => w.status == WalStatus.synced).toList();
+    await _deleteWalsOnDevice(toDelete);
     _wals = _wals.where((w) => w.status != WalStatus.synced).toList();
+    listener.onWalUpdated();
   }
 
   @override
   Future<void> deleteAllPendingWals() async {
+    final toDelete = _wals.where((w) => w.status == WalStatus.miss).toList();
+    await _deleteWalsOnDevice(toDelete);
     _wals = _wals.where((w) => w.status != WalStatus.miss).toList();
+    listener.onWalUpdated();
+  }
+
+  /// Deletes files on the device via CMD_DELETE_FILE. Firmware re-indexes files
+  /// after each delete (higher indices shift down by 1), so delete highest index
+  /// first to keep remaining fileNums valid.
+  Future<void> _deleteWalsOnDevice(List<Wal> wals) async {
+    if (wals.isEmpty || _device == null) return;
+    final connection = await ServiceManager.instance().device.ensureConnection(_device!.id);
+    if (connection == null) {
+      Logger.debug('StorageSync._deleteWalsOnDevice: no connection, skipping firmware delete');
+      return;
+    }
+    final targets = wals.where((w) => w.fileNum >= 0).toList()..sort((a, b) => b.fileNum.compareTo(a.fileNum));
+    final deletedIds = targets.map((w) => w.id).toSet();
+    for (final wal in targets) {
+      try {
+        final ok = await connection.deleteStorageFile(wal.fileNum);
+        Logger.debug('StorageSync._deleteWalsOnDevice: deleted fileNum=${wal.fileNum} ok=$ok');
+        if (ok) {
+          // Firmware shifts remaining indices down by 1 for any file above the deleted one.
+          for (final other in _wals) {
+            if (deletedIds.contains(other.id)) continue;
+            if (other.fileNum > wal.fileNum) {
+              other.fileNum -= 1;
+            }
+          }
+        }
+      } catch (e) {
+        Logger.debug('StorageSync._deleteWalsOnDevice: failed fileNum=${wal.fileNum}: $e');
+      }
+    }
   }
 
   @override

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.532+813
+version: 1.0.532+814
 
 
 environment:


### PR DESCRIPTION
## Summary
- Fixes a bug where Clear, Clear All, and swipe-to-delete on the auto-sync page only removed WALs from memory — files reappeared on next launch.
- `StorageSyncImpl` now sends `CMD_DELETE_FILE` to firmware for each target, deleting highest index first and shifting remaining `fileNum`s (matching the pattern already used in `syncAll`).
- `local_wal_sync` (persists to `wals.json`) and `sdcard_wal_sync` (issues firmware clear command) were already correct; only the new multi-file storage protocol path was broken.

## Test plan
- [ ] On a device using the new storage protocol, sync files so they appear in the auto-sync list.
- [ ] Tap Clear All — list empties.
- [ ] Force-quit and reopen the app — list should stay empty (no files re-listed from firmware).
- [ ] Repeat with Clear Synced / Clear Pending individually.
- [ ] Repeat with swipe-to-delete on a single WAL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)