### PR TITLE
Fix desktop onboarding goal step CTA gating

### DIFF
--- a/desktop/Desktop/Sources/OnboardingGoalStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingGoalStepView.swift
@@ -20,7 +20,8 @@ struct OnboardingGoalStepView: View {
       totalSteps: totalSteps,
       eyebrow: "Goal",
       title: "Pick one goal.",
-      description: "Omi will optimize for this first.",
+      description:
+        "Selecting a correct and detailed goal is very important - Omi will optimize all advice to achieve that goal. Make sure your goal contains a number to measure progress.",
       onForceComplete: onForceComplete
     ) {
       VStack(alignment: .leading, spacing: 18) {
@@ -63,19 +64,21 @@ struct OnboardingGoalStepView: View {
             .foregroundColor(OmiColors.warning)
         }
 
-        Button(coordinator.isSavingGoal ? "Saving…" : "Continue") {
-          Task {
-            coordinator.goalSaved = false
-            await coordinator.saveGoalIfNeeded()
-            guard coordinator.goalSaved else { return }
-            let completed = await coordinator.completeIntro(appState: appState)
-            if completed {
-              onContinue()
+        if shouldShowContinue {
+          Button(coordinator.isSavingGoal ? "Saving…" : "Continue") {
+            Task {
+              coordinator.goalSaved = false
+              await coordinator.saveGoalIfNeeded()
+              guard coordinator.goalSaved else { return }
+              let completed = await coordinator.completeIntro(appState: appState)
+              if completed {
+                onContinue()
+              }
             }
           }
+          .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
+          .disabled(coordinator.isSavingGoal)
         }
-        .buttonStyle(OnboardingCardButtonStyle(isPrimary: true))
-        .disabled(coordinator.isSavingGoal || trimmedGoal.isEmpty)
       }
       .frame(maxWidth: .infinity, alignment: .leading)
       .onAppear {
@@ -102,6 +105,10 @@ struct OnboardingGoalStepView: View {
 
   private var trimmedGoal: String {
     coordinator.goalDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private var shouldShowContinue: Bool {
+    !trimmedGoal.isEmpty
   }
 }
 


### PR DESCRIPTION
## Summary
- hide the goal-step Continue button until a suggestion is selected or a custom goal is typed
- update the goal-step helper copy to emphasize detailed measurable goals

## Verification
- built and launched a local custom desktop bundle (`GoalStepTest.app`)
- confirmed the onboarding goal step was updated in the running app
