### PR TITLE
Filler words stripped off in Deepgram multi-language bug fix

### DIFF
--- a/backend/tests/unit/test_streaming_deepgram_backoff.py
+++ b/backend/tests/unit/test_streaming_deepgram_backoff.py
@@ -8,6 +8,7 @@ Verifies:
 
 import asyncio
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, AsyncMock
 
 import pytest
@@ -39,7 +40,7 @@ if 'deepgram' in _mock_modules:
     sys.modules['deepgram'].LiveTranscriptionEvents = MagicMock()
     sys.modules['deepgram.clients.live.v1'].LiveOptions = MagicMock
 
-from utils.stt.streaming import connect_to_deepgram_with_backoff, process_audio_dg  # noqa: E402
+from utils.stt.streaming import connect_to_deepgram, connect_to_deepgram_with_backoff, process_audio_dg  # noqa: E402
 from utils.stt.streaming import deepgram_options, deepgram_cloud_options  # noqa: E402
 from utils.stt.streaming import get_stt_service_for_language, STTService  # noqa: E402
 
@@ -360,6 +361,54 @@ def test_deepgram_options_no_keepalive():
         # DeepgramClientOptions stores options dict — keepalive key must be absent
         if hasattr(opts, 'options') and isinstance(opts.options, dict):
             assert 'keepalive' not in opts.options, f'{name} must not contain "keepalive" key'
+
+
+def test_connect_to_deepgram_preserves_filler_words_in_multi_language():
+    """Multi-language STT must preserve tokens like Portuguese 'um' (#6575)."""
+    mock_dg_conn = MagicMock()
+    mock_dg_conn.start.return_value = True
+    mock_deepgram = MagicMock()
+    mock_deepgram.listen.websocket.v.return_value = mock_dg_conn
+
+    with patch('utils.stt.streaming.deepgram', mock_deepgram), patch(
+        'utils.stt.streaming.LiveOptions', side_effect=lambda **kwargs: SimpleNamespace(**kwargs)
+    ):
+        result = connect_to_deepgram(
+            on_message=MagicMock(),
+            on_error=MagicMock(),
+            language='multi',
+            sample_rate=16000,
+            channels=1,
+            model='nova-3',
+        )
+
+    assert result is mock_dg_conn
+    options = mock_dg_conn.start.call_args.args[0]
+    assert options.filler_words is True
+
+
+def test_connect_to_deepgram_keeps_filler_stripping_for_english_only():
+    """English-only STT keeps the existing filler-stripping behavior (#6575)."""
+    mock_dg_conn = MagicMock()
+    mock_dg_conn.start.return_value = True
+    mock_deepgram = MagicMock()
+    mock_deepgram.listen.websocket.v.return_value = mock_dg_conn
+
+    with patch('utils.stt.streaming.deepgram', mock_deepgram), patch(
+        'utils.stt.streaming.LiveOptions', side_effect=lambda **kwargs: SimpleNamespace(**kwargs)
+    ):
+        result = connect_to_deepgram(
+            on_message=MagicMock(),
+            on_error=MagicMock(),
+            language='en',
+            sample_rate=16000,
+            channels=1,
+            model='nova-3',
+        )
+
+    assert result is mock_dg_conn
+    options = mock_dg_conn.start.call_args.args[0]
+    assert options.filler_words is False
 
 
 @pytest.mark.asyncio

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -362,7 +362,7 @@ def connect_to_deepgram(
             smart_format=True,
             profanity_filter=False,
             diarize=True,
-            filler_words=False,
+            filler_words=language == 'multi',
             channels=channels,
             multichannel=channels > 1,
             model=model,

--- a/backend/utils/stt/streaming.py
+++ b/backend/utils/stt/streaming.py
@@ -378,7 +378,7 @@ def connect_to_deepgram(
             smart_format=True,
             profanity_filter=False,
             diarize=True,
-            filler_words=False,
+            filler_words=language == 'multi',
             channels=channels,
             multichannel=channels > 1,
             model=model,


### PR DESCRIPTION
## Summary

Fixes Deepgram streaming STT filler-word handling in multi-language mode.

Previously, Omi sent `filler_words=false` for all streaming transcription requests. In Deepgram, that strips filler-like tokens such as `um` and `uh`. In multi-language mode, those tokens can be real words in non-English languages. 

This PR now preserves filler-like tokens when streaming with `language="multi"`, while keeping the existing English-only filler stripping behavior unchanged.

Fixes #6575 

## Changes

- Set Deepgram `filler_words=True` for `language="multi"`
- Keep `filler_words=False` for English-only streaming
- Add unit tests covering both multi-language and English-only Deepgram LiveOptions behavior

## Testing

- `python3 -m py_compile backend/utils/stt/streaming.py backend/tests/unit/test_streaming_deepgram_backoff.py`
- `git diff --check -- backend/utils/stt/streaming.py backend/tests/unit/test_streaming_deepgram_backoff.py`