### PR TITLE
Update CHANGELOG.json for v0.11.306 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -2,6 +2,13 @@
   "unreleased": [],
   "releases": [
     {
+      "version": "0.11.306",
+      "date": "2026-04-14",
+      "changes": [
+        "Bug fixes and improvements"
+      ]
+    },
+    {
       "version": "0.11.304",
       "date": "2026-04-14",
       "changes": [


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.306 and clears the unreleased array.