### PR TITLE
Set transparent floating bar as default for new users

### DIFF
--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -427,7 +427,7 @@ class ShortcutSettings: ObservableObject {
         self.askOmiEnabled = UserDefaults.standard.object(forKey: "shortcut_askOmiEnabled") as? Bool ?? true
         self.pttEnabled = UserDefaults.standard.object(forKey: "shortcut_pttEnabled") as? Bool ?? true
         self.doubleTapForLock = UserDefaults.standard.object(forKey: "shortcut_doubleTapForLock") as? Bool ?? true
-        self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? true
+        self.solidBackground = UserDefaults.standard.object(forKey: "shortcut_solidBackground") as? Bool ?? false
         self.pttSoundsEnabled = UserDefaults.standard.object(forKey: "shortcut_pttSoundsEnabled") as? Bool ?? true
         self.selectedModel = UserDefaults.standard.string(forKey: "shortcut_selectedModel") ?? "claude-sonnet-4-6"
         if let saved = UserDefaults.standard.string(forKey: "shortcut_pttTranscriptionMode"),


### PR DESCRIPTION
## Summary
- change the floating bar background fallback default from solid dark to transparent
- leave existing users untouched by keeping their saved `shortcut_solidBackground` preference

## Verification
- code change only
- no local OMI build run because this repo forbids local desktop builds unless explicitly overridden
