### PR TITLE
Add voice picker to floating bar settings

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,7 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Added a voice picker in the floating bar settings with 10 ElevenLabs voices to choose from"
+  ],
   "releases": [
     {
       "version": "0.11.318",

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarVoicePlaybackService.swift
@@ -148,7 +148,9 @@ final class FloatingBarVoicePlaybackService: NSObject, AVAudioPlayerDelegate {
     guard getenv("OMI_API_URL") != nil else {
       return .systemFallback
     }
-    return .elevenLabs(voiceID: Self.defaultVoiceID)
+    let voiceID = ShortcutSettings.shared.selectedVoiceID
+    let resolvedVoiceID = voiceID.isEmpty ? Self.defaultVoiceID : voiceID
+    return .elevenLabs(voiceID: resolvedVoiceID)
   }
 
   private func drainBufferedText(isFinal: Bool, mode: PlaybackMode) {

--- a/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/ShortcutSettings.swift
@@ -394,6 +394,47 @@ class ShortcutSettings: ObservableObject {
         return "Maximum"
     }
 
+    /// A selectable ElevenLabs voice for floating-bar replies.
+    struct VoiceOption: Identifiable, Equatable {
+        enum Gender: String {
+            case female
+            case male
+        }
+
+        let id: String
+        let name: String
+        let gender: Gender
+        let description: String
+    }
+
+    /// Curated ElevenLabs voices available from the voice picker.
+    static let availableVoices: [VoiceOption] = [
+        VoiceOption(id: "BAMYoBHLZM7lJgJAmFz0", name: "Sloane", gender: .female, description: "Warm, confident"),
+        VoiceOption(id: "XB0fDUnXU5powFXDhCwa", name: "Charlotte", gender: .female, description: "Smooth, sultry"),
+        VoiceOption(id: "21m00Tcm4TlvDq8ikWAM", name: "Rachel", gender: .female, description: "Calm, breathy"),
+        VoiceOption(id: "XrExE9yKIg1WjnnlVkGX", name: "Matilda", gender: .female, description: "Soft, mature"),
+        VoiceOption(id: "piTKgcLEGmPE4e6mEKli", name: "Nicole", gender: .female, description: "Whispery, intimate"),
+        VoiceOption(id: "pNInz6obpgDQGcFmaJgB", name: "Adam", gender: .male, description: "Deep American"),
+        VoiceOption(id: "ErXwobaYiN019PkySvjV", name: "Antoni", gender: .male, description: "Warm, friendly"),
+        VoiceOption(id: "TxGEqnHWrfWFTfGW9XjX", name: "Josh", gender: .male, description: "Young, deep"),
+        VoiceOption(id: "N2lVS1w4EtoT3dr4eOWO", name: "Callum", gender: .male, description: "Intense, gravelly"),
+        VoiceOption(id: "onwK4e9ZLuTAKqWW03F9", name: "Daniel", gender: .male, description: "Authoritative British"),
+    ]
+
+    static let defaultVoiceID = "BAMYoBHLZM7lJgJAmFz0"
+
+    static func voiceOption(for id: String) -> VoiceOption {
+        availableVoices.first(where: { $0.id == id }) ?? availableVoices[0]
+    }
+
+    /// Selected ElevenLabs voice ID for floating-bar TTS replies.
+    @Published var selectedVoiceID: String {
+        didSet {
+            UserDefaults.standard.set(selectedVoiceID, forKey: "shortcut_selectedVoiceID")
+            FloatingBarVoicePlaybackService.shared.stop()
+        }
+    }
+
     var hasAnyFloatingBarVoiceAnswersEnabled: Bool {
         floatingBarVoiceAnswersEnabled || floatingBarTypedQuestionVoiceAnswersEnabled
     }
@@ -441,6 +482,11 @@ class ShortcutSettings: ObservableObject {
         self.floatingBarTypedQuestionVoiceAnswersEnabled =
             UserDefaults.standard.object(forKey: "shortcut_floatingBarTypedQuestionVoiceAnswersEnabled") as? Bool ?? false
         self.voicePlaybackSpeed = UserDefaults.standard.object(forKey: "shortcut_voicePlaybackSpeed") as? Float ?? 1.4
+        let storedVoiceID = UserDefaults.standard.string(forKey: "shortcut_selectedVoiceID") ?? Self.defaultVoiceID
+        let validVoiceID = Self.availableVoices.contains(where: { $0.id == storedVoiceID })
+            ? storedVoiceID
+            : Self.defaultVoiceID
+        self.selectedVoiceID = validVoiceID
     }
 
     private func persistShortcut(_ shortcut: KeyboardShortcut, forKey key: String) {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -1929,9 +1929,47 @@ struct SettingsContentView: View {
         }
       }
 
+      voicePicker(settingId: "floatingbar.voice")
+        .opacity(shortcutSettings.hasAnyFloatingBarVoiceAnswersEnabled ? 1 : 0.55)
+        .disabled(!shortcutSettings.hasAnyFloatingBarVoiceAnswersEnabled)
+
       voiceSpeedSlider(settingId: "floatingbar.voicespeed")
         .opacity(shortcutSettings.hasAnyFloatingBarVoiceAnswersEnabled ? 1 : 0.55)
         .disabled(!shortcutSettings.hasAnyFloatingBarVoiceAnswersEnabled)
+    }
+  }
+
+  private func voicePicker(settingId: String) -> some View {
+    settingsCard(settingId: settingId) {
+      HStack(spacing: 16) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Voice")
+            .scaledFont(size: 16, weight: .semibold)
+            .foregroundColor(OmiColors.textPrimary)
+          Text(
+            ShortcutSettings.voiceOption(for: shortcutSettings.selectedVoiceID).description
+          )
+          .scaledFont(size: 13)
+          .foregroundColor(OmiColors.textSecondary)
+        }
+        Spacer()
+        Picker("", selection: $shortcutSettings.selectedVoiceID) {
+          Section("Female") {
+            ForEach(ShortcutSettings.availableVoices.filter { $0.gender == .female }) { voice in
+              Text(voice.name).tag(voice.id)
+            }
+          }
+          Section("Male") {
+            ForEach(ShortcutSettings.availableVoices.filter { $0.gender == .male }) { voice in
+              Text(voice.name).tag(voice.id)
+            }
+          }
+        }
+        .pickerStyle(.menu)
+        .labelsHidden()
+        .frame(width: 180)
+        .tint(OmiColors.purplePrimary)
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds a voice picker dropdown to the floating bar settings with 10 curated ElevenLabs voices (5 female, 5 male)
- Persists the selected voice via `ShortcutSettings.selectedVoiceID` (UserDefaults key `shortcut_selectedVoiceID`)
- `FloatingBarVoicePlaybackService` now reads the selected voice instead of the hardcoded Sloane ID; stops current playback when the user switches voices

## Test plan
- [x] Open Settings → Floating Bar, verify the Voice row appears below the Typed Questions toggle
- [x] Pick a different voice and ask a question via push-to-talk — the reply is spoken in the new voice
- [x] Toggle all voice-answer switches off — the picker dims/disables correctly
- [x] Restart the app — the previously selected voice persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)