### PR TITLE
feat(admin): analytics dashboard polish (position + scroll restore + cache)

### DIFF
--- a/web/admin/app/(protected)/dashboard/analytics/page.tsx
+++ b/web/admin/app/(protected)/dashboard/analytics/page.tsx
@@ -595,6 +595,69 @@ export default function AnalyticsPage() {
         </Card>
       </div>
 
+      {/* Cumulative Total Users — headline chart, right after the revenue KPIs */}
+      <Card className="p-6">
+        <div className="flex items-start justify-between mb-1">
+          <div>
+            <h2 className="text-lg font-semibold">Cumulative Users</h2>
+            <p className="text-sm text-muted-foreground">Total users across all platforms</p>
+          </div>
+          <div className="flex rounded-md border border-input overflow-hidden">
+            {(["7d", "30d", "all"] as const).map((w) => (
+              <button
+                key={w}
+                onClick={() => setCumulativeWindow(w)}
+                className={`px-2.5 py-1 text-xs font-medium transition-colors ${
+                  cumulativeWindow === w
+                    ? "bg-primary text-primary-foreground"
+                    : "bg-background text-muted-foreground hover:bg-accent"
+                }`}
+              >
+                {w === "7d" ? "Last week" : w === "30d" ? "Last month" : "All time"}
+              </button>
+            ))}
+          </div>
+        </div>
+        <div className="h-[350px] mt-4">
+          {dailyNewUsersLoading ? (
+            <div className="flex items-center justify-center h-full">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : cumulativeSeries.length > 0 ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <AreaChart data={cumulativeSeries}>
+                <defs>
+                  <linearGradient id="cumulativeGradient" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis
+                  dataKey="date"
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={shortDate}
+                  minTickGap={40}
+                />
+                <YAxis
+                  className="text-xs"
+                  tick={{ fill: "hsl(var(--muted-foreground))" }}
+                  tickFormatter={formatCompact}
+                  domain={cumulativeYDomain}
+                  allowDataOverflow={false}
+                  width={56}
+                />
+                <Tooltip formatter={(value: number) => [value.toLocaleString(), "Total Users"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
+                <Area type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={2} fill="url(#cumulativeGradient)" dot={false} activeDot={{ r: 4 }} />
+              </AreaChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+          )}
+        </div>
+      </Card>
+
       {/* MRR Trend */}
       <Card className="p-6">
         <h2 className="text-lg font-semibold mb-1">MRR Over Time</h2>
@@ -1307,96 +1370,30 @@ export default function AnalyticsPage() {
         </div>
       </Card>
 
-      {/* Two charts side by side: Cumulative Users + DAU */}
-      <div className="grid gap-6 lg:grid-cols-2">
-        {/* Cumulative Total Users */}
-        <Card className="p-6">
-          <div className="flex items-start justify-between mb-1">
-            <div>
-              <h2 className="text-lg font-semibold">Cumulative Users</h2>
-              <p className="text-sm text-muted-foreground">Total users across all platforms</p>
+      {/* Daily Active Users */}
+      <Card className="p-6">
+        <h2 className="text-lg font-semibold mb-1">Daily Active Users</h2>
+        <p className="text-sm text-muted-foreground mb-4">Unique macOS users per day</p>
+        <div className="h-[300px]">
+          {dauLoading ? (
+            <div className="flex items-center justify-center h-full">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
             </div>
-            <div className="flex rounded-md border border-input overflow-hidden">
-              {(["7d", "30d", "all"] as const).map((w) => (
-                <button
-                  key={w}
-                  onClick={() => setCumulativeWindow(w)}
-                  className={`px-2.5 py-1 text-xs font-medium transition-colors ${
-                    cumulativeWindow === w
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-background text-muted-foreground hover:bg-accent"
-                  }`}
-                >
-                  {w === "7d" ? "Last week" : w === "30d" ? "Last month" : "All time"}
-                </button>
-              ))}
-            </div>
-          </div>
-          <div className="h-[300px] mt-4">
-            {dailyNewUsersLoading ? (
-              <div className="flex items-center justify-center h-full">
-                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              </div>
-            ) : cumulativeSeries.length > 0 ? (
-              <ResponsiveContainer width="100%" height="100%">
-                <AreaChart data={cumulativeSeries}>
-                  <defs>
-                    <linearGradient id="cumulativeGradient" x1="0" y1="0" x2="0" y2="1">
-                      <stop offset="5%" stopColor="#22c55e" stopOpacity={0.3} />
-                      <stop offset="95%" stopColor="#22c55e" stopOpacity={0} />
-                    </linearGradient>
-                  </defs>
-                  <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                  <XAxis
-                    dataKey="date"
-                    className="text-xs"
-                    tick={{ fill: "hsl(var(--muted-foreground))" }}
-                    tickFormatter={shortDate}
-                    minTickGap={40}
-                  />
-                  <YAxis
-                    className="text-xs"
-                    tick={{ fill: "hsl(var(--muted-foreground))" }}
-                    tickFormatter={formatCompact}
-                    domain={cumulativeYDomain}
-                    allowDataOverflow={false}
-                    width={56}
-                  />
-                  <Tooltip formatter={(value: number) => [value.toLocaleString(), "Total Users"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
-                  <Area type="monotone" dataKey="cumulative" stroke="#22c55e" strokeWidth={2} fill="url(#cumulativeGradient)" dot={false} activeDot={{ r: 4 }} />
-                </AreaChart>
-              </ResponsiveContainer>
-            ) : (
-              <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
-            )}
-          </div>
-        </Card>
-
-        {/* Daily Active Users */}
-        <Card className="p-6">
-          <h2 className="text-lg font-semibold mb-1">Daily Active Users</h2>
-          <p className="text-sm text-muted-foreground mb-4">Unique macOS users per day</p>
-          <div className="h-[300px]">
-            {dauLoading ? (
-              <div className="flex items-center justify-center h-full">
-                <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
-              </div>
-            ) : dauData.length > 0 ? (
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={dauData}>
-                  <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
-                  <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
-                  <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
-                  <Tooltip formatter={(value: number) => [value.toLocaleString(), "DAU"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
-                  <Bar dataKey="dau" name="DAU" fill="#f59e0b" radius={[2, 2, 0, 0]} />
-                </BarChart>
-              </ResponsiveContainer>
-            ) : (
-              <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
-            )}
-          </div>
-        </Card>
-      </div>
+          ) : dauData.length > 0 ? (
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart data={dauData}>
+                <CartesianGrid strokeDasharray="3 3" className="stroke-muted" />
+                <XAxis dataKey="date" className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} tickFormatter={shortDate} />
+                <YAxis className="text-xs" tick={{ fill: "hsl(var(--muted-foreground))" }} />
+                <Tooltip formatter={(value: number) => [value.toLocaleString(), "DAU"]} labelFormatter={fullDate} contentStyle={tooltipStyle} />
+                <Bar dataKey="dau" name="DAU" fill="#f59e0b" radius={[2, 2, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          ) : (
+            <div className="flex items-center justify-center h-full text-muted-foreground">No data available</div>
+          )}
+        </div>
+      </Card>
 
       {/* Crash Rate */}
       <Card className="p-6">

--- a/web/admin/app/(protected)/dashboard/layout.tsx
+++ b/web/admin/app/(protected)/dashboard/layout.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useAuth } from '@/components/auth-provider';
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 import { DashboardSidebar } from "@/components/dashboard/sidebar";
 import { DashboardHeader } from "@/components/dashboard/header";
 
@@ -13,6 +13,70 @@ const LoadingScreen = () => (
   </div>
 );
 
+const SCROLL_STORAGE_PREFIX = 'omi-admin-scroll:';
+
+function useScrollRestoration(
+  mainRef: React.RefObject<HTMLElement>,
+  enabled: boolean,
+) {
+  const pathname = usePathname();
+  const storageKey = `${SCROLL_STORAGE_PREFIX}${pathname ?? '/'}`;
+
+  // Restore scroll position on mount / route change. We poll briefly
+  // because the page content mounts and grows as SWR data arrives, so
+  // the target scrollTop may not be reachable on the first frame.
+  useEffect(() => {
+    if (!enabled) return;
+    const el = mainRef.current;
+    if (!el) return;
+
+    let saved: number | null = null;
+    try {
+      const raw = window.sessionStorage.getItem(storageKey);
+      if (raw != null) saved = parseInt(raw, 10);
+    } catch {
+      /* noop */
+    }
+    if (saved == null || Number.isNaN(saved)) return;
+
+    let tries = 0;
+    const maxTries = 40; // ~2s at 50ms cadence
+    const tick = () => {
+      const node = mainRef.current;
+      if (!node) return;
+      node.scrollTop = saved!;
+      if (Math.abs(node.scrollTop - saved!) > 2 && tries++ < maxTries) {
+        setTimeout(tick, 50);
+      }
+    };
+    tick();
+  }, [enabled, mainRef, storageKey]);
+
+  // Save scroll position as the user scrolls. Throttled via rAF.
+  useEffect(() => {
+    if (!enabled) return;
+    const el = mainRef.current;
+    if (!el) return;
+
+    let pending = false;
+    const onScroll = () => {
+      if (pending) return;
+      pending = true;
+      requestAnimationFrame(() => {
+        pending = false;
+        try {
+          window.sessionStorage.setItem(storageKey, String(el.scrollTop));
+        } catch {
+          /* noop */
+        }
+      });
+    };
+
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [enabled, mainRef, storageKey]);
+}
+
 export default function DashboardLayout({
   children,
 }: {
@@ -20,6 +84,9 @@ export default function DashboardLayout({
 }) {
   const { user, isAdmin, loading } = useAuth();
   const router = useRouter();
+  const mainRef = useRef<HTMLElement>(null);
+  const authenticated = !!(user && isAdmin && !loading);
+  useScrollRestoration(mainRef, authenticated);
 
   useEffect(() => {
     if (loading) {
@@ -43,7 +110,7 @@ export default function DashboardLayout({
         <DashboardSidebar />
         <div className="flex-1 flex flex-col min-h-screen">
           <DashboardHeader />
-          <main className="flex-1 p-4 md:p-6 overflow-y-auto">
+          <main ref={mainRef} className="flex-1 p-4 md:p-6 overflow-y-auto">
             {children}
           </main>
         </div>

--- a/web/admin/components/swr-provider.tsx
+++ b/web/admin/components/swr-provider.tsx
@@ -1,16 +1,104 @@
 'use client';
 
 import { SWRConfig } from 'swr';
-import { ReactNode } from 'react';
+import { ReactNode, useMemo } from 'react';
+
+// localStorage-backed SWR cache provider. On first render we rehydrate
+// any previously-cached responses so the dashboard paints instantly with
+// stale data, then SWR revalidates in the background. Every mutation of
+// the cache is mirrored back to localStorage inside a microtask so we
+// don't block renders on writes.
+//
+// We cap each entry at ~1MB and the total payload at ~5MB, because the
+// iOS/desktop webkit localStorage quota is 5MB per origin.
+const STORAGE_KEY = 'omi-admin-swr-cache-v1';
+const MAX_ENTRY_BYTES = 1_000_000;
+const MAX_TOTAL_BYTES = 5_000_000;
+
+type CacheEntry = { data: unknown; error: unknown; isValidating: boolean; isLoading: boolean };
+
+function createLocalStorageProvider(): Map<string, CacheEntry> {
+  if (typeof window === 'undefined') {
+    return new Map();
+  }
+
+  let hydrated: [string, CacheEntry][] = [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (raw) hydrated = JSON.parse(raw);
+  } catch (err) {
+    console.warn('SWR cache rehydrate failed:', err);
+  }
+
+  const map = new Map<string, CacheEntry>(hydrated);
+
+  let persistScheduled = false;
+  const schedulePersist = () => {
+    if (persistScheduled) return;
+    persistScheduled = true;
+    queueMicrotask(() => {
+      persistScheduled = false;
+      try {
+        // Only persist entries that actually carry data, skip errored /
+        // in-flight entries and anything too large to fit in the quota.
+        const entries: [string, CacheEntry][] = [];
+        let totalBytes = 0;
+        map.forEach((value, key) => {
+          if (totalBytes >= MAX_TOTAL_BYTES) return;
+          if (value == null || value.error != null || value.data == null) return;
+          const serialized = JSON.stringify([key, { data: value.data }]);
+          if (serialized.length > MAX_ENTRY_BYTES) return;
+          if (totalBytes + serialized.length > MAX_TOTAL_BYTES) return;
+          entries.push([key, { data: value.data, error: null, isValidating: false, isLoading: false }]);
+          totalBytes += serialized.length;
+        });
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+      } catch (err) {
+        // Quota exceeded, invalid JSON, etc. — silently drop the cache.
+        try {
+          window.localStorage.removeItem(STORAGE_KEY);
+        } catch {
+          /* noop */
+        }
+      }
+    });
+  };
+
+  // Patch the mutating Map methods to schedule a persist.
+  const originalSet = map.set.bind(map);
+  map.set = (key, value) => {
+    originalSet(key, value);
+    schedulePersist();
+    return map;
+  };
+  const originalDelete = map.delete.bind(map);
+  map.delete = (key) => {
+    const result = originalDelete(key);
+    if (result) schedulePersist();
+    return result;
+  };
+
+  return map;
+}
 
 export function SWRProvider({ children }: { children: ReactNode }) {
+  const provider = useMemo(() => {
+    const cache = createLocalStorageProvider();
+    return () => cache;
+  }, []);
+
   return (
     <SWRConfig
       value={{
+        provider,
         errorRetryCount: 3,
         errorRetryInterval: 3000,
         dedupingInterval: 5000,
         revalidateOnReconnect: true,
+        // Revalidate on mount so the stale cached data gets refreshed
+        // in the background; SWR will show the cached value immediately.
+        revalidateOnMount: true,
+        revalidateIfStale: true,
         onErrorRetry: (error, _key, _config, revalidate, { retryCount }) => {
           // Don't retry on auth errors — re-login is needed
           if (error?.status === 401 || error?.status === 403) return;


### PR DESCRIPTION
## Summary
Three UX improvements on `/dashboard/analytics`.

### 1. Cumulative Users promoted to headline position
Moves the Cumulative Users card from deep in the analytics section (paired with DAU) to right after the Revenue KPI cards, before MRR Over Time. DAU gets its own full-width card in the old slot.

### 2. Scroll position persists on refresh
The dashboard layout's scrollable `<main>` now saves `scrollTop` to `sessionStorage` (keyed by pathname) on scroll and restores it on mount. Because the page grows as SWR fills in, a ~2s poller keeps nudging the scroll back until it sticks.

### 3. Instant refresh via SWR localStorage cache
`SWRProvider` now installs a localStorage-backed Map cache provider that rehydrates on first render and mirrors writes in a microtask. On refresh the dashboard paints instantly with stale cached data while each endpoint revalidates in the background — no more cold-start waits while the 15+ charts fetch from scratch.

Quota-safe: 1MB per entry, 5MB total, skips error/empty entries, silently drops on quota-exceeded.

## Test plan
- [ ] Load `/dashboard/analytics`, confirm Cumulative Users card appears above MRR Over Time, DAU is below
- [ ] Scroll down, refresh (⌘R), confirm the page lands on the same scroll position
- [ ] Refresh a second time, confirm charts render immediately from cache while network requests fire in background

🤖 Generated with [Claude Code](https://claude.com/claude-code)