### PR TITLE
fix(mcp): search_memories 500 — wrong key name from vector_db

### DIFF
--- a/backend/routers/mcp_sse.py
+++ b/backend/routers/mcp_sse.py
@@ -337,11 +337,11 @@ def execute_tool(user_id: str, tool_name: str, arguments: dict) -> dict:
         if not matches:
             return {"memories": []}
 
-        memory_ids = [m['id'] for m in matches]
+        memory_ids = [m['memory_id'] for m in matches]
         memories = memories_db.get_memories_by_ids(user_id, memory_ids)
 
         # Build score lookup and filter locked
-        score_map = {m['id']: m.get('score', 0) for m in matches}
+        score_map = {m['memory_id']: m.get('score', 0) for m in matches}
         results = []
         for mem in memories:
             if mem.get('is_locked', False):


### PR DESCRIPTION
## Summary
`search_memories` was crashing with 500 because `vector_db.find_similar_memories()` returns `memory_id` but the code accessed `id` → `KeyError`.

One-line fix: `m['id']` → `m['memory_id']` in two places.

Closes #6579

## Test plan
- [ ] `search_memories` with a valid query returns results instead of 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)