### PR TITLE
Restore desktop chat bubble colors

### DIFF
--- a/desktop/Desktop/Sources/MainWindow/Pages/ChatPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/ChatPage.swift
@@ -682,6 +682,10 @@ struct ChatBubble: View {
             case .text(_, let text):
               if !text.isEmpty {
                 SelectableMarkdown(text: text, sender: .ai)
+                  .padding(.horizontal, 14)
+                  .padding(.vertical, 10)
+                  .background(OmiColors.backgroundTertiary.opacity(0.92))
+                  .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
                   .padding(.top, 2)
               }
             case .toolCalls(_, let calls):
@@ -728,6 +732,13 @@ struct ChatBubble: View {
           // User messages or AI messages without content blocks (loaded from Firestore)
           VStack(alignment: message.sender == .user ? .trailing : .leading, spacing: 4) {
             SelectableMarkdown(text: displayText, sender: message.sender)
+              .padding(.horizontal, 14)
+              .padding(.vertical, 10)
+              .background(
+                message.sender == .user
+                  ? OmiColors.userBubble : OmiColors.backgroundTertiary.opacity(0.95)
+              )
+              .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
               .padding(.top, 2)
 
             // Show more / Show less toggle for long messages


### PR DESCRIPTION
## Summary
- restore the previous desktop chat bubble backgrounds for user and AI messages
- keep the newer chat metadata layout while bringing back the purple user bubble and dark AI bubble containers

## Validation
- rebuilt and relaunched `/Applications/Omi Dev.app` locally from this branch
- attached to `com.omi.desktop-dev` with `agent-swift` and verified the app is running