### PR TITLE
Plan & Usage: Unlimited→Plus rename + monthly chat caps

### DIFF
--- a/backend/database/user_usage.py
+++ b/backend/database/user_usage.py
@@ -1,10 +1,62 @@
-from datetime import datetime
+from calendar import monthrange
+from datetime import datetime, timezone
 from typing import Optional
 from google.cloud import firestore
 from google.cloud.firestore_v1 import FieldFilter
 
 from ._client import db
 from models.user_usage import UsageStats
+
+
+def get_monthly_chat_usage(uid: str, now: Optional[datetime] = None) -> dict:
+    """Sum current-month chat usage from `users/{uid}/llm_usage/{YYYY-MM-DD}` docs.
+
+    Returns keys:
+      - questions: total user-initiated chat calls (desktop_chat* + backend `chat.*`)
+      - cost_usd:  total desktop_chat* cost_usd (backend GPT/Gemini chat has no cost field)
+      - reset_at:  unix seconds of the start of next UTC month (when the bucket resets)
+
+    Proactive, memory-extraction, knowledge-graph, conversation-processing etc. are
+    excluded on purpose — those are company-driven, not user-initiated questions.
+    """
+    now = now or datetime.now(timezone.utc)
+    month_prefix = f'{now.year}-{now.month:02d}-'
+
+    llm_usage_ref = db.collection('users').document(uid).collection('llm_usage')
+    questions = 0
+    cost_usd = 0.0
+    for doc in llm_usage_ref.list_documents():
+        if not doc.id.startswith(month_prefix):
+            continue
+        snap = doc.get()
+        if not snap.exists:
+            continue
+        data = snap.to_dict() or {}
+        for key, value in data.items():
+            if not isinstance(value, (int, float)):
+                continue
+            if key.startswith('desktop_chat'):
+                if key.endswith('.call_count'):
+                    questions += int(value)
+                elif key.endswith('.cost_usd'):
+                    cost_usd += float(value)
+            elif key.startswith('chat.') and key.endswith('.call_count'):
+                # user-initiated backend chat (any model)
+                questions += int(value)
+
+    # Compute end-of-month boundary in UTC for the reset timestamp.
+    last_day = monthrange(now.year, now.month)[1]
+    if now.month == 12:
+        next_year, next_month = now.year + 1, 1
+    else:
+        next_year, next_month = now.year, now.month + 1
+    reset_at = int(datetime(next_year, next_month, 1, tzinfo=timezone.utc).timestamp())
+
+    return {
+        'questions': questions,
+        'cost_usd': round(cost_usd, 4),
+        'reset_at': reset_at,
+    }
 
 
 def update_hourly_usage(uid: str, date: datetime, updates: dict):

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -28,6 +28,26 @@ class PlanLimits(BaseModel):
     words_transcribed: Optional[int] = None
     insights_gained: Optional[int] = None
     memories_created: Optional[int] = None
+    # Chat caps. Exactly one of these is set per plan: `free` and `unlimited`
+    # (displayed as "Plus") cap by question count; `pro` caps by cost_usd.
+    chat_questions_per_month: Optional[int] = None
+    chat_cost_usd_per_month: Optional[float] = None
+
+
+class ChatQuotaUnit(str, Enum):
+    questions = 'questions'
+    cost_usd = 'cost_usd'
+
+
+class ChatUsageQuota(BaseModel):
+    plan: str  # display name: "Free", "Plus", "Pro"
+    plan_type: str  # internal id: "basic" | "unlimited" | "pro"
+    unit: ChatQuotaUnit
+    used: float
+    limit: Optional[float] = None  # None = unlimited (fallback)
+    percent: float = 0.0
+    allowed: bool = True
+    reset_at: Optional[int] = None  # unix seconds — start of next month UTC
 
 
 class Subscription(BaseModel):

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -49,15 +49,25 @@ from typing import Optional
 from models.user_usage import UserUsageResponse, UsagePeriod
 from datetime import datetime, time, timedelta
 
