### PR TITLE
feat(backend): POST /v3/memories/batch — fix Cloud Armor 429 on onboarding

### DIFF
--- a/backend/database/vector_db.py
+++ b/backend/database/vector_db.py
@@ -176,6 +176,44 @@ def upsert_memory_vector(uid: str, memory_id: str, content: str, category: str):
     return vector
 
 
+def upsert_memory_vectors_batch(uid: str, items: List[dict]) -> int:
+    """
+    Upsert many memory embeddings to Pinecone in a single request.
+
+    Each item must be a dict with keys: 'memory_id', 'content', 'category'.
+    Batching cuts latency from N embedding calls + N upserts to one embedding
+    call + one upsert. Used by POST /v3/memories/batch and the dev batch API.
+    Returns the number of vectors written (0 if Pinecone is not configured).
+    """
+    if index is None:
+        logger.warning('Pinecone index not initialized, skipping memory vector batch upsert')
+        return 0
+
+    if not items:
+        return 0
+
+    contents = [item['content'] for item in items]
+    vectors = embeddings.embed_documents(contents)
+
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+    payload = [
+        {
+            "id": f"{uid}-{item['memory_id']}",
+            "values": vectors[i],
+            "metadata": {
+                "uid": uid,
+                "memory_id": item['memory_id'],
+                "category": item['category'],
+                "created_at": now_ts,
+            },
+        }
+        for i, item in enumerate(items)
+    ]
+    res = index.upsert(vectors=payload, namespace=MEMORIES_NAMESPACE)
+    logger.info(f'upsert_memory_vectors_batch count={len(payload)} {res}')
+    return len(payload)
+
+
 def find_similar_memories(uid: str, content: str, threshold: float = 0.85, limit: int = 5) -> List[dict]:
     """
     Find memories similar to the given content.

--- a/backend/routers/developer.py
+++ b/backend/routers/developer.py
@@ -14,6 +14,7 @@ import database.action_items as action_items_db
 import database.goals as goals_db
 import database.users as users_db
 import database.folders as folders_db
+from database.vector_db import upsert_memory_vectors_batch
 
 from models.memories import MemoryCategory, Memory, MemoryDB
 from models.conversation import CreateConversation, ExternalIntegrationCreateConversation
@@ -270,6 +271,21 @@ def create_memories_batch(
 
     # Save all memories to database
     memories_db.save_memories(uid, [mem.dict() for mem in memory_dbs])
+
+    # Upsert vectors in a single Pinecone call so these memories show up in
+    # semantic search. Previously the dev batch endpoint skipped this step and
+    # batch-created memories were invisible to RAG retrieval.
+    upsert_memory_vectors_batch(
+        uid,
+        [
+            {
+                "memory_id": mem.id,
+                "content": mem.content,
+                "category": mem.category.value,
+            }
+            for mem in memory_dbs
+        ],
+    )
 
     # Update personas if any memory is public
     if has_public:

--- a/backend/routers/memories.py
+++ b/backend/routers/memories.py
@@ -1,12 +1,17 @@
+import asyncio
 import logging
 import threading
 from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from pydantic import ValidationError
+from pydantic import BaseModel, Field, ValidationError
 
 import database.memories as memories_db
-from database.vector_db import upsert_memory_vector, delete_memory_vector
+from database.vector_db import (
+    delete_memory_vector,
+    upsert_memory_vector,
+    upsert_memory_vectors_batch,
+)
 from models.memories import MemoryDB, Memory, MemoryCategory
 from utils.apps import update_personas_async
 from utils.other import endpoints as auth
@@ -14,6 +19,22 @@ from utils.other import endpoints as auth
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
+
+# Hard cap on memories per batch request. Keep aligned with the corresponding
+# Pydantic max_length validator below and with the Swift client chunker.
+MEMORIES_BATCH_MAX = 100
+
+
+class BatchMemoriesRequest(BaseModel):
+    memories: List[Memory] = Field(
+        description="List of memories to create in a single batch request",
+        max_length=MEMORIES_BATCH_MAX,
+    )
+
+
+class BatchMemoriesResponse(BaseModel):
+    memories: List[MemoryDB]
+    created_count: int
 
 
 def _validate_memory(uid: str, memory_id: str) -> dict:
@@ -38,6 +59,64 @@ def create_memory(memory: Memory, uid: str = Depends(auth.get_current_user_uid))
     if memory.visibility == 'public':
         threading.Thread(target=update_personas_async, args=(uid,)).start()
     return memory_db
+
+
+@router.post(
+    '/v3/memories/batch',
+    tags=['memories'],
+    response_model=BatchMemoriesResponse,
+)
+async def create_memories_batch(
+    request: BatchMemoriesRequest,
+    uid: str = Depends(auth.with_rate_limit(auth.get_current_user_uid, "memories:batch")),
+):
+    """
+    Create many memories in a single request.
+
+    Solves the Cloud Armor throttling seen on onboarding: the desktop client
+    used to fan out one `POST /v3/memories` per local-file memory (up to 2800
+    per user), blowing through the 120 req/min per-Authorization Cloud Armor
+    rule and collaterally 429-ing unrelated calls (goals, sync, chat).
+
+    One HTTP request here = one Firestore batch write + one embeddings call +
+    one Pinecone upsert, regardless of batch size.
+    """
+    if not request.memories:
+        return BatchMemoriesResponse(memories=[], created_count=0)
+
+    # Hardcode category to manual to match the single-create endpoint. Callers
+    # that need auto-categorization should use the dev API.
+    memory_dbs: List[MemoryDB] = []
+    has_public = False
+    for memory in request.memories:
+        memory.category = MemoryCategory.manual
+        memory_db = MemoryDB.from_memory(memory, uid, None, True)
+        memory_dbs.append(memory_db)
+        if memory.visibility == 'public':
+            has_public = True
+
+    # Firestore batch write + Pinecone batch upsert run on a worker thread so a
+    # slow embeddings/Pinecone call can't starve the FastAPI sync threadpool.
+    def _persist():
+        memories_db.save_memories(uid, [m.dict() for m in memory_dbs])
+        upsert_memory_vectors_batch(
+            uid,
+            [
+                {
+                    "memory_id": m.id,
+                    "content": m.content,
+                    "category": m.category.value,
+                }
+                for m in memory_dbs
+            ],
+        )
+
+    await asyncio.to_thread(_persist)
+
+    if has_public:
+        threading.Thread(target=update_personas_async, args=(uid,)).start()
+
+    return BatchMemoriesResponse(memories=memory_dbs, created_count=len(memory_dbs))
 
 
 @router.get('/v3/memories', tags=['memories'], response_model=List[MemoryDB])

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -74,6 +74,7 @@ pytest tests/unit/test_pusher_circuit_breaker.py -v
 pytest tests/unit/test_lock_bypass_fixes.py -v
 pytest tests/unit/test_dev_api_lock_bypass.py -v
 pytest tests/unit/test_rate_limiting.py -v
+pytest tests/unit/test_memories_batch.py -v
 pytest tests/unit/test_sync_v2.py -v
 pytest tests/unit/test_sync_transcription_prefs.py -v
 pytest tests/unit/test_vision_stream_async.py -v

--- a/backend/tests/unit/test_memories_batch.py
+++ b/backend/tests/unit/test_memories_batch.py
@@ -1,0 +1,197 @@
+"""
+Tests for the memories batch endpoint and its supporting Pinecone helper.
+
+Regression goal: POST /v3/memories/batch must (a) compute embeddings in a
+single batch call, (b) upsert all vectors in a single Pinecone request, and
+(c) short-circuit cleanly when Pinecone is not configured. These properties
+are what make the endpoint cheap enough to run under Cloud Armor without
+fanning out N requests per memory.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub heavy deps before importing vector_db / routers.memories. These
+# modules pull in `pinecone`, `google.cloud.firestore`, `firebase_admin`, and
+# `utils.llm.clients.embeddings` at import time, none of which are available
+# (or desirable) in the unit test environment.
+for mod_name in [
+    'pinecone',
+    'firebase_admin',
+    'firebase_admin.auth',
+    'google',
+    'google.cloud',
+    'google.cloud.firestore',
+]:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = types.ModuleType(mod_name)
+
+sys.modules['pinecone'].Pinecone = MagicMock
+
+
+class _FakeFirestoreClient:
+    def collection(self, *a, **kw):
+        return MagicMock()
+
+    def batch(self):
+        return MagicMock()
+
+
+sys.modules['google.cloud.firestore'].Client = _FakeFirestoreClient
+sys.modules['google.cloud.firestore'].ArrayUnion = MagicMock
+sys.modules['google.cloud.firestore'].ArrayRemove = MagicMock
+sys.modules['google.cloud.firestore'].Increment = MagicMock
+sys.modules['google.cloud.firestore'].SERVER_TIMESTAMP = object()
+sys.modules['google.cloud.firestore'].DELETE_FIELD = object()
+sys.modules['google.cloud.firestore'].FieldFilter = MagicMock
+sys.modules['google.cloud.firestore'].Query = MagicMock
+sys.modules['firebase_admin.auth'].InvalidIdTokenError = type('InvalidIdTokenError', (Exception,), {})
+
+# Stub `utils.llm.clients.embeddings` only. Don't overwrite `utils` or
+# `utils.llm` as packages — other real submodules (utils.rate_limit_config,
+# utils.other.endpoints) must remain importable.
+if 'utils.llm.clients' not in sys.modules:
+    clients_stub = types.ModuleType('utils.llm.clients')
+    clients_stub.embeddings = MagicMock()
+    sys.modules['utils.llm.clients'] = clients_stub
+
+
+from database import vector_db  # noqa: E402
+
+
+class TestUpsertMemoryVectorsBatch:
+    def _setup_mocks(self, monkeypatch, *, index_none=False):
+        fake_index = MagicMock()
+        fake_index.upsert = MagicMock(return_value={'upserted_count': 2})
+        monkeypatch.setattr(vector_db, 'index', None if index_none else fake_index)
+
+        fake_embeddings = MagicMock()
+        fake_embeddings.embed_documents = MagicMock(
+            side_effect=lambda texts: [[0.1 * i, 0.2 * i] for i, _ in enumerate(texts, start=1)]
+        )
+        monkeypatch.setattr(vector_db, 'embeddings', fake_embeddings)
+        return fake_index, fake_embeddings
+
+    def test_batch_upsert_uses_single_embed_and_single_upsert(self, monkeypatch):
+        """The whole point of the helper: one embed call + one upsert call."""
+        fake_index, fake_embeddings = self._setup_mocks(monkeypatch)
+
+        items = [
+            {'memory_id': 'm1', 'content': 'apple', 'category': 'manual'},
+            {'memory_id': 'm2', 'content': 'banana', 'category': 'manual'},
+            {'memory_id': 'm3', 'content': 'cherry', 'category': 'interesting'},
+        ]
+
+        written = vector_db.upsert_memory_vectors_batch('uid-abc', items)
+
+        assert written == 3
+        # Exactly one embeddings call, with all three contents.
+        fake_embeddings.embed_documents.assert_called_once_with(['apple', 'banana', 'cherry'])
+        # Exactly one Pinecone upsert, with all three vectors.
+        fake_index.upsert.assert_called_once()
+        kwargs = fake_index.upsert.call_args.kwargs
+        assert kwargs['namespace'] == vector_db.MEMORIES_NAMESPACE
+        vectors = kwargs['vectors']
+        assert [v['id'] for v in vectors] == ['uid-abc-m1', 'uid-abc-m2', 'uid-abc-m3']
+        assert [v['metadata']['memory_id'] for v in vectors] == ['m1', 'm2', 'm3']
+        assert [v['metadata']['category'] for v in vectors] == ['manual', 'manual', 'interesting']
+        assert all(v['metadata']['uid'] == 'uid-abc' for v in vectors)
+
+    def test_batch_upsert_empty_list_is_noop(self, monkeypatch):
+        fake_index, fake_embeddings = self._setup_mocks(monkeypatch)
+
+        written = vector_db.upsert_memory_vectors_batch('uid-abc', [])
+
+        assert written == 0
+        fake_embeddings.embed_documents.assert_not_called()
+        fake_index.upsert.assert_not_called()
+
+    def test_batch_upsert_skips_when_pinecone_not_configured(self, monkeypatch):
+        """Helper must no-op cleanly when Pinecone isn't configured (tests, local dev)."""
+        _, fake_embeddings = self._setup_mocks(monkeypatch, index_none=True)
+
+        written = vector_db.upsert_memory_vectors_batch(
+            'uid-abc',
+            [{'memory_id': 'm1', 'content': 'hello', 'category': 'manual'}],
+        )
+
+        assert written == 0
+        fake_embeddings.embed_documents.assert_not_called()
+
+
+class TestBatchMemoriesRateLimitPolicy:
+    def test_policy_exists_with_expected_limits(self):
+        """Guardrail so the policy isn't accidentally dropped from the config."""
+        from utils.rate_limit_config import RATE_POLICIES
+
+        assert 'memories:batch' in RATE_POLICIES
+        max_requests, window = RATE_POLICIES['memories:batch']
+        # Intentionally tight — each request can create up to 100 memories.
+        assert max_requests == 30
+        assert window == 3600
+
+
+class TestBatchMemoriesRequestValidation:
+    """
+    Pydantic-level validation on the batch request model.
+
+    We can't import `routers.memories` in a unit test without pulling in the
+    whole Firestore stack, so we parse the max cap out of the source file.
+    Ugly but durable: if someone bumps MEMORIES_BATCH_MAX, the test follows.
+    """
+
+    @staticmethod
+    def _module_max() -> int:
+        import os
+        import re
+
+        path = os.path.join(os.path.dirname(__file__), '..', '..', 'routers', 'memories.py')
+        with open(os.path.abspath(path), 'r') as f:
+            content = f.read()
+        m = re.search(r'MEMORIES_BATCH_MAX\s*=\s*(\d+)', content)
+        assert m, "MEMORIES_BATCH_MAX constant not found in routers/memories.py"
+        return int(m.group(1))
+
+    def _build_request_model(self, max_length: int):
+        """Reconstruct BatchMemoriesRequest locally so we can test the validator
+        without importing routers.memories (which pulls in google.cloud.firestore)."""
+        from pydantic import BaseModel, Field
+        from typing import List as _List
+
+        from models.memories import Memory
+
+        class _BatchMemoriesRequest(BaseModel):
+            memories: _List[Memory] = Field(max_length=max_length)
+
+        return _BatchMemoriesRequest
+
+    def test_module_exposes_expected_max(self):
+        """Hard-coded expectation: if this drops below 100 we want a signal."""
+        assert self._module_max() == 100
+
+    def test_request_accepts_up_to_max(self):
+        max_len = self._module_max()
+        BatchMemoriesRequest = self._build_request_model(max_len)
+
+        memories = [{'content': f'memory {i}', 'visibility': 'private'} for i in range(max_len)]
+        req = BatchMemoriesRequest(memories=memories)
+        assert len(req.memories) == max_len
+
+    def test_request_rejects_over_max(self):
+        from pydantic import ValidationError
+
+        max_len = self._module_max()
+        BatchMemoriesRequest = self._build_request_model(max_len)
+
+        memories = [{'content': f'memory {i}', 'visibility': 'private'} for i in range(max_len + 1)]
+        with pytest.raises(ValidationError):
+            BatchMemoriesRequest(memories=memories)
+
+    def test_empty_batch_is_allowed(self):
+        """Empty batch is a legal no-op — endpoint returns created_count=0."""
+        BatchMemoriesRequest = self._build_request_model(self._module_max())
+        req = BatchMemoriesRequest(memories=[])
+        assert req.memories == []

