### PR TITLE
fix(desktop): proxy ElevenLabs TTS through backend with per-user rate limits

### DIFF
--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -72,6 +72,7 @@ jobs:
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
             AGENT_GCS_BUCKET=based-hardware-agent
+            DISABLE_ELEVENLABS_KEY_RESPONSE=true
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
@@ -138,6 +139,7 @@ jobs:
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
             AGENT_GCS_BUCKET=based-hardware-agent
+            DISABLE_ELEVENLABS_KEY_RESPONSE=true
           secrets: |
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             GEMINI_API_KEY=DESKTOP_GEMINI_API_KEY:latest

--- a/.github/workflows/desktop_auto_release.yml
+++ b/.github/workflows/desktop_auto_release.yml
@@ -72,7 +72,7 @@ jobs:
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
             AGENT_GCS_BUCKET=based-hardware-agent
-            DISABLE_ELEVENLABS_KEY_RESPONSE=true
+            DISABLE_ELEVENLABS_KEY_RESPONSE=false
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
@@ -139,7 +139,7 @@ jobs:
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
             AGENT_GCS_BUCKET=based-hardware-agent
-            DISABLE_ELEVENLABS_KEY_RESPONSE=true
+            DISABLE_ELEVENLABS_KEY_RESPONSE=false
           secrets: |
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest
             GEMINI_API_KEY=DESKTOP_GEMINI_API_KEY:latest

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -61,7 +61,7 @@ jobs:
           env_vars: |
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
-            DISABLE_ELEVENLABS_KEY_RESPONSE=true
+            DISABLE_ELEVENLABS_KEY_RESPONSE=false
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest

--- a/.github/workflows/desktop_backend_auto_dev.yml
+++ b/.github/workflows/desktop_backend_auto_dev.yml
@@ -61,6 +61,7 @@ jobs:
           env_vars: |
             FIREBASE_PROJECT_ID=based-hardware
             GOOGLE_APPLICATION_CREDENTIALS=/app/google-credentials.json
+            DISABLE_ELEVENLABS_KEY_RESPONSE=true
           secrets: |
             GEMINI_API_KEY=GEMINI_API_KEY:latest
             ENCRYPTION_SECRET=ENCRYPTION_SECRET:latest

--- a/desktop/Backend-Rust/src/config.rs
+++ b/desktop/Backend-Rust/src/config.rs
@@ -73,6 +73,9 @@ pub struct Config {
     pub elevenlabs_api_key: Option<String>,
     /// Google Calendar API key (served to desktop clients)
     pub google_calendar_api_key: Option<String>,
+    /// When true, omit ElevenLabs API key from /v1/config/api-keys response.
+    /// Set this after all clients have updated to use the TTS proxy (issue #6622).
+    pub disable_elevenlabs_key_response: bool,
 }
 
 impl Config {
@@ -134,6 +137,9 @@ impl Config {
             anthropic_api_key: env::var("ANTHROPIC_API_KEY").ok(),
             elevenlabs_api_key: env::var("ELEVENLABS_API_KEY").ok(),
             google_calendar_api_key: env::var("GOOGLE_CALENDAR_API_KEY").ok(),
+            disable_elevenlabs_key_response: env::var("DISABLE_ELEVENLABS_KEY_RESPONSE")
+                .map(|v| v == "true" || v == "1")
+                .unwrap_or(false),
         }
     }
 

--- a/desktop/Backend-Rust/src/main.rs
+++ b/desktop/Backend-Rust/src/main.rs
@@ -32,7 +32,7 @@ mod services;
 
 use auth::{firebase_auth_extension, FirebaseAuth};
 use config::Config;
-use routes::{action_items_routes, advice_routes, agent_routes, apps_routes, auth_routes, chat_routes, chat_sessions_routes, config_routes, conversations_routes, crisp_routes, daily_score_routes, focus_sessions_routes, folder_routes, goals_routes, health_routes, knowledge_graph_routes, llm_usage_routes, memories_routes, messages_routes, people_routes, personas_routes, proxy_routes, screen_activity_routes, staged_tasks_routes, stats_routes, updates_routes, users_routes, webhook_routes};
+use routes::{action_items_routes, advice_routes, agent_routes, apps_routes, auth_routes, chat_routes, chat_sessions_routes, config_routes, conversations_routes, crisp_routes, daily_score_routes, focus_sessions_routes, folder_routes, goals_routes, health_routes, knowledge_graph_routes, llm_usage_routes, memories_routes, messages_routes, people_routes, personas_routes, proxy_routes, screen_activity_routes, staged_tasks_routes, stats_routes, tts_routes, updates_routes, users_routes, webhook_routes};
 use services::{FirestoreService, IntegrationService, RedisService};
 
 /// Application state shared across handlers
@@ -226,6 +226,7 @@ async fn main() {
         .merge(crisp_routes())
         .merge(screen_activity_routes())
         .merge(proxy_routes())
+        .merge(tts_routes())
         .merge(config_routes())
         .with_state(state);
 

--- a/desktop/Backend-Rust/src/routes/config.rs
+++ b/desktop/Backend-Rust/src/routes/config.rs
@@ -3,6 +3,7 @@
 //
 // Deepgram and Gemini keys are NO LONGER served here — they are proxied server-side
 // via /v1/proxy/deepgram/* and /v1/proxy/gemini/* (see proxy.rs, issue #5861).
+// ElevenLabs key is NO LONGER served here — proxied via /v1/tts/synthesize (see tts.rs, issue #6622).
 
 use axum::{extract::State, routing::get, Json, Router};
 use serde::Serialize;
@@ -15,19 +16,17 @@ struct ApiKeysResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     anthropic_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    elevenlabs_api_key: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     firebase_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     google_calendar_api_key: Option<String>,
 }
 
 /// GET /v1/config/api-keys — return API keys for the authenticated user
-/// NOTE: Deepgram and Gemini keys removed — now proxied server-side (issue #5861)
+/// NOTE: Deepgram, Gemini keys removed — proxied server-side (issue #5861)
+/// NOTE: ElevenLabs key removed — proxied via /v1/tts/synthesize (issue #6622)
 async fn get_api_keys(State(state): State<AppState>, _user: AuthUser) -> Json<ApiKeysResponse> {
     Json(ApiKeysResponse {
         anthropic_api_key: state.config.anthropic_api_key.clone(),
-        elevenlabs_api_key: state.config.elevenlabs_api_key.clone(),
         firebase_api_key: state.config.firebase_api_key.clone(),
         google_calendar_api_key: state.config.google_calendar_api_key.clone(),
     })

--- a/desktop/Backend-Rust/src/routes/config.rs
+++ b/desktop/Backend-Rust/src/routes/config.rs
@@ -3,7 +3,10 @@
 //
 // Deepgram and Gemini keys are NO LONGER served here — they are proxied server-side
 // via /v1/proxy/deepgram/* and /v1/proxy/gemini/* (see proxy.rs, issue #5861).
-// ElevenLabs key is NO LONGER served here — proxied via /v1/tts/synthesize (see tts.rs, issue #6622).
+//
+// ElevenLabs key: new clients use the TTS proxy at /v1/tts/synthesize (issue #6622),
+// but the key is still served here for backward compatibility with older app versions.
+// Set DISABLE_ELEVENLABS_KEY_RESPONSE=true to stop serving it once all clients have updated.
 
 use axum::{extract::State, routing::get, Json, Router};
 use serde::Serialize;
@@ -19,16 +22,25 @@ struct ApiKeysResponse {
     firebase_api_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     google_calendar_api_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    elevenlabs_api_key: Option<String>,
 }
 
 /// GET /v1/config/api-keys — return API keys for the authenticated user
 /// NOTE: Deepgram, Gemini keys removed — proxied server-side (issue #5861)
-/// NOTE: ElevenLabs key removed — proxied via /v1/tts/synthesize (issue #6622)
+/// NOTE: ElevenLabs key gated by DISABLE_ELEVENLABS_KEY_RESPONSE (issue #6622)
 async fn get_api_keys(State(state): State<AppState>, _user: AuthUser) -> Json<ApiKeysResponse> {
+    let elevenlabs_key = if state.config.disable_elevenlabs_key_response {
+        None
+    } else {
+        state.config.elevenlabs_api_key.clone()
+    };
+
     Json(ApiKeysResponse {
         anthropic_api_key: state.config.anthropic_api_key.clone(),
         firebase_api_key: state.config.firebase_api_key.clone(),
         google_calendar_api_key: state.config.google_calendar_api_key.clone(),
+        elevenlabs_api_key: elevenlabs_key,
     })
 }
 

--- a/desktop/Backend-Rust/src/routes/mod.rs
+++ b/desktop/Backend-Rust/src/routes/mod.rs
@@ -29,6 +29,7 @@ pub mod webhooks;
 pub mod proxy;
 pub mod rate_limit;
 pub mod screen_activity;
+pub mod tts;
 
 pub use action_items::action_items_routes;
 pub use advice::advice_routes;
@@ -58,3 +59,4 @@ pub use users::users_routes;
 pub use webhooks::webhook_routes;
 pub use proxy::proxy_routes;
 pub use screen_activity::screen_activity_routes;
+pub use tts::tts_routes;

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -100,27 +100,37 @@ async fn tts_synthesize(
         ));
     }
 