-from models.users import WebhookType, UserSubscriptionResponse, SubscriptionPlan, PlanType, PricingOption
+from models.users import (
+    WebhookType,
+    UserSubscriptionResponse,
+    SubscriptionPlan,
+    PlanType,
+    PricingOption,
+    ChatUsageQuota,
+    ChatQuotaUnit,
+)
 from utils.apps import get_available_app_by_id
 from utils.subscription import (
     get_paid_plan_definitions,
+    get_plan_display_name,
     get_plan_limits,
     get_plan_features,
     get_monthly_usage_for_subscription,
     reconcile_basic_plan_with_stripe,
 )
+from database import user_usage as user_usage_db
 from utils import stripe as stripe_utils
 from utils.log_sanitizer import sanitize
 from utils.llm.followup import followup_question_prompt
@@ -897,6 +907,46 @@ def get_user_subscription_endpoint(
 # **************************************
 # ****** Daily Summary Settings ********
 # **************************************
+
+
+@router.get('/v1/users/me/usage-quota', tags=['users'], response_model=ChatUsageQuota)
+def get_user_chat_usage_quota(uid: str = Depends(auth.get_current_user_uid)):
+    """Current-month chat usage for the user, plus their plan's cap.
+
+    - Free / Plus: counted in questions (user-initiated chat turns)
+    - Pro: counted in dollar spend on desktop chat
+    - Resets at the start of each UTC month
+    """
+    subscription = get_user_valid_subscription(uid)
+    plan = subscription.plan if subscription else PlanType.basic
+    limits = get_plan_limits(plan)
+    usage = user_usage_db.get_monthly_chat_usage(uid)
+
+    if limits.chat_cost_usd_per_month is not None:
+        unit = ChatQuotaUnit.cost_usd
+        used = float(usage['cost_usd'])
+        limit_value = float(limits.chat_cost_usd_per_month)
+    else:
+        unit = ChatQuotaUnit.questions
+        used = float(usage['questions'])
+        limit_value = float(limits.chat_questions_per_month) if limits.chat_questions_per_month is not None else None
+
+    percent = 0.0
+    allowed = True
+    if limit_value is not None and limit_value > 0:
+        percent = min(100.0, round(100.0 * used / limit_value, 2))
+        allowed = used < limit_value
+
+    return ChatUsageQuota(
+        plan=get_plan_display_name(plan),
+        plan_type=plan.value,
+        unit=unit,
+        used=round(used, 4),
+        limit=limit_value,
+        percent=percent,
+        allowed=allowed,
+        reset_at=usage['reset_at'],
+    )
 
 
 class DailySummarySettingsResponse(BaseModel):

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -69,14 +69,31 @@ BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_WORDS_T
 BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH', '0'))
 BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH', '0'))
 
+# Chat caps per plan. Env-overridable for ops.
+FREE_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('FREE_CHAT_QUESTIONS_PER_MONTH', '30'))
+PLUS_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('PLUS_CHAT_QUESTIONS_PER_MONTH', '200'))
+PRO_CHAT_COST_USD_PER_MONTH = float(os.getenv('PRO_CHAT_COST_USD_PER_MONTH', '400.0'))
+
+# Display names shown to users. Internal PlanType stays the same for Stripe compat.
+PLAN_DISPLAY_NAMES = {
+    PlanType.basic: 'Free',
+    PlanType.unlimited: 'Plus',
+    PlanType.pro: 'Pro',
+}
+
+
+def get_plan_display_name(plan: PlanType) -> str:
+    return PLAN_DISPLAY_NAMES.get(plan, plan.value.capitalize())
+
 
 def get_basic_plan_limits() -> PlanLimits:
