### PR TITLE
Fix pusher Dockerfile missing google-credentials.json

### DIFF
--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -54,6 +54,8 @@ COPY backend/models/ ./models/
 COPY backend/routers/ ./routers/
 COPY backend/utils/ ./utils/
 COPY backend/pusher/ ./pusher/
+# CI writes google-credentials.json to backend/ before build
+COPY backend/google-credentials.json ./google-credentials.json
 
 EXPOSE 8080
 CMD ["uvicorn", "pusher.main:app", "--host", "0.0.0.0", "--port", "8080", "--ws-ping-interval", "20", "--ws-ping-timeout", "20"]


### PR DESCRIPTION
Fixes CrashLoopBackOff on GKE pusher pods after #6681 merge.

The whitelist COPY introduced in #6681 missed the CI-generated `google-credentials.json` that the workflow writes to `./backend/` before build. Old Dockerfile used `COPY backend/ .` which copied everything; new whitelist needs it explicitly.

---
_by AI for @beastoin_