### PR TITLE
fix: stop sending audio to Omi backend when custom STT is active (prevents listening-minute consumption)

### DIFF
--- a/app/lib/services/sockets/composite_transcription_socket.dart
+++ b/app/lib/services/sockets/composite_transcription_socket.dart
@@ -15,11 +15,17 @@ class CompositeTranscriptionSocket implements IPureSocket {
   final String? suggestedTranscriptType;
   final String? sttProvider;
 
-  /// When true, raw audio bytes are sent only to [primarySocket].
-  /// [secondarySocket] receives only forwarded transcript JSON, not audio.
+  /// When true, calls to [send] route messages only to [primarySocket].
+  /// [secondarySocket] still receives forwarded transcript JSON via
+  /// [_forwardAsSuggestedTranscript] — only the raw [send] path is skipped.
+  ///
   /// Use this when a custom STT provider handles transcription so the Omi
-  /// backend never processes audio — preventing listening-minute consumption.
-  final bool skipAudioToSecondary;
+  /// backend never processes raw audio — preventing listening-minute consumption.
+  ///
+  /// Note: [PureSocket] sets pingInterval=20s at connect time, so the secondary
+  /// WebSocket connection stays alive during silence without application-level
+  /// keep-alive messages.
+  final bool skipSendToSecondary;
 
   PureSocketStatus _status = PureSocketStatus.notConnected;
   IPureSocketListener? _listener;
@@ -32,7 +38,7 @@ class CompositeTranscriptionSocket implements IPureSocket {
     required this.secondarySocket,
     this.suggestedTranscriptType = 'suggested_transcript',
     this.sttProvider,
-    this.skipAudioToSecondary = false,
+    this.skipSendToSecondary = false,
   }) {
     _primaryListener = _PrimarySocketListener(this);
     _secondaryListener = _SecondarySocketListener(this);
@@ -150,11 +156,13 @@ class CompositeTranscriptionSocket implements IPureSocket {
       return;
     }
     primarySocket.send(message);
-    // When skipAudioToSecondary is set, the secondary socket only receives
-    // forwarded transcript JSON (via _forwardAsSuggestedTranscript), never
-    // raw audio bytes. This prevents the Omi backend from transcribing the
-    // audio and counting listening minutes when a custom STT provider is used.
-    if (!skipAudioToSecondary) {
+    // When skipSendToSecondary is set, messages passed to send() go only to
+    // the primary socket. The secondary socket still receives forwarded
+    // transcript JSON via _forwardAsSuggestedTranscript (which calls
+    // secondarySocket.send directly), so conversation processing continues.
+    // WebSocket-level keepalives (pingInterval=20s in PureSocket) keep the
+    // secondary connection alive during silence without audio data.
+    if (!skipSendToSecondary) {
       secondarySocket.send(message);
     }
   }

--- a/app/lib/services/sockets/composite_transcription_socket.dart
+++ b/app/lib/services/sockets/composite_transcription_socket.dart
@@ -15,6 +15,12 @@ class CompositeTranscriptionSocket implements IPureSocket {
   final String? suggestedTranscriptType;
   final String? sttProvider;
 
+  /// When true, raw audio bytes are sent only to [primarySocket].
+  /// [secondarySocket] receives only forwarded transcript JSON, not audio.
+  /// Use this when a custom STT provider handles transcription so the Omi
+  /// backend never processes audio — preventing listening-minute consumption.
+  final bool skipAudioToSecondary;
+
   PureSocketStatus _status = PureSocketStatus.notConnected;
   IPureSocketListener? _listener;
 
@@ -26,6 +32,7 @@ class CompositeTranscriptionSocket implements IPureSocket {
     required this.secondarySocket,
     this.suggestedTranscriptType = 'suggested_transcript',
     this.sttProvider,
+    this.skipAudioToSecondary = false,
   }) {
     _primaryListener = _PrimarySocketListener(this);
     _secondaryListener = _SecondarySocketListener(this);
@@ -143,7 +150,13 @@ class CompositeTranscriptionSocket implements IPureSocket {
       return;
     }
     primarySocket.send(message);
-    secondarySocket.send(message);
+    // When skipAudioToSecondary is set, the secondary socket only receives
+    // forwarded transcript JSON (via _forwardAsSuggestedTranscript), never
+    // raw audio bytes. This prevents the Omi backend from transcribing the
+    // audio and counting listening minutes when a custom STT provider is used.
+    if (!skipAudioToSecondary) {
+      secondarySocket.send(message);
+    }
   }
 
   void _onPrimaryMessage(dynamic message) {

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -477,7 +477,7 @@ class TranscriptSocketServiceFactory {
       // the Omi backend, never raw audio. Without this, the backend transcribes
       // the audio stream in parallel and counts listening minutes even though
       // the custom provider is doing the actual transcription work.
-      skipAudioToSecondary: true,
+      skipSendToSecondary: true,
     );
     return TranscriptSegmentSocketService.withSocket(
       sampleRate,

--- a/app/lib/services/sockets/transcription_service.dart
+++ b/app/lib/services/sockets/transcription_service.dart
@@ -473,6 +473,11 @@ class TranscriptSocketServiceFactory {
       primarySocket: primarySocket,
       secondarySocket: secondaryService.socket,
       sttProvider: sttProvider,
+      // Custom STT handles transcription — send only forwarded transcripts to
+      // the Omi backend, never raw audio. Without this, the backend transcribes
+      // the audio stream in parallel and counts listening minutes even though
+      // the custom provider is doing the actual transcription work.
+      skipAudioToSecondary: true,
     );
     return TranscriptSegmentSocketService.withSocket(
       sampleRate,


### PR DESCRIPTION
## Bug

When a custom STT provider (Deepgram, Local Whisper, or a custom endpoint) is configured, `CompositeTranscriptionSocket` opens **two WebSocket connections simultaneously** and sends every raw audio chunk to both:

```
Audio chunk → primarySocket  → custom STT provider   ✅ intended
Audio chunk → secondarySocket → api.omi.me/v4/listen  ❌ unintended
```

The secondary connection causes the Omi backend to **transcribe the audio in parallel**, consuming listening minutes from the user's quota — even though the custom provider is handling all transcription.

This makes the "bring your own STT" feature misleading. Per Omi's own support:
> *"If you're still sending sessions through the cloud /v4/listen pipeline, listening minutes will count even with custom STT."*

The `custom_stt=enabled` query flag tells the backend to use forwarded transcripts instead of its own transcription output, but it does **not** stop the audio stream from being received and metered.

## Root Cause

`composite_transcription_socket.dart` `send()` (lines 141-147 before this fix):

```dart
void send(dynamic message) {
    primarySocket.send(message);   // audio → custom STT
    secondarySocket.send(message); // audio → /v4/listen — always, unconditionally
}
```

## Fix

Add `skipAudioToSecondary` flag to `CompositeTranscriptionSocket`. When `true`:
- Raw audio bytes go **only** to the primary socket (custom STT provider)
- Secondary socket still connects and receives **forwarded transcript JSON** via `_forwardAsSuggestedTranscript`
- Conversation saving, AI processing, and memory extraction on the Omi backend continue normally
- Audio transcription — and minute counting — is skipped

Set `skipAudioToSecondary: true` unconditionally in `_createCompositeService` since the composite path is only reached when a custom STT config is active.

## Behaviour After Fix

| | Before | After |
|---|---|---|
| Custom STT transcription | ✅ works | ✅ works |
| Conversation saving | ✅ works | ✅ works |
| AI processing / memories | ✅ works | ✅ works |
| Listening minutes consumed | ❌ always | ✅ not consumed |
| Audio sent to api.omi.me | ❌ always | ✅ never |

## Changes

2 files, 19 lines added, 1 line changed.

| File | Change |
|---|---|
| `composite_transcription_socket.dart` | Add `skipAudioToSecondary` field + conditional in `send()` |
| `transcription_service.dart` | Pass `skipAudioToSecondary: true` in `_createCompositeService` |