-    """Returns the PlanLimits object for the basic tier."""
+    """Returns the PlanLimits object for the basic (Free) tier."""
     return PlanLimits(
         transcription_seconds=BASIC_TIER_MONTHLY_SECONDS_LIMIT,
         words_transcribed=BASIC_TIER_WORDS_TRANSCRIBED_LIMIT_PER_MONTH,
         insights_gained=BASIC_TIER_INSIGHTS_GAINED_LIMIT_PER_MONTH,
         memories_created=BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH,
+        chat_questions_per_month=FREE_CHAT_QUESTIONS_PER_MONTH,
     )
 
 
@@ -86,13 +103,26 @@ def get_default_basic_subscription() -> Subscription:
 
 
 def get_plan_limits(plan: PlanType) -> PlanLimits:
-    """Returns the PlanLimits object for the given plan."""
-    if is_paid_plan(plan):
+    """Returns the PlanLimits object for the given plan.
+
+    Plan display names: basic=Free, unlimited=Plus, pro=Pro.
+    Chat caps: Free/Plus count questions, Pro caps dollar spend.
+    """
+    if plan == PlanType.unlimited:
         return PlanLimits(
             transcription_seconds=None,
             words_transcribed=None,
             insights_gained=None,
             memories_created=None,
+            chat_questions_per_month=PLUS_CHAT_QUESTIONS_PER_MONTH,
+        )
+    if plan == PlanType.pro:
+        return PlanLimits(
+            transcription_seconds=None,
+            words_transcribed=None,
+            insights_gained=None,
+            memories_created=None,
+            chat_cost_usd_per_month=PRO_CHAT_COST_USD_PER_MONTH,
         )
     return get_basic_plan_limits()
 

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -23,7 +23,7 @@ def get_paid_plan_definitions() -> list[dict]:
         {
             "plan_type": PlanType.unlimited,
             "plan_id": "unlimited",
-            "title": "Unlimited Plan",
+            "title": "Plus",
             "monthly_price_id": os.getenv('STRIPE_UNLIMITED_MONTHLY_PRICE_ID'),
             "annual_price_id": os.getenv('STRIPE_UNLIMITED_ANNUAL_PRICE_ID'),
             "annual_description": "Save 20% with annual billing.",
@@ -131,18 +131,18 @@ def get_plan_features(plan: PlanType) -> List[str]:
     """Returns the list of feature strings for the given plan."""
     if plan == PlanType.pro:
         return [
-            "Automations",
-            "Vibe coding",
-            "Unlimited actions",
+            f"Up to ${int(PRO_CHAT_COST_USD_PER_MONTH)} of chat usage per month",
+            "Automations and vibe coding",
+            "Unlimited listening, memories, and insights",
             "Priority desktop AI features",
         ]
 
     if plan == PlanType.unlimited:
         return [
-            "Unlimited listening time",
-            "Unlimited words transcribed",
-            "Unlimited insights",
-            "Unlimited memories",
+            f"{PLUS_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
+            "Unlimited listening and transcription",
+            "Unlimited memories and insights",
+            "Shared with mobile and web",
         ]
 
     # Basic plan

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -4923,6 +4923,45 @@ extension APIClient {
     }
   }
 
