### PR TITLE
feat: self-hosted backend URL override in Developer Settings

### DIFF
--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -303,6 +303,10 @@ class SharedPreferencesUtil {
 
   set devLogsToFileEnabled(bool value) => saveBool('devLogsToFileEnabled', value);
 
+  String get customBackendUrl => getString('customBackendUrl');
+
+  set customBackendUrl(String value) => saveString('customBackendUrl', value);
+
   bool get permissionStoreRecordingsEnabled => getBool('permissionStoreRecordingsEnabled');
 
   set permissionStoreRecordingsEnabled(bool value) => saveBool('permissionStoreRecordingsEnabled', value);
@@ -573,10 +577,6 @@ class SharedPreferencesUtil {
   List<String> get enabledCalendarIds => getStringList('enabledCalendarIds');
 
   //--------------------------------- Auth ------------------------------------//
-
-  String get customBackendUrl => getString('customBackendUrl');
-
-  set customBackendUrl(String value) => saveString('customBackendUrl', value);
 
   String get authToken => getString('authToken');
 

--- a/app/lib/backend/preferences.dart
+++ b/app/lib/backend/preferences.dart
@@ -574,6 +574,10 @@ class SharedPreferencesUtil {
 
   //--------------------------------- Auth ------------------------------------//
 
+  String get customBackendUrl => getString('customBackendUrl');
+
+  set customBackendUrl(String value) => saveString('customBackendUrl', value);
+
   String get authToken => getString('authToken');
 
   set authToken(String value) => saveString('authToken', value);

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10632,5 +10632,41 @@
             }
         }
     },
-    "tasksMarkComplete": "Marked as complete"
+    "tasksMarkComplete": "Marked as complete",
+    "selfHostedBackendSectionTitle": "Self-Hosted Backend",
+    "@selfHostedBackendSectionTitle": {
+        "description": "Section header for self-hosted backend URL setting in Developer Settings"
+    },
+    "selfHostedBackendSubtitle": "Override the API URL to use your own backend instead of api.omi.me. Leave empty to use the default. Requires app restart to take effect.",
+    "@selfHostedBackendSubtitle": {
+        "description": "Description shown under the Self-Hosted Backend section header"
+    },
+    "selfHostedBackendUrlHint": "https://your-backend.example.com",
+    "@selfHostedBackendUrlHint": {
+        "description": "Placeholder hint text for the backend URL input field"
+    },
+    "selfHostedBackendSaveButton": "Save Backend URL",
+    "@selfHostedBackendSaveButton": {
+        "description": "Button label to save the custom backend URL"
+    },
+    "selfHostedBackendSavedRestart": "Backend URL saved — restart app to apply",
+    "@selfHostedBackendSavedRestart": {
+        "description": "Snackbar shown after saving a custom backend URL"
+    },
+    "selfHostedBackendClearedRestart": "Backend URL cleared — restart app to apply",
+    "@selfHostedBackendClearedRestart": {
+        "description": "Snackbar shown after clearing the custom backend URL"
+    },
+    "selfHostedBackendRestoredRestart": "Restored default backend — restart app to apply",
+    "@selfHostedBackendRestoredRestart": {
+        "description": "Snackbar shown after clearing URL via save with empty field"
+    },
+    "selfHostedBackendHttpError": "URL must start with http:// or https://",
+    "@selfHostedBackendHttpError": {
+        "description": "Validation error when backend URL does not start with http"
+    },
+    "selfHostedBackendNote": "Note: your backend must have LOCAL_DEVELOPMENT=true to accept tokens from the Omi app.",
+    "@selfHostedBackendNote": {
+        "description": "Informational note shown below the backend URL save button"
+    }
 }

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -159,7 +159,8 @@ Future _init() async {
   }
 
   // TestFlight environment detection — must be after SharedPreferencesUtil.init()
