### PR TITLE
Unify notification provenance for Focus / Task / Memory + restore home chat sync

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Task, memory, and focus notifications now open the floating bar with full provenance and sync into home chat history, so follow-up questions can reference the source app, window, and context"
+  ],
   "releases": [
     {
       "version": "0.11.299",

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1303,6 +1303,17 @@ class FloatingControlBarManager {
     private func persistNotificationMessageIfNeeded(_ notification: FloatingBarNotification) {
         guard storedNotificationMessages[notification.id] == nil else { return }
 
+        // Also append the notification as an assistant message in the main chat
+        // history provider so it is visible on the home-page chat and synced to
+        // the backend. The floating bar still uses its own provider for follow-up
+        // questions (see openNotificationConversation), so this append does not
+        // affect the floating-bar session in any way.
+        if let historyProvider = historyChatProvider {
+            let bodyText = notification.message.trimmingCharacters(in: .whitespacesAndNewlines)
+            let messageText = bodyText.isEmpty ? notification.title : bodyText
+            _ = historyProvider.appendAssistantMessage(messageText)
+        }
+
         storedNotificationMessages[notification.id] = StoredNotificationMessage(
             notification: notification,
             context: notification.context,

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/Focus/FocusAssistant.swift
@@ -519,6 +519,17 @@ actor FocusAssistant: ProactiveAssistant {
                         FocusAssistantSettings.shared.notificationsEnabled
                     }
 
+                    let context = FloatingBarNotificationContext(
+                        sourceTitle: "Focus",
+                        assistantId: identifier,
+                        sourceApp: analysis.appOrSite.isEmpty ? nil : analysis.appOrSite,
+                        windowTitle: frame.windowTitle,
+                        contextSummary: nil,
+                        currentActivity: analysis.description.isEmpty ? nil : analysis.description,
+                        reasoning: "Distraction detected: user switched from focused work to \(analysis.appOrSite).",
+                        detail: message
+                    )
+
                     await MainActor.run {
                         // Track focus alert shown
                         AnalyticsManager.shared.focusAlertShown(app: analysis.appOrSite)
@@ -528,7 +539,8 @@ actor FocusAssistant: ProactiveAssistant {
                                 title: "Focus",
                                 message: fullMessage,
                                 assistantId: identifier,
-                                sound: .none
+                                sound: .none,
+                                context: context
                             )
                         }
                     }
@@ -564,13 +576,24 @@ actor FocusAssistant: ProactiveAssistant {
                         let notificationsEnabled = await MainActor.run {
                             FocusAssistantSettings.shared.notificationsEnabled
                         }
+                        let context = FloatingBarNotificationContext(
+                            sourceTitle: "Focus",
+                            assistantId: identifier,
+                            sourceApp: analysis.appOrSite.isEmpty ? nil : analysis.appOrSite,
+                            windowTitle: frame.windowTitle,
+                            contextSummary: nil,
+                            currentActivity: analysis.description.isEmpty ? nil : analysis.description,
+                            reasoning: "Focus restored: user returned to focused work after a distraction.",
+                            detail: message
+                        )
                         if notificationsEnabled {
                             await MainActor.run {
                                 NotificationService.shared.sendNotification(
                                     title: "Focus",
                                     message: message,
                                     assistantId: identifier,
-                                    sound: .none
+                                    sound: .none,
+                                    context: context
                                 )
                             }
                         }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/MemoryExtraction/MemoryAssistant.swift
@@ -205,7 +205,11 @@ actor MemoryAssistant: ProactiveAssistant {
             MemoryAssistantSettings.shared.notificationsEnabled
         }
         if notificationsEnabled {
-            await sendMemoryNotification(memory: memory)
+            await sendMemoryNotification(
+                memory: memory,
+                result: memoryResult,
+                windowTitle: windowTitle
+            )
         }
 
         // Send event to Flutter
@@ -273,15 +277,30 @@ actor MemoryAssistant: ProactiveAssistant {
     }
 
     /// Send a notification for the extracted memory
-    private func sendMemoryNotification(memory: ExtractedMemory) async {
+    private func sendMemoryNotification(
+        memory: ExtractedMemory,
+        result: MemoryExtractionResult,
+        windowTitle: String?
+    ) async {
         let title = memory.category == .interesting ? "Wisdom Captured" : "Memory Saved"
-        let message = memory.content
+        let message = "New memory: \(memory.content)"
+        let context = FloatingBarNotificationContext(
+            sourceTitle: title,
+            assistantId: identifier,
+            sourceApp: memory.sourceApp.isEmpty ? nil : memory.sourceApp,
+            windowTitle: windowTitle,
+            contextSummary: result.contextSummary,
+            currentActivity: result.currentActivity,
+            reasoning: nil,
+            detail: memory.content
+        )
 
         await MainActor.run {
             NotificationService.shared.sendNotification(
                 title: title,
                 message: message,
-                assistantId: identifier
+                assistantId: identifier,
+                context: context
             )
         }
     }

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskAssistant.swift
@@ -482,18 +482,6 @@ actor TaskAssistant: ProactiveAssistant {
         }
     }
 
-    /// Send a notification for the extracted task
-    private func sendTaskNotification(task: ExtractedTask) async {
-        let message = task.title
-        await MainActor.run {
-            NotificationService.shared.sendNotification(
-                title: "Task",
-                message: message,
-                assistantId: identifier
-            )
-        }
-    }
-
     func onAppSwitch(newApp: String) async {
         if newApp != currentApp {
             if let currentApp = currentApp {

--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
@@ -79,12 +79,14 @@ actor TaskPromotionService {
                         TaskAssistantSettings.shared.notificationsEnabled
                     }
                     if notificationsEnabled {
-                        let message = promotedTask.description
+                        let message = "New task: \(promotedTask.description)"
+                        let context = Self.buildNotificationContext(from: promotedTask)
                         await MainActor.run {
                             NotificationService.shared.sendNotification(
                                 title: "Task",
                                 message: message,
-                                assistantId: "task"
+                                assistantId: "task",
+                                context: context
                             )
                         }
                     }
@@ -115,5 +117,52 @@ actor TaskPromotionService {
     func ensureMinimumOnStartup() async -> [TaskActionItem] {
         log("TaskPromotion: Checking minimum on startup")
         return await promoteIfNeeded()
+    }
+
+    // MARK: - Notification Context
+
+    /// Build a `FloatingBarNotificationContext` so the floating bar follow-up chat
+    /// can explain exactly which task the notification was about, rather than guessing
+    /// from recent conversation history.
+    private static func buildNotificationContext(from task: TaskActionItem) -> FloatingBarNotificationContext {
+        let sourceApp = Self.parseSourceApp(from: task.metadata)
+        let reasoning = Self.buildReasoning(from: task)
+        return FloatingBarNotificationContext(
+            sourceTitle: "Task",
+            assistantId: "task",
+            sourceApp: sourceApp,
+            windowTitle: nil,
+            contextSummary: task.contextSummary,
+            currentActivity: task.currentActivity,
+            reasoning: reasoning,
+            detail: task.description
+        )
+    }
+
+    private static func parseSourceApp(from metadataJson: String?) -> String? {
+        guard let json = metadataJson,
+              let data = json.data(using: .utf8),
+              let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        let app = parsed["source_app"] as? String
+        return (app?.isEmpty == false) ? app : nil
+    }
+
+    private static func buildReasoning(from task: TaskActionItem) -> String? {
+        var parts: [String] = []
+        if let priority = task.priority, !priority.isEmpty {
+            parts.append("priority=\(priority)")
+        }
+        if let category = task.category, !category.isEmpty {
+            parts.append("category=\(category)")
+        }
+        if let dueAt = task.dueAt {
+            let formatter = ISO8601DateFormatter()
+            parts.append("due=\(formatter.string(from: dueAt))")
+        }
+        if let source = task.source, !source.isEmpty {
+            parts.append("source=\(source)")
+        }
+        return parts.isEmpty ? nil : "Promoted from staged tasks (" + parts.joined(separator: ", ") + ")"
     }
 }


### PR DESCRIPTION
## Summary
- Focus, Task-promotion, and Memory notifications now build a `FloatingBarNotificationContext` the same way Insight notifications did in #6580 — so clicking the notification opens a floating-bar chat that can explain the **real** source (app, window, context summary, current activity, reasoning, detail) instead of guessing from recent history
- Restore notification persistence into home-page chat history: `persistNotificationMessageIfNeeded` now also appends the notification as an assistant message in `historyChatProvider`, which was accidentally dropped in #6580 when the floating-bar session unification was added
- Prefix Task notification bodies with `New task: ` and Memory notification bodies with `New memory: ` so they read clearly when they land in home chat
- Delete `TaskAssistant.sendTaskNotification` — defined but never called (confirmed via grep, zero callers)

## Why

The failure mode we saw this afternoon: a promoted task notification appeared in the floating bar, but clicking it and asking "where is this from?" produced *"I can't find any specific conversation about 'Derek' and a contract in your recent history"*. Root cause: #6580 built provenance plumbing (`FloatingBarNotificationContext`, `notificationContextSuffixIfNeeded`, floating-bar session unification) but only wired it up for `InsightAssistant`. Task/Memory/Focus all passed `context: nil`, so the follow-up prompt only saw the bare message text and the model pattern-matched its way into a confabulation.

Separately, #6580 stopped appending notifications to the main chat provider as part of the session-unification refactor, so notifications stopped showing up in the home-page chat tab. Unintended regression.

## What I did NOT touch

The scope is intentionally minimal — I avoided any changes to the core floating bar or chat flow:
- `FloatingControlBar/FloatingControlBarState.swift` — unchanged
- `Chat/ACPBridge.swift`, `acp-bridge/*.ts` — unchanged
- `Providers/ChatProvider.swift` — unchanged
- `NotificationService.swift` — unchanged (already accepted `context:` from #6580)
- `ProactiveAssistantsPlugin.swift` — unchanged (test triggers are pre-existing)
- `sendAIQuery` / `openNotificationConversation` / `notificationContextSuffixIfNeeded` / `activeFloatingProvider` — all unchanged

The only edit outside `ProactiveAssistants/Assistants/` is 11 lines inside `persistNotificationMessageIfNeeded`.

## Test plan
- [x] Compile clean (`xcrun swift build -c debug --package-path Desktop` → warnings only, all pre-existing)
- [x] Launched named bundle `notif-context-unified.app` locally with `./run.sh --yolo`
- [x] Posted `com.omi.test.notification` DistributedNotifications for Task / Memory / Focus via a `/tmp/post-notif.swift` helper
- [x] Confirmed follow-up chat correctly cites the provenance: Task test → *"The notification came from you reviewing Derek's contract redlines in Gmail — Derek's last email asked for a signed clean PDF back before end of day today"*; Focus test → *"it was triggered because you switched from Notion (where you were drafting landing page copy) to Twitter"*
- [x] Verified home-chat persistence: 6 real startup-promoted tasks ("New task: Reply to PostHog AI…", "New task: Fix Omi macOS bug…", etc.) plus the test-fired Task/Memory/Focus notifications all show up as assistant messages in the home-page chat tab and sync to backend (`Saved assistant message to backend: <uuid>` in `/tmp/omi-dev.log`)
- [x] Verified "New task: " / "New memory: " prefixes appear on real promotions from `TaskPromotionService` and `MemoryAssistant`
- [x] Confirmed floating bar notification UI is unchanged — no title/icon/layout differences, same click behaviour
- [ ] Mac mini test on real Codemagic build

🤖 Generated with [Claude Code](https://claude.com/claude-code)