### PR TITLE
feat: add MiniMax provider support for chat and persona models

### DIFF
--- a/backend/.env.template
+++ b/backend/.env.template
@@ -17,6 +17,13 @@ DEEPGRAM_API_KEY=
 ADMIN_KEY=
 OPENAI_API_KEY=
 
+# MiniMax AI provider (optional alternative to OpenRouter for persona chat)
+# Get your API key from https://platform.minimax.io
+# When set, MiniMax-M2.7 and MiniMax-M2.7-highspeed are used for persona chat
+MINIMAX_API_KEY=
+# Optional: override the MiniMax API base URL (defaults to https://api.minimax.io/v1)
+MINIMAX_BASE_URL=
+
 GITHUB_TOKEN=
 
 WORKFLOW_API_KEY=

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -88,6 +88,7 @@ pytest tests/unit/test_staged_tasks_batch_scores.py -v
 pytest tests/unit/test_dg_start_guard.py -v
 pytest tests/unit/test_available_plans_resilience.py -v
 pytest tests/unit/test_voice_duration_limiter.py -v
+pytest tests/unit/test_minimax_provider.py -v
 
 # Fair-use integration tests (require Redis; skip gracefully if unavailable)
 if redis-cli ping >/dev/null 2>&1; then

--- a/backend/tests/unit/test_minimax_provider.py
+++ b/backend/tests/unit/test_minimax_provider.py
@@ -1,0 +1,225 @@
+"""Tests for MiniMax provider configuration in utils/llm/clients.py.
+
+Verifies that:
+1. MiniMax clients are conditionally created based on MINIMAX_API_KEY
+2. Correct models and base URL are used (MiniMax-M2.7, MiniMax-M2.7-highspeed)
+3. temperature is set to 1.0 (MiniMax requires (0.0, 1.0], not 0)
+4. Persona models use MiniMax when MINIMAX_API_KEY is configured
+5. Persona models fall back to OpenRouter when MINIMAX_API_KEY is not configured
+"""
+
+import importlib
+import sys
+import os
+import types
+from unittest.mock import MagicMock, patch
+
+
+def _make_tiktoken_mock():
+    """Create a proper module mock for tiktoken that passes __spec__ checks."""
+    mod = types.ModuleType('tiktoken')
+    mod.__spec__ = None  # Prevents importlib.util.find_spec() ValueError
+    enc_mock = MagicMock()
+    enc_mock.encode.return_value = []
+    mod.encoding_for_model = lambda model: enc_mock
+    mod.get_encoding = lambda name: enc_mock
+    return mod
+
+
+def _make_anthropic_mock():
+    """Create a proper module mock for anthropic."""
+    mod = types.ModuleType('anthropic')
+    mod.__spec__ = None
+
+    class AsyncAnthropic:
+        def __init__(self, **kwargs):
+            self._kwargs = kwargs
+
+    mod.AsyncAnthropic = AsyncAnthropic
+    return mod
+
+
+def _make_httpx_mock():
+    """Create a proper module mock for httpx."""
+    mod = types.ModuleType('httpx')
+    mod.__spec__ = None
+
+    resp = MagicMock()
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = {"embedding": {"values": []}}
+    mod.post = MagicMock(return_value=resp)
+    return mod
+
+
+def _fresh_import_clients(env_overrides: dict):
+    """Import utils.llm.clients with fresh environment and collect ChatOpenAI calls."""
+    calls = []
+
+    def capturing_chat_openai(**kwargs):
+        calls.append(kwargs)
+        return MagicMock()
+
+    # Remove any cached version of the module under test and its dependencies
+    for key in list(sys.modules.keys()):
+        if key in ('utils.llm.clients', 'utils.llm.usage_tracker'):
+            del sys.modules[key]
+
+    mock_usage_tracker = types.ModuleType('utils.llm.usage_tracker')
+    mock_usage_tracker.__spec__ = None
+    mock_usage_tracker.get_usage_callback = MagicMock(return_value=MagicMock())
+
+    mock_structured = types.ModuleType('models.structured')
+    mock_structured.__spec__ = None
+    mock_structured.Structured = MagicMock()
+
+    mock_db_client = types.ModuleType('database._client')
+    mock_db_client.__spec__ = None
+
+    mock_langchain_openai = types.ModuleType('langchain_openai')
+    mock_langchain_openai.__spec__ = None
+    mock_langchain_openai.ChatOpenAI = MagicMock(side_effect=capturing_chat_openai)
+    mock_langchain_openai.OpenAIEmbeddings = MagicMock(return_value=MagicMock())
+
+    mock_lc_parsers = types.ModuleType('langchain_core.output_parsers')
+    mock_lc_parsers.__spec__ = None
+    mock_lc_parsers.PydanticOutputParser = MagicMock(return_value=MagicMock())
+
+    mock_lc_core = types.ModuleType('langchain_core')
+    mock_lc_core.__spec__ = None
+
+    extra_modules = {
+        'tiktoken': _make_tiktoken_mock(),
+        'anthropic': _make_anthropic_mock(),
+        'httpx': _make_httpx_mock(),
+        'database._client': mock_db_client,
+        'utils.llm.usage_tracker': mock_usage_tracker,
+        'models.structured': mock_structured,
+        'langchain_openai': mock_langchain_openai,
+        'langchain_core': mock_lc_core,
+        'langchain_core.output_parsers': mock_lc_parsers,
+    }
+
+    # Build a clean environment
+    clean_env = {}
+    # Only carry over keys needed for OpenAI default init (avoid side effects)
+    for k in ('OPENAI_API_KEY', 'OPENROUTER_API_KEY'):
+        if k in os.environ:
+            clean_env[k] = os.environ[k]
+    clean_env.update(env_overrides)
+    # Ensure MINIMAX keys are not inherited unless explicitly provided
+    if 'MINIMAX_API_KEY' not in env_overrides:
+        clean_env.pop('MINIMAX_API_KEY', None)
+    if 'MINIMAX_BASE_URL' not in env_overrides:
+        clean_env.pop('MINIMAX_BASE_URL', None)
+
+    with patch.dict('sys.modules', extra_modules):
+        with patch.dict('os.environ', clean_env, clear=True):
+            mod = importlib.import_module('utils.llm.clients')
+
+    return mod, calls
+
+
+class TestMiniMaxClientsCreated:
+    """MiniMax clients are created when MINIMAX_API_KEY is set."""
+
+    def test_llm_minimax_created(self):
+        mod, _ = _fresh_import_clients({'MINIMAX_API_KEY': 'test-minimax-key'})
+        assert mod.llm_minimax is not None
+
+    def test_llm_minimax_stream_created(self):
+        mod, _ = _fresh_import_clients({'MINIMAX_API_KEY': 'test-minimax-key'})
+        assert mod.llm_minimax_stream is not None
+
+    def test_llm_minimax_fast_stream_created(self):
+        mod, _ = _fresh_import_clients({'MINIMAX_API_KEY': 'test-minimax-key'})
+        assert mod.llm_minimax_fast_stream is not None
+
+
+class TestMiniMaxClientsNoneWithoutKey:
+    """MiniMax clients are None when MINIMAX_API_KEY is not set."""
+
+    def test_llm_minimax_none_without_key(self):
+        mod, _ = _fresh_import_clients({'MINIMAX_API_KEY': ''})
+        assert mod.llm_minimax is None
+
+    def test_llm_minimax_stream_none_without_key(self):
+        mod, _ = _fresh_import_clients({'MINIMAX_API_KEY': ''})
+        assert mod.llm_minimax_stream is None
+
+    def test_llm_minimax_fast_stream_none_without_key(self):
+        mod, _ = _fresh_import_clients({'MINIMAX_API_KEY': ''})
+        assert mod.llm_minimax_fast_stream is None
+
+
+class TestMiniMaxClientConfiguration:
+    """MiniMax clients use correct models and base URL."""
+
+    def test_minimax_uses_default_base_url(self):
+        _, calls = _fresh_import_clients({'MINIMAX_API_KEY': 'test-key'})
+        minimax_calls = [c for c in calls if c.get('model') in ('MiniMax-M2.7', 'MiniMax-M2.7-highspeed')]
+        assert len(minimax_calls) > 0
+        for call in minimax_calls:
+            assert 'minimax.io/v1' in call.get(
+                'base_url', ''
+            ), f"base_url {call.get('base_url')!r} should contain minimax.io/v1"
+
+    def test_minimax_uses_custom_base_url(self):
+        _, calls = _fresh_import_clients(
+            {'MINIMAX_API_KEY': 'test-key', 'MINIMAX_BASE_URL': 'https://custom.minimax.io/v1'}
+        )
+        minimax_calls = [c for c in calls if c.get('model') in ('MiniMax-M2.7', 'MiniMax-M2.7-highspeed')]
+        assert len(minimax_calls) > 0
+        for call in minimax_calls:
+            assert call.get('base_url') == 'https://custom.minimax.io/v1'
+
+    def test_minimax_temperature_is_1_0(self):
+        """MiniMax requires temperature in (0.0, 1.0], default must be 1.0."""
+        _, calls = _fresh_import_clients({'MINIMAX_API_KEY': 'test-key'})
+        minimax_calls = [c for c in calls if c.get('model') in ('MiniMax-M2.7', 'MiniMax-M2.7-highspeed')]
+        assert len(minimax_calls) > 0
+        for call in minimax_calls:
+            assert call.get('temperature') == 1.0, f"temperature must be 1.0 for MiniMax, got {call.get('temperature')}"
+
+    def test_minimax_m2_7_and_highspeed_models_used(self):
+        """Only MiniMax-M2.7 and MiniMax-M2.7-highspeed models are used."""
+        _, calls = _fresh_import_clients({'MINIMAX_API_KEY': 'test-key'})
+        minimax_models = {c.get('model') for c in calls if 'minimax.io' in c.get('base_url', '')}
+        assert 'MiniMax-M2.7' in minimax_models, f"Expected MiniMax-M2.7 in {minimax_models}"
+        assert 'MiniMax-M2.7-highspeed' in minimax_models, f"Expected MiniMax-M2.7-highspeed in {minimax_models}"
+
+    def test_no_unsupported_minimax_models(self):
+        """Only approved MiniMax models are used — no other model names."""
+        _, calls = _fresh_import_clients({'MINIMAX_API_KEY': 'test-key'})
+        minimax_calls = [c for c in calls if 'minimax.io' in c.get('base_url', '')]
+        approved = {'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'}
+        for call in minimax_calls:
+            assert call.get('model') in approved, f"Unexpected MiniMax model: {call.get('model')!r}"
+
+
+class TestPersonaModelsUseMiniMax:
+    """Persona models use MiniMax when MINIMAX_API_KEY is configured."""
+
+    def test_persona_mini_uses_minimax_highspeed_model(self):
+        _, calls = _fresh_import_clients({'MINIMAX_API_KEY': 'test-key'})
+        persona_mini_calls = [c for c in calls if c.get('model') == 'MiniMax-M2.7-highspeed']
+        assert len(persona_mini_calls) > 0, "persona mini stream should use MiniMax-M2.7-highspeed"
+
+    def test_persona_medium_uses_minimax_m2_7_model(self):
+        _, calls = _fresh_import_clients({'MINIMAX_API_KEY': 'test-key'})
+        persona_medium_minimax_calls = [
+            c for c in calls if c.get('model') == 'MiniMax-M2.7' and 'minimax.io' in c.get('base_url', '')
+        ]
+        assert len(persona_medium_minimax_calls) > 0, "persona medium stream should use MiniMax-M2.7"
+
+    def test_persona_uses_openrouter_when_no_minimax_key(self):
+        _, calls = _fresh_import_clients({'MINIMAX_API_KEY': '', 'OPENROUTER_API_KEY': 'openrouter-key'})
+        openrouter_calls = [c for c in calls if 'openrouter.ai' in c.get('base_url', '')]
+        assert (
+            len(openrouter_calls) >= 2
+        ), "at least two persona models should use OpenRouter when MINIMAX_API_KEY is not set"
+
+    def test_persona_mini_uses_streaming(self):
+        """Persona models must be streaming for real-time responses."""
+        _, calls = _fresh_import_clients({'MINIMAX_API_KEY': 'test-key'})
+        minimax_streaming_calls = [c for c in calls if 'minimax.io' in c.get('base_url', '') and c.get('streaming')]
+        assert len(minimax_streaming_calls) >= 2, "MiniMax persona models must enable streaming"

