### PR TITLE
Fix README badge row rendering on GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,9 @@ Trusted by 300,000+ professionals.
 ## Quick Start
 
 <p align="center">
-  <a href="https://macos.omi.me">
-    <img src="docs/assets/readme/download-macos-badge.png" alt="Download for macOS" height="50">
-  </a>
-  <a href="https://apps.apple.com/us/app/friend-ai-wearable/id6502156163">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/3/3c/Download_on_the_App_Store_Badge.svg" alt="Download on the App Store" height="50">
-  </a>
-  <a href="https://play.google.com/store/apps/details?id=com.friend.ios">
-    <img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg" alt="Get it on Google Play" height="50">
-  </a>
+  <a href="https://macos.omi.me"><img src="docs/assets/readme/download-macos-badge.png" alt="Download for macOS" height="50"></a>
+  <a href="https://apps.apple.com/us/app/friend-ai-wearable/id6502156163"><img src="https://upload.wikimedia.org/wikipedia/commons/3/3c/Download_on_the_App_Store_Badge.svg" alt="Download on the App Store" height="50"></a>
+  <a href="https://play.google.com/store/apps/details?id=com.friend.ios"><img src="https://upload.wikimedia.org/wikipedia/commons/7/78/Google_Play_Store_badge_EN.svg" alt="Get it on Google Play" height="50"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary
- collapse the top download badge anchors into single-line inline HTML
- remove underlined whitespace artifacts that GitHub was rendering between badges

## Verification
- refreshed the local README preview at http://127.0.0.1:4861
- verified the badge row renders cleanly after the markup change
