### PR TITLE
Add audio-duration rate limiting to voice-message STT endpoints

### DIFF
--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -673,13 +673,23 @@ async def transcribe_voice_message_stream(
         # Start segment sender task
         sender_task = asyncio.create_task(segment_sender())
 
-        # Audio receive loop with idle timeout
+        # Audio receive loop with audio-idle timeout.
+        # Timeout is based on last *audio* frame, not last message — text-only
+        # frames (e.g. "finalize") don't reset the idle clock.
         last_audio_time = asyncio.get_event_loop().time()
         while websocket_active:
+            # Compute remaining idle budget based on last audio receipt
+            now = asyncio.get_event_loop().time()
+            remaining_idle = _WS_IDLE_TIMEOUT_S - (now - last_audio_time)
+            if remaining_idle <= 0:
+                logger.info(f'transcribe-stream: audio-idle timeout ({_WS_IDLE_TIMEOUT_S}s) uid={uid}')
+                await websocket.close(code=1008, reason=f'Idle timeout: no audio for {_WS_IDLE_TIMEOUT_S}s')
+                break
+
             try:
-                message = await asyncio.wait_for(websocket.receive(), timeout=_WS_IDLE_TIMEOUT_S)
+                message = await asyncio.wait_for(websocket.receive(), timeout=remaining_idle)
             except asyncio.TimeoutError:
-                logger.info(f'transcribe-stream: idle timeout ({_WS_IDLE_TIMEOUT_S}s) uid={uid}')
+                logger.info(f'transcribe-stream: audio-idle timeout ({_WS_IDLE_TIMEOUT_S}s) uid={uid}')
                 await websocket.close(code=1008, reason=f'Idle timeout: no audio for {_WS_IDLE_TIMEOUT_S}s')
                 break
             except WebSocketDisconnect:
@@ -690,6 +700,7 @@ async def transcribe_voice_message_stream(
 
             # Handle text "finalize" message: flush remaining audio, finalize Deepgram,
             # wait for final transcript, then continue receiving (client closes when ready).
+            # Note: text frames do NOT reset the audio-idle timer.
             text_data = message.get("text")
             if text_data and text_data.strip() == "finalize":
                 if dg_socket and not dg_socket.is_connection_dead:

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -49,8 +49,6 @@ from utils.llm.usage_tracker import set_usage_context, reset_usage_context, Feat
 from utils.users import get_user_display_name
 from utils.observability import submit_langsmith_feedback
 from utils.voice_duration_limiter import (
-    MAX_SESSION_DURATION_S,
-    compute_max_pcm_bytes,
     compute_pcm_duration_ms,
     read_wav_duration_ms,
     try_consume_budget,
@@ -365,12 +363,10 @@ async def create_voice_message_stream(
     if len(wav_paths) == 0:
         raise HTTPException(status_code=400, detail='Wav path is invalid')
 
-    # Per-session duration cap + daily budget (first file only — matches actual DG usage)
+    # Daily budget check (first file only — matches actual DG usage)
     first_wav = list(wav_paths)[0]
     duration_ms = read_wav_duration_ms(first_wav)
     if duration_ms is not None:
-        if duration_ms > MAX_SESSION_DURATION_S * 1000:
-            raise HTTPException(status_code=413, detail=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
         allowed, used_ms, remaining_ms = try_consume_budget(uid, duration_ms)
         if not allowed:
             raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
@@ -417,12 +413,6 @@ async def transcribe_voice_message(
             raise HTTPException(status_code=422, detail='sample_rate must be between 8000 and 48000')
         if channels < 1 or channels > 2:
             raise HTTPException(status_code=422, detail='channels must be 1 or 2')
-
-        # Per-session duration cap: reject if audio exceeds 120s at the given format
-        max_bytes = compute_max_pcm_bytes(sample_rate, channels, MAX_SESSION_DURATION_S)
-        if len(audio_bytes) > max_bytes:
-            del audio_bytes
-            raise HTTPException(status_code=413, detail=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
 
         # Daily budget check
         duration_ms = compute_pcm_duration_ms(len(audio_bytes), sample_rate, channels)
@@ -483,22 +473,12 @@ async def transcribe_voice_message(
         if converted_wav_paths:
             wav_paths.extend(converted_wav_paths)
 
-    # Per-session duration cap + daily budget check (sum all files)
+    # Daily budget check (sum all files)
     total_duration_ms = 0
     for wav_path in wav_paths:
         dur = read_wav_duration_ms(wav_path)
         if dur is not None:
             total_duration_ms += dur
-
-    if total_duration_ms > MAX_SESSION_DURATION_S * 1000:
-        # Cleanup temp files before rejecting
-        for p in wav_paths:
-            if p.startswith(f"/tmp/{uid}_"):
-                try:
-                    Path(p).unlink()
-                except Exception:
-                    pass
-        raise HTTPException(status_code=413, detail=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
 
     if total_duration_ms > 0:
         allowed, used_ms, remaining_ms = try_consume_budget(uid, total_duration_ms)
@@ -640,11 +620,10 @@ async def transcribe_voice_message_stream(
     dg_socket = None
     sender_task = None
     stt_audio_buffer = bytearray()
-    total_audio_bytes = 0  # Track cumulative bytes for duration cap + budget recording
+    total_audio_bytes = 0  # Track cumulative bytes for budget recording
     # 30ms flush threshold for Deepgram streaming quality (16-bit PCM = 2 bytes per sample per channel)
     bytes_per_second = sample_rate * channels * 2
     stt_buffer_flush_size = int(bytes_per_second * 0.03)
-    max_session_bytes = bytes_per_second * MAX_SESSION_DURATION_S
 
     # PTT transcribe-stream always uses Deepgram (lightweight, no conversation lifecycle).
     # get_stt_service_for_language resolves the language/model for the DG call.
@@ -734,23 +713,6 @@ async def transcribe_voice_message_stream(
             if len(data) > 5 * 1024 * 1024:
                 logger.warning(f'transcribe-stream: oversized frame uid={uid} size={len(data)}')
                 continue
-
-            # Per-session duration cap: close WS at 120s of cumulative audio
-            # Check BEFORE incrementing so rejected frames don't inflate the budget charge
-            if total_audio_bytes + len(data) > max_session_bytes:
-                logger.info(f'transcribe-stream: session duration cap reached uid={uid}')
-                # Finalize DG to get last transcript, then close
-                if dg_socket and not dg_socket.is_connection_dead:
-                    if len(stt_audio_buffer) > 0:
-                        dg_socket.send(bytes(stt_audio_buffer))
-                        stt_audio_buffer.clear()
-                    try:
-                        dg_socket.finalize()
-                        await asyncio.sleep(0.3)
-                    except Exception:
-                        pass
-                await websocket.close(code=1008, reason=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
-                break
 
             total_audio_bytes += len(data)
             stt_audio_buffer.extend(data)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -48,13 +48,23 @@ from utils.retrieval.graph import execute_graph_chat, execute_chat_stream, execu
 from utils.llm.usage_tracker import set_usage_context, reset_usage_context, Features
 from utils.users import get_user_display_name
 from utils.observability import submit_langsmith_feedback
+from utils.voice_duration_limiter import (
+    MAX_SESSION_DURATION_S,
+    compute_max_pcm_bytes,
+    compute_pcm_duration_ms,
+    read_wav_duration_ms,
+    try_consume_budget,
+    check_budget,
+    record_actual_duration,
+)
 import logging
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-_MAX_PCM_BODY_BYTES = 15 * 1024 * 1024  # 15 MB ≈ ~480 s (~8 min) of 16kHz mono 16-bit PCM
+# WS idle timeout: close if no audio bytes received for this long
+_WS_IDLE_TIMEOUT_S = 60
 
 
 def filter_messages(messages, app_id):
@@ -355,11 +365,21 @@ async def create_voice_message_stream(
     if len(wav_paths) == 0:
         raise HTTPException(status_code=400, detail='Wav path is invalid')
 
+    # Per-session duration cap + daily budget (first file only — matches actual DG usage)
+    first_wav = list(wav_paths)[0]
+    duration_ms = read_wav_duration_ms(first_wav)
+    if duration_ms is not None:
+        if duration_ms > MAX_SESSION_DURATION_S * 1000:
+            raise HTTPException(status_code=413, detail=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
+        allowed, used_ms, remaining_ms = try_consume_budget(uid, duration_ms)
+        if not allowed:
+            raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
+
     resolved_language = resolve_voice_message_language(uid, language)
 
     # process
     async def generate_stream():
-        async for chunk in process_voice_message_segment_stream(list(wav_paths)[0], uid, language=resolved_language):
+        async for chunk in process_voice_message_segment_stream(first_wav, uid, language=resolved_language):
             yield chunk
 
     return StreamingResponse(generate_stream(), media_type="text/event-stream")
@@ -384,8 +404,6 @@ async def transcribe_voice_message(
         audio_bytes = await request.body()
         if not audio_bytes or len(audio_bytes) == 0:
             raise HTTPException(status_code=400, detail='No audio data provided')
-        if len(audio_bytes) > _MAX_PCM_BODY_BYTES:
-            raise HTTPException(status_code=413, detail='Audio payload too large')
 
         language = request.query_params.get("language")
         encoding = request.query_params.get("encoding", "linear16")
@@ -399,6 +417,19 @@ async def transcribe_voice_message(
             raise HTTPException(status_code=422, detail='sample_rate must be between 8000 and 48000')
         if channels < 1 or channels > 2:
             raise HTTPException(status_code=422, detail='channels must be 1 or 2')
+
+        # Per-session duration cap: reject if audio exceeds 120s at the given format
+        max_bytes = compute_max_pcm_bytes(sample_rate, channels, MAX_SESSION_DURATION_S)
+        if len(audio_bytes) > max_bytes:
+            del audio_bytes
+            raise HTTPException(status_code=413, detail=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
+
+        # Daily budget check
+        duration_ms = compute_pcm_duration_ms(len(audio_bytes), sample_rate, channels)
+        allowed, used_ms, remaining_ms = try_consume_budget(uid, duration_ms)
+        if not allowed:
+            del audio_bytes
+            raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
 
         resolved_language = resolve_voice_message_language(uid, language)
         try:
@@ -451,6 +482,34 @@ async def transcribe_voice_message(
         converted_wav_paths = decode_files_to_wav(other_file_paths)
         if converted_wav_paths:
             wav_paths.extend(converted_wav_paths)
+
+    # Per-session duration cap + daily budget check (sum all files)
+    total_duration_ms = 0
+    for wav_path in wav_paths:
+        dur = read_wav_duration_ms(wav_path)
+        if dur is not None:
+            total_duration_ms += dur
+
+    if total_duration_ms > MAX_SESSION_DURATION_S * 1000:
+        # Cleanup temp files before rejecting
+        for p in wav_paths:
+            if p.startswith(f"/tmp/{uid}_"):
+                try:
+                    Path(p).unlink()
+                except Exception:
+                    pass
+        raise HTTPException(status_code=413, detail=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
+
+    if total_duration_ms > 0:
+        allowed, used_ms, remaining_ms = try_consume_budget(uid, total_duration_ms)
+        if not allowed:
+            for p in wav_paths:
+                if p.startswith(f"/tmp/{uid}_"):
+                    try:
+                        Path(p).unlink()
+                    except Exception:
+                        pass
+            raise HTTPException(status_code=429, detail='Daily transcription budget exhausted')
 
     # Process all WAV files and collect transcripts
     transcripts = []
@@ -568,12 +627,24 @@ async def transcribe_voice_message_stream(
     except Exception:
         pass  # Fail-open, consistent with Redis rate limiting elsewhere
 
+    # Daily budget check — reject if already exhausted before opening DG connection
+    try:
+        has_budget, used_ms, remaining_ms = check_budget(uid)
+        if not has_budget:
+            await websocket.close(code=1008, reason='Daily transcription budget exhausted')
+            return
+    except Exception:
+        pass  # Fail-open
+
     websocket_active = True
     dg_socket = None
     sender_task = None
     stt_audio_buffer = bytearray()
+    total_audio_bytes = 0  # Track cumulative bytes for duration cap + budget recording
     # 30ms flush threshold for Deepgram streaming quality (16-bit PCM = 2 bytes per sample per channel)
-    stt_buffer_flush_size = int(sample_rate * channels * 2 * 0.03)
+    bytes_per_second = sample_rate * channels * 2
+    stt_buffer_flush_size = int(bytes_per_second * 0.03)
+    max_session_bytes = bytes_per_second * MAX_SESSION_DURATION_S
 
     # PTT transcribe-stream always uses Deepgram (lightweight, no conversation lifecycle).
     # get_stt_service_for_language resolves the language/model for the DG call.
@@ -623,10 +694,15 @@ async def transcribe_voice_message_stream(
         # Start segment sender task
         sender_task = asyncio.create_task(segment_sender())
 
-        # Audio receive loop
+        # Audio receive loop with idle timeout
+        last_audio_time = asyncio.get_event_loop().time()
         while websocket_active:
             try:
-                message = await websocket.receive()
+                message = await asyncio.wait_for(websocket.receive(), timeout=_WS_IDLE_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                logger.info(f'transcribe-stream: idle timeout ({_WS_IDLE_TIMEOUT_S}s) uid={uid}')
+                await websocket.close(code=1008, reason=f'Idle timeout: no audio for {_WS_IDLE_TIMEOUT_S}s')
+                break
             except WebSocketDisconnect:
                 break
 
@@ -652,10 +728,29 @@ async def transcribe_voice_message_stream(
             if data is None:
                 continue
 
+            last_audio_time = asyncio.get_event_loop().time()
+
             # Guard against oversized frames (5 MB matches REST endpoint limit)
             if len(data) > 5 * 1024 * 1024:
                 logger.warning(f'transcribe-stream: oversized frame uid={uid} size={len(data)}')
                 continue
+
+            # Per-session duration cap: close WS at 120s of cumulative audio
+            total_audio_bytes += len(data)
+            if total_audio_bytes > max_session_bytes:
+                logger.info(f'transcribe-stream: session duration cap reached uid={uid}')
+                # Finalize DG to get last transcript, then close
+                if dg_socket and not dg_socket.is_connection_dead:
+                    if len(stt_audio_buffer) > 0:
+                        dg_socket.send(bytes(stt_audio_buffer))
+                        stt_audio_buffer.clear()
+                    try:
+                        dg_socket.finalize()
+                        await asyncio.sleep(0.3)
+                    except Exception:
+                        pass
+                await websocket.close(code=1008, reason=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
+                break
 
             stt_audio_buffer.extend(data)
 
@@ -677,6 +772,11 @@ async def transcribe_voice_message_stream(
         logger.error(f'transcribe-stream: error uid={uid}: {e}')
     finally:
         websocket_active = False
+
+        # Record actual consumed duration against daily budget
+        if total_audio_bytes > 0 and bytes_per_second > 0:
+            actual_duration_ms = compute_pcm_duration_ms(total_audio_bytes, sample_rate, channels)
+            record_actual_duration(uid, actual_duration_ms)
 
         # Flush remaining audio buffer
         if dg_socket and not dg_socket.is_connection_dead and len(stt_audio_buffer) > 0:

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -64,6 +64,10 @@ router = APIRouter()
 # WS idle timeout: close if no audio bytes received for this long
 _WS_IDLE_TIMEOUT_S = 60
 
+# Hard body-size cap for octet-stream uploads (200 MB).
+# Prevents memory exhaustion from oversized payloads regardless of budget.
+_MAX_PCM_BODY_BYTES = 200_000_000
+
 
 def filter_messages(messages, app_id):
     logger.info(f'filter_messages {len(messages)} {app_id}')
@@ -397,9 +401,18 @@ async def transcribe_voice_message(
     content_type = request.headers.get("content-type", "")
 
     if "application/octet-stream" in content_type:
+        # Check Content-Length before buffering to reject oversized payloads early
+        content_length = request.headers.get("content-length")
+        if content_length and int(content_length) > _MAX_PCM_BODY_BYTES:
+            raise HTTPException(status_code=413, detail=f'Body too large (max {_MAX_PCM_BODY_BYTES} bytes)')
+
         audio_bytes = await request.body()
         if not audio_bytes or len(audio_bytes) == 0:
             raise HTTPException(status_code=400, detail='No audio data provided')
+
+        if len(audio_bytes) > _MAX_PCM_BODY_BYTES:
+            del audio_bytes
+            raise HTTPException(status_code=413, detail=f'Body too large (max {_MAX_PCM_BODY_BYTES} bytes)')
 
         language = request.query_params.get("language")
         encoding = request.query_params.get("encoding", "linear16")
@@ -727,19 +740,18 @@ async def transcribe_voice_message_stream(
                 logger.warning(f'transcribe-stream: oversized frame uid={uid} size={len(data)}')
                 continue
 
-            total_audio_bytes += len(data)
-
-            # In-session budget enforcement: close if cumulative audio exceeds
-            # the remaining daily budget captured at connect time.
+            # In-session budget enforcement: check BEFORE incrementing total_audio_bytes
+            # so that the triggering frame is not counted as consumed (it won't be sent to DG).
             if budget_remaining_ms is not None and bytes_per_second > 0:
-                elapsed_ms = compute_pcm_duration_ms(total_audio_bytes, sample_rate, channels)
-                if elapsed_ms > budget_remaining_ms:
+                prospective_ms = compute_pcm_duration_ms(total_audio_bytes + len(data), sample_rate, channels)
+                if prospective_ms > budget_remaining_ms:
                     logger.info(
-                        f'transcribe-stream: budget exhausted mid-session uid={uid} elapsed={elapsed_ms}ms remaining={budget_remaining_ms}ms'
+                        f'transcribe-stream: budget exhausted mid-session uid={uid} elapsed={prospective_ms}ms remaining={budget_remaining_ms}ms'
                     )
                     await websocket.close(code=1008, reason='Daily transcription budget exhausted')
                     break
 
+            total_audio_bytes += len(data)
             stt_audio_buffer.extend(data)
 
             # Flush to Deepgram in 30ms chunks

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -608,11 +608,13 @@ async def transcribe_voice_message_stream(
         pass  # Fail-open, consistent with Redis rate limiting elsewhere
 
     # Daily budget check — reject if already exhausted before opening DG connection
+    budget_remaining_ms = None  # None = fail-open (no enforcement)
     try:
         has_budget, used_ms, remaining_ms = check_budget(uid)
         if not has_budget:
             await websocket.close(code=1008, reason='Daily transcription budget exhausted')
             return
+        budget_remaining_ms = remaining_ms
     except Exception:
         pass  # Fail-open
 
@@ -726,6 +728,18 @@ async def transcribe_voice_message_stream(
                 continue
 
             total_audio_bytes += len(data)
+
+            # In-session budget enforcement: close if cumulative audio exceeds
+            # the remaining daily budget captured at connect time.
+            if budget_remaining_ms is not None and bytes_per_second > 0:
+                elapsed_ms = compute_pcm_duration_ms(total_audio_bytes, sample_rate, channels)
+                if elapsed_ms > budget_remaining_ms:
+                    logger.info(
+                        f'transcribe-stream: budget exhausted mid-session uid={uid} elapsed={elapsed_ms}ms remaining={budget_remaining_ms}ms'
+                    )
+                    await websocket.close(code=1008, reason='Daily transcription budget exhausted')
+                    break
+
             stt_audio_buffer.extend(data)
 
             # Flush to Deepgram in 30ms chunks

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -736,8 +736,8 @@ async def transcribe_voice_message_stream(
                 continue
 
             # Per-session duration cap: close WS at 120s of cumulative audio
-            total_audio_bytes += len(data)
-            if total_audio_bytes > max_session_bytes:
+            # Check BEFORE incrementing so rejected frames don't inflate the budget charge
+            if total_audio_bytes + len(data) > max_session_bytes:
                 logger.info(f'transcribe-stream: session duration cap reached uid={uid}')
                 # Finalize DG to get last transcript, then close
                 if dg_socket and not dg_socket.is_connection_dead:
@@ -752,6 +752,7 @@ async def transcribe_voice_message_stream(
                 await websocket.close(code=1008, reason=f'Audio duration exceeds {MAX_SESSION_DURATION_S}s limit')
                 break
 
+            total_audio_bytes += len(data)
             stt_audio_buffer.extend(data)
 
             # Flush to Deepgram in 30ms chunks

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -83,6 +83,7 @@ pytest tests/unit/test_desktop_migration.py -v
 pytest tests/unit/test_staged_tasks_batch_scores.py -v
 pytest tests/unit/test_dg_start_guard.py -v
 pytest tests/unit/test_available_plans_resilience.py -v
+pytest tests/unit/test_voice_duration_limiter.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -1216,3 +1216,108 @@ class TestWsIdleTimeout:
                                         ws.receive_json()  # should fail — WS closed
         finally:
             _cleanup_chat_client(saved)
+
+    def test_ws_idle_timeout_fires_despite_text_frames(self):
+        """WS should still close for audio-idle even if text frames (finalize) are sent."""
+        client, module, saved = _make_chat_client()
+        try:
+            mock_dg_socket = MagicMock()
+            mock_dg_socket.is_connection_dead = False
+            mock_dg_socket.death_reason = None
+
+            async def mock_process_audio_dg(stream_transcript, **kwargs):
+                mock_dg_socket.send = MagicMock()
+                mock_dg_socket.finalize = MagicMock()
+                mock_dg_socket.finish = MagicMock()
+                return mock_dg_socket
+
+            # Set idle timeout very short for test
+            with patch.object(module, '_WS_IDLE_TIMEOUT_S', 0.2):
+                with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                    with patch.object(
+                        module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')
+                    ):
+                        with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                            with patch.object(module, 'record_actual_duration'):
+                                with pytest.raises(Exception):
+                                    with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                        import time
+
+                                        # Send finalize text frame — should NOT reset audio-idle timer
+                                        time.sleep(0.1)
+                                        ws.send_text('finalize')
+                                        time.sleep(0.2)
+                                        # Audio-idle timeout should have fired despite the text frame
+                                        ws.receive_json()
+        finally:
+            _cleanup_chat_client(saved)
+
+
+class TestVoiceMessagesBudgetHappyPath:
+    """Test /v2/voice-messages budget consumption on the happy path."""
+
+    def test_voice_messages_budget_consumed_on_success(self):
+        """Budget should be consumed with first WAV duration on successful stream."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+
+            async def mock_stream(*args, **kwargs):
+                yield 'data: {"text": "hello"}\n\n'
+
+            with patch.object(module, 'retrieve_file_paths', return_value=['/tmp/test_vm.wav']):
+                with patch.object(module, 'decode_files_to_wav', return_value=['/tmp/test_vm_decoded.wav']):
+                    with patch.object(module, 'read_wav_duration_ms', return_value=45_000):
+                        with patch.object(
+                            module, 'try_consume_budget', return_value=(True, 45000, 7155000)
+                        ) as mock_budget:
+                            with patch.object(module, 'resolve_voice_message_language', return_value='en'):
+                                with patch.object(
+                                    module, 'process_voice_message_segment_stream', side_effect=mock_stream
+                                ):
+                                    resp = client.post(
+                                        '/v2/voice-messages',
+                                        files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                                    )
+                                    assert resp.status_code == 200
+                                    # Budget consumed with first WAV duration only
+                                    mock_budget.assert_called_once()
+                                    call_args = mock_budget.call_args[0]
+                                    assert call_args[0] == 'test-uid'
+                                    assert call_args[1] == 45000
+        finally:
+            _cleanup_chat_client(saved)
+
+
+class TestMultipartBudgetAggregation:
+    """Test that multipart multi-file uploads sum WAV durations correctly."""
+
+    def test_multipart_multi_file_budget_sums_durations(self):
+        """Budget should be consumed with sum of all WAV durations."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            # Simulate 3 files: 1000ms, None (unreadable), 2000ms → budget call with 3000
+            duration_values = iter([1000, None, 2000])
+
+            with patch.object(module, 'read_wav_duration_ms', side_effect=lambda p: next(duration_values)):
+                with patch.object(module, 'try_consume_budget', return_value=(True, 3000, 7197000)) as mock_budget:
+                    with patch.object(module, 'transcribe_voice_message_segment', return_value=('hello', 'en')):
+                        resp = client.post(
+                            '/v2/voice-message/transcribe',
+                            files=[
+                                ('files', ('a.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
+                                ('files', ('b.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
+                                ('files', ('c.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
+                            ],
+                        )
+                        assert resp.status_code == 200
+                        # Budget consumed with sum: 1000 + 2000 = 3000 (None skipped)
+                        mock_budget.assert_called_once()
+                        call_args = mock_budget.call_args[0]
+                        assert call_args[0] == 'test-uid'
+                        assert call_args[1] == 3000
+        finally:
+            _cleanup_chat_client(saved)

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -1330,7 +1330,11 @@ class TestWsMidSessionBudgetEnforcement:
     """Test that WS closes mid-session when cumulative audio exceeds remaining budget."""
 
     def test_ws_closes_when_budget_exceeded_mid_session(self):
-        """WS should close with 1008 when cumulative audio exceeds remaining daily budget."""
+        """WS should close with 1008 when cumulative audio exceeds remaining daily budget.
+
+        The triggering frame should NOT be counted — total_audio_bytes is only
+        incremented for frames that pass the budget check and reach Deepgram.
+        """
         client, module, saved = _make_chat_client()
         try:
             mock_dg_socket = MagicMock()
@@ -1356,8 +1360,9 @@ class TestWsMidSessionBudgetEnforcement:
 
                                     time.sleep(0.1)
                                     ws.receive_json()  # should fail — WS closed due to budget
-                            # Duration should still be recorded for the audio that was sent
-                            mock_record.assert_called_once()
+                            # The triggering frame is NOT counted (check happens before increment),
+                            # so record_actual_duration should NOT be called (0 bytes processed)
+                            mock_record.assert_not_called()
         finally:
             _cleanup_chat_client(saved)
 
@@ -1384,5 +1389,61 @@ class TestWsMidSessionBudgetEnforcement:
                                 # Send 32000 bytes = 1000ms at 16kHz mono — well within 60s remaining
                                 ws.send_bytes(b'\x00' * 32000)
                                 # Connection should stay open — no 1008 close
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_ws_mid_session_records_only_processed_audio(self):
+        """WS should only record audio that was processed, not the triggering frame."""
+        client, module, saved = _make_chat_client()
+        try:
+            mock_dg_socket = MagicMock()
+            mock_dg_socket.is_connection_dead = False
+            mock_dg_socket.death_reason = None
+
+            async def mock_process_audio_dg(stream_transcript, **kwargs):
+                mock_dg_socket.send = MagicMock()
+                mock_dg_socket.finalize = MagicMock()
+                mock_dg_socket.finish = MagicMock()
+                return mock_dg_socket
+
+            # User has 1500ms of budget remaining
+            with patch.object(module, 'check_budget', return_value=(True, 7198500, 1500)):
+                with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
+                    with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                        with patch.object(module, 'record_actual_duration') as mock_record:
+                            with pytest.raises(Exception):
+                                with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                    # Frame 1: 32000 bytes = 1000ms — within 1500ms budget
+                                    ws.send_bytes(b'\x00' * 32000)
+                                    # Frame 2: 32000 bytes = would be 2000ms total — exceeds 1500ms
+                                    ws.send_bytes(b'\x00' * 32000)
+                                    import time
+
+                                    time.sleep(0.1)
+                                    ws.receive_json()
+                            # Only frame 1 was processed (1000ms), frame 2 was rejected
+                            mock_record.assert_called_once()
+                            call_args = mock_record.call_args[0]
+                            assert call_args[1] == 1000  # 32000 / (16000*1*2) * 1000
+        finally:
+            _cleanup_chat_client(saved)
+
+
+class TestOctetStreamBodySizeGuard:
+    """Test that octet-stream rejects oversized payloads before buffering."""
+
+    @patch('utils.chat.transcribe_pcm_bytes')
+    def test_oversized_body_rejected_413(self, mock_transcribe):
+        """Body exceeding _MAX_PCM_BODY_BYTES should be rejected with 413."""
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, '_MAX_PCM_BODY_BYTES', 1000):
+                resp = client.post(
+                    '/v2/voice-message/transcribe',
+                    content=b'\x00' * 1500,
+                    headers={'Content-Type': 'application/octet-stream'},
+                )
+                assert resp.status_code == 413
+                mock_transcribe.assert_not_called()
         finally:
             _cleanup_chat_client(saved)

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -1023,3 +1023,175 @@ class TestVoiceMessageTranscribeBoundary:
             assert resp.status_code == 200
         finally:
             _cleanup_chat_client(saved)
+
+
+# ---------------------------------------------------------------------------
+# Duration budget enforcement: octet-stream, multipart, and WebSocket
+# ---------------------------------------------------------------------------
+
+
+class TestDurationBudgetEnforcement:
+    """Test per-session duration cap and daily budget across all three endpoints."""
+
+    def test_octet_stream_budget_exhausted_429(self):
+        """Octet-stream request with exhausted budget should return 429."""
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'try_consume_budget', return_value=(False, 7200000, 0)):
+                resp = client.post(
+                    '/v2/voice-message/transcribe',
+                    content=b'\x00' * 3200,
+                    headers={'Content-Type': 'application/octet-stream'},
+                )
+                assert resp.status_code == 429
+                assert 'budget exhausted' in resp.json()['detail']
+        finally:
+            _cleanup_chat_client(saved)
+
+    @patch('utils.chat.transcribe_pcm_bytes')
+    def test_octet_stream_budget_consumed_with_correct_duration(self, mock_transcribe):
+        """Successful octet-stream request should consume budget with correct duration_ms."""
+        mock_transcribe.return_value = ('hello', 'en')
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'try_consume_budget', return_value=(True, 1000, 7199000)) as mock_budget:
+                resp = client.post(
+                    '/v2/voice-message/transcribe',
+                    # 32000 bytes at 16kHz mono = 1 second = 1000ms
+                    content=b'\x00' * 32000,
+                    headers={'Content-Type': 'application/octet-stream'},
+                )
+                assert resp.status_code == 200
+                mock_budget.assert_called_once()
+                call_args = mock_budget.call_args[0]
+                assert call_args[0] == 'test-uid'
+                assert call_args[1] == 1000  # 32000 / (16000*1*2) * 1000
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_multipart_wav_over_120s_rejected_413(self):
+        """Multipart WAV exceeding 120s total should return 413."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'read_wav_duration_ms', return_value=130_000):
+                resp = client.post(
+                    '/v2/voice-message/transcribe',
+                    files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                )
+                assert resp.status_code == 413
+                assert 'duration exceeds' in resp.json()['detail']
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_multipart_budget_exhausted_429(self):
+        """Multipart upload with exhausted budget should return 429."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'read_wav_duration_ms', return_value=60_000):
+                with patch.object(module, 'try_consume_budget', return_value=(False, 7200000, 0)):
+                    resp = client.post(
+                        '/v2/voice-message/transcribe',
+                        files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                    )
+                    assert resp.status_code == 429
+                    assert 'budget exhausted' in resp.json()['detail']
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_multipart_multi_file_duration_sum_413(self):
+        """Multiple WAV files whose summed duration exceeds 120s should return 413."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            # Each file reports 70s → 2 files = 140s > 120s cap
+            with patch.object(module, 'read_wav_duration_ms', return_value=70_000):
+                resp = client.post(
+                    '/v2/voice-message/transcribe',
+                    files=[
+                        ('files', ('a.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
+                        ('files', ('b.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
+                    ],
+                )
+                assert resp.status_code == 413
+                assert 'duration exceeds' in resp.json()['detail']
+        finally:
+            _cleanup_chat_client(saved)
+
+
+class TestWsBudgetAndSessionCap:
+    """Test WS budget gate, per-session cap, and actual duration recording."""
+
+    def test_ws_budget_exhausted_rejects_at_connect(self):
+        """WS should close with 1008 if daily budget is exhausted at connect."""
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'check_budget', return_value=(False, 7200000, 0)):
+                with pytest.raises(Exception):
+                    with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                        ws.receive_json()
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_ws_session_cap_closes_connection(self):
+        """WS should close when cumulative audio exceeds session duration cap."""
+        client, module, saved = _make_chat_client()
+        try:
+            mock_dg_socket = MagicMock()
+            mock_dg_socket.is_connection_dead = False
+            mock_dg_socket.death_reason = None
+
+            async def mock_process_audio_dg(stream_transcript, **kwargs):
+                mock_dg_socket.send = MagicMock()
+                mock_dg_socket.finalize = MagicMock()
+                mock_dg_socket.finish = MagicMock()
+                return mock_dg_socket
+
+            # Patch session cap to 1s → max_session_bytes = 32000 at 16kHz mono
+            with patch.object(module, 'MAX_SESSION_DURATION_S', 1):
+                with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                    with patch.object(
+                        module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')
+                    ):
+                        with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                            with patch.object(module, 'record_actual_duration'):
+                                with pytest.raises(Exception):
+                                    with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                        # 33000 bytes > 32000 (1s at 16kHz mono) → cap hit
+                                        ws.send_bytes(b'\x00' * 33000)
+                                        ws.receive_json()  # should fail — WS closed by server
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_ws_records_actual_duration_on_close(self):
+        """WS should call record_actual_duration with correct ms after session ends."""
+        client, module, saved = _make_chat_client()
+        try:
+            mock_dg_socket = MagicMock()
+            mock_dg_socket.is_connection_dead = False
+            mock_dg_socket.death_reason = None
+
+            async def mock_process_audio_dg(stream_transcript, **kwargs):
+                mock_dg_socket.send = MagicMock()
+                mock_dg_socket.finalize = MagicMock()
+                mock_dg_socket.finish = MagicMock()
+                return mock_dg_socket
+
+            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
+                    with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                        with patch.object(module, 'record_actual_duration') as mock_record:
+                            with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                # Send 32000 bytes = 1s at 16kHz mono
+                                ws.send_bytes(b'\x00' * 32000)
+                            # After WS close, finally block should have called record_actual_duration
+                            mock_record.assert_called_once()
+                            call_args = mock_record.call_args[0]
+                            assert call_args[0] == 'test-uid'
+                            assert call_args[1] == 1000  # 32000 / (16000*1*2) * 1000
+        finally:
+            _cleanup_chat_client(saved)

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -1138,3 +1138,81 @@ class TestWsBudgetAndSessionCap:
                             assert call_args[1] == 1000  # 32000 / (16000*1*2) * 1000
         finally:
             _cleanup_chat_client(saved)
+
+
+class TestNoPerSessionCap:
+    """Verify that audio >120s is accepted when daily budget remains (no per-session cap)."""
+
+    @patch('utils.chat.transcribe_pcm_bytes')
+    def test_octet_stream_over_120s_accepted(self, mock_transcribe):
+        """Octet-stream with >120s audio should be accepted if budget allows."""
+        mock_transcribe.return_value = ('long message', 'en')
+        client, module, saved = _make_chat_client()
+        try:
+            # 300s at 16kHz mono = 9,600,000 bytes → well over 120s
+            audio_300s = b'\x00' * (16000 * 1 * 2 * 300)
+            with patch.object(module, 'try_consume_budget', return_value=(True, 300000, 6900000)):
+                resp = client.post(
+                    '/v2/voice-message/transcribe',
+                    content=audio_300s,
+                    headers={'Content-Type': 'application/octet-stream'},
+                )
+                assert resp.status_code == 200
+                assert resp.json()['transcript'] == 'long message'
+        finally:
+            del audio_300s
+            _cleanup_chat_client(saved)
+
+    def test_multipart_over_120s_accepted(self):
+        """Multipart WAV with >120s duration should be accepted if budget allows."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            # WAV reports 300s (5 minutes) — should NOT be rejected
+            with patch.object(module, 'read_wav_duration_ms', return_value=300_000):
+                with patch.object(module, 'try_consume_budget', return_value=(True, 300000, 6900000)):
+                    with patch.object(module, 'transcribe_voice_message_segment', return_value=('long msg', 'en')):
+                        resp = client.post(
+                            '/v2/voice-message/transcribe',
+                            files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                        )
+                        assert resp.status_code == 200
+        finally:
+            _cleanup_chat_client(saved)
+
+
+class TestWsIdleTimeout:
+    """Test that WS idle timeout is based on audio frames, not all messages."""
+
+    def test_ws_idle_timeout_fires(self):
+        """WS should close after idle timeout when no audio is sent."""
+        client, module, saved = _make_chat_client()
+        try:
+            mock_dg_socket = MagicMock()
+            mock_dg_socket.is_connection_dead = False
+            mock_dg_socket.death_reason = None
+
+            async def mock_process_audio_dg(stream_transcript, **kwargs):
+                mock_dg_socket.send = MagicMock()
+                mock_dg_socket.finalize = MagicMock()
+                mock_dg_socket.finish = MagicMock()
+                return mock_dg_socket
+
+            # Set idle timeout very short for test
+            with patch.object(module, '_WS_IDLE_TIMEOUT_S', 0.1):
+                with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                    with patch.object(
+                        module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')
+                    ):
+                        with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                            with patch.object(module, 'record_actual_duration'):
+                                with pytest.raises(Exception):
+                                    with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                        # Don't send any audio — idle timeout should fire
+                                        import time
+
+                                        time.sleep(0.3)
+                                        ws.receive_json()  # should fail — WS closed
+        finally:
+            _cleanup_chat_client(saved)

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -712,19 +712,20 @@ class TestTranscribeStreamWebSocket:
                 mock_dg_socket.finish = MagicMock()
                 return mock_dg_socket
 
-            with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
-                with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
-                    with client.websocket_connect(
-                        '/v2/voice-message/transcribe-stream?language=en&sample_rate=16000'
-                    ) as ws:
-                        # Send enough audio to trigger a 30ms flush (16000 * 2 * 0.03 = 960 bytes)
-                        ws.send_bytes(b'\x00' * 960)
-                        # Receive the transcript segment
-                        data = ws.receive_json()
-                        assert isinstance(data, list)
-                        assert len(data) == 1
-                        assert data[0]['text'] == 'Hello'
-                        assert data[0]['speaker'] == 'SPEAKER_00'
+            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
+                    with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                        with client.websocket_connect(
+                            '/v2/voice-message/transcribe-stream?language=en&sample_rate=16000'
+                        ) as ws:
+                            # Send enough audio to trigger a 30ms flush (16000 * 2 * 0.03 = 960 bytes)
+                            ws.send_bytes(b'\x00' * 960)
+                            # Receive the transcript segment
+                            data = ws.receive_json()
+                            assert isinstance(data, list)
+                            assert len(data) == 1
+                            assert data[0]['text'] == 'Hello'
+                            assert data[0]['speaker'] == 'SPEAKER_00'
         finally:
             _cleanup_chat_client(saved)
 
@@ -793,19 +794,20 @@ class TestTranscribeStreamWebSocket:
                 mock_dg_socket.finish = MagicMock()
                 return mock_dg_socket
 
-            with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
-                with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
-                    with client.websocket_connect(
-                        '/v2/voice-message/transcribe-stream?language=en&sample_rate=16000'
-                    ) as ws:
-                        # Send sub-threshold audio (less than 960 bytes = 30ms at 16kHz)
-                        ws.send_bytes(b'\x00' * 500)
-                        # Send finalize — should flush the sub-threshold buffer
-                        ws.send_text('finalize')
-                        # Receive the transcript from flushed audio
-                        data = ws.receive_json()
-                        assert isinstance(data, list)
-                        assert data[0]['text'] == 'Final'
+            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
+                    with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                        with client.websocket_connect(
+                            '/v2/voice-message/transcribe-stream?language=en&sample_rate=16000'
+                        ) as ws:
+                            # Send sub-threshold audio (less than 960 bytes = 30ms at 16kHz)
+                            ws.send_bytes(b'\x00' * 500)
+                            # Send finalize — should flush the sub-threshold buffer
+                            ws.send_text('finalize')
+                            # Receive the transcript from flushed audio
+                            data = ws.receive_json()
+                            assert isinstance(data, list)
+                            assert data[0]['text'] == 'Final'
 
             # Verify finalize was called
             mock_dg_socket.finalize.assert_called()
@@ -842,19 +844,20 @@ class TestTranscribeStreamWebSocket:
                 mock_dg_socket.finish = MagicMock()
                 return mock_dg_socket
 
-            with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
-                with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
-                    with client.websocket_connect(
-                        '/v2/voice-message/transcribe-stream?language=en&sample_rate=16000&channels=2'
-                    ) as ws:
-                        # Stereo 30ms flush = 16000 * 2 * 2 * 0.03 = 1920 bytes
-                        # Send 960 bytes — should NOT flush (mono threshold, but stereo needs 1920)
-                        ws.send_bytes(b'\x00' * 960)
-                        # Send remaining to reach stereo threshold
-                        ws.send_bytes(b'\x00' * 960)
-                        data = ws.receive_json()
-                        assert isinstance(data, list)
-                        assert data[0]['text'] == 'Stereo'
+            with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
+                    with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                        with client.websocket_connect(
+                            '/v2/voice-message/transcribe-stream?language=en&sample_rate=16000&channels=2'
+                        ) as ws:
+                            # Stereo 30ms flush = 16000 * 2 * 2 * 0.03 = 1920 bytes
+                            # Send 960 bytes — should NOT flush (mono threshold, but stereo needs 1920)
+                            ws.send_bytes(b'\x00' * 960)
+                            # Send remaining to reach stereo threshold
+                            ws.send_bytes(b'\x00' * 960)
+                            data = ws.receive_json()
+                            assert isinstance(data, list)
+                            assert data[0]['text'] == 'Stereo'
         finally:
             _cleanup_chat_client(saved)
 
@@ -1319,5 +1322,67 @@ class TestMultipartBudgetAggregation:
                         call_args = mock_budget.call_args[0]
                         assert call_args[0] == 'test-uid'
                         assert call_args[1] == 3000
+        finally:
+            _cleanup_chat_client(saved)
+
+
+class TestWsMidSessionBudgetEnforcement:
+    """Test that WS closes mid-session when cumulative audio exceeds remaining budget."""
+
+    def test_ws_closes_when_budget_exceeded_mid_session(self):
+        """WS should close with 1008 when cumulative audio exceeds remaining daily budget."""
+        client, module, saved = _make_chat_client()
+        try:
+            mock_dg_socket = MagicMock()
+            mock_dg_socket.is_connection_dead = False
+            mock_dg_socket.death_reason = None
+
+            async def mock_process_audio_dg(stream_transcript, **kwargs):
+                mock_dg_socket.send = MagicMock()
+                mock_dg_socket.finalize = MagicMock()
+                mock_dg_socket.finish = MagicMock()
+                return mock_dg_socket
+
+            # User has only 500ms of budget remaining
+            with patch.object(module, 'check_budget', return_value=(True, 7199500, 500)):
+                with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
+                    with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                        with patch.object(module, 'record_actual_duration') as mock_record:
+                            with pytest.raises(Exception):
+                                with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                    # Send 32000 bytes = 1000ms at 16kHz mono — exceeds 500ms remaining
+                                    ws.send_bytes(b'\x00' * 32000)
+                                    import time
+
+                                    time.sleep(0.1)
+                                    ws.receive_json()  # should fail — WS closed due to budget
+                            # Duration should still be recorded for the audio that was sent
+                            mock_record.assert_called_once()
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_ws_allows_audio_within_remaining_budget(self):
+        """WS should accept audio that fits within remaining budget."""
+        client, module, saved = _make_chat_client()
+        try:
+            mock_dg_socket = MagicMock()
+            mock_dg_socket.is_connection_dead = False
+            mock_dg_socket.death_reason = None
+
+            async def mock_process_audio_dg(stream_transcript, **kwargs):
+                mock_dg_socket.send = MagicMock()
+                mock_dg_socket.finalize = MagicMock()
+                mock_dg_socket.finish = MagicMock()
+                return mock_dg_socket
+
+            # User has 60s of budget remaining
+            with patch.object(module, 'check_budget', return_value=(True, 7140000, 60000)):
+                with patch.object(module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')):
+                    with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                        with patch.object(module, 'record_actual_duration'):
+                            with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                # Send 32000 bytes = 1000ms at 16kHz mono — well within 60s remaining
+                                ws.send_bytes(b'\x00' * 32000)
+                                # Connection should stay open — no 1008 close
         finally:
             _cleanup_chat_client(saved)

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -595,7 +595,7 @@ class TestVoiceMessageTranscribeEndpoint:
                 headers={'Content-Type': 'application/octet-stream'},
             )
             assert resp.status_code == 413
-            assert 'too large' in resp.json()['detail']
+            assert 'duration exceeds' in resp.json()['detail'] or 'too large' in resp.json()['detail']
         finally:
             _cleanup_chat_client(saved)
 

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -1123,6 +1123,47 @@ class TestDurationBudgetEnforcement:
             _cleanup_chat_client(saved)
 
 
+class TestVoiceMessagesEndpointBudget:
+    """Test /v2/voice-messages duration cap and budget enforcement."""
+
+    def test_voice_messages_over_120s_rejected_413(self):
+        """WAV exceeding 120s on /v2/voice-messages should return 413."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'retrieve_file_paths', return_value=['/tmp/test_vm.wav']):
+                with patch.object(module, 'decode_files_to_wav', return_value=['/tmp/test_vm_decoded.wav']):
+                    with patch.object(module, 'read_wav_duration_ms', return_value=130_000):
+                        resp = client.post(
+                            '/v2/voice-messages',
+                            files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                        )
+                        assert resp.status_code == 413
+                        assert 'duration exceeds' in resp.json()['detail']
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_voice_messages_budget_exhausted_429(self):
+        """Exhausted budget on /v2/voice-messages should return 429."""
+        import io
+
+        client, module, saved = _make_chat_client()
+        try:
+            with patch.object(module, 'retrieve_file_paths', return_value=['/tmp/test_vm.wav']):
+                with patch.object(module, 'decode_files_to_wav', return_value=['/tmp/test_vm_decoded.wav']):
+                    with patch.object(module, 'read_wav_duration_ms', return_value=60_000):
+                        with patch.object(module, 'try_consume_budget', return_value=(False, 7200000, 0)):
+                            resp = client.post(
+                                '/v2/voice-messages',
+                                files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
+                            )
+                            assert resp.status_code == 429
+                            assert 'budget exhausted' in resp.json()['detail']
+        finally:
+            _cleanup_chat_client(saved)
+
+
 class TestWsBudgetAndSessionCap:
     """Test WS budget gate, per-session cap, and actual duration recording."""
 
@@ -1164,6 +1205,44 @@ class TestWsBudgetAndSessionCap:
                                         # 33000 bytes > 32000 (1s at 16kHz mono) → cap hit
                                         ws.send_bytes(b'\x00' * 33000)
                                         ws.receive_json()  # should fail — WS closed by server
+        finally:
+            _cleanup_chat_client(saved)
+
+    def test_ws_session_cap_overflow_frame_not_billed(self):
+        """Overflow frame that triggers cap should not inflate the billed duration."""
+        client, module, saved = _make_chat_client()
+        try:
+            mock_dg_socket = MagicMock()
+            mock_dg_socket.is_connection_dead = False
+            mock_dg_socket.death_reason = None
+
+            async def mock_process_audio_dg(stream_transcript, **kwargs):
+                mock_dg_socket.send = MagicMock()
+                mock_dg_socket.finalize = MagicMock()
+                mock_dg_socket.finish = MagicMock()
+                return mock_dg_socket
+
+            # Cap to 1s → 32000 bytes at 16kHz mono
+            with patch.object(module, 'MAX_SESSION_DURATION_S', 1):
+                with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
+                    with patch.object(
+                        module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')
+                    ):
+                        with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
+                            with patch.object(module, 'record_actual_duration') as mock_record:
+                                with pytest.raises(Exception):
+                                    with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
+                                        # Frame 1: 20000 bytes (accepted, under 32000 cap)
+                                        ws.send_bytes(b'\x00' * 20000)
+                                        # Frame 2: 15000 bytes → 20000+15000=35000 > 32000 → cap
+                                        ws.send_bytes(b'\x00' * 15000)
+                                        ws.receive_json()
+                                # Only the accepted 20000 bytes should be billed
+                                mock_record.assert_called_once()
+                                call_args = mock_record.call_args[0]
+                                assert call_args[0] == 'test-uid'
+                                # 20000 / (16000*1*2) * 1000 = 625ms
+                                assert call_args[1] == 625
         finally:
             _cleanup_chat_client(saved)
 

--- a/backend/tests/unit/test_desktop_transcribe.py
+++ b/backend/tests/unit/test_desktop_transcribe.py
@@ -585,20 +585,6 @@ class TestVoiceMessageTranscribeEndpoint:
         finally:
             _cleanup_chat_client(saved)
 
-    def test_octet_stream_oversize_413(self):
-        """Oversized octet-stream body should return 413."""
-        client, module, saved = _make_chat_client()
-        try:
-            resp = client.post(
-                '/v2/voice-message/transcribe',
-                content=b'\x00' * (6 * 1024 * 1024),
-                headers={'Content-Type': 'application/octet-stream'},
-            )
-            assert resp.status_code == 413
-            assert 'duration exceeds' in resp.json()['detail'] or 'too large' in resp.json()['detail']
-        finally:
-            _cleanup_chat_client(saved)
-
     def test_octet_stream_bad_sample_rate_422(self):
         """Non-integer sample_rate should return 422, not 500."""
         client, module, saved = _make_chat_client()
@@ -1031,7 +1017,7 @@ class TestVoiceMessageTranscribeBoundary:
 
 
 class TestDurationBudgetEnforcement:
-    """Test per-session duration cap and daily budget across all three endpoints."""
+    """Test daily budget enforcement across all three endpoints."""
 
     def test_octet_stream_budget_exhausted_429(self):
         """Octet-stream request with exhausted budget should return 429."""
@@ -1069,22 +1055,6 @@ class TestDurationBudgetEnforcement:
         finally:
             _cleanup_chat_client(saved)
 
-    def test_multipart_wav_over_120s_rejected_413(self):
-        """Multipart WAV exceeding 120s total should return 413."""
-        import io
-
-        client, module, saved = _make_chat_client()
-        try:
-            with patch.object(module, 'read_wav_duration_ms', return_value=130_000):
-                resp = client.post(
-                    '/v2/voice-message/transcribe',
-                    files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
-                )
-                assert resp.status_code == 413
-                assert 'duration exceeds' in resp.json()['detail']
-        finally:
-            _cleanup_chat_client(saved)
-
     def test_multipart_budget_exhausted_429(self):
         """Multipart upload with exhausted budget should return 429."""
         import io
@@ -1102,47 +1072,9 @@ class TestDurationBudgetEnforcement:
         finally:
             _cleanup_chat_client(saved)
 
-    def test_multipart_multi_file_duration_sum_413(self):
-        """Multiple WAV files whose summed duration exceeds 120s should return 413."""
-        import io
-
-        client, module, saved = _make_chat_client()
-        try:
-            # Each file reports 70s → 2 files = 140s > 120s cap
-            with patch.object(module, 'read_wav_duration_ms', return_value=70_000):
-                resp = client.post(
-                    '/v2/voice-message/transcribe',
-                    files=[
-                        ('files', ('a.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
-                        ('files', ('b.wav', io.BytesIO(b'\x00' * 100), 'audio/wav')),
-                    ],
-                )
-                assert resp.status_code == 413
-                assert 'duration exceeds' in resp.json()['detail']
-        finally:
-            _cleanup_chat_client(saved)
-
 
 class TestVoiceMessagesEndpointBudget:
-    """Test /v2/voice-messages duration cap and budget enforcement."""
-
-    def test_voice_messages_over_120s_rejected_413(self):
-        """WAV exceeding 120s on /v2/voice-messages should return 413."""
-        import io
-
-        client, module, saved = _make_chat_client()
-        try:
-            with patch.object(module, 'retrieve_file_paths', return_value=['/tmp/test_vm.wav']):
-                with patch.object(module, 'decode_files_to_wav', return_value=['/tmp/test_vm_decoded.wav']):
-                    with patch.object(module, 'read_wav_duration_ms', return_value=130_000):
-                        resp = client.post(
-                            '/v2/voice-messages',
-                            files=[('files', ('test.wav', io.BytesIO(b'\x00' * 100), 'audio/wav'))],
-                        )
-                        assert resp.status_code == 413
-                        assert 'duration exceeds' in resp.json()['detail']
-        finally:
-            _cleanup_chat_client(saved)
+    """Test /v2/voice-messages daily budget enforcement."""
 
     def test_voice_messages_budget_exhausted_429(self):
         """Exhausted budget on /v2/voice-messages should return 429."""
@@ -1165,7 +1097,7 @@ class TestVoiceMessagesEndpointBudget:
 
 
 class TestWsBudgetAndSessionCap:
-    """Test WS budget gate, per-session cap, and actual duration recording."""
+    """Test WS budget gate and actual duration recording."""
 
     def test_ws_budget_exhausted_rejects_at_connect(self):
         """WS should close with 1008 if daily budget is exhausted at connect."""
@@ -1175,74 +1107,6 @@ class TestWsBudgetAndSessionCap:
                 with pytest.raises(Exception):
                     with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
                         ws.receive_json()
-        finally:
-            _cleanup_chat_client(saved)
-
-    def test_ws_session_cap_closes_connection(self):
-        """WS should close when cumulative audio exceeds session duration cap."""
-        client, module, saved = _make_chat_client()
-        try:
-            mock_dg_socket = MagicMock()
-            mock_dg_socket.is_connection_dead = False
-            mock_dg_socket.death_reason = None
-
-            async def mock_process_audio_dg(stream_transcript, **kwargs):
-                mock_dg_socket.send = MagicMock()
-                mock_dg_socket.finalize = MagicMock()
-                mock_dg_socket.finish = MagicMock()
-                return mock_dg_socket
-
-            # Patch session cap to 1s → max_session_bytes = 32000 at 16kHz mono
-            with patch.object(module, 'MAX_SESSION_DURATION_S', 1):
-                with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
-                    with patch.object(
-                        module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')
-                    ):
-                        with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
-                            with patch.object(module, 'record_actual_duration'):
-                                with pytest.raises(Exception):
-                                    with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
-                                        # 33000 bytes > 32000 (1s at 16kHz mono) → cap hit
-                                        ws.send_bytes(b'\x00' * 33000)
-                                        ws.receive_json()  # should fail — WS closed by server
-        finally:
-            _cleanup_chat_client(saved)
-
-    def test_ws_session_cap_overflow_frame_not_billed(self):
-        """Overflow frame that triggers cap should not inflate the billed duration."""
-        client, module, saved = _make_chat_client()
-        try:
-            mock_dg_socket = MagicMock()
-            mock_dg_socket.is_connection_dead = False
-            mock_dg_socket.death_reason = None
-
-            async def mock_process_audio_dg(stream_transcript, **kwargs):
-                mock_dg_socket.send = MagicMock()
-                mock_dg_socket.finalize = MagicMock()
-                mock_dg_socket.finish = MagicMock()
-                return mock_dg_socket
-
-            # Cap to 1s → 32000 bytes at 16kHz mono
-            with patch.object(module, 'MAX_SESSION_DURATION_S', 1):
-                with patch.object(module, 'check_budget', return_value=(True, 0, 7200000)):
-                    with patch.object(
-                        module, 'get_stt_service_for_language', return_value=(MagicMock(), 'en', 'nova-3')
-                    ):
-                        with patch.object(module, 'process_audio_dg', side_effect=mock_process_audio_dg):
-                            with patch.object(module, 'record_actual_duration') as mock_record:
-                                with pytest.raises(Exception):
-                                    with client.websocket_connect('/v2/voice-message/transcribe-stream') as ws:
-                                        # Frame 1: 20000 bytes (accepted, under 32000 cap)
-                                        ws.send_bytes(b'\x00' * 20000)
-                                        # Frame 2: 15000 bytes → 20000+15000=35000 > 32000 → cap
-                                        ws.send_bytes(b'\x00' * 15000)
-                                        ws.receive_json()
-                                # Only the accepted 20000 bytes should be billed
-                                mock_record.assert_called_once()
-                                call_args = mock_record.call_args[0]
-                                assert call_args[0] == 'test-uid'
-                                # 20000 / (16000*1*2) * 1000 = 625ms
-                                assert call_args[1] == 625
         finally:
             _cleanup_chat_client(saved)
 

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -160,90 +160,8 @@ class TestWAVDurationReader:
         finally:
             os.unlink(path)
 
-    def test_wav_with_extra_chunk_before_data(self):
-        """WAV with a LIST chunk between fmt and data should still parse correctly."""
-        from utils.voice_duration_limiter import read_wav_duration_ms
-
-        sample_rate = 16000
-        channels = 1
-        bits_per_sample = 16
-        duration_s = 2.0
-        byte_rate = sample_rate * channels * (bits_per_sample // 8)
-        data_size = int(byte_rate * duration_s)
-        block_align = channels * (bits_per_sample // 8)
-        fmt_chunk_size = 16
-
-        # Extra LIST chunk between fmt and data
-        list_data = b'INFO' + b'\x00' * 20
-        list_chunk = b'LIST' + struct.pack('<I', len(list_data)) + list_data
-
-        riff_size = 4 + (8 + fmt_chunk_size) + len(list_chunk) + (8 + data_size)
-
-        buf = bytearray()
-        buf.extend(b'RIFF')
-        buf.extend(struct.pack('<I', riff_size))
-        buf.extend(b'WAVE')
-        buf.extend(b'fmt ')
-        buf.extend(struct.pack('<I', fmt_chunk_size))
-        buf.extend(struct.pack('<HHIIHH', 1, channels, sample_rate, byte_rate, block_align, bits_per_sample))
-        buf.extend(list_chunk)
-        buf.extend(b'data')
-        buf.extend(struct.pack('<I', data_size))
-        buf.extend(b'\x00' * data_size)
-
-        fd, path = tempfile.mkstemp(suffix='.wav')
-        with os.fdopen(fd, 'wb') as f:
-            f.write(buf)
-        try:
-            duration = read_wav_duration_ms(path)
-            assert duration is not None
-            assert abs(duration - 2000) <= 1
-        finally:
-            os.unlink(path)
-
-    def test_wav_with_odd_sized_chunk_before_data(self):
-        """WAV with an odd-sized LIST chunk (requires RIFF pad byte) should still parse correctly."""
-        from utils.voice_duration_limiter import read_wav_duration_ms
-
-        sample_rate = 16000
-        channels = 1
-        bits_per_sample = 16
-        duration_s = 1.0
-        byte_rate = sample_rate * channels * (bits_per_sample // 8)
-        data_size = int(byte_rate * duration_s)
-        block_align = channels * (bits_per_sample // 8)
-        fmt_chunk_size = 16
-
-        # Odd-sized LIST chunk: 25 bytes payload → requires 1 pad byte
-        list_data = b'INFO' + b'X' * 21  # 25 bytes total (odd)
-        list_chunk = b'LIST' + struct.pack('<I', len(list_data)) + list_data + b'\x00'  # pad byte
-
-        riff_size = 4 + (8 + fmt_chunk_size) + len(list_chunk) + (8 + data_size)
-
-        buf = bytearray()
-        buf.extend(b'RIFF')
-        buf.extend(struct.pack('<I', riff_size))
-        buf.extend(b'WAVE')
-        buf.extend(b'fmt ')
-        buf.extend(struct.pack('<I', fmt_chunk_size))
-        buf.extend(struct.pack('<HHIIHH', 1, channels, sample_rate, byte_rate, block_align, bits_per_sample))
-        buf.extend(list_chunk)
-        buf.extend(b'data')
-        buf.extend(struct.pack('<I', data_size))
-        buf.extend(b'\x00' * data_size)
-
-        fd, path = tempfile.mkstemp(suffix='.wav')
-        with os.fdopen(fd, 'wb') as f:
-            f.write(buf)
-        try:
-            duration = read_wav_duration_ms(path)
-            assert duration is not None, "Parser failed on WAV with odd-sized chunk (missing pad byte handling)"
-            assert abs(duration - 1000) <= 1
-        finally:
-            os.unlink(path)
-
-    def test_wav_truncated_fmt_returns_none(self):
-        """WAV with truncated fmt chunk (< 16 bytes) should return None."""
+    def test_corrupted_wav_returns_none(self):
+        """Truncated/corrupted WAV should return None (av raises, we catch)."""
         from utils.voice_duration_limiter import read_wav_duration_ms
 
         buf = bytearray()
@@ -251,40 +169,8 @@ class TestWAVDurationReader:
         buf.extend(struct.pack('<I', 26))
         buf.extend(b'WAVE')
         buf.extend(b'fmt ')
-        buf.extend(struct.pack('<I', 10))  # claims 10 bytes, less than required 16
+        buf.extend(struct.pack('<I', 10))  # truncated fmt
         buf.extend(b'\x00' * 10)
-
-        fd, path = tempfile.mkstemp(suffix='.wav')
-        with os.fdopen(fd, 'wb') as f:
-            f.write(buf)
-        try:
-            assert read_wav_duration_ms(path) is None
-        finally:
-            os.unlink(path)
-
-    def test_wav_zero_byte_rate_returns_none(self):
-        """WAV with byte_rate=0 should return None (no division by zero)."""
-        from utils.voice_duration_limiter import read_wav_duration_ms
-
-        sample_rate = 16000
-        channels = 1
-        bits_per_sample = 16
-        data_size = 32000
-        block_align = channels * (bits_per_sample // 8)
-        fmt_chunk_size = 16
-        riff_size = 4 + (8 + fmt_chunk_size) + (8 + data_size)
-
-        buf = bytearray()
-        buf.extend(b'RIFF')
-        buf.extend(struct.pack('<I', riff_size))
-        buf.extend(b'WAVE')
-        buf.extend(b'fmt ')
-        buf.extend(struct.pack('<I', fmt_chunk_size))
-        # byte_rate = 0 (invalid)
-        buf.extend(struct.pack('<HHIIHH', 1, channels, sample_rate, 0, block_align, bits_per_sample))
-        buf.extend(b'data')
-        buf.extend(struct.pack('<I', data_size))
-        buf.extend(b'\x00' * data_size)
 
         fd, path = tempfile.mkstemp(suffix='.wav')
         with os.fdopen(fd, 'wb') as f:

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -1,7 +1,7 @@
 """Tests for voice_duration_limiter module.
 
 Covers:
-- Per-session duration cap (compute_pcm_duration_ms, compute_max_pcm_bytes)
+- PCM duration computation (compute_pcm_duration_ms, compute_max_pcm_bytes)
 - WAV header duration reader (read_wav_duration_ms)
 - Rolling daily budget (try_consume_budget, check_budget, record_actual_duration)
 - Shared budget across endpoints (single pool per UID)

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -415,10 +415,22 @@ class TestGetBudgetStatus:
 class TestBudgetBoundary:
     """Test exact budget boundary behavior."""
 
-    def test_consume_at_exact_budget_rejected(self, mock_redis):
-        """When used==budget, a non-zero consume should be rejected."""
+    def test_consume_at_exact_budget_allowed(self, mock_redis):
+        """When used + request == budget exactly, should be allowed (boundary is >)."""
         _, mock_script = mock_redis
-        mock_script.return_value = [0, 7200000, 0]
+        mock_script.return_value = [1, 7200000, 0]
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import try_consume_budget
+
+            allowed, used, remaining = try_consume_budget('uid123', 1000)
+
+        assert allowed is True
+
+    def test_consume_over_budget_rejected(self, mock_redis):
+        """When used + request > budget, should be rejected."""
+        _, mock_script = mock_redis
+        mock_script.return_value = [0, 7200001, 0]
 
         with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
             from utils.voice_duration_limiter import try_consume_budget
@@ -428,18 +440,17 @@ class TestBudgetBoundary:
         assert allowed is False
         assert remaining == 0
 
-    def test_check_budget_at_exact_limit_exhausted(self, mock_redis):
-        """check_budget should report exhausted when used==budget."""
+    def test_check_budget_at_exact_limit_has_budget(self, mock_redis):
+        """check_budget should report has_budget when used==budget (boundary is >)."""
         _, mock_script = mock_redis
-        mock_script.return_value = [0, 7200000, 0]
+        mock_script.return_value = [1, 7200000, 0]
 
         with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
             from utils.voice_duration_limiter import check_budget
 
             has_budget, used, remaining = check_budget('uid123')
 
-        assert has_budget is False
-        assert remaining == 0
+        assert has_budget is True
 
     def test_consume_just_under_budget_allowed(self, mock_redis):
         """When used + request < budget, should be allowed."""
@@ -496,11 +507,6 @@ class TestSharedBudget:
 
 
 class TestConstants:
-    def test_session_cap(self):
-        from utils.voice_duration_limiter import MAX_SESSION_DURATION_S
-
-        assert MAX_SESSION_DURATION_S == 120
-
     def test_daily_budget(self):
         from utils.voice_duration_limiter import DAILY_BUDGET_MS
 

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -204,12 +204,18 @@ class TestBudgetConsumeLogic:
         assert used == 7200000
         assert remaining == 0
 
-    def test_consume_zero_duration_always_allowed(self):
-        from utils.voice_duration_limiter import try_consume_budget, DAILY_BUDGET_MS
+    def test_consume_zero_duration_probes_budget(self, mock_redis):
+        """Zero-duration consume probes budget status without recording."""
+        _, mock_script = mock_redis
+        mock_script.return_value = [1, 0, 7200000]
 
-        allowed, used, remaining = try_consume_budget('uid123', 0)
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import try_consume_budget
+
+            allowed, used, remaining = try_consume_budget('uid123', 0)
+
         assert allowed is True
-        assert remaining == DAILY_BUDGET_MS
+        assert remaining == 7200000
 
     def test_consume_redis_error_fails_open(self, mock_redis):
         _, mock_script = mock_redis
@@ -274,6 +280,9 @@ class TestRecordActualDuration:
 
         assert result is True
         mock_script.assert_called_once()
+        # Verify force=1 is passed as 5th arg
+        call_args = mock_script.call_args
+        assert call_args[1]['args'][4] == 1
 
     def test_record_zero_skips_redis(self, mock_redis):
         _, mock_script = mock_redis
@@ -303,6 +312,69 @@ class TestGetBudgetStatus:
         assert status['used_ms'] == 3600000
         assert status['remaining_ms'] == 3600000
         assert status['exhausted'] is False
+
+
+# ===========================================================================
+# Boundary tests: used == DAILY_BUDGET_MS
+# ===========================================================================
+
+
+class TestBudgetBoundary:
+    """Test exact budget boundary behavior."""
+
+    def test_consume_at_exact_budget_rejected(self, mock_redis):
+        """When used==budget, a non-zero consume should be rejected."""
+        _, mock_script = mock_redis
+        mock_script.return_value = [0, 7200000, 0]
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import try_consume_budget
+
+            allowed, used, remaining = try_consume_budget('uid123', 1000)
+
+        assert allowed is False
+        assert remaining == 0
+
+    def test_check_budget_at_exact_limit_exhausted(self, mock_redis):
+        """check_budget should report exhausted when used==budget."""
+        _, mock_script = mock_redis
+        mock_script.return_value = [0, 7200000, 0]
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import check_budget
+
+            has_budget, used, remaining = check_budget('uid123')
+
+        assert has_budget is False
+        assert remaining == 0
+
+    def test_consume_just_under_budget_allowed(self, mock_redis):
+        """When used + request < budget, should be allowed."""
+        _, mock_script = mock_redis
+        mock_script.return_value = [1, 7199999, 1]
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import try_consume_budget
+
+            allowed, used, remaining = try_consume_budget('uid123', 999)
+
+        assert allowed is True
+        assert remaining == 1
+
+    def test_record_actual_duration_force_records(self, mock_redis):
+        """record_actual_duration should always record (force=1), even over budget."""
+        _, mock_script = mock_redis
+        mock_script.return_value = [1, 7260000, 0]  # force-recorded over budget
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import record_actual_duration
+
+            result = record_actual_duration('uid123', 60000)
+
+        assert result is True
+        # Verify force=1 was passed as 5th arg
+        call_args = mock_script.call_args
+        assert call_args[1]['args'][4] == 1  # force flag
 
 
 # ===========================================================================

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -160,6 +160,99 @@ class TestWAVDurationReader:
         finally:
             os.unlink(path)
 
+    def test_wav_with_extra_chunk_before_data(self):
+        """WAV with a LIST chunk between fmt and data should still parse correctly."""
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        sample_rate = 16000
+        channels = 1
+        bits_per_sample = 16
+        duration_s = 2.0
+        byte_rate = sample_rate * channels * (bits_per_sample // 8)
+        data_size = int(byte_rate * duration_s)
+        block_align = channels * (bits_per_sample // 8)
+        fmt_chunk_size = 16
+
+        # Extra LIST chunk between fmt and data
+        list_data = b'INFO' + b'\x00' * 20
+        list_chunk = b'LIST' + struct.pack('<I', len(list_data)) + list_data
+
+        riff_size = 4 + (8 + fmt_chunk_size) + len(list_chunk) + (8 + data_size)
+
+        buf = bytearray()
+        buf.extend(b'RIFF')
+        buf.extend(struct.pack('<I', riff_size))
+        buf.extend(b'WAVE')
+        buf.extend(b'fmt ')
+        buf.extend(struct.pack('<I', fmt_chunk_size))
+        buf.extend(struct.pack('<HHIIHH', 1, channels, sample_rate, byte_rate, block_align, bits_per_sample))
+        buf.extend(list_chunk)
+        buf.extend(b'data')
+        buf.extend(struct.pack('<I', data_size))
+        buf.extend(b'\x00' * data_size)
+
+        fd, path = tempfile.mkstemp(suffix='.wav')
+        with os.fdopen(fd, 'wb') as f:
+            f.write(buf)
+        try:
+            duration = read_wav_duration_ms(path)
+            assert duration is not None
+            assert abs(duration - 2000) <= 1
+        finally:
+            os.unlink(path)
+
+    def test_wav_truncated_fmt_returns_none(self):
+        """WAV with truncated fmt chunk (< 16 bytes) should return None."""
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        buf = bytearray()
+        buf.extend(b'RIFF')
+        buf.extend(struct.pack('<I', 26))
+        buf.extend(b'WAVE')
+        buf.extend(b'fmt ')
+        buf.extend(struct.pack('<I', 10))  # claims 10 bytes, less than required 16
+        buf.extend(b'\x00' * 10)
+
+        fd, path = tempfile.mkstemp(suffix='.wav')
+        with os.fdopen(fd, 'wb') as f:
+            f.write(buf)
+        try:
+            assert read_wav_duration_ms(path) is None
+        finally:
+            os.unlink(path)
+
+    def test_wav_zero_byte_rate_returns_none(self):
+        """WAV with byte_rate=0 should return None (no division by zero)."""
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        sample_rate = 16000
+        channels = 1
+        bits_per_sample = 16
+        data_size = 32000
+        block_align = channels * (bits_per_sample // 8)
+        fmt_chunk_size = 16
+        riff_size = 4 + (8 + fmt_chunk_size) + (8 + data_size)
+
+        buf = bytearray()
+        buf.extend(b'RIFF')
+        buf.extend(struct.pack('<I', riff_size))
+        buf.extend(b'WAVE')
+        buf.extend(b'fmt ')
+        buf.extend(struct.pack('<I', fmt_chunk_size))
+        # byte_rate = 0 (invalid)
+        buf.extend(struct.pack('<HHIIHH', 1, channels, sample_rate, 0, block_align, bits_per_sample))
+        buf.extend(b'data')
+        buf.extend(struct.pack('<I', data_size))
+        buf.extend(b'\x00' * data_size)
+
+        fd, path = tempfile.mkstemp(suffix='.wav')
+        with os.fdopen(fd, 'wb') as f:
+            f.write(buf)
+        try:
+            assert read_wav_duration_ms(path) is None
+        finally:
+            os.unlink(path)
+
 
 # ===========================================================================
 # Redis budget — mock Redis for unit testing

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -201,6 +201,47 @@ class TestWAVDurationReader:
         finally:
             os.unlink(path)
 
+    def test_wav_with_odd_sized_chunk_before_data(self):
+        """WAV with an odd-sized LIST chunk (requires RIFF pad byte) should still parse correctly."""
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        sample_rate = 16000
+        channels = 1
+        bits_per_sample = 16
+        duration_s = 1.0
+        byte_rate = sample_rate * channels * (bits_per_sample // 8)
+        data_size = int(byte_rate * duration_s)
+        block_align = channels * (bits_per_sample // 8)
+        fmt_chunk_size = 16
+
+        # Odd-sized LIST chunk: 25 bytes payload → requires 1 pad byte
+        list_data = b'INFO' + b'X' * 21  # 25 bytes total (odd)
+        list_chunk = b'LIST' + struct.pack('<I', len(list_data)) + list_data + b'\x00'  # pad byte
+
+        riff_size = 4 + (8 + fmt_chunk_size) + len(list_chunk) + (8 + data_size)
+
+        buf = bytearray()
+        buf.extend(b'RIFF')
+        buf.extend(struct.pack('<I', riff_size))
+        buf.extend(b'WAVE')
+        buf.extend(b'fmt ')
+        buf.extend(struct.pack('<I', fmt_chunk_size))
+        buf.extend(struct.pack('<HHIIHH', 1, channels, sample_rate, byte_rate, block_align, bits_per_sample))
+        buf.extend(list_chunk)
+        buf.extend(b'data')
+        buf.extend(struct.pack('<I', data_size))
+        buf.extend(b'\x00' * data_size)
+
+        fd, path = tempfile.mkstemp(suffix='.wav')
+        with os.fdopen(fd, 'wb') as f:
+            f.write(buf)
+        try:
+            duration = read_wav_duration_ms(path)
+            assert duration is not None, "Parser failed on WAV with odd-sized chunk (missing pad byte handling)"
+            assert abs(duration - 1000) <= 1
+        finally:
+            os.unlink(path)
+
     def test_wav_truncated_fmt_returns_none(self):
         """WAV with truncated fmt chunk (< 16 bytes) should return None."""
         from utils.voice_duration_limiter import read_wav_duration_ms

--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -1,0 +1,342 @@
+"""Tests for voice_duration_limiter module.
+
+Covers:
+- Per-session duration cap (compute_pcm_duration_ms, compute_max_pcm_bytes)
+- WAV header duration reader (read_wav_duration_ms)
+- Rolling daily budget (try_consume_budget, check_budget, record_actual_duration)
+- Shared budget across endpoints (single pool per UID)
+- Edge cases: concurrent requests, zero duration, Redis failure (fail-open)
+"""
+
+import os
+import struct
+import tempfile
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helper: create a minimal WAV file with known duration
+# ---------------------------------------------------------------------------
+
+
+def _make_wav(duration_s: float, sample_rate: int = 16000, channels: int = 1, bits_per_sample: int = 16) -> str:
+    """Create a temporary WAV file with the specified duration and return its path."""
+    byte_rate = sample_rate * channels * (bits_per_sample // 8)
+    data_size = int(byte_rate * duration_s)
+    # Pad to even number of bytes
+    if data_size % 2 != 0:
+        data_size += 1
+
+    fmt_chunk_size = 16
+    riff_size = 4 + (8 + fmt_chunk_size) + (8 + data_size)
+
+    buf = bytearray()
+    # RIFF header
+    buf.extend(b'RIFF')
+    buf.extend(struct.pack('<I', riff_size))
+    buf.extend(b'WAVE')
+    # fmt chunk
+    buf.extend(b'fmt ')
+    buf.extend(struct.pack('<I', fmt_chunk_size))
+    audio_format = 1  # PCM
+    block_align = channels * (bits_per_sample // 8)
+    buf.extend(struct.pack('<HHIIHH', audio_format, channels, sample_rate, byte_rate, block_align, bits_per_sample))
+    # data chunk
+    buf.extend(b'data')
+    buf.extend(struct.pack('<I', data_size))
+    buf.extend(b'\x00' * data_size)
+
+    fd, path = tempfile.mkstemp(suffix='.wav')
+    with os.fdopen(fd, 'wb') as f:
+        f.write(buf)
+    return path
+
+
+# ===========================================================================
+# compute_pcm_duration_ms / compute_max_pcm_bytes
+# ===========================================================================
+
+
+class TestPCMDurationComputation:
+    def test_16khz_mono_1s(self):
+        from utils.voice_duration_limiter import compute_pcm_duration_ms
+
+        # 1 second of 16kHz mono 16-bit = 32000 bytes
+        assert compute_pcm_duration_ms(32000, 16000, 1) == 1000
+
+    def test_48khz_stereo_1s(self):
+        from utils.voice_duration_limiter import compute_pcm_duration_ms
+
+        # 1 second of 48kHz stereo 16-bit = 192000 bytes
+        assert compute_pcm_duration_ms(192000, 48000, 2) == 1000
+
+    def test_zero_bytes(self):
+        from utils.voice_duration_limiter import compute_pcm_duration_ms
+
+        assert compute_pcm_duration_ms(0, 16000, 1) == 0
+
+    def test_zero_sample_rate(self):
+        from utils.voice_duration_limiter import compute_pcm_duration_ms
+
+        assert compute_pcm_duration_ms(1000, 0, 1) == 0
+
+    def test_max_pcm_bytes_16khz_mono_120s(self):
+        from utils.voice_duration_limiter import compute_max_pcm_bytes
+
+        # 120s of 16kHz mono 16-bit = 16000 * 1 * 2 * 120 = 3,840,000
+        assert compute_max_pcm_bytes(16000, 1, 120) == 3_840_000
+
+    def test_max_pcm_bytes_48khz_stereo_120s(self):
+        from utils.voice_duration_limiter import compute_max_pcm_bytes
+
+        # 120s of 48kHz stereo 16-bit = 48000 * 2 * 2 * 120 = 23,040,000
+        assert compute_max_pcm_bytes(48000, 2, 120) == 23_040_000
+
+
+# ===========================================================================
+# read_wav_duration_ms
+# ===========================================================================
+
+
+class TestWAVDurationReader:
+    def test_valid_wav_1s(self):
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        path = _make_wav(1.0)
+        try:
+            duration = read_wav_duration_ms(path)
+            assert duration is not None
+            assert abs(duration - 1000) <= 1  # Allow 1ms rounding
+        finally:
+            os.unlink(path)
+
+    def test_valid_wav_120s(self):
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        path = _make_wav(120.0)
+        try:
+            duration = read_wav_duration_ms(path)
+            assert duration is not None
+            assert abs(duration - 120000) <= 1
+        finally:
+            os.unlink(path)
+
+    def test_stereo_48khz(self):
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        path = _make_wav(5.0, sample_rate=48000, channels=2)
+        try:
+            duration = read_wav_duration_ms(path)
+            assert duration is not None
+            assert abs(duration - 5000) <= 1
+        finally:
+            os.unlink(path)
+
+    def test_invalid_file_returns_none(self):
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        fd, path = tempfile.mkstemp()
+        with os.fdopen(fd, 'wb') as f:
+            f.write(b'not a wav file')
+        try:
+            assert read_wav_duration_ms(path) is None
+        finally:
+            os.unlink(path)
+
+    def test_nonexistent_file_returns_none(self):
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        assert read_wav_duration_ms('/tmp/nonexistent_wav_12345.wav') is None
+
+    def test_empty_file_returns_none(self):
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        fd, path = tempfile.mkstemp()
+        os.close(fd)
+        try:
+            assert read_wav_duration_ms(path) is None
+        finally:
+            os.unlink(path)
+
+
+# ===========================================================================
+# Redis budget — mock Redis for unit testing
+# ===========================================================================
+
+
+@pytest.fixture
+def mock_redis():
+    """Mock the Redis client and Lua script for budget tests."""
+    mock_r = MagicMock()
+    mock_script = MagicMock()
+    mock_r.register_script.return_value = mock_script
+    return mock_r, mock_script
+
+
+class TestBudgetConsumeLogic:
+    """Test try_consume_budget with mocked Redis."""
+
+    def test_consume_allowed(self, mock_redis):
+        _, mock_script = mock_redis
+        mock_script.return_value = [1, 60000, 7140000]  # allowed, used=60s, remaining=7140s
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import try_consume_budget
+
+            allowed, used, remaining = try_consume_budget('uid123', 60000)
+
+        assert allowed is True
+        assert used == 60000
+        assert remaining == 7140000
+
+    def test_consume_rejected(self, mock_redis):
+        _, mock_script = mock_redis
+        mock_script.return_value = [0, 7200000, 0]  # rejected, budget exhausted
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import try_consume_budget
+
+            allowed, used, remaining = try_consume_budget('uid123', 60000)
+
+        assert allowed is False
+        assert used == 7200000
+        assert remaining == 0
+
+    def test_consume_zero_duration_always_allowed(self):
+        from utils.voice_duration_limiter import try_consume_budget, DAILY_BUDGET_MS
+
+        allowed, used, remaining = try_consume_budget('uid123', 0)
+        assert allowed is True
+        assert remaining == DAILY_BUDGET_MS
+
+    def test_consume_redis_error_fails_open(self, mock_redis):
+        _, mock_script = mock_redis
+        mock_script.side_effect = Exception('Redis connection refused')
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import try_consume_budget, DAILY_BUDGET_MS
+
+            allowed, used, remaining = try_consume_budget('uid123', 60000)
+
+        assert allowed is True  # Fail-open
+        assert remaining == DAILY_BUDGET_MS
+
+    def test_consume_lua_none_fails_open(self):
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', None):
+            from utils.voice_duration_limiter import try_consume_budget, DAILY_BUDGET_MS
+
+            allowed, used, remaining = try_consume_budget('uid123', 60000)
+
+        assert allowed is True  # Fail-open
+        assert remaining == DAILY_BUDGET_MS
+
+
+class TestCheckBudget:
+    """Test check_budget (zero-consume probe)."""
+
+    def test_check_budget_has_budget(self, mock_redis):
+        _, mock_script = mock_redis
+        mock_script.return_value = [1, 3600000, 3600000]
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import check_budget
+
+            has_budget, used, remaining = check_budget('uid123')
+
+        assert has_budget is True
+
+    def test_check_budget_exhausted(self, mock_redis):
+        _, mock_script = mock_redis
+        # When consuming 0, the Lua script still checks used > budget
+        mock_script.return_value = [0, 7200000, 0]
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import check_budget
+
+            has_budget, used, remaining = check_budget('uid123')
+
+        assert has_budget is False
+
+
+class TestRecordActualDuration:
+    """Test record_actual_duration (used by WS on session end)."""
+
+    def test_record_positive(self, mock_redis):
+        _, mock_script = mock_redis
+        mock_script.return_value = [1, 60000, 7140000]
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import record_actual_duration
+
+            result = record_actual_duration('uid123', 60000)
+
+        assert result is True
+        mock_script.assert_called_once()
+
+    def test_record_zero_skips_redis(self, mock_redis):
+        _, mock_script = mock_redis
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import record_actual_duration
+
+            result = record_actual_duration('uid123', 0)
+
+        assert result is True
+        mock_script.assert_not_called()
+
+
+class TestGetBudgetStatus:
+    """Test get_budget_status dict output."""
+
+    def test_status_format(self, mock_redis):
+        _, mock_script = mock_redis
+        mock_script.return_value = [1, 3600000, 3600000]
+
+        with patch('utils.voice_duration_limiter._CONSUME_LUA', mock_script):
+            from utils.voice_duration_limiter import get_budget_status, DAILY_BUDGET_MS
+
+            status = get_budget_status('uid123')
+
+        assert status['daily_limit_ms'] == DAILY_BUDGET_MS
+        assert status['used_ms'] == 3600000
+        assert status['remaining_ms'] == 3600000
+        assert status['exhausted'] is False
+
+
+# ===========================================================================
+# Shared budget verification (all endpoints deduct from same pool)
+# ===========================================================================
+
+
+class TestSharedBudget:
+    """Verify that all three endpoints share the same Redis key namespace."""
+
+    def test_budget_key_format(self):
+        from utils.voice_duration_limiter import _budget_key
+
+        key = _budget_key('user_abc')
+        assert key == 'voice_duration:user_abc'
+
+    def test_different_uids_different_keys(self):
+        from utils.voice_duration_limiter import _budget_key
+
+        assert _budget_key('user_a') != _budget_key('user_b')
+
+
+# ===========================================================================
+# Constants
+# ===========================================================================
+
+
+class TestConstants:
+    def test_session_cap(self):
+        from utils.voice_duration_limiter import MAX_SESSION_DURATION_S
+
+        assert MAX_SESSION_DURATION_S == 120
+
+    def test_daily_budget(self):
+        from utils.voice_duration_limiter import DAILY_BUDGET_MS
+
+        assert DAILY_BUDGET_MS == 7_200_000  # 2 hours

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -72,14 +72,14 @@ for _, member in ipairs(entries) do
     end
 end
 
--- 3. Check budget (>= so used==budget is rejected too)
+-- 3. Check budget (> so users can consume the full allowance)
 -- Skip check when force=1 (post-session recording must always succeed)
 if force ~= 1 then
-    if used + request >= budget and request > 0 then
+    if used + request > budget and request > 0 then
         return {0, used, math.max(0, budget - used)}
     end
-    -- Probe-only (request==0): reject only when already at or over budget
-    if request == 0 and used >= budget then
+    -- Probe-only (request==0): reject only when already over budget
+    if request == 0 and used > budget then
         return {0, used, 0}
     end
 end

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -48,6 +48,7 @@ local now       = tonumber(ARGV[1])
 local window    = tonumber(ARGV[2])
 local budget    = tonumber(ARGV[3])
 local request   = tonumber(ARGV[4])
+local force     = tonumber(ARGV[5] or 0)  -- 1 = force-record (skip budget check)
 
 -- 1. Prune entries older than the rolling window
 local cutoff = now - window
@@ -57,24 +58,42 @@ redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
 local entries = redis.call('ZRANGE', key, 0, -1)
 local used = 0
 for _, member in ipairs(entries) do
-    -- member format: "timestamp_ms:duration_ms"
-    local sep = string.find(member, ':', 1, true)
-    if sep then
-        used = used + tonumber(string.sub(member, sep + 1))
+    -- member format: "timestamp_ms:duration_ms:nonce"
+    local sep1 = string.find(member, ':', 1, true)
+    if sep1 then
+        local sep2 = string.find(member, ':', sep1 + 1, true)
+        local dur_str
+        if sep2 then
+            dur_str = string.sub(member, sep1 + 1, sep2 - 1)
+        else
+            dur_str = string.sub(member, sep1 + 1)
+        end
+        used = used + tonumber(dur_str)
     end
 end
 
--- 3. Check budget
-if used + request > budget then
-    return {0, used, math.max(0, budget - used)}
+-- 3. Check budget (>= so used==budget is rejected too)
+-- Skip check when force=1 (post-session recording must always succeed)
+if force ~= 1 then
+    if used + request >= budget and request > 0 then
+        return {0, used, math.max(0, budget - used)}
+    end
+    -- Probe-only (request==0): reject only when already at or over budget
+    if request == 0 and used >= budget then
+        return {0, used, 0}
+    end
 end
 
 -- 4. Record consumption (skip if request is zero — probe-only call)
 if request > 0 then
-    local member = tostring(math.floor(now * 1000)) .. ':' .. tostring(request)
+    -- Use INCR counter as nonce to guarantee unique members even within
+    -- the same millisecond (prevents ZADD overwrite under concurrency).
+    local counter = redis.call('INCR', key .. ':seq')
+    local member = tostring(math.floor(now * 1000)) .. ':' .. tostring(request) .. ':' .. tostring(counter)
     redis.call('ZADD', key, now, member)
     -- Set TTL = window + 1h buffer so the key self-cleans
     redis.call('EXPIRE', key, window + 3600)
+    redis.call('EXPIRE', key .. ':seq', window + 3600)
 end
 
 return {1, used + request, math.max(0, budget - used - request)}
@@ -137,14 +156,26 @@ def record_actual_duration(uid: str, duration_ms: int) -> bool:
 
     For WebSocket sessions where the exact duration isn't known upfront,
     call this after the session ends with the actual duration.
+    Uses force-record to always persist the usage even if over budget,
+    so the overspend is tracked for subsequent requests.
 
     Returns True on success, False on error (but still fail-open).
     """
     if duration_ms <= 0:
         return True
 
-    allowed, _, _ = try_consume_budget(uid, duration_ms)
-    return allowed
+    if _CONSUME_LUA is None:
+        return True
+
+    try:
+        _CONSUME_LUA(
+            keys=[_budget_key(uid)],
+            args=[time.time(), _WINDOW_S, DAILY_BUDGET_MS, duration_ms, 1],  # force=1
+        )
+        return True
+    except Exception as e:
+        logger.error(f'voice_duration_limiter: Redis error recording duration for uid={uid}: {e}')
+        return True  # Fail-open
 
 
 def get_budget_status(uid: str) -> dict:

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -238,6 +238,9 @@ def read_wav_duration_ms(file_path: str) -> int | None:
                 chunk_id = chunk_header[:4]
                 chunk_size = struct.unpack('<I', chunk_header[4:8])[0]
 
+                # RIFF chunks are padded to even byte boundaries
+                pad = chunk_size % 2
+
                 if chunk_id == b'fmt ':
                     if chunk_size < 16:
                         return None
@@ -246,15 +249,15 @@ def read_wav_duration_ms(file_path: str) -> int | None:
                         return None
                     sample_rate = struct.unpack('<I', fmt_data[4:8])[0]
                     byte_rate = struct.unpack('<I', fmt_data[8:12])[0]
-                    # Skip remaining fmt data if any
-                    remaining = chunk_size - len(fmt_data)
+                    # Skip remaining fmt data + pad byte if any
+                    remaining = chunk_size - len(fmt_data) + pad
                     if remaining > 0:
                         f.seek(remaining, 1)
                 elif chunk_id == b'data':
                     data_size = chunk_size
                     break
                 else:
-                    f.seek(chunk_size, 1)
+                    f.seek(chunk_size + pad, 1)
 
             if sample_rate and byte_rate and data_size and byte_rate > 0:
                 duration_s = data_size / byte_rate

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -17,6 +17,7 @@ Constants:
 """
 
 import logging
+import struct
 import time
 
 from database.redis_db import r
@@ -218,8 +219,6 @@ def read_wav_duration_ms(file_path: str) -> int | None:
     Returns duration in milliseconds, or None if the file cannot be read
     or has an invalid/unsupported format.
     """
-    import struct
-
     try:
         with open(file_path, 'rb') as f:
             # Read RIFF header

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -1,0 +1,236 @@
+"""
+Voice-message audio-duration budget enforcement.
+
+Shared rolling 24h budget across all three voice-message STT endpoints
+(/v2/voice-message/transcribe, /v2/voice-message/transcribe-stream,
+/v2/voice-messages) to prevent unbounded Deepgram cost.
+
+Design:
+- Single Redis sorted set per UID with minute-granularity buckets.
+- Atomic Lua script: prune stale entries → sum consumed → reject or record.
+- Fail-open on Redis errors (consistent with existing rate limiting).
+- Separate namespace from fair_use.py DG budget (different purpose/scope).
+
+Constants:
+- MAX_SESSION_DURATION_S: 120 seconds per request/session.
+- DAILY_BUDGET_MS: 7,200,000 ms (2 hours) per rolling 24h window.
+"""
+
+import logging
+import time
+
+from database.redis_db import r
+
+logger = logging.getLogger(__name__)
+
+MAX_SESSION_DURATION_S = 120
+DAILY_BUDGET_MS = 7_200_000
+_WINDOW_S = 86400  # 24 hours in seconds
+
+# ---------------------------------------------------------------------------
+# Lua script: atomic consume-or-reject for the rolling-window duration budget.
+#
+# KEYS[1] = sorted-set key  (voice_duration:{uid})
+# ARGV[1] = current timestamp (seconds, float)
+# ARGV[2] = window size (seconds)
+# ARGV[3] = budget limit (ms)
+# ARGV[4] = duration to consume (ms)
+#
+# Returns: [allowed (0/1), used_ms, remaining_ms]
+#
+# The sorted set stores (score=timestamp, member=timestamp:random) with value
+# encoded in the member as "timestamp_ms:duration_ms".  We use the score for
+# range pruning and parse the member for summing.
+# ---------------------------------------------------------------------------
+_CONSUME_LUA_SRC = """
+local key       = KEYS[1]
+local now       = tonumber(ARGV[1])
+local window    = tonumber(ARGV[2])
+local budget    = tonumber(ARGV[3])
+local request   = tonumber(ARGV[4])
+
+-- 1. Prune entries older than the rolling window
+local cutoff = now - window
+redis.call('ZREMRANGEBYSCORE', key, '-inf', cutoff)
+
+-- 2. Sum consumed ms from remaining entries
+local entries = redis.call('ZRANGE', key, 0, -1)
+local used = 0
+for _, member in ipairs(entries) do
+    -- member format: "timestamp_ms:duration_ms"
+    local sep = string.find(member, ':', 1, true)
+    if sep then
+        used = used + tonumber(string.sub(member, sep + 1))
+    end
+end
+
+-- 3. Check budget
+if used + request > budget then
+    return {0, used, math.max(0, budget - used)}
+end
+
+-- 4. Record consumption (skip if request is zero — probe-only call)
+if request > 0 then
+    local member = tostring(math.floor(now * 1000)) .. ':' .. tostring(request)
+    redis.call('ZADD', key, now, member)
+    -- Set TTL = window + 1h buffer so the key self-cleans
+    redis.call('EXPIRE', key, window + 3600)
+end
+
+return {1, used + request, math.max(0, budget - used - request)}
+"""
+
+try:
+    _CONSUME_LUA = r.register_script(_CONSUME_LUA_SRC)
+except Exception:
+    _CONSUME_LUA = None
+    logger.warning('voice_duration_limiter: failed to register Lua script (Redis unavailable?)')
+
+
+def _budget_key(uid: str) -> str:
+    return f'voice_duration:{uid}'
+
+
+def try_consume_budget(uid: str, duration_ms: int) -> tuple[bool, int, int]:
+    """Atomically try to consume duration_ms from the user's rolling 24h budget.
+
+    Args:
+        uid: User ID.
+        duration_ms: Duration to consume in milliseconds.
+
+    Returns:
+        (allowed, used_ms, remaining_ms).
+        On Redis error: (True, 0, DAILY_BUDGET_MS) — fail-open.
+    """
+    if duration_ms < 0:
+        return True, 0, DAILY_BUDGET_MS
+
+    if _CONSUME_LUA is None:
+        return True, 0, DAILY_BUDGET_MS
+
+    try:
+        result = _CONSUME_LUA(
+            keys=[_budget_key(uid)],
+            args=[time.time(), _WINDOW_S, DAILY_BUDGET_MS, duration_ms],
+        )
+        allowed = bool(result[0])
+        used_ms = int(result[1])
+        remaining_ms = int(result[2])
+        return allowed, used_ms, remaining_ms
+    except Exception as e:
+        logger.error(f'voice_duration_limiter: Redis error for uid={uid}: {e}')
+        return True, 0, DAILY_BUDGET_MS
+
+
+def check_budget(uid: str) -> tuple[bool, int, int]:
+    """Check remaining budget without consuming.
+
+    Returns:
+        (has_budget, used_ms, remaining_ms).
+        On Redis error: (True, 0, DAILY_BUDGET_MS) — fail-open.
+    """
+    return try_consume_budget(uid, 0)
+
+
+def record_actual_duration(uid: str, duration_ms: int) -> bool:
+    """Record actual consumed duration (used by WebSocket on session end).
+
+    For WebSocket sessions where the exact duration isn't known upfront,
+    call this after the session ends with the actual duration.
+
+    Returns True on success, False on error (but still fail-open).
+    """
+    if duration_ms <= 0:
+        return True
+
+    allowed, _, _ = try_consume_budget(uid, duration_ms)
+    return allowed
+
+
+def get_budget_status(uid: str) -> dict:
+    """Get the current budget status for a user.
+
+    Returns dict with: daily_limit_ms, used_ms, remaining_ms, exhausted.
+    """
+    has_budget, used_ms, remaining_ms = check_budget(uid)
+    return {
+        'daily_limit_ms': DAILY_BUDGET_MS,
+        'used_ms': used_ms,
+        'remaining_ms': remaining_ms,
+        'exhausted': not has_budget,
+    }
+
+
+def compute_pcm_duration_ms(byte_length: int, sample_rate: int, channels: int) -> int:
+    """Compute audio duration in milliseconds from PCM byte length.
+
+    PCM 16-bit: bytes = samples * channels * 2
+    duration_s = samples / sample_rate = bytes / (sample_rate * channels * 2)
+    """
+    bytes_per_second = sample_rate * channels * 2
+    if bytes_per_second <= 0:
+        return 0
+    return int((byte_length / bytes_per_second) * 1000)
+
+
+def compute_max_pcm_bytes(sample_rate: int, channels: int, max_duration_s: int = MAX_SESSION_DURATION_S) -> int:
+    """Compute maximum PCM byte size for a given duration.
+
+    Returns the byte limit that corresponds to max_duration_s at the given format.
+    """
+    return sample_rate * channels * 2 * max_duration_s
+
+
+def read_wav_duration_ms(file_path: str) -> int | None:
+    """Read duration from a WAV file header.
+
+    Returns duration in milliseconds, or None if the file cannot be read
+    or has an invalid/unsupported format.
+    """
+    import struct
+
+    try:
+        with open(file_path, 'rb') as f:
+            # Read RIFF header
+            riff = f.read(12)
+            if len(riff) < 12 or riff[:4] != b'RIFF' or riff[8:12] != b'WAVE':
+                return None
+
+            # Find 'fmt ' chunk
+            sample_rate = None
+            byte_rate = None
+            data_size = None
+
+            while True:
+                chunk_header = f.read(8)
+                if len(chunk_header) < 8:
+                    break
+                chunk_id = chunk_header[:4]
+                chunk_size = struct.unpack('<I', chunk_header[4:8])[0]
+
+                if chunk_id == b'fmt ':
+                    if chunk_size < 16:
+                        return None
+                    fmt_data = f.read(min(chunk_size, 40))
+                    if len(fmt_data) < 16:
+                        return None
+                    sample_rate = struct.unpack('<I', fmt_data[4:8])[0]
+                    byte_rate = struct.unpack('<I', fmt_data[8:12])[0]
+                    # Skip remaining fmt data if any
+                    remaining = chunk_size - len(fmt_data)
+                    if remaining > 0:
+                        f.seek(remaining, 1)
+                elif chunk_id == b'data':
+                    data_size = chunk_size
+                    break
+                else:
+                    f.seek(chunk_size, 1)
+
+            if sample_rate and byte_rate and data_size and byte_rate > 0:
+                duration_s = data_size / byte_rate
+                return int(duration_s * 1000)
+
+            return None
+    except Exception as e:
+        logger.warning(f'voice_duration_limiter: failed to read WAV header from {file_path}: {e}')
+        return None

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -17,8 +17,9 @@ Constants:
 """
 
 import logging
-import struct
 import time
+
+import av
 
 from database.redis_db import r
 
@@ -214,56 +215,19 @@ def compute_max_pcm_bytes(sample_rate: int, channels: int, max_duration_s: int =
 
 
 def read_wav_duration_ms(file_path: str) -> int | None:
-    """Read duration from a WAV file header.
+    """Read audio duration using PyAV (FFmpeg).
 
     Returns duration in milliseconds, or None if the file cannot be read
     or has an invalid/unsupported format.
     """
     try:
-        with open(file_path, 'rb') as f:
-            # Read RIFF header
-            riff = f.read(12)
-            if len(riff) < 12 or riff[:4] != b'RIFF' or riff[8:12] != b'WAVE':
+        with av.open(file_path) as container:
+            if not container.streams.audio:
                 return None
-
-            # Find 'fmt ' chunk
-            sample_rate = None
-            byte_rate = None
-            data_size = None
-
-            while True:
-                chunk_header = f.read(8)
-                if len(chunk_header) < 8:
-                    break
-                chunk_id = chunk_header[:4]
-                chunk_size = struct.unpack('<I', chunk_header[4:8])[0]
-
-                # RIFF chunks are padded to even byte boundaries
-                pad = chunk_size % 2
-
-                if chunk_id == b'fmt ':
-                    if chunk_size < 16:
-                        return None
-                    fmt_data = f.read(min(chunk_size, 40))
-                    if len(fmt_data) < 16:
-                        return None
-                    sample_rate = struct.unpack('<I', fmt_data[4:8])[0]
-                    byte_rate = struct.unpack('<I', fmt_data[8:12])[0]
-                    # Skip remaining fmt data + pad byte if any
-                    remaining = chunk_size - len(fmt_data) + pad
-                    if remaining > 0:
-                        f.seek(remaining, 1)
-                elif chunk_id == b'data':
-                    data_size = chunk_size
-                    break
-                else:
-                    f.seek(chunk_size + pad, 1)
-
-            if sample_rate and byte_rate and data_size and byte_rate > 0:
-                duration_s = data_size / byte_rate
-                return int(duration_s * 1000)
-
-            return None
+            duration_s = float(container.duration) / av.time_base
+            if duration_s <= 0:
+                return None
+            return int(duration_s * 1000)
     except Exception as e:
-        logger.warning(f'voice_duration_limiter: failed to read WAV header from {file_path}: {e}')
+        logger.warning(f'voice_duration_limiter: failed to read audio duration from {file_path}: {e}')
         return None


### PR DESCRIPTION
Closes #6463

Adds shared rolling 24h audio-duration budget enforcement across all three voice-message STT endpoints (`/v2/voice-message/transcribe`, `/v2/voice-message/transcribe-stream`, `/v2/voice-messages`) to prevent unbounded Deepgram cost from authenticated users. No per-session cap — heavy users can send long messages freely within the daily budget.

## Changes
- New `utils/voice_duration_limiter.py`: atomic Redis Lua script for concurrent-safe budget tracking (sorted set with INCR nonce), fail-open on Redis errors, PyAV-based audio duration reader, PCM byte-to-duration computation
- `routers/chat.py`: daily budget check/consume on all endpoints, 200MB body size guard on octet-stream, WS audio-idle timeout (60s — only binary audio frames reset the timer), WS in-session budget enforcement (closes 1008 when cumulative audio exceeds remaining daily budget), `record_actual_duration` in finally block for WS
- 87 unit tests covering all enforcement paths, budget lifecycle, boundary cases, mid-session WS enforcement, body size guard, and fail-open behavior
- Budget constants: 7,200,000ms (2h) rolling 24h window, no per-session cap

## Design decisions
- Budget boundary uses `>` (not `>=`) so users can consume the full 2hr allowance
- Audio duration read via PyAV (`av.open()`) — already a dependency, handles all container formats reliably (replaced hand-rolled RIFF parser)
- WS idle timeout is audio-idle: tracks last binary audio frame timestamp, not last message — prevents "finalize" text frames from keeping the connection alive
- WS in-session enforcement: captures `remaining_ms` at connect, compares cumulative `compute_pcm_duration_ms(total_audio_bytes)` on each frame — prevents a single long session from bypassing the daily limit (pure integer comparison, no Redis call during session)
- WS mid-session close checks budget BEFORE incrementing total_audio_bytes — triggering frame is not billed since it never reaches Deepgram
- Force-record mode for WS post-session recording (always persists even if over budget, so overspend is tracked)
- Fail-open on all Redis errors (consistent with existing rate limiting)
- 200MB hard cap on octet-stream body to prevent memory exhaustion

## Deployment
Standard backend deploy via `gcp_backend.yml`. No Redis migration, no Helm changes, no new env vars. Uses existing Redis connection with new sorted set key pattern `voice_duration:{uid}` (self-cleaning via Lua pruning). `av==12.0.0` already in `requirements.txt`. Fail-open on Redis errors. Rollback = standard Cloud Run revision rollback.

## Testing
- 87 unit tests pass (30 voice_duration_limiter + 57 desktop_transcribe)
- L1 live tests against running backend with real Redis Cloud:

| # | Test | Expected | Result |
|---|------|----------|--------|
| 1 | Octet-stream happy path | 200 | PASS |
| 2 | Body size guard (>200MB) | 413 | PASS |
| 3 | Budget exhausted | 429 | PASS |
| 4 | Invalid sample_rate | 422 | PASS |
| 5 | Empty body | 400 | PASS |
| 6 | WS happy path | Normal close | PASS |
| 7 | WS budget exhausted at connect | 1008 close | PASS |

---
_by AI for @beastoin_