### PR TITLE
Silence startup task promotion notifications

### DIFF
--- a/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Assistants/TaskExtraction/TaskPromotionService.swift
@@ -46,7 +46,7 @@ actor TaskPromotionService {
     /// (either cap reached or no staged tasks available).
     /// Returns the list of promoted tasks so callers can insert them directly.
     @discardableResult
-    func promoteIfNeeded() async -> [TaskActionItem] {
+    func promoteIfNeeded(shouldNotify: Bool = true) async -> [TaskActionItem] {
         guard !isPromoting else {
             log("TaskPromotion: Already promoting, skipping")
             return []
@@ -78,7 +78,7 @@ actor TaskPromotionService {
                     let notificationsEnabled = await MainActor.run {
                         TaskAssistantSettings.shared.notificationsEnabled
                     }
-                    if notificationsEnabled {
+                    if shouldNotify && notificationsEnabled {
                         let message = "New task: \(promotedTask.description)"
                         let context = Self.buildNotificationContext(from: promotedTask)
                         await MainActor.run {
@@ -116,7 +116,7 @@ actor TaskPromotionService {
     @discardableResult
     func ensureMinimumOnStartup() async -> [TaskActionItem] {
         log("TaskPromotion: Checking minimum on startup")
-        return await promoteIfNeeded()
+        return await promoteIfNeeded(shouldNotify: false)
     }
 
     // MARK: - Notification Context


### PR DESCRIPTION
## Summary
- keep startup task promotion enabled so the task list is still backfilled on launch
- suppress task notifications only for the app-launch promotion path
- keep normal task notifications unchanged for all non-startup promotion flows

## Validation
- rebuilt and relaunched `/Applications/Omi Dev.app` locally from this branch
- verified startup logs still showed `TaskPromotion: Promoted 5 tasks total` and `TasksStore: Inserted 5 promoted tasks on startup`
- verified the same startup block had no task notification send logs and no `Saved assistant message to backend` entries for those promoted tasks