### PR TITLE
Fix None duration crash in read_wav_duration_ms

### DIFF
--- a/backend/tests/unit/test_voice_duration_limiter.py
+++ b/backend/tests/unit/test_voice_duration_limiter.py
@@ -12,7 +12,8 @@ import os
 import struct
 import tempfile
 import time
-from unittest.mock import MagicMock, patch
+from fractions import Fraction
+from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
@@ -179,6 +180,60 @@ class TestWAVDurationReader:
             assert read_wav_duration_ms(path) is None
         finally:
             os.unlink(path)
+
+    def test_container_duration_none_falls_back_to_stream(self):
+        """When container.duration is None, fall back to stream.duration * stream.time_base."""
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        mock_stream = MagicMock()
+        mock_stream.duration = 48000  # 3 seconds at 16000 sample rate
+        mock_stream.time_base = Fraction(1, 16000)
+
+        mock_container = MagicMock()
+        mock_container.duration = None
+        mock_container.streams.audio = [mock_stream]
+        mock_container.__enter__ = MagicMock(return_value=mock_container)
+        mock_container.__exit__ = MagicMock(return_value=False)
+
+        with patch('utils.voice_duration_limiter.av.open', return_value=mock_container):
+            duration = read_wav_duration_ms('/tmp/fake.wav')
+
+        assert duration is not None
+        assert duration == 3000  # 48000 * (1/16000) = 3s = 3000ms
+
+    def test_both_durations_none_returns_none(self):
+        """When both container.duration and stream.duration are None, returns None."""
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        mock_stream = MagicMock()
+        mock_stream.duration = None
+        mock_stream.time_base = Fraction(1, 16000)
+
+        mock_container = MagicMock()
+        mock_container.duration = None
+        mock_container.streams.audio = [mock_stream]
+        mock_container.__enter__ = MagicMock(return_value=mock_container)
+        mock_container.__exit__ = MagicMock(return_value=False)
+
+        with patch('utils.voice_duration_limiter.av.open', return_value=mock_container):
+            assert read_wav_duration_ms('/tmp/fake.wav') is None
+
+    def test_stream_time_base_none_returns_none(self):
+        """When stream.time_base is None, returns None (can't compute duration)."""
+        from utils.voice_duration_limiter import read_wav_duration_ms
+
+        mock_stream = MagicMock()
+        mock_stream.duration = 48000
+        mock_stream.time_base = None
+
+        mock_container = MagicMock()
+        mock_container.duration = None
+        mock_container.streams.audio = [mock_stream]
+        mock_container.__enter__ = MagicMock(return_value=mock_container)
+        mock_container.__exit__ = MagicMock(return_value=False)
+
+        with patch('utils.voice_duration_limiter.av.open', return_value=mock_container):
+            assert read_wav_duration_ms('/tmp/fake.wav') is None
 
 
 # ===========================================================================

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -224,6 +224,8 @@ def read_wav_duration_ms(file_path: str) -> int | None:
         with av.open(file_path) as container:
             if not container.streams.audio:
                 return None
+            if container.duration is None:
+                return None
             duration_s = float(container.duration) / av.time_base
             if duration_s <= 0:
                 return None

--- a/backend/utils/voice_duration_limiter.py
+++ b/backend/utils/voice_duration_limiter.py
@@ -224,9 +224,14 @@ def read_wav_duration_ms(file_path: str) -> int | None:
         with av.open(file_path) as container:
             if not container.streams.audio:
                 return None
-            if container.duration is None:
+            stream = container.streams.audio[0]
+            # Prefer container-level duration; fall back to stream-level
+            if container.duration is not None:
+                duration_s = float(container.duration) / av.time_base
+            elif stream.duration is not None and stream.time_base is not None:
+                duration_s = float(stream.duration * stream.time_base)
+            else:
                 return None
-            duration_s = float(container.duration) / av.time_base
             if duration_s <= 0:
                 return None
             return int(duration_s * 1000)


### PR DESCRIPTION
Fixes a prod warning observed after #6670 deploy (part of #6463).

### Current Behavior
`read_wav_duration_ms` crashes with `TypeError: float() argument must be a string or a real number, not NoneType` when `container.duration` is `None`. The exception is caught by the outer try/except (fail-open), so requests proceed — but budget is not enforced for those files and WARNING logs spam prod.

### Root Cause
Users uploading **zero-data WAV files** (valid RIFF header but `data_size=0`). PyAV opens them successfully but both `container.duration` and `stream.duration` are `None`.

### Solution
Check `container.duration` first; if `None`, fall back to `stream.duration * stream.time_base` (FFmpeg sometimes has duration at stream level but not container level). If both are `None`, return `None` (fail-open). Eliminates TypeError and WARNING log spam.

### Affected Areas
| File | Line | Description |
|------|------|-------------|
| `backend/utils/voice_duration_limiter.py` | 227 | `float(container.duration)` crashes when `container.duration is None` |

### Files Modified
- `backend/utils/voice_duration_limiter.py` — add stream-level fallback + None guard
- `backend/tests/unit/test_voice_duration_limiter.py` — 3 regression tests for None fallback branches

### Testing
- 90 unit tests pass (33 voice_duration_limiter + 57 desktop_transcribe)
- 3 new regression tests: stream fallback, both-None, time_base-None
- Real audio tests against running backend:
  - 3s sine wave via octet-stream → 200 OK
  - 3s sine wave via WebSocket → normal close
  - Zero-data WAV (prod failure case) → returns None, no TypeError crash
  - All standard formats verified (wav, mp3, ogg, opus, m4a, flac, adts) — container.duration always populated

### Deployment
Standard backend deploy via `gcp_backend.yml`. No Redis migration, no Helm changes, no new env vars. Rollback = standard Cloud Run revision rollback.

---
_by AI for @beastoin_