-  if (F.env == Environment.prod) {
+  // Skip when a custom backend URL is already set — user intent takes priority.
+  if (F.env == Environment.prod && customBackend.isEmpty) {
     final isTestFlight = await EnvironmentDetector.isTestFlight();
     if (isTestFlight) {
       Env.isTestFlight = true;

--- a/app/lib/main.dart
+++ b/app/lib/main.dart
@@ -151,6 +151,13 @@ Future _init() async {
 
   await SharedPreferencesUtil.init();
 
+  // Self-hosted backend URL — must be after SharedPreferencesUtil.init()
+  final customBackend = SharedPreferencesUtil().customBackendUrl;
+  if (customBackend.isNotEmpty) {
+    Env.overrideApiBaseUrl(customBackend);
+    debugPrint('Self-hosted backend: using $customBackend');
+  }
+
   // TestFlight environment detection — must be after SharedPreferencesUtil.init()
   if (F.env == Environment.prod) {
     final isTestFlight = await EnvironmentDetector.isTestFlight();

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -677,7 +677,6 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                                     onPressed: () {
                                       _backendUrlController.clear();
                                       SharedPreferencesUtil().customBackendUrl = '';
-                                      Env.overrideApiBaseUrl('');
                                       setState(() {});
                                       AppSnackbar.showSnackbar('Backend URL cleared — restart app to apply');
                                     },
@@ -699,7 +698,6 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                                 return;
                               }
                               SharedPreferencesUtil().customBackendUrl = url;
-                              Env.overrideApiBaseUrl(url.isNotEmpty ? url : Env.apiBaseUrl ?? '');
                               setState(() {});
                               AppSnackbar.showSnackbar(
                                 url.isEmpty ? 'Restored default backend — restart app to apply' : 'Backend URL saved — restart app to apply',

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -40,12 +40,21 @@ class DeveloperSettingsPage extends StatefulWidget {
 }
 
 class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
+  final _backendUrlController = TextEditingController();
+
   @override
   void initState() {
+    _backendUrlController.text = SharedPreferencesUtil().customBackendUrl;
     WidgetsBinding.instance.addPostFrameCallback((_) async {
       context.read<McpProvider>().fetchKeys();
     });
     super.initState();
+  }
+
+  @override
+  void dispose() {
+    _backendUrlController.dispose();
+    super.dispose();
   }
 
   Widget _buildSectionContainer({required List<Widget> children}) {
@@ -599,6 +608,119 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                           FaIcon(FontAwesomeIcons.chevronRight, color: Colors.grey.shade600, size: 14),
                         ],
                       ),
+                    ),
+                  ),
+                  const SizedBox(height: 32),
+
+                  // Self-Hosted Backend Section
+                  _buildSectionHeader(
+                    'Self-Hosted Backend',
+                    subtitle: 'Override the API URL to use your own backend instead of api.omi.me. '
+                        'Leave empty to use the default. Requires app restart to take effect.',
+                  ),
+                  Container(
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(color: const Color(0xFF1C1C1E), borderRadius: BorderRadius.circular(14)),
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Container(
+                              width: 40,
+                              height: 40,
+                              decoration: BoxDecoration(
+                                color: const Color(0xFF2A2A2E),
+                                borderRadius: BorderRadius.circular(10),
+                              ),
+                              child: Center(
+                                child: FaIcon(FontAwesomeIcons.server, color: Colors.grey.shade400, size: 16),
+                              ),
+                            ),
+                            const SizedBox(width: 14),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  const Text(
+                                    'Backend URL',
+                                    style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
+                                  ),
+                                  const SizedBox(height: 2),
+                                  Text(
+                                    Env.apiBaseUrl ?? 'https://api.omi.me',
+                                    style: TextStyle(color: Colors.grey.shade500, fontSize: 12),
+                                    overflow: TextOverflow.ellipsis,
+                                  ),
+                                ],
+                              ),
+                            ),
+                          ],
+                        ),
+                        const SizedBox(height: 16),
+                        TextField(
+                          controller: _backendUrlController,
+                          style: const TextStyle(color: Colors.white, fontSize: 14),
+                          decoration: InputDecoration(
+                            hintText: 'https://your-backend.example.com',
+                            hintStyle: TextStyle(color: Colors.grey.shade600, fontSize: 14),
+                            filled: true,
+                            fillColor: const Color(0xFF2A2A2E),
+                            border: OutlineInputBorder(
+                              borderRadius: BorderRadius.circular(10),
+                              borderSide: BorderSide.none,
+                            ),
+                            contentPadding: const EdgeInsets.symmetric(horizontal: 14, vertical: 12),
+                            suffixIcon: _backendUrlController.text.isNotEmpty
+                                ? IconButton(
+                                    icon: Icon(Icons.clear, color: Colors.grey.shade500, size: 18),
+                                    onPressed: () {
+                                      _backendUrlController.clear();
+                                      SharedPreferencesUtil().customBackendUrl = '';
+                                      Env.overrideApiBaseUrl('');
+                                      setState(() {});
+                                      AppSnackbar.showSnackbar('Backend URL cleared — restart app to apply');
+                                    },
+                                  )
+                                : null,
+                          ),
+                          onChanged: (_) => setState(() {}),
+                          keyboardType: TextInputType.url,
+                          autocorrect: false,
+                        ),
+                        const SizedBox(height: 12),
+                        SizedBox(
+                          width: double.infinity,
+                          child: ElevatedButton(
+                            onPressed: () {
+                              final url = _backendUrlController.text.trim().replaceAll(RegExp(r'/+$'), '');
+                              if (url.isNotEmpty && !url.startsWith('http')) {
+                                AppSnackbar.showSnackbar('URL must start with http:// or https://');
+                                return;
+                              }
+                              SharedPreferencesUtil().customBackendUrl = url;
+                              Env.overrideApiBaseUrl(url.isNotEmpty ? url : Env.apiBaseUrl ?? '');
+                              setState(() {});
+                              AppSnackbar.showSnackbar(
+                                url.isEmpty ? 'Restored default backend — restart app to apply' : 'Backend URL saved — restart app to apply',
+                              );
+                            },
+                            style: ElevatedButton.styleFrom(
+                              backgroundColor: const Color(0xFF2A2A2E),
+                              foregroundColor: Colors.white,
+                              padding: const EdgeInsets.symmetric(vertical: 12),
+                              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
+                              elevation: 0,
+                            ),
+                            child: const Text('Save Backend URL', style: TextStyle(fontWeight: FontWeight.w500)),
+                          ),
+                        ),
+                        const SizedBox(height: 10),
+                        Text(
+                          'Note: your backend must have LOCAL_DEVELOPMENT=true to accept tokens from the Omi app.',
+                          style: TextStyle(color: Colors.grey.shade600, fontSize: 11),
+                        ),
+                      ],
                     ),
                   ),
                   const SizedBox(height: 32),

