### PR TITLE
Backend: version-gate Operator/Architect to macOS beta (v0.11.324+)

### DIFF
--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -168,7 +168,11 @@ def _try_reactivate_subscription(uid: str, target_price_id: str) -> dict | None:
 
 
 @router.get('/v1/payments/available-plans', response_model=AvailablePlansResponse)
-def get_available_plans_endpoint(uid: str = Depends(auth.get_current_user_uid)):
+def get_available_plans_endpoint(
+    uid: str = Depends(auth.get_current_user_uid),
+    x_app_platform: Optional[str] = Header(None, alias='X-App-Platform'),
+    x_app_version: Optional[str] = Header(None, alias='X-App-Version'),
+):
     """Get available subscription plans with their price IDs and billing intervals."""
     try:
         # Get user's current subscription to determine which plan is active
@@ -214,13 +218,23 @@ def get_available_plans_endpoint(uid: str = Depends(auth.get_current_user_uid)):
         else:
             logger.info(f"No active paid subscription found for user {uid}")
 
-        # Legacy plans (Unlimited, old Pro) only show up if the user is
-        # currently subscribed to one of them; new users see only Oracle + Architect.
-        from utils.subscription import filter_plans_for_user
+        # Version-gate the new Operator + Architect catalog. Mobile and older
+        # desktop builds see the pre-rollout plan shape. Then legacy-filter so
+        # existing subscribers still see their current plan.
+        from utils.subscription import (
+            filter_plans_for_user,
+            should_show_new_plans,
+            adapt_plans_for_legacy_client,
+        )
+
+        new_plans_enabled = should_show_new_plans(x_app_platform, x_app_version)
+        all_definitions = get_paid_plan_definitions()
+        if not new_plans_enabled:
+            all_definitions = adapt_plans_for_legacy_client(all_definitions)
 
         current_plan = current_subscription.plan if current_subscription else PlanType.basic
         pricing_options: List[PricingOption] = []
-        for definition in filter_plans_for_user(get_paid_plan_definitions(), current_plan):
+        for definition in filter_plans_for_user(all_definitions, current_plan):
             monthly_price_id = definition["monthly_price_id"]
             annual_price_id = definition["annual_price_id"]
             if monthly_price_id:

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -67,6 +67,9 @@ from utils.subscription import (
     get_monthly_usage_for_subscription,
     reconcile_basic_plan_with_stripe,
     filter_plans_for_user,
+    should_show_new_plans,
+    adapt_plans_for_legacy_client,
+    legacy_plan_features,
 )
 from database import user_usage as user_usage_db
 from utils import stripe as stripe_utils
