### PR TITLE
Stage liblc3 to fixed path in Dockerfiles

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -21,6 +21,10 @@ RUN git clone https://github.com/google/liblc3.git && \
     cd build && \
     meson install && \
     ldconfig && \
+    # Stage shared libs to a fixed path (meson install path varies by arch)
+    mkdir -p /opt/liblc3 && \
+    cp /usr/local/lib/*/liblc3.so* /opt/liblc3/ 2>/dev/null || \
+    cp /usr/local/lib/liblc3.so* /opt/liblc3/ && \
     cd /tmp/liblc3 && \
     python3 -m pip wheel --no-cache-dir --wheel-dir /tmp/wheels .
 
@@ -37,8 +41,8 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 RUN apt-get update && apt-get -y install ffmpeg curl && rm -rf /var/lib/apt/lists/*
 
-# Copy compiled liblc3 library and wheel from builder
-COPY --from=builder /usr/local/lib/liblc3.so* /usr/local/lib/
+# Copy compiled liblc3 library from builder staging dir
+COPY --from=builder /opt/liblc3/ /usr/local/lib/
 COPY --from=builder /tmp/wheels /tmp/wheels
 
 # Install liblc3 Python package and set library path

--- a/backend/pusher/Dockerfile
+++ b/backend/pusher/Dockerfile
@@ -21,6 +21,10 @@ RUN git clone https://github.com/google/liblc3.git && \
     cd build && \
     meson install && \
     ldconfig && \
+    # Stage shared libs to a fixed path (meson install path varies by arch)
+    mkdir -p /opt/liblc3 && \
+    cp /usr/local/lib/*/liblc3.so* /opt/liblc3/ 2>/dev/null || \
+    cp /usr/local/lib/liblc3.so* /opt/liblc3/ && \
     cd /tmp/liblc3 && \
     python3 -m pip wheel --no-cache-dir --wheel-dir /tmp/wheels .
 
@@ -37,8 +41,8 @@ ENV LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
 
 RUN apt-get update && apt-get -y install ffmpeg curl && rm -rf /var/lib/apt/lists/*
 
-# Copy compiled liblc3 library and wheel from builder
-COPY --from=builder /usr/local/lib/liblc3.so* /usr/local/lib/
+# Copy compiled liblc3 library from builder staging dir
+COPY --from=builder /opt/liblc3/ /usr/local/lib/
 COPY --from=builder /tmp/wheels /tmp/wheels
 
 # Install liblc3 Python package and set library path


### PR DESCRIPTION
Follow-up to #6681. Stages liblc3 shared libs to `/opt/liblc3/` in the builder stage so the runtime `COPY --from=builder` uses an exact directory path instead of a glob (`liblc3.so*`).

The glob works in Docker but fails in buildah (used for local builds), making it impossible to verify images locally. Both backend and pusher Dockerfiles updated.

Verified locally: both images build and run successfully with buildah — backend ONNX VAD inference OK, pusher imports and Firestore init OK.

---
_by AI for @beastoin_