### PR TITLE
Replace bare except clauses with typed exceptions in backend tools

### DIFF
--- a/backend/modal/speech_profile_modal.py
+++ b/backend/modal/speech_profile_modal.py
@@ -135,9 +135,9 @@ def endpoint(uid: str, audio_file: UploadFile = File(...), segments: str = Form(
     people = []
     try:
         result = classify_segments(audio_file.filename, profile_path, people, transcript_segments)
-        # print(result)
         return result
-    except:
+    except Exception as e:
+        logger.error(f"Error classifying speech segments: {e}")
         return default
     finally:
         os.remove(profile_path)

--- a/backend/routers/chat.py
+++ b/backend/routers/chat.py
@@ -523,7 +523,7 @@ async def transcribe_voice_message(
                 if p.startswith(f"/tmp/{uid}_"):
                     try:
                         Path(p).unlink()
-                    except:
+                    except OSError:
                         pass
             raise HTTPException(status_code=500, detail=f'Transcription failed: {str(e)}')
         finally:
@@ -531,7 +531,7 @@ async def transcribe_voice_message(
             if wav_path.startswith(f"/tmp/{uid}_"):
                 try:
                     Path(wav_path).unlink()
-                except:
+                except OSError:
                     pass
 
     if is_multi:

--- a/backend/utils/retrieval/tools/apple_health_tools.py
+++ b/backend/utils/retrieval/tools/apple_health_tools.py
@@ -121,7 +121,7 @@ def get_apple_health_steps_tool(
             try:
                 sync_dt = datetime.fromisoformat(last_synced.replace('Z', '+00:00'))
                 sync_info = f"\n\n(Data last synced: {sync_dt.strftime('%Y-%m-%d %H:%M')} UTC)"
-            except:
+            except (ValueError, TypeError):
                 pass
 
         result = f"Apple Health Step Data (Last {period_days} days):\n\n"
@@ -204,7 +204,7 @@ def get_apple_health_sleep_tool(
             try:
                 sync_dt = datetime.fromisoformat(last_synced.replace('Z', '+00:00'))
                 result += f"\n(Data last synced: {sync_dt.strftime('%Y-%m-%d %H:%M')} UTC)"
-            except:
+            except (ValueError, TypeError):
                 pass
 
         return result.strip()
@@ -263,7 +263,7 @@ def get_apple_health_heart_rate_tool(
             try:
                 sync_dt = datetime.fromisoformat(last_synced.replace('Z', '+00:00'))
                 result += f"\n(Data last synced: {sync_dt.strftime('%Y-%m-%d %H:%M')} UTC)"
-            except:
+            except (ValueError, TypeError):
                 pass
 
         return result.strip()
@@ -326,7 +326,7 @@ def get_apple_health_workouts_tool(
                 try:
                     start_dt = datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc).astimezone(user_tz)
                     date_str = f" - {start_dt.strftime('%m/%d %I:%M %p')}"
-                except:
+                except (ValueError, TypeError, OSError):
                     pass
 
             result += f"{i}. {workout_type}{date_str}\n"
@@ -343,7 +343,7 @@ def get_apple_health_workouts_tool(
             try:
                 sync_dt = datetime.fromisoformat(last_synced.replace('Z', '+00:00'))
                 result += f"(Data last synced: {sync_dt.strftime('%Y-%m-%d %H:%M')} UTC)"
-            except:
+            except (ValueError, TypeError):
                 pass
 
         return result.strip()
@@ -459,7 +459,7 @@ def get_apple_health_summary_tool(
             try:
                 sync_dt = datetime.fromisoformat(last_synced.replace('Z', '+00:00'))
                 result += f"\n(Data last synced: {sync_dt.strftime('%Y-%m-%d %H:%M')} UTC)"
-            except:
+            except (ValueError, TypeError):
                 pass
 
         return result.strip()

--- a/backend/utils/retrieval/tools/apple_health_tools.py
+++ b/backend/utils/retrieval/tools/apple_health_tools.py
@@ -326,7 +326,7 @@ def get_apple_health_workouts_tool(
                 try:
                     start_dt = datetime.fromtimestamp(start_ms / 1000, tz=timezone.utc).astimezone(user_tz)
                     date_str = f" - {start_dt.strftime('%m/%d %I:%M %p')}"
-                except (ValueError, TypeError, OSError):
+                except (ValueError, TypeError, OSError, OverflowError):
                     pass
 
             result += f"{i}. {workout_type}{date_str}\n"

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -1170,7 +1170,7 @@ def delete_calendar_event_tool(
                                     delete_google_calendar_event(new_token, event_id)
                                     deleted_count += 1
                                 except Exception as e:
-                                    logger.warning(f"Failed to delete event {event_id} after token refresh: {e}")
+                                    logger.warning(f"Failed to delete event {event_id} after token refresh: {sanitize(str(e))}")
 
                         if deleted_count > 0:
                             return f"✅ Successfully deleted {deleted_count} calendar event(s)"

--- a/backend/utils/retrieval/tools/calendar_tools.py
+++ b/backend/utils/retrieval/tools/calendar_tools.py
@@ -605,13 +605,13 @@ def get_calendar_events_tool(
                         try:
                             start_dt = datetime.fromisoformat(start['dateTime'].replace('Z', '+00:00'))
                             events_with_time.append((start_dt, event))
-                        except:
+                        except (ValueError, TypeError):
                             events_with_time.append((datetime.min.replace(tzinfo=timezone.utc), event))
                     elif 'date' in start:
                         try:
                             start_dt = datetime.fromisoformat(start['date'] + 'T00:00:00+00:00')
                             events_with_time.append((start_dt, event))
-                        except:
+                        except (ValueError, TypeError):
                             events_with_time.append((datetime.min.replace(tzinfo=timezone.utc), event))
                     else:
                         events_with_time.append((datetime.min.replace(tzinfo=timezone.utc), event))
@@ -693,7 +693,7 @@ def get_calendar_events_tool(
                 try:
                     start_dt = datetime.fromisoformat(start['dateTime'].replace('Z', '+00:00'))
                     result += f"   Start: {start_dt.strftime('%Y-%m-%d %H:%M:%S %Z')}\n"
-                except:
+                except (ValueError, TypeError):
                     result += f"   Start: {start.get('dateTime', 'Unknown')}\n"
             elif 'date' in start:
                 result += f"   Date: {start.get('date', 'Unknown')}\n"
@@ -704,7 +704,7 @@ def get_calendar_events_tool(
                 try:
                     end_dt = datetime.fromisoformat(end['dateTime'].replace('Z', '+00:00'))
                     result += f"   End: {end_dt.strftime('%Y-%m-%d %H:%M:%S %Z')}\n"
-                except:
+                except (ValueError, TypeError):
                     result += f"   End: {end.get('dateTime', 'Unknown')}\n"
             elif 'date' in end:
                 result += f"   End Date: {end.get('date', 'Unknown')}\n"
@@ -1107,7 +1107,7 @@ def delete_calendar_event_tool(
                         try:
                             start_dt = datetime.fromisoformat(start['dateTime'].replace('Z', '+00:00'))
                             result += f"   - {summary} ({start_dt.strftime('%Y-%m-%d %H:%M')})\n"
-                        except:
+                        except (ValueError, TypeError):
                             result += f"   - {summary}\n"
                     else:
                         result += f"   - {summary}\n"
@@ -1169,8 +1169,8 @@ def delete_calendar_event_tool(
                                 try:
                                     delete_google_calendar_event(new_token, event_id)
                                     deleted_count += 1
-                                except:
-                                    pass
+                                except Exception as e:
+                                    logger.warning(f"Failed to delete event {event_id} after token refresh: {e}")
 
                         if deleted_count > 0:
                             return f"✅ Successfully deleted {deleted_count} calendar event(s)"

--- a/backend/utils/retrieval/tools/gmail_tools.py
+++ b/backend/utils/retrieval/tools/gmail_tools.py
@@ -152,7 +152,7 @@ def parse_gmail_message(message: dict) -> dict:
 
             date_parsed = parsedate_to_datetime(date_str)
         except (ValueError, TypeError) as e:
-            logger.debug(f"Could not parse email date '{date_str}': {e}")
+            logger.debug(f"Could not parse email date: {e}")
             pass
 
     return {

--- a/backend/utils/retrieval/tools/gmail_tools.py
+++ b/backend/utils/retrieval/tools/gmail_tools.py
@@ -151,7 +151,8 @@ def parse_gmail_message(message: dict) -> dict:
             from email.utils import parsedate_to_datetime
 
             date_parsed = parsedate_to_datetime(date_str)
-        except:
+        except (ValueError, TypeError) as e:
+            logger.debug(f"Could not parse email date '{date_str}': {e}")
             pass
 
     return {


### PR DESCRIPTION
## Summary

- Replace 16 bare `except:` clauses across 5 backend files with properly typed exception handlers
- Bare `except:` silently catches everything including `KeyboardInterrupt` and `SystemExit`, making debugging harder and hiding real failures
- Add `logger.debug`/`logger.warning`/`logger.error` calls where exceptions were previously swallowed silently

## Changes by file

| File | Count | Exception types |
|------|-------|----------------|
| `backend/utils/retrieval/tools/calendar_tools.py` | 6 | `(ValueError, TypeError)` for date parsing; `Exception` with warning log for failed event deletion |
| `backend/utils/retrieval/tools/apple_health_tools.py` | 6 | `(ValueError, TypeError)` for sync timestamp parsing; `(ValueError, TypeError, OSError)` for workout timestamp conversion |
| `backend/utils/retrieval/tools/gmail_tools.py` | 1 | `(ValueError, TypeError)` for email date parsing + debug log |
| `backend/routers/chat.py` | 2 | `OSError` for temp file cleanup |
| `backend/modal/speech_profile_modal.py` | 1 | `Exception` with error log for segment classification |

## Rationale

These are all date-parsing or file-cleanup blocks where the expected exceptions are `ValueError`/`TypeError`/`OSError`. The bare `except:` was overly broad and could mask:
- `KeyboardInterrupt` (Ctrl+C during development)
- `SystemExit` (graceful shutdown signals)
- `MemoryError` or other system-level failures

The typed exceptions preserve identical behavior for all expected error cases while allowing truly unexpected errors to propagate correctly.

## Test plan

- [ ] Verify no bare `except:` remain in changed files (`grep -rn 'except:' backend/utils/retrieval/tools/ backend/routers/chat.py backend/modal/speech_profile_modal.py`)
- [ ] Confirm existing backend tests still pass
- [ ] Verify date parsing edge cases (malformed ISO strings, None values) are still handled gracefully