### PR TITLE
Rollback activeConnectionsPerPod for backend-listen to 22

### DIFF
--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -408,7 +408,7 @@ autoscaling:
   # targetMemoryUtilizationPercentage: 70
   # failedResponseCode: 10
   requestsPerPod: 10
-  activeConnectionsPerPod: 30
+  activeConnectionsPerPod: 22
 
 podDisruptionBudget:
   minAvailable: "80%"


### PR DESCRIPTION
Low CPU usage doesn't mean backend-listen has spare capacity to process the requests.
It comes down to CPU occupation and concurrent. 
I'll keep the activeConnectionsPerPod as 22 for now.  Once new enhancement has been deployed, I will try to adjust this value again.

Changes:
- Rollback activeConnectionsPerPod for backend-listen to 22