### PR TITLE
Remove skip-for-now on onboarding permissions screen

### DIFF
--- a/app/lib/pages/onboarding/permissions/permissions_checker.dart
+++ b/app/lib/pages/onboarding/permissions/permissions_checker.dart
@@ -217,25 +217,6 @@ class PermissionsInterstitialPage extends StatelessWidget {
                                 ),
                               ),
                             ),
-
-                      const SizedBox(height: 16),
-
-                      // Skip for now
-                      GestureDetector(
-                        onTap: () {
-                          MixpanelManager().permissionsInterstitialSkipped();
-                          _goHome(context);
-                        },
-                        child: Text(
-                          context.l10n.skipForNow,
-                          style: TextStyle(
-                            color: Colors.white.withValues(alpha: 0.6),
-                            fontSize: 15,
-                            fontWeight: FontWeight.w500,
-                            fontFamily: 'Manrope',
-                          ),
-                        ),
-                      ),
                     ],
                   ),
                 ),

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.532+819
+version: 1.0.532+820
 
 
 environment:


### PR DESCRIPTION
## Summary

Makes Continue the only action on the permissions interstitial (`PermissionsInterstitialPage`) so the primary CTA always triggers the OS permission prompts. Previously users could tap "Skip for now" to bypass the permission flow entirely without ever seeing the system dialog.

Also bumps the build to 820.

## Test plan

- [ ] Fresh install: verify only the Continue button is shown on the permissions screen
- [ ] Tap Continue: verify iOS/Android permission dialogs appear for location and notifications
- [ ] Deny either dialog: verify the app still proceeds to the home page
- [ ] Android: verify background permission prompt still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)