### PR TITLE
Update CHANGELOG.json for v0.11.316 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Restored crash reporting and error telemetry (Sentry DSN was pointing at an inaccessible org since 2026-03-22, silently dropping every event)"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.316",
+      "date": "2026-04-15",
+      "changes": [
+        "Restored crash reporting and error telemetry (Sentry DSN was pointing at an inaccessible org since 2026-03-22, silently dropping every event)"
+      ]
+    },
     {
       "version": "0.11.314",
       "date": "2026-04-15",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.316 and clears the unreleased array.