### PR TITLE
Restore NSHealthUpdateUsageDescription to fix App Store upload

### DIFF
--- a/app/ios/Runner/Info.plist
+++ b/app/ios/Runner/Info.plist
@@ -140,6 +140,8 @@
 	<string>We need access to your reminders to export action items from Omi conversations.</string>
 	<key>NSHealthShareUsageDescription</key>
 	<string>Omi reads your steps, walking and running distance, active energy, heart rate, sleep, and workouts from Apple Health so you can ask about your fitness, sleep, and activity in Omi Chat. Omi never writes to Apple Health.</string>
+	<key>NSHealthUpdateUsageDescription</key>
+	<string>Omi does not write any data to Apple Health. This string is only present because iOS requires it when the HealthKit framework is linked.</string>
 	<key>PermissionGroupNotification</key>
 	<string>You need to enable notifications to receive your pro-active feedback.</string>
 	<key>NSCameraUsageDescription</key>

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.532+815
+version: 1.0.532+816
 
 
 environment:


### PR DESCRIPTION
## Summary
App Store Connect validation was rejecting build 815 with:

> Missing purpose string in Info.plist. The Info.plist file for the "Runner.app" bundle should contain a NSHealthUpdateUsageDescription key.

A linked dependency pulls HealthKit write symbols into the binary, so Apple's static analyzer requires the purpose string even though Omi never calls write APIs. The earlier PR (#6639) removed this key to avoid an (incorrect) 2.5.1 flag — this PR restores it with an explicit, honest string.

- Restored `NSHealthUpdateUsageDescription` with: *"Omi does not write any data to Apple Health. This string is only present because iOS requires it when the HealthKit framework is linked."*
- `NSHealthShareUsageDescription` still enumerates exactly what Omi reads.
- Bumped build number to 816.

## Test plan
- [ ] Archive + upload the app to App Store Connect — validation should pass
- [ ] Smoke test Apple Health connect flow on device (no functional changes expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)