### PR TITLE
Update CHANGELOG.json for v0.11.319 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Added a voice picker in the floating bar settings with 10 ElevenLabs voices to choose from"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.319",
+      "date": "2026-04-16",
+      "changes": [
+        "Added a voice picker in the floating bar settings with 10 ElevenLabs voices to choose from"
+      ]
+    },
     {
       "version": "0.11.318",
       "date": "2026-04-15",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.319 and clears the unreleased array.