### PR TITLE
Fix notifications job Dockerfile dependency conflict

### DIFF
--- a/backend/modal/Dockerfile.notifications_job
+++ b/backend/modal/Dockerfile.notifications_job
@@ -4,8 +4,7 @@ ENV PATH="/opt/venv/bin:$PATH"
 RUN python -m venv /opt/venv
 
 COPY backend/requirements.txt /tmp/reqs/requirements.txt
-COPY backend/modal/requirements.txt /tmp/reqs/modal/requirements.txt
-RUN pip install --no-cache-dir --upgrade -r /tmp/reqs/modal/requirements.txt
+RUN pip install --no-cache-dir --upgrade -r /tmp/reqs/requirements.txt
 
 FROM python:3.11-slim
 


### PR DESCRIPTION
Follow-up to #6695. The notifications job Dockerfile used `modal/requirements.txt` which pulls in torch/pyannote/speechbrain (~2GB), but `job.py` only imports base backend deps (firebase_admin, asyncio, utils). This caused a dependency conflict: pyannote-audio 3.3.1 requires speechbrain>=1.0.0 but modal/requirements.txt pins speechbrain==0.5.16.

Fix: use `backend/requirements.txt` directly. Also makes the image ~2GB smaller.

---
_by AI for @beastoin_