### PR TITLE
fix no auth token fatal crash on socket connect

### DIFF
--- a/app/lib/backend/http/shared.dart
+++ b/app/lib/backend/http/shared.dart
@@ -38,12 +38,8 @@ Future<String> getAuthHeader() async {
     hasAuthToken = SharedPreferencesUtil().authToken.isNotEmpty;
   }
 
-  if (!hasAuthToken) {
-    if (AuthService.instance.isSignedIn()) {
-      // should only throw if the user is signed in but the token is not found
-      // if the user is not signed in, the token will always be empty
-      throw Exception('No auth token found');
-    }
+  if (!hasAuthToken && AuthService.instance.isSignedIn()) {
+    Logger.handle(Exception('No auth token found'), StackTrace.current, message: 'No auth token found');
   }
   return 'Bearer ${SharedPreferencesUtil().authToken}';
 }


### PR DESCRIPTION
## Summary
- `getAuthHeader()` was throwing `Exception('No auth token found')` when Firebase token refresh returned `null` while the user was still signed in
- The exception propagated uncaught through `PureSocket.connect()` up to the `Timer` callback in `_startKeepAliveServices`, causing a fatal `FlutterError` crash
- Replaced the `throw` with `Logger.handle()` — logs a non-fatal report to Crashlytics and continues, returning `'Bearer '` (empty token)
- The empty token causes the WebSocket handshake to fail with a 401, which surfaces as `WebSocketChannelException` — already caught by the existing error accumulator in `connect()` — and the keep-alive timer retries in 15s

## Test plan
- [ ] Add `throw Exception('No auth token found')` at top of `getAuthHeader()` to force the condition
- [ ] Hot restart, connect Omi device or start phone mic recording to trigger WebSocket
- [ ] Confirm no fatal crash — only a non-fatal Crashlytics log and a socket retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)