### PR TITLE
fix daily recap language not updating when user changes primary language

### DIFF
--- a/backend/utils/llm/external_integrations.py
+++ b/backend/utils/llm/external_integrations.py
@@ -152,7 +152,7 @@ def generate_comprehensive_daily_summary(
     user_name, memories_str = get_prompt_memories(uid)
 
     # Get user's language preference for generating summary in their language
-    user_language = users_db.get_user_language_preference(uid)
+    output_language = user_profile.get('language', '') or 'en'
 
     all_person_ids = []
     for m in conversations:
@@ -213,6 +213,7 @@ def generate_comprehensive_daily_summary(
     convo_id_map = {i + 1: c.id for i, c in enumerate(non_discarded)}
 
     prompt = f"""You are creating a daily summary for {user_name}. {memories_str}
+OUTPUT LANGUAGE: {output_language}. You MUST write every word of this summary in {output_language}, regardless of the language the conversations are in.
 
 Today's date: {date_str}
 Conversations: {total_conversations}
@@ -264,7 +265,7 @@ RULES:
 - conversation_number: Reference which conversation (1-{total_conversations}) it came from.
 - SKIP sections entirely if no quality content.
 - Be snappy. No fluff. No corporate speak. Only include sections that are genuinely useful and relevant.
-{f'- IMPORTANT: You MUST write the ENTIRE summary in {user_language}. All text including headline, overview, highlights, questions, decisions, and knowledge nuggets MUST be in {user_language}. Do NOT write in English.' if user_language and user_language != 'en' else ''}
+- OUTPUT LANGUAGE: Every word — headline, overview, highlights, questions, decisions, knowledge nuggets — MUST be in {output_language}. Do not use any other language.
 
 Respond with ONLY valid JSON. Do not include any other text or comments."""
 


### PR DESCRIPTION
## Summary
- Daily Recap notifications/summaries were not switching to the new language after a user changed their Primary Language setting
- Two failure modes in the prompt: (1) language instruction was omitted entirely when language was set to `en`, causing the LLM to fall back to the conversation content language; (2) for non-English switches, the single conditional instruction at the end of the rules section was too weak to override strongly-in-old-language conversation content
- Fix: always inject the output language requirement unconditionally — anchored at the top of the prompt before any conversation content, and reinforced again in the rules section. Also eliminates a redundant Firestore read by reusing the already-fetched `user_profile` instead of calling `get_user_language_preference` separately.

## Test plan
- [ ] Change Primary Language to a non-English language (e.g. Spanish) — next Daily Recap should be entirely in Spanish
- [ ] Change Primary Language to English from another language — next Daily Recap should be in English (previously fell back to old language)
- [ ] Change Primary Language between two non-English languages — next recap should use the new language

Closes #5789

🤖 Generated with [Claude Code](https://claude.com/claude-code)