### PR TITLE
BLE: richer disconnect diagnostics to diagnose reconnect-burst reports

### DIFF
--- a/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
+++ b/app/android/app/src/main/kotlin/com/example/my_project/MainActivity.kt
@@ -64,6 +64,16 @@ class MainActivity: FlutterActivity() {
         }
     }
 
+    override fun onResume() {
+        super.onResume()
+        OmiBleManager.isAppForeground = true
+    }
+
+    override fun onPause() {
+        OmiBleManager.isAppForeground = false
+        super.onPause()
+    }
+
     override fun onDestroy() {
         // When user closes the app (swipe away), stop the foreground service.
         // The service handles disconnecting all managed devices in onDestroy.

--- a/app/android/app/src/main/kotlin/com/friend/ios/BleHostApiImpl.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/BleHostApiImpl.kt
@@ -112,7 +112,8 @@ class BleHostApiImpl(private val getActivity: () -> Activity?) : BleHostApi {
             callback(Result.success(BleDeviceDiagnostics(
                 disconnectHistory = emptyList(),
                 reconnectionCount = 0,
-                connectedAt = 0
+                connectedAt = 0,
+                failToConnectCount = 0
             )))
         }
     }

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -43,6 +43,7 @@ class OmiBleForegroundService : Service() {
         private const val PREFS_DIAGNOSTICS = "ble_diagnostics"
         private const val KEY_DISCONNECT_HISTORY = "disconnect_history"
         private const val KEY_RECONNECT_COUNT = "reconnect_count"
+        private const val KEY_FAIL_TO_CONNECT_COUNT = "fail_to_connect_count"
         private const val MAX_DISCONNECT_HISTORY = 20
 
         @Volatile
@@ -103,7 +104,15 @@ class OmiBleForegroundService : Service() {
         var currentGattHash: Int? = null,
         var hasEverConnected: Boolean = false,
         var pendingReconnect: Runnable? = null,
-        var stabilityTimerRunnable: Runnable? = null
+        var stabilityTimerRunnable: Runnable? = null,
+        /** Reset to false on each connectGatt attempt; set true when the GATT
+         *  callback reports CONNECTED. Used to distinguish fail-to-connect from
+         *  an established link dropping. Independent of hasEverConnected which
+         *  tracks the full device lifetime. */
+        var currentAttemptEstablished: Boolean = false,
+        /** Timestamp of the last persisted unexpected disconnect event, used to
+         *  backfill time-to-reconnect on the next successful connect. */
+        var pendingReconnectMarkerTs: Long? = null
     )
 
     private val managedDevices = ConcurrentHashMap<String, ManagedDevice>()
@@ -124,9 +133,11 @@ class OmiBleForegroundService : Service() {
             Log.i(TAG, "onGattConnected: $addr")
             if (managed.hasEverConnected) {
                 incrementReconnectionCount(addr)
+                backfillTimeToReconnect(addr, managed)
             }
             managed.retryCount = 0
             managed.hasEverConnected = true
+            managed.currentAttemptEstablished = true
             managed.pendingReconnect?.let { handler.removeCallbacks(it) }
             managed.pendingReconnect = null
             managed.connectionStartTime = System.currentTimeMillis()
@@ -262,7 +273,7 @@ class OmiBleForegroundService : Service() {
             .putBoolean(PREFS_USER_DISCONNECTED, true)
             .apply()
 
-        persistDisconnectEvent(addr, 0, isManual = true)
+        persistDisconnectEvent(addr, 0, isManual = true, eventType = "disconnect")
 
         bleManager.mainHandler.post {
             bleManager.flutterApi?.onPeripheralDisconnected(addr, "unmanaged") {}
@@ -302,6 +313,7 @@ class OmiBleForegroundService : Service() {
 
             managed.currentGattHash = gatt.hashCode()
             managed.connectionStartTime = System.currentTimeMillis()
+            managed.currentAttemptEstablished = false
             updateNotification("Connecting to Omi...")
         }
     }
@@ -360,7 +372,12 @@ class OmiBleForegroundService : Service() {
         val userDisconnected = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
             .getBoolean(PREFS_USER_DISCONNECTED, false)
         if (!userDisconnected) {
-            persistDisconnectEvent(addr, status, isManual = false)
+            val attemptEstablished = managed?.currentAttemptEstablished ?: false
+            val eventType = if (attemptEstablished) "disconnect" else "fail_to_connect"
+            persistDisconnectEvent(addr, status, isManual = false, eventType = eventType)
+            if (eventType == "fail_to_connect") {
+                incrementFailToConnectCount(addr)
+            }
         }
 
         bleManager.mainHandler.post {
@@ -559,18 +576,44 @@ class OmiBleForegroundService : Service() {
 
     private fun historyKey(address: String) = "${KEY_DISCONNECT_HISTORY}_${address.uppercase()}"
     private fun reconnectKey(address: String) = "${KEY_RECONNECT_COUNT}_${address.uppercase()}"
+    private fun failToConnectKey(address: String) = "${KEY_FAIL_TO_CONNECT_COUNT}_${address.uppercase()}"
 
-    private fun persistDisconnectEvent(address: String, status: Int, isManual: Boolean) {
+    private fun currentAppState(): String = if (OmiBleManager.isAppForeground) "foreground" else "background"
+
+    private fun persistDisconnectEvent(
+        address: String,
+        status: Int,
+        isManual: Boolean,
+        eventType: String
+    ) {
         val prefs = getSharedPreferences(PREFS_DIAGNOSTICS, MODE_PRIVATE)
         val key = historyKey(address)
         val historyJson = prefs.getString(key, "[]") ?: "[]"
         val history = try { JSONArray(historyJson) } catch (_: Exception) { JSONArray() }
 
+        val addr = address.uppercase()
+        val managed = managedDevices[addr]
+        val now = System.currentTimeMillis()
+        val durationMs: Long = if (
+            eventType == "disconnect" &&
+            managed?.currentAttemptEstablished == true &&
+            managed.connectionStartTime != null
+        ) {
+            now - (managed.connectionStartTime ?: now)
+        } else {
+            0L
+        }
+
         val event = JSONObject().apply {
-            put("timestamp", System.currentTimeMillis())
+            put("timestamp", now)
             put("reason", if (isManual) "manual" else hciStatusDescription(status))
             put("reasonCode", status)
             put("isManual", isManual)
+            put("eventType", eventType)
+            put("lastRssi", bleManager.lastRssi[addr] ?: 0)
+            put("connectionDurationMs", durationMs)
+            put("appState", currentAppState())
+            put("timeToReconnectMs", 0L)
         }
         history.put(event)
 
@@ -580,6 +623,33 @@ class OmiBleForegroundService : Service() {
         }
 
         prefs.edit().putString(key, history.toString()).apply()
+
+        // Remember the event timestamp so the next successful connect can backfill
+        // the time-to-reconnect latency on this record.
+        if (!isManual && managed != null) {
+            managed.pendingReconnectMarkerTs = now
+        }
+    }
+
+    private fun backfillTimeToReconnect(address: String, managed: ManagedDevice) {
+        val markerTs = managed.pendingReconnectMarkerTs ?: return
+        managed.pendingReconnectMarkerTs = null
+
+        val prefs = getSharedPreferences(PREFS_DIAGNOSTICS, MODE_PRIVATE)
+        val key = historyKey(address)
+        val historyJson = prefs.getString(key, "[]") ?: "[]"
+        val history = try { JSONArray(historyJson) } catch (_: Exception) { return }
+
+        val now = System.currentTimeMillis()
+        // Walk backwards; history is small (≤ MAX_DISCONNECT_HISTORY).
+        for (i in history.length() - 1 downTo 0) {
+            val obj = history.getJSONObject(i)
+            if (obj.optLong("timestamp", 0L) == markerTs) {
+                obj.put("timeToReconnectMs", (now - markerTs).coerceAtLeast(0L))
+                prefs.edit().putString(key, history.toString()).apply()
+                return
+            }
+        }
     }
 
     private fun incrementReconnectionCount(address: String) {
@@ -589,11 +659,19 @@ class OmiBleForegroundService : Service() {
         prefs.edit().putInt(key, count + 1).apply()
     }
 
+    private fun incrementFailToConnectCount(address: String) {
+        val prefs = getSharedPreferences(PREFS_DIAGNOSTICS, MODE_PRIVATE)
+        val key = failToConnectKey(address)
+        val count = prefs.getInt(key, 0)
+        prefs.edit().putInt(key, count + 1).apply()
+    }
+
     fun getDeviceDiagnostics(address: String): BleDeviceDiagnostics {
         val prefs = getSharedPreferences(PREFS_DIAGNOSTICS, MODE_PRIVATE)
         val historyJson = prefs.getString(historyKey(address), "[]") ?: "[]"
         val history = try { JSONArray(historyJson) } catch (_: Exception) { JSONArray() }
         val reconnectCount = prefs.getInt(reconnectKey(address), 0)
+        val failToConnectCount = prefs.getInt(failToConnectKey(address), 0)
 
         val events = mutableListOf<BleDisconnectEvent>()
         for (i in 0 until history.length()) {
@@ -602,7 +680,12 @@ class OmiBleForegroundService : Service() {
                 timestamp = obj.getLong("timestamp"),
                 reason = obj.getString("reason"),
                 reasonCode = obj.getInt("reasonCode").toLong(),
-                isManual = obj.getBoolean("isManual")
+                isManual = obj.getBoolean("isManual"),
+                eventType = obj.optString("eventType", "disconnect"),
+                lastRssi = obj.optLong("lastRssi", 0L),
+                connectionDurationMs = obj.optLong("connectionDurationMs", 0L),
+                appState = obj.optString("appState", ""),
+                timeToReconnectMs = obj.optLong("timeToReconnectMs", 0L)
             ))
         }
 
@@ -612,7 +695,8 @@ class OmiBleForegroundService : Service() {
         return BleDeviceDiagnostics(
             disconnectHistory = events,
             reconnectionCount = reconnectCount.toLong(),
-            connectedAt = connectedAt
+            connectedAt = connectedAt,
+            failToConnectCount = failToConnectCount.toLong()
         )
     }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -45,6 +45,23 @@ class OmiBleForegroundService : Service() {
         private const val KEY_RECONNECT_COUNT = "reconnect_count"
         private const val KEY_FAIL_TO_CONNECT_COUNT = "fail_to_connect_count"
         private const val MAX_DISCONNECT_HISTORY = 20
+        private const val RSSI_TREND_WINDOW_MS = 15_000L
+        private const val RSSI_TREND_FADING_DROP_DB = 10
+
+        /** Classify the RSSI trajectory in the window before [nowMs]. See BleDisconnectEvent.rssiTrend
+         *  for the semantics of each label. */
+        private fun classifyRssiTrend(samples: List<Pair<Long, Int>>, nowMs: Long): String {
+            val windowStart = nowMs - RSSI_TREND_WINDOW_MS
+            val recent = samples.filter { it.first >= windowStart }
+            if (recent.isEmpty()) return "gap"
+            if (recent.size < 3) return "unknown"
+            val third = (recent.size / 3).coerceAtLeast(1)
+            val oldestAvg = recent.take(third).sumOf { it.second } / third
+            val newestAvg = recent.takeLast(third).sumOf { it.second } / third
+            // RSSI is negative; a larger drop = newestAvg more negative than oldestAvg.
+            val dropDb = oldestAvg - newestAvg
+            return if (dropDb >= RSSI_TREND_FADING_DROP_DB) "fading" else "sudden"
+        }
 
         @Volatile
         var instance: OmiBleForegroundService? = null
@@ -604,6 +621,11 @@ class OmiBleForegroundService : Service() {
             0L
         }
 
+        val rssiSnapshot = bleManager.rssiHistory[addr]?.let { deque ->
+            synchronized(deque) { deque.toList() }
+        } ?: emptyList()
+        val trend = classifyRssiTrend(rssiSnapshot, now)
+
         val event = JSONObject().apply {
             put("timestamp", now)
             put("reason", if (isManual) "manual" else hciStatusDescription(status))
@@ -614,6 +636,7 @@ class OmiBleForegroundService : Service() {
             put("connectionDurationMs", durationMs)
             put("appState", currentAppState())
             put("timeToReconnectMs", 0L)
+            put("rssiTrend", trend)
         }
         history.put(event)
 
@@ -685,7 +708,8 @@ class OmiBleForegroundService : Service() {
                 lastRssi = obj.optLong("lastRssi", 0L),
                 connectionDurationMs = obj.optLong("connectionDurationMs", 0L),
                 appState = obj.optString("appState", ""),
-                timeToReconnectMs = obj.optLong("timeToReconnectMs", 0L)
+                timeToReconnectMs = obj.optLong("timeToReconnectMs", 0L),
+                rssiTrend = obj.optString("rssiTrend", "")
             ))
         }
 

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleForegroundService.kt
@@ -558,7 +558,7 @@ class OmiBleForegroundService : Service() {
         for ((addr, managed) in managedDevices) {
             managed.pendingReconnect?.let { handler.removeCallbacks(it) }
             managed.stabilityTimerRunnable?.let { handler.removeCallbacks(it) }
-            persistDisconnectEvent(addr, -1, isManual = false)
+            persistDisconnectEvent(addr, -1, isManual = false, eventType = "disconnect")
             bleManager.disconnectGatt(addr)
             bleManager.closeGatt(addr)
             bleManager.mainHandler.post {

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -48,6 +48,11 @@ class OmiBleManager private constructor(private val application: Application) {
         @Volatile
         var isFlutterAlive: Boolean = false
 
+        /** True while MainActivity is resumed. Set from onResume/onPause. Used to tag
+         *  diagnostic disconnect events with the app lifecycle state at the moment of the event. */
+        @Volatile
+        var isAppForeground: Boolean = false
+
         fun initialize(application: Application) {
             if (_instance == null) {
                 synchronized(this) {
@@ -99,6 +104,10 @@ class OmiBleManager private constructor(private val application: Application) {
     private val rssiKeepAliveInterval = 3000L // ms
     @Volatile
     var isRssiStreamingEnabled = false
+
+    /// Most recent RSSI per device (uppercase MAC). Used by the foreground service
+    /// to annotate disconnect events so we can tell range-driven drops from healthy-signal drops.
+    val lastRssi = java.util.concurrent.ConcurrentHashMap<String, Int>()
 
     private var bondCompletionCallback: ((Boolean) -> Unit)? = null
     private var bondTimeoutRunnable: Runnable? = null
@@ -657,8 +666,9 @@ class OmiBleManager private constructor(private val application: Application) {
                 Log.w(TAG, "RSSI read failed: status=$status for ${gatt.device.address}")
                 return
             }
+            val address = gatt.device.address.uppercase()
+            lastRssi[address] = rssi
             if (isRssiStreamingEnabled) {
-                val address = gatt.device.address.uppercase()
                 mainHandler.post {
                     flutterApi?.onRssiUpdate(address, rssi.toLong()) {}
                 }

--- a/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/OmiBleManager.kt
@@ -30,6 +30,7 @@ class OmiBleManager private constructor(private val application: Application) {
 
     companion object {
         private const val TAG = "OmiBle"
+        private const val RSSI_HISTORY_LIMIT = 10
         private const val BOND_TIMEOUT_MS = 15000L // 15s — bond request timeout
 
         @Volatile
@@ -108,6 +109,11 @@ class OmiBleManager private constructor(private val application: Application) {
     /// Most recent RSSI per device (uppercase MAC). Used by the foreground service
     /// to annotate disconnect events so we can tell range-driven drops from healthy-signal drops.
     val lastRssi = java.util.concurrent.ConcurrentHashMap<String, Int>()
+
+    /// Sliding window of recent (timestamp_ms, rssi_dbm) samples per device, used
+    /// by the foreground service to classify RSSI trajectory at disconnect time.
+    /// Synchronized on the deque itself for reader/writer safety.
+    val rssiHistory = java.util.concurrent.ConcurrentHashMap<String, java.util.ArrayDeque<Pair<Long, Int>>>()
 
     private var bondCompletionCallback: ((Boolean) -> Unit)? = null
     private var bondTimeoutRunnable: Runnable? = null
@@ -668,6 +674,11 @@ class OmiBleManager private constructor(private val application: Application) {
             }
             val address = gatt.device.address.uppercase()
             lastRssi[address] = rssi
+            val deque = rssiHistory.getOrPut(address) { java.util.ArrayDeque() }
+            synchronized(deque) {
+                deque.addLast(Pair(System.currentTimeMillis(), rssi))
+                while (deque.size > RSSI_HISTORY_LIMIT) deque.removeFirst()
+            }
             if (isRssiStreamingEnabled) {
                 mainHandler.post {
                     flutterApi?.onRssiUpdate(address, rssi.toLong()) {}

--- a/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
@@ -166,7 +166,29 @@ data class BleDisconnectEvent (
   val timestamp: Long,
   val reason: String,
   val reasonCode: Long,
-  val isManual: Boolean
+  val isManual: Boolean,
+  /**
+   * Kind of event: "disconnect" (link lost after connect) or "fail_to_connect"
+   * (connect attempt never established). Defaults to "disconnect" for legacy records.
+   */
+  val eventType: String,
+  /** Last RSSI sample captured before this event (dBm). 0 if unknown. */
+  val lastRssi: Long,
+  /**
+   * How long the link was established before this event (ms). 0 if unknown
+   * or for fail_to_connect events.
+   */
+  val connectionDurationMs: Long,
+  /**
+   * App lifecycle state at the moment of the event: "foreground", "background",
+   * or "inactive" (iOS transitioning). Empty string if unknown.
+   */
+  val appState: String,
+  /**
+   * ms between this disconnect and the subsequent successful reconnect.
+   * 0 while the device has not yet reconnected.
+   */
+  val timeToReconnectMs: Long
 )
  {
   companion object {
@@ -175,7 +197,12 @@ data class BleDisconnectEvent (
       val reason = pigeonVar_list[1] as String
       val reasonCode = pigeonVar_list[2] as Long
       val isManual = pigeonVar_list[3] as Boolean
-      return BleDisconnectEvent(timestamp, reason, reasonCode, isManual)
+      val eventType = pigeonVar_list[4] as String
+      val lastRssi = pigeonVar_list[5] as Long
+      val connectionDurationMs = pigeonVar_list[6] as Long
+      val appState = pigeonVar_list[7] as String
+      val timeToReconnectMs = pigeonVar_list[8] as Long
+      return BleDisconnectEvent(timestamp, reason, reasonCode, isManual, eventType, lastRssi, connectionDurationMs, appState, timeToReconnectMs)
     }
   }
   fun toList(): List<Any?> {
@@ -184,6 +211,11 @@ data class BleDisconnectEvent (
       reason,
       reasonCode,
       isManual,
+      eventType,
+      lastRssi,
+      connectionDurationMs,
+      appState,
+      timeToReconnectMs,
     )
   }
   override fun equals(other: Any?): Boolean {
@@ -206,7 +238,12 @@ data class BleDisconnectEvent (
 data class BleDeviceDiagnostics (
   val disconnectHistory: List<BleDisconnectEvent>,
   val reconnectionCount: Long,
-  val connectedAt: Long
+  val connectedAt: Long,
+  /**
+   * Count of connect attempts that never reached didConnect. Surfaces the
+   * silent-failure path separately from established-then-dropped disconnects.
+   */
+  val failToConnectCount: Long
 )
  {
   companion object {
@@ -214,7 +251,8 @@ data class BleDeviceDiagnostics (
       val disconnectHistory = pigeonVar_list[0] as List<BleDisconnectEvent>
       val reconnectionCount = pigeonVar_list[1] as Long
       val connectedAt = pigeonVar_list[2] as Long
-      return BleDeviceDiagnostics(disconnectHistory, reconnectionCount, connectedAt)
+      val failToConnectCount = pigeonVar_list[3] as Long
+      return BleDeviceDiagnostics(disconnectHistory, reconnectionCount, connectedAt, failToConnectCount)
     }
   }
   fun toList(): List<Any?> {
@@ -222,6 +260,7 @@ data class BleDeviceDiagnostics (
       disconnectHistory,
       reconnectionCount,
       connectedAt,
+      failToConnectCount,
     )
   }
   override fun equals(other: Any?): Boolean {

--- a/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
+++ b/app/android/app/src/main/kotlin/com/friend/ios/PigeonCommunicator.g.kt
@@ -188,7 +188,16 @@ data class BleDisconnectEvent (
    * ms between this disconnect and the subsequent successful reconnect.
    * 0 while the device has not yet reconnected.
    */
-  val timeToReconnectMs: Long
+  val timeToReconnectMs: Long,
+  /**
+   * RSSI trajectory over the ~15s before this event. One of:
+   *   "fading"  — signal declined ≥10 dB before the drop (walk-away)
+   *   "sudden"  — signal stable then link died (interference/stall/device off)
+   *   "gap"     — no recent RSSI samples (keep-alive wasn't running)
+   *   "unknown" — insufficient samples to classify
+   * Empty string on legacy records written before this field existed.
+   */
+  val rssiTrend: String
 )
  {
   companion object {
@@ -202,7 +211,8 @@ data class BleDisconnectEvent (
       val connectionDurationMs = pigeonVar_list[6] as Long
       val appState = pigeonVar_list[7] as String
       val timeToReconnectMs = pigeonVar_list[8] as Long
-      return BleDisconnectEvent(timestamp, reason, reasonCode, isManual, eventType, lastRssi, connectionDurationMs, appState, timeToReconnectMs)
+      val rssiTrend = pigeonVar_list[9] as String
+      return BleDisconnectEvent(timestamp, reason, reasonCode, isManual, eventType, lastRssi, connectionDurationMs, appState, timeToReconnectMs, rssiTrend)
     }
   }
   fun toList(): List<Any?> {
@@ -216,6 +226,7 @@ data class BleDisconnectEvent (
       connectionDurationMs,
       appState,
       timeToReconnectMs,
+      rssiTrend,
     )
   }
   override fun equals(other: Any?): Boolean {

--- a/app/ios/Runner/OmiBleManager.swift
+++ b/app/ios/Runner/OmiBleManager.swift
@@ -48,6 +48,11 @@ final class OmiBleManager: NSObject {
     /// apart from disconnects with healthy signal.
     private var lastRssi: [String: Int64] = [:]
 
+    /// Sliding window of recent (timestamp_ms, rssi) samples per peripheral, used
+    /// to classify the trajectory before a disconnect (fading vs. sudden vs. gap).
+    /// Capped at rssiHistoryLimit — beyond that we drop the oldest.
+    private var rssiHistory: [String: [(ts: Int64, rssi: Int64)]] = [:]
+
     /// Timestamp of the most recently persisted unexpected disconnect per peripheral.
     /// On the next successful didConnect we backfill `timeToReconnectMs` on that event.
     private var pendingReconnectForEvent: [String: Int64] = [:]
@@ -303,6 +308,27 @@ final class OmiBleManager: NSObject {
     private static let reconnectCountKeyPrefix = "ble_diagnostics_reconnect_count_"
     private static let failToConnectCountKeyPrefix = "ble_diagnostics_fail_to_connect_count_"
     private static let maxDisconnectHistory = 20
+    private static let rssiHistoryLimit = 10
+    private static let rssiTrendWindowMs: Int64 = 15_000
+    private static let rssiTrendFadingDropDb: Int64 = 10
+
+    /// Classify the RSSI trajectory in the window before `nowMs`. See `rssiTrend`
+    /// on BleDisconnectEvent for the semantics of each label.
+    private static func classifyRssiTrend(samples: [(ts: Int64, rssi: Int64)], nowMs: Int64) -> String {
+        let windowStart = nowMs - rssiTrendWindowMs
+        let recent = samples.filter { $0.ts >= windowStart }
+        // No recent samples — keep-alive wasn't running, so we can't say.
+        if recent.isEmpty { return "gap" }
+        if recent.count < 3 { return "unknown" }
+        // Compare the average of the oldest third to the newest third. A drop of
+        // ≥rssiTrendFadingDropDb dB indicates a fading signal (walk-away).
+        let third = max(1, recent.count / 3)
+        let oldestAvg = recent.prefix(third).map { $0.rssi }.reduce(0, +) / Int64(third)
+        let newestAvg = recent.suffix(third).map { $0.rssi }.reduce(0, +) / Int64(third)
+        let dropDb = oldestAvg - newestAvg // RSSI is negative; larger drop = more negative newer value
+        if dropDb >= rssiTrendFadingDropDb { return "fading" }
+        return "sudden"
+    }
 
     private static func historyKey(_ uuid: String) -> String { "\(diagnosticsKeyPrefix)\(uuid)" }
     private static func reconnectKey(_ uuid: String) -> String { "\(reconnectCountKeyPrefix)\(uuid)" }
@@ -354,6 +380,7 @@ final class OmiBleManager: NSObject {
         let startedAt = connectionStartTimes[uuid] ?? 0
         let durationMs: Int64 = (eventType == "disconnect" && startedAt > 0) ? (now - startedAt) : 0
 
+        let trend = OmiBleManager.classifyRssiTrend(samples: rssiHistory[uuid] ?? [], nowMs: now)
         let event: [String: Any] = [
             "timestamp": now,
             "reason": isManual ? "manual" : (reason ?? "unknown"),
@@ -364,6 +391,7 @@ final class OmiBleManager: NSObject {
             "connectionDurationMs": durationMs,
             "appState": currentAppState(),
             "timeToReconnectMs": 0,
+            "rssiTrend": trend,
         ]
         history.append(event)
 
@@ -431,7 +459,8 @@ final class OmiBleManager: NSObject {
                 lastRssi: obj["lastRssi"] as? Int64 ?? 0,
                 connectionDurationMs: obj["connectionDurationMs"] as? Int64 ?? 0,
                 appState: obj["appState"] as? String ?? "",
-                timeToReconnectMs: obj["timeToReconnectMs"] as? Int64 ?? 0
+                timeToReconnectMs: obj["timeToReconnectMs"] as? Int64 ?? 0,
+                rssiTrend: obj["rssiTrend"] as? String ?? ""
             )
         }
 
@@ -570,11 +599,12 @@ extension OmiBleManager: CBCentralManagerDelegate {
         let isManual = manuallyDisconnected.contains(uuid)
         NSLog("[OmiBle] didDisconnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
         cleanupPeripheral(uuid)
-        connectionStartTimes.removeValue(forKey: uuid)
 
         if !isManual {
             let reason = Self.bleReasonString(from: error)
             let code = (error as? CBError)?.code.rawValue ?? -1
+            // Persist BEFORE clearing connectionStartTimes — the persist step reads
+            // it to compute connection_duration_ms.
             persistDisconnectEvent(
                 uuid: uuid,
                 reason: reason,
@@ -583,6 +613,7 @@ extension OmiBleManager: CBCentralManagerDelegate {
                 eventType: "disconnect"
             )
         }
+        connectionStartTimes.removeValue(forKey: uuid)
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) { _ in }
 
@@ -636,13 +667,23 @@ extension OmiBleManager: CBPeripheralDelegate {
     func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
         guard error == nil else { return }
         let uuid = peripheralUuidString(peripheral)
+        let value = Int64(RSSI.intValue)
         // Always remember the latest sample — used to annotate disconnect events
         // so we can tell signal-driven drops apart from drops with healthy RSSI.
-        lastRssi[uuid] = Int64(RSSI.intValue)
+        lastRssi[uuid] = value
+
+        // Append to the trajectory window used by rssiTrend classification.
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        var samples = rssiHistory[uuid] ?? []
+        samples.append((ts: now, rssi: value))
+        if samples.count > OmiBleManager.rssiHistoryLimit {
+            samples.removeFirst(samples.count - OmiBleManager.rssiHistoryLimit)
+        }
+        rssiHistory[uuid] = samples
 
         // Forward to Flutter only while the diagnostics screen has subscribed.
         if isRssiStreamingEnabled {
-            flutterApi?.onRssiUpdate(peripheralUuid: uuid, rssi: Int64(RSSI.intValue)) { _ in }
+            flutterApi?.onRssiUpdate(peripheralUuid: uuid, rssi: value) { _ in }
         }
     }
 

--- a/app/ios/Runner/OmiBleManager.swift
+++ b/app/ios/Runner/OmiBleManager.swift
@@ -1,5 +1,6 @@
 import CoreBluetooth
 import Flutter
+import UIKit
 
 /// Native CoreBluetooth manager that handles BLE lifecycle, state restoration,
 /// reconnection, service discovery, and audio batching.
@@ -41,6 +42,15 @@ final class OmiBleManager: NSObject {
 
     /// Tracks peripherals that have connected at least once (for reconnection counting).
     private var everConnected: Set<String> = []
+
+    /// Most recent RSSI sample per peripheral, captured in didReadRSSI. Used to
+    /// annotate disconnect events so we can tell range/interference-driven drops
+    /// apart from disconnects with healthy signal.
+    private var lastRssi: [String: Int64] = [:]
+
+    /// Timestamp of the most recently persisted unexpected disconnect per peripheral.
+    /// On the next successful didConnect we backfill `timeToReconnectMs` on that event.
+    private var pendingReconnectForEvent: [String: Int64] = [:]
 
     /// Scanning state.
     private var isScanning = false
@@ -130,7 +140,7 @@ final class OmiBleManager: NSObject {
 
     func disconnectPeripheral(uuid: String) {
         manuallyDisconnected.insert(uuid)
-        persistDisconnectEvent(uuid: uuid, reason: "manual", reasonCode: 0, isManual: true)
+        persistDisconnectEvent(uuid: uuid, reason: "manual", reasonCode: 0, isManual: true, eventType: "disconnect")
         guard let peripheral = peripherals[uuid] else { return }
         centralManager.cancelPeripheralConnection(peripheral)
     }
@@ -291,10 +301,30 @@ final class OmiBleManager: NSObject {
 
     private static let diagnosticsKeyPrefix = "ble_diagnostics_disconnect_history_"
     private static let reconnectCountKeyPrefix = "ble_diagnostics_reconnect_count_"
+    private static let failToConnectCountKeyPrefix = "ble_diagnostics_fail_to_connect_count_"
     private static let maxDisconnectHistory = 20
 
     private static func historyKey(_ uuid: String) -> String { "\(diagnosticsKeyPrefix)\(uuid)" }
     private static func reconnectKey(_ uuid: String) -> String { "\(reconnectCountKeyPrefix)\(uuid)" }
+    private static func failToConnectKey(_ uuid: String) -> String { "\(failToConnectCountKeyPrefix)\(uuid)" }
+
+    /// Sample the UIApplication state from whatever thread we're on. The BLE
+    /// callbacks run on the main queue already (centralManager was created with
+    /// queue: nil) so this is safe, but we guard anyway for restoration paths.
+    private func currentAppState() -> String {
+        let state: UIApplication.State
+        if Thread.isMainThread {
+            state = UIApplication.shared.applicationState
+        } else {
+            state = DispatchQueue.main.sync { UIApplication.shared.applicationState }
+        }
+        switch state {
+        case .active: return "foreground"
+        case .inactive: return "inactive"
+        case .background: return "background"
+        @unknown default: return ""
+        }
+    }
 
     private static func bleReasonString(from error: Error?) -> String {
         guard let cbError = error as? CBError else { return "clean_disconnect" }
@@ -306,16 +336,34 @@ final class OmiBleManager: NSObject {
         }
     }
 
-    private func persistDisconnectEvent(uuid: String, reason: String?, reasonCode: Int, isManual: Bool) {
+    /// Append a disconnect/fail event to the per-device history ring buffer.
+    /// `eventType` is "disconnect" for an established link lost, or "fail_to_connect"
+    /// for a connect attempt that never reached didConnect.
+    private func persistDisconnectEvent(
+        uuid: String,
+        reason: String?,
+        reasonCode: Int,
+        isManual: Bool,
+        eventType: String
+    ) {
         let defaults = UserDefaults.standard
         let key = OmiBleManager.historyKey(uuid)
         var history = defaults.array(forKey: key) as? [[String: Any]] ?? []
 
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        let startedAt = connectionStartTimes[uuid] ?? 0
+        let durationMs: Int64 = (eventType == "disconnect" && startedAt > 0) ? (now - startedAt) : 0
+
         let event: [String: Any] = [
-            "timestamp": Int64(Date().timeIntervalSince1970 * 1000),
+            "timestamp": now,
             "reason": isManual ? "manual" : (reason ?? "unknown"),
             "reasonCode": reasonCode,
             "isManual": isManual,
+            "eventType": eventType,
+            "lastRssi": lastRssi[uuid] ?? 0,
+            "connectionDurationMs": durationMs,
+            "appState": currentAppState(),
+            "timeToReconnectMs": 0,
         ]
         history.append(event)
 
@@ -324,6 +372,33 @@ final class OmiBleManager: NSObject {
         }
 
         defaults.set(history, forKey: key)
+
+        // Remember this event's timestamp so the next successful didConnect can
+        // backfill timeToReconnectMs. Only track unexpected (non-manual) events.
+        if !isManual {
+            pendingReconnectForEvent[uuid] = now
+        }
+    }
+
+    /// On successful didConnect, find the most recent unexpected event for this
+    /// peripheral and write the reconnect-latency value into it.
+    private func backfillTimeToReconnect(uuid: String) {
+        guard let markerTs = pendingReconnectForEvent.removeValue(forKey: uuid) else { return }
+        let defaults = UserDefaults.standard
+        let key = OmiBleManager.historyKey(uuid)
+        guard var history = defaults.array(forKey: key) as? [[String: Any]] else { return }
+
+        // Walk backwards for the matching timestamp. History is small (≤20).
+        let now = Int64(Date().timeIntervalSince1970 * 1000)
+        for i in stride(from: history.count - 1, through: 0, by: -1) {
+            if let ts = history[i]["timestamp"] as? Int64, ts == markerTs {
+                var event = history[i]
+                event["timeToReconnectMs"] = max(Int64(0), now - markerTs)
+                history[i] = event
+                defaults.set(history, forKey: key)
+                return
+            }
+        }
     }
 
     private func incrementReconnectionCount(uuid: String) {
@@ -333,17 +408,30 @@ final class OmiBleManager: NSObject {
         defaults.set(count + 1, forKey: key)
     }
 
+    private func incrementFailToConnectCount(uuid: String) {
+        let defaults = UserDefaults.standard
+        let key = OmiBleManager.failToConnectKey(uuid)
+        let count = defaults.integer(forKey: key)
+        defaults.set(count + 1, forKey: key)
+    }
+
     func getDeviceDiagnostics(uuid: String) -> BleDeviceDiagnostics {
         let defaults = UserDefaults.standard
         let history = defaults.array(forKey: OmiBleManager.historyKey(uuid)) as? [[String: Any]] ?? []
         let reconnectCount = defaults.integer(forKey: OmiBleManager.reconnectKey(uuid))
+        let failToConnectCount = defaults.integer(forKey: OmiBleManager.failToConnectKey(uuid))
 
         let events = history.map { obj -> BleDisconnectEvent in
             BleDisconnectEvent(
                 timestamp: obj["timestamp"] as? Int64 ?? 0,
                 reason: obj["reason"] as? String ?? "unknown",
                 reasonCode: Int64(obj["reasonCode"] as? Int ?? -1),
-                isManual: obj["isManual"] as? Bool ?? false
+                isManual: obj["isManual"] as? Bool ?? false,
+                eventType: obj["eventType"] as? String ?? "disconnect",
+                lastRssi: obj["lastRssi"] as? Int64 ?? 0,
+                connectionDurationMs: obj["connectionDurationMs"] as? Int64 ?? 0,
+                appState: obj["appState"] as? String ?? "",
+                timeToReconnectMs: obj["timeToReconnectMs"] as? Int64 ?? 0
             )
         }
 
@@ -352,7 +440,8 @@ final class OmiBleManager: NSObject {
         return BleDeviceDiagnostics(
             disconnectHistory: events,
             reconnectionCount: Int64(reconnectCount),
-            connectedAt: connectedAt
+            connectedAt: connectedAt,
+            failToConnectCount: Int64(failToConnectCount)
         )
     }
 
@@ -435,6 +524,8 @@ extension OmiBleManager: CBCentralManagerDelegate {
         // Track reconnections (not first connect)
         if everConnected.contains(uuid) {
             incrementReconnectionCount(uuid: uuid)
+            // Backfill the prior unexpected event with how long it took to recover.
+            backfillTimeToReconnect(uuid: uuid)
         }
         everConnected.insert(uuid)
         connectionStartTimes[uuid] = Int64(Date().timeIntervalSince1970 * 1000)
@@ -445,9 +536,33 @@ extension OmiBleManager: CBCentralManagerDelegate {
 
     func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
         let uuid = peripheralUuidString(peripheral)
+        let isManual = manuallyDisconnected.contains(uuid)
         NSLog("[OmiBle] didFailToConnect: \(peripheral.name ?? "<nil>"), uuid=\(uuid), error=\(error?.localizedDescription ?? "nil")")
         cleanupPeripheral(uuid)
+
+        if !isManual {
+            let reason = Self.bleReasonString(from: error)
+            let code = (error as? CBError)?.code.rawValue ?? -1
+            persistDisconnectEvent(
+                uuid: uuid,
+                reason: reason,
+                reasonCode: Int(code),
+                isManual: false,
+                eventType: "fail_to_connect"
+            )
+            incrementFailToConnectCount(uuid: uuid)
+        }
+
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) { _ in }
+
+        // Retry previously-connected peripherals — otherwise a failed connect silently
+        // drops the user. iOS queues this at the chipset level; it's free while waiting.
+        if !isManual, everConnected.contains(uuid) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) { [weak self] in
+                guard let self = self else { return }
+                self.centralManager.connect(peripheral, options: nil)
+            }
+        }
     }
 
     func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
@@ -460,7 +575,13 @@ extension OmiBleManager: CBCentralManagerDelegate {
         if !isManual {
             let reason = Self.bleReasonString(from: error)
             let code = (error as? CBError)?.code.rawValue ?? -1
-            persistDisconnectEvent(uuid: uuid, reason: reason, reasonCode: Int(code), isManual: false)
+            persistDisconnectEvent(
+                uuid: uuid,
+                reason: reason,
+                reasonCode: Int(code),
+                isManual: false,
+                eventType: "disconnect"
+            )
         }
 
         flutterApi?.onPeripheralDisconnected(peripheralUuid: uuid, error: error?.localizedDescription) { _ in }
@@ -513,9 +634,14 @@ extension OmiBleManager: CBPeripheralDelegate {
     }
 
     func peripheral(_ peripheral: CBPeripheral, didReadRSSI RSSI: NSNumber, error: Error?) {
-        // Pure keep-alive — only forward to Flutter when diagnostics screen is open
-        if isRssiStreamingEnabled, error == nil {
-            let uuid = peripheralUuidString(peripheral)
+        guard error == nil else { return }
+        let uuid = peripheralUuidString(peripheral)
+        // Always remember the latest sample — used to annotate disconnect events
+        // so we can tell signal-driven drops apart from drops with healthy RSSI.
+        lastRssi[uuid] = Int64(RSSI.intValue)
+
+        // Forward to Flutter only while the diagnostics screen has subscribed.
+        if isRssiStreamingEnabled {
             flutterApi?.onRssiUpdate(peripheralUuid: uuid, rssi: Int64(RSSI.intValue)) { _ in }
         }
     }

--- a/app/ios/Runner/PigeonCommunicator.g.swift
+++ b/app/ios/Runner/PigeonCommunicator.g.swift
@@ -224,6 +224,13 @@ struct BleDisconnectEvent: Hashable {
   /// ms between this disconnect and the subsequent successful reconnect.
   /// 0 while the device has not yet reconnected.
   var timeToReconnectMs: Int64
+  /// RSSI trajectory over the ~15s before this event. One of:
+  ///   "fading"  — signal declined ≥10 dB before the drop (walk-away)
+  ///   "sudden"  — signal stable then link died (interference/stall/device off)
+  ///   "gap"     — no recent RSSI samples (keep-alive wasn't running)
+  ///   "unknown" — insufficient samples to classify
+  /// Empty string on legacy records written before this field existed.
+  var rssiTrend: String
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -237,6 +244,7 @@ struct BleDisconnectEvent: Hashable {
     let connectionDurationMs = pigeonVar_list[6] as! Int64
     let appState = pigeonVar_list[7] as! String
     let timeToReconnectMs = pigeonVar_list[8] as! Int64
+    let rssiTrend = pigeonVar_list[9] as! String
 
     return BleDisconnectEvent(
       timestamp: timestamp,
@@ -247,7 +255,8 @@ struct BleDisconnectEvent: Hashable {
       lastRssi: lastRssi,
       connectionDurationMs: connectionDurationMs,
       appState: appState,
-      timeToReconnectMs: timeToReconnectMs
+      timeToReconnectMs: timeToReconnectMs,
+      rssiTrend: rssiTrend
     )
   }
   func toList() -> [Any?] {
@@ -261,6 +270,7 @@ struct BleDisconnectEvent: Hashable {
       connectionDurationMs,
       appState,
       timeToReconnectMs,
+      rssiTrend,
     ]
   }
   static func == (lhs: BleDisconnectEvent, rhs: BleDisconnectEvent) -> Bool {

--- a/app/ios/Runner/PigeonCommunicator.g.swift
+++ b/app/ios/Runner/PigeonCommunicator.g.swift
@@ -210,6 +210,20 @@ struct BleDisconnectEvent: Hashable {
   var reason: String
   var reasonCode: Int64
   var isManual: Bool
+  /// Kind of event: "disconnect" (link lost after connect) or "fail_to_connect"
+  /// (connect attempt never established). Defaults to "disconnect" for legacy records.
+  var eventType: String
+  /// Last RSSI sample captured before this event (dBm). 0 if unknown.
+  var lastRssi: Int64
+  /// How long the link was established before this event (ms). 0 if unknown
+  /// or for fail_to_connect events.
+  var connectionDurationMs: Int64
+  /// App lifecycle state at the moment of the event: "foreground", "background",
+  /// or "inactive" (iOS transitioning). Empty string if unknown.
+  var appState: String
+  /// ms between this disconnect and the subsequent successful reconnect.
+  /// 0 while the device has not yet reconnected.
+  var timeToReconnectMs: Int64
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -218,12 +232,22 @@ struct BleDisconnectEvent: Hashable {
     let reason = pigeonVar_list[1] as! String
     let reasonCode = pigeonVar_list[2] as! Int64
     let isManual = pigeonVar_list[3] as! Bool
+    let eventType = pigeonVar_list[4] as! String
+    let lastRssi = pigeonVar_list[5] as! Int64
+    let connectionDurationMs = pigeonVar_list[6] as! Int64
+    let appState = pigeonVar_list[7] as! String
+    let timeToReconnectMs = pigeonVar_list[8] as! Int64
 
     return BleDisconnectEvent(
       timestamp: timestamp,
       reason: reason,
       reasonCode: reasonCode,
-      isManual: isManual
+      isManual: isManual,
+      eventType: eventType,
+      lastRssi: lastRssi,
+      connectionDurationMs: connectionDurationMs,
+      appState: appState,
+      timeToReconnectMs: timeToReconnectMs
     )
   }
   func toList() -> [Any?] {
@@ -232,6 +256,11 @@ struct BleDisconnectEvent: Hashable {
       reason,
       reasonCode,
       isManual,
+      eventType,
+      lastRssi,
+      connectionDurationMs,
+      appState,
+      timeToReconnectMs,
     ]
   }
   static func == (lhs: BleDisconnectEvent, rhs: BleDisconnectEvent) -> Bool {
@@ -248,6 +277,9 @@ struct BleDeviceDiagnostics: Hashable {
   var disconnectHistory: [BleDisconnectEvent]
   var reconnectionCount: Int64
   var connectedAt: Int64
+  /// Count of connect attempts that never reached didConnect. Surfaces the
+  /// silent-failure path separately from established-then-dropped disconnects.
+  var failToConnectCount: Int64
 
 
   // swift-format-ignore: AlwaysUseLowerCamelCase
@@ -255,11 +287,13 @@ struct BleDeviceDiagnostics: Hashable {
     let disconnectHistory = pigeonVar_list[0] as! [BleDisconnectEvent]
     let reconnectionCount = pigeonVar_list[1] as! Int64
     let connectedAt = pigeonVar_list[2] as! Int64
+    let failToConnectCount = pigeonVar_list[3] as! Int64
 
     return BleDeviceDiagnostics(
       disconnectHistory: disconnectHistory,
       reconnectionCount: reconnectionCount,
-      connectedAt: connectedAt
+      connectedAt: connectedAt,
+      failToConnectCount: failToConnectCount
     )
   }
   func toList() -> [Any?] {
@@ -267,6 +301,7 @@ struct BleDeviceDiagnostics: Hashable {
       disconnectHistory,
       reconnectionCount,
       connectedAt,
+      failToConnectCount,
     ]
   }
   static func == (lhs: BleDeviceDiagnostics, rhs: BleDeviceDiagnostics) -> Bool {

--- a/app/lib/gen/pigeon_communicator.g.dart
+++ b/app/lib/gen/pigeon_communicator.g.dart
@@ -150,6 +150,11 @@ class BleDisconnectEvent {
     required this.reason,
     required this.reasonCode,
     required this.isManual,
+    required this.eventType,
+    required this.lastRssi,
+    required this.connectionDurationMs,
+    required this.appState,
+    required this.timeToReconnectMs,
   });
 
   int timestamp;
@@ -160,12 +165,36 @@ class BleDisconnectEvent {
 
   bool isManual;
 
+  /// Kind of event: "disconnect" (link lost after connect) or "fail_to_connect"
+  /// (connect attempt never established). Defaults to "disconnect" for legacy records.
+  String eventType;
+
+  /// Last RSSI sample captured before this event (dBm). 0 if unknown.
+  int lastRssi;
+
+  /// How long the link was established before this event (ms). 0 if unknown
+  /// or for fail_to_connect events.
+  int connectionDurationMs;
+
+  /// App lifecycle state at the moment of the event: "foreground", "background",
+  /// or "inactive" (iOS transitioning). Empty string if unknown.
+  String appState;
+
+  /// ms between this disconnect and the subsequent successful reconnect.
+  /// 0 while the device has not yet reconnected.
+  int timeToReconnectMs;
+
   List<Object?> _toList() {
     return <Object?>[
       timestamp,
       reason,
       reasonCode,
       isManual,
+      eventType,
+      lastRssi,
+      connectionDurationMs,
+      appState,
+      timeToReconnectMs,
     ];
   }
 
@@ -179,6 +208,11 @@ class BleDisconnectEvent {
       reason: result[1]! as String,
       reasonCode: result[2]! as int,
       isManual: result[3]! as bool,
+      eventType: result[4]! as String,
+      lastRssi: result[5]! as int,
+      connectionDurationMs: result[6]! as int,
+      appState: result[7]! as String,
+      timeToReconnectMs: result[8]! as int,
     );
   }
 
@@ -206,6 +240,7 @@ class BleDeviceDiagnostics {
     required this.disconnectHistory,
     required this.reconnectionCount,
     required this.connectedAt,
+    required this.failToConnectCount,
   });
 
   List<BleDisconnectEvent> disconnectHistory;
@@ -214,11 +249,16 @@ class BleDeviceDiagnostics {
 
   int connectedAt;
 
+  /// Count of connect attempts that never reached didConnect. Surfaces the
+  /// silent-failure path separately from established-then-dropped disconnects.
+  int failToConnectCount;
+
   List<Object?> _toList() {
     return <Object?>[
       disconnectHistory,
       reconnectionCount,
       connectedAt,
+      failToConnectCount,
     ];
   }
 
@@ -231,6 +271,7 @@ class BleDeviceDiagnostics {
       disconnectHistory: (result[0] as List<Object?>?)!.cast<BleDisconnectEvent>(),
       reconnectionCount: result[1]! as int,
       connectedAt: result[2]! as int,
+      failToConnectCount: result[3]! as int,
     );
   }
 

--- a/app/lib/gen/pigeon_communicator.g.dart
+++ b/app/lib/gen/pigeon_communicator.g.dart
@@ -155,6 +155,7 @@ class BleDisconnectEvent {
     required this.connectionDurationMs,
     required this.appState,
     required this.timeToReconnectMs,
+    required this.rssiTrend,
   });
 
   int timestamp;
@@ -184,6 +185,14 @@ class BleDisconnectEvent {
   /// 0 while the device has not yet reconnected.
   int timeToReconnectMs;
 
+  /// RSSI trajectory over the ~15s before this event. One of:
+  ///   "fading"  — signal declined ≥10 dB before the drop (walk-away)
+  ///   "sudden"  — signal stable then link died (interference/stall/device off)
+  ///   "gap"     — no recent RSSI samples (keep-alive wasn't running)
+  ///   "unknown" — insufficient samples to classify
+  /// Empty string on legacy records written before this field existed.
+  String rssiTrend;
+
   List<Object?> _toList() {
     return <Object?>[
       timestamp,
@@ -195,6 +204,7 @@ class BleDisconnectEvent {
       connectionDurationMs,
       appState,
       timeToReconnectMs,
+      rssiTrend,
     ];
   }
 
@@ -213,6 +223,7 @@ class BleDisconnectEvent {
       connectionDurationMs: result[6]! as int,
       appState: result[7]! as String,
       timeToReconnectMs: result[8]! as int,
+      rssiTrend: result[9]! as String,
     );
   }
 

--- a/app/lib/pages/settings/device_diagnostics.dart
+++ b/app/lib/pages/settings/device_diagnostics.dart
@@ -81,9 +81,20 @@ class _DeviceDiagnosticsState extends State<DeviceDiagnostics> {
       'battery': deviceProvider.batteryLevel,
       'connected_at': _diagnostics?.connectedAt ?? 0,
       'reconnection_count': _diagnostics?.reconnectionCount ?? 0,
+      'fail_to_connect_count': _diagnostics?.failToConnectCount ?? 0,
       'rssi_samples': _rssiPoints.map((p) => {'ts': p.time.millisecondsSinceEpoch, 'rssi': p.rssi}).toList(),
       'disconnect_history': (_diagnostics?.disconnectHistory ?? [])
-          .map((e) => {'ts': e.timestamp, 'reason': e.reason, 'code': e.reasonCode, 'manual': e.isManual})
+          .map((e) => {
+                'ts': e.timestamp,
+                'reason': e.reason,
+                'code': e.reasonCode,
+                'manual': e.isManual,
+                'event_type': e.eventType,
+                'last_rssi': e.lastRssi,
+                'connection_duration_ms': e.connectionDurationMs,
+                'app_state': e.appState,
+                'time_to_reconnect_ms': e.timeToReconnectMs,
+              })
           .toList(),
     };
 
@@ -436,18 +447,28 @@ class _DeviceDiagnosticsState extends State<DeviceDiagnostics> {
     final time = DateTime.fromMillisecondsSinceEpoch(event.timestamp);
     final timeStr = DateFormat('MMM d, HH:mm:ss').format(time);
     final isManual = event.isManual;
+    final isFail = event.eventType == 'fail_to_connect';
     final reason = _formatReason(event.reason);
+
+    final Color dot = isManual ? const Color(0xFF8E8E93) : (isFail ? const Color(0xFFFF9500) : const Color(0xFFF44336));
+
+    final metaParts = <String>[];
+    if (event.lastRssi != 0) metaParts.add('${event.lastRssi} dBm');
+    if (event.connectionDurationMs > 0) metaParts.add(_formatDurationMs(event.connectionDurationMs));
+    if (event.appState.isNotEmpty) metaParts.add(event.appState);
+    if (event.timeToReconnectMs > 0) metaParts.add('reconn ${_formatDurationMs(event.timeToReconnectMs)}');
 
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
       child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Container(
-            width: 8,
-            height: 8,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: isManual ? const Color(0xFF8E8E93) : const Color(0xFFF44336),
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Container(
+              width: 8,
+              height: 8,
+              decoration: BoxDecoration(shape: BoxShape.circle, color: dot),
             ),
           ),
           const SizedBox(width: 12),
@@ -461,10 +482,23 @@ class _DeviceDiagnosticsState extends State<DeviceDiagnostics> {
                 ),
                 const SizedBox(height: 2),
                 Text(timeStr, style: TextStyle(color: Colors.grey.shade500, fontSize: 12)),
+                if (metaParts.isNotEmpty) ...[
+                  const SizedBox(height: 4),
+                  Text(
+                    metaParts.join(' · '),
+                    style: TextStyle(color: Colors.grey.shade400, fontSize: 11),
+                  ),
+                ],
               ],
             ),
           ),
-          if (isManual)
+          if (isFail)
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
+              decoration: BoxDecoration(color: const Color(0xFF3A2A10), borderRadius: BorderRadius.circular(8)),
+              child: const Text('fail', style: TextStyle(color: Color(0xFFFF9500), fontSize: 11)),
+            )
+          else if (isManual)
             Container(
               padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 3),
               decoration: BoxDecoration(color: const Color(0xFF2A2A2E), borderRadius: BorderRadius.circular(8)),
@@ -473,6 +507,13 @@ class _DeviceDiagnosticsState extends State<DeviceDiagnostics> {
         ],
       ),
     );
+  }
+
+  String _formatDurationMs(int ms) {
+    if (ms < 1000) return '${ms}ms';
+    if (ms < 60000) return '${(ms / 1000).toStringAsFixed(1)}s';
+    if (ms < 3600000) return '${(ms / 60000).toStringAsFixed(1)}m';
+    return '${(ms / 3600000).toStringAsFixed(1)}h';
   }
 
   String _formatReason(String reason) {

--- a/app/lib/pages/settings/device_diagnostics.dart
+++ b/app/lib/pages/settings/device_diagnostics.dart
@@ -94,6 +94,7 @@ class _DeviceDiagnosticsState extends State<DeviceDiagnostics> {
                 'connection_duration_ms': e.connectionDurationMs,
                 'app_state': e.appState,
                 'time_to_reconnect_ms': e.timeToReconnectMs,
+                'rssi_trend': e.rssiTrend,
               })
           .toList(),
     };
@@ -453,6 +454,7 @@ class _DeviceDiagnosticsState extends State<DeviceDiagnostics> {
     final Color dot = isManual ? const Color(0xFF8E8E93) : (isFail ? const Color(0xFFFF9500) : const Color(0xFFF44336));
 
     final metaParts = <String>[];
+    if (event.rssiTrend.isNotEmpty) metaParts.add(event.rssiTrend);
     if (event.lastRssi != 0) metaParts.add('${event.lastRssi} dBm');
     if (event.connectionDurationMs > 0) metaParts.add(_formatDurationMs(event.connectionDurationMs));
     if (event.appState.isNotEmpty) metaParts.add(event.appState);

--- a/app/lib/pigeon_interfaces.dart
+++ b/app/lib/pigeon_interfaces.dart
@@ -108,6 +108,14 @@ class BleDisconnectEvent {
   /// 0 while the device has not yet reconnected.
   final int timeToReconnectMs;
 
+  /// RSSI trajectory over the ~15s before this event. One of:
+  ///   "fading"  — signal declined ≥10 dB before the drop (walk-away)
+  ///   "sudden"  — signal stable then link died (interference/stall/device off)
+  ///   "gap"     — no recent RSSI samples (keep-alive wasn't running)
+  ///   "unknown" — insufficient samples to classify
+  /// Empty string on legacy records written before this field existed.
+  final String rssiTrend;
+
   BleDisconnectEvent({
     required this.timestamp,
     required this.reason,
@@ -118,6 +126,7 @@ class BleDisconnectEvent {
     required this.connectionDurationMs,
     required this.appState,
     required this.timeToReconnectMs,
+    required this.rssiTrend,
   });
 }
 

--- a/app/lib/pigeon_interfaces.dart
+++ b/app/lib/pigeon_interfaces.dart
@@ -89,7 +89,36 @@ class BleDisconnectEvent {
   final int reasonCode;
   final bool isManual;
 
-  BleDisconnectEvent({required this.timestamp, required this.reason, required this.reasonCode, required this.isManual});
+  /// Kind of event: "disconnect" (link lost after connect) or "fail_to_connect"
+  /// (connect attempt never established). Defaults to "disconnect" for legacy records.
+  final String eventType;
+
+  /// Last RSSI sample captured before this event (dBm). 0 if unknown.
+  final int lastRssi;
+
+  /// How long the link was established before this event (ms). 0 if unknown
+  /// or for fail_to_connect events.
+  final int connectionDurationMs;
+
+  /// App lifecycle state at the moment of the event: "foreground", "background",
+  /// or "inactive" (iOS transitioning). Empty string if unknown.
+  final String appState;
+
+  /// ms between this disconnect and the subsequent successful reconnect.
+  /// 0 while the device has not yet reconnected.
+  final int timeToReconnectMs;
+
+  BleDisconnectEvent({
+    required this.timestamp,
+    required this.reason,
+    required this.reasonCode,
+    required this.isManual,
+    required this.eventType,
+    required this.lastRssi,
+    required this.connectionDurationMs,
+    required this.appState,
+    required this.timeToReconnectMs,
+  });
 }
 
 /// Diagnostics data read from native preferences on demand.
@@ -98,7 +127,16 @@ class BleDeviceDiagnostics {
   final int reconnectionCount;
   final int connectedAt;
 
-  BleDeviceDiagnostics({required this.disconnectHistory, required this.reconnectionCount, required this.connectedAt});
+  /// Count of connect attempts that never reached didConnect. Surfaces the
+  /// silent-failure path separately from established-then-dropped disconnects.
+  final int failToConnectCount;
+
+  BleDeviceDiagnostics({
+    required this.disconnectHistory,
+    required this.reconnectionCount,
+    required this.connectedAt,
+    required this.failToConnectCount,
+  });
 }
 
 /// Dart → Native: commands sent from Flutter to the native BLE module.

--- a/app/pubspec.yaml
+++ b/app/pubspec.yaml
@@ -3,7 +3,7 @@ description: A new Flutter project.
 
 publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.532+820
+version: 1.0.532+821
 
 
 environment:


### PR DESCRIPTION
## Why

Users report BLE reconnect bursts on both iOS and Android, but our current diagnostics (`BleDisconnectEvent`: timestamp, reason, code, isManual) can't distinguish between:

- **range / RF / peripheral-sleep drops** vs. **healthy-signal drops** (need last RSSI)
- **brief-link flaps** vs. **long-stable connections that dropped** (need duration)
- **foreground** vs. **backgrounded** (iOS suspension, Android service throttling)
- **reconnection lag** the user actually perceives as the bug (need time-to-reconnect)
- **silent fail-to-connect** vs. **established-then-dropped** (iOS `didFailToConnect` currently persists nothing and never retries)

Without this split, a user's 20-disconnect diagnostic is just 20 identical "connection_timeout" rows — we can't tell a bug from expected behaviour.

## What

Extends the Pigeon contract and both native implementations to capture:

- `event_type` — `disconnect` vs `fail_to_connect`
- `last_rssi` — signal at the moment of the drop (-53 dBm = healthy; -85 dBm = range)
- `connection_duration_ms` — how long the link was established before dropping
- `app_state` — foreground / inactive / background at event time
- `time_to_reconnect_ms` — backfilled on the next successful connect (this is likely the real user complaint)
- `fail_to_connect_count` — separate top-level counter so silent-failure paths are visible

### iOS side-effect fixes
`didFailToConnect` previously dropped the user silently — no retry, no diagnostic. Now it:
- Persists a `fail_to_connect` event
- Increments `failToConnectCount`
- Re-issues `connect()` after 200ms for previously-connected peripherals (mirrors `didDisconnect` behaviour)

### Android event-type resolution
`hasEverConnected` is a device-lifetime flag and can't tell a reconnect failure from a link drop once the device has ever connected. Added `currentAttemptEstablished` which resets on each `connectGatt` call and is set when `onGattConnected` fires — this is what actually answers "did this attempt establish?"

## What I deliberately did *not* do

- No exponential-backoff change on the reconnect path (was speculation without data)
- No firmware supervision-timeout change (separate decision — Apple ADG allows up to 6s vs. our current 4s, but worth shipping telemetry first to know if it moves the needle)
- No RSSI-keep-alive timing change (another speculation)

The point is to **get signal from affected users** before making behaviour changes that could regress.

## Per-file commits
- `pigeon_interfaces.dart` — contract
- `pigeon_communicator.g.*` × 3 — regenerated Dart / Swift / Kotlin stubs
- `OmiBleManager.swift` — iOS capture + fail-to-connect retry
- `OmiBleManager.kt` — per-device `lastRssi` map + `isAppForeground` flag
- `OmiBleForegroundService.kt` — Android persistence + per-attempt flag
- `MainActivity.kt` — lifecycle hook for `isAppForeground`
- `device_diagnostics.dart` — UI row metadata + JSON export

## Test plan

- [ ] Flutter dev build, open Device Diagnostics, trigger a manual disconnect → verify `manual` event has `isManual=true`, no `last_rssi` surprise
- [ ] Walk out of range until drop → event should show degraded `last_rssi` and a `connection_duration_ms`
- [ ] Force-kill app during active connection → event shows `background` app_state
- [ ] iOS: unplug device firmware mid-scan to trigger `didFailToConnect` → event shows `event_type=fail_to_connect` with orange pill
- [ ] Wait for reconnect, inspect same event → `time_to_reconnect_ms` backfilled
- [ ] Export JSON → confirm new fields present in the saved file
- [ ] Android: same matrix on a real device

## Next step

Once this is in users' hands and we have a fresh diagnostic, decide whether the underlying issue is:
- (a) range / RF — firmware timeout bump helps
- (b) long reconnect latency — reconnect path needs work
- (c) fail-to-connect loops — retry logic needs backoff
- (d) something else entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)