--- a/app/lib/pages/settings/developer.dart
+++ b/app/lib/pages/settings/developer.dart
@@ -614,9 +614,8 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
 
                   // Self-Hosted Backend Section
                   _buildSectionHeader(
-                    'Self-Hosted Backend',
-                    subtitle: 'Override the API URL to use your own backend instead of api.omi.me. '
-                        'Leave empty to use the default. Requires app restart to take effect.',
+                    context.l10n.selfHostedBackendSectionTitle,
+                    subtitle: context.l10n.selfHostedBackendSubtitle,
                   ),
                   Container(
                     padding: const EdgeInsets.all(16),
@@ -642,9 +641,9 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                               child: Column(
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  const Text(
-                                    'Backend URL',
-                                    style: TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
+                                  Text(
+                                    context.l10n.backendUrlLabel,
+                                    style: const TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.w500),
                                   ),
                                   const SizedBox(height: 2),
                                   Text(
@@ -662,7 +661,7 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                           controller: _backendUrlController,
                           style: const TextStyle(color: Colors.white, fontSize: 14),
                           decoration: InputDecoration(
-                            hintText: 'https://your-backend.example.com',
+                            hintText: context.l10n.selfHostedBackendUrlHint,
                             hintStyle: TextStyle(color: Colors.grey.shade600, fontSize: 14),
                             filled: true,
                             fillColor: const Color(0xFF2A2A2E),
@@ -678,7 +677,7 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                                       _backendUrlController.clear();
                                       SharedPreferencesUtil().customBackendUrl = '';
                                       setState(() {});
-                                      AppSnackbar.showSnackbar('Backend URL cleared — restart app to apply');
+                                      AppSnackbar.showSnackbar(context.l10n.selfHostedBackendClearedRestart);
                                     },
                                   )
                                 : null,
@@ -694,13 +693,15 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                             onPressed: () {
                               final url = _backendUrlController.text.trim().replaceAll(RegExp(r'/+$'), '');
                               if (url.isNotEmpty && !url.startsWith('http')) {
-                                AppSnackbar.showSnackbar('URL must start with http:// or https://');
+                                AppSnackbar.showSnackbar(context.l10n.selfHostedBackendHttpError);
                                 return;
                               }
                               SharedPreferencesUtil().customBackendUrl = url;
                               setState(() {});
                               AppSnackbar.showSnackbar(
-                                url.isEmpty ? 'Restored default backend — restart app to apply' : 'Backend URL saved — restart app to apply',
+                                url.isEmpty
+                                    ? context.l10n.selfHostedBackendRestoredRestart
+                                    : context.l10n.selfHostedBackendSavedRestart,
                               );
                             },
                             style: ElevatedButton.styleFrom(
@@ -710,12 +711,12 @@ class _DeveloperSettingsPageState extends State<DeveloperSettingsPage> {
                               shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(10)),
                               elevation: 0,
                             ),
-                            child: const Text('Save Backend URL', style: TextStyle(fontWeight: FontWeight.w500)),
+                            child: Text(context.l10n.selfHostedBackendSaveButton, style: const TextStyle(fontWeight: FontWeight.w500)),
                           ),
                         ),
                         const SizedBox(height: 10),
                         Text(
-                          'Note: your backend must have LOCAL_DEVELOPMENT=true to accept tokens from the Omi app.',
+                          context.l10n.selfHostedBackendNote,
                           style: TextStyle(color: Colors.grey.shade600, fontSize: 11),
                         ),
                       ],