--- a/backend/utils/llm/clients.py
+++ b/backend/utils/llm/clients.py
@@ -19,6 +19,44 @@ ANTHROPIC_AGENT_COMPLEX_MODEL = "claude-sonnet-4-6"
 # Get the usage tracking callback
 _usage_callback = get_usage_callback()
 
+# MiniMax provider configuration
+# Set MINIMAX_API_KEY to use MiniMax models (https://api.minimax.io)
+_minimax_api_key = os.environ.get('MINIMAX_API_KEY')
+_minimax_base_url = os.environ.get('MINIMAX_BASE_URL', 'https://api.minimax.io/v1')
+
+if _minimax_api_key:
+    # MiniMax-M2.7: Peak Performance. Ultimate Value. Master the Complex.
+    llm_minimax = ChatOpenAI(
+        model='MiniMax-M2.7',
+        api_key=_minimax_api_key,
+        base_url=_minimax_base_url,
+        temperature=1.0,  # MiniMax requires temperature in (0.0, 1.0], not 0
+        callbacks=[_usage_callback],
+    )
+    llm_minimax_stream = ChatOpenAI(
+        model='MiniMax-M2.7',
+        api_key=_minimax_api_key,
+        base_url=_minimax_base_url,
+        temperature=1.0,
+        streaming=True,
+        stream_options={"include_usage": True},
+        callbacks=[_usage_callback],
+    )
+    # MiniMax-M2.7-highspeed: Same performance, faster and more agile
+    llm_minimax_fast_stream = ChatOpenAI(
+        model='MiniMax-M2.7-highspeed',
+        api_key=_minimax_api_key,
+        base_url=_minimax_base_url,
+        temperature=1.0,
+        streaming=True,
+        stream_options={"include_usage": True},
+        callbacks=[_usage_callback],
+    )
+else:
+    llm_minimax = None
+    llm_minimax_stream = None
+    llm_minimax_fast_stream = None
+
 # Base models for general use
 llm_mini = ChatOpenAI(model='gpt-4.1-mini', callbacks=[_usage_callback])
 llm_mini_stream = ChatOpenAI(
@@ -76,26 +114,47 @@ llm_agent_stream = ChatOpenAI(
     callbacks=[_usage_callback],
     model_kwargs=_agent_cache_kwargs,
 )
-llm_persona_mini_stream = ChatOpenAI(
-    temperature=0.8,
-    model="google/gemini-flash-1.5-8b",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Chat"},
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
-llm_persona_medium_stream = ChatOpenAI(
-    temperature=0.8,
-    model="anthropic/claude-3.5-sonnet",
-    api_key=os.environ.get('OPENROUTER_API_KEY'),
-    base_url="https://openrouter.ai/api/v1",
-    default_headers={"X-Title": "Omi Chat"},
-    streaming=True,
-    stream_options={"include_usage": True},
-    callbacks=[_usage_callback],
-)
+if _minimax_api_key:
+    # Use MiniMax models directly for persona chat when MINIMAX_API_KEY is configured
+    llm_persona_mini_stream = ChatOpenAI(
+        model='MiniMax-M2.7-highspeed',
+        api_key=_minimax_api_key,
+        base_url=_minimax_base_url,
+        temperature=1.0,  # MiniMax requires temperature in (0.0, 1.0], not 0
+        streaming=True,
+        stream_options={"include_usage": True},
+        callbacks=[_usage_callback],
+    )
+    llm_persona_medium_stream = ChatOpenAI(
+        model='MiniMax-M2.7',
+        api_key=_minimax_api_key,
+        base_url=_minimax_base_url,
+        temperature=1.0,
+        streaming=True,
+        stream_options={"include_usage": True},
+        callbacks=[_usage_callback],
+    )
+else:
+    llm_persona_mini_stream = ChatOpenAI(
+        temperature=0.8,
+        model="google/gemini-flash-1.5-8b",
+        api_key=os.environ.get('OPENROUTER_API_KEY'),
+        base_url="https://openrouter.ai/api/v1",
+        default_headers={"X-Title": "Omi Chat"},
+        streaming=True,
+        stream_options={"include_usage": True},
+        callbacks=[_usage_callback],
+    )
+    llm_persona_medium_stream = ChatOpenAI(
+        temperature=0.8,
+        model="anthropic/claude-3.5-sonnet",
+        api_key=os.environ.get('OPENROUTER_API_KEY'),
+        base_url="https://openrouter.ai/api/v1",
+        default_headers={"X-Title": "Omi Chat"},
+        streaming=True,
+        stream_options={"include_usage": True},
+        callbacks=[_usage_callback],
+    )
 
 # Gemini models for large context analysis
 llm_gemini_flash = ChatOpenAI(


### PR DESCRIPTION
## Summary

- Add **MiniMax-M2.7** and **MiniMax-M2.7-highspeed** as an optional LLM provider in `backend/utils/llm/clients.py`
- When `MINIMAX_API_KEY` is set, MiniMax models are used for persona chat (replacing the OpenRouter proxy)
- When `MINIMAX_API_KEY` is not set, the existing OpenRouter/Gemini behavior is preserved
- Add `MINIMAX_BASE_URL` env var for custom endpoint overrides (defaults to `https://api.minimax.io/v1`)
- Add 15 unit tests covering client creation, configuration, model names, temperature, and persona routing

## Changes

| File | Change |
|------|--------|
| `backend/utils/llm/clients.py` | Add `llm_minimax`, `llm_minimax_stream`, `llm_minimax_fast_stream`; update persona models to use MiniMax when configured |
| `backend/.env.template` | Document `MINIMAX_API_KEY` and `MINIMAX_BASE_URL` |
| `backend/tests/unit/test_minimax_provider.py` | 15 unit tests for MiniMax provider |
| `backend/test.sh` | Register new test file |

## Configuration

To use MiniMax, add to your `.env`:
```
MINIMAX_API_KEY=your-api-key-here
# Optional: MINIMAX_BASE_URL=https://api.minimax.io/v1
```

## API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api

## Models

| Model | Use |
|-------|-----|
| `MiniMax-M2.7` | Persona medium (quality) |
| `MiniMax-M2.7-highspeed` | Persona mini (fast) |

## Test Plan

- [x] `python -m pytest backend/tests/unit/test_minimax_provider.py -v` — all 15 tests pass
- [x] Integration verified: MiniMax-M2.7-highspeed API returns 200 with valid response
- [x] Existing persona behavior preserved when `MINIMAX_API_KEY` is not set