### PR TITLE
fix: respond in user local timezone instead of UTC (#6214)

### DIFF
--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -1068,7 +1068,7 @@ def retrieve_metadata_fields_from_transcript(
 
     Make sure as a first step, you infer and fix any raw transcript errors and then proceed to extract the information from the entire content.
 
-    For context when extracting dates, today is {created_at.astimezone(timezone.utc).strftime('%Y-%m-%d')} in UTC. {tz} is the user's timezone, respond in user local timezone.
+    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). {tz} is the user's timezone, respond in user local timezone.
     If one says "today", it means the current day.
     If one says "tomorrow", it means the next day after today.
     If one says "yesterday", it means the day before today.
@@ -1151,7 +1151,7 @@ def retrieve_metadata_from_message(
     3. Organizations, products, locations, or other entities mentioned
     4. Any dates or time references
 
-    For context when extracting dates, today is {created_at.astimezone(timezone.utc).strftime('%Y-%m-%d')} in UTC. 
+    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). 
     {tz} is the user's timezone, respond in user local timezone.
     If the message mentions "today", it means the current day.
     If the message mentions "tomorrow", it means the next day after today.
@@ -1185,7 +1185,7 @@ def retrieve_metadata_from_text(
     3. Organizations, products, locations, or other entities mentioned
     4. Any dates or time references
 
-    For context when extracting dates, today is {created_at.astimezone(timezone.utc).strftime('%Y-%m-%d')} in UTC. 
+    For context when extracting dates, today is {created_at.astimezone(ZoneInfo(tz)).strftime('%Y-%m-%d')} in {tz} (user's local timezone). 
     {tz} is the user's timezone, respond in user local timezone.
     If the text mentions "today", it means the current day.
     If the text mentions "tomorrow", it means the next day after today.

--- a/backend/utils/llm/chat.py
+++ b/backend/utils/llm/chat.py
@@ -1068,7 +1068,7 @@ def retrieve_metadata_fields_from_transcript(
 
     Make sure as a first step, you infer and fix any raw transcript errors and then proceed to extract the information from the entire content.
 
-    For context when extracting dates, today is {created_at.astimezone(timezone.utc).strftime('%Y-%m-%d')} in UTC. {tz} is the user's timezone, convert it to UTC and respond in UTC.
+    For context when extracting dates, today is {created_at.astimezone(timezone.utc).strftime('%Y-%m-%d')} in UTC. {tz} is the user's timezone, respond in user local timezone.
     If one says "today", it means the current day.
     If one says "tomorrow", it means the next day after today.
     If one says "yesterday", it means the day before today.
@@ -1152,7 +1152,7 @@ def retrieve_metadata_from_message(
     4. Any dates or time references
 
     For context when extracting dates, today is {created_at.astimezone(timezone.utc).strftime('%Y-%m-%d')} in UTC. 
-    {tz} is the user's timezone, convert it to UTC and respond in UTC.
+    {tz} is the user's timezone, respond in user local timezone.
     If the message mentions "today", it means the current day.
     If the message mentions "tomorrow", it means the next day after today.
     If the message mentions "yesterday", it means the day before today.
@@ -1186,7 +1186,7 @@ def retrieve_metadata_from_text(
     4. Any dates or time references
 
     For context when extracting dates, today is {created_at.astimezone(timezone.utc).strftime('%Y-%m-%d')} in UTC. 
-    {tz} is the user's timezone, convert it to UTC and respond in UTC.
+    {tz} is the user's timezone, respond in user local timezone.
     If the text mentions "today", it means the current day.
     If the text mentions "tomorrow", it means the next day after today.
     If the text mentions "yesterday", it means the day before today.

--- a/backend/utils/llm/conversation_processing.py
+++ b/backend/utils/llm/conversation_processing.py
@@ -640,7 +640,7 @@ def get_transcript_structure(
     • Vague suggestions ("let's grab coffee soon")
     • Hypothetical scenarios ("if we meet Tuesday...")
 
-    For date context, this content was captured on {started_at}. {tz} is the user's timezone; convert all event times to UTC and respond in UTC.
+    For date context, this content was captured on {started_at}. {tz} is the user's timezone; respond in user local timezone.
 
     {format_instructions}'''.replace(
         '    ', ''
@@ -723,7 +723,7 @@ def get_reprocess_transcript_structure(
     • Vague suggestions ("let's grab coffee soon")
     • Hypothetical scenarios ("if we meet Tuesday...")
     
-    For date context, this content was captured on {started_at}. {tz} is the user's timezone; convert all event times to UTC and respond in UTC.
+    For date context, this content was captured on {started_at}. {tz} is the user's timezone; respond in user local timezone.
 
     Content:
     {full_context}

--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -32,7 +32,7 @@ def get_message_structure(
     For the overview, summarize the message with the main points discussed, make sure to capture the key information and important details.
     For the action items, include any tasks or actions that need to be taken based on the message.
     For the category, classify the message into one of the available categories.
-    For Calendar Events, include any events or meetings mentioned in the message. For date context, this message was sent on {started_at}. {tz} is the user's timezone, convert it to UTC and respond in UTC.
+    For Calendar Events, include any events or meetings mentioned in the message. For date context, this message was sent on {started_at}. {tz} is the user's timezone, respond in user local timezone.
 
     Message Content: ```{text}```
     Message Source: {text_source_spec}


### PR DESCRIPTION
## Summary
Fixes issue #6214 - Chat assistant gives wrong times due to timezone confusion.
When users asked about times/dates, the AI was responding in UTC instead of their local timezone, causing incorrect timestamps (e.g., user in UTC-3 would get times 3 hours off).
## Changes
Changed LLM prompts to respond in user's local timezone instead of UTC:
- `backend/utils/llm/chat.py` - 3 locations
- `backend/utils/llm/conversation_processing.py` - 2 locations  
- `backend/utils/llm/external_integrations.py` - 1 location
## Testing
- 98 unit tests passed
- Logic verified: now responds in user's local timezone instead of UTC

Before (bug):
- User in America/Sao_Paulo (UTC-3) asks: "What time did X happen?"
- AI responds in UTC → Wrong time (3 hours ahead)

After (fix):
- User in America/Sao_Paulo (UTC-3) asks: "What time did X happen?"
- AI responds in local timezone → Correct time