### PR TITLE
Desktop: ACP bridge chat quota gate

### DIFF
--- a/desktop/Desktop/Sources/Chat/ACPBridge.swift
+++ b/desktop/Desktop/Sources/Chat/ACPBridge.swift
@@ -353,6 +353,19 @@ actor ACPBridge {
       throw BridgeError.notRunning
     }
 
+    // Hard cap: check monthly chat quota before spending any Anthropic tokens.
+    // Free / Operator / Unlimited cap by question count; Architect (pro) caps by
+    // cost_usd. Raises BridgeError.quotaExceeded if over — caller shows upgrade UI.
+    if let quota = await APIClient.shared.fetchChatUsageQuota(), !quota.allowed {
+      throw BridgeError.quotaExceeded(
+        plan: quota.plan,
+        unit: quota.unit,
+        used: quota.used,
+        limit: quota.limit,
+        resetAtUnix: quota.resetAt
+      )
+    }
+
     var queryDict: [String: Any] = [
       "type": "query",
       "id": UUID().uuidString,
@@ -875,6 +888,11 @@ enum BridgeError: LocalizedError {
   case outOfMemory
   case stopped
   case agentError(String)
+  /// User is past their monthly chat cap; the client should render an
+  /// upgrade modal instead of a generic error. `plan` is the user-facing
+  /// plan label (e.g. "Free" / "Operator" / "Architect") and `resetAtUnix`
+  /// is the Unix-seconds timestamp of the cap reset (start of next UTC month).
+  case quotaExceeded(plan: String, unit: String, used: Double, limit: Double?, resetAtUnix: Int?)
 
   var errorDescription: String? {
     switch self {
@@ -917,6 +935,19 @@ enum BridgeError: LocalizedError {
         return "AI service is temporarily unavailable. Please try again later."
       }
       return "Something went wrong. Please try again."
+    case .quotaExceeded(let plan, let unit, let used, let limit, _):
+      let limitStr: String = {
+        guard let limit = limit else { return "your monthly limit" }
+        return unit == "cost_usd"
+          ? String(format: "$%.0f of monthly chat usage", limit)
+          : "\(Int(limit)) chat questions per month"
+      }()
+      let usedStr: String = {
+        unit == "cost_usd"
+          ? String(format: "$%.2f used", used)
+          : "\(Int(used)) used"
+      }()
+      return "You've hit your \(plan) plan limit (\(limitStr); \(usedStr)). Upgrade in Settings → Plan and Usage, or wait until the next reset."
     }
   }
 }


### PR DESCRIPTION
Complements PR #6723. That PR wired enforcement into the backend \`/v2/messages\` endpoint — which covers mobile + backend-driven chat but **not** the desktop ACP path where the biggest \$ burn lives (Claude via Claude Agent SDK).

This PR adds a pre-call check in \`ACPBridge.query()\`:

- Before sending \`session/prompt\` to the agent, call \`GET /v1/users/me/usage-quota\`
- If the backend returns \`allowed: false\`, throw \`BridgeError.quotaExceeded(plan, unit, used, limit, resetAtUnix)\`
- Caller renders the upgrade modal via the existing error-description path

Enforcement stays gated by the server-side \`CHAT_CAP_ENFORCEMENT_ENABLED\` kill-switch — when it's \`false\`, \`/v1/users/me/usage-quota\` always returns \`allowed: true\` and this gate is a no-op.

## Why this matters

Without this, the \$400/mo Architect cap doesn't actually prevent the top Claude spenders. One specific user was burning ~\$15/day on desktop Claude — that traffic goes Swift → ACP bridge → Anthropic directly, never touching the backend \`/v2/messages\` endpoint. This PR closes that gap.

## Test plan

- [x] Swift compiles clean
- [ ] Beta: with \`CHAT_CAP_ENFORCEMENT_ENABLED=true\` on dev backend, Luis-level test user hits quota → sees modal with plan name, used/limit, reset date
- [ ] Beta: Free user, 31st question → modal fires
- [ ] Beta: healthy user under cap → normal flow, no latency regression visible
- [ ] With kill-switch \`false\` → no change in behaviour vs. before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)