### PR TITLE
fix daily recap empty days and wrong action items

### DIFF
--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -1,7 +1,11 @@
+import json
+import re
+import uuid
 from datetime import datetime, timezone
 from typing import List
 import pytz
 from langchain_core.prompts import ChatPromptTemplate
+import database.action_items as action_items_db
 import database.users as users_db
 from models.conversation import Conversation
 from models.structured import Structured
@@ -137,10 +141,6 @@ def generate_comprehensive_daily_summary(
 
     Returns a dictionary matching the DailySummary model structure.
     """
-    import json
-    import uuid
-    import database.action_items as action_items_db
-
     # Get user's timezone
     user_profile = users_db.get_user_profile(uid)
     user_tz_str = user_profile.get('time_zone', 'UTC')
@@ -195,11 +195,12 @@ def generate_comprehensive_daily_summary(
                 }
             )
 
-    # Fetch actual action items from the database for this date range
+    # Fetch action items for the specific conversations being summarised.
+    # Querying by conversation_id (not date range) prevents pulling in items whose
+    # async processing happened to land on the same UTC day as an unrelated conversation.
     actual_action_items = []
-    if start_date_utc and end_date_utc:
-        db_action_items = action_items_db.get_action_items(uid, start_date=start_date_utc, end_date=end_date_utc)
-        for item in db_action_items:
+    for c in non_discarded:
+        for item in action_items_db.get_action_items(uid, conversation_id=c.id):
             actual_action_items.append(
                 {
                     "description": item.get("description", ""),
@@ -280,8 +281,6 @@ Respond with ONLY valid JSON. Do not include any other text or comments."""
         response = response.strip()
 
         # Try to repair common JSON issues from LLM
-        import re
-
         response = re.sub(r':\s*\\"([^"]*)\\"', r': "\1"', response)
         response = response.replace('\\"', '"')
 

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -136,6 +136,11 @@ def _send_summary_notification(user_data: tuple):
     if not conversations:
         return
 
+    # Skip recap if no conversation captured any speech.
+    if not any(c.transcript_segments for c in conversations):
+        logger.info(f'Skipping daily summary for uid={uid} on {date_str}: no conversations with transcript content')
+        return
+
     summary_data = generate_comprehensive_daily_summary(uid, conversations, date_str, start_date_utc, end_date_utc)
 
     # Store in database

--- a/backend/utils/other/notifications.py
+++ b/backend/utils/other/notifications.py
@@ -137,7 +137,7 @@ def _send_summary_notification(user_data: tuple):
         return
 
     # Skip recap if no conversation captured any speech.
-    if not any(c.transcript_segments for c in conversations):
+    if not any(c.transcript_segments for c in conversations if not c.discarded):
         logger.info(f'Skipping daily summary for uid={uid} on {date_str}: no conversations with transcript content')
         return
 


### PR DESCRIPTION
## Summary
- Skip daily recap generation when no conversation on that day has transcript segments (recording was started but nothing was captured)
- Fix action items in recap pulling from unrelated conversations — now fetches per `conversation_id` instead of by `created_at` date range, which previously picked up items whose async processing completed on the same UTC day

## Test plan
- [ ] Day with no conversations → no recap generated
- [ ] Day with conversations but empty recordings (0 transcript segments) → no recap generated
- [ ] Day with real conversations → recap generated with only action items from those specific conversations

closes #6389

🤖 Generated with [Claude Code](https://claude.com/claude-code)