### PR TITLE
Update CHANGELOG.json for v0.11.311 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,9 +1,14 @@
 {
-  "unreleased": [
-    "Added usage-limit popup when free-tier transcription or chat quota is hit, with one-click upgrade to Plan & Usage",
-    "Lowered free-tier chat limit to 30 messages/month shared between main chat and the floating bar"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.311",
+      "date": "2026-04-14",
+      "changes": [
+        "Added usage-limit popup when free-tier transcription or chat quota is hit, with one-click upgrade to Plan & Usage",
+        "Lowered free-tier chat limit to 30 messages/month shared between main chat and the floating bar"
+      ]
+    },
     {
       "version": "0.11.310",
       "date": "2026-04-14",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.311 and clears the unreleased array.