--- a/backend/utils/rate_limit_config.py
+++ b/backend/utils/rate_limit_config.py
@@ -55,6 +55,9 @@ RATE_POLICIES: dict[str, tuple[int, int]] = {
     "mcp:sse": (200, 3600),
     # Memories — single LLM call each
     "memories:create": (60, 3600),
+    # Memory batch writes — each request can create up to 100 memories, so the
+    # per-request cap is intentionally tighter than memories:create.
+    "memories:batch": (30, 3600),
     # Goals — single LLM call
     "goals:suggest": (30, 3600),
     "goals:advice": (30, 3600),


### PR DESCRIPTION
## Summary

Adds `POST /v3/memories/batch` so the desktop client can create up to 100 memories per HTTP call. Fixes the Cloud Armor 429 storm blocking onboarding.

## Root cause

Cloud Armor policy `prod-omi-backend-api-cloud-armor-policy` enforces **120 req/min per Authorization header** at the `api.omi.me` load balancer. The desktop `OnboardingPagedIntroCoordinator.importLocalFileMemories` fans out up to ~2800 parallel `POST /v3/memories` calls during onboarding, blowing through that cap in ~3 seconds. Everything else from the same user in that 60s window — `POST /v1/goals` (onboarding Continue button), `/v2/messages` (floating bar chat), `/v1/goals/all` (dashboard) — gets collaterally 429'd.

In the last 24h, GCP logs showed ~10k Cloud Armor throttles across ~10 client IPs, dominated by `POST /v3/memories` (8142 throttles) and `POST /v2/sync-local-files` (1826 throttles).

## Change

- `POST /v3/memories/batch` (async handler) — creates up to 100 memories per call
  - Single Firestore batch write via `memories_db.save_memories`
  - Single OpenAI embed call + single Pinecone upsert via new `upsert_memory_vectors_batch` helper
  - `asyncio.to_thread` for the persistence step so a slow OpenAI/Pinecone call can't starve the FastAPI sync threadpool
  - Hardcoded `category=manual` to match `POST /v3/memories` behavior
- New `memories:batch` rate limit policy: `(30, 3600)` — deliberately tight (30 batches/hr × 100 = 3000 memories/hr per user)
- Fixes a latent bug in the dev batch endpoint (`POST /v1/dev/user/memories/batch`): previously wrote to Firestore but never upserted Pinecone vectors, so batch-created memories were invisible to semantic search. Now uses the same helper.
- Unit tests covering the helper, the rate limit policy, and the Pydantic max-length validator

Existing `POST /v3/memories` untouched for backward compat with older desktop clients.

## Ordering

Merge + deploy this BEFORE BasedHardware/omi#6599 (desktop client switchover).

## Test plan

- [x] `pytest tests/unit/test_memories_batch.py -v` → 8 passed
- [ ] CI full suite
- [ ] Deploy to prod
- [ ] Verify `POST /v3/memories/batch` returns 200 with a sample payload
- [ ] Verify `POST /v1/dev/user/memories/batch` now populates Pinecone (previously broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)