### PR TITLE
fix(desktop): recover from silent Bluetooth mic and mix system audio into transcript

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed silent recordings when Bluetooth headphones are connected while another app plays audio, and included system audio in the conversation transcript"
+  ],
   "releases": [
     {
       "version": "0.11.309",

--- a/desktop/Desktop/Sources/AppState.swift
+++ b/desktop/Desktop/Sources/AppState.swift
@@ -57,6 +57,10 @@ class AppState: ObservableObject {
   /// Tracks the source for the current recording (for API tagging)
   private var currentConversationSource: ConversationSource = .desktop
 
+  /// Guards against re-entering the silent-mic fallback path multiple times in a single session.
+  /// The user-visible banner lives in `SilentMicNoticeMonitor.shared`.
+  private var silentMicFallbackInProgress: Bool = false
+
   // Audio levels moved to AudioLevelMonitor to avoid triggering global re-renders
   // Access via AudioLevelMonitor.shared.microphoneLevel / .systemLevel
   var microphoneAudioLevel: Float { AudioLevelMonitor.shared.microphoneLevel }
@@ -1436,52 +1440,98 @@ class AppState: ObservableObject {
     }
   }
 
-  /// Start microphone audio capture — sends mono mic audio directly to Python backend
+  /// Start microphone + system audio capture — mixes mic and system audio into a single
+  /// mono stream (via AudioMixer) and sends it to the Python backend (`channels=1`).
+  /// This way anything playing through the Mac's speakers (YouTube, calls, music)
+  /// ends up in the conversation transcript alongside the user's voice.
   private func startMicrophoneAudioCapture() async {
     guard let audioCaptureService = audioCaptureService else { return }
 
+    // Silent-mic watchdog: on A2DP profile conflict the Bluetooth input device returns
+    // zero samples even though CoreAudio reports healthy capture. Fall back to the
+    // built-in mic when the watchdog fires.
+    audioCaptureService.onSilentMicDetected = { [weak self] in
+      Task { @MainActor in
+        self?.handleSilentMicFallback()
+      }
+    }
+
+    // Start the mixer — it sums mic + system into a mono stream and forwards it to
+    // the transcription WebSocket.
+    audioMixer?.start { [weak self] monoMixed in
+      self?.transcriptionService?.sendAudio(monoMixed)
+    }
+
     do {
-      // Start microphone capture — send audio directly to transcription service (mono)
-      // Python backend handles diarization server-side, no need for stereo mixing
+      // Microphone capture → mixer (mic channel). Level still drives the UI.
       try await audioCaptureService.startCapture(
         onAudioChunk: { [weak self] audioData in
-          self?.transcriptionService?.sendAudio(audioData)
+          self?.audioMixer?.setMicAudio(audioData)
         },
         onAudioLevel: { level in
           // Use dedicated monitor to avoid triggering AppState re-renders
           AudioLevelMonitor.shared.updateMicrophoneLevel(level)
         }
       )
-      log("Transcription: Microphone capture started (mono, Python backend)")
+      log("Transcription: Microphone capture started (→ mixer, Python backend mono)")
 
-      // Start system audio capture if available (macOS 14.4+)
-      // System audio is still captured for audio level display but NOT sent to transcription
-      // (Python backend receives mono mic-only audio with channels=1)
+      // Start system audio capture if available (macOS 14.4+). When present, its
+      // samples are mixed into the same mono stream so YouTube/calls/music end up
+      // in the transcript too. If unavailable or it fails, we simply keep mic-only
+      // audio flowing through the mixer.
       if #available(macOS 14.4, *) {
         if let systemService = systemAudioCaptureService as? SystemAudioCaptureService {
           do {
             try await systemService.startCapture(
               onAudioChunk: { [weak self] audioData in
-                // Still mix system audio for audio level monitoring
                 self?.audioMixer?.setSystemAudio(audioData)
               },
               onAudioLevel: { level in
                 AudioLevelMonitor.shared.updateSystemLevel(level)
               }
             )
-            log("Transcription: System audio capture started (level monitoring only)")
+            log("Transcription: System audio capture started (→ mixer, mono sum)")
           } catch {
-            // System audio is optional - continue with mic only
+            // System audio is optional — continue with mic only (mixer will just
+            // emit mic samples summed with zero system samples).
             logError(
               "Transcription: System audio capture failed (continuing with mic only)", error: error)
           }
         }
       }
 
-      log("Transcription: Audio capture started (mono mic → Python backend)")
+      log("Transcription: Audio capture started (mic + system → mono mix → Python backend)")
     } catch {
       logError("Transcription: Failed to start audio capture", error: error)
       stopTranscription()
+    }
+  }
+
+  /// Fall back from a silent Bluetooth mic to the built-in microphone.
+  /// Triggered by `AudioCaptureService.onSilentMicDetected`.
+  @MainActor
+  private func handleSilentMicFallback() {
+    guard isTranscribing, !silentMicFallbackInProgress else { return }
+    silentMicFallbackInProgress = true
+
+    guard let builtInID = AudioCaptureService.findBuiltInMicDeviceID() else {
+      log("Transcription: silent-mic detected but no built-in microphone available — leaving capture as-is")
+      silentMicFallbackInProgress = false
+      return
+    }
+
+    log("Transcription: silent-mic fallback — switching to built-in mic (deviceID=\(builtInID))")
+
+    // Tear down the dead Bluetooth capture and spin a new one pinned to the built-in mic.
+    // Silent healing — no user-facing UI, the recording just keeps working.
+    audioCaptureService?.stopCapture()
+    audioCaptureService = AudioCaptureService(overrideDeviceID: builtInID)
+    recordingInputDeviceName =
+      AudioCaptureService.getCurrentMicrophoneName() ?? "Built-in Microphone"
+
+    Task { @MainActor in
+      await self.startMicrophoneAudioCapture()
+      self.silentMicFallbackInProgress = false
     }
   }
 
@@ -1579,6 +1629,7 @@ class AppState: ObservableObject {
 
     stopAudioCapture()
     clearTranscriptionState()
+    silentMicFallbackInProgress = false
 
     // After WS close, the Python backend processes the conversation automatically.
     // Call force-process to ensure finalization and get the backend conversation ID.

--- a/desktop/Desktop/Sources/Audio/AudioSourceManager.swift
+++ b/desktop/Desktop/Sources/Audio/AudioSourceManager.swift
@@ -231,9 +231,11 @@ final class AudioSourceManager: ObservableObject {
             systemAudioCaptureService = SystemAudioCaptureService()
         }
 
-        // Start the audio mixer
-        audioMixer?.start { [weak self] stereoData in
-            self?.onStereoAudio?(stereoData)
+        // Start the audio mixer (dormant path — AudioSourceManager.startStreaming
+        // is not currently used by any caller, but keep the signature in sync with
+        // the updated AudioMixer API for future reactivation.)
+        audioMixer?.start { [weak self] mixed in
+            self?.onStereoAudio?(mixed)
         }
 
         // Start microphone capture

--- a/desktop/Desktop/Sources/AudioCaptureService.swift
+++ b/desktop/Desktop/Sources/AudioCaptureService.swift
@@ -43,8 +43,34 @@ class AudioCaptureService: @unchecked Sendable {
     private var defaultDeviceListenerBlock: AudioObjectPropertyListenerBlock?
     private var deviceFormatListenerBlock: AudioObjectPropertyListenerBlock?
     private var isCapturing = false
+
+    /// Optional explicit device to open instead of the system default input.
+    /// Used by the silent-mic fallback path to bind directly to the built-in mic.
+    private let overrideDeviceID: AudioDeviceID?
+
+    /// Default initializer — opens the system default input device.
+    init() {
+        self.overrideDeviceID = nil
+    }
+
+    /// Initializer that binds to an explicit CoreAudio device (e.g. built-in mic after
+    /// a silent-mic fallback). Pass `kAudioObjectUnknown` to disable the override.
+    init(overrideDeviceID: AudioDeviceID) {
+        self.overrideDeviceID = (overrideDeviceID == kAudioObjectUnknown) ? nil : overrideDeviceID
+    }
+
     private var onAudioChunk: AudioChunkHandler?
     private var onAudioLevel: AudioLevelHandler?
+
+    /// Called once when the mic has been alive-but-silent for `silentMicWindowThreshold`
+    /// seconds AND the current device transports over Bluetooth. Caller is expected to
+    /// fall back to the built-in mic. Fires at most once per capture session.
+    var onSilentMicDetected: (() -> Void)?
+
+    // Silent-mic watchdog (fires once per session)
+    private var consecutiveSilentWindows: Int = 0
+    private var silentMicDetectedFired: Bool = false
+    private let silentMicWindowThreshold: Int = 2  // windows of ~1s each
 
     /// Target sample rate for DeepGram
     private let targetSampleRate: Double = 16000
@@ -63,6 +89,11 @@ class AudioCaptureService: @unchecked Sendable {
     // Device change handling
     private var isReconfiguring = false
     private let listenerQueue = DispatchQueue(label: "com.omi.audiocapture.listener")
+
+    // Silent-mic watchdog state — tracks peak amplitude within a ~1 second window
+    // so we can detect a Bluetooth mic that's alive-but-silent (A2DP profile conflict).
+    private var watchdogWindowPeak: Int16 = 0
+    private var watchdogWindowStart: CFAbsoluteTime = 0
 
     /// Dedicated queue for CoreAudio device operations (start/stop/reconfigure)
     /// to avoid blocking the main thread on AudioDeviceStart/Stop calls.
@@ -136,26 +167,32 @@ class AudioCaptureService: @unchecked Sendable {
 
     /// Performs all blocking CoreAudio HAL setup. Must be called on audioQueue, not the main thread.
     private func startCaptureOnQueue() throws {
-        // 1. Get default input device
+        // 1. Resolve input device: explicit override (fallback path) wins over system default.
         var inputDeviceID: AudioDeviceID = kAudioObjectUnknown
-        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
-        var address = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
 
-        let status = AudioObjectGetPropertyData(
-            AudioObjectID(kAudioObjectSystemObject),
-            &address,
-            0,
-            nil,
-            &size,
-            &inputDeviceID
-        )
+        if let override = overrideDeviceID {
+            inputDeviceID = override
+            log("AudioCapture: Using override device ID \(override)")
+        } else {
+            var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+            var address = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultInputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
 
-        guard status == noErr, inputDeviceID != kAudioObjectUnknown else {
-            throw AudioCaptureError.noInputAvailable
+            let status = AudioObjectGetPropertyData(
+                AudioObjectID(kAudioObjectSystemObject),
+                &address,
+                0,
+                nil,
+                &size,
+                &inputDeviceID
+            )
+
+            guard status == noErr, inputDeviceID != kAudioObjectUnknown else {
+                throw AudioCaptureError.noInputAvailable
+            }
         }
         self.deviceID = inputDeviceID
 
@@ -414,6 +451,39 @@ class AudioCaptureService: @unchecked Sendable {
             return Data(buffer: buffer)
         }
 
+        // Silent-mic watchdog: on Bluetooth-to-Bluetooth A2DP/HFP profile conflicts macOS
+        // accepts the IOProc but delivers only zero samples. Track the peak amplitude within
+        // a rolling ~1s window; if the window is silent AND the device transports over
+        // Bluetooth, fire onSilentMicDetected so the caller can swap to the built-in mic.
+        // Fires at most once per capture session.
+        if !silentMicDetectedFired {
+            for s in pcmData {
+                // Int16.min has magnitude 32768 which is out of Int16 range — clamp.
+                let a = s == Int16.min ? Int16.max : Int16(s.magnitude)
+                if a > watchdogWindowPeak { watchdogWindowPeak = a }
+            }
+            let nowAbs = CFAbsoluteTimeGetCurrent()
+            if watchdogWindowStart == 0 { watchdogWindowStart = nowAbs }
+            if nowAbs - watchdogWindowStart >= 1.0 {
+                // Window closed — classify and reset.
+                // peak ≤ 5 (≈ -76 dBFS) is effectively silent compared to real speech.
+                if watchdogWindowPeak <= 5 {
+                    consecutiveSilentWindows += 1
+                } else {
+                    consecutiveSilentWindows = 0
+                }
+                if consecutiveSilentWindows >= silentMicWindowThreshold,
+                   Self.isBluetoothTransport(deviceID: deviceID) {
+                    silentMicDetectedFired = true
+                    log("AudioCapture: Bluetooth mic returning silence for \(consecutiveSilentWindows)s — falling back to built-in mic")
+                    let handler = onSilentMicDetected
+                    DispatchQueue.main.async { handler?() }
+                }
+                watchdogWindowPeak = 0
+                watchdogWindowStart = nowAbs
+            }
+        }
+
         // Calculate and report audio level (RMS normalized to 0.0 - 1.0)
         // Uses smoothing and decay to match system audio behavior
         if let levelHandler = onAudioLevel, !pcmData.isEmpty {
@@ -453,26 +523,30 @@ class AudioCaptureService: @unchecked Sendable {
     // MARK: - Property Listeners
 
     private func installPropertyListeners() {
-        // Listen for default input device changes
-        var defaultDeviceAddress = AudioObjectPropertyAddress(
-            mSelector: kAudioHardwarePropertyDefaultInputDevice,
-            mScope: kAudioObjectPropertyScopeGlobal,
-            mElement: kAudioObjectPropertyElementMain
-        )
+        // Listen for default input device changes — only when we're tracking the
+        // system default. If we're using an explicit override (silent-mic fallback path)
+        // we deliberately ignore default-device changes so we stay pinned to our target.
+        if overrideDeviceID == nil {
+            var defaultDeviceAddress = AudioObjectPropertyAddress(
+                mSelector: kAudioHardwarePropertyDefaultInputDevice,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
 
-        let deviceBlock: AudioObjectPropertyListenerBlock = { [weak self] numberAddresses, addresses in
-            self?.audioQueue.async {
-                self?.handleConfigurationChange()
+            let deviceBlock: AudioObjectPropertyListenerBlock = { [weak self] numberAddresses, addresses in
+                self?.audioQueue.async {
+                    self?.handleConfigurationChange()
+                }
             }
-        }
-        self.defaultDeviceListenerBlock = deviceBlock
+            self.defaultDeviceListenerBlock = deviceBlock
 
-        AudioObjectAddPropertyListenerBlock(
-            AudioObjectID(kAudioObjectSystemObject),
-            &defaultDeviceAddress,
-            listenerQueue,
-            deviceBlock
-        )
+            AudioObjectAddPropertyListenerBlock(
+                AudioObjectID(kAudioObjectSystemObject),
+                &defaultDeviceAddress,
+                listenerQueue,
+                deviceBlock
+            )
+        }
 
         // Listen for format changes on current device
         var formatAddress = AudioObjectPropertyAddress(
@@ -693,6 +767,100 @@ class AudioCaptureService: @unchecked Sendable {
             logError("AudioCapture: Giving up after \(retryCount + 1) attempts")
             isReconfiguring = false
         }
+    }
+
+    // MARK: - Static helpers for silent-mic fallback
+
+    /// Return true if the given CoreAudio device transports over Bluetooth.
+    /// Used by the silent-mic watchdog to decide whether a dead input stream
+    /// is the known A2DP/HFP profile-conflict case on macOS.
+    static func isBluetoothTransport(deviceID: AudioDeviceID) -> Bool {
+        guard deviceID != kAudioObjectUnknown else { return false }
+        var transport: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyTransportType,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &transport)
+        guard status == noErr else { return false }
+        return transport == kAudioDeviceTransportTypeBluetooth
+            || transport == kAudioDeviceTransportTypeBluetoothLE
+    }
+
+    /// Locate the CoreAudio device ID of the built-in microphone (if present).
+    /// Returns `nil` when no built-in input is available (e.g. desktop Mac without a mic).
+    static func findBuiltInMicDeviceID() -> AudioDeviceID? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDevices,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &size
+        ) == noErr else { return nil }
+
+        let count = Int(size) / MemoryLayout<AudioDeviceID>.size
+        guard count > 0 else { return nil }
+        var deviceIDs = [AudioDeviceID](repeating: kAudioObjectUnknown, count: count)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject),
+            &address,
+            0,
+            nil,
+            &size,
+            &deviceIDs
+        ) == noErr else { return nil }
+
+        for id in deviceIDs where id != kAudioObjectUnknown {
+            guard deviceHasInputChannels(id) else { continue }
+
+            var transport: UInt32 = 0
+            var tsize = UInt32(MemoryLayout<UInt32>.size)
+            var taddr = AudioObjectPropertyAddress(
+                mSelector: kAudioDevicePropertyTransportType,
+                mScope: kAudioObjectPropertyScopeGlobal,
+                mElement: kAudioObjectPropertyElementMain
+            )
+            let status = AudioObjectGetPropertyData(id, &taddr, 0, nil, &tsize, &transport)
+            if status == noErr, transport == kAudioDeviceTransportTypeBuiltIn {
+                return id
+            }
+        }
+        return nil
+    }
+
+    /// Return true if the device has at least one input channel.
+    private static func deviceHasInputChannels(_ deviceID: AudioDeviceID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size) == noErr,
+              size > 0 else { return false }
+
+        let raw = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(size),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { raw.deallocate() }
+        let bufferList = raw.bindMemory(to: AudioBufferList.self, capacity: 1)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, bufferList) == noErr else {
+            return false
+        }
+        let buffers = UnsafeMutableAudioBufferListPointer(bufferList)
+        for buffer in buffers where buffer.mNumberChannels > 0 {
+            return true
+        }
+        return false
     }
 
     deinit {

--- a/desktop/Desktop/Sources/AudioMixer.swift
+++ b/desktop/Desktop/Sources/AudioMixer.swift
@@ -1,19 +1,33 @@
 import Foundation
 
-/// Mixes microphone and system audio into a stereo stream for multichannel transcription
-/// Channel 0 (left) = Microphone (user)
-/// Channel 1 (right) = System audio (others)
+/// Mixes microphone and system audio into a single stream for transcription.
+///
+/// Two output modes:
+///  - `.mono`: mic and system are summed (with clip protection) into a single
+///    16kHz mono Int16 stream. Use when the backend is configured for `channels=1`.
+///  - `.stereo`: mic on left, system on right, interleaved. Use when the backend
+///    accepts multichannel audio with per-channel speaker mapping.
 class AudioMixer {
 
     // MARK: - Types
 
-    /// Callback for receiving stereo audio chunks
-    typealias StereoAudioHandler = (Data) -> Void
+    /// Callback for receiving mixed audio chunks (mono or interleaved stereo)
+    typealias AudioChunkHandler = (Data) -> Void
+
+    enum OutputMode {
+        case mono
+        case stereo
+    }
 
     // MARK: - Properties
 
-    private var onStereoChunk: StereoAudioHandler?
+    private let outputMode: OutputMode
+    private var onMixedChunk: AudioChunkHandler?
     private var isRunning = false
+
+    init(outputMode: OutputMode = .mono) {
+        self.outputMode = outputMode
+    }
 
     // Audio buffers (16kHz mono Int16 PCM)
     private var micBuffer = Data()
@@ -29,15 +43,16 @@ class AudioMixer {
     // MARK: - Public Methods
 
     /// Start the mixer
-    /// - Parameter onStereoChunk: Callback receiving interleaved stereo 16-bit PCM at 16kHz
-    func start(onStereoChunk: @escaping StereoAudioHandler) {
+    /// - Parameter onChunk: Callback receiving mono (summed) or stereo (interleaved)
+    ///   16-bit PCM at 16kHz depending on `outputMode`.
+    func start(onChunk: @escaping AudioChunkHandler) {
         bufferLock.lock()
-        self.onStereoChunk = onStereoChunk
+        self.onMixedChunk = onChunk
         self.isRunning = true
         micBuffer = Data()
         systemBuffer = Data()
         bufferLock.unlock()
-        log("AudioMixer: Started")
+        log("AudioMixer: Started (mode=\(outputMode == .mono ? "mono" : "stereo"))")
     }
 
     /// Stop the mixer and flush remaining audio
@@ -48,7 +63,7 @@ class AudioMixer {
         processBuffers(flush: true)
         micBuffer = Data()
         systemBuffer = Data()
-        onStereoChunk = nil
+        onMixedChunk = nil
         bufferLock.unlock()
         log("AudioMixer: Stopped")
     }
@@ -137,11 +152,45 @@ class AudioMixer {
             systemBuffer = Data()
         }
 
-        // Interleave into stereo
-        let stereoData = interleave(mic: micData, system: sysData)
+        // Produce mixed output in the configured mode
+        let mixed: Data
+        switch outputMode {
+        case .mono:
+            mixed = sumToMono(mic: micData, system: sysData)
+        case .stereo:
+            mixed = interleave(mic: micData, system: sysData)
+        }
 
         // Send to callback
-        onStereoChunk?(stereoData)
+        onMixedChunk?(mixed)
+    }
+
+    /// Sum two mono Int16 streams into a single mono Int16 stream.
+    /// Summed amplitude is clipped to Int16 range to prevent wrap-around overflow.
+    /// This is a straight sum, not an average — speech from both sources stays at
+    /// its natural loudness, and speech-on-speech overlap saturates cleanly instead
+    /// of halving into unintelligibility.
+    private func sumToMono(mic: Data, system: Data) -> Data {
+        let sampleCount = mic.count / 2  // Int16 = 2 bytes
+        var monoSamples = [Int16]()
+        monoSamples.reserveCapacity(sampleCount)
+
+        mic.withUnsafeBytes { micPtr in
+            system.withUnsafeBytes { sysPtr in
+                let micSamples = micPtr.bindMemory(to: Int16.self)
+                let sysSamples = sysPtr.bindMemory(to: Int16.self)
+
+                for i in 0..<sampleCount {
+                    let m = i < micSamples.count ? Int32(micSamples[i]) : 0
+                    let s = i < sysSamples.count ? Int32(sysSamples[i]) : 0
+                    let summed = m + s
+                    let clamped = max(Int32(Int16.min), min(Int32(Int16.max), summed))
+                    monoSamples.append(Int16(clamped))
+                }
+            }
+        }
+
+        return monoSamples.withUnsafeBufferPointer { Data(buffer: $0) }
     }
 
     /// Interleave two mono Int16 streams into stereo

--- a/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/PushToTalkManager.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Cocoa
 import Combine
+import CoreAudio
 
 /// Push-to-talk manager for voice input via the Option (⌥) key.
 ///
@@ -514,11 +515,23 @@ class PushToTalkManager: ObservableObject {
     }
   }
 
-  private func startMicCapture(batchMode: Bool = false) {
+  private func startMicCapture(batchMode: Bool = false, overrideDeviceID: AudioDeviceID? = nil) {
     if audioCaptureService == nil {
-      audioCaptureService = AudioCaptureService()
+      if let override = overrideDeviceID {
+        audioCaptureService = AudioCaptureService(overrideDeviceID: override)
+      } else {
+        audioCaptureService = AudioCaptureService()
+      }
     }
     guard let capture = audioCaptureService else { return }
+
+    // Silent-mic watchdog: Bluetooth input often returns zero samples while another app
+    // holds A2DP output. Fall back to the built-in mic so PTT still captures the user.
+    capture.onSilentMicDetected = { [weak self] in
+      Task { @MainActor in
+        self?.handleSilentMicFallback(batchMode: batchMode)
+      }
+    }
 
     Task { @MainActor [weak self] in
       guard let self else { return }
@@ -544,6 +557,23 @@ class PushToTalkManager: ObservableObject {
         self.stopListening()
       }
     }
+  }
+
+  /// Swap the current capture for one pinned to the built-in mic when the silent-mic
+  /// watchdog detects a dead Bluetooth input (A2DP profile conflict).
+  @MainActor
+  private func handleSilentMicFallback(batchMode: Bool) {
+    guard state == .listening || state == .lockedListening || state == .pendingLockDecision else {
+      return
+    }
+    guard let builtInID = AudioCaptureService.findBuiltInMicDeviceID() else {
+      log("PushToTalkManager: silent-mic detected but no built-in mic to fall back to")
+      return
+    }
+    log("PushToTalkManager: silent-mic fallback — switching to built-in mic (deviceID=\(builtInID))")
+    audioCaptureService?.stopCapture()
+    audioCaptureService = nil
+    startMicCapture(batchMode: batchMode, overrideDeviceID: builtInID)
   }
 
   private func stopAudioTranscription() {


### PR DESCRIPTION
Closes BasedHardware/omi#6645.

When a Bluetooth headset (tested: Sony WH-1000XM6) is the default mic and another app is already playing audio to it over A2DP, macOS accepts Omi's CoreAudio IOProc and fires it at the expected rate but delivers only zero samples — so Conversation Record and Quick Note captured 16 KB/s of silence and the live transcript stayed empty even though the sidebar waveform looked active (because it's `max(mic, system)` and the ScreenCaptureKit system-audio tap was still healthy). This PR adds a ~1s-window silent-mic watchdog in `AudioCaptureService` that, on a Bluetooth-transport input with two consecutive silent windows, fires a one-shot callback; both `AppState.startMicrophoneAudioCapture` (conversation record) and `PushToTalkManager.startMicCapture` (quick note) respond by tearing down the dead capture and restarting against the built-in mic — silent healing, no banner or alert. While in there, the dormant `AudioMixer` is finally started with a new mono output mode so mic + system audio are summed into a single mono stream that's forwarded to the existing `channels=1` `/v4/listen` backend; previously system audio was captured only to drive the level meter and then thrown away, so YouTube/calls/music never showed up in the transcript. No backend or protocol changes.

---
_by AI for @beastoin_