@@ -837,11 +840,19 @@ def get_user_subscription_endpoint(
     insights_gained_limit = subscription.limits.insights_gained or 0
     memories_created_limit = subscription.limits.memories_created or 0
 
-    # Build available plans for upgrading. Legacy plans (Unlimited, old Pro)
-    # only appear if the user is already on that plan — new users see only
-    # Oracle + Architect.
+    # Build available plans for upgrading. Two gates applied in order:
+    #   1. Version-gate: only macOS desktop clients at NEW_PLANS_MIN_DESKTOP_VERSION
+    #      or newer see the new Operator + Architect catalog. Everyone else
+    #      (mobile, older desktop builds) gets the pre-v0.11.324 plan shape
+    #      so we don't break them while the beta rollout bakes.
+    #   2. Legacy-filter: existing Unlimited subscribers still see their plan;
+    #      brand-new users don't.
+    new_plans_enabled = should_show_new_plans(x_app_platform, x_app_version)
+    all_definitions = get_paid_plan_definitions()
+    if not new_plans_enabled:
+        all_definitions = adapt_plans_for_legacy_client(all_definitions)
     available_plans: List[SubscriptionPlan] = []
-    definitions_for_user = filter_plans_for_user(get_paid_plan_definitions(), subscription.plan)
+    definitions_for_user = filter_plans_for_user(all_definitions, subscription.plan)
     for definition in definitions_for_user:
         plan_prices: List[PricingOption] = []
         monthly_price_id = definition["monthly_price_id"]
@@ -892,11 +903,16 @@ def get_user_subscription_endpoint(
                 )
 
         if plan_prices:
+            features = (
+                get_plan_features(definition["plan_type"])
+                if new_plans_enabled
+                else legacy_plan_features(definition["plan_type"])
+            )
             available_plans.append(
                 SubscriptionPlan(
                     id=definition["plan_id"],
                     title=definition["title"],
-                    features=get_plan_features(definition["plan_type"]),
+                    features=features,
                     prices=plan_prices,
                     legacy=bool(definition.get("legacy")),
                 )

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime, timezone
-from typing import List
+from typing import List, Optional
 import stripe
 
 import database.users as users_db
@@ -65,6 +65,80 @@ def filter_plans_for_user(definitions: list[dict], current_plan: PlanType) -> li
     A brand-new user on `basic` sees only non-legacy plans.
     """
     return [d for d in definitions if not d.get('legacy') or d['plan_type'] == current_plan]
+
+
+# Minimum desktop build that ships with the new plan catalog + quota UI.
+# Clients below this threshold — older desktop, or any mobile build — get the
+# pre-Operator plan shape. Once a stable release catches up, lower this.
+NEW_PLANS_MIN_DESKTOP_VERSION = os.getenv('NEW_PLANS_MIN_DESKTOP_VERSION', '0.11.324')
+
+
+def should_show_new_plans(platform: Optional[str], app_version: Optional[str]) -> bool:
+    """True iff this caller's client has the Swift code that understands the new
+    Operator + Architect plan shape and the /v1/users/me/usage-quota endpoint.
+
+    Only macOS desktop builds on `NEW_PLANS_MIN_DESKTOP_VERSION` or newer
+    qualify. iOS / Android / older desktop builds get the legacy plan catalog
+    so the rollout is gated to the beta channel without cross-client breakage.
+    """
+    # Lazy import so we don't pull the database layer at module import time
+    # and to avoid turning this into another circular-import sinkhole.
+    from database.announcements import _compare_versions
+
+    if not platform or platform.lower() != 'macos':
+        return False
+    if not app_version:
+        return False
+    try:
+        return _compare_versions(app_version, NEW_PLANS_MIN_DESKTOP_VERSION) >= 0
+    except Exception:
+        return False
+
+
+def adapt_plans_for_legacy_client(definitions: list[dict]) -> list[dict]:
+    """Transform the new-shape plan catalog back into the pre-v0.11.324 shape
+    so older clients (mobile, stable desktop) keep showing the old plan titles
+    and don't see Operator in their purchase options.
+
+    Hides the Operator entry entirely, renames Architect back to "Omi Pro",
+    and drops the legacy suffix + flag from Unlimited so pre-rollout clients
+    still see it as a normal (non-legacy) Unlimited Plan.
+    """
+    out: list[dict] = []
+    for d in definitions:
+        if d['plan_id'] == 'operator':
+            continue
+        adapted = dict(d)
+        if d['plan_id'] == 'pro':
+            adapted['title'] = 'Omi Pro'
+        elif d['plan_id'] == 'unlimited':
+            adapted['title'] = 'Unlimited Plan'
+            adapted['legacy'] = False
+        out.append(adapted)
+    return out
+
+
+def legacy_plan_features(plan: PlanType) -> List[str]:
+    """Feature strings matching the pre-v0.11.324 plan catalog.
+
+    Mirrors what `get_plan_features` used to return before the Operator /
+    Architect rename so older clients' UI doesn't change under them.
+    """
+    if plan == PlanType.pro:
+        return [
+            "Automations",
+            "Vibe coding",
+            "Unlimited actions",
+            "Priority desktop AI features",
+        ]
+    if plan in (PlanType.unlimited, PlanType.operator):
+        return [
+            "Unlimited listening time",
+            "Unlimited words transcribed",
+            "Unlimited insights",
+            "Unlimited memories",
+        ]
+    return get_plan_features(plan)
 
 
 def get_plan_type_from_price_id(price_id: str) -> PlanType:


### PR DESCRIPTION
Gates the new plan catalog rollout so only beta-channel desktop builds see Operator + Architect. Mobile (iOS/Android) and stable desktop continue seeing the pre-v0.11.324 shape — no cross-platform surprise.

## What

New helper in \`utils/subscription.py\`:

- **\`should_show_new_plans(platform, app_version)\`** — returns true only when \`platform == "macos"\` AND \`app_version >= NEW_PLANS_MIN_DESKTOP_VERSION\` (default \`0.11.324\`, env-overridable).
- **\`adapt_plans_for_legacy_client(definitions)\`** — takes the new catalog shape and rewrites it to the old shape: drops Operator, renames \`Architect\` → \`Omi Pro\`, renames \`Unlimited (legacy)\` → \`Unlimited Plan\`, clears the legacy flag.
- **\`legacy_plan_features(plan)\`** — returns the pre-rename bullet list for a given \`PlanType\`.

Both \`/v1/users/me/subscription\` and \`/v1/payments/available-plans\` read \`X-App-Platform\` + \`X-App-Version\`, pick between new/old catalogs, and select the matching feature bullets.

## Verified locally

Three client shapes, same endpoint:

| Client | Platform / Version | \`available_plans[*].title\` | \`features[0]\` |
|---|---|---|---|
| iOS mobile | \`ios\` / \`1.0.800\` | \`Omi Pro\` / \`Unlimited Plan\` | \`Automations\` / \`Unlimited listening time\` |
| Stable desktop | \`macos\` / \`0.11.300\` | \`Omi Pro\` / \`Unlimited Plan\` | same old bullets |
| Beta desktop | \`macos\` / \`0.11.324\` | **\`Operator\`** / **\`Architect\`** | \`500 chat questions per month\` / \`Automations and vibe coding\` |

## Rollout

1. Merge this PR → auto-deploy to dev (from \`gcp_backend_auto_dev.yml\`)
2. Deploy to prod when you're ready: \`gh workflow run gcp_backend.yml -f environment=prod -f branch=main\`
3. When the new plan catalog is stable on beta, lower \`NEW_PLANS_MIN_DESKTOP_VERSION\` (or remove the gate entirely) to roll to stable desktop + mobile

If beta feedback is negative, bump \`NEW_PLANS_MIN_DESKTOP_VERSION\` above the shipped beta version → everyone goes back to the old shape. No client redeploy needed.

## Pairs with

- #6717 — display rename + \`/v1/users/me/usage-quota\`
- #6723 — Operator + Architect plans + \`CHAT_CAP_ENFORCEMENT_ENABLED\` kill-switch
- #6725 — ACP bridge quota gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)