### PR TITLE
Update CHANGELOG.json for v0.11.322 [skip ci]

### DIFF
--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,8 +1,13 @@
 {
-  "unreleased": [
-    "Fixed Rewind screen capture contending with other screenshot apps (e.g. CleanShot) and causing brief UI stalls"
-  ],
+  "unreleased": [],
   "releases": [
+    {
+      "version": "0.11.322",
+      "date": "2026-04-16",
+      "changes": [
+        "Fixed Rewind screen capture contending with other screenshot apps (e.g. CleanShot) and causing brief UI stalls"
+      ]
+    },
     {
       "version": "0.11.321",
       "date": "2026-04-16",


### PR DESCRIPTION
Auto-generated: consolidates unreleased entries into v0.11.322 and clears the unreleased array.