### PR TITLE
fix(desktop): tighten Gemini proxy — model allowlist, body size limit, request validation

### DIFF
--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -30,9 +30,11 @@ const GEMINI_ALLOWED_ACTIONS: &[&str] = &[
 // Allowed Gemini models — only these can be requested through the proxy.
 // Desktop app uses: gemini-3-flash-preview (default), gemini-pro-latest (tasks/insights),
 // gemini-embedding-001 (embeddings). Rate limiting may rewrite pro → flash.
+// gemini-3-pro-preview: used by desktop app versions before Mar 2026, kept for backward compatibility.
 const GEMINI_ALLOWED_MODELS: &[&str] = &[
     "gemini-3-flash-preview",
     "gemini-pro-latest",
+    "gemini-3-pro-preview",
     "gemini-embedding-001",
 ];
 

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -490,10 +490,22 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
     // Generation-specific validation (not for embed actions)
     let is_embed = action == "embedContent" || action == "batchEmbedContents";
     if !is_embed {
-        // Helper: parse a JSON value as u64 from either a number or a string
-        // (ProtoJSON allows integer fields to be encoded as quoted strings)
+        // Helper: parse a JSON value as u64 from a number (int or integral float),
+        // or a string. ProtoJSON allows integer fields as quoted strings and
+        // protobuf parsers accept integral floats (e.g. 8.0) for int32/int64.
         let parse_as_u64 = |v: &serde_json::Value| -> Option<u64> {
-            v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
+            v.as_u64()
+                .or_else(|| {
+                    // Handle integral floats like 8.0, 999999.0
+                    v.as_f64().and_then(|f| {
+                        if f >= 0.0 && f <= (u64::MAX as f64) && f == (f as u64 as f64) {
+                            Some(f as u64)
+                        } else {
+                            None
+                        }
+                    })
+                })
+                .or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
         };
 
         // Reject top-level candidate_count > 1
@@ -521,10 +533,10 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
                     }
                 }
 
