### PR TITLE
fix(backend): preserve conversations when LLM returns empty title (#5668)

### DIFF
--- a/backend/test.sh
+++ b/backend/test.sh
@@ -20,6 +20,7 @@ pytest tests/unit/test_user_speaker_embedding.py -v
 pytest tests/unit/test_memory_leak_buffers.py -v
 pytest tests/unit/test_llm_usage_tracker.py -v
 pytest tests/unit/test_process_conversation_usage_context.py -v
+pytest tests/unit/test_empty_title_no_discard.py -v
 pytest tests/unit/test_llm_usage_db.py -v
 pytest tests/unit/test_llm_usage_endpoints.py -v
 pytest tests/unit/test_app_uid_keyerror.py -v

--- a/backend/tests/unit/test_empty_title_no_discard.py
+++ b/backend/tests/unit/test_empty_title_no_discard.py
@@ -1,0 +1,214 @@
+"""Regression tests for #5668: empty LLM title must not silently discard conversations.
+
+These tests are pure — no DB, no network, no LLM calls. They verify that
+`_get_conversation_obj` accepts an explicit `discarded` parameter and respects
+it instead of re-deriving from `structured.title == ''`.
+"""
+
+import os
+import sys
+import types
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+os.environ.setdefault(
+    "ENCRYPTION_SECRET",
+    "omi_ZwB2ZNqB2HHpMK6wStk7sTpavJiPTFg7gXUHnc4tFABPU6pZ2c2DKgehtfgi4RZv",
+)
+
+
+# -- Module stubbing (mirrors test_process_conversation_usage_context.py) --
+# `utils.conversations.process_conversation` transitively imports heavy DB/LLM
+# packages (google-cloud-firestore, Pinecone, etc.) that are not installed in
+# the unit-test env. We stub them here so the module under test can be imported.
+def _stub_module(name: str) -> types.ModuleType:
+    mod = types.ModuleType(name)
+    sys.modules[name] = mod
+    return mod
+
+
+database_mod = _stub_module("database")
+database_mod.__path__ = []
+for submodule in [
+    "redis_db",
+    "memories",
+    "conversations",
+    "notifications",
+    "users",
+    "tasks",
+    "trends",
+    "action_items",
+    "folders",
+    "calendar_meetings",
+    "vector_db",
+    "apps",
+    "llm_usage",
+    "_client",
+]:
+    mod = _stub_module(f"database.{submodule}")
+    setattr(database_mod, submodule, mod)
+
+vector_db_mod = sys.modules["database.vector_db"]
+for attr in [
+    "find_similar_memories",
+    "upsert_memory_vector",
+    "delete_memory_vector",
+    "upsert_vector2",
+    "update_vector_metadata",
+]:
+    setattr(vector_db_mod, attr, MagicMock())
+
+apps_mod = sys.modules["database.apps"]
+for attr in ["record_app_usage", "get_omi_personas_by_uid_db", "get_app_by_id_db"]:
+    setattr(apps_mod, attr, MagicMock())
+
+llm_usage_mod = sys.modules["database.llm_usage"]
+llm_usage_mod.record_llm_usage = MagicMock()
+
+client_mod = sys.modules["database._client"]
+client_mod.document_id_from_seed = MagicMock(return_value="doc-id")
+
+for name in [
+    "utils.apps",
+    "utils.analytics",
+    "utils.llm.memories",
+    "utils.llm.conversation_processing",
+    "utils.llm.external_integrations",
+    "utils.llm.trends",
+    "utils.llm.goals",
+    "utils.llm.chat",
+    "utils.llm.clients",
+    "utils.notifications",
+    "utils.other.hume",
+    "utils.retrieval.rag",
+    "utils.webhooks",
+    "utils.task_sync",
+    "utils.other.storage",
+]:
+    if name not in sys.modules:
+        sys.modules[name] = types.ModuleType(name)
+
+utils_apps = sys.modules["utils.apps"]
+for attr in ["get_available_apps", "update_personas_async", "sync_update_persona_prompt"]:
+    setattr(utils_apps, attr, MagicMock())
+
+utils_analytics = sys.modules["utils.analytics"]
+utils_analytics.record_usage = MagicMock()
+
+llm_memories = sys.modules["utils.llm.memories"]
+for attr in ["resolve_memory_conflict", "extract_memories_from_text", "new_memories_extractor"]:
+    setattr(llm_memories, attr, MagicMock())
+
+llm_conv = sys.modules["utils.llm.conversation_processing"]
+for attr in [
+    "get_transcript_structure",
+    "get_app_result",
+    "should_discard_conversation",
+    "select_best_app_for_conversation",
+    "get_suggested_apps_for_conversation",
+    "get_reprocess_transcript_structure",
+    "assign_conversation_to_folder",
+    "extract_action_items",
+]:
+    setattr(llm_conv, attr, MagicMock())
+
+llm_external = sys.modules["utils.llm.external_integrations"]
+for attr in ["summarize_experience_text", "get_message_structure"]:
+    setattr(llm_external, attr, MagicMock())
+
+llm_trends = sys.modules["utils.llm.trends"]
+llm_trends.trends_extractor = MagicMock()
+
+llm_goals = sys.modules["utils.llm.goals"]
+llm_goals.extract_and_update_goal_progress = MagicMock()
+
+llm_chat = sys.modules["utils.llm.chat"]
+for attr in [
+    "retrieve_metadata_from_text",
+    "retrieve_metadata_from_message",
+    "retrieve_metadata_fields_from_transcript",
+    "obtain_emotional_message",
+]:
+    setattr(llm_chat, attr, MagicMock())
+
+llm_clients = sys.modules["utils.llm.clients"]
+llm_clients.generate_embedding = MagicMock()
+
+utils_notifications = sys.modules["utils.notifications"]
+for attr in ["send_notification", "send_important_conversation_message", "send_action_item_data_message"]:
+    setattr(utils_notifications, attr, MagicMock())
+
+utils_hume = sys.modules["utils.other.hume"]
+for attr in ["get_hume", "HumeJobCallbackModel", "HumeJobModelPredictionResponseModel"]:
+    setattr(utils_hume, attr, MagicMock())
+
+utils_rag = sys.modules["utils.retrieval.rag"]
+utils_rag.retrieve_rag_conversation_context = MagicMock()
+
+utils_webhooks = sys.modules["utils.webhooks"]
+utils_webhooks.conversation_created_webhook = MagicMock()
+
+utils_task_sync = sys.modules["utils.task_sync"]
+utils_task_sync.auto_sync_action_items_batch = MagicMock()
+
+utils_storage = sys.modules["utils.other.storage"]
+utils_storage.precache_conversation_audio = MagicMock()
+
+
+# -- Test fixtures --
+from models.conversation import CreateConversation
+from models.structured import Structured
+from models.transcript_segment import TranscriptSegment
+from utils.conversations.process_conversation import _get_conversation_obj
+
+
+def _make_create_conversation(transcript_text: str = "Some real content.") -> CreateConversation:
+    """Build a minimal CreateConversation with one transcript segment."""
+    now = datetime.now(timezone.utc)
+    segment = TranscriptSegment(
+        text=transcript_text,
+        is_user=False,
+        start=0.0,
+        end=1.0,
+    )
+    return CreateConversation(
+        started_at=now,
+        finished_at=now,
+        transcript_segments=[segment],
+    )
+
+
+class TestGetConversationObjRespectsDiscardedParam:
+    """Regression tests for signal-loss fix in _get_conversation_obj."""
+
+    def test_empty_title_with_discarded_false_preserves_conversation(self):
+        """Key regression test for #5668: valid conversation with empty LLM title must not be discarded."""
+        structured = Structured(title='', overview='Real conversation content')
+        conv = _make_create_conversation()
+
+        result = _get_conversation_obj('uid_1', structured, conv, discarded=False)
+
+        assert result.discarded is False, (
+            "Conversation was silently discarded despite explicit discarded=False. "
+            "This is the #5668 bug: title == '' was used as a discard proxy."
+        )
+
+    def test_empty_title_with_discarded_true_marks_conversation_discarded(self):
+        """Protect the legitimate discard path — explicit discarded=True must still mark the conversation as discarded."""
+        structured = Structured(title='', emoji='🎉')
+        conv = _make_create_conversation()
+
+        result = _get_conversation_obj('uid_1', structured, conv, discarded=True)
+
+        assert result.discarded is True
+
+    def test_get_conversation_obj_default_discarded_is_false(self):
+        """Safety net: verify default parameter value with a valid LLM response preserves the conversation."""
+        structured = Structured(title='Valid title from LLM', overview='Some content')
+        conv = _make_create_conversation()
+
+        result = _get_conversation_obj('uid_1', structured, conv)
+
+        assert result.discarded is False

--- a/backend/tests/unit/test_empty_title_no_discard.py
+++ b/backend/tests/unit/test_empty_title_no_discard.py
@@ -161,7 +161,10 @@ utils_storage.precache_conversation_audio = MagicMock()
 from models.conversation import CreateConversation
 from models.structured import Structured
 from models.transcript_segment import TranscriptSegment
-from utils.conversations.process_conversation import _get_conversation_obj
+from utils.conversations.process_conversation import (
+    _fallback_title_for_empty_llm_response,
+    _get_conversation_obj,
+)
 
 
 def _make_create_conversation(transcript_text: str = "Some real content.") -> CreateConversation:
@@ -212,3 +215,49 @@ class TestGetConversationObjRespectsDiscardedParam:
         result = _get_conversation_obj('uid_1', structured, conv)
 
         assert result.discarded is False
+
+
+class TestFallbackTitleForEmptyLlmResponse:
+    """Unit tests for the deterministic fallback title helper."""
+
+    def test_fallback_prefers_overview_first_sentence(self):
+        structured = Structured(title='', overview='Budget meeting notes. Discussed Q2 goals and budget cuts.')
+        started_at = datetime(2026, 4, 15, tzinfo=timezone.utc)
+
+        result = _fallback_title_for_empty_llm_response(structured, started_at)
+
+        assert result == 'Budget meeting notes'
+
+    def test_fallback_uses_date_when_overview_empty(self):
+        structured = Structured(title='', overview='')
+        started_at = datetime(2026, 4, 15, tzinfo=timezone.utc)
+
+        result = _fallback_title_for_empty_llm_response(structured, started_at)
+
+        assert result == 'Conversation on Apr 15, 2026'
+
+    def test_fallback_skips_overly_long_overview_first_sentence(self):
+        """Long overview first sentence should fall through to date fallback rather than becoming a noisy title."""
+        long_sentence = 'This is an unusually long first sentence of the overview that exceeds sixty characters of text'
+        structured = Structured(title='', overview=f"{long_sentence}. Rest.")
+        started_at = datetime(2026, 4, 15, tzinfo=timezone.utc)
+
+        result = _fallback_title_for_empty_llm_response(structured, started_at)
+
+        assert result == 'Conversation on Apr 15, 2026'
+
+    def test_fallback_handles_missing_started_at(self):
+        structured = Structured(title='', overview='')
+
+        result = _fallback_title_for_empty_llm_response(structured, None)
+
+        assert result == 'Untitled Conversation'
+
+    def test_fallback_skips_single_word_first_sentence(self):
+        """Avoid noisy one-word titles from abbreviations ('Dr. Smith...') or decimals ('Scored 3.5...')."""
+        structured = Structured(title='', overview='Dr. Smith met with the team.')
+        started_at = datetime(2026, 4, 15, tzinfo=timezone.utc)
+
+        result = _fallback_title_for_empty_llm_response(structured, started_at)
+
+        assert result == 'Conversation on Apr 15, 2026'

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -218,8 +218,15 @@ def _get_conversation_obj(
     uid: str,
     structured: Structured,
     conversation: Union[Conversation, CreateConversation, ExternalIntegrationCreateConversation],
+    discarded: bool = False,
 ):
-    discarded = structured.title == ''
+    # The authoritative `discarded` signal is passed by the caller from
+    # `_get_structured`, which already applies the `should_discard_conversation`
+    # heuristic to transcript content. Previously this function re-derived
+    # `discarded = structured.title == ''`, which silently dropped valid
+    # conversations whenever the LLM returned an empty title (see #5668).
+    # The default `False` is a safety net: any future caller that forgets to
+    # pass a value will preserve the conversation rather than silently drop it.
     if isinstance(conversation, CreateConversation):
         conversation_dict = conversation.dict()
         # Store calendar context in external_data if available
@@ -654,7 +661,7 @@ def process_conversation(
         people = [Person(**p) for p in people_data]
 
     structured, discarded = _get_structured(uid, language_code, conversation, force_process, people=people)
-    conversation = _get_conversation_obj(uid, structured, conversation)
+    conversation = _get_conversation_obj(uid, structured, conversation, discarded=discarded)
 
     # AI-based folder assignment
     assigned_folder_id = None

--- a/backend/utils/conversations/process_conversation.py
+++ b/backend/utils/conversations/process_conversation.py
@@ -76,6 +76,56 @@ from utils.other.storage import precache_conversation_audio
 logger = logging.getLogger(__name__)
 
 
+_FALLBACK_TITLE_MONTH_ABBR = (
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+)
+
+
+def _fallback_title_for_empty_llm_response(
+    structured: Structured,
+    started_at: Optional[datetime],
+) -> str:
+    """
+    Produce a deterministic fallback title when the conversation-processing
+    LLM returns an empty title for a conversation with substantive content.
+
+    Preference order:
+      1. First sentence of the LLM-generated overview (if >= 2 words and <= 60 chars).
+      2. Date-stamped label (e.g. "Conversation on Apr 15, 2026").
+      3. Static fallback "Untitled Conversation" when no date is available.
+
+    Notes:
+      * The 2-word minimum avoids producing noisy one-word titles when overview
+        begins with an abbreviation ("Dr. Smith met..." → first_sentence=="Dr")
+        or a decimal ("Scored 3.5..." → first_sentence=="Scored 3").
+      * Month name is hard-coded in English rather than using strftime('%b')
+        so the label is locale-independent (strftime is locale-sensitive and
+        would return "avr." on an fr_FR.UTF-8 system).
+
+    No LLM retry — intentionally cheap and deterministic. See #5668.
+    """
+    overview = (structured.overview or '').strip()
+    if overview:
+        first_sentence = overview.split('.')[0].strip()
+        if len(first_sentence.split()) >= 2 and len(first_sentence) <= 60:
+            return first_sentence
+    if started_at:
+        month_abbr = _FALLBACK_TITLE_MONTH_ABBR[started_at.month - 1]
+        return f"Conversation on {month_abbr} {started_at.day}, {started_at.year}"
+    return "Untitled Conversation"
+
+
 def _get_structured(
     uid: str,
     language_code: str,
@@ -208,6 +258,15 @@ def _get_structured(
                 calendar_meeting_context=calendar_context,
                 output_language_code=user_language,
             )
+
+        # Belt-and-suspenders: the signal fix in `_get_conversation_obj`
+        # guarantees this conversation is not silently discarded, but an
+        # empty LLM title would still render as '' in the UI and break
+        # search indexing. Apply a deterministic fallback for substantive
+        # transcripts (>=100 words) so users always see a label. See #5668.
+        if not structured.title.strip() and len(transcript_text.split()) >= 100:
+            structured.title = _fallback_title_for_empty_llm_response(structured, conversation.started_at)
+
         return structured, False
     except Exception as e:
         logger.error(e)


### PR DESCRIPTION
## Summary

Fixes #5668 — P1 data-loss bug where valid conversations were silently discarded when the LLM returned an empty title.

Two-part fix, split across two commits for reviewability:

1. **`fix(backend)` — root-cause signal fix.** `_get_conversation_obj` was re-deriving `discarded` from `structured.title == ''`. The authoritative `discarded` bool is already correctly computed by `_get_structured` via `should_discard_conversation`, and is used correctly downstream for folder assignment and analytics. It was just being dropped at the `_get_conversation_obj` call boundary. This commit passes it explicitly and removes the fragile title-based proxy. Default value is `False` so any future caller that forgets to pass it preserves the conversation rather than silently dropping it.

2. **`feat(backend)` — deterministic fallback title.** Even with silent-discard protection, an empty title still renders as `""` in the UI and breaks search indexing. When the main transcript path's LLM call returns empty title for a transcript ≥100 words, a deterministic fallback is applied (preferring overview first-sentence with a ≥2-word guard, then a locale-independent date label, then `"Untitled Conversation"`). No retry LLM call — intentionally cheap.

## Scope

- **Fix (1) protects all 5 return paths** of `_get_structured` from silent discard (main transcript, force-process/reprocess, external-integration audio/message/other).
- **Fix (2) is scoped to the main transcript path only.** External integrations typically get titles from their source systems (Limitless, iOS Shortcuts, etc.); force-process preserves the existing title as an LLM hint. Those paths are protected from data loss by fix (1) but don't get cosmetic fallback titles — keeping the PR narrow.

## Files

- `backend/utils/conversations/process_conversation.py` — signature change, new helper, fallback trigger, caller update
- `backend/tests/unit/test_empty_title_no_discard.py` — **new** — 8 pure unit tests
- `backend/test.sh` — register new test file

## Note on line numbers

The issue cites some stale line numbers (`conversation.py:169-170`, `process_conversation.py:209`). Since the issue was filed, `Structured` was extracted into its own module (`models/structured.py`) and the `title == ''` check is now at `process_conversation.py:222`. The bug itself is unchanged.

## Implementation details worth knowing

- **Locale-independent date formatting**: uses a hard-coded English month-abbreviation tuple rather than `strftime('%b %d, %Y')`, which is locale-sensitive (returns `\"avr.\"` on `fr_FR.UTF-8`). This makes the fallback and its tests deterministic on any developer's machine.
- **2-word minimum on overview first sentence**: avoids noisy one-word titles like `\"Dr\"` (from \"Dr. Smith met with...\") or `\"Scored 3\"` (from \"Scored 3.5 on...\").
- **Pure unit tests**: all 8 tests avoid mocking `_get_structured`. Stubbing of heavy transitive imports (Firestore, Pinecone, RAG, etc.) follows the same pattern as `test_process_conversation_usage_context.py`.

## Out of scope

- Retry LLM title generation (extra cost for an edge case)
- Making `Structured.title` a required Pydantic field (would break ≥6 placeholder construction sites in `transcribe.py`, `merge_conversations.py`, `conversation_processing.py`)
- Fallback titles for external-integration and force-process paths

## Potential follow-up (for post-merge, not this PR)

- Add a \`logger.info(...)\` at the fallback trigger site for observability — would let maintainers spot LLM regressions via log volume without waiting for user reports.

## Test plan

- [x] \`pytest tests/unit/test_empty_title_no_discard.py -v\` → **8/8 passing**
- [x] \`pytest tests/unit/test_conversation_model_split.py -v\` → unchanged, existing assertions (\`Structured().title == ''\` default) still pass
- [x] \`bash test.sh\` run locally (new test registered)
- [x] \`black --line-length 120 --skip-string-normalization\` applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)