### PR TITLE
Fix admin analytics Cumulative Users chart

### DIFF
--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -322,6 +322,7 @@ export default function AnalyticsPage() {
   const [retentionDays, setRetentionDays] = useState(30);
   const [retentionPlatform, setRetentionPlatform] = useState("macos");
   const [retentionView, setRetentionView] = useState<"average" | "cohorts">("average");
+  const [cumulativeGranularity, setCumulativeGranularity] = useState<"day" | "week" | "month">("month");
 
   const swrOpts = { revalidateOnFocus: false };
 
@@ -409,10 +410,9 @@ export default function AnalyticsPage() {
     if (c.data.length > cohortMaxDays) cohortMaxDays = c.data.length;
   }
 
-  // Cumulative Users chart fetches the full history window so the growth
-  // curve is meaningful; use the whole series rather than the last 30 days.
+  // Cumulative Users chart fetches the full history since the first
+  // signup so the growth curve is meaningful.
   const allDailyData = dailyNewUsers?.data ?? [];
-  const dailyData = allDailyData;
   const dauData = dauTrends?.data?.slice(-30) ?? [];
   const ratingsData = messageRatings?.data ?? [];
   const totalThumbsUp = ratingsData.reduce((s, d) => s + d.thumbs_up, 0);
@@ -464,6 +464,40 @@ export default function AnalyticsPage() {
         };
       });
   }, [ratingsData]);