-                // Cap max_output_tokens (handles both numeric and string-encoded values)
+                // Cap max_output_tokens (handles numeric, integral float, and string-encoded values)
                 for mot_key in &["max_output_tokens", "maxOutputTokens"] {
                     if let Some(mot) = gc.get_mut(*mot_key) {
-                        if let Some(n) = mot.as_u64().or_else(|| mot.as_str().and_then(|s| s.parse::<u64>().ok())) {
+                        if let Some(n) = parse_as_u64(mot) {
                             if n > MAX_OUTPUT_TOKENS_CAP {
                                 *mot = serde_json::Value::Number(MAX_OUTPUT_TOKENS_CAP.into());
                             }
@@ -928,6 +940,39 @@ mod tests {
         );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("candidate_count"));
+    }
+
+    #[test]
+    fn sanitize_rejects_float_encoded_candidate_count() {
+        // Protobuf parsers accept integral floats (8.0) for int32 fields
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generationConfig": {"candidateCount": 8.0}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("candidate_count"));
+    }
+
+    #[test]
+    fn sanitize_caps_float_encoded_max_output_tokens() {
+        // Float-encoded maxOutputTokens must still be capped
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generationConfig": {"maxOutputTokens": 999999.0}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(
+            parsed["generationConfig"]["maxOutputTokens"],
+            serde_json::json!(MAX_OUTPUT_TOKENS_CAP)
+        );
     }
 
     #[test]

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -3,10 +3,11 @@
 //
 // Issue #5861: Remove client-side API key exposure risk.
 // Issue #6098 L2: Tiered rate limiting with Pro→Flash degradation.
+// Issue #6624: Model allowlist, body size limit, request body validation.
 
 use axum::{
     body::Bytes,
-    extract::{Path, State},
+    extract::{DefaultBodyLimit, Path, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     routing::{any, post},
@@ -25,6 +26,23 @@ const GEMINI_ALLOWED_ACTIONS: &[&str] = &[
     "embedContent",
     "batchEmbedContents",
 ];
+
+// Allowed Gemini models — only these can be requested through the proxy.
+// Desktop app uses: gemini-3-flash-preview (default), gemini-pro-latest (tasks/insights),
+// gemini-embedding-001 (embeddings). Rate limiting may rewrite pro → flash.
+const GEMINI_ALLOWED_MODELS: &[&str] = &[
+    "gemini-3-flash-preview",
+    "gemini-pro-latest",
+    "gemini-embedding-001",
+];
+
+/// Maximum request body size for Gemini proxy routes (5 MB).
+/// Normal app payloads are 300-600 KB (base64 JPEG + prompt); 5 MB gives ~8x headroom.
+const GEMINI_MAX_BODY_SIZE: usize = 5 * 1024 * 1024;
+
+/// Maximum allowed max_output_tokens in generation_config.
+/// App uses 8192 (GeminiClient.swift:553,922,1026).
+const MAX_OUTPUT_TOKENS_CAP: u64 = 8192;
 
 /// Proxy-specific error type — allows JSON 429 responses alongside bare status codes.
 enum ProxyError {
@@ -76,6 +94,20 @@ async fn gemini_proxy(
         return Err(ProxyError::Status(StatusCode::FORBIDDEN));
     }
 
+    // Validate the model is in our allowlist (issue #6624)
+    let model = extract_gemini_model(&path);
+    if !is_gemini_model_allowed(model) {
+        tracing::warn!("gemini_proxy: blocked model '{}' in path '{}'", model, path);
+        return Err(ProxyError::Status(StatusCode::FORBIDDEN));
+    }
+
+    // Sanitize request body: cap max_output_tokens, reject candidate_count > 1,
+    // strip safety_settings and cached_content (issue #6624)
+    let sanitized_body = sanitize_gemini_body(&body, action).map_err(|e| {
+        tracing::warn!("gemini_proxy: body validation failed: {}", e);
+        ProxyError::Status(StatusCode::BAD_REQUEST)
+    })?;
+
     // Rate limit check
     let decision = state.gemini_rate_limiter.check_and_record(&user.uid, state.redis.as_ref()).await;
     if decision == RateDecision::Reject {
@@ -99,7 +131,7 @@ async fn gemini_proxy(
     let upstream = reqwest::Client::new()
         .post(&url)
         .header("content-type", "application/json")
-        .body(body)
+        .body(sanitized_body)
         .send()
         .await
         .map_err(|e| {
@@ -140,6 +172,19 @@ async fn gemini_stream_proxy(
         return Err(ProxyError::Status(StatusCode::FORBIDDEN));
     }
 
+    // Validate the model is in our allowlist (issue #6624)
+    let model = extract_gemini_model(&path);
+    if !is_gemini_model_allowed(model) {
+        tracing::warn!("gemini_stream_proxy: blocked model '{}' in path '{}'", model, path);
+        return Err(ProxyError::Status(StatusCode::FORBIDDEN));
+    }
+
+    // Sanitize request body (issue #6624)
+    let sanitized_body = sanitize_gemini_body(&body, action).map_err(|e| {
+        tracing::warn!("gemini_stream_proxy: body validation failed: {}", e);
+        ProxyError::Status(StatusCode::BAD_REQUEST)
+    })?;
+
     // Rate limit check
     let decision = state.gemini_rate_limiter.check_and_record(&user.uid, state.redis.as_ref()).await;
     if decision == RateDecision::Reject {
@@ -164,7 +209,7 @@ async fn gemini_stream_proxy(
     let upstream = reqwest::Client::new()
         .post(&upstream_url)
         .header("content-type", "application/json")
-        .body(body)
+        .body(sanitized_body)
         .send()
         .await
         .map_err(|e| {
@@ -401,9 +446,82 @@ fn extract_gemini_action(path: &str) -> &str {
     path.rsplit(':').next().unwrap_or("")
 }
 
+/// Extract the model from a Gemini API path (e.g., "models/gemini-3-flash-preview:generateContent" → "gemini-3-flash-preview")
+fn extract_gemini_model(path: &str) -> &str {
+    path.strip_prefix("models/")
+        .and_then(|rest| rest.split(':').next())
+        .unwrap_or("")
+}
+
 /// Check if a Gemini action is in the allowlist
 fn is_gemini_action_allowed(action: &str) -> bool {
     GEMINI_ALLOWED_ACTIONS.contains(&action)
+}
+
+/// Check if a Gemini model is in the allowlist (issue #6624)
+fn is_gemini_model_allowed(model: &str) -> bool {
+    GEMINI_ALLOWED_MODELS.contains(&model)
+}
+
+/// Sanitize a Gemini request body (issue #6624).
+///
+/// For generateContent/streamGenerateContent:
+///   - Cap generation_config.max_output_tokens to MAX_OUTPUT_TOKENS_CAP
+///   - Reject candidate_count > 1
+///   - Strip safety_settings and cached_content
+///   - Preserve all other fields (contents, system_instruction, tools, etc.)
+///
+/// For embedContent/batchEmbedContents:
+///   - Skip generation-specific validation (different schema)
+///   - Strip safety_settings and cached_content only
+fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
+    let mut json: serde_json::Value = serde_json::from_slice(body)
+        .map_err(|e| format!("invalid JSON: {}", e))?;
+
+    let obj = json.as_object_mut()
+        .ok_or_else(|| "request body must be a JSON object".to_string())?;
+
+    // Strip dangerous fields from all request types
+    obj.remove("safety_settings");
+    obj.remove("safetySettings");
+    obj.remove("cached_content");
+    obj.remove("cachedContent");
+
+    // Generation-specific validation (not for embed actions)
+    let is_embed = action == "embedContent" || action == "batchEmbedContents";
+    if !is_embed {
+        // Reject candidate_count > 1
+        if let Some(cc) = obj.get("candidate_count").or_else(|| obj.get("candidateCount")) {
+            if let Some(n) = cc.as_u64() {
+                if n > 1 {
+                    return Err(format!("candidate_count must be 1 or absent, got {}", n));
+                }
+            }
+        }
+
+        // Cap max_output_tokens in generation_config
+        let gc_key = if obj.contains_key("generation_config") {
+            "generation_config"
+        } else {
+            "generationConfig"
+        };
+        if let Some(gc) = obj.get_mut(gc_key).and_then(|v| v.as_object_mut()) {
+            let mot_key = if gc.contains_key("max_output_tokens") {
+                "max_output_tokens"
+            } else {
+                "maxOutputTokens"
+            };
+            if let Some(mot) = gc.get_mut(mot_key) {
+                if let Some(n) = mot.as_u64() {
+                    if n > MAX_OUTPUT_TOKENS_CAP {
+                        *mot = serde_json::Value::Number(MAX_OUTPUT_TOKENS_CAP.into());
+                    }
+                }
+            }
+        }
+    }
+
+    serde_json::to_vec(&json).map_err(|e| format!("failed to re-serialize: {}", e))
 }
 
 /// Build upstream Gemini URL for non-streaming requests
@@ -461,6 +579,9 @@ pub fn proxy_routes() -> Router<AppState> {
             "/v1/proxy/deepgram/ws/v1/listen",
             any(deepgram_ws_proxy),
         )
+        // Issue #6624: 5 MB body size limit for proxy routes only (not global).
+        // Normal app payloads are 300-600 KB; 5 MB gives ~8x headroom.
+        .layer(DefaultBodyLimit::max(GEMINI_MAX_BODY_SIZE))
 }
 
 #[cfg(test)]
@@ -532,6 +653,230 @@ mod tests {
         assert!(!is_gemini_action_allowed("deleteModel"));
         assert!(!is_gemini_action_allowed("foo"));
         assert!(!is_gemini_action_allowed(""));
+    }
+
+    // --- Gemini model extraction ---
+
+    #[test]
+    fn extract_model_flash() {
+        assert_eq!(
+            extract_gemini_model("models/gemini-3-flash-preview:generateContent"),
+            "gemini-3-flash-preview"
+        );
+    }
+
+    #[test]
+    fn extract_model_pro() {
+        assert_eq!(
+            extract_gemini_model("models/gemini-pro-latest:streamGenerateContent"),
+            "gemini-pro-latest"
+        );
+    }
+
+    #[test]
+    fn extract_model_embedding() {
+        assert_eq!(
+            extract_gemini_model("models/gemini-embedding-001:embedContent"),
+            "gemini-embedding-001"
+        );
+    }
+
+    #[test]
+    fn extract_model_no_prefix() {
+        assert_eq!(extract_gemini_model("gemini-pro:generateContent"), "");
+    }
+
+    #[test]
+    fn extract_model_empty() {
+        assert_eq!(extract_gemini_model(""), "");
+    }
+
+    // --- Gemini model allowlist ---
+
+    #[test]
+    fn model_allowlist_permits_valid_models() {
+        assert!(is_gemini_model_allowed("gemini-3-flash-preview"));
+        assert!(is_gemini_model_allowed("gemini-pro-latest"));
+        assert!(is_gemini_model_allowed("gemini-embedding-001"));
+    }
+
+    #[test]
+    fn model_allowlist_blocks_unknown() {
+        assert!(!is_gemini_model_allowed("gemini-2.5-pro"));
+        assert!(!is_gemini_model_allowed("gemini-1.5-pro"));
+        assert!(!is_gemini_model_allowed("gemini-ultra"));
+        assert!(!is_gemini_model_allowed(""));
+    }
+
+    #[test]
+    fn model_allowlist_blocks_prefix_bypass() {
+        assert!(!is_gemini_model_allowed("gemini-3-flash-preview-exp"));
+        assert!(!is_gemini_model_allowed("gemini-pro-latest-2"));
+    }
+
+    // --- Body sanitization ---
+
+    #[test]
+    fn sanitize_caps_max_output_tokens() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generation_config": {"max_output_tokens": 99999}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(
+            parsed["generation_config"]["max_output_tokens"],
+            serde_json::json!(MAX_OUTPUT_TOKENS_CAP)
+        );
+    }
+
+    #[test]
+    fn sanitize_preserves_valid_max_output_tokens() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generation_config": {"max_output_tokens": 4096}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["generation_config"]["max_output_tokens"], 4096);
+    }
+
+    #[test]
+    fn sanitize_caps_camel_case_max_output_tokens() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generationConfig": {"maxOutputTokens": 50000}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(
+            parsed["generationConfig"]["maxOutputTokens"],
+            serde_json::json!(MAX_OUTPUT_TOKENS_CAP)
+        );
+    }
+
+    #[test]
+    fn sanitize_rejects_candidate_count_gt_1() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "candidate_count": 8
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("candidate_count"));
+    }
+
+    #[test]
+    fn sanitize_allows_candidate_count_1() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "candidate_count": 1
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sanitize_strips_safety_settings() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "safety_settings": [{"category": "HARM_CATEGORY_HATE_SPEECH", "threshold": "BLOCK_NONE"}]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(parsed.get("safety_settings").is_none());
+        assert!(parsed.get("safetySettings").is_none());
+    }
+
+    #[test]
+    fn sanitize_strips_cached_content() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "cachedContent": "projects/123/cachedContents/abc"
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(parsed.get("cachedContent").is_none());
+        assert!(parsed.get("cached_content").is_none());
+    }
+
+    #[test]
+    fn sanitize_preserves_tools_field() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "tools": [{"function_declarations": [{"name": "execute_sql"}]}],
+            "generation_config": {"max_output_tokens": 8192}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(parsed.get("tools").is_some());
+    }
+
+    #[test]
+    fn sanitize_skips_generation_validation_for_embed() {
+        let body = serde_json::json!({
+            "model": "models/gemini-embedding-001",
+            "content": {"parts": [{"text": "hello"}]},
+            "taskType": "RETRIEVAL_DOCUMENT",
+            "candidate_count": 5
+        });
+        // candidate_count > 1 should NOT be rejected for embed actions
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "embedContent",
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sanitize_strips_safety_from_embed() {
+        let body = serde_json::json!({
+            "model": "models/gemini-embedding-001",
+            "content": {"parts": [{"text": "hello"}]},
+            "safetySettings": []
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "embedContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert!(parsed.get("safetySettings").is_none());
+    }
+
+    #[test]
+    fn sanitize_rejects_non_json() {
+        let result = sanitize_gemini_body(b"not json", "generateContent");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_rejects_non_object() {
+        let result = sanitize_gemini_body(b"[1,2,3]", "generateContent");
+        assert!(result.is_err());
     }
 
     // --- Gemini URL construction ---

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -499,39 +499,28 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
             }
         }
 
-        // Validate inside generation_config / generationConfig
-        let gc_key = if obj.contains_key("generation_config") {
-            "generation_config"
-        } else {
-            "generationConfig"
-        };
-        if let Some(gc) = obj.get_mut(gc_key).and_then(|v| v.as_object_mut()) {
-            // Reject candidate_count > 1 inside generation_config
-            let cc_key = if gc.contains_key("candidate_count") {
-                Some("candidate_count")
-            } else if gc.contains_key("candidateCount") {
-                Some("candidateCount")
-            } else {
-                None
-            };
-            if let Some(cc_key) = cc_key {
-                if let Some(n) = gc.get(cc_key).and_then(|v| v.as_u64()) {
-                    if n > 1 {
-                        return Err(format!("candidate_count must be 1 or absent, got {}", n));
+        // Validate inside generation_config / generationConfig.
+        // Check BOTH casings to prevent dual-key bypass where an attacker
+        // sends an empty generation_config + a real generationConfig.
+        for gc_key in &["generation_config", "generationConfig"] {
+            if let Some(gc) = obj.get_mut(*gc_key).and_then(|v| v.as_object_mut()) {
+                // Reject candidate_count > 1
+                for cc_key in &["candidate_count", "candidateCount"] {
+                    if let Some(n) = gc.get(*cc_key).and_then(|v| v.as_u64()) {
+                        if n > 1 {
+                            return Err(format!("candidate_count must be 1 or absent, got {}", n));
+                        }
                     }
                 }
-            }
 
-            // Cap max_output_tokens
-            let mot_key = if gc.contains_key("max_output_tokens") {
-                "max_output_tokens"
-            } else {
-                "maxOutputTokens"
-            };
-            if let Some(mot) = gc.get_mut(mot_key) {
-                if let Some(n) = mot.as_u64() {
-                    if n > MAX_OUTPUT_TOKENS_CAP {
-                        *mot = serde_json::Value::Number(MAX_OUTPUT_TOKENS_CAP.into());
+                // Cap max_output_tokens
+                for mot_key in &["max_output_tokens", "maxOutputTokens"] {
+                    if let Some(mot) = gc.get_mut(*mot_key) {
+                        if let Some(n) = mot.as_u64() {
+                            if n > MAX_OUTPUT_TOKENS_CAP {
+                                *mot = serde_json::Value::Number(MAX_OUTPUT_TOKENS_CAP.into());
+                            }
+                        }
                     }
                 }
             }
@@ -847,6 +836,42 @@ mod tests {
             "generateContent",
         );
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sanitize_rejects_dual_key_bypass() {
+        // Attacker sends empty generation_config + real generationConfig to bypass validation
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generation_config": {},
+            "generationConfig": {"candidateCount": 8, "maxOutputTokens": 999999}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("candidate_count"));
+    }
+
+    #[test]
+    fn sanitize_caps_dual_key_max_tokens() {
+        // Both casings present — max_output_tokens should be capped in both
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generation_config": {"max_output_tokens": 100},
+            "generationConfig": {"maxOutputTokens": 999999}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(parsed["generation_config"]["max_output_tokens"], 100);
+        assert_eq!(
+            parsed["generationConfig"]["maxOutputTokens"],
+            serde_json::json!(MAX_OUTPUT_TOKENS_CAP)
+        );
     }
 
     #[test]

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -30,11 +30,9 @@ const GEMINI_ALLOWED_ACTIONS: &[&str] = &[
 // Allowed Gemini models — only these can be requested through the proxy.
 // Desktop app uses: gemini-3-flash-preview (default), gemini-pro-latest (tasks/insights),
 // gemini-embedding-001 (embeddings). Rate limiting may rewrite pro → flash.
-// gemini-3-pro-preview: used by desktop app versions before Mar 2026, kept for backward compatibility.
 const GEMINI_ALLOWED_MODELS: &[&str] = &[
     "gemini-3-flash-preview",
     "gemini-pro-latest",
-    "gemini-3-pro-preview",
     "gemini-embedding-001",
 ];
 

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -490,9 +490,15 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
     // Generation-specific validation (not for embed actions)
     let is_embed = action == "embedContent" || action == "batchEmbedContents";
     if !is_embed {
+        // Helper: parse a JSON value as u64 from either a number or a string
+        // (ProtoJSON allows integer fields to be encoded as quoted strings)
+        let parse_as_u64 = |v: &serde_json::Value| -> Option<u64> {
+            v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse::<u64>().ok()))
+        };
+
         // Reject top-level candidate_count > 1
         if let Some(cc) = obj.get("candidate_count").or_else(|| obj.get("candidateCount")) {
-            if let Some(n) = cc.as_u64() {
+            if let Some(n) = parse_as_u64(cc) {
                 if n > 1 {
                     return Err(format!("candidate_count must be 1 or absent, got {}", n));
                 }
@@ -506,17 +512,19 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
             if let Some(gc) = obj.get_mut(*gc_key).and_then(|v| v.as_object_mut()) {
                 // Reject candidate_count > 1
                 for cc_key in &["candidate_count", "candidateCount"] {
-                    if let Some(n) = gc.get(*cc_key).and_then(|v| v.as_u64()) {
-                        if n > 1 {
-                            return Err(format!("candidate_count must be 1 or absent, got {}", n));
+                    if let Some(v) = gc.get(*cc_key) {
+                        if let Some(n) = parse_as_u64(v) {
+                            if n > 1 {
+                                return Err(format!("candidate_count must be 1 or absent, got {}", n));
+                            }
                         }
                     }
                 }
 
-                // Cap max_output_tokens
+                // Cap max_output_tokens (handles both numeric and string-encoded values)
                 for mot_key in &["max_output_tokens", "maxOutputTokens"] {
                     if let Some(mot) = gc.get_mut(*mot_key) {
-                        if let Some(n) = mot.as_u64() {
+                        if let Some(n) = mot.as_u64().or_else(|| mot.as_str().and_then(|s| s.parse::<u64>().ok())) {
                             if n > MAX_OUTPUT_TOKENS_CAP {
                                 *mot = serde_json::Value::Number(MAX_OUTPUT_TOKENS_CAP.into());
                             }
@@ -872,6 +880,54 @@ mod tests {
             parsed["generationConfig"]["maxOutputTokens"],
             serde_json::json!(MAX_OUTPUT_TOKENS_CAP)
         );
+    }
+
+    #[test]
+    fn sanitize_rejects_string_encoded_candidate_count() {
+        // ProtoJSON allows integer fields as quoted strings — must still be caught
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generationConfig": {"candidateCount": "8"}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("candidate_count"));
+    }
+
+    #[test]
+    fn sanitize_caps_string_encoded_max_output_tokens() {
+        // String-encoded maxOutputTokens must still be capped
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generationConfig": {"maxOutputTokens": "999999"}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        ).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&result).unwrap();
+        assert_eq!(
+            parsed["generationConfig"]["maxOutputTokens"],
+            serde_json::json!(MAX_OUTPUT_TOKENS_CAP)
+        );
+    }
+
+    #[test]
+    fn sanitize_rejects_string_encoded_top_level_candidate_count() {
+        // Top-level candidate_count as string must also be caught
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "candidateCount": "5"
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("candidate_count"));
     }
 
     #[test]

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -490,7 +490,7 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
     // Generation-specific validation (not for embed actions)
     let is_embed = action == "embedContent" || action == "batchEmbedContents";
     if !is_embed {
-        // Reject candidate_count > 1
+        // Reject top-level candidate_count > 1
         if let Some(cc) = obj.get("candidate_count").or_else(|| obj.get("candidateCount")) {
             if let Some(n) = cc.as_u64() {
                 if n > 1 {
@@ -499,13 +499,30 @@ fn sanitize_gemini_body(body: &[u8], action: &str) -> Result<Vec<u8>, String> {
             }
         }
 
-        // Cap max_output_tokens in generation_config
+        // Validate inside generation_config / generationConfig
         let gc_key = if obj.contains_key("generation_config") {
             "generation_config"
         } else {
             "generationConfig"
         };
         if let Some(gc) = obj.get_mut(gc_key).and_then(|v| v.as_object_mut()) {
+            // Reject candidate_count > 1 inside generation_config
+            let cc_key = if gc.contains_key("candidate_count") {
+                Some("candidate_count")
+            } else if gc.contains_key("candidateCount") {
+                Some("candidateCount")
+            } else {
+                None
+            };
+            if let Some(cc_key) = cc_key {
+                if let Some(n) = gc.get(cc_key).and_then(|v| v.as_u64()) {
+                    if n > 1 {
+                        return Err(format!("candidate_count must be 1 or absent, got {}", n));
+                    }
+                }
+            }
+
+            // Cap max_output_tokens
             let mot_key = if gc.contains_key("max_output_tokens") {
                 "max_output_tokens"
             } else {
@@ -783,6 +800,47 @@ mod tests {
         let body = serde_json::json!({
             "contents": [{"parts": [{"text": "hello"}]}],
             "candidate_count": 1
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn sanitize_rejects_nested_candidate_count_gt_1() {
+        // candidateCount inside generationConfig (real Gemini API shape)
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generationConfig": {"candidateCount": 4, "maxOutputTokens": 1024}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("candidate_count"));
+    }
+
+    #[test]
+    fn sanitize_rejects_nested_snake_case_candidate_count() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generation_config": {"candidate_count": 3}
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn sanitize_allows_nested_candidate_count_1() {
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": "hello"}]}],
+            "generationConfig": {"candidateCount": 1, "maxOutputTokens": 4096}
         });
         let result = sanitize_gemini_body(
             serde_json::to_vec(&body).unwrap().as_slice(),

--- a/desktop/Backend-Rust/src/routes/proxy.rs
+++ b/desktop/Backend-Rust/src/routes/proxy.rs
@@ -976,6 +976,28 @@ mod tests {
     }
 
     #[test]
+    fn body_size_limit_constant_is_5mb() {
+        // Verify the body size limit constant matches spec (5 MB)
+        assert_eq!(GEMINI_MAX_BODY_SIZE, 5 * 1024 * 1024);
+    }
+
+    #[test]
+    fn sanitize_rejects_body_exceeding_reasonable_size() {
+        // While DefaultBodyLimit handles the actual HTTP 413, the sanitizer
+        // should still handle large valid JSON gracefully (not panic/OOM).
+        // This tests a ~1MB valid JSON body passes sanitization fine.
+        let large_text = "x".repeat(1_000_000);
+        let body = serde_json::json!({
+            "contents": [{"parts": [{"text": large_text}]}]
+        });
+        let result = sanitize_gemini_body(
+            serde_json::to_vec(&body).unwrap().as_slice(),
+            "generateContent",
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn sanitize_strips_safety_settings() {
         let body = serde_json::json!({
             "contents": [{"parts": [{"text": "hello"}]}],

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Tightened Gemini proxy security with model allowlist, request body size limit, and input validation"
+  ],
   "releases": [
     {
       "version": "0.11.307",


### PR DESCRIPTION
## Summary

Tighten the Gemini API proxy security with three hardening layers (closes #6624):

1. **Model allowlist**: Only `gemini-3-flash-preview`, `gemini-pro-latest`, and `gemini-embedding-001` are permitted. Unknown models return 403.
2. **Request body size limit**: 5 MB via `DefaultBodyLimit` on proxy routes only (not global). Normal payloads are 300-600 KB.
3. **Request body validation**: Parse JSON and enforce:
   - `candidate_count` must be 1 or absent (rejects >1 via numeric, string, or float encoding)
   - `max_output_tokens` capped at 8192 (handles numeric, string, and float values)
   - `safety_settings` and `cached_content` stripped (both snake_case and camelCase)
   - `tools` field preserved for function-calling requests
   - Embed actions (`embedContent`, `batchEmbedContents`) skip generation-specific validation

### Review-cycle fixes
- **Iteration 1**: Moved candidateCount validation inside `generationConfig` object (not just top-level)
- **Iteration 2**: Fixed dual-key bypass where both `generation_config` and `generationConfig` coexist
- **Iteration 3**: Handle ProtoJSON string-encoded integers (`"8"` for candidateCount)
- **Iteration 4**: Handle integral float bypass (`8.0` for candidateCount, `999999.0` for maxOutputTokens)

## Test plan

- [x] 54 unit tests covering model extraction, model allowlist, body sanitization (numeric/string/float/dual-key), body size limit, embed skip, safety stripping, tools preservation
- [x] `cargo test routes::proxy` — all 54 pass
- [x] L1: Rust backend builds and starts; health 200; proxy routes registered and auth-gated
- [x] L2: Desktop app compiles and installs; all app-used models in allowlist; backward compatible (zero app-side changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

_by AI for @beastoin_