### PR TITLE
fix(ios): reconnect stale BLE peripherals on app foreground

### DIFF
--- a/app/ios/Runner/AppDelegate.swift
+++ b/app/ios/Runner/AppDelegate.swift
@@ -242,6 +242,11 @@ extension FlutterError: Error {}
       completionHandler(exportedMappings.isEmpty ? .noData : .newData)
   }
 
+  override func applicationWillEnterForeground(_ application: UIApplication) {
+    super.applicationWillEnterForeground(application)
+    OmiBleManager.shared.reconnectStalePeripherals()
+  }
+
   override func applicationWillTerminate(_ application: UIApplication) {
     OmiBleManager.shared.disconnectAllPeripherals()
 

--- a/app/ios/Runner/OmiBleManager.swift
+++ b/app/ios/Runner/OmiBleManager.swift
@@ -146,13 +146,17 @@ final class OmiBleManager: NSObject {
         return peripherals[uuid]?.state == .connected
     }
 
-    /// Re-issue `connect()` on any known peripheral that isn't currently connected
-    /// and wasn't manually disconnected. Safe to call whenever the app returns to
-    /// the foreground — `centralManager.connect` is idempotent and pending connects
+    /// Re-issue `connect()` on any previously-connected peripheral that isn't
+    /// currently connected and wasn't manually disconnected. Scan-discovered
+    /// peripherals that never completed a connection are excluded via the
+    /// `everConnected` guard so we don't try to connect to unrelated devices
+    /// picked up during a scan. Safe to call whenever the app returns to the
+    /// foreground — `centralManager.connect` is idempotent and pending connects
     /// cost nothing while iOS waits at the chipset level.
     func reconnectStalePeripherals() {
         guard centralManager.state == .poweredOn else { return }
         for (uuid, peripheral) in peripherals {
+            guard everConnected.contains(uuid) else { continue }
             if manuallyDisconnected.contains(uuid) { continue }
             switch peripheral.state {
             case .connected, .connecting:

--- a/app/ios/Runner/OmiBleManager.swift
+++ b/app/ios/Runner/OmiBleManager.swift
@@ -146,6 +146,25 @@ final class OmiBleManager: NSObject {
         return peripherals[uuid]?.state == .connected
     }
 
+    /// Re-issue `connect()` on any known peripheral that isn't currently connected
+    /// and wasn't manually disconnected. Safe to call whenever the app returns to
+    /// the foreground — `centralManager.connect` is idempotent and pending connects
+    /// cost nothing while iOS waits at the chipset level.
+    func reconnectStalePeripherals() {
+        guard centralManager.state == .poweredOn else { return }
+        for (uuid, peripheral) in peripherals {
+            if manuallyDisconnected.contains(uuid) { continue }
+            switch peripheral.state {
+            case .connected, .connecting:
+                continue
+            default:
+                NSLog("[OmiBle] Re-issuing connect on foreground for \(uuid), state=\(peripheral.state.rawValue)")
+                peripheral.delegate = self
+                centralManager.connect(peripheral, options: nil)
+            }
+        }
+    }
+
     // MARK: - Characteristic Operations
 
     func readCharacteristic(


### PR DESCRIPTION
## Summary

- Add `OmiBleManager.reconnectStalePeripherals()` that re-issues `connect()` on any known peripheral whose state isn't `connected`/`connecting` and wasn't manually disconnected.
- Hook `applicationWillEnterForeground` in `AppDelegate` to call it every time the app returns to the foreground.

## Why

The iOS auto-reconnect path in `didDisconnectPeripheral` schedules a single `central.connect(peripheral, nil)` 200 ms after a drop. That succeeds when the peripheral reappears shortly after. But if CoreBluetooth instead routes the attempt into `didFailToConnect` (peripheral out of range too long, chipset-level error, etc.), the handler currently just cleans up — no further retry is scheduled, and the peripheral ends up forgotten by the central manager. The app then stays stuck on `disconnected` until the user force-quits.

This most commonly shows up as: user backgrounds the app, walks out of BLE range (or the device dies/reboots), comes back into range later, opens the app — and has to force-quit to reconnect.

A foreground-resume sweep is a cheap, idempotent safety net: iOS pending connects cost nothing while waiting at the chipset level, so re-issuing them on every foreground recovers from any silently-terminated retry chain.

## Test plan

- [ ] Connect Omi, background app, move device out of range for several minutes until connection is lost
- [ ] Bring device back into range, foreground the app — verify it reconnects within a few seconds without needing a force-quit
- [ ] Verify a manually-disconnected peripheral stays disconnected after foregrounding (no auto-reconnect regression)
- [ ] Verify no regressions in the normal in-range foreground/background cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)