+  // MARK: - Chat Usage Quota
+
+  /// Current-month chat usage + the plan's cap. Backed by Python backend
+  /// endpoint `/v1/users/me/usage-quota` which reads `users/{uid}/llm_usage/*`.
+  struct ChatUsageQuota: Decodable {
+    let plan: String       // display name: "Free" | "Plus" | "Pro"
+    let planType: String   // internal id: "basic" | "unlimited" | "pro"
+    let unit: String       // "questions" | "cost_usd"
+    let used: Double
+    let limit: Double?     // nil means unlimited
+    let percent: Double
+    let allowed: Bool
+    let resetAt: Int?      // unix seconds — start of next UTC month
+
+    enum CodingKeys: String, CodingKey {
+      case plan
+      case planType = "plan_type"
+      case unit
+      case used
+      case limit
+      case percent
+      case allowed
+      case resetAt = "reset_at"
+    }
+  }
+
+  func fetchChatUsageQuota() async -> ChatUsageQuota? {
+    do {
+      let res: ChatUsageQuota = try await get("v1/users/me/usage-quota")
+      log(
+        "APIClient: Quota plan=\(res.plan) unit=\(res.unit) used=\(res.used) limit=\(res.limit ?? -1) allowed=\(res.allowed)"
+      )
+      return res
+    } catch {
+      log("APIClient: Chat quota fetch failed: \(error.localizedDescription)")
+      return nil
+    }
+  }
+
   // MARK: - API Keys
 
   struct ApiKeysResponse: Decodable {

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -5806,17 +5806,17 @@ struct SettingsContentView: View {
     switch planId {
     case "pro":
       return [
-        "Automations",
-        "Vibe coding",
-        "Unlimited actions",
+        "Up to $400 of chat usage per month",
+        "Automations and vibe coding",
+        "Unlimited listening, memories, and insights",
         "Priority desktop AI features",
       ]
     case "unlimited":
       return [
-        "Unlimited listening time",
-        "Unlimited words transcribed",
-        "Unlimited insights",
-        "Unlimited memories",
+        "200 chat questions per month",
+        "Unlimited listening and transcription",
+        "Unlimited memories and insights",
+        "Shared with mobile and web",
       ]
     default:
       return []

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -224,6 +224,8 @@ struct SettingsContentView: View {
   @State private var userSubscription: UserSubscriptionResponse?
   @State private var isLoadingSubscription: Bool = false
   @State private var subscriptionError: String?
+  @State private var chatUsageQuota: APIClient.ChatUsageQuota?
+  @State private var isLoadingChatUsage: Bool = false
   @State private var fallbackPlanCatalog: [SubscriptionPlanOption] = []
   @State private var activeCheckoutPriceId: String?
   @State private var selectedPlanIdForCheckout: String?
@@ -1797,6 +1799,8 @@ struct SettingsContentView: View {
         }
       }
 
+      chatUsageQuotaCard
+
       if shouldShowPlanPurchaseOptions {
         settingsCard(settingId: "planusage.purchase") {
           VStack(alignment: .leading, spacing: 18) {
@@ -1819,6 +1823,100 @@ struct SettingsContentView: View {
         }
       }
     }
+  }
+
+  // MARK: - Chat Usage Quota Card
+
+  @ViewBuilder
+  private var chatUsageQuotaCard: some View {
+    if let quota = chatUsageQuota {
+      settingsCard(settingId: "planusage.current") {
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Text("Usage this month")
+              .scaledFont(size: 14, weight: .semibold)
+              .foregroundColor(OmiColors.textPrimary)
+            Spacer()
+            Text(chatUsageQuotaValueText(quota))
+              .scaledFont(size: 13, weight: .medium)
+              .foregroundColor(chatUsageBarColor(quota))
+              .monospacedDigit()
+          }
+
+          ProgressView(value: min(quota.percent / 100.0, 1.0))
+            .progressViewStyle(LinearProgressViewStyle(tint: chatUsageBarColor(quota)))
+            .frame(height: 6)
+
+          HStack {
+            Text(chatUsageQuotaDescription(quota))
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.textTertiary)
+            Spacer()
+            if let resetText = chatUsageQuotaResetText(quota) {
+              Text(resetText)
+                .scaledFont(size: 12)
+                .foregroundColor(OmiColors.textTertiary)
+            }
+          }
+
+          if !quota.allowed {
+            Text("You've reached this month's limit. Upgrade your plan or wait until the next reset.")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.warning)
+          } else if quota.percent >= 80.0 {
+            Text("You're close to your monthly limit.")
+              .scaledFont(size: 12)
+              .foregroundColor(OmiColors.warning)
+          }
+        }
+      }
+    } else if isLoadingChatUsage {
+      settingsCard(settingId: "planusage.current") {
+        HStack {
+          ProgressView().controlSize(.small)
+          Text("Loading usage…")
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textTertiary)
+        }
+      }
+    }
+  }
+
+  private func chatUsageQuotaValueText(_ q: APIClient.ChatUsageQuota) -> String {
+    if q.unit == "cost_usd" {
+      let limit = q.limit.map { String(format: "$%.0f", $0) } ?? "—"
+      return String(format: "$%.2f / %@", q.used, limit)
+    }
+    let used = Int(q.used)
+    let limit = q.limit.map { "\(Int($0))" } ?? "∞"
+    return "\(used) / \(limit)"
+  }
+
+  private func chatUsageQuotaDescription(_ q: APIClient.ChatUsageQuota) -> String {
+    if q.unit == "cost_usd" {
+      return "Chat spend on \(q.plan) plan"
+    }
+    return "Chat questions on \(q.plan) plan"
+  }
+
+  private func chatUsageQuotaResetText(_ q: APIClient.ChatUsageQuota) -> String? {
+    guard let resetAt = q.resetAt else { return nil }
+    let resetDate = Date(timeIntervalSince1970: TimeInterval(resetAt))
+    let now = Date()
+    let days = max(0, Int(resetDate.timeIntervalSince(now) / 86400))
+    if days <= 0 {
+      return "Resets today"
+    }
+    if days == 1 {
+      return "Resets tomorrow"
+    }
+    return "Resets in \(days) days"
+  }
+
+  private func chatUsageBarColor(_ q: APIClient.ChatUsageQuota) -> Color {
+    if !q.allowed || q.percent >= 100.0 { return OmiColors.warning }
+    if q.percent >= 80.0 { return OmiColors.warning }
+    return OmiColors.purplePrimary
   }
 
   // MARK: - AI Chat Section