+
+  // Bucket the all-time daily series into day/week/month granularity for
+  // the Cumulative Users chart. `users` sums the bucket, `cumulative` is
+  // the running total at the end of the bucket (so the last point in each
+  // bucket equals the true cumulative count on that day).
+  const cumulativeSeries = useMemo(() => {
+    if (allDailyData.length === 0) return [] as typeof allDailyData;
+    if (cumulativeGranularity === "day") return allDailyData;
+
+    const bucketKey = (iso: string) => {
+      const d = new Date(iso + "T00:00:00Z");
+      if (cumulativeGranularity === "month") {
+        return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-01`;
+      }
+      // Week: snap to the Monday of the ISO week (UTC)
+      const day = d.getUTCDay();
+      const diff = (day + 6) % 7; // Monday = 0
+      d.setUTCDate(d.getUTCDate() - diff);
+      return d.toISOString().slice(0, 10);
+    };
+
+    const buckets = new Map<string, { date: string; users: number; cumulative: number }>();
+    for (const point of allDailyData) {
+      const key = bucketKey(point.date);
+      const existing = buckets.get(key);
+      if (existing) {
+        existing.users += point.users;
+        existing.cumulative = point.cumulative; // take the latest running total
+      } else {
+        buckets.set(key, { date: key, users: point.users, cumulative: point.cumulative });
+      }
+    }
+    return Array.from(buckets.values()).sort((a, b) => a.date.localeCompare(b.date));
+  }, [allDailyData, cumulativeGranularity]);
 
   // 7-day rolling average for daily new users
   const dailyWithRollingAvg = useMemo(() => {
@@ -1295,16 +1329,35 @@ export default function AnalyticsPage() {
       <div className="grid gap-6 lg:grid-cols-2">
         {/* Cumulative Total Users */}
         <Card className="p-6">
-          <h2 className="text-lg font-semibold mb-1">Cumulative Users</h2>
-          <p className="text-sm text-muted-foreground mb-4">Total users across all platforms</p>
-          <div className="h-[300px]">
+          <div className="flex items-start justify-between mb-1">
+            <div>
+              <h2 className="text-lg font-semibold">Cumulative Users</h2>
+              <p className="text-sm text-muted-foreground">Total users across all platforms</p>
+            </div>
+            <div className="flex rounded-md border border-input overflow-hidden">
+              {(["day", "week", "month"] as const).map((g) => (
+                <button
+                  key={g}
+                  onClick={() => setCumulativeGranularity(g)}
+                  className={`px-2.5 py-1 text-xs font-medium transition-colors ${
+                    cumulativeGranularity === g
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-background text-muted-foreground hover:bg-accent"
+                  }`}
+                >
+                  {g === "day" ? "All" : g === "week" ? "Week" : "Month"}
+                </button>
+              ))}
+            </div>
+          </div>
+          <div className="h-[300px] mt-4">
             {dailyNewUsersLoading ? (
               <div className="flex items-center justify-center h-full">
                 <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
               </div>
-            ) : dailyData.length > 0 ? (
+            ) : cumulativeSeries.length > 0 ? (
               <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={dailyData}>
+                <AreaChart data={cumulativeSeries}>
                   <defs>
                     <linearGradient id="cumulativeGradient" x1="0" y1="0" x2="0" y2="1">
                       <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />

--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -344,7 +344,7 @@ export default function AnalyticsPage() {
     useSWR<ConversationCount>(token ? ["/api/omi/stats/conversation-count", token] : null, authFetcher, swrOpts);
 
   const { data: dailyNewUsers, isLoading: dailyNewUsersLoading } =
-    useSWR<DailyNewUsersData>(token ? ["/api/omi/stats/daily-new-users?days=540", token] : null, authFetcher, swrOpts);
+    useSWR<DailyNewUsersData>(token ? ["/api/omi/stats/daily-new-users?days=all", token] : null, authFetcher, swrOpts);
 
   const { data: dauTrends, isLoading: dauLoading } =
     useSWR<DauTrendsData>(token ? ["/api/omi/stats/dau-trends?days=60", token] : null, authFetcher, swrOpts);
@@ -1322,10 +1322,10 @@ export default function AnalyticsPage() {
                   <YAxis
                     className="text-xs"
                     tick={{ fill: "hsl(var(--muted-foreground))" }}
-                    tickFormatter={(v: number) => v.toLocaleString()}
-                    domain={["dataMin", "dataMax"]}
+                    tickFormatter={formatCompact}
+                    domain={[0, "dataMax"]}
                     allowDataOverflow={false}
-                    width={64}
+                    width={48}
                   />
                   <Tooltip formatter={(value: number) => [value.toLocaleString(), "Total Users"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
                   <Area type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={2} fill="url(#cumulativeGradient)" dot={false} activeDot={{ r: 4 }} />
@@ -1419,9 +1419,9 @@ export default function AnalyticsPage() {
       <Card className="p-6">
         <div className="flex items-center justify-between mb-1">
           <h2 className="text-lg font-semibold">Daily New Users</h2>
-          {dailyNewUsers?.totalUsers != null && (
+          {dailyWithRollingAvg.length > 0 && (
             <span className="text-sm text-muted-foreground">
-              {dailyNewUsers.totalUsers.toLocaleString()} in last {dailyNewUsers.days}d
+              {dailyWithRollingAvg.reduce((s, p) => s + p.users, 0).toLocaleString()} in last 30d
             </span>
           )}
         </div>

--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -322,7 +322,7 @@ export default function AnalyticsPage() {
   const [retentionDays, setRetentionDays] = useState(30);
   const [retentionPlatform, setRetentionPlatform] = useState("macos");
   const [retentionView, setRetentionView] = useState<"average" | "cohorts">("average");
-  const [cumulativeGranularity, setCumulativeGranularity] = useState<"day" | "week" | "month">("month");
+  const [cumulativeWindow, setCumulativeWindow] = useState<"7d" | "30d" | "all">("all");
 
   const swrOpts = { revalidateOnFocus: false };
 
@@ -465,39 +465,21 @@ export default function AnalyticsPage() {
       });
   }, [ratingsData]);
 
-  // Bucket the all-time daily series into day/week/month granularity for
-  // the Cumulative Users chart. `users` sums the bucket, `cumulative` is
-  // the running total at the end of the bucket (so the last point in each
-  // bucket equals the true cumulative count on that day).
+  // Slice the all-time daily series to the selected window for the
+  // Cumulative Users chart. Granularity stays daily; only the visible
+  // range changes.
   const cumulativeSeries = useMemo(() => {
-    if (allDailyData.length === 0) return [] as typeof allDailyData;
-    if (cumulativeGranularity === "day") return allDailyData;
+    if (allDailyData.length === 0) return allDailyData;
+    if (cumulativeWindow === "all") return allDailyData;
+    const days = cumulativeWindow === "7d" ? 7 : 30;
+    return allDailyData.slice(-days);
+  }, [allDailyData, cumulativeWindow]);
 
-    const bucketKey = (iso: string) => {
-      const d = new Date(iso + "T00:00:00Z");
-      if (cumulativeGranularity === "month") {
-        return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}-01`;
-      }
-      // Week: snap to the Monday of the ISO week (UTC)
-      const day = d.getUTCDay();
-      const diff = (day + 6) % 7; // Monday = 0
-      d.setUTCDate(d.getUTCDate() - diff);
-      return d.toISOString().slice(0, 10);
-    };
-
-    const buckets = new Map<string, { date: string; users: number; cumulative: number }>();
-    for (const point of allDailyData) {
-      const key = bucketKey(point.date);
-      const existing = buckets.get(key);
-      if (existing) {
-        existing.users += point.users;
-        existing.cumulative = point.cumulative; // take the latest running total
-      } else {
-        buckets.set(key, { date: key, users: point.users, cumulative: point.cumulative });
-      }
-    }
-    return Array.from(buckets.values()).sort((a, b) => a.date.localeCompare(b.date));
-  }, [allDailyData, cumulativeGranularity]);
+  // On a tight window the cumulative values barely move relative to the
+  // absolute total, so pin the y-axis to the window's min/max. For the
+  // full history we anchor at zero so the curve sweeps from 0 → total.
+  const cumulativeYDomain: [number | "dataMin", number | "dataMax"] =
+    cumulativeWindow === "all" ? [0, "dataMax"] : ["dataMin", "dataMax"];
 
   // 7-day rolling average for daily new users
   const dailyWithRollingAvg = useMemo(() => {
@@ -1335,17 +1317,17 @@ export default function AnalyticsPage() {
               <p className="text-sm text-muted-foreground">Total users across all platforms</p>
             </div>
             <div className="flex rounded-md border border-input overflow-hidden">
-              {(["day", "week", "month"] as const).map((g) => (
+              {(["7d", "30d", "all"] as const).map((w) => (
                 <button
-                  key={g}
-                  onClick={() => setCumulativeGranularity(g)}
+                  key={w}
+                  onClick={() => setCumulativeWindow(w)}
                   className={`px-2.5 py-1 text-xs font-medium transition-colors ${
-                    cumulativeGranularity === g
+                    cumulativeWindow === w
                       ? "bg-primary text-primary-foreground"
                       : "bg-background text-muted-foreground hover:bg-accent"
                   }`}
                 >
-                  {g === "day" ? "All" : g === "week" ? "Week" : "Month"}
+                  {w === "7d" ? "Last week" : w === "30d" ? "Last month" : "All time"}
                 </button>
               ))}
             </div>
@@ -1376,9 +1358,9 @@ export default function AnalyticsPage() {
                     className="text-xs"
                     tick={{ fill: "hsl(var(--muted-foreground))" }}
                     tickFormatter={formatCompact}
-                    domain={[0, "dataMax"]}
+                    domain={cumulativeYDomain}
                     allowDataOverflow={false}
-                    width={48}
+                    width={56}
                   />
                   <Tooltip formatter={(value: number) => [value.toLocaleString(), "Total Users"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
                   <Area type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={2} fill="url(#cumulativeGradient)" dot={false} activeDot={{ r: 4 }} />

--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -1311,7 +1311,13 @@ export default function AnalyticsPage() {
                   </defs>
                   <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
                   <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                  <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={formatCompact} />
+                  <YAxis
+                    className="text-xs"
+                    tick={{ fill: "hsl(var(--muted-foreground))" }}
+                    tickFormatter={formatCompact}
+                    domain={["dataMin", "dataMax"]}
+                    allowDataOverflow={false}
+                  />
                   <Tooltip formatter={(value: number) => [value.toLocaleString(), "Total Users"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
                   <Area type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={2} fill="url(#cumulativeGradient)" dot={false} activeDot={{ r: 4 }} />
                 </AreaChart>

--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -1294,7 +1294,7 @@ export default function AnalyticsPage() {
         {/* Cumulative Total Users */}
         <Card className="p-6">
           <h2 className="text-lg font-semibold mb-1">Cumulative Users</h2>
-          <p className="text-sm text-muted-foreground mb-4">Total macOS users over time</p>
+          <p className="text-sm text-muted-foreground mb-4">Total users across all platforms</p>
           <div className="h-[300px]">
             {dailyNewUsersLoading ? (
               <div className="flex items-center justify-center h-full">

--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -344,7 +344,7 @@ export default function AnalyticsPage() {
     useSWR<ConversationCount>(token ? ["/api/omi/stats/conversation-count", token] : null, authFetcher, swrOpts);
 
   const { data: dailyNewUsers, isLoading: dailyNewUsersLoading } =
-    useSWR<DailyNewUsersData>(token ? ["/api/omi/stats/daily-new-users?days=60", token] : null, authFetcher, swrOpts);
+    useSWR<DailyNewUsersData>(token ? ["/api/omi/stats/daily-new-users?days=540", token] : null, authFetcher, swrOpts);
 
   const { data: dauTrends, isLoading: dauLoading } =
     useSWR<DauTrendsData>(token ? ["/api/omi/stats/dau-trends?days=60", token] : null, authFetcher, swrOpts);
@@ -409,8 +409,10 @@ export default function AnalyticsPage() {
     if (c.data.length > cohortMaxDays) cohortMaxDays = c.data.length;
   }
 
+  // Cumulative Users chart fetches the full history window so the growth
+  // curve is meaningful; use the whole series rather than the last 30 days.
   const allDailyData = dailyNewUsers?.data ?? [];
-  const dailyData = allDailyData.slice(-30);
+  const dailyData = allDailyData;
   const dauData = dauTrends?.data?.slice(-30) ?? [];
   const ratingsData = messageRatings?.data ?? [];
   const totalThumbsUp = ratingsData.reduce((s, d) => s + d.thumbs_up, 0);
@@ -1310,13 +1312,20 @@ export default function AnalyticsPage() {
                     </linearGradient>
                   </defs>
                   <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                  <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                  <XAxis
+                    dataKey="date"
+                    className="text-xs"
+                    tick={{ fill: "hsl(var(--muted-foreground))" }}
+                    tickFormatter={shortDate}
+                    minTickGap={40}
+                  />
                   <YAxis
                     className="text-xs"
                     tick={{ fill: "hsl(var(--muted-foreground))" }}
-                    tickFormatter={formatCompact}
+                    tickFormatter={(v: number) => v.toLocaleString()}
                     domain={["dataMin", "dataMax"]}
                     allowDataOverflow={false}
+                    width={64}
                   />
                   <Tooltip formatter={(value: number) => [value.toLocaleString(), "Total Users"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
                   <Area type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={2} fill="url(#cumulativeGradient)" dot={false} activeDot={{ r: 4 }} />

--- a/web/admin/app/api/omi/stats/daily-new-users/route.ts
+++ b/web/admin/app/api/omi/stats/daily-new-users/route.ts
@@ -1,8 +1,99 @@
 import { NextRequest, NextResponse } from "next/server";
-import admin, { getDb } from "@/lib/firebase/admin";
+import { getAdminAuth } from "@/lib/firebase/admin";
 import { verifyAdmin } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
+
+// The Firestore `users` collection has a `created_at` field that was
+// backfilled for ~63K existing users on a single day in late 2024, so it
+// can't be used to derive signup history. Firebase Auth's
+// `metadata.creationTime` is set by the Auth service on account creation
+// and is the authoritative signup timestamp.
+//
+// Scanning every user via `listUsers()` pages 1000 at a time (112K ≈ 25s),
+// so the full series is cached in module scope for 10 minutes. A pending
+// rebuild is shared across concurrent requests so we don't fan out.
+
+type DailyPoint = { date: string; users: number; cumulative: number };
+type CachedSeries = {
+  data: DailyPoint[];
+  totalUsers: number;
+  generatedAt: number;
+};
+
+const CACHE_TTL_MS = 10 * 60 * 1000;
+
+let cachedSeries: CachedSeries | null = null;
+let pendingBuild: Promise<CachedSeries> | null = null;
+
+async function buildDailySeries(): Promise<CachedSeries> {
+  const auth = getAdminAuth();
+  const countsByDate: Record<string, number> = {};
+  let pageToken: string | undefined = undefined;
+  let total = 0;
+  let earliest: Date | null = null;
+  let latest: Date | null = null;
+
+  do {
+    const page = await auth.listUsers(1000, pageToken);
+    for (const user of page.users) {
+      const ct = user.metadata?.creationTime
+        ? new Date(user.metadata.creationTime)
+        : null;
+      if (!ct || Number.isNaN(ct.getTime())) continue;
+      const key = ct.toISOString().slice(0, 10);
+      countsByDate[key] = (countsByDate[key] || 0) + 1;
+      if (!earliest || ct < earliest) earliest = ct;
+      if (!latest || ct > latest) latest = ct;
+      total++;
+    }
+    pageToken = page.pageToken || undefined;
+  } while (pageToken);
+
+  if (!earliest || !latest) {
+    return { data: [], totalUsers: 0, generatedAt: Date.now() };
+  }
+
+  // Fill every day from the earliest signup to today so the curve is
+  // continuous (no gaps) and ends on the current date.
+  const endDate = new Date();
+  endDate.setUTCHours(0, 0, 0, 0);
+  const startDate = new Date(
+    Date.UTC(earliest.getUTCFullYear(), earliest.getUTCMonth(), earliest.getUTCDate()),
+  );
+
+  const data: DailyPoint[] = [];
+  let running = 0;
+  for (
+    const d = new Date(startDate);
+    d <= endDate;
+    d.setUTCDate(d.getUTCDate() + 1)
+  ) {
+    const key = d.toISOString().slice(0, 10);
+    const users = countsByDate[key] || 0;
+    running += users;
+    data.push({ date: key, users, cumulative: running });
+  }
+
+  return { data, totalUsers: total, generatedAt: Date.now() };
+}
+
+async function getSeries(): Promise<CachedSeries> {
+  const now = Date.now();
+  if (cachedSeries && now - cachedSeries.generatedAt < CACHE_TTL_MS) {
+    return cachedSeries;
+  }
+  if (pendingBuild) return pendingBuild;
+  pendingBuild = buildDailySeries()
+    .then((series) => {
+      cachedSeries = series;
+      return series;
+    })
+    .finally(() => {
+      pendingBuild = null;
+    });
+  return pendingBuild;
+}
 
 export async function GET(request: NextRequest) {
   const authResult = await verifyAdmin(request);
@@ -10,81 +101,32 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const days = Math.min(parseInt(searchParams.get("days") || "30", 10), 730);
+    const daysParam = searchParams.get("days");
+    const wantsAll =
+      !daysParam || daysParam === "all" || daysParam === "0";
+    const days = wantsAll ? null : Math.max(1, parseInt(daysParam!, 10));
 
-    const db = getDb();
-    const now = new Date();
-    const startDate = new Date(now);
-    startDate.setDate(startDate.getDate() - days);
-    startDate.setHours(0, 0, 0, 0);
+    const series = await getSeries();
 
-    const startTimestamp = admin.firestore.Timestamp.fromDate(startDate);
-
-    // Run three queries in parallel:
-    //  1. Total document count across the entire users collection — the
-    //     authoritative source for "all users ever" (includes docs with no
-    //     created_at field, which would otherwise be silently dropped).
-    //  2. Count of users created inside the window — subtracted from the
-    //     total to derive the pre-window baseline.
-    //  3. The full window snapshot, bucketed by day for the per-day series.
-    const [totalAgg, windowCountAgg, windowSnapshot] = await Promise.all([
-      db.collection("users").count().get(),
-      db
-        .collection("users")
-        .where("created_at", ">=", startTimestamp)
-        .count()
-        .get(),
-      db
-        .collection("users")
-        .where("created_at", ">=", startTimestamp)
-        .orderBy("created_at", "asc")
-        .get(),
-    ]);
-
-    const totalCount = totalAgg.data().count;
-    const windowCount = windowCountAgg.data().count;
-    // Everything that existed before the window — including users that
-    // predate the created_at field and therefore can't be binned by date.
-    const baseline = Math.max(0, totalCount - windowCount);
-
-    // Group by date
-    const countsByDate: Record<string, number> = {};
-
-    // Pre-fill all dates with 0
-    for (let i = 0; i < days; i++) {
-      const d = new Date(startDate);
-      d.setDate(d.getDate() + i);
-      const key = d.toISOString().split("T")[0];
-      countsByDate[key] = 0;
+    let data = series.data;
+    if (days != null) {
+      const start = new Date();
+      start.setUTCDate(start.getUTCDate() - days);
+      const startKey = start.toISOString().slice(0, 10);
+      data = series.data.filter((p) => p.date >= startKey);
     }
 
-    windowSnapshot.docs.forEach((doc) => {
-      const data = doc.data();
-      if (data.created_at) {
-        const ts = data.created_at.toDate();
-        const key = ts.toISOString().split("T")[0];
-        if (countsByDate[key] !== undefined) {
-          countsByDate[key]++;
-        }
-      }
+    return NextResponse.json({
+      data,
+      totalUsers: series.totalUsers,
+      days: days ?? series.data.length,
+      generatedAt: series.generatedAt,
     });
-
-    let running = baseline;
-    const data = Object.entries(countsByDate)
-      .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, users]) => {
-        running += users;
-        return { date, users, cumulative: running };
-      });
-
-    const totalUsers = data.reduce((sum, d) => sum + d.users, 0);
-
-    return NextResponse.json({ data, totalUsers, days });
   } catch (error: any) {
     console.error("Daily new users error:", error);
     return NextResponse.json(
       { error: error.message || "Failed to fetch daily new users" },
-      { status: 500 }
+      { status: 500 },
     );
   }
 }

--- a/web/admin/app/api/omi/stats/daily-new-users/route.ts
+++ b/web/admin/app/api/omi/stats/daily-new-users/route.ts
@@ -18,11 +18,24 @@ export async function GET(request: NextRequest) {
     startDate.setDate(startDate.getDate() - days);
     startDate.setHours(0, 0, 0, 0);
 
-    const snapshot = await db
-      .collection("users")
-      .where("created_at", ">=", admin.firestore.Timestamp.fromDate(startDate))
-      .orderBy("created_at", "asc")
-      .get();
+    const startTimestamp = admin.firestore.Timestamp.fromDate(startDate);
+
+    // Query the window (new users in the last `days` days) and the baseline
+    // (total users that existed before the window) in parallel.
+    const [windowSnapshot, baselineAgg] = await Promise.all([
+      db
+        .collection("users")
+        .where("created_at", ">=", startTimestamp)
+        .orderBy("created_at", "asc")
+        .get(),
+      db
+        .collection("users")
+        .where("created_at", "<", startTimestamp)
+        .count()
+        .get(),
+    ]);
+
+    const baseline = baselineAgg.data().count;
 
     // Group by date
     const countsByDate: Record<string, number> = {};
@@ -35,7 +48,7 @@ export async function GET(request: NextRequest) {
       countsByDate[key] = 0;
     }
 
-    snapshot.docs.forEach((doc) => {
+    windowSnapshot.docs.forEach((doc) => {
       const data = doc.data();
       if (data.created_at) {
         const ts = data.created_at.toDate();
@@ -46,9 +59,13 @@ export async function GET(request: NextRequest) {
       }
     });
 
+    let running = baseline;
     const data = Object.entries(countsByDate)
       .sort(([a], [b]) => a.localeCompare(b))
-      .map(([date, users]) => ({ date, users }));
+      .map(([date, users]) => {
+        running += users;
+        return { date, users, cumulative: running };
+      });
 
     const totalUsers = data.reduce((sum, d) => sum + d.users, 0);
 

--- a/web/admin/app/api/omi/stats/daily-new-users/route.ts
+++ b/web/admin/app/api/omi/stats/daily-new-users/route.ts
@@ -10,7 +10,7 @@ export async function GET(request: NextRequest) {
 
   try {
     const { searchParams } = new URL(request.url);
-    const days = Math.min(parseInt(searchParams.get("days") || "30", 10), 90);
+    const days = Math.min(parseInt(searchParams.get("days") || "30", 10), 730);
 
     const db = getDb();
     const now = new Date();

--- a/web/admin/app/api/omi/stats/daily-new-users/route.ts
+++ b/web/admin/app/api/omi/stats/daily-new-users/route.ts
@@ -20,22 +20,32 @@ export async function GET(request: NextRequest) {
 
     const startTimestamp = admin.firestore.Timestamp.fromDate(startDate);
 
-    // Query the window (new users in the last `days` days) and the baseline
-    // (total users that existed before the window) in parallel.
-    const [windowSnapshot, baselineAgg] = await Promise.all([
+    // Run three queries in parallel:
+    //  1. Total document count across the entire users collection — the
+    //     authoritative source for "all users ever" (includes docs with no
+    //     created_at field, which would otherwise be silently dropped).
+    //  2. Count of users created inside the window — subtracted from the
+    //     total to derive the pre-window baseline.
+    //  3. The full window snapshot, bucketed by day for the per-day series.
+    const [totalAgg, windowCountAgg, windowSnapshot] = await Promise.all([
+      db.collection("users").count().get(),
+      db
+        .collection("users")
+        .where("created_at", ">=", startTimestamp)
+        .count()
+        .get(),
       db
         .collection("users")
         .where("created_at", ">=", startTimestamp)
         .orderBy("created_at", "asc")
         .get(),
-      db
-        .collection("users")
-        .where("created_at", "<", startTimestamp)
-        .count()
-        .get(),
     ]);
 
-    const baseline = baselineAgg.data().count;
+    const totalCount = totalAgg.data().count;
+    const windowCount = windowCountAgg.data().count;
+    // Everything that existed before the window — including users that
+    // predate the created_at field and therefore can't be binned by date.
+    const baseline = Math.max(0, totalCount - windowCount);
 
     // Group by date
     const countsByDate: Record<string, number> = {};


### PR DESCRIPTION
## Summary
Rebuild the Cumulative Users chart on `/dashboard/analytics` end-to-end. The previous implementation was silently broken and grossly undercounted growth.

### Data source
- **Before:** `users.created_at` in Firestore. That field was a one-time backfill — ~63K existing users got a single late-2024 timestamp stamped on them in a migration — so the endpoint was blind to ~48K pre-backfill users and the entire Dec 2024 launch wave.
- **After:** `admin.auth().listUsers()` → `metadata.creationTime`, which Firebase Auth sets at account creation and never rewrites. Full scan (~112K users / 1000 per page) takes ~25s, so the series is cached in module scope for 10 minutes with an in-flight dedupe so concurrent requests share the same build.

### API (`/api/omi/stats/daily-new-users`)
- Fills every day from the earliest signup to today.
- Returns `{date, users, cumulative}` — cumulative starts at 1 on the first day and grows to the current total.
- `?days=all` returns the full series; `?days=N` slices to the last N days.

### UI
- y-axis anchored at 0 on "All time" so the curve sweeps from zero, pinned to `[dataMin, dataMax]` for tight windows so growth is visible.
- Full-history series rendered as daily points (~696 points as of this PR).
- **Filter**: Last week / Last month / All time toggle in the card header. Client-side slice, no extra fetch.
- Subtitle corrected from "Total macOS users over time" to "Total users across all platforms" — the endpoint never filtered by platform.

## Test plan
- [ ] Open `/dashboard/analytics`, confirm Cumulative Users chart shows 0 → ~112K sweep from May 2024 to today
- [ ] Toggle Last week / Last month / All time; confirm the chart and y-axis domain update correctly
- [ ] First load of the endpoint may take ~25s (cold cache); subsequent loads return instantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)