### PR TITLE
feat: support FIREBASE_PROJECT_ID for self-hosted backend auth (no service account required)

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -42,6 +42,11 @@ RAPID_API_KEY=
 # Firebase OAuth
 FIREBASE_API_KEY=
 FIREBASE_AUTH_DOMAIN=
+# Firebase project ID for token verification.
+# Self-hosted deployments: set this to the project ID used by your app build.
+# Using the stock Omi iOS/Android app (no rebuild): FIREBASE_PROJECT_ID=based-hardware-dev
+# Using a custom app build with your own Firebase project: set to your project ID and provide SERVICE_ACCOUNT_JSON.
+# When SERVICE_ACCOUNT_JSON is set, the project ID is taken from the service account and this value is ignored.
 FIREBASE_PROJECT_ID=
 
 # Encrypt the conversations, memories, chat messages

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -26,6 +26,7 @@ async def get_current_user_id(
         return decoded_token["uid"]
     except Exception as e:
         if os.getenv('LOCAL_DEVELOPMENT') == 'true':
+            logger.warning(f"LOCAL_DEVELOPMENT bypass: token verification failed ({e}), returning stub uid '123'")
             return '123'
         logger.error(f"Error verifying Firebase ID token: {e}")
         raise HTTPException(status_code=401, detail="Invalid authentication credentials")

--- a/backend/dependencies.py
+++ b/backend/dependencies.py
@@ -1,3 +1,4 @@
+import os
 from typing import List, Optional
 
 from fastapi import Depends, HTTPException, Security
@@ -24,6 +25,8 @@ async def get_current_user_id(
         decoded_token = auth.verify_id_token(id_token)
         return decoded_token["uid"]
     except Exception as e:
+        if os.getenv('LOCAL_DEVELOPMENT') == 'true':
+            return '123'
         logger.error(f"Error verifying Firebase ID token: {e}")
         raise HTTPException(status_code=401, detail="Invalid authentication credentials")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -71,9 +71,17 @@ log_langsmith_status()
 validate_stripe_price_ids()
 
 if os.environ.get('SERVICE_ACCOUNT_JSON'):
+    # Full service account credentials — standard cloud deployment
     service_account_info = json.loads(os.environ["SERVICE_ACCOUNT_JSON"])
     credentials = firebase_admin.credentials.Certificate(service_account_info)
     firebase_admin.initialize_app(credentials)
+elif os.environ.get('FIREBASE_PROJECT_ID'):
+    # Self-hosted mode: verify tokens using Firebase's public signing keys only.
+    # No service account required. The SDK fetches public keys from:
+    #   https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com
+    # Set FIREBASE_PROJECT_ID to the project ID used by your app build.
+    # For the stock Omi iOS/Android app: FIREBASE_PROJECT_ID=based-hardware-dev
+    firebase_admin.initialize_app(options={'projectId': os.environ['FIREBASE_PROJECT_ID']})
 else:
     firebase_admin.initialize_app()
 


### PR DESCRIPTION
## Problem

Self-hosted Omi deployments have no working authentication path. The backend requires `SERVICE_ACCOUNT_JSON` (Omi's private Firebase credentials) to initialize Firebase Admin — credentials only Omi possesses. Without them, any Firebase token sent by the iOS/Android app is rejected with `InvalidIdTokenError`.

The only workaround today is `LOCAL_DEVELOPMENT=true`, which disables auth entirely. That is acceptable for a home lab but is not appropriate for any deployment handling real user data.

## Root Cause

Firebase token verification is **asymmetric**. The Firebase Admin SDK verifies JWTs using Firebase's **public** signing keys:
```
https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com
```
No private credentials are needed — only the expected project ID (to validate the token's `aud` claim). The `options={'projectId': ...}` initialization mode is documented and supported by firebase-admin-python for exactly this use case.

## Solution

Add a `FIREBASE_PROJECT_ID` initialization path in `main.py`:

```python
elif os.environ.get('FIREBASE_PROJECT_ID'):
    firebase_admin.initialize_app(options={'projectId': os.environ['FIREBASE_PROJECT_ID']})
```

Self-hosters set this to the Firebase project ID used by their app build. For the **stock Omi iOS/Android app** (no rebuild required), this is `based-hardware-dev` — already publicly committed in `app/setup/prebuilt/GoogleService-Info.plist`.

Priority order is preserved:
1. `SERVICE_ACCOUNT_JSON` — full credentials, standard cloud deployment (unchanged)
2. `FIREBASE_PROJECT_ID` — public-key-only verification, self-hosted deployments (new)
3. Neither — Application Default Credentials (unchanged)

## Also Fixed

`get_current_user_id()` in `dependencies.py` was missing the `LOCAL_DEVELOPMENT` bypass that `endpoints.py verify_token()` already had. This caused auth failures in some code paths during local development even with `LOCAL_DEVELOPMENT=true` set.

## Self-Hosting Setup (after this PR + #6604)

```env
# backend/.env
FIREBASE_PROJECT_ID=based-hardware-dev   # accepts stock Omi app tokens
LOCAL_DEVELOPMENT=false                  # proper auth, no bypass needed
```

No app rebuild. No service account. No `LOCAL_DEVELOPMENT` hack.

## Privacy Motivation

The Omi pendant records continuous audio including conversations with PII and PHI. For users in healthcare, legal, or privacy-sensitive roles, sending this data to Omi's cloud is not acceptable — it may violate HIPAA, legal privilege, or GDPR obligations. Self-hosting is the only viable path for these users, and it is blocked entirely today by the authentication gap this PR closes.

## Changes

| File | Change |
|---|---|
| `backend/main.py` | Add `FIREBASE_PROJECT_ID` initialization path |
| `backend/dependencies.py` | Add missing `LOCAL_DEVELOPMENT` bypass; add `import os` |
| `backend/.env.template` | Document `FIREBASE_PROJECT_ID` with self-hosting guidance |

3 files, 16 lines added.