### PR TITLE
Fix desktop home recording falsely stopping on transient capture failures

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed screen recording randomly stopping with a false Permission Required notification after closing a tab or dismissing a popup"
+  ],
   "releases": [
     {
       "version": "0.11.308",

--- a/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
+++ b/desktop/Desktop/Sources/ProactiveAssistants/ProactiveAssistantsPlugin.swift
@@ -688,10 +688,23 @@ public class ProactiveAssistantsPlugin: NSObject {
         if #available(macOS 14.0, *) {
             // Use the window ID already resolved above (line 624) to avoid stale cache hits
             // from a second getActiveWindowInfoAsync() call inside captureActiveWindowCGImage()
-            let cgImage: CGImage? = if let wid = windowID {
-                await screenCaptureService.captureWindowCGImage(windowID: wid)
+            var cgImage: CGImage? = nil
+            if let wid = windowID {
+                switch await screenCaptureService.captureWindowCGImage(windowID: wid) {
+                case .success(let image):
+                    cgImage = image
+                case .windowGone:
+                    // The window disappeared between resolution and capture (user closed
+                    // a tab, dismissed a modal, app destroyed the window). Re-resolve the
+                    // active window fresh and retry once — do NOT count this as a capture
+                    // failure. This used to trip the consecutive-failure counter and falsely
+                    // declare "screen recording permission lost" after normal user actions.
+                    cgImage = await screenCaptureService.captureActiveWindowCGImage()
+                case .failed:
+                    cgImage = nil
+                }
             } else {
-                await screenCaptureService.captureActiveWindowCGImage()
+                cgImage = await screenCaptureService.captureActiveWindowCGImage()
             }
             if let cgImage = cgImage,
                let appName = appName {
@@ -1163,29 +1176,48 @@ public class ProactiveAssistantsPlugin: NSObject {
             return
         }
 
-        // Refresh permission state
+        // First pass: run a single permission test.
         refreshScreenRecordingPermission()
 
-        // Check if permission is actually lost
-        if !hasScreenRecordingPermission {
-            log("ProactiveAssistantsPlugin: Screen recording permission lost")
+        if hasScreenRecordingPermission {
+            // Permission appears granted but capture is failing
+            // This could be a transient issue - enter recovery mode instead of stopping
+            log("ProactiveAssistantsPlugin: Capture failing with permission granted, entering recovery mode")
+            enterRecoveryMode()
+            return
+        }
+
+        // First permission test failed. Do NOT declare permission lost yet —
+        // `/usr/sbin/screencapture` can transiently fail during app-switches,
+        // mid-animation, or while macOS is mid-context-switch. A single failed
+        // probe previously stopped monitoring + fired a scary "permission lost"
+        // notification even though real recording was still working.
+        // Re-test after a short delay; only stop if both tests fail.
+        log("ProactiveAssistantsPlugin: First permission test failed, re-testing to avoid false positive")
+        Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: 1_500_000_000)  // 1.5s
+            guard let self = self, self.isMonitoring else { return }
+
+            self.refreshScreenRecordingPermission()
+            if self.hasScreenRecordingPermission {
+                log("ProactiveAssistantsPlugin: Permission test recovered on second check — treating initial failure as transient, entering recovery mode")
+                self.enterRecoveryMode()
+                return
+            }
+
+            log("ProactiveAssistantsPlugin: Screen recording permission lost (confirmed by second test)")
 
             // Post notification for AppState to update UI
             NotificationCenter.default.post(name: .screenCapturePermissionLost, object: nil)
 
             // Stop monitoring since we can't capture
-            stopMonitoring()
+            self.stopMonitoring()
 
             // Send user notification
             NotificationService.shared.sendNotification(
                 title: "Screen Recording Permission Required",
                 message: "omi needs screen recording permission to continue monitoring. Please re-enable it in System Settings."
             )
-        } else {
-            // Permission appears granted but capture is failing
-            // This could be a transient issue - enter recovery mode instead of stopping
-            log("ProactiveAssistantsPlugin: Capture failing with permission granted, entering recovery mode")
-            enterRecoveryMode()
         }
     }
 

--- a/desktop/Desktop/Sources/ScreenCaptureService.swift
+++ b/desktop/Desktop/Sources/ScreenCaptureService.swift
@@ -751,11 +751,22 @@ final class ScreenCaptureService: Sendable {
 
   // MARK: - CGImage Capture (macOS 14+)
 
+  /// Result of an attempted per-window capture.
+  /// Distinguishes "the window went away" (normal — the user closed a tab / modal)
+  /// from a real capture engine failure (permission revoked, stream error, etc.).
+  enum WindowCaptureResult {
+    case success(CGImage)
+    case windowGone
+    case failed
+  }
+
   /// Capture the active window and return the raw CGImage (no JPEG encoding).
   /// Use this on macOS 14+ to avoid redundant encode/decode round-trips.
   @available(macOS 14.0, *)
-  /// Capture a specific window by ID (avoids re-resolving the active window)
-  func captureWindowCGImage(windowID: CGWindowID) async -> CGImage? {
+  /// Capture a specific window by ID (avoids re-resolving the active window).
+  /// Returns a detailed result so the caller can distinguish transient window
+  /// disappearance from real capture failures.
+  func captureWindowCGImage(windowID: CGWindowID) async -> WindowCaptureResult {
     do {
       let content = try await SCShareableContent.excludingDesktopWindows(
         false,
@@ -786,17 +797,21 @@ final class ScreenCaptureService: Sendable {
       }
 
       guard let (filter, config) = filterAndConfig else {
-        log("Window \(windowID) not found in SCShareableContent")
-        return nil
+        // Window ID no longer exists — the user closed a tab, dismissed a modal,
+        // or the app destroyed the window between resolution and capture. This is
+        // routine, not a capture failure. Caller should re-resolve and retry.
+        log("Window \(windowID) not found in SCShareableContent (window closed)")
+        return .windowGone
       }
 
-      return try await SCScreenshotManager.captureImage(
+      let image = try await SCScreenshotManager.captureImage(
         contentFilter: filter,
         configuration: config
       )
+      return .success(image)
     } catch {
       log("ScreenCaptureKit CGImage error for window \(windowID): \(error.localizedDescription)")
-      return nil
+      return .failed
     }
   }
 


### PR DESCRIPTION
## Summary
- Fixes "home recording randomly stops with a red Screen Recording Permission Required notification after an auto-update" — the second root cause behind widespread user reports (the first was the pre-v0.11.275 `tccutil reset` self-wipe bug already shipped in PR #6493).
- Distinguishes a disappearing window (user closed a tab / Telegram dismissed a modal / an app destroyed a window) from a real capture-engine failure.
- Requires **two** consecutive `/usr/sbin/screencapture` probe failures before declaring permission lost, not one.

## Why
Observed in real user log from Arav (Omi Beta v0.11.309), two separate incidents in 24h:

```
[04:40:02.813] Window 355 not found in SCShareableContent
[04:40:02.814] ProactiveAssistantsPlugin: Capture failed (1 consecutive)
... 4 more window-355-not-found failures in 200ms ...
[04:40:03.016] Detected 5 consecutive capture failures
[04:40:04.047] Screen capture test: FAILED (exit code: 1)
[04:40:04.047] ProactiveAssistantsPlugin: Screen recording permission lost  ← wrong
[04:40:04.051] (stopMonitoring fires, notification sent, bar turns red)
...
[04:40:23.594] Screen capture recovered after 7 failures  ← it was transient
```

Telegram destroyed the window the capture pipeline was mid-frame on. The plugin counted 5 "window not found" lookups as real capture failures, then ran a single `/usr/sbin/screencapture` probe which also transiently failed during the same app-switch, and the app declared permission lost. 20s later everything worked fine on its own — but the user had already seen a red notification and had to manually re-enable monitoring.

Same pattern at 19:55:03 — Arc tab closed, window 32260 disappeared, 5 failures, permission lost, 52s later `Screen capture test: SUCCESS`.

## What changes

**`ScreenCaptureService.swift`** — `captureWindowCGImage(windowID:)` now returns a `WindowCaptureResult` enum:
- `.success(CGImage)` — captured fine
- `.windowGone` — the window ID no longer exists; routine, caller should re-resolve
- `.failed` — real capture engine error

**`ProactiveAssistantsPlugin.swift`**:
- On `.windowGone`, re-resolve the active window fresh (`captureActiveWindowCGImage`) and retry instead of counting it as a capture failure.
- `handleRepeatedCaptureFailures` no longer declares permission lost from a single failed CLI probe. If the first test fails, wait 1.5s and re-test. Only stop monitoring if **both** fail. If the second test recovers, enter recovery mode instead.

## Test plan
- [ ] Builds clean (verified locally, `xcrun swift build -c debug` succeeds, no new warnings)
- [ ] Mac mini: app launches with `OMI_APP_NAME="fix-screen-capture-window-gone" bash run.sh --yolo`
- [ ] Mac mini: home recording starts and captures frames
- [ ] Mac mini: close a browser tab / dismiss a popup while monitoring — no "Screen Recording Permission Required" notification, no spurious "Screen recording permission lost" log line
- [ ] Mac mini: `/private/tmp/omi-dev.log` shows `Window N not found in SCShareableContent (window closed)` followed by continued successful captures (re-resolve retry worked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)