### PR DESCRIPTION
## Problem

Self-hosting the Omi backend is documented and supported, but the iOS app hardcodes `api.omi.me` — making it impossible to use a self-hosted backend without maintaining a full fork of the app.

This was raised in #842 and closed citing "e2e authentication" as the blocker. That reasoning is incomplete:

- **Firebase mismatch** is already solved by `LOCAL_DEVELOPMENT=true` in the backend (`endpoints.py`) — self-hosters can enable this flag
- **The real blocker** is Flutter's `dart:io` using BoringSSL (its own TLS stack), which ignores iOS's system certificate store. Even with a custom CA installed and trusted in iOS Settings, the app rejects it with `CERTIFICATE_VERIFY_FAILED`. The only fix is using a domain you control — which requires changing the hardcoded URL

## Solution

Add a **Self-Hosted Backend** section to Developer Settings with a URL text field. The infrastructure was already 90% in place:

```dart
// env.dart — already existed, just never exposed in UI
static String? _apiBaseUrlOverride;
static void overrideApiBaseUrl(String url) { ... }
static String? get apiBaseUrl => _apiBaseUrlOverride ?? _instance.apiBaseUrl;
```

This PR simply wires a UI to that existing method.

## Changes

- **`app/lib/backend/preferences.dart`** — add `customBackendUrl` getter/setter (1 key in SharedPreferences)
- **`app/lib/main.dart`** — restore saved URL via `Env.overrideApiBaseUrl()` on launch, before any network calls
- **`app/lib/pages/settings/developer.dart`** — new "Self-Hosted Backend" section with text field, save, and clear

## Behaviour

1. User enters `https://my-backend.example.com` in Developer Settings → Self-Hosted Backend
2. Taps **Save Backend URL** — persisted to SharedPreferences, snackbar prompts restart
3. On next launch: `main.dart` restores the URL before any network call
4. All API and WebSocket calls go to the custom backend
5. Clear field + save → reverts to default `api.omi.me`

A note in the UI tells users their backend needs `LOCAL_DEVELOPMENT=true` for Firebase token bypass.

## Who needs this

- Privacy-focused users who don't want voice data on Omi's servers
- Users who exceeded transcription minute limits and want to self-host
- Enterprise deployments (the original motivation in #842)
- Developers testing against local backends without rebuilding the app on every change

## What this is NOT

This does not remove or weaken any existing auth. It only lets users redirect API calls to a backend they control. The backend is still responsible for its own auth decisions.

Closes #842