### PR TITLE
fix(desktop): floating bar Copy button copies the clicked message, not the latest

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Fixed floating bar Copy button copying the wrong message when multiple responses are visible"
+  ],
   "releases": [
     {
       "version": "0.11.312",

--- a/desktop/Desktop/Sources/FloatingControlBar/AIResponseView.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/AIResponseView.swift
@@ -201,17 +201,22 @@ struct AIResponseView: View {
 
     // MARK: - Per-Message Hover Action Overlay
 
-    /// Wraps an AI message's content with a hover-triggered action bar
+    /// Wraps an AI message's content with a hover-triggered action bar.
+    /// The `.id(message.id)` is load-bearing: without it SwiftUI can reuse an
+    /// overlay view instance (and its Button action closures) across different
+    /// messages in the same structural slot, which caused clicking Copy on an
+    /// older message to read the current message's text.
     private func messageWithHoverActions(message: ChatMessage) -> some View {
         MessageHoverOverlay(
             message: message,
-            onRate: { rating in
-                onRate?(message.id, rating)
+            onRate: { [id = message.id] rating in
+                onRate?(id, rating)
             }
         )
         {
             contentBlocksView(for: message)
         }
+        .id(message.id)
     }
 
     // MARK: - Chat History
@@ -535,40 +540,47 @@ struct MessageHoverOverlay<Content: View>: View {
     }
 
     private var actionBar: some View {
-        VStack(alignment: .trailing, spacing: 2) {
+        // Capture the message's value-type fields once per body evaluation so every
+        // button action operates on the exact message the user sees — not whatever
+        // `self.message` happens to point to when the click is dispatched.
+        let messageText = message.text
+        let currentRating = message.rating
+        return VStack(alignment: .trailing, spacing: 2) {
             HStack(spacing: 6) {
                 // Thumbs up
-                Button(action: {
-                    let newRating = message.rating == 1 ? nil : 1
+                Button(action: { [currentRating] in
+                    let newRating = currentRating == 1 ? nil : 1
                     guard newRating != lastSubmittedRating else { return }
                     lastSubmittedRating = newRating
                     onRate(newRating)
                     if newRating != nil { showRatingFeedbackBriefly() }
                 }) {
-                    Image(systemName: message.rating == 1 ? "hand.thumbsup.fill" : "hand.thumbsup")
+                    Image(systemName: currentRating == 1 ? "hand.thumbsup.fill" : "hand.thumbsup")
                         .scaledFont(size: 11)
-                        .foregroundColor(message.rating == 1 ? .green : .secondary)
+                        .foregroundColor(currentRating == 1 ? .green : .secondary)
                 }
                 .buttonStyle(.plain)
                 .help("Helpful response")
 
                 // Thumbs down
-                Button(action: {
-                    let newRating = message.rating == -1 ? nil : -1
+                Button(action: { [currentRating] in
+                    let newRating = currentRating == -1 ? nil : -1
                     guard newRating != lastSubmittedRating else { return }
                     lastSubmittedRating = newRating
                     onRate(newRating)
                     if newRating != nil { showRatingFeedbackBriefly() }
                 }) {
-                    Image(systemName: message.rating == -1 ? "hand.thumbsdown.fill" : "hand.thumbsdown")
+                    Image(systemName: currentRating == -1 ? "hand.thumbsdown.fill" : "hand.thumbsdown")
                         .scaledFont(size: 11)
-                        .foregroundColor(message.rating == -1 ? .red : .secondary)
+                        .foregroundColor(currentRating == -1 ? .red : .secondary)
                 }
                 .buttonStyle(.plain)
                 .help("Not helpful")
 
-                // Copy
-                Button(action: { copyMessageText() }) {
+                // Copy — captures `messageText` explicitly so we always copy the
+                // message this button was drawn for, even if SwiftUI reuses the
+                // overlay view across re-renders.
+                Button(action: { [messageText] in copyText(messageText) }) {
                     Image(systemName: showCopied ? "checkmark" : "doc.on.doc")
                         .scaledFont(size: 11)
                         .foregroundColor(showCopied ? .green : .secondary)
@@ -621,10 +633,14 @@ struct MessageHoverOverlay<Content: View>: View {
         }
     }
 
-    private func copyMessageText() {
-        guard !message.text.isEmpty else { return }
+    /// Copy the exact text passed in — *not* `self.message.text`.
+    /// Callers must pass the captured text from the closure's capture list so
+    /// clicking Copy on a historical message writes the correct content to the
+    /// pasteboard even when SwiftUI has reused the overlay view across renders.
+    private func copyText(_ text: String) {
+        guard !text.isEmpty else { return }
         NSPasteboard.general.clearContents()
-        NSPasteboard.general.setString(message.text, forType: .string)
+        NSPasteboard.general.setString(text, forType: .string)
         AnalyticsManager.shared.shareAction(category: "floating_bar_response_copy")
         withAnimation { showCopied = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {


### PR DESCRIPTION
## Summary

Copy button on a historical floating bar AI message no longer writes the latest message's text to the pasteboard. Fix is in \`MessageHoverOverlay\` (\`AIResponseView.swift\`).

## Root cause

Two compounding issues:

1. **Implicit \`self.message\` reads in button closures.** \`copyMessageText()\` read \`self.message.text\`, and the thumbs up/down buttons read \`self.message.rating\`. SwiftUI re-evaluates body and should produce new closures capturing the current struct, but there are known edge cases — particularly when a view at a structural slot gets reused across different messages — where the closure ends up resolving \`self.message\` to a stale or wrong value at click time.
2. **No stable per-message view identity.** \`messageWithHoverActions(message:)\` called \`MessageHoverOverlay\` without an \`.id(message.id)\`, so SwiftUI inferred identity from structural position. In the floating bar's ScrollView the history items come from a \`ForEach(chatHistory)\` (identified by exchange UUID) and the current response lives in a fixed slot — if an overlay drifts between the two contexts during archive-on-follow-up, SwiftUI can reuse the same view instance across different messages with the \`@State\` from the prior render still attached.

Symptom: clicking Copy on an older AI message in the chat history wrote the latest streaming response to the pasteboard.

## Fix

**\`messageWithHoverActions(message:)\`**
\`\`\`swift
MessageHoverOverlay(
    message: message,
    onRate: { [id = message.id] rating in onRate?(id, rating) }
)
{ contentBlocksView(for: message) }
.id(message.id)  // ← stable per-message identity
\`\`\`

**\`MessageHoverOverlay.actionBar\`** — all three buttons now use explicit capture lists:
\`\`\`swift
let messageText = message.text
let currentRating = message.rating
// …
Button(action: { [currentRating] in
    let newRating = currentRating == 1 ? nil : 1
    // …
}) { … }

Button(action: { [messageText] in copyText(messageText) }) { … }
\`\`\`

**\`copyMessageText()\` → \`copyText(_ text: String)\`** — takes the captured text as an explicit parameter so there's no implicit \`self.message\` read at all.

These are **defensive** changes that close the class of bug even if the root cause is subtler than I could pin down from static analysis alone.

## Test plan

- [ ] On Mac mini: run a floating bar query ("what's 2+2"), wait for response, send follow-up ("now multiply by 7"), hover over the first historical response, click Copy → pasteboard contains the first response's text, not the second
- [ ] Repeat for thumbs up/down on a historical message → rating applies to that specific message (verify via Sentry / API / local state)
- [ ] Regression check: Copy on the current response still works
- [ ] Regression check: metadata info popover still shows the correct message's metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)