### PR TITLE
Update CHANGELOG.json for v0.11.303 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Task, memory, and focus notifications now open the floating bar with full provenance and sync into home chat history, so follow-up questions can reference the source app, window, and context"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.303",
+      "date": "2026-04-14",
+      "changes": [
+        "Task, memory, and focus notifications now open the floating bar with full provenance and sync into home chat history, so follow-up questions can reference the source app, window, and context"
+      ]
+    },
     {
       "version": "0.11.302",
       "date": "2026-04-13",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.303 and clears the unreleased array.