### PR TITLE
fix(desktop): usage-limit popup + 30 msg/month shared chat cap

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added usage-limit popup when free-tier transcription or chat quota is hit, with one-click upgrade to Plan & Usage",
+    "Lowered free-tier chat limit to 30 messages/month shared between main chat and the floating bar"
+  ],
   "releases": [
     {
       "version": "0.11.310",

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -115,6 +115,19 @@ class AppState: ObservableObject {
   @Published var isAccessibilityBroken = false  // TCC says yes but AX calls actually fail (common after macOS updates/app re-signs)
   @Published var hasFullDiskAccess = false
 
+  /// Usage-limit popup state. Set by `triggerUsageLimitPopup(reason:)` when the
+  /// user hits a free-tier cap (transcription minutes, monthly chat messages, etc).
+  /// The popup is mounted as an overlay in `DesktopHomeView` and is closable.
+  @Published var showUsageLimitPopup: Bool = false
+  @Published var usageLimitReason: String = ""
+
+  /// Trigger the monthly-limit popup. Safe to call repeatedly — SwiftUI's
+  /// `@Published` dedupes identical-value writes automatically.
+  func triggerUsageLimitPopup(reason: String) {
+    usageLimitReason = reason
+    showUsageLimitPopup = true
+  }
+
   /// True if notifications are enabled but won't show visual banners
   var isNotificationBannerDisabled: Bool {
     hasNotificationPermission && notificationAlertStyle == .none
@@ -2509,6 +2522,7 @@ class AppState: ObservableObject {
     case "freemium_threshold_reached":
       let remaining = event.raw["remaining_seconds"] as? Int ?? 0
       log("Transcription: Freemium threshold reached, \(remaining)s remaining")
+      triggerUsageLimitPopup(reason: "transcription")
 
     case "translating":
       if let segmentsArray = event.raw["segments"] as? [[String: Any]] {
@@ -3026,6 +3040,8 @@ extension Notification.Name {
   static let screenCaptureKitBroken = Notification.Name("screenCaptureKitBroken")
   /// Posted to show the "Try asking" popup centered over the full window
   static let showTryAskingPopup = Notification.Name("showTryAskingPopup")
+  /// Posted to show the over-usage-limit popup. userInfo["reason"] = "transcription" | "chat" | "floating_bar".
+  static let showUsageLimitPopup = Notification.Name("showUsageLimitPopup")
   /// Posted to navigate to Rewind settings
   static let navigateToRewindSettings = Notification.Name("navigateToRewindSettings")
   /// Posted to navigate to Rewind page (global hotkey: Cmd+Option+R)

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -1,16 +1,24 @@
 import Foundation
 
-/// Tracks weekly floating bar query usage and enforces limits for free users.
+/// Tracks AI chat/query usage and enforces a shared monthly limit for free users.
+///
+/// Shared between the floating bar (Ask omi / PTT queries) and the main chat page
+/// (ChatProvider.sendMessage). A single 30-message monthly pool is counted against
+/// both surfaces so the free tier can't be stretched by bouncing between the two.
 @MainActor
 final class FloatingBarUsageLimiter: ObservableObject {
     static let shared = FloatingBarUsageLimiter()
 
-    static let weeklyFreeLimit = 50
+    /// Monthly free cap, shared across floating bar + main chat.
+    static let monthlyFreeLimit = 30
+
+    /// Rolling window in seconds (30 days).
+    static let windowSeconds: Double = 30 * 24 * 3600
 
     private static let queryTimestampsKey = "floatingBar_queryTimestamps"
     private static let cachedPlanKey = "floatingBar_cachedPlan"
 
-    @Published private(set) var weeklyQueriesUsed: Int = 0
+    @Published private(set) var monthlyQueriesUsed: Int = 0
     @Published private(set) var hasPaidPlan: Bool = false
     private var planFetched = false
 
@@ -37,14 +45,15 @@ final class FloatingBarUsageLimiter: ObservableObject {
     }
 
     var isLimitReached: Bool {
-        !hasPaidPlan && weeklyQueriesUsed >= Self.weeklyFreeLimit
+        !hasPaidPlan && monthlyQueriesUsed >= Self.monthlyFreeLimit
     }
 
     var remainingQueries: Int {
-        hasPaidPlan ? .max : max(0, Self.weeklyFreeLimit - weeklyQueriesUsed)
+        hasPaidPlan ? .max : max(0, Self.monthlyFreeLimit - monthlyQueriesUsed)
     }
 
-    /// Record a query. Call after successfully sending a floating bar query.
+    /// Record a query. Call after successfully sending a query from the floating bar
+    /// OR the main chat page — both surfaces share this pool.
     func recordQuery() {
         var timestamps = loadTimestamps()
         timestamps.append(Date().timeIntervalSince1970)
@@ -53,11 +62,11 @@ final class FloatingBarUsageLimiter: ObservableObject {
     }
 
     private func pruneAndCount() {
-        let cutoff = Date().timeIntervalSince1970 - 7 * 24 * 3600
+        let cutoff = Date().timeIntervalSince1970 - Self.windowSeconds
         var timestamps = loadTimestamps()
         timestamps.removeAll { $0 < cutoff }
         UserDefaults.standard.set(timestamps, forKey: Self.queryTimestampsKey)
-        weeklyQueriesUsed = timestamps.count
+        monthlyQueriesUsed = timestamps.count
     }
 
     private func loadTimestamps() -> [Double] {

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1466,17 +1466,22 @@ class FloatingControlBarManager {
         prepareVisibleQueryState(message, in: barWindow, fromVoice: queryFromVoice)
         let generation = activeQueryGeneration
 
-        // Check weekly usage limit for free users
+        // Check monthly usage limit for free users (shared with main chat page).
         let limiter = FloatingBarUsageLimiter.shared
         if limiter.isLimitReached {
             guard isActiveQueryGeneration(generation) else { return }
             barWindow.state.isAILoading = false
             barWindow.state.showingAIResponse = true
             barWindow.state.currentAIMessage = ChatMessage(
-                text: "You've used all \(FloatingBarUsageLimiter.weeklyFreeLimit) free queries this week. Upgrade to Pro for unlimited access, or wait for your weekly reset.",
+                text: "You've hit your monthly limit of \(FloatingBarUsageLimiter.monthlyFreeLimit) free messages. Upgrade to keep chatting without restrictions.",
                 sender: .ai
             )
             barWindow.resizeToResponseHeightPublic(animated: true)
+            NotificationCenter.default.post(
+                name: .showUsageLimitPopup,
+                object: nil,
+                userInfo: ["reason": "floating_bar"]
+            )
             return
         }
 

--- a/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
+++ b/desktop/Desktop/Sources/MainWindow/DesktopHomeView.swift
@@ -101,6 +101,27 @@ struct DesktopHomeView: View {
             }
           mainContent
             .opacity(viewModelContainer.isInitialLoadComplete ? 1 : 0)
+            .overlay {
+              if appState.showUsageLimitPopup {
+                UsageLimitPopupView(
+                  reason: appState.usageLimitReason,
+                  onUpgrade: {
+                    appState.showUsageLimitPopup = false
+                    selectedSettingsSection = .planUsage
+                    withAnimation(.easeInOut(duration: 0.2)) {
+                      selectedIndex = SidebarNavItem.settings.rawValue
+                    }
+                  },
+                  onDismiss: {
+                    appState.showUsageLimitPopup = false
+                  }
+                )
+              }
+            }
+            .onReceive(NotificationCenter.default.publisher(for: .showUsageLimitPopup)) { notification in
+              let reason = notification.userInfo?["reason"] as? String ?? ""
+              appState.triggerUsageLimitPopup(reason: reason)
+            }
             .onAppear {
               log("DesktopHomeView: Showing mainContent (signed in and onboarded)")
               // Check all permissions on launch

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -2122,6 +2122,21 @@ A screenshot may be attached — use it silently only if relevant. Never mention
             return
         }
 
+        // Monthly free-tier limit shared with the floating bar (30 messages/month).
+        // Block the send, surface the popup, and let the user upgrade.
+        let usageLimiter = FloatingBarUsageLimiter.shared
+        if usageLimiter.isLimitReached {
+            log("ChatProvider: sendMessage blocked — free-tier monthly chat limit reached")
+            errorMessage = "You've hit your monthly limit of \(FloatingBarUsageLimiter.monthlyFreeLimit) free messages. Upgrade to keep chatting."
+            NotificationCenter.default.post(
+                name: .showUsageLimitPopup,
+                object: nil,
+                userInfo: ["reason": "chat"]
+            )
+            return
+        }
+        usageLimiter.recordQuery()
+
         // Ensure bridge is running
         guard await ensureBridgeStarted() else {
             errorMessage = "AI not available"

--- a/desktop/Desktop/Sources/UsageLimitPopupView.swift
+++ b/desktop/Desktop/Sources/UsageLimitPopupView.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+/// Modal overlay shown when the user hits a free-tier usage cap
+/// (transcription minutes, monthly chat/floating-bar messages, etc).
+///
+/// Rendered as a `.overlay` on `DesktopHomeView.mainContent` so it appears
+/// above every page. The user can dismiss it with the X button or the
+/// "Not now" button; clicking "Upgrade" navigates to Settings → Plan & Usage.
+struct UsageLimitPopupView: View {
+  let reason: String
+  let onUpgrade: () -> Void
+  let onDismiss: () -> Void
+
+  private var headline: String {
+    "You've hit your monthly limit"
+  }
+
+  private var body_text: String {
+    switch reason {
+    case "transcription":
+      return "You've hit your monthly limit. Upgrade to make sure your new recordings aren't lost."
+    case "chat", "floating_bar":
+      return "You've hit your monthly limit. Upgrade to keep chatting with Omi without restrictions."
+    default:
+      return "You've hit your monthly limit. Upgrade to make sure your new recordings aren't lost."
+    }
+  }
+
+  var body: some View {
+    ZStack {
+      // Semi-transparent backdrop, tap-to-dismiss
+      Color.black.opacity(0.55)
+        .ignoresSafeArea()
+        .onTapGesture { onDismiss() }
+
+      // Centered card
+      VStack(spacing: 0) {
+        // Close X in the top-right corner
+        HStack {
+          Spacer()
+          Button(action: onDismiss) {
+            Image(systemName: "xmark")
+              .scaledFont(size: 14, weight: .semibold)
+              .foregroundColor(OmiColors.textTertiary)
+              .padding(8)
+              .contentShape(Rectangle())
+          }
+          .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 8)
+        .padding(.top, 8)
+
+        VStack(spacing: 20) {
+          // Icon
+          ZStack {
+            Circle()
+              .fill(OmiColors.purplePrimary.opacity(0.15))
+              .frame(width: 64, height: 64)
+            Image(systemName: "exclamationmark.triangle.fill")
+              .scaledFont(size: 28, weight: .semibold)
+              .foregroundColor(OmiColors.purplePrimary)
+          }
+
+          VStack(spacing: 8) {
+            Text(headline)
+              .scaledFont(size: 20, weight: .bold)
+              .foregroundColor(OmiColors.textPrimary)
+              .multilineTextAlignment(.center)
+
+            Text(body_text)
+              .scaledFont(size: 14)
+              .foregroundColor(OmiColors.textTertiary)
+              .multilineTextAlignment(.center)
+              .fixedSize(horizontal: false, vertical: true)
+              .padding(.horizontal, 16)
+          }
+
+          VStack(spacing: 10) {
+            Button(action: onUpgrade) {
+              Text("Upgrade")
+                .scaledFont(size: 15, weight: .semibold)
+                .foregroundColor(.white)
+                .frame(maxWidth: .infinity)
+                .frame(height: 44)
+                .background(
+                  RoundedRectangle(cornerRadius: 10)
+                    .fill(OmiColors.purplePrimary)
+                )
+            }
+            .buttonStyle(.plain)
+
+            Button(action: onDismiss) {
+              Text("Not now")
+                .scaledFont(size: 13, weight: .medium)
+                .foregroundColor(OmiColors.textTertiary)
+                .frame(maxWidth: .infinity)
+                .frame(height: 32)
+            }
+            .buttonStyle(.plain)
+          }
+          .padding(.horizontal, 24)
+        }
+        .padding(.bottom, 28)
+      }
+      .frame(width: 380)
+      .background(
+        RoundedRectangle(cornerRadius: 16)
+          .fill(OmiColors.backgroundRaised)
+          .overlay(
+            RoundedRectangle(cornerRadius: 16)
+              .stroke(OmiColors.border, lineWidth: 1)
+          )
+      )
+      .shadow(color: .black.opacity(0.5), radius: 24, y: 8)
+    }
+    .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+  }
+}
+
+#Preview {
+  UsageLimitPopupView(
+    reason: "transcription",
+    onUpgrade: {},
+    onDismiss: {}
+  )
+  .frame(width: 900, height: 600)
+}


### PR DESCRIPTION
## Summary

- New closable modal `UsageLimitPopupView` surfaces whenever a free-tier cap is hit (transcription minutes or monthly chat messages)
- Popup is mounted as an overlay on `DesktopHomeView.mainContent` so it appears above every sidebar page
- Clicking **Upgrade** navigates directly to Settings → Plan and Usage; **Not now** / the X / tap-backdrop all dismiss
- The transcription backend event `freemium_threshold_reached` is now actually handled instead of being a dead log line
- Main chat page (`ChatProvider.sendMessage`) now shares `FloatingBarUsageLimiter` with the floating bar — a single 30 messages/month pool counts against both surfaces
- Floating bar over-limit text updated from "50 queries this week" → "30 free messages this month"

## Why

Two concrete bugs were fixed:

1. **Transcription freemium cap was completely silent.** `AppState.swift:2509-2511` handled the backend `freemium_threshold_reached` WebSocket event by calling `log()` and nothing else — no state update, no banner, no modal, no indication that the user had hit their monthly limit. Transcription quietly stopped recording new segments while the mic level kept wiggling and the "Recording" pill stayed on. Users interpreted it as "transcription broke after today's update" and filed confused support reports. Many of our "recording stopped after update" complaints are likely this.
2. **Main chat page had no usage gating at all.** Only the floating bar's 50-queries-a-week counter existed. A free-tier user could send unlimited messages via the main chat page and never hit a paywall. That's zero monetization pressure on the core AI surface.

## Changes

**`FloatingBarUsageLimiter.swift`** (rework)
- `weeklyFreeLimit = 50` → `monthlyFreeLimit = 30`
- Rolling window `7 * 24 * 3600` → `30 * 24 * 3600`
- Renamed internal vars `weekly* → monthly*`
- Same `UserDefaults` keys, same public `recordQuery` / `isLimitReached` API — existing callers keep working

**`ChatProvider.sendMessage`** (new gating)
- After the `isSending` concurrency guard, check `FloatingBarUsageLimiter.shared.isLimitReached`
- On hit: set `errorMessage`, post `Notification.Name.showUsageLimitPopup` with `reason: "chat"`, return
- On success: call `recordQuery()` so floating bar + chat share the same pool

**`FloatingControlBarWindow.sendAIQuery`** (reuse)
- Inline chat message text updated to say "30 free messages this month" (was "50 queries this week")
- Additionally posts the `showUsageLimitPopup` notification with `reason: "floating_bar"` — the existing inline message is informative but doesn't drive the user to upgrade, the popup does

**`AppState.swift`** (new state + wiring)
- New published: `showUsageLimitPopup: Bool`, `usageLimitReason: String`
- New method: `triggerUsageLimitPopup(reason:)` — sets both and lets SwiftUI drive the overlay
- `handleListenEvent` case `"freemium_threshold_reached"` now calls `triggerUsageLimitPopup(reason: "transcription")` alongside the existing log line
- New `Notification.Name.showUsageLimitPopup` declaration for cross-service triggering

**`UsageLimitPopupView.swift`** (new, ~127 lines)
- Semi-transparent backdrop (tap-to-dismiss)
- Centered 380-wide card with warning icon, headline, body copy, Upgrade + Not now buttons, X in corner
- Body copy varies by `reason`:
  - `"transcription"` → "You've hit your monthly limit. Upgrade to make sure your new recordings aren't lost."
  - `"chat"` / `"floating_bar"` → "You've hit your monthly limit. Upgrade to keep chatting with Omi without restrictions."

**`DesktopHomeView.swift`** (mount)
- `.overlay { if appState.showUsageLimitPopup { UsageLimitPopupView(...) } }` on `mainContent`
- `onUpgrade` closure: clears flag, sets `selectedSettingsSection = .planUsage`, animates `selectedIndex` to Settings
- `onDismiss` closure: clears flag
- Subscribes to `NotificationCenter.default.publisher(for: .showUsageLimitPopup)` and calls `appState.triggerUsageLimitPopup(reason:)` with the `userInfo["reason"]` — this is how ChatProvider/FloatingControlBarWindow reach the AppState instance that owns the overlay

## Test plan

- [ ] Build on Mac mini with `OMI_APP_NAME=usage-popup ./run.sh`
- [ ] Free-tier account: send 30 floating bar queries, 31st triggers popup with "chat" copy, Upgrade navigates to Settings → Plan and Usage
- [ ] Free-tier account: send a chat message in the main chat page after hitting the cap — same popup appears
- [ ] Paid account (Unlimited / Pro): chat messages flow freely, popup never appears (verified by `hasPaidPlan` branch in limiter)
- [ ] Simulate `freemium_threshold_reached` via a test WebSocket event injected into `AppState.handleListenEvent` — popup shows with "transcription" copy, text emphasizes recordings
- [ ] Popup X button, "Not now" button, and backdrop tap all dismiss
- [ ] Upgrade button navigates to Settings → Plan and Usage section
- [ ] Popup appears over every sidebar page (Home, Conversations, Memories, Tasks, Rewind, Apps, Settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)