### PR TITLE
fix(desktop): add Cancel link on sign-in view to recover from hung web OAuth

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added a Cancel link on the sign-in screen so a failed web OAuth attempt no longer leaves the sign-in buttons permanently disabled"
+  ],
   "releases": [
     {
       "version": "0.11.299",

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -467,6 +467,11 @@ class AuthService {
             // Fetch conversations after successful sign-in
             fetchConversations()
 
+        } catch AuthError.cancelled {
+            // User-initiated cancel: clear any stale error and stay silent.
+            NSLog("OMI AUTH: %@ web OAuth sign-in cancelled by user", provider)
+            self.error = nil
+            throw AuthError.cancelled
         } catch {
             let nsError = error as NSError
             NSLog("OMI AUTH: Error during sign in: %@", error.localizedDescription)
@@ -550,6 +555,24 @@ class AuthService {
 
         NSLog("OMI AUTH: Successfully extracted code and state from callback")
         oauthContinuation?.resume(returning: (code: code, state: state))
+        oauthContinuation = nil
+    }
+
+    /// Cancel an in-flight web OAuth sign-in so the user can retry from a clean
+    /// state. The recovery path we care about: the user fails on the web side
+    /// (closed the tab, denied, or just walked away) and comes back to a
+    /// desktop app whose sign-in buttons are still disabled waiting on a
+    /// callback that will never arrive.
+    @MainActor
+    func cancelSignIn() {
+        guard oauthContinuation != nil else {
+            // No in-flight web OAuth; still reset loading so the UI unblocks.
+            isLoading = false
+            return
+        }
+        NSLog("OMI AUTH: User cancelled in-flight web OAuth sign-in")
+        pendingOAuthState = nil
+        oauthContinuation?.resume(throwing: AuthError.cancelled)
         oauthContinuation = nil
     }
 
@@ -1279,6 +1302,7 @@ enum AuthError: LocalizedError {
     case invalidResponse
     case tokenExchangeFailed(Int)
     case missingCustomToken
+    case cancelled
 
     var errorDescription: String? {
         switch self {
@@ -1308,6 +1332,8 @@ enum AuthError: LocalizedError {
             return "Token exchange failed with status \(code)"
         case .missingCustomToken:
             return "Server did not return authentication token"
+        case .cancelled:
+            return "Sign in cancelled"
         }
     }
 }

--- a/desktop/Desktop/Sources/SignInView.swift
+++ b/desktop/Desktop/Sources/SignInView.swift
@@ -42,6 +42,10 @@ struct SignInView: View {
                         Task {
                             do {
                                 try await AuthService.shared.signInWithApple()
+                            } catch is CancellationError {
+                                // swallow — user initiated
+                            } catch AuthError.cancelled {
+                                // swallow — user initiated
                             } catch {
                                 let errorMsg = "Error: \(error.localizedDescription)"
                                 authState.error = errorMsg
@@ -69,6 +73,10 @@ struct SignInView: View {
                         Task {
                             do {
                                 try await AuthService.shared.signInWithGoogle()
+                            } catch is CancellationError {
+                                // swallow — user initiated
+                            } catch AuthError.cancelled {
+                                // swallow — user initiated
                             } catch {
                                 let errorMsg = "Error: \(error.localizedDescription)"
                                 authState.error = errorMsg
@@ -100,6 +108,20 @@ struct SignInView: View {
                         ProgressView()
                             .progressViewStyle(CircularProgressViewStyle(tint: OmiColors.textPrimary))
                             .padding(.top, 8)
+
+                        // Minimal escape hatch so a failed web sign-in (closed tab,
+                        // denied on Apple/Google, etc.) doesn't trap the user with
+                        // permanently disabled buttons waiting for a callback that
+                        // will never arrive.
+                        Button(action: {
+                            AuthService.shared.cancelSignIn()
+                        }) {
+                            Text("Cancel")
+                                .font(.caption)
+                                .foregroundColor(OmiColors.textTertiary)
+                        }
+                        .buttonStyle(.plain)
+                        .padding(.top, 4)
                     }
 
                     if let error = authState.error {


### PR DESCRIPTION
## Summary

Adds a minimal grey *"Cancel"* text button under the spinner on the sign-in screen whenever `authState.isLoading` is true. Clicking it calls a new `AuthService.cancelSignIn()` which resumes the pending `oauthContinuation` with `AuthError.cancelled`, clears `pendingOAuthState`, and lets the `defer { isLoading = false }` in `signIn(provider:)` re-enable the Apple/Google buttons so the user can retry.

## Why

A user reported failing auth on the web side (Apple provider) and then being unable to re-sign in — both buttons stayed disabled forever because the desktop app was still waiting on a callback that was never going to arrive. The only escape hatch today is the 5-minute `AuthError.timeout` in `waitForOAuthCallback`, which is way too long.

Industry standard for native OAuth flows is: always expose a user-initiated Cancel, and never trust the app to detect browser-side failure (it can't). This is what GitHub Desktop, Linear, Notion, Figma, Slack, VS Code, and Zoom all do.

## What this PR does

- `AuthService.swift`:
  - Adds `AuthError.cancelled` with description *"Sign in cancelled"*.
  - Adds `@MainActor func cancelSignIn()` that tears down the in-flight `oauthContinuation` and clears `pendingOAuthState`. Falls through to setting `isLoading = false` even when there's no continuation, so the UI always unblocks.
  - Adds a dedicated `catch AuthError.cancelled` arm in `signIn(provider:)` that stays silent: no error banner, no `signInFailed` analytics event — this was user-initiated, not a failure.
- `SignInView.swift`:
  - Renders a `caption`-sized grey `Cancel` text button under the spinner, styled with `OmiColors.textTertiary` so it doesn't draw attention away from the primary buttons.
  - Button catches in the two `Sign in with …` buttons now swallow `AuthError.cancelled` and `CancellationError` so the red error row stays empty when the user cancels.
- `CHANGELOG.json`: one-line entry under `unreleased`.

## Test plan

- [ ] Launch a named bundle, click *Sign in with Apple*, when the browser opens click *Cancel* in the app — buttons re-enable, no error banner shown
- [ ] Click *Sign in with Apple*, let it sit for a few seconds, click *Cancel*, click *Sign in with Google* — new flow starts cleanly
- [ ] Click *Sign in with Apple*, complete the browser flow normally — sign-in still succeeds and lands in the main app
- [ ] Click *Sign in with Apple*, deny on the provider's page — existing error path still surfaces the provider's error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)