### PR TITLE
fix(desktop): revert Sentry DSN to mediar-n5/omi-computer

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Restored crash reporting and error telemetry (Sentry DSN was pointing at an inaccessible org since 2026-03-22, silently dropping every event)"
+  ],
   "releases": [
     {
       "version": "0.11.314",

--- a/desktop/Desktop/Sources/OmiApp.swift
+++ b/desktop/Desktop/Sources/OmiApp.swift
@@ -280,11 +280,22 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     _ = UpdaterViewModel.shared
     UpdaterViewModel.shared.checkForUpdatesImmediatelyAfterLaunchIfNeeded()
 
-    // Initialize Sentry for crash reporting and error tracking (including dev builds)
+    // Initialize Sentry for crash reporting and error tracking (including dev builds).
+    //
+    // DSN points at the `mediar-n5/omi-computer` project — we control this org,
+    // `desktop/.env` has a valid SENTRY_AUTH_TOKEN for it, and `sentry-monitor.sh`
+    // / the `sentry-release` and `user-logs` skills all query this project.
+    //
+    // Do NOT swap this DSN without also (a) confirming we have admin access to the
+    // new org, (b) enabling the new project's Default key, (c) updating
+    // desktop/.env + SENTRY_ORG / SENTRY_PROJECT, and (d) repointing every script
+    // under desktop/scripts/ that reads those env vars. Commit 377295cbe swapped
+    // this DSN to an org we didn't have access to and every event was silently
+    // dropped for ~3 weeks.
     let isDev = AnalyticsManager.isDevBuild
     SentrySDK.start { options in
       options.dsn =
-        "https://bbffa02d948c81ea4dccd36246c7bd20@o4511085999816704.ingest.us.sentry.io/4511086024851456"
+        "https://8f700584deda57b26041ff015539c8c1@o4507617161314304.ingest.us.sentry.io/4510790686277632"
       options.debug = false
       options.enableAutoSessionTracking = true
       options.environment = isDev ? "development" : "production"


### PR DESCRIPTION
## Summary

Reverts the Sentry DSN in \`OmiApp.swift:287\` from
\`https://bbffa02d...@o4511085999816704/4511086024851456\`
back to
\`https://8f700584...@o4507617161314304/4510790686277632\`
and re-enables the \`mediar-n5/omi-computer\` project's \"Default\" key (which was left \`isActive: false\` server-side).

## Why

Commit \`377295cbe\` (2026-03-22, *\"Update Sentry DSN to new Omi organization\"*) swapped the desktop DSN to a different Sentry org that we don't have admin access to. The new destination has been returning \`HTTP 429: \"Sentry dropped data due to a quota or internal rate limit being reached\"\` continuously since the first build with that DSN rolled out via Sparkle on 2026-03-31.

**Consequence: every single desktop Sentry event has been silently dropped at ingest for ~3 weeks.** Not just errors — *everything*: crashes, hangs, user feedback submissions, release session tracking, transaction data. I verified this earlier today when investigating why gargaarav79's recent Report Issue submission wasn't reachable in our Sentry UI:

- \`omi-computer\` project accepted-event stats, last 14 days, grouped by day:
  - error: \`[47536, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\`
  - default: \`[188, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]\`
  - attachment: \`[0] × 14\`
- PostHog \`Feedback Submitted\` events, same window: **55 events across 35 users** — every one of which should have landed in Sentry as a \`User Report: ...\` message event with an attached \`omi.log\`. None did.
- Last \`User Report\` issue in \`mediar-n5/omi-computer\`: **2026-03-16** (nearly a month ago).
- Test POST to the hardcoded DSN (\`bbffa02d...\`) via the envelope endpoint: \`HTTP 429 {\"detail\":\"Sentry dropped data due to a quota or internal rate limit being reached\"}\`.

## What this PR does

- **OmiApp.swift**: revert the hardcoded DSN string to the original \`mediar-n5/omi-computer\` DSN. Added a prominent block comment above \`options.dsn\` explaining exactly which steps have to happen *together* if someone wants to move to a new Sentry org in the future — admin access confirmation, key re-enable, \`desktop/.env\` update, and every script under \`desktop/scripts/\` repointed to the new org. Swapping only the DSN (which is what happened in \`377295cbe\`) is the specific mistake this comment is meant to prevent from recurring.
- **CHANGELOG.json**: one-line unreleased entry.

## Server-side change (already applied, not in this PR)

I re-enabled the \`mediar-n5/omi-computer\` project's Default key via the Sentry REST API (\`PUT /api/0/projects/mediar-n5/omi-computer/keys/8f700584.../\` with \`{\"isActive\": true}\`). Without this the DSN revert would still be rejected because the key was manually disabled at the time of the swap. API response confirmed:
\`\`\`json
{\"isActive\": true, \"public\": \"https://8f700584...@o4507617161314304.ingest.us.sentry.io/4510790686277632\"}
\`\`\`

## What happens after merge

1. Auto-release cuts a new \`v*-macos\` tag within a few hours.
2. Codemagic builds that tag with the reverted DSN.
3. Sparkle delivers it to Omi Beta users.
4. On launch, each user's Sentry SDK points at the re-enabled \`mediar-n5/omi-computer\` ingest endpoint.
5. Events start flowing again within minutes.
6. The \`sentry-monitor.sh\` script, the \`sentry-release\` skill, and the \`user-logs\` skill all start returning real data again.
7. Per-release crash rate becomes available for the new Releases page (once that ships).

## Test plan

- [ ] Merge + wait for Codemagic to publish a new release
- [ ] Update Omi Beta on one machine
- [ ] Trigger a test event: open Report Issue from the menu bar, submit with message *\"dsn-revert-verify\"*
- [ ] Query \`/api/0/projects/mediar-n5/omi-computer/events/?query=message:dsn-revert-verify\` within 5 minutes — event should appear with \`omi.log\` attached
- [ ] Confirm \`omi-computer\` project stats for today show non-zero \`accepted\` in the \`error\`, \`default\`, and \`attachment\` categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)