@@ -5569,13 +5667,13 @@ struct SettingsContentView: View {
 
   private var currentPlanTitle: String {
     guard let subscription = userSubscription?.subscription else {
-      return isLoadingSubscription ? "Loading plan..." : "Basic"
+      return isLoadingSubscription ? "Loading plan..." : "Free"
     }
     switch subscription.plan {
     case .basic:
-      return "Basic"
+      return "Free"
     case .unlimited:
-      return "Unlimited Plan"
+      return "Plus"
     case .pro:
       return "Omi Pro"
     }
@@ -5625,9 +5723,9 @@ struct SettingsContentView: View {
   private func planSubtitle(for planId: String) -> String? {
     switch planId {
     case "unlimited":
-      return "Current mobile and web subscription"
+      return "200 questions per month"
     case "pro":
-      return "Desktop power-user tier"
+      return "Up to $400 of monthly chat usage"
     default:
       return nil
     }
@@ -5667,9 +5765,9 @@ struct SettingsContentView: View {
   private func planDescription(for planId: String) -> String {
     switch planId {
     case "unlimited":
-      return "Uses the existing Unlimited subscription from mobile and web."
+      return "200 chat questions per month. Shared with mobile and web."
     case "pro":
-      return "Unlock automations, vibe coding, and unlimited actions on desktop."
+      return "Automations, vibe coding, and up to $400 of chat usage per month."
     default:
       return ""
     }
@@ -5747,7 +5845,7 @@ struct SettingsContentView: View {
       let title: String
       switch planId {
       case "unlimited":
-        title = "Unlimited Plan"
+        title = "Plus"
       case "pro":
         title = "Omi Pro"
       default:
@@ -6238,6 +6336,19 @@ struct SettingsContentView: View {
           subscriptionError = "Failed to load plan information."
           isLoadingSubscription = false
         }
+      }
+    }
+    loadChatUsageQuota()
+  }
+
+  private func loadChatUsageQuota() {
+    guard !isLoadingChatUsage else { return }
+    isLoadingChatUsage = true
+    Task {
+      let quota = await APIClient.shared.fetchChatUsageQuota()
+      await MainActor.run {
+        chatUsageQuota = quota
+        isLoadingChatUsage = false
       }
     }
   }

--- a/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
+++ b/desktop/Desktop/Sources/MainWindow/SettingsSidebar.swift
@@ -164,8 +164,8 @@ struct SettingsSearchItem: Identifiable {
       keywords: ["current plan", "renewal", "billing"], section: .planUsage, icon: "creditcard",
       settingId: "planusage.current"),
     SettingsSearchItem(
-      name: "Upgrade Plan", subtitle: "Buy Unlimited Plan or Omi Pro",
-      keywords: ["upgrade", "buy", "pricing", "checkout", "pro", "unlimited"], section: .planUsage,
+      name: "Upgrade Plan", subtitle: "Buy Plus or Omi Pro",
+      keywords: ["upgrade", "buy", "pricing", "checkout", "pro", "plus", "unlimited"], section: .planUsage,
       icon: "creditcard", settingId: "planusage.purchase"),
 
     // About


### PR DESCRIPTION
## Summary
- Rename the **Unlimited** plan to **Plus** across the desktop UI (display only — internal `PlanType.unlimited` and Stripe price IDs are unchanged so existing subscribers aren't affected). Free tier label changes from "Basic" to "Free" for clarity.
- Define per-plan chat caps: **Free 30 / Plus 200 questions/month**, **Pro $400 of chat spend/month**. All env-overridable (`FREE_CHAT_QUESTIONS_PER_MONTH`, `PLUS_CHAT_QUESTIONS_PER_MONTH`, `PRO_CHAT_COST_USD_PER_MONTH`).
- Add `GET /v1/users/me/usage-quota` — returns plan, unit (questions or cost_usd), used, limit, percent, allowed, reset_at. Reads from the existing `users/{uid}/llm_usage/{YYYY-MM-DD}` Firestore bucket; no new collection needed.
- Add a "Plan & Usage" card on the desktop Settings page with a progress bar of current-month usage, "resets in N days" label, and a warning when ≥80%.

## Why

Post-launch telemetry showed macOS burning ~\$5,800/day vs. ~\$250/day revenue from macOS users — driven mostly by a long tail of free / basic-plan users with no per-user cap. Example: one Pro user ran up \$443 of Claude chat cost this month alone. With no enforcement surface, we have no way to stop runaway usage without either angry users or a company-level kill switch.

This PR is step 1 — **define the tiers, expose the data to users, make the cap visible**. Actual request-time enforcement (deny over-quota requests before spending Anthropic tokens) is the next PR.

## What I did NOT touch

- No Stripe product/price ID changes — existing subscribers keep exactly their current billing. Only display strings changed.
- No enforcement path — backend does not yet refuse chat requests based on quota. Shipping display + API first, enforcement in a follow-up PR so the rollout is reviewable in pieces.
- No BYOK (bring-your-own-Anthropic-key) flow — planned as a separate PR after enforcement lands.
- No changes to the existing transcription/memory/insight limits in `PlanLimits` — only added new chat fields.

## Test plan
- [x] Swift compile clean (`xcrun swift build -c debug --package-path Desktop` → warnings only, all pre-existing)
- [x] Python imports clean — `get_plan_limits(PlanType.basic/unlimited/pro)` returns correct chat caps
- [x] Verified on real users via Firestore probe:
  - Luis (Pro) — already at \$443.73 chat cost this month → `allowed=false` once enforcement ships
  - Random Plus user — 5 questions used out of 200
- [x] Launched named bundle `plan-caps.app` locally with `./run.sh --yolo` and opened Settings → Plan and Usage
- [ ] Once backend auto-deploys, confirm the Plan & Usage card populates with real numbers in the running desktop app
- [ ] Mac mini release build

## Rollout
1. Merge this PR → backend auto-deploys the new endpoint to prod
2. Next desktop release picks up the rename + usage card
3. Follow-up PR: pre-call enforcement in ACP bridge path + backend chat endpoint
4. Follow-up PR: BYOK flow for Pro users at \$400 ceiling

🤖 Generated with [Claude Code](https://claude.com/claude-code)