### PR TITLE
Fix onboarding shortcut confirmation flow

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/GlobalShortcutManager.swift
@@ -10,6 +10,7 @@ class GlobalShortcutManager {
     static let askAINotification = Notification.Name("com.omi.desktop.askAI")
 
     private var hotKeyRefs: [HotKeyID: EventHotKeyRef] = [:]
+    private var isRegistrationSuspended = false
 
     private enum HotKeyID: UInt32 {
         case askOmi = 2
@@ -42,11 +43,22 @@ class GlobalShortcutManager {
 
     func registerShortcuts() {
         unregisterShortcuts()
+        guard !isRegistrationSuspended else { return }
         // Register Ask Omi shortcut from user settings
         registerAskOmi()
     }
 
+    func setRegistrationSuspended(_ suspended: Bool) {
+        isRegistrationSuspended = suspended
+        if suspended {
+            unregisterShortcuts()
+        } else {
+            registerShortcuts()
+        }
+    }
+
     private func registerAskOmi() {
+        guard !isRegistrationSuspended else { return }
         // Unregister previous Ask Omi hotkey if any
         if let ref = hotKeyRefs.removeValue(forKey: .askOmi) {
             UnregisterEventHotKey(ref)

--- a/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingFloatingBarShortcutStepView.swift
@@ -96,12 +96,12 @@ struct OnboardingFloatingBarShortcutStepView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .background(OmiColors.backgroundPrimary)
         .onAppear {
-            GlobalShortcutManager.shared.unregisterShortcuts()
+            GlobalShortcutManager.shared.setRegistrationSuspended(true)
             installKeyMonitor()
         }
         .onDisappear {
             removeKeyMonitors()
-            GlobalShortcutManager.shared.registerShortcuts()
+            GlobalShortcutManager.shared.setRegistrationSuspended(false)
         }
     }
 
@@ -150,7 +150,7 @@ struct OnboardingFloatingBarShortcutStepView: View {
 
                 Spacer()
 
-                Button(action: beginCustomShortcutCapture) {
+                Button(action: handleCustomShortcutSaveButton) {
                     Text(isRecordingCustomShortcut ? "Listening..." : "Save")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundColor(OmiColors.textPrimary)
@@ -162,6 +162,7 @@ struct OnboardingFloatingBarShortcutStepView: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .disabled(isRecordingCustomShortcut)
             }
 
             Text("Use at least one non-modifier key, like J or Return.")
@@ -246,9 +247,25 @@ struct OnboardingFloatingBarShortcutStepView: View {
         resetDetectionState()
     }
 
+    private func handleCustomShortcutSaveButton() {
+        guard shortcutSettings.askOmiUsesCustomShortcut else {
+            beginCustomShortcutCapture()
+            return
+        }
+        confirmShortcutAndContinue()
+    }
+
     private func resetDetectionState() {
         shortcutDetected = false
         showContinue = false
+    }
+
+    private func confirmShortcutAndContinue() {
+        captureError = nil
+        shortcutDetected = true
+        withAnimation(.easeInOut(duration: 0.3)) {
+            showContinue = true
+        }
     }
 
     private func installKeyMonitor() {
@@ -260,12 +277,12 @@ struct OnboardingFloatingBarShortcutStepView: View {
             _ = handleShortcutEvent(event)
         }
 
-        // Temporarily strip the main menu so ⌘-key combos (⌘O, ⌘J, ⌘Return, etc.) aren't
-        // swallowed by NSMenu's performKeyEquivalent before our monitor sees them.
-        DispatchQueue.main.async {
+        // Strip the main menu immediately so the first keypress can't be swallowed
+        // by NSMenu key equivalents before our monitor sees it.
+        if Self.savedMenu == nil {
             Self.savedMenu = NSApp.mainMenu
-            NSApp.mainMenu = nil
         }
+        NSApp.mainMenu = nil
     }
 
     private func removeKeyMonitors() {
@@ -292,10 +309,7 @@ struct OnboardingFloatingBarShortcutStepView: View {
         guard shortcutSettings.askOmiShortcut.matchesKeyDown(event) else { return false }
 
         DispatchQueue.main.async {
-            shortcutDetected = true
-            withAnimation(.easeInOut(duration: 0.3)) {
-                showContinue = true
-            }
+            confirmShortcutAndContinue()
         }
         return true
     }

--- a/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
+++ b/desktop/Desktop/Sources/OnboardingVoiceShortcutStepView.swift
@@ -161,7 +161,7 @@ struct OnboardingVoiceShortcutStepView: View {
 
                 Spacer()
 
-                Button(action: beginCustomShortcutCapture) {
+                Button(action: handleCustomShortcutSaveButton) {
                     Text(isRecordingCustomShortcut ? "Listening..." : "Save")
                         .font(.system(size: 12, weight: .semibold))
                         .foregroundColor(OmiColors.textPrimary)
@@ -173,6 +173,7 @@ struct OnboardingVoiceShortcutStepView: View {
                         )
                 }
                 .buttonStyle(.plain)
+                .disabled(isRecordingCustomShortcut)
             }
 
             Text("You can use one key or a combination like ⌘ J.")
@@ -257,9 +258,25 @@ struct OnboardingVoiceShortcutStepView: View {
         resetDetectionState()
     }
 
+    private func handleCustomShortcutSaveButton() {
+        guard shortcutSettings.pttUsesCustomShortcut else {
+            beginCustomShortcutCapture()
+            return
+        }
+        confirmShortcutAndContinue()
+    }
+
     private func resetDetectionState() {
         shortcutDetected = false
         showContinue = false
+    }
+
+    private func confirmShortcutAndContinue() {
+        captureError = nil
+        shortcutDetected = true
+        withAnimation(.easeInOut(duration: 0.3)) {
+            showContinue = true
+        }
     }
 
     private func installKeyMonitor() {
@@ -271,10 +288,10 @@ struct OnboardingVoiceShortcutStepView: View {
             _ = handleShortcutEvent(event)
         }
 
-        DispatchQueue.main.async {
+        if Self.savedMenu == nil {
             Self.savedMenu = NSApp.mainMenu
-            NSApp.mainMenu = nil
         }
+        NSApp.mainMenu = nil
     }
 
     private func removeKeyMonitors() {
@@ -312,10 +329,7 @@ struct OnboardingVoiceShortcutStepView: View {
 
         guard detected else { return false }
 
-        shortcutDetected = true
-        withAnimation(.easeInOut(duration: 0.3)) {
-            showContinue = true
-        }
+        confirmShortcutAndContinue()
         return true
     }
 


### PR DESCRIPTION
## Summary
- fix the onboarding ask-question shortcut step so saving a custom shortcut reveals Continue
- keep shortcut detection working after switching from Custom back to a preset during onboarding
- suspend global shortcut registration during onboarding shortcut capture and remove the menu immediately so first key presses are not swallowed

## Validation
- launched `/Applications/Omi Dev.app` from this branch
- verified clean startup for `com.omi.desktop-dev` with healthy pid-scoped unified logs
- attached with `agent-swift` and confirmed the onboarding shortcut UI is interactive