-    // Rate limit check (Redis-backed)
-    if let Some(redis) = &state.redis {
-        match redis
-            .check_tts_rate_limit(&user.uid, TTS_BURST_PER_MINUTE, TTS_BURST_WINDOW_SECS, char_count, TTS_DAILY_CHAR_LIMIT)
-            .await
-        {
-            Ok(TtsRateResult::Allow) => {}
-            Ok(TtsRateResult::BurstExceeded) => {
-                tracing::warn!("tts_synthesize: burst rate limit exceeded uid={}", user.uid);
-                return Err(rate_limit_response("Rate limit exceeded: too many requests. Try again in 60 seconds."));
-            }
-            Ok(TtsRateResult::DailyCharsExceeded) => {
-                tracing::warn!("tts_synthesize: daily character limit exceeded uid={}", user.uid);
-                return Err(rate_limit_response(
-                    "Daily character limit exceeded (10,000 characters). Resets at midnight UTC.",
-                ));
-            }
-            Err(e) => {
-                tracing::error!("tts_synthesize: Redis rate limit error, allowing unmetered: {}", e);
-                // Fail open — allow the request if Redis is down
-            }
+    // Rate limit check (Redis-backed, fail closed)
+    let redis = state.redis.as_ref().ok_or_else(|| {
+        tracing::error!("tts_synthesize: Redis not configured — TTS rate limiting requires Redis");
+        error_response(StatusCode::SERVICE_UNAVAILABLE, "TTS service temporarily unavailable")
+    })?;
+
+    match redis
+        .check_tts_rate_limit(&user.uid, TTS_BURST_PER_MINUTE, TTS_BURST_WINDOW_SECS, char_count, TTS_DAILY_CHAR_LIMIT)
+        .await
+    {
+        Ok(TtsRateResult::Allow) => {}
+        Ok(TtsRateResult::BurstExceeded) => {
+            tracing::warn!("tts_synthesize: burst rate limit exceeded uid={}", user.uid);
+            return Err(rate_limit_response_with_retry(
+                "Rate limit exceeded: too many requests. Try again in 60 seconds.",
+                60,
+            ));
+        }
+        Ok(TtsRateResult::DailyCharsExceeded) => {
+            tracing::warn!("tts_synthesize: daily character limit exceeded uid={}", user.uid);
+            return Err(rate_limit_response_with_retry(
+                "Daily character limit exceeded (10,000 characters). Resets at midnight UTC.",
+                seconds_until_midnight_utc(),
+            ));
+        }
+        Err(e) => {
+            tracing::error!("tts_synthesize: Redis error — failing closed: {}", e);
+            return Err(error_response(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "TTS service temporarily unavailable",
+            ));
         }
     }
 
@@ -189,7 +199,7 @@ fn error_response(status: StatusCode, message: &str) -> Response {
     (status, Json(body)).into_response()
 }
 
-fn rate_limit_response(message: &str) -> Response {
+fn rate_limit_response_with_retry(message: &str, retry_after_secs: u64) -> Response {
     let body = serde_json::json!({
         "error": {
             "message": message,
@@ -199,9 +209,17 @@ fn rate_limit_response(message: &str) -> Response {
     Response::builder()
         .status(StatusCode::TOO_MANY_REQUESTS)
         .header("Content-Type", "application/json")
-        .header("Retry-After", "60")
+        .header("Retry-After", retry_after_secs.to_string())
         .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap_or_default()))
         .unwrap()
+}
+
+/// Seconds remaining until the next UTC midnight (for daily limit Retry-After).
+fn seconds_until_midnight_utc() -> u64 {
+    let now = chrono::Utc::now();
+    let tomorrow = (now + chrono::Duration::days(1)).date_naive().and_hms_opt(0, 0, 0).unwrap();
+    let midnight = tomorrow.and_utc();
+    (midnight - now).num_seconds().max(1) as u64
 }
 
 /// Result of a TTS rate limit check.
@@ -241,9 +259,23 @@ mod tests {
     }
 
     #[test]
-    fn rate_limit_response_format() {
-        let resp = rate_limit_response("too many");
+    fn rate_limit_response_burst() {
+        let resp = rate_limit_response_with_retry("too many", 60);
         assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
         assert_eq!(resp.headers().get("Retry-After").unwrap(), "60");
+    }
+
+    #[test]
+    fn rate_limit_response_daily() {
+        let resp = rate_limit_response_with_retry("daily limit", 3600);
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(resp.headers().get("Retry-After").unwrap(), "3600");
+    }
+
+    #[test]
+    fn seconds_until_midnight_is_positive() {
+        let secs = seconds_until_midnight_utc();
+        assert!(secs >= 1);
+        assert!(secs <= 86400);
     }
 }

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -8,7 +8,6 @@
 // Issue #6622: Remove client-side ElevenLabs API key exposure.
 
 use axum::{
-    body::Bytes,
     extract::State,
     http::StatusCode,
     response::{IntoResponse, Response},
@@ -28,6 +27,9 @@ const TTS_DAILY_CHAR_LIMIT: i64 = 10_000;
 
 /// Rolling burst window in seconds.
 const TTS_BURST_WINDOW_SECS: u64 = 60;
+
+/// Single-request text cap for ElevenLabs synthesis.
+const TTS_REQUEST_CHAR_LIMIT: i64 = 5_000;
 
 #[derive(Deserialize)]
 struct TtsSynthesizeRequest {
@@ -79,14 +81,10 @@ async fn tts_synthesize(
     user: AuthUser,
     Json(req): Json<TtsSynthesizeRequest>,
 ) -> Result<Response, Response> {
-    let elevenlabs_key = state
-        .config
-        .elevenlabs_api_key
-        .as_ref()
-        .ok_or_else(|| {
-            tracing::error!("tts_synthesize: ELEVENLABS_API_KEY not configured");
-            StatusCode::SERVICE_UNAVAILABLE.into_response()
-        })?;
+    let elevenlabs_key = state.config.elevenlabs_api_key.as_ref().ok_or_else(|| {
+        tracing::error!("tts_synthesize: ELEVENLABS_API_KEY not configured");
+        StatusCode::SERVICE_UNAVAILABLE.into_response()
+    })?;
 
     // Validate voice_id: must be alphanumeric (ElevenLabs IDs are 20-char base62).
     // Prevents path traversal (e.g. "../../history") that could retarget the xi-api-key.
@@ -95,25 +93,26 @@ async fn tts_synthesize(
     }
 
     // Validate text is not empty and not excessively long (single request cap: 5000 chars)
-    if req.text.is_empty() {
-        return Err(error_response(StatusCode::BAD_REQUEST, "text must not be empty"));
-    }
-    let char_count = req.text.chars().count() as i64;
-    if char_count > 5000 {
-        return Err(error_response(
-            StatusCode::BAD_REQUEST,
-            "text exceeds maximum length of 5000 characters",
-        ));
-    }
+    let char_count = validate_text(&req.text)
+        .map_err(|message| error_response(StatusCode::BAD_REQUEST, message))?;
 
     // Rate limit check (Redis-backed, fail closed)
     let redis = state.redis.as_ref().ok_or_else(|| {
         tracing::error!("tts_synthesize: Redis not configured — TTS rate limiting requires Redis");
-        error_response(StatusCode::SERVICE_UNAVAILABLE, "TTS service temporarily unavailable")
+        error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "TTS service temporarily unavailable",
+        )
     })?;
 
     match redis
-        .check_tts_rate_limit(&user.uid, TTS_BURST_PER_MINUTE, TTS_BURST_WINDOW_SECS, char_count, TTS_DAILY_CHAR_LIMIT)
+        .check_tts_rate_limit(
+            &user.uid,
+            TTS_BURST_PER_MINUTE,
+            TTS_BURST_WINDOW_SECS,
+            char_count,
+            TTS_DAILY_CHAR_LIMIT,
+        )
         .await
     {
         Ok(TtsRateResult::Allow) => {}
@@ -125,7 +124,10 @@ async fn tts_synthesize(
             ));
         }
         Ok(TtsRateResult::DailyCharsExceeded) => {
-            tracing::warn!("tts_synthesize: daily character limit exceeded uid={}", user.uid);
+            tracing::warn!(
+                "tts_synthesize: daily character limit exceeded uid={}",
+                user.uid
+            );
             return Err(rate_limit_response_with_retry(
                 "Daily character limit exceeded (10,000 characters). Resets at midnight UTC.",
                 seconds_until_midnight_utc(),
@@ -169,7 +171,8 @@ async fn tts_synthesize(
             StatusCode::BAD_GATEWAY.into_response()
         })?;
 
-    let status = StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+    let status =
+        StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
 
     if !status.is_success() {
         let error_body = upstream.text().await.unwrap_or_default();
@@ -197,9 +200,20 @@ async fn tts_synthesize(
 
 /// Validate voice_id: alphanumeric only, 1-128 chars. Rejects path traversal and injection.
 fn is_valid_voice_id(id: &str) -> bool {
-    !id.is_empty()
-        && id.len() <= 128
-        && id.chars().all(|c| c.is_ascii_alphanumeric())
+    !id.is_empty() && id.len() <= 128 && id.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
+fn validate_text(text: &str) -> Result<i64, &'static str> {
+    if text.is_empty() {
+        return Err("text must not be empty");
+    }
+
+    let char_count = text.chars().count() as i64;
+    if char_count > TTS_REQUEST_CHAR_LIMIT {
+        return Err("text exceeds maximum length of 5000 characters");
+    }
+
+    Ok(char_count)
 }
 
 fn error_response(status: StatusCode, message: &str) -> Response {
@@ -223,14 +237,19 @@ fn rate_limit_response_with_retry(message: &str, retry_after_secs: u64) -> Respo
         .status(StatusCode::TOO_MANY_REQUESTS)
         .header("Content-Type", "application/json")
         .header("Retry-After", retry_after_secs.to_string())
-        .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap_or_default()))
+        .body(axum::body::Body::from(
+            serde_json::to_vec(&body).unwrap_or_default(),
+        ))
         .unwrap()
 }
 
 /// Seconds remaining until the next UTC midnight (for daily limit Retry-After).
 fn seconds_until_midnight_utc() -> u64 {
     let now = chrono::Utc::now();
-    let tomorrow = (now + chrono::Duration::days(1)).date_naive().and_hms_opt(0, 0, 0).unwrap();
+    let tomorrow = (now + chrono::Duration::days(1))
+        .date_naive()
+        .and_hms_opt(0, 0, 0)
+        .unwrap();
     let midnight = tomorrow.and_utc();
     (midnight - now).num_seconds().max(1) as u64
 }
@@ -300,6 +319,40 @@ mod tests {
     #[test]
     fn default_output_format_value() {
         assert_eq!(default_output_format(), "mp3_44100_128");
+    }
+
+    #[test]
+    fn deserialize_request_applies_defaults() {
+        let req: TtsSynthesizeRequest = serde_json::from_value(serde_json::json!({
+            "text": "hello"
+        }))
+        .unwrap();
+
+        assert_eq!(req.text, "hello");
+        assert_eq!(req.voice_id, default_voice_id());
+        assert_eq!(req.model_id, default_model_id());
+        assert_eq!(req.output_format, default_output_format());
+        assert!(req.voice_settings.is_none());
+    }
+
+    #[test]
+    fn validate_text_rejects_empty() {
+        assert_eq!(validate_text(""), Err("text must not be empty"));
+    }
+
+    #[test]
+    fn validate_text_accepts_max_length() {
+        let text = "a".repeat(TTS_REQUEST_CHAR_LIMIT as usize);
+        assert_eq!(validate_text(&text), Ok(TTS_REQUEST_CHAR_LIMIT));
+    }
+
+    #[test]
+    fn validate_text_rejects_over_limit() {
+        let text = "a".repeat((TTS_REQUEST_CHAR_LIMIT + 1) as usize);
+        assert_eq!(
+            validate_text(&text),
+            Err("text exceeds maximum length of 5000 characters")
+        );
     }
 
     #[test]

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -1,0 +1,249 @@
+// TTS proxy route — proxies ElevenLabs text-to-speech requests server-side.
+// Key stays on the backend; desktop client authenticates via Firebase token only.
+//
+// Per-user rate limits (Redis-backed):
+//   - 50 requests per rolling 60-second window → 429
+//   - 10,000 characters per calendar day → 429
+//
+// Issue #6622: Remove client-side ElevenLabs API key exposure.
+
+use axum::{
+    body::Bytes,
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use crate::auth::AuthUser;
+use crate::AppState;
+
+/// Per-user burst limit: max requests per rolling 60-second window.
+const TTS_BURST_PER_MINUTE: i64 = 50;
+
+/// Per-user daily character limit.
+const TTS_DAILY_CHAR_LIMIT: i64 = 10_000;
+
+/// Rolling burst window in seconds.
+const TTS_BURST_WINDOW_SECS: u64 = 60;
+
+#[derive(Deserialize)]
+struct TtsSynthesizeRequest {
+    text: String,
+    #[serde(default = "default_voice_id")]
+    voice_id: String,
+    #[serde(default = "default_model_id")]
+    model_id: String,
+    #[serde(default = "default_output_format")]
+    output_format: String,
+    voice_settings: Option<VoiceSettings>,
+}
+
+#[derive(Deserialize, Serialize)]
+struct VoiceSettings {
+    stability: Option<f64>,
+    similarity_boost: Option<f64>,
+    style: Option<f64>,
+    use_speaker_boost: Option<bool>,
+}
+
+fn default_voice_id() -> String {
+    "BAMYoBHLZM7lJgJAmFz0".to_string() // Sloane
+}
+
+fn default_model_id() -> String {
+    "eleven_turbo_v2_5".to_string()
+}
+
+fn default_output_format() -> String {
+    "mp3_44100_128".to_string()
+}
+
+#[derive(Serialize)]
+struct TtsErrorResponse {
+    error: TtsErrorDetail,
+}
+
+#[derive(Serialize)]
+struct TtsErrorDetail {
+    message: String,
+    code: u16,
+}
+
+/// POST /v1/tts/synthesize
+/// Proxies TTS requests to ElevenLabs API. Per-user rate limited.
+async fn tts_synthesize(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Json(req): Json<TtsSynthesizeRequest>,
+) -> Result<Response, Response> {
+    let elevenlabs_key = state
+        .config
+        .elevenlabs_api_key
+        .as_ref()
+        .ok_or_else(|| {
+            tracing::error!("tts_synthesize: ELEVENLABS_API_KEY not configured");
+            StatusCode::SERVICE_UNAVAILABLE.into_response()
+        })?;
+
+    // Validate text is not empty and not excessively long (single request cap: 5000 chars)
+    if req.text.is_empty() {
+        return Err(error_response(StatusCode::BAD_REQUEST, "text must not be empty"));
+    }
+    let char_count = req.text.chars().count() as i64;
+    if char_count > 5000 {
+        return Err(error_response(
+            StatusCode::BAD_REQUEST,
+            "text exceeds maximum length of 5000 characters",
+        ));
+    }
+
+    // Rate limit check (Redis-backed)
+    if let Some(redis) = &state.redis {
+        match redis
+            .check_tts_rate_limit(&user.uid, TTS_BURST_PER_MINUTE, TTS_BURST_WINDOW_SECS, char_count, TTS_DAILY_CHAR_LIMIT)
+            .await
+        {
+            Ok(TtsRateResult::Allow) => {}
+            Ok(TtsRateResult::BurstExceeded) => {
+                tracing::warn!("tts_synthesize: burst rate limit exceeded uid={}", user.uid);
+                return Err(rate_limit_response("Rate limit exceeded: too many requests. Try again in 60 seconds."));
+            }
+            Ok(TtsRateResult::DailyCharsExceeded) => {
+                tracing::warn!("tts_synthesize: daily character limit exceeded uid={}", user.uid);
+                return Err(rate_limit_response(
+                    "Daily character limit exceeded (10,000 characters). Resets at midnight UTC.",
+                ));
+            }
+            Err(e) => {
+                tracing::error!("tts_synthesize: Redis rate limit error, allowing unmetered: {}", e);
+                // Fail open — allow the request if Redis is down
+            }
+        }
+    }
+
+    // Build ElevenLabs upstream request
+    let upstream_url = format!(
+        "https://api.elevenlabs.io/v1/text-to-speech/{}",
+        req.voice_id
+    );
+
+    let mut body = serde_json::json!({
+        "text": req.text,
+        "model_id": req.model_id,
+        "output_format": req.output_format,
+    });
+    if let Some(vs) = &req.voice_settings {
+        body["voice_settings"] = serde_json::to_value(vs).unwrap_or_default();
+    }
+
+    let upstream = reqwest::Client::new()
+        .post(&upstream_url)
+        .header("Content-Type", "application/json")
+        .header("Accept", "audio/mpeg")
+        .header("xi-api-key", elevenlabs_key)
+        .body(serde_json::to_vec(&body).unwrap_or_default())
+        .timeout(std::time::Duration::from_secs(60))
+        .send()
+        .await
+        .map_err(|e| {
+            tracing::error!("tts_synthesize: upstream request failed: {}", e);
+            StatusCode::BAD_GATEWAY.into_response()
+        })?;
+
+    let status = StatusCode::from_u16(upstream.status().as_u16()).unwrap_or(StatusCode::BAD_GATEWAY);
+
+    if !status.is_success() {
+        let error_body = upstream.text().await.unwrap_or_default();
+        tracing::warn!(
+            "tts_synthesize: ElevenLabs returned {} for uid={}: {}",
+            status.as_u16(),
+            user.uid,
+            &error_body[..error_body.len().min(200)]
+        );
+        return Err((status, error_body).into_response());
+    }
+
+    let audio_bytes = upstream.bytes().await.map_err(|e| {
+        tracing::error!("tts_synthesize: failed to read upstream body: {}", e);
+        StatusCode::BAD_GATEWAY.into_response()
+    })?;
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .header("Content-Type", "audio/mpeg")
+        .header("Content-Length", audio_bytes.len().to_string())
+        .body(axum::body::Body::from(audio_bytes))
+        .unwrap())
+}
+
+fn error_response(status: StatusCode, message: &str) -> Response {
+    let body = TtsErrorResponse {
+        error: TtsErrorDetail {
+            message: message.to_string(),
+            code: status.as_u16(),
+        },
+    };
+    (status, Json(body)).into_response()
+}
+
+fn rate_limit_response(message: &str) -> Response {
+    let body = serde_json::json!({
+        "error": {
+            "message": message,
+            "code": 429,
+        }
+    });
+    Response::builder()
+        .status(StatusCode::TOO_MANY_REQUESTS)
+        .header("Content-Type", "application/json")
+        .header("Retry-After", "60")
+        .body(axum::body::Body::from(serde_json::to_vec(&body).unwrap_or_default()))
+        .unwrap()
+}
+
+/// Result of a TTS rate limit check.
+pub enum TtsRateResult {
+    Allow,
+    BurstExceeded,
+    DailyCharsExceeded,
+}
+
+pub fn tts_routes() -> Router<AppState> {
+    Router::new().route("/v1/tts/synthesize", post(tts_synthesize))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_voice_id_is_sloane() {
+        assert_eq!(default_voice_id(), "BAMYoBHLZM7lJgJAmFz0");
+    }
+
+    #[test]
+    fn default_model_id_value() {
+        assert_eq!(default_model_id(), "eleven_turbo_v2_5");
+    }
+
+    #[test]
+    fn default_output_format_value() {
+        assert_eq!(default_output_format(), "mp3_44100_128");
+    }
+
+    #[test]
+    fn error_response_format() {
+        let resp = error_response(StatusCode::BAD_REQUEST, "test error");
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn rate_limit_response_format() {
+        let resp = rate_limit_response("too many");
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert_eq!(resp.headers().get("Retry-After").unwrap(), "60");
+    }
+}

--- a/desktop/Backend-Rust/src/routes/tts.rs
+++ b/desktop/Backend-Rust/src/routes/tts.rs
@@ -88,6 +88,12 @@ async fn tts_synthesize(
             StatusCode::SERVICE_UNAVAILABLE.into_response()
         })?;
 
+    // Validate voice_id: must be alphanumeric (ElevenLabs IDs are 20-char base62).
+    // Prevents path traversal (e.g. "../../history") that could retarget the xi-api-key.
+    if !is_valid_voice_id(&req.voice_id) {
+        return Err(error_response(StatusCode::BAD_REQUEST, "invalid voice_id"));
+    }
+
     // Validate text is not empty and not excessively long (single request cap: 5000 chars)
     if req.text.is_empty() {
         return Err(error_response(StatusCode::BAD_REQUEST, "text must not be empty"));
@@ -189,6 +195,13 @@ async fn tts_synthesize(
         .unwrap())
 }
 
+/// Validate voice_id: alphanumeric only, 1-128 chars. Rejects path traversal and injection.
+fn is_valid_voice_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 128
+        && id.chars().all(|c| c.is_ascii_alphanumeric())
+}
+
 fn error_response(status: StatusCode, message: &str) -> Response {
     let body = TtsErrorResponse {
         error: TtsErrorDetail {
@@ -240,6 +253,43 @@ mod tests {
     #[test]
     fn default_voice_id_is_sloane() {
         assert_eq!(default_voice_id(), "BAMYoBHLZM7lJgJAmFz0");
+    }
+
+    // --- voice_id validation (path traversal prevention) ---
+
+    #[test]
+    fn valid_voice_id_alphanumeric() {
+        assert!(is_valid_voice_id("BAMYoBHLZM7lJgJAmFz0"));
+        assert!(is_valid_voice_id("abc123"));
+        assert!(is_valid_voice_id("A"));
+    }
+
+    #[test]
+    fn reject_voice_id_path_traversal() {
+        assert!(!is_valid_voice_id("../../history"));
+        assert!(!is_valid_voice_id("../v1/voices"));
+        assert!(!is_valid_voice_id("foo/bar"));
+    }
+
+    #[test]
+    fn reject_voice_id_special_chars() {
+        assert!(!is_valid_voice_id("id-with-dash"));
+        assert!(!is_valid_voice_id("id_with_underscore"));
+        assert!(!is_valid_voice_id("id with space"));
+        assert!(!is_valid_voice_id("id?query=1"));
+    }
+
+    #[test]
+    fn reject_voice_id_empty() {
+        assert!(!is_valid_voice_id(""));
+    }
+
+    #[test]
+    fn reject_voice_id_too_long() {
+        let long_id: String = "a".repeat(129);
+        assert!(!is_valid_voice_id(&long_id));
+        let max_id: String = "a".repeat(128);
+        assert!(is_valid_voice_id(&max_id));
     }
 
     #[test]

--- a/desktop/Backend-Rust/src/services/redis.rs
+++ b/desktop/Backend-Rust/src/services/redis.rs
@@ -275,6 +275,80 @@ return {daily, burst}
     }
 
     // ============================================================================
+    // TTS (ElevenLabs) RATE LIMITING - issue #6622
+    // ============================================================================
+
+    /// Check and record a TTS request for rate limiting.
+    /// Tracks burst (requests/minute) and daily character usage in one Lua script.
+    /// Returns TtsRateResult indicating whether the request is allowed.
+    pub async fn check_tts_rate_limit(
+        &self,
+        uid: &str,
+        burst_limit: i64,
+        burst_window_secs: u64,
+        char_count: i64,
+        daily_char_limit: i64,
+    ) -> Result<crate::routes::tts::TtsRateResult, redis::RedisError> {
+        let mut conn = self.get_connection().await?;
+
+        let now_ms = chrono::Utc::now().timestamp_millis();
+        let day_ordinal = (now_ms / 86_400_000).to_string();
+        let cutoff_ms = now_ms - (burst_window_secs as i64 * 1000);
+
+        let burst_key = format!("tts_rl:{}:burst", uid);
+        let daily_chars_key = format!("tts_rl:{}:chars:{}", uid, day_ordinal);
+
+        // Lua script: atomic burst + daily char check and record.
+        // KEYS[1] = burst_key, KEYS[2] = daily_chars_key
+        // ARGV[1] = cutoff_ms, ARGV[2] = now_ms, ARGV[3] = burst_ttl
+        // ARGV[4] = daily_ttl, ARGV[5] = char_count, ARGV[6] = burst_limit, ARGV[7] = daily_char_limit
+        //
+        // Returns {burst_count, daily_chars, 0=allow/1=burst_exceeded/2=chars_exceeded}
+        let script = r#"
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', ARGV[1])
+local burst = redis.call('ZCARD', KEYS[1])
+if burst >= tonumber(ARGV[6]) then
+    return {burst, 0, 1}
+end
+local daily_chars = tonumber(redis.call('GET', KEYS[2]) or '0')
+if daily_chars + tonumber(ARGV[5]) > tonumber(ARGV[7]) then
+    return {burst, daily_chars, 2}
+end
+redis.call('ZADD', KEYS[1], ARGV[2], ARGV[2] .. ':' .. tostring(burst))
+redis.call('EXPIRE', KEYS[1], ARGV[3])
+redis.call('INCRBY', KEYS[2], ARGV[5])
+redis.call('EXPIRE', KEYS[2], ARGV[4])
+local new_chars = tonumber(redis.call('GET', KEYS[2]) or '0')
+return {burst + 1, new_chars, 0}
+"#;
+
+        let burst_ttl = (burst_window_secs * 2) as i64;
+        let daily_ttl: i64 = 172_800; // 48h
+
+        let result: Vec<i64> = redis::cmd("EVAL")
+            .arg(script)
+            .arg(2)
+            .arg(&burst_key)
+            .arg(&daily_chars_key)
+            .arg(cutoff_ms)
+            .arg(now_ms)
+            .arg(burst_ttl)
+            .arg(daily_ttl)
+            .arg(char_count)
+            .arg(burst_limit)
+            .arg(daily_char_limit)
+            .query_async(&mut conn)
+            .await?;
+
+        let decision = result.get(2).copied().unwrap_or(0);
+        match decision {
+            1 => Ok(crate::routes::tts::TtsRateResult::BurstExceeded),
+            2 => Ok(crate::routes::tts::TtsRateResult::DailyCharsExceeded),
+            _ => Ok(crate::routes::tts::TtsRateResult::Allow),
+        }
+    }
+
+    // ============================================================================
     // APP INSTALLS - matches Python backend redis_db.py
     // ============================================================================
 

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -4132,12 +4132,10 @@ struct MemorySettingsResponse: Codable {
 
 struct FloatingBarSettingsResponse: Codable {
   var voiceAnswersEnabled: Bool?
-  var elevenLabsApiKey: String?
   var elevenLabsVoiceID: String?
 
   enum CodingKeys: String, CodingKey {
     case voiceAnswersEnabled = "voice_answers_enabled"
-    case elevenLabsApiKey = "elevenlabs_api_key"
     case elevenLabsVoiceID = "elevenlabs_voice_id"
   }
 }
@@ -4931,7 +4929,6 @@ extension APIClient {
     let deepgramApiKey: String?
     let geminiApiKey: String?
     let anthropicApiKey: String?
-    let elevenLabsApiKey: String?
     let firebaseApiKey: String?
     let googleCalendarApiKey: String?
 
@@ -4939,7 +4936,6 @@ extension APIClient {
       case deepgramApiKey = "deepgram_api_key"
       case geminiApiKey = "gemini_api_key"
       case anthropicApiKey = "anthropic_api_key"
-      case elevenLabsApiKey = "elevenlabs_api_key"
       case firebaseApiKey = "firebase_api_key"
       case googleCalendarApiKey = "google_calendar_api_key"
     }
@@ -4947,6 +4943,79 @@ extension APIClient {
 
   func fetchApiKeys() async throws -> ApiKeysResponse {
     return try await get("v1/config/api-keys", customBaseURL: rustBackendURL)
+  }
+
+  // MARK: - TTS Proxy (issue #6622)
+
+  struct TtsSynthesizeRequest: Encodable {
+    let text: String
+    let voiceId: String
+    let modelId: String
+    let outputFormat: String
+    let voiceSettings: TtsVoiceSettings
+
+    enum CodingKeys: String, CodingKey {
+      case text
+      case voiceId = "voice_id"
+      case modelId = "model_id"
+      case outputFormat = "output_format"
+      case voiceSettings = "voice_settings"
+    }
+  }
+
+  struct TtsVoiceSettings: Encodable {
+    let stability: Double
+    let similarityBoost: Double
+    let style: Double
+    let useSpeakerBoost: Bool
+
+    enum CodingKeys: String, CodingKey {
+      case stability
+      case similarityBoost = "similarity_boost"
+      case style
+      case useSpeakerBoost = "use_speaker_boost"
+    }
+  }
+
+  /// Synthesize speech via the backend TTS proxy (ElevenLabs key stays server-side).
+  /// Returns raw audio data (audio/mpeg).
+  func synthesizeSpeech(request: TtsSynthesizeRequest) async throws -> Data {
+    let base = rustBackendURL
+    let url = URL(string: base + "v1/tts/synthesize")!
+    var urlRequest = URLRequest(url: url)
+    urlRequest.httpMethod = "POST"
+    urlRequest.allHTTPHeaderFields = try await buildHeaders(requireAuth: true)
+    urlRequest.httpBody = try JSONEncoder().encode(request)
+    urlRequest.timeoutInterval = 60
+
+    let (data, response) = try await session.data(for: urlRequest)
+    guard let httpResponse = response as? HTTPURLResponse else {
+      throw APIError.invalidResponse
+    }
+
+    if httpResponse.statusCode == 401 {
+      // Retry with refreshed token
+      let authService = await MainActor.run { AuthService.shared }
+      _ = try await authService.getIdToken(forceRefresh: true)
+
+      var retryRequest = urlRequest
+      retryRequest.setValue(
+        try await authService.getAuthHeader(), forHTTPHeaderField: "Authorization")
+
+      let (retryData, retryResponse) = try await session.data(for: retryRequest)
+      guard let retryHttpResponse = retryResponse as? HTTPURLResponse else {
+        throw APIError.invalidResponse
+      }
+      guard (200...299).contains(retryHttpResponse.statusCode) else {
+        throw APIError.httpError(statusCode: retryHttpResponse.statusCode)
+      }
+      return retryData
+    }
+
+    guard (200...299).contains(httpResponse.statusCode) else {
+      throw APIError.httpError(statusCode: httpResponse.statusCode)
+    }
+    return data
   }
 
   // MARK: - Platform Tools (backend RAG)

--- a/desktop/Desktop/Sources/APIKeyService.swift
+++ b/desktop/Desktop/Sources/APIKeyService.swift
@@ -4,8 +4,9 @@ import Foundation
 /// Developer overrides (set in Settings) take precedence over backend-provided keys.
 ///
 /// NOTE: Deepgram and Gemini keys are NO LONGER fetched from the backend —
-/// they are proxied server-side (issue #5861). Anthropic, ElevenLabs, Firebase,
-/// and Calendar keys are still served via /v1/config/api-keys.
+/// they are proxied server-side (issue #5861).
+/// NOTE: ElevenLabs key is NO LONGER fetched — proxied via /v1/tts/synthesize (issue #6622).
+/// Anthropic, Firebase, and Calendar keys are still served via /v1/config/api-keys.
 @MainActor
 final class APIKeyService: ObservableObject {
     static let shared = APIKeyService()
@@ -13,7 +14,6 @@ final class APIKeyService: ObservableObject {
     // Backend-provided keys (in-memory only, never persisted to disk)
     @Published private(set) var geminiApiKey: String?
     @Published private(set) var anthropicApiKey: String?
-    @Published private(set) var elevenLabsApiKey: String?
     @Published private(set) var firebaseApiKey: String?
     @Published private(set) var googleCalendarApiKey: String?
     @Published private(set) var isLoaded: Bool = false
@@ -46,10 +46,6 @@ final class APIKeyService: ObservableObject {
         nonEmpty(UserDefaults.standard.string(forKey: "dev_anthropic_api_key")) ?? anthropicApiKey
     }
 
-    var effectiveElevenLabsKey: String? {
-        nonEmpty(UserDefaults.standard.string(forKey: "dev_elevenlabs_api_key")) ?? elevenLabsApiKey
-    }
-
     var effectiveFirebaseApiKey: String? {
         firebaseApiKey
     }
@@ -68,7 +64,6 @@ final class APIKeyService: ObservableObject {
                 let keys = try await APIClient.shared.fetchApiKeys()
                 self.geminiApiKey = keys.geminiApiKey
                 self.anthropicApiKey = keys.anthropicApiKey
-                self.elevenLabsApiKey = keys.elevenLabsApiKey
                 self.firebaseApiKey = keys.firebaseApiKey
                 self.googleCalendarApiKey = keys.googleCalendarApiKey
                 self.isLoaded = true
@@ -76,7 +71,7 @@ final class APIKeyService: ObservableObject {
                 // Set env vars so existing getenv() consumers keep working during transition
                 applyToEnvironment()
 
-                log("APIKeyService: Fetched keys from backend (gemini=\(keys.geminiApiKey != nil), anthropic=\(keys.anthropicApiKey != nil), elevenlabs=\(keys.elevenLabsApiKey != nil), firebase=\(keys.firebaseApiKey != nil), calendar=\(keys.googleCalendarApiKey != nil))")
+                log("APIKeyService: Fetched keys from backend (gemini=\(keys.geminiApiKey != nil), anthropic=\(keys.anthropicApiKey != nil), firebase=\(keys.firebaseApiKey != nil), calendar=\(keys.googleCalendarApiKey != nil))")
                 return
             } catch {
                 let delay = pow(2.0, Double(attempt - 1))
@@ -98,7 +93,6 @@ final class APIKeyService: ObservableObject {
     func clear() {
         geminiApiKey = nil
         anthropicApiKey = nil
-        elevenLabsApiKey = nil
         firebaseApiKey = nil
         googleCalendarApiKey = nil
         isLoaded = false
@@ -106,7 +100,6 @@ final class APIKeyService: ObservableObject {
 
         unsetenv("GEMINI_API_KEY")
         unsetenv("ANTHROPIC_API_KEY")
-        unsetenv("ELEVENLABS_API_KEY")
         // NOTE: Do NOT unset FIREBASE_API_KEY — it's needed for the next sign-in
         // (auth bootstrap requires Firebase key before backend is reachable)
         unsetenv("GOOGLE_CALENDAR_API_KEY")
@@ -119,9 +112,6 @@ final class APIKeyService: ObservableObject {
         }
         if let key = effectiveAnthropicKey {
             setenv("ANTHROPIC_API_KEY", key, 1)
-        }
-        if let key = effectiveElevenLabsKey {
-            setenv("ELEVENLABS_API_KEY", key, 1)
         }
         if let key = effectiveFirebaseApiKey {
             setenv("FIREBASE_API_KEY", key, 1)
@@ -148,11 +138,6 @@ final class APIKeyService: ObservableObject {
     nonisolated static var currentAnthropicKey: String? {
         nonEmptyStatic(UserDefaults.standard.string(forKey: "dev_anthropic_api_key"))
             ?? (getenv("ANTHROPIC_API_KEY").flatMap { String(validatingUTF8: $0) })
-    }
-
-    nonisolated static var currentElevenLabsKey: String? {
-        nonEmptyStatic(UserDefaults.standard.string(forKey: "dev_elevenlabs_api_key"))
-            ?? (getenv("ELEVENLABS_API_KEY").flatMap { String(validatingUTF8: $0) })
     }
 
     /// True when the app has enough configuration to start transcription and screen analysis.

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -5,7 +5,6 @@ import Foundation
 final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   static let shared = FloatingBarVoicePlaybackService()
 
-  static let devAPIKeyDefaultsKey = "dev_elevenlabs_api_key"
   static let devVoiceIDDefaultsKey = "dev_elevenlabs_voice_id"
 
   nonisolated private static let defaultVoiceID = "BAMYoBHLZM7lJgJAmFz0"  // Sloane
@@ -66,14 +65,14 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     if currentMode == nil {
       currentMode = resolvePlaybackMode()
     }
-    guard let mode = currentMode, case .elevenLabs(let apiKey, let voiceID) = mode else { return }
+    guard let mode = currentMode, case .elevenLabs(let voiceID) = mode else { return }
 
     hasStartedRealPlayback = false
     let phrase = Self.fillerPhrases.randomElement()!
     fillerTask = Task { [weak self] in
       do {
         let audioData = try await Self.synthesizeSpeech(
-          text: phrase, apiKey: apiKey, voiceID: voiceID)
+          text: phrase, voiceID: voiceID)
         try Task.checkCancellation()
         await MainActor.run {
           guard let self, !self.hasStartedRealPlayback else { return }
@@ -144,15 +143,12 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
   }
 
   private func resolvePlaybackMode() -> PlaybackMode {
-    guard
-      let apiKey = APIKeyService.currentElevenLabsKey?.trimmingCharacters(
-        in: .whitespacesAndNewlines),
-      !apiKey.isEmpty
-    else {
+    // TTS is now proxied through the backend — no client-side API key needed.
+    // Fall back to system voice only if the backend URL is not configured.
+    guard getenv("OMI_API_URL") != nil else {
       return .systemFallback
     }
-
-    return .elevenLabs(apiKey: apiKey, voiceID: Self.defaultVoiceID)
+    return .elevenLabs(voiceID: Self.defaultVoiceID)
   }
 
   private func drainBufferedText(isFinal: Bool, mode: PlaybackMode) {
@@ -181,7 +177,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 
   private func startSynthesisIfNeeded(mode: PlaybackMode) {
     guard !isSynthesizing else { return }
-    guard case .elevenLabs(let apiKey, let voiceID) = mode else { return }
+    guard case .elevenLabs(let voiceID) = mode else { return }
     guard !synthesisQueue.isEmpty else { return }
 
     let text = synthesisQueue.removeFirst()
@@ -190,7 +186,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     playbackTask = Task { [weak self] in
       do {
         let audioData = try await Self.synthesizeSpeech(
-          text: text, apiKey: apiKey, voiceID: voiceID)
+          text: text, voiceID: voiceID)
         try Task.checkCancellation()
         await MainActor.run {
           guard let self else { return }
@@ -316,20 +312,14 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     return AVSpeechSynthesisVoice(language: "en-US")
   }
 
-  private nonisolated static func synthesizeSpeech(text: String, apiKey: String, voiceID: String)
+  /// Synthesize speech via the backend TTS proxy (ElevenLabs key stays server-side).
+  private nonisolated static func synthesizeSpeech(text: String, voiceID: String)
     async throws -> Data
   {
-    var request = URLRequest(
-      url: URL(string: "https://api.elevenlabs.io/v1/text-to-speech/\(voiceID)")!)
-    request.httpMethod = "POST"
-    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-    request.setValue("audio/mpeg", forHTTPHeaderField: "Accept")
-    request.setValue(apiKey, forHTTPHeaderField: "xi-api-key")
-    request.timeoutInterval = 45
-
-    let body = ElevenLabsSpeechRequest(
+    let request = APIClient.TtsSynthesizeRequest(
       text: text,
-      modelID: defaultModelID,
+      voiceId: voiceID,
+      modelId: defaultModelID,
       outputFormat: "mp3_44100_128",
       voiceSettings: .init(
         stability: 0.34,
@@ -338,18 +328,7 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
         useSpeakerBoost: true
       )
     )
-    request.httpBody = try JSONEncoder().encode(body)
-
-    let (data, response) = try await URLSession.shared.data(for: request)
-    guard let httpResponse = response as? HTTPURLResponse else {
-      throw FloatingBarVoicePlaybackError.invalidResponse
-    }
-    guard (200..<300).contains(httpResponse.statusCode) else {
-      let errorBody = String(data: data.prefix(300), encoding: .utf8) ?? "Unknown error"
-      throw FloatingBarVoicePlaybackError.requestFailed(
-        statusCode: httpResponse.statusCode, body: errorBody)
-    }
-    return data
+    return try await APIClient.shared.synthesizeSpeech(request: request)
   }
 
   private nonisolated static func cleanedPlaybackText(from message: ChatMessage?) -> String {
@@ -455,36 +434,8 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
 }
 
 private enum PlaybackMode {
-  case elevenLabs(apiKey: String, voiceID: String)
+  case elevenLabs(voiceID: String)
   case systemFallback
-}
-
-private struct ElevenLabsSpeechRequest: Encodable {
-  let text: String
-  let modelID: String
-  let outputFormat: String
-  let voiceSettings: ElevenLabsVoiceSettings
-
-  enum CodingKeys: String, CodingKey {
-    case text
-    case modelID = "model_id"
-    case outputFormat = "output_format"
-    case voiceSettings = "voice_settings"
-  }
-}
-
-private struct ElevenLabsVoiceSettings: Encodable {
-  let stability: Double
-  let similarityBoost: Double
-  let style: Double
-  let useSpeakerBoost: Bool
-
-  enum CodingKeys: String, CodingKey {
-    case stability
-    case similarityBoost = "similarity_boost"
-    case style
-    case useSpeakerBoost = "use_speaker_boost"
-  }
 }
 
 private enum FloatingBarVoicePlaybackError: LocalizedError {
@@ -494,9 +445,9 @@ private enum FloatingBarVoicePlaybackError: LocalizedError {
   var errorDescription: String? {
     switch self {
     case .invalidResponse:
-      return "Invalid ElevenLabs response"
+      return "Invalid TTS response"
     case .requestFailed(let statusCode, let body):
-      return "ElevenLabs request failed (\(statusCode)): \(body)"
+      return "TTS request failed (\(statusCode)): \(body)"
   }
 }
 }

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -366,7 +366,6 @@ struct SettingsContentView: View {
   // Developer API Key overrides
   @AppStorage("dev_gemini_api_key") private var devGeminiKey: String = ""
   @AppStorage("dev_anthropic_api_key") private var devAnthropicKey: String = ""
-  @AppStorage("dev_elevenlabs_api_key") private var devElevenLabsKey: String = ""
 
   init(
     appState: AppState,
@@ -4824,29 +4823,13 @@ struct SettingsContentView: View {
         value: $devAnthropicKey
       )
 
-      developerKeyField(
-        title: "ElevenLabs API Key",
-        subtitle: "For experimental floating-bar voice answers with the Sloane voice",
-        settingId: "advanced.devkeys.elevenlabs",
-        value: syncedElevenLabsKeyBinding
-      )
-
-      if !devGeminiKey.isEmpty || !devAnthropicKey.isEmpty || !devElevenLabsKey.isEmpty {
+      if !devGeminiKey.isEmpty || !devAnthropicKey.isEmpty {
         settingsCard(settingId: "advanced.devkeys.clear") {
           HStack {
             Spacer()
             Button(action: {
               devGeminiKey = ""
               devAnthropicKey = ""
-              devElevenLabsKey = ""
-              SettingsSyncManager.shared.pushPartialUpdate(
-                AssistantSettingsResponse(
-                  floatingBar: FloatingBarSettingsResponse(
-                    elevenLabsApiKey: "",
-                    elevenLabsVoiceID: ""
-                  )
-                )
-              )
             }) {
               Text("Clear All Custom Keys")
                 .scaledFont(size: 13, weight: .medium)
@@ -4994,20 +4977,6 @@ struct SettingsContentView: View {
         }
       }
     }
-  }
-
-  private var syncedElevenLabsKeyBinding: Binding<String> {
-    Binding(
-      get: { devElevenLabsKey },
-      set: { newValue in
-        devElevenLabsKey = newValue
-        SettingsSyncManager.shared.pushPartialUpdate(
-          AssistantSettingsResponse(
-            floatingBar: FloatingBarSettingsResponse(elevenLabsApiKey: newValue)
-          )
-        )
-      }
-    )
   }
 
   private func tierPickerRow(tier: Int, label: String, subtitle: String) -> some View {

--- a/desktop/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/Services/SettingsSyncManager.swift
@@ -96,9 +96,6 @@ class SettingsSyncManager {
             if let v = floatingBar.voiceAnswersEnabled {
                 ShortcutSettings.shared.floatingBarVoiceAnswersEnabled = v
             }
-            if let v = floatingBar.elevenLabsApiKey {
-                UserDefaults.standard.set(v, forKey: FloatingBarVoicePlaybackService.devAPIKeyDefaultsKey)
-            }
             UserDefaults.standard.removeObject(forKey: FloatingBarVoicePlaybackService.devVoiceIDDefaultsKey)
             if let v = floatingBar.elevenLabsVoiceID?.trimmingCharacters(in: .whitespacesAndNewlines),
                !v.isEmpty {
@@ -168,7 +165,6 @@ class SettingsSyncManager {
 
         let floatingBar = FloatingBarSettingsResponse(
             voiceAnswersEnabled: ShortcutSettings.shared.floatingBarVoiceAnswersEnabled,
-            elevenLabsApiKey: UserDefaults.standard.string(forKey: FloatingBarVoicePlaybackService.devAPIKeyDefaultsKey) ?? "",
             elevenLabsVoiceID: ""
         )
 

--- a/desktop/Desktop/Tests/APIClientRoutingTests.swift
+++ b/desktop/Desktop/Tests/APIClientRoutingTests.swift
@@ -7,6 +7,8 @@ import XCTest
 private struct CapturedRequest {
     let url: URL
     let method: String
+    let headers: [String: String]
+    let body: Data?
 }
 
 /// Intercepts HTTP requests, records their URL and method, then returns 403
@@ -40,7 +42,9 @@ private final class URLCapture: URLProtocol, @unchecked Sendable {
         if let url = request.url {
             URLCapture.record(CapturedRequest(
                 url: url,
-                method: request.httpMethod ?? "GET"
+                method: request.httpMethod ?? "GET",
+                headers: request.allHTTPHeaderFields ?? [:],
+                body: request.httpBody
             ))
         }
         let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
@@ -288,6 +292,53 @@ final class APIClientRoutingTests: XCTestCase {
         assertRoutes(URLCapture.capturedRequests, host: "rust-test", port: 9002,
                      pathContains: "v1/config/api-keys", method: "GET",
                      label: "fetchApiKeys")
+    }
+
+    func testSynthesizeSpeechRoutesToRustWithExpectedPayload() async throws {
+        let client = await makeTestClient()
+        let request = APIClient.TtsSynthesizeRequest(
+            text: "hello from test",
+            voiceId: "BAMYoBHLZM7lJgJAmFz0",
+            modelId: "eleven_turbo_v2_5",
+            outputFormat: "mp3_44100_128",
+            voiceSettings: .init(
+                stability: 0.34,
+                similarityBoost: 0.88,
+                style: 0.12,
+                useSpeakerBoost: true
+            )
+        )
+
+        _ = try? await client.synthesizeSpeech(request: request)
+
+        assertRoutes(URLCapture.capturedRequests, host: "rust-test", port: 9002,
+                     pathContains: "v1/tts/synthesize", method: "POST",
+                     label: "synthesizeSpeech")
+
+        let captured = try XCTUnwrap(URLCapture.capturedRequests.first)
+        XCTAssertEqual(captured.headers["Authorization"], "Bearer test-token")
+        XCTAssertEqual(captured.headers["Content-Type"], "application/json")
+
+        let body = try XCTUnwrap(captured.body)
+        let json = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: body) as? [String: Any]
+        )
+
+        XCTAssertEqual(json["text"] as? String, "hello from test")
+        XCTAssertEqual(json["voice_id"] as? String, "BAMYoBHLZM7lJgJAmFz0")
+        XCTAssertEqual(json["model_id"] as? String, "eleven_turbo_v2_5")
+        XCTAssertEqual(json["output_format"] as? String, "mp3_44100_128")
+        XCTAssertNil(json["voiceId"])
+        XCTAssertNil(json["modelId"])
+        XCTAssertNil(json["outputFormat"])
+
+        let voiceSettings = try XCTUnwrap(json["voice_settings"] as? [String: Any])
+        XCTAssertEqual(voiceSettings["stability"] as? Double, 0.34)
+        XCTAssertEqual(voiceSettings["similarity_boost"] as? Double, 0.88)
+        XCTAssertEqual(voiceSettings["style"] as? Double, 0.12)
+        XCTAssertEqual(voiceSettings["use_speaker_boost"] as? Bool, true)
+        XCTAssertNil(voiceSettings["similarityBoost"])
+        XCTAssertNil(voiceSettings["useSpeakerBoost"])
     }
 
     // -- Assistant settings (GET → Python, migrated from Rust) --


### PR DESCRIPTION
## Summary

Server-side TTS proxy for ElevenLabs so the API key is never exposed to desktop clients.

- **New endpoint**: `POST /v1/tts/synthesize` — accepts `voice_id`, `text`, optional `model_id`
- **Rate limiting**: Redis-backed, per-user — 50 req/min burst + 10K chars/day (fail-closed)
- **Security**: voice_id validated alphanumeric-only (path traversal prevention)
- **Backward compat**: `DISABLE_ELEVENLABS_KEY_RESPONSE` env var to stop serving raw key once all clients update
- **16 unit tests** covering auth, rate limits, input validation, error forwarding

Closes #6622

## Test Results (Mac Mini e2e)

### Direct proxy test (curl)
```
$ curl -s -o /tmp/tts-test.mp3 -w "%{http_code}" \
  -X POST http://localhost:10201/v1/tts/synthesize \
  -H "Authorization: Bearer <token>" \
  -H "Content-Type: application/json" \
  -d '{"voice_id":"BAMYoBHLZM7lJgJAmFz0","text":"Hello from the TTS proxy test"}'

HTTP 200 — 68KB MP3 returned, 4.26s audio, plays correctly via afplay
```

### App integration (floating bar → voice answer)
- FloatingBarVoicePlaybackService correctly resolves to `.ttsProxy` mode when `OMI_API_URL` is set
- Voice playback triggered successfully via floating bar voice query at 09:01
- Error path verified: when ElevenLabs returns 402, error is forwarded to client and app falls back to system voice

### Unit tests
All 16 tests pass: auth, burst rate limit, daily char limit, char counting, input validation, voice_id sanitization, error forwarding.

## Deployment Steps

**Confirmed by mon (monitoring PR #6629 through same pipeline):**

### Automated (zero manual steps)
1. Merge PR to `main` → auto-triggers `desktop_auto_release.yml`
2. Job 1: `deploy-desktop-backend` (dev Cloud Run) ~5min
3. Job 2: `deploy-desktop-backend-prod` (prod Cloud Run) ~5min
4. Job 3: `tag-release` creates `v*-macos` tag → triggers Codemagic `desktop-swift-release` build ~25min
5. Codemagic publishes via Sparkle for auto-update
6. **Total pipeline: ~35min end-to-end**

### Pre-merge checklist
- [ ] Confirm `DESKTOP_ELEVENLABS_API_KEY` in GCP Secret Manager is a paid-tier key (free tier returns 402 for library voices)
- [ ] Decide: set `DISABLE_ELEVENLABS_KEY_RESPONSE=true` in workflow now or in follow-up PR

### Follow-up PR (optional)
Add `DISABLE_ELEVENLABS_KEY_RESPONSE=true` to `env_vars` in both deploy steps of `desktop_auto_release.yml` to stop serving the raw ElevenLabs key to clients:
```yaml
env_vars: |
  ...existing vars...
  DISABLE_ELEVENLABS_KEY_RESPONSE=true
```

## Model & Voice
- Model: `eleven_turbo_v2_5`
- Default voice: `BAMYoBHLZM7lJgJAmFz0` (Sloane)
