### PR TITLE
fix(desktop): batch onboarding local-file memory import

### DIFF
--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -1360,6 +1360,28 @@ extension APIClient {
     return try await post("v3/memories", body: body)
   }
 
+  /// Max memories per POST /v3/memories/batch call. Must match the
+  /// `MEMORIES_BATCH_MAX` constant in backend/routers/memories.py.
+  static let memoriesBatchMaxSize = 100
+
+  /// Creates many memories in a single HTTP call. Used by the onboarding
+  /// local-file import flow to avoid fanning out N requests and tripping
+  /// Cloud Armor's per-Authorization 120/min throttle.
+  ///
+  /// Caller is responsible for chunking input into groups of at most
+  /// `memoriesBatchMaxSize`. Returns the created count from the server.
+  func createMemoriesBatch(_ memories: [MemoryBatchItem]) async throws -> BatchMemoriesResponse {
+    precondition(
+      memories.count <= Self.memoriesBatchMaxSize,
+      "createMemoriesBatch received \(memories.count) memories, max is \(Self.memoriesBatchMaxSize)"
+    )
+    struct BatchRequest: Encodable {
+      let memories: [MemoryBatchItem]
+    }
+    let body = BatchRequest(memories: memories)
+    return try await post("v3/memories/batch", body: body)
+  }
+
   /// Deletes a memory by ID
   func deleteMemory(id: String) async throws {
     try await delete("v3/memories/\(id)")
@@ -1468,6 +1490,42 @@ extension APIClient {
 struct CreateMemoryResponse: Codable {
   let id: String
   let message: String?
+}
+
+/// One item in a POST /v3/memories/batch payload. Mirrors the `Memory` model
+/// in `backend/models/memories.py` (the server hardcodes category=manual on
+/// batch creation, so we intentionally don't send it).
+struct MemoryBatchItem: Encodable {
+  let content: String
+  let visibility: String
+  let tags: [String]
+  let headline: String?
+
+  init(content: String, visibility: String = "private", tags: [String] = [], headline: String? = nil)
+  {
+    self.content = content
+    self.visibility = visibility
+    self.tags = tags
+    self.headline = headline
+  }
+}
+
+/// Response from POST /v3/memories/batch. The server returns the full
+/// created memories list; we only care about `createdCount` for onboarding
+/// telemetry, but keep `memories` available for future callers.
+struct BatchMemoriesResponse: Decodable {
+  let memories: [BatchMemory]
+  let createdCount: Int
+
+  enum CodingKeys: String, CodingKey {
+    case memories
+    case createdCount = "created_count"
+  }
+
+  struct BatchMemory: Decodable {
+    let id: String
+    let content: String
+  }
 }
 
 struct MemoryStatusResponse: Codable {

--- a/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
+++ b/desktop/Desktop/Sources/OnboardingPagedIntroCoordinator.swift
@@ -1276,47 +1276,41 @@ final class OnboardingPagedIntroCoordinator: ObservableObject {
       let drafts = await buildLocalFileMemoryDrafts(from: snapshot)
       guard !drafts.isEmpty else { return 0 }
 
-      let concurrency = min(12, drafts.count)
-      var nextIndex = 0
-
-      let saved = await withTaskGroup(of: Bool.self, returning: Int.self) { group in
-        func enqueueNext() {
-          guard nextIndex < drafts.count else { return }
-          let draft = drafts[nextIndex]
-          nextIndex += 1
-          group.addTask {
-            do {
-              _ = try await APIClient.shared.createMemory(
-                content: draft.content,
-                visibility: "private",
-                tags: draft.tags,
-                source: draft.source,
-                headline: draft.headline
-              )
-              return true
-            } catch {
-              log("OnboardingPagedIntroCoordinator: Failed to save local file memory: \(error)")
-              return false
-            }
-          }
+      // Batch the drafts through POST /v3/memories/batch. The previous
+      // implementation fanned out 12 concurrent POST /v3/memories calls
+      // per draft; with up to ~2800 drafts, that blew through Cloud
+      // Armor's 120 req/min per-Authorization limit in seconds and
+      // collaterally 429'd unrelated onboarding calls (goals, sync, chat).
+      //
+      // One batch request = one Firestore write + one embeddings call +
+      // one Pinecone upsert on the server, regardless of batch size.
+      let chunkSize = APIClient.memoriesBatchMaxSize
+      var savedCount = 0
+      var index = 0
+      while index < drafts.count {
+        let end = min(index + chunkSize, drafts.count)
+        let chunk = drafts[index..<end].map { draft in
+          MemoryBatchItem(
+            content: draft.content,
+            visibility: "private",
+            tags: draft.tags,
+            headline: draft.headline
+          )
         }
+        index = end
 
-        for _ in 0..<concurrency {
-          enqueueNext()
+        do {
+          let response = try await APIClient.shared.createMemoriesBatch(Array(chunk))
+          savedCount += response.createdCount
+        } catch {
+          log(
+            "OnboardingPagedIntroCoordinator: Failed to save local file memory batch "
+              + "(\(chunk.count) items): \(error)")
         }
-
-        var savedCount = 0
-        while let success = await group.next() {
-          if success {
-            savedCount += 1
-          }
-          enqueueNext()
-        }
-        return savedCount
       }
 
-      log("OnboardingPagedIntroCoordinator: Saved \(saved) local file memories")
-      return saved
+      log("OnboardingPagedIntroCoordinator: Saved \(savedCount) local file memories")
+      return savedCount
     }
 
     localFileMemoryImportTask = task


### PR DESCRIPTION
## Summary

Replaces the 12-worker `POST /v3/memories` fan-out in `importLocalFileMemories` with chunked `POST /v3/memories/batch` calls, fixing the Cloud Armor 429 storm that was blocking onboarding.

## Root cause

Cloud Armor security policy `prod-omi-backend-api-cloud-armor-policy` enforces **120 req/min per Authorization header** at the LB. `OnboardingPagedIntroCoordinator.importLocalFileMemories` was fanning out up to ~2800 parallel `POST /v3/memories` calls during onboarding (concurrency=12, one call per local file). That burned through the 120/min cap in ~3 seconds and collaterally 429'd everything else in the same window:
- `POST /v1/goals` → \"HTTP error: 429\" on the onboarding goal screen
- `/v2/messages` chat stream → \"Failed to get a response. Please try again.\" on the floating bar

In the last 24h, ~10k Cloud Armor throttles were observed across ~10 client IPs — the top 2 IPs each burned ~3000 requests. Almost all were `POST /v3/memories` from `omi/11299`.

## Change

With `POST /v3/memories/batch` (chunk size 100), the worst-case 2800-draft import is **~28 HTTP requests** completing in ~8s — well under the 120/min cap with headroom for goals/sync/chat.

- Adds `APIClient.createMemoriesBatch` + `MemoryBatchItem` + `BatchMemoriesResponse` types
- Rewrites `importLocalFileMemories` as a sequential chunked loop
- On chunk failure: logs and continues (same partial-tolerance as the old per-item loop)

Depends on: backend PR adding `POST /v3/memories/batch` (must deploy before this merges).

## Test plan

- [ ] `xcrun swift build -c debug --package-path Desktop` clean
- [ ] Build named bundle on Mac mini, launch, verify app opens
- [ ] Walk onboarding flow, verify no 429 error on goal step
- [ ] Floating bar chat: send a message, verify response streams
- [ ] Main dashboard loads goals/memories without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)