### PR TITLE
feat: subscription restructure — Basic + Operator ($49) + Architect ($400) (#6734)

### DIFF
--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2910,5 +2910,13 @@
     "planDeprecationMessage": "يتم إيقاف خطة Unlimited الخاصة بك. انتقل إلى خطة Operator — نفس الميزات الرائعة بسعر $49/شهريًا. ستستمر خطتك الحالية في العمل في هذه الأثناء.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "قم بترقية خطتك",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "أنت على خطة مدفوعة.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ar.arb
+++ b/app/lib/l10n/app_ar.arb
@@ -2902,5 +2902,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "حذف الحساب نهائياً",
     "keepMyAccount": "الاحتفاظ بحسابي",
-    "deleteAccountFailed": "تعذر حذف حسابك. يرجى المحاولة مرة أخرى."
+    "deleteAccountFailed": "تعذر حذف حسابك. يرجى المحاولة مرة أخرى.",
+    "planUpdate": "تحديث الخطة",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "يتم إيقاف خطة Unlimited الخاصة بك. انتقل إلى خطة Operator — نفس الميزات الرائعة بسعر $49/شهريًا. ستستمر خطتك الحالية في العمل في هذه الأثناء.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "Ваш план Unlimited спыняецца. Пераключыцеся на план Operator — тыя ж выдатныя магчымасці за $49/мес. Ваш бягучы план будзе працягваць працаваць тым часам.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Палепшыце свой план",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Вы на платным плане.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_be.arb
+++ b/app/lib/l10n/app_be.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Выдаліць уліковы запіс назаўсёды",
     "keepMyAccount": "Захаваць мой уліковы запіс",
-    "deleteAccountFailed": "Не атрымалася выдаліць ваш уліковы запіс. Паспрабуйце яшчэ раз."
+    "deleteAccountFailed": "Не атрымалася выдаліць ваш уліковы запіс. Паспрабуйце яшчэ раз.",
+    "planUpdate": "Абнаўленне плана",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Ваш план Unlimited спыняецца. Пераключыцеся на план Operator — тыя ж выдатныя магчымасці за $49/мес. Ваш бягучы план будзе працягваць працаваць тым часам.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2904,5 +2904,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Изтрий акаунта окончателно",
     "keepMyAccount": "Запази акаунта ми",
-    "deleteAccountFailed": "Акаунтът ви не може да бъде изтрит. Моля, опитайте отново."
+    "deleteAccountFailed": "Акаунтът ви не може да бъде изтрит. Моля, опитайте отново.",
+    "planUpdate": "Актуализация на плана",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Вашият план Unlimited се прекратява. Преминете към план Operator — същите страхотни функции за $49/мес. Текущият ви план ще продължи да работи междувременно.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_bg.arb
+++ b/app/lib/l10n/app_bg.arb
@@ -2912,5 +2912,13 @@
     "planDeprecationMessage": "Вашият план Unlimited се прекратява. Преминете към план Operator — същите страхотни функции за $49/мес. Текущият ви план ще продължи да работи междувременно.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Надградете плана си",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Вие сте на платен план.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "অ্যাকাউন্ট স্থায়ীভাবে মুছুন",
     "keepMyAccount": "আমার অ্যাকাউন্ট রাখুন",
-    "deleteAccountFailed": "আপনার অ্যাকাউন্ট মুছে ফেলা যায়নি। আবার চেষ্টা করুন।"
+    "deleteAccountFailed": "আপনার অ্যাকাউন্ট মুছে ফেলা যায়নি। আবার চেষ্টা করুন।",
+    "planUpdate": "প্ল্যান আপডেট",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "আপনার Unlimited প্ল্যান বন্ধ হচ্ছে। Operator প্ল্যানে স্যুইচ করুন — একই দুর্দান্ত ফিচার $49/মাসে। আপনার বর্তমান প্ল্যান এর মধ্যে কাজ করতে থাকবে।",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_bn.arb
+++ b/app/lib/l10n/app_bn.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "আপনার Unlimited প্ল্যান বন্ধ হচ্ছে। Operator প্ল্যানে স্যুইচ করুন — একই দুর্দান্ত ফিচার $49/মাসে। আপনার বর্তমান প্ল্যান এর মধ্যে কাজ করতে থাকবে।",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "আপনার প্ল্যান আপগ্রেড করুন",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "আপনি একটি পেইড প্ল্যানে আছেন।",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Trajno obriši račun",
     "keepMyAccount": "Zadrži moj račun",
-    "deleteAccountFailed": "Brisanje vašeg računa nije uspjelo. Pokušajte ponovo."
+    "deleteAccountFailed": "Brisanje vašeg računa nije uspjelo. Pokušajte ponovo.",
+    "planUpdate": "Ažuriranje plana",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Vaš Unlimited plan se ukida. Pređite na Operator plan — iste odlične funkcije za $49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_bs.arb
+++ b/app/lib/l10n/app_bs.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "Vaš Unlimited plan se ukida. Pređite na Operator plan — iste odlične funkcije za $49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Nadogradite svoj plan",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Na plaćenom ste planu.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2904,5 +2904,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Eliminar compte permanentment",
     "keepMyAccount": "Mantenir el meu compte",
-    "deleteAccountFailed": "No s'ha pogut eliminar el teu compte. Torna-ho a provar."
+    "deleteAccountFailed": "No s'ha pogut eliminar el teu compte. Torna-ho a provar.",
+    "planUpdate": "Actualització del pla",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "El vostre pla Unlimited s'està retirant. Canvieu al pla Operator — les mateixes funcions excel·lents a $49/mes. El vostre pla actual continuarà funcionant mentrestant.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_ca.arb
+++ b/app/lib/l10n/app_ca.arb
@@ -2912,5 +2912,13 @@
     "planDeprecationMessage": "El vostre pla Unlimited s'està retirant. Canvieu al pla Operator — les mateixes funcions excel·lents a $49/mes. El vostre pla actual continuarà funcionant mentrestant.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Actualitza el teu pla",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Estàs en un pla de pagament.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2904,5 +2904,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Trvale smazat účet",
     "keepMyAccount": "Ponechat můj účet",
-    "deleteAccountFailed": "Váš účet se nepodařilo smazat. Zkuste to znovu."
+    "deleteAccountFailed": "Váš účet se nepodařilo smazat. Zkuste to znovu.",
+    "planUpdate": "Aktualizace plánu",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Váš plán Unlimited je rušen. Přejděte na plán Operator — stejné skvělé funkce za $49/měs. Váš stávající plán bude zatím nadále fungovat.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_cs.arb
+++ b/app/lib/l10n/app_cs.arb
@@ -2912,5 +2912,13 @@
     "planDeprecationMessage": "Váš plán Unlimited je rušen. Přejděte na plán Operator — stejné skvělé funkce za $49/měs. Váš stávající plán bude zatím nadále fungovat.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Upgradujte svůj plán",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Máte placený plán.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2944,5 +2944,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Slet konto permanent",
     "keepMyAccount": "Behold min konto",
-    "deleteAccountFailed": "Kunne ikke slette din konto. Prøv igen."
+    "deleteAccountFailed": "Kunne ikke slette din konto. Prøv igen.",
+    "planUpdate": "Planopdatering",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Dit Unlimited-abonnement bliver udfaset. Skift til Operator-abonnementet — samme fantastiske funktioner til $49/md. Dit nuværende abonnement vil fortsætte med at fungere i mellemtiden.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_da.arb
+++ b/app/lib/l10n/app_da.arb
@@ -2952,5 +2952,13 @@
     "planDeprecationMessage": "Dit Unlimited-abonnement bliver udfaset. Skift til Operator-abonnementet — samme fantastiske funktioner til $49/md. Dit nuværende abonnement vil fortsætte med at fungere i mellemtiden.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Opgrader din plan",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Du er på en betalt plan.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2911,5 +2911,13 @@
     "planDeprecationMessage": "Ihr Unlimited-Plan wird eingestellt. Wechseln Sie zum Operator-Plan — dieselben großartigen Funktionen für $49/Monat. Ihr aktueller Plan funktioniert in der Zwischenzeit weiterhin.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Upgrade deinen Plan",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Du hast einen kostenpflichtigen Plan.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_de.arb
+++ b/app/lib/l10n/app_de.arb
@@ -2903,5 +2903,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Konto endgültig löschen",
     "keepMyAccount": "Mein Konto behalten",
-    "deleteAccountFailed": "Dein Konto konnte nicht gelöscht werden. Bitte versuche es erneut."
+    "deleteAccountFailed": "Dein Konto konnte nicht gelöscht werden. Bitte versuche es erneut.",
+    "planUpdate": "Plan-Aktualisierung",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Ihr Unlimited-Plan wird eingestellt. Wechseln Sie zum Operator-Plan — dieselben großartigen Funktionen für $49/Monat. Ihr aktueller Plan funktioniert in der Zwischenzeit weiterhin.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Το πλάνο Unlimited σας καταργείται. Μεταβείτε στο πλάνο Operator — ίδιες εξαιρετικές λειτουργίες στα $49/μήνα. Το τρέχον πλάνο σας θα συνεχίσει να λειτουργεί στο μεταξύ.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Αναβαθμίστε το πλάνο σας",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Είστε σε πληρωμένο πλάνο.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_el.arb
+++ b/app/lib/l10n/app_el.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Οριστική διαγραφή λογαριασμού",
     "keepMyAccount": "Διατήρηση λογαριασμού μου",
-    "deleteAccountFailed": "Δεν ήταν δυνατή η διαγραφή του λογαριασμού σας. Δοκιμάστε ξανά."
+    "deleteAccountFailed": "Δεν ήταν δυνατή η διαγραφή του λογαριασμού σας. Δοκιμάστε ξανά.",
+    "planUpdate": "Ενημέρωση πλάνου",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Το πλάνο Unlimited σας καταργείται. Μεταβείτε στο πλάνο Operator — ίδιες εξαιρετικές λειτουργίες στα $49/μήνα. Το τρέχον πλάνο σας θα συνεχίσει να λειτουργεί στο μεταξύ.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10728,5 +10728,13 @@
     "deleteAccountFailed": "Could not delete your account. Please try again.",
     "@deleteAccountFailed": {
         "description": "Error shown when deletion API fails"
+    },
+    "planUpdate": "Plan Update",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Your Unlimited plan is being retired. Switch to the Operator plan — same great features at $49/mo. Your current plan will continue to work in the meantime.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
     }
 }

--- a/app/lib/l10n/app_en.arb
+++ b/app/lib/l10n/app_en.arb
@@ -10736,5 +10736,13 @@
     "planDeprecationMessage": "Your Unlimited plan is being retired. Switch to the Operator plan — same great features at $49/mo. Your current plan will continue to work in the meantime.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Upgrade Your Plan",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "You are on a paid plan.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2936,5 +2936,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Eliminar cuenta permanentemente",
     "keepMyAccount": "Conservar mi cuenta",
-    "deleteAccountFailed": "No se pudo eliminar tu cuenta. Inténtalo de nuevo."
+    "deleteAccountFailed": "No se pudo eliminar tu cuenta. Inténtalo de nuevo.",
+    "planUpdate": "Actualización del plan",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Su plan Unlimited está siendo retirado. Cambie al plan Operator — las mismas excelentes funciones a $49/mes. Su plan actual seguirá funcionando mientras tanto.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_es.arb
+++ b/app/lib/l10n/app_es.arb
@@ -2944,5 +2944,13 @@
     "planDeprecationMessage": "Su plan Unlimited está siendo retirado. Cambie al plan Operator — las mismas excelentes funciones a $49/mes. Su plan actual seguirá funcionando mientras tanto.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Mejora tu plan",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Estás en un plan de pago.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Kustuta konto jäädavalt",
     "keepMyAccount": "Säilita minu konto",
-    "deleteAccountFailed": "Sinu kontot ei õnnestunud kustutada. Palun proovi uuesti."
+    "deleteAccountFailed": "Sinu kontot ei õnnestunud kustutada. Palun proovi uuesti.",
+    "planUpdate": "Plaani uuendus",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Teie Unlimited plaan lõpetatakse. Lülitage Operator plaanile — samad suurepärased funktsioonid hinnaga $49/kuus. Teie praegune plaan jätkab vahepeal tööd.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_et.arb
+++ b/app/lib/l10n/app_et.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Teie Unlimited plaan lõpetatakse. Lülitage Operator plaanile — samad suurepärased funktsioonid hinnaga $49/kuus. Teie praegune plaan jätkab vahepeal tööd.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Uuenda oma plaani",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Oled tasulisel plaanil.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "طرح Unlimited شما در حال بازنشسته شدن است. به طرح Operator تغییر دهید — همان ویژگی‌های عالی با $49/ماه. طرح فعلی شما در این مدت به کار خود ادامه خواهد داد.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "طرح خود را ارتقا دهید",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "شما در یک طرح پولی هستید.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_fa.arb
+++ b/app/lib/l10n/app_fa.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "حذف دائمی حساب",
     "keepMyAccount": "حفظ حساب من",
-    "deleteAccountFailed": "حذف حساب شما ممکن نشد. لطفاً دوباره تلاش کنید."
+    "deleteAccountFailed": "حذف حساب شما ممکن نشد. لطفاً دوباره تلاش کنید.",
+    "planUpdate": "به‌روزرسانی طرح",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "طرح Unlimited شما در حال بازنشسته شدن است. به طرح Operator تغییر دهید — همان ویژگی‌های عالی با $49/ماه. طرح فعلی شما در این مدت به کار خود ادامه خواهد داد.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Poista tili pysyvästi",
     "keepMyAccount": "Säilytä tilini",
-    "deleteAccountFailed": "Tiliäsi ei voitu poistaa. Yritä uudelleen."
+    "deleteAccountFailed": "Tiliäsi ei voitu poistaa. Yritä uudelleen.",
+    "planUpdate": "Tilauksen päivitys",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Unlimited-tilauksesi poistetaan käytöstä. Vaihda Operator-tilaukseen — samat loistavat ominaisuudet hintaan $49/kk. Nykyinen tilauksesi jatkaa toimintaansa sillä välin.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_fi.arb
+++ b/app/lib/l10n/app_fi.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Unlimited-tilauksesi poistetaan käytöstä. Vaihda Operator-tilaukseen — samat loistavat ominaisuudet hintaan $49/kk. Nykyinen tilauksesi jatkaa toimintaansa sillä välin.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Päivitä tilauksesi",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Sinulla on maksullinen tilaus.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2978,5 +2978,13 @@
     "planDeprecationMessage": "Votre plan Unlimited est en cours de retrait. Passez au plan Operator — les mêmes fonctionnalités à $49/mois. Votre plan actuel continuera de fonctionner en attendant.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Améliorez votre forfait",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Vous êtes sur un forfait payant.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_fr.arb
+++ b/app/lib/l10n/app_fr.arb
@@ -2970,5 +2970,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Supprimer le compte définitivement",
     "keepMyAccount": "Conserver mon compte",
-    "deleteAccountFailed": "Impossible de supprimer votre compte. Veuillez réessayer."
+    "deleteAccountFailed": "Impossible de supprimer votre compte. Veuillez réessayer.",
+    "planUpdate": "Mise à jour du plan",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Votre plan Unlimited est en cours de retrait. Passez au plan Operator — les mêmes fonctionnalités à $49/mois. Votre plan actuel continuera de fonctionner en attendant.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "תוכנית ה-Unlimited שלך מופסקת. עברו לתוכנית Operator — אותן תכונות מעולות ב-$49/חודש. התוכנית הנוכחית שלך תמשיך לפעול בינתיים.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "שדרג את התוכנית שלך",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "אתה על תוכנית בתשלום.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_he.arb
+++ b/app/lib/l10n/app_he.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "מחק חשבון לצמיתות",
     "keepMyAccount": "שמור על החשבון שלי",
-    "deleteAccountFailed": "לא ניתן היה למחוק את החשבון שלך. נסה שוב."
+    "deleteAccountFailed": "לא ניתן היה למחוק את החשבון שלך. נסה שוב.",
+    "planUpdate": "עדכון תוכנית",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "תוכנית ה-Unlimited שלך מופסקת. עברו לתוכנית Operator — אותן תכונות מעולות ב-$49/חודש. התוכנית הנוכחית שלך תמשיך לפעול בינתיים.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2944,5 +2944,13 @@
     "planDeprecationMessage": "आपका Unlimited प्लान बंद किया जा रहा है। Operator प्लान पर स्विच करें — वही बेहतरीन सुविधाएँ $49/माह पर। आपका वर्तमान प्लान तब तक काम करता रहेगा।",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "अपना प्लान अपग्रेड करें",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "आप एक सशुल्क प्लान पर हैं।",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_hi.arb
+++ b/app/lib/l10n/app_hi.arb
@@ -2936,5 +2936,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "खाता स्थायी रूप से हटाएँ",
     "keepMyAccount": "मेरा खाता रखें",
-    "deleteAccountFailed": "आपका खाता हटाया नहीं जा सका। कृपया पुनः प्रयास करें।"
+    "deleteAccountFailed": "आपका खाता हटाया नहीं जा सका। कृपया पुनः प्रयास करें।",
+    "planUpdate": "प्लान अपडेट",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "आपका Unlimited प्लान बंद किया जा रहा है। Operator प्लान पर स्विच करें — वही बेहतरीन सुविधाएँ $49/माह पर। आपका वर्तमान प्लान तब तक काम करता रहेगा।",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Trajno izbriši račun",
     "keepMyAccount": "Zadrži moj račun",
-    "deleteAccountFailed": "Brisanje vašeg računa nije uspjelo. Pokušajte ponovno."
+    "deleteAccountFailed": "Brisanje vašeg računa nije uspjelo. Pokušajte ponovno.",
+    "planUpdate": "Ažuriranje plana",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Vaš Unlimited plan se ukida. Prijeđite na Operator plan — iste izvrsne značajke za $49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_hr.arb
+++ b/app/lib/l10n/app_hr.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "Vaš Unlimited plan se ukida. Prijeđite na Operator plan — iste izvrsne značajke za $49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Nadogradite svoj plan",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Na plaćenom ste planu.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3039,5 +3039,13 @@
     "planDeprecationMessage": "Az Unlimited csomagja megszűnik. Váltson az Operator csomagra — ugyanazok a kiváló funkciók $49/hó áron. A jelenlegi csomagja addig is tovább működik.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Frissítsd a csomagodat",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Fizetős csomagod van.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_hu.arb
+++ b/app/lib/l10n/app_hu.arb
@@ -3031,5 +3031,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Fiók végleges törlése",
     "keepMyAccount": "Fiókom megtartása",
-    "deleteAccountFailed": "Nem sikerült törölni a fiókodat. Próbáld újra."
+    "deleteAccountFailed": "Nem sikerült törölni a fiókodat. Próbáld újra.",
+    "planUpdate": "Csomag frissítés",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Az Unlimited csomagja megszűnik. Váltson az Operator csomagra — ugyanazok a kiváló funkciók $49/hó áron. A jelenlegi csomagja addig is tovább működik.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2977,5 +2977,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Hapus akun secara permanen",
     "keepMyAccount": "Pertahankan akun saya",
-    "deleteAccountFailed": "Tidak dapat menghapus akun Anda. Silakan coba lagi."
+    "deleteAccountFailed": "Tidak dapat menghapus akun Anda. Silakan coba lagi.",
+    "planUpdate": "Pembaruan Paket",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Paket Unlimited Anda akan dihentikan. Beralih ke paket Operator — fitur hebat yang sama seharga $49/bulan. Paket Anda saat ini akan terus berfungsi untuk sementara.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_id.arb
+++ b/app/lib/l10n/app_id.arb
@@ -2985,5 +2985,13 @@
     "planDeprecationMessage": "Paket Unlimited Anda akan dihentikan. Beralih ke paket Operator — fitur hebat yang sama seharga $49/bulan. Paket Anda saat ini akan terus berfungsi untuk sementara.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Tingkatkan Paket Anda",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Anda menggunakan paket berbayar.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Il tuo piano Unlimited viene ritirato. Passa al piano Operator — le stesse fantastiche funzionalità a $49/mese. Il tuo piano attuale continuerà a funzionare nel frattempo.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Aggiorna il tuo piano",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Sei su un piano a pagamento.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_it.arb
+++ b/app/lib/l10n/app_it.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Elimina account definitivamente",
     "keepMyAccount": "Mantieni il mio account",
-    "deleteAccountFailed": "Impossibile eliminare il tuo account. Riprova."
+    "deleteAccountFailed": "Impossibile eliminare il tuo account. Riprova.",
+    "planUpdate": "Aggiornamento del piano",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Il tuo piano Unlimited viene ritirato. Passa al piano Operator — le stesse fantastiche funzionalità a $49/mese. Il tuo piano attuale continuerà a funzionare nel frattempo.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2944,5 +2944,13 @@
     "planDeprecationMessage": "Unlimitedプランは廃止予定です。Operatorプランに切り替えてください — 同じ優れた機能が月額$49でご利用いただけます。現在のプランは当面の間引き続きご利用いただけます。",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "プランをアップグレード",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "有料プランをご利用中です。",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ja.arb
+++ b/app/lib/l10n/app_ja.arb
@@ -2936,5 +2936,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "アカウントを完全に削除",
     "keepMyAccount": "アカウントを残す",
-    "deleteAccountFailed": "アカウントを削除できませんでした。もう一度お試しください。"
+    "deleteAccountFailed": "アカウントを削除できませんでした。もう一度お試しください。",
+    "planUpdate": "プラン更新",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Unlimitedプランは廃止予定です。Operatorプランに切り替えてください — 同じ優れた機能が月額$49でご利用いただけます。現在のプランは当面の間引き続きご利用いただけます。",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "ಖಾತೆಯನ್ನು ಶಾಶ್ವತವಾಗಿ ಅಳಿಸಿ",
     "keepMyAccount": "ನನ್ನ ಖಾತೆಯನ್ನು ಇರಿಸಿ",
-    "deleteAccountFailed": "ನಿಮ್ಮ ಖಾತೆಯನ್ನು ಅಳಿಸಲಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ."
+    "deleteAccountFailed": "ನಿಮ್ಮ ಖಾತೆಯನ್ನು ಅಳಿಸಲಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.",
+    "planUpdate": "ಯೋಜನೆ ನವೀಕರಣ",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "ನಿಮ್ಮ Unlimited ಯೋಜನೆಯನ್ನು ನಿಲ್ಲಿಸಲಾಗುತ್ತಿದೆ. Operator ಯೋಜನೆಗೆ ಬದಲಾಯಿಸಿ — ಅದೇ ಅದ್ಭುತ ವೈಶಿಷ್ಟ್ಯಗಳು $49/ತಿಂಗಳಿಗೆ. ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಯೋಜನೆ ಈ ಮಧ್ಯೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಲೇ ಇರುತ್ತದೆ.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_kn.arb
+++ b/app/lib/l10n/app_kn.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "ನಿಮ್ಮ Unlimited ಯೋಜನೆಯನ್ನು ನಿಲ್ಲಿಸಲಾಗುತ್ತಿದೆ. Operator ಯೋಜನೆಗೆ ಬದಲಾಯಿಸಿ — ಅದೇ ಅದ್ಭುತ ವೈಶಿಷ್ಟ್ಯಗಳು $49/ತಿಂಗಳಿಗೆ. ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಯೋಜನೆ ಈ ಮಧ್ಯೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಲೇ ಇರುತ್ತದೆ.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "ನಿಮ್ಮ ಯೋಜನೆಯನ್ನು ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "ನೀವು ಪಾವತಿಸಿದ ಯೋಜನೆಯಲ್ಲಿದ್ದೀರಿ.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Unlimited 플랜이 중단됩니다. Operator 플랜으로 전환하세요 — 동일한 훌륭한 기능을 월 $49에 이용할 수 있습니다. 현재 플랜은 당분간 계속 사용할 수 있습니다.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "플랜 업그레이드",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "유료 플랜을 사용 중입니다.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ko.arb
+++ b/app/lib/l10n/app_ko.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "계정 영구 삭제",
     "keepMyAccount": "내 계정 유지",
-    "deleteAccountFailed": "계정을 삭제할 수 없습니다. 다시 시도해 주세요."
+    "deleteAccountFailed": "계정을 삭제할 수 없습니다. 다시 시도해 주세요.",
+    "planUpdate": "플랜 업데이트",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Unlimited 플랜이 중단됩니다. Operator 플랜으로 전환하세요 — 동일한 훌륭한 기능을 월 $49에 이용할 수 있습니다. 현재 플랜은 당분간 계속 사용할 수 있습니다.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16844,6 +16844,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Could not delete your account. Please try again.'**
   String get deleteAccountFailed;
+
+  /// Header for plan deprecation notice
+  ///
+  /// In en, this message translates to:
+  /// **'Plan Update'**
+  String get planUpdate;
+
+  /// Deprecation notice for legacy Unlimited subscribers
+  ///
+  /// In en, this message translates to:
+  /// **'Your Unlimited plan is being retired. Switch to the Operator plan — same great features at \$49/mo. Your current plan will continue to work in the meantime.'**
+  String get planDeprecationMessage;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations.dart
+++ b/app/lib/l10n/app_localizations.dart
@@ -16856,6 +16856,18 @@ abstract class AppLocalizations {
   /// In en, this message translates to:
   /// **'Your Unlimited plan is being retired. Switch to the Operator plan — same great features at \$49/mo. Your current plan will continue to work in the meantime.'**
   String get planDeprecationMessage;
+
+  /// Header for plan upgrade screen for non-paid users
+  ///
+  /// In en, this message translates to:
+  /// **'Upgrade Your Plan'**
+  String get upgradeYourPlan;
+
+  /// Subtitle for paid plan users on plans sheet
+  ///
+  /// In en, this message translates to:
+  /// **'You are on a paid plan.'**
+  String get youAreOnAPaidPlan;
 }
 
 class _AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8947,4 +8947,11 @@ class AppLocalizationsAr extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'تعذر حذف حسابك. يرجى المحاولة مرة أخرى.';
+
+  @override
+  String get planUpdate => 'تحديث الخطة';
+
+  @override
+  String get planDeprecationMessage =>
+      'يتم إيقاف خطة Unlimited الخاصة بك. انتقل إلى خطة Operator — نفس الميزات الرائعة بسعر \$49/شهريًا. ستستمر خطتك الحالية في العمل في هذه الأثناء.';
 }

--- a/app/lib/l10n/app_localizations_ar.dart
+++ b/app/lib/l10n/app_localizations_ar.dart
@@ -8954,4 +8954,10 @@ class AppLocalizationsAr extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'يتم إيقاف خطة Unlimited الخاصة بك. انتقل إلى خطة Operator — نفس الميزات الرائعة بسعر \$49/شهريًا. ستستمر خطتك الحالية في العمل في هذه الأثناء.';
+
+  @override
+  String get upgradeYourPlan => 'قم بترقية خطتك';
+
+  @override
+  String get youAreOnAPaidPlan => 'أنت على خطة مدفوعة.';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9040,4 +9040,10 @@ class AppLocalizationsBe extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Ваш план Unlimited спыняецца. Пераключыцеся на план Operator — тыя ж выдатныя магчымасці за \$49/мес. Ваш бягучы план будзе працягваць працаваць тым часам.';
+
+  @override
+  String get upgradeYourPlan => 'Палепшыце свой план';
+
+  @override
+  String get youAreOnAPaidPlan => 'Вы на платным плане.';
 }

--- a/app/lib/l10n/app_localizations_be.dart
+++ b/app/lib/l10n/app_localizations_be.dart
@@ -9033,4 +9033,11 @@ class AppLocalizationsBe extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Не атрымалася выдаліць ваш уліковы запіс. Паспрабуйце яшчэ раз.';
+
+  @override
+  String get planUpdate => 'Абнаўленне плана';
+
+  @override
+  String get planDeprecationMessage =>
+      'Ваш план Unlimited спыняецца. Пераключыцеся на план Operator — тыя ж выдатныя магчымасці за \$49/мес. Ваш бягучы план будзе працягваць працаваць тым часам.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9043,4 +9043,11 @@ class AppLocalizationsBg extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Акаунтът ви не може да бъде изтрит. Моля, опитайте отново.';
+
+  @override
+  String get planUpdate => 'Актуализация на плана';
+
+  @override
+  String get planDeprecationMessage =>
+      'Вашият план Unlimited се прекратява. Преминете към план Operator — същите страхотни функции за \$49/мес. Текущият ви план ще продължи да работи междувременно.';
 }

--- a/app/lib/l10n/app_localizations_bg.dart
+++ b/app/lib/l10n/app_localizations_bg.dart
@@ -9050,4 +9050,10 @@ class AppLocalizationsBg extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Вашият план Unlimited се прекратява. Преминете към план Operator — същите страхотни функции за \$49/мес. Текущият ви план ще продължи да работи междувременно.';
+
+  @override
+  String get upgradeYourPlan => 'Надградете плана си';
+
+  @override
+  String get youAreOnAPaidPlan => 'Вие сте на платен план.';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9024,4 +9024,10 @@ class AppLocalizationsBn extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'আপনার Unlimited প্ল্যান বন্ধ হচ্ছে। Operator প্ল্যানে স্যুইচ করুন — একই দুর্দান্ত ফিচার \$49/মাসে। আপনার বর্তমান প্ল্যান এর মধ্যে কাজ করতে থাকবে।';
+
+  @override
+  String get upgradeYourPlan => 'আপনার প্ল্যান আপগ্রেড করুন';
+
+  @override
+  String get youAreOnAPaidPlan => 'আপনি একটি পেইড প্ল্যানে আছেন।';
 }

--- a/app/lib/l10n/app_localizations_bn.dart
+++ b/app/lib/l10n/app_localizations_bn.dart
@@ -9017,4 +9017,11 @@ class AppLocalizationsBn extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'আপনার অ্যাকাউন্ট মুছে ফেলা যায়নি। আবার চেষ্টা করুন।';
+
+  @override
+  String get planUpdate => 'প্ল্যান আপডেট';
+
+  @override
+  String get planDeprecationMessage =>
+      'আপনার Unlimited প্ল্যান বন্ধ হচ্ছে। Operator প্ল্যানে স্যুইচ করুন — একই দুর্দান্ত ফিচার \$49/মাসে। আপনার বর্তমান প্ল্যান এর মধ্যে কাজ করতে থাকবে।';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9038,4 +9038,10 @@ class AppLocalizationsBs extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Vaš Unlimited plan se ukida. Pređite na Operator plan — iste odlične funkcije za \$49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.';
+
+  @override
+  String get upgradeYourPlan => 'Nadogradite svoj plan';
+
+  @override
+  String get youAreOnAPaidPlan => 'Na plaćenom ste planu.';
 }

--- a/app/lib/l10n/app_localizations_bs.dart
+++ b/app/lib/l10n/app_localizations_bs.dart
@@ -9031,4 +9031,11 @@ class AppLocalizationsBs extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Brisanje vašeg računa nije uspjelo. Pokušajte ponovo.';
+
+  @override
+  String get planUpdate => 'Ažuriranje plana';
+
+  @override
+  String get planDeprecationMessage =>
+      'Vaš Unlimited plan se ukida. Pređite na Operator plan — iste odlične funkcije za \$49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9062,4 +9062,11 @@ class AppLocalizationsCa extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'No s\'ha pogut eliminar el teu compte. Torna-ho a provar.';
+
+  @override
+  String get planUpdate => 'Actualització del pla';
+
+  @override
+  String get planDeprecationMessage =>
+      'El vostre pla Unlimited s\'està retirant. Canvieu al pla Operator — les mateixes funcions excel·lents a \$49/mes. El vostre pla actual continuarà funcionant mentrestant.';
 }

--- a/app/lib/l10n/app_localizations_ca.dart
+++ b/app/lib/l10n/app_localizations_ca.dart
@@ -9069,4 +9069,10 @@ class AppLocalizationsCa extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'El vostre pla Unlimited s\'està retirant. Canvieu al pla Operator — les mateixes funcions excel·lents a \$49/mes. El vostre pla actual continuarà funcionant mentrestant.';
+
+  @override
+  String get upgradeYourPlan => 'Actualitza el teu pla';
+
+  @override
+  String get youAreOnAPaidPlan => 'Estàs en un pla de pagament.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9004,4 +9004,11 @@ class AppLocalizationsCs extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Váš účet se nepodařilo smazat. Zkuste to znovu.';
+
+  @override
+  String get planUpdate => 'Aktualizace plánu';
+
+  @override
+  String get planDeprecationMessage =>
+      'Váš plán Unlimited je rušen. Přejděte na plán Operator — stejné skvělé funkce za \$49/měs. Váš stávající plán bude zatím nadále fungovat.';
 }

--- a/app/lib/l10n/app_localizations_cs.dart
+++ b/app/lib/l10n/app_localizations_cs.dart
@@ -9011,4 +9011,10 @@ class AppLocalizationsCs extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Váš plán Unlimited je rušen. Přejděte na plán Operator — stejné skvělé funkce za \$49/měs. Váš stávající plán bude zatím nadále fungovat.';
+
+  @override
+  String get upgradeYourPlan => 'Upgradujte svůj plán';
+
+  @override
+  String get youAreOnAPaidPlan => 'Máte placený plán.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -8994,4 +8994,11 @@ class AppLocalizationsDa extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Kunne ikke slette din konto. Prøv igen.';
+
+  @override
+  String get planUpdate => 'Planopdatering';
+
+  @override
+  String get planDeprecationMessage =>
+      'Dit Unlimited-abonnement bliver udfaset. Skift til Operator-abonnementet — samme fantastiske funktioner til \$49/md. Dit nuværende abonnement vil fortsætte med at fungere i mellemtiden.';
 }

--- a/app/lib/l10n/app_localizations_da.dart
+++ b/app/lib/l10n/app_localizations_da.dart
@@ -9001,4 +9001,10 @@ class AppLocalizationsDa extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Dit Unlimited-abonnement bliver udfaset. Skift til Operator-abonnementet — samme fantastiske funktioner til \$49/md. Dit nuværende abonnement vil fortsætte med at fungere i mellemtiden.';
+
+  @override
+  String get upgradeYourPlan => 'Opgrader din plan';
+
+  @override
+  String get youAreOnAPaidPlan => 'Du er på en betalt plan.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9085,4 +9085,11 @@ class AppLocalizationsDe extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Dein Konto konnte nicht gelöscht werden. Bitte versuche es erneut.';
+
+  @override
+  String get planUpdate => 'Plan-Aktualisierung';
+
+  @override
+  String get planDeprecationMessage =>
+      'Ihr Unlimited-Plan wird eingestellt. Wechseln Sie zum Operator-Plan — dieselben großartigen Funktionen für \$49/Monat. Ihr aktueller Plan funktioniert in der Zwischenzeit weiterhin.';
 }

--- a/app/lib/l10n/app_localizations_de.dart
+++ b/app/lib/l10n/app_localizations_de.dart
@@ -9092,4 +9092,10 @@ class AppLocalizationsDe extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Ihr Unlimited-Plan wird eingestellt. Wechseln Sie zum Operator-Plan — dieselben großartigen Funktionen für \$49/Monat. Ihr aktueller Plan funktioniert in der Zwischenzeit weiterhin.';
+
+  @override
+  String get upgradeYourPlan => 'Upgrade deinen Plan';
+
+  @override
+  String get youAreOnAPaidPlan => 'Du hast einen kostenpflichtigen Plan.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9073,4 +9073,11 @@ class AppLocalizationsEl extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Δεν ήταν δυνατή η διαγραφή του λογαριασμού σας. Δοκιμάστε ξανά.';
+
+  @override
+  String get planUpdate => 'Ενημέρωση πλάνου';
+
+  @override
+  String get planDeprecationMessage =>
+      'Το πλάνο Unlimited σας καταργείται. Μεταβείτε στο πλάνο Operator — ίδιες εξαιρετικές λειτουργίες στα \$49/μήνα. Το τρέχον πλάνο σας θα συνεχίσει να λειτουργεί στο μεταξύ.';
 }

--- a/app/lib/l10n/app_localizations_el.dart
+++ b/app/lib/l10n/app_localizations_el.dart
@@ -9080,4 +9080,10 @@ class AppLocalizationsEl extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Το πλάνο Unlimited σας καταργείται. Μεταβείτε στο πλάνο Operator — ίδιες εξαιρετικές λειτουργίες στα \$49/μήνα. Το τρέχον πλάνο σας θα συνεχίσει να λειτουργεί στο μεταξύ.';
+
+  @override
+  String get upgradeYourPlan => 'Αναβαθμίστε το πλάνο σας';
+
+  @override
+  String get youAreOnAPaidPlan => 'Είστε σε πληρωμένο πλάνο.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9004,4 +9004,11 @@ class AppLocalizationsEn extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Could not delete your account. Please try again.';
+
+  @override
+  String get planUpdate => 'Plan Update';
+
+  @override
+  String get planDeprecationMessage =>
+      'Your Unlimited plan is being retired. Switch to the Operator plan — same great features at \$49/mo. Your current plan will continue to work in the meantime.';
 }

--- a/app/lib/l10n/app_localizations_en.dart
+++ b/app/lib/l10n/app_localizations_en.dart
@@ -9011,4 +9011,10 @@ class AppLocalizationsEn extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Your Unlimited plan is being retired. Switch to the Operator plan — same great features at \$49/mo. Your current plan will continue to work in the meantime.';
+
+  @override
+  String get upgradeYourPlan => 'Upgrade Your Plan';
+
+  @override
+  String get youAreOnAPaidPlan => 'You are on a paid plan.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9029,4 +9029,11 @@ class AppLocalizationsEs extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'No se pudo eliminar tu cuenta. Inténtalo de nuevo.';
+
+  @override
+  String get planUpdate => 'Actualización del plan';
+
+  @override
+  String get planDeprecationMessage =>
+      'Su plan Unlimited está siendo retirado. Cambie al plan Operator — las mismas excelentes funciones a \$49/mes. Su plan actual seguirá funcionando mientras tanto.';
 }

--- a/app/lib/l10n/app_localizations_es.dart
+++ b/app/lib/l10n/app_localizations_es.dart
@@ -9036,4 +9036,10 @@ class AppLocalizationsEs extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Su plan Unlimited está siendo retirado. Cambie al plan Operator — las mismas excelentes funciones a \$49/mes. Su plan actual seguirá funcionando mientras tanto.';
+
+  @override
+  String get upgradeYourPlan => 'Mejora tu plan';
+
+  @override
+  String get youAreOnAPaidPlan => 'Estás en un plan de pago.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9005,4 +9005,11 @@ class AppLocalizationsEt extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Sinu kontot ei õnnestunud kustutada. Palun proovi uuesti.';
+
+  @override
+  String get planUpdate => 'Plaani uuendus';
+
+  @override
+  String get planDeprecationMessage =>
+      'Teie Unlimited plaan lõpetatakse. Lülitage Operator plaanile — samad suurepärased funktsioonid hinnaga \$49/kuus. Teie praegune plaan jätkab vahepeal tööd.';
 }

--- a/app/lib/l10n/app_localizations_et.dart
+++ b/app/lib/l10n/app_localizations_et.dart
@@ -9012,4 +9012,10 @@ class AppLocalizationsEt extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Teie Unlimited plaan lõpetatakse. Lülitage Operator plaanile — samad suurepärased funktsioonid hinnaga \$49/kuus. Teie praegune plaan jätkab vahepeal tööd.';
+
+  @override
+  String get upgradeYourPlan => 'Uuenda oma plaani';
+
+  @override
+  String get youAreOnAPaidPlan => 'Oled tasulisel plaanil.';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9010,4 +9010,11 @@ class AppLocalizationsFa extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'حذف حساب شما ممکن نشد. لطفاً دوباره تلاش کنید.';
+
+  @override
+  String get planUpdate => 'به‌روزرسانی طرح';
+
+  @override
+  String get planDeprecationMessage =>
+      'طرح Unlimited شما در حال بازنشسته شدن است. به طرح Operator تغییر دهید — همان ویژگی‌های عالی با \$49/ماه. طرح فعلی شما در این مدت به کار خود ادامه خواهد داد.';
 }

--- a/app/lib/l10n/app_localizations_fa.dart
+++ b/app/lib/l10n/app_localizations_fa.dart
@@ -9017,4 +9017,10 @@ class AppLocalizationsFa extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'طرح Unlimited شما در حال بازنشسته شدن است. به طرح Operator تغییر دهید — همان ویژگی‌های عالی با \$49/ماه. طرح فعلی شما در این مدت به کار خود ادامه خواهد داد.';
+
+  @override
+  String get upgradeYourPlan => 'طرح خود را ارتقا دهید';
+
+  @override
+  String get youAreOnAPaidPlan => 'شما در یک طرح پولی هستید.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9014,4 +9014,10 @@ class AppLocalizationsFi extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Unlimited-tilauksesi poistetaan käytöstä. Vaihda Operator-tilaukseen — samat loistavat ominaisuudet hintaan \$49/kk. Nykyinen tilauksesi jatkaa toimintaansa sillä välin.';
+
+  @override
+  String get upgradeYourPlan => 'Päivitä tilauksesi';
+
+  @override
+  String get youAreOnAPaidPlan => 'Sinulla on maksullinen tilaus.';
 }

--- a/app/lib/l10n/app_localizations_fi.dart
+++ b/app/lib/l10n/app_localizations_fi.dart
@@ -9007,4 +9007,11 @@ class AppLocalizationsFi extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Tiliäsi ei voitu poistaa. Yritä uudelleen.';
+
+  @override
+  String get planUpdate => 'Tilauksen päivitys';
+
+  @override
+  String get planDeprecationMessage =>
+      'Unlimited-tilauksesi poistetaan käytöstä. Vaihda Operator-tilaukseen — samat loistavat ominaisuudet hintaan \$49/kk. Nykyinen tilauksesi jatkaa toimintaansa sillä välin.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9098,4 +9098,10 @@ class AppLocalizationsFr extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Votre plan Unlimited est en cours de retrait. Passez au plan Operator — les mêmes fonctionnalités à \$49/mois. Votre plan actuel continuera de fonctionner en attendant.';
+
+  @override
+  String get upgradeYourPlan => 'Améliorez votre forfait';
+
+  @override
+  String get youAreOnAPaidPlan => 'Vous êtes sur un forfait payant.';
 }

--- a/app/lib/l10n/app_localizations_fr.dart
+++ b/app/lib/l10n/app_localizations_fr.dart
@@ -9091,4 +9091,11 @@ class AppLocalizationsFr extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Impossible de supprimer votre compte. Veuillez réessayer.';
+
+  @override
+  String get planUpdate => 'Mise à jour du plan';
+
+  @override
+  String get planDeprecationMessage =>
+      'Votre plan Unlimited est en cours de retrait. Passez au plan Operator — les mêmes fonctionnalités à \$49/mois. Votre plan actuel continuera de fonctionner en attendant.';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -8943,4 +8943,10 @@ class AppLocalizationsHe extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'תוכנית ה-Unlimited שלך מופסקת. עברו לתוכנית Operator — אותן תכונות מעולות ב-\$49/חודש. התוכנית הנוכחית שלך תמשיך לפעול בינתיים.';
+
+  @override
+  String get upgradeYourPlan => 'שדרג את התוכנית שלך';
+
+  @override
+  String get youAreOnAPaidPlan => 'אתה על תוכנית בתשלום.';
 }

--- a/app/lib/l10n/app_localizations_he.dart
+++ b/app/lib/l10n/app_localizations_he.dart
@@ -8936,4 +8936,11 @@ class AppLocalizationsHe extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'לא ניתן היה למחוק את החשבון שלך. נסה שוב.';
+
+  @override
+  String get planUpdate => 'עדכון תוכנית';
+
+  @override
+  String get planDeprecationMessage =>
+      'תוכנית ה-Unlimited שלך מופסקת. עברו לתוכנית Operator — אותן תכונות מעולות ב-\$49/חודש. התוכנית הנוכחית שלך תמשיך לפעול בינתיים.';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8995,4 +8995,10 @@ class AppLocalizationsHi extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'आपका Unlimited प्लान बंद किया जा रहा है। Operator प्लान पर स्विच करें — वही बेहतरीन सुविधाएँ \$49/माह पर। आपका वर्तमान प्लान तब तक काम करता रहेगा।';
+
+  @override
+  String get upgradeYourPlan => 'अपना प्लान अपग्रेड करें';
+
+  @override
+  String get youAreOnAPaidPlan => 'आप एक सशुल्क प्लान पर हैं।';
 }

--- a/app/lib/l10n/app_localizations_hi.dart
+++ b/app/lib/l10n/app_localizations_hi.dart
@@ -8988,4 +8988,11 @@ class AppLocalizationsHi extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'आपका खाता हटाया नहीं जा सका। कृपया पुनः प्रयास करें।';
+
+  @override
+  String get planUpdate => 'प्लान अपडेट';
+
+  @override
+  String get planDeprecationMessage =>
+      'आपका Unlimited प्लान बंद किया जा रहा है। Operator प्लान पर स्विच करें — वही बेहतरीन सुविधाएँ \$49/माह पर। आपका वर्तमान प्लान तब तक काम करता रहेगा।';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9038,4 +9038,11 @@ class AppLocalizationsHr extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Brisanje vašeg računa nije uspjelo. Pokušajte ponovno.';
+
+  @override
+  String get planUpdate => 'Ažuriranje plana';
+
+  @override
+  String get planDeprecationMessage =>
+      'Vaš Unlimited plan se ukida. Prijeđite na Operator plan — iste izvrsne značajke za \$49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.';
 }

--- a/app/lib/l10n/app_localizations_hr.dart
+++ b/app/lib/l10n/app_localizations_hr.dart
@@ -9045,4 +9045,10 @@ class AppLocalizationsHr extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Vaš Unlimited plan se ukida. Prijeđite na Operator plan — iste izvrsne značajke za \$49/mj. Vaš trenutni plan će nastaviti raditi u međuvremenu.';
+
+  @override
+  String get upgradeYourPlan => 'Nadogradite svoj plan';
+
+  @override
+  String get youAreOnAPaidPlan => 'Na plaćenom ste planu.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9047,4 +9047,11 @@ class AppLocalizationsHu extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Nem sikerült törölni a fiókodat. Próbáld újra.';
+
+  @override
+  String get planUpdate => 'Csomag frissítés';
+
+  @override
+  String get planDeprecationMessage =>
+      'Az Unlimited csomagja megszűnik. Váltson az Operator csomagra — ugyanazok a kiváló funkciók \$49/hó áron. A jelenlegi csomagja addig is tovább működik.';
 }

--- a/app/lib/l10n/app_localizations_hu.dart
+++ b/app/lib/l10n/app_localizations_hu.dart
@@ -9054,4 +9054,10 @@ class AppLocalizationsHu extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Az Unlimited csomagja megszűnik. Váltson az Operator csomagra — ugyanazok a kiváló funkciók \$49/hó áron. A jelenlegi csomagja addig is tovább működik.';
+
+  @override
+  String get upgradeYourPlan => 'Frissítsd a csomagodat';
+
+  @override
+  String get youAreOnAPaidPlan => 'Fizetős csomagod van.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9018,4 +9018,11 @@ class AppLocalizationsId extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Tidak dapat menghapus akun Anda. Silakan coba lagi.';
+
+  @override
+  String get planUpdate => 'Pembaruan Paket';
+
+  @override
+  String get planDeprecationMessage =>
+      'Paket Unlimited Anda akan dihentikan. Beralih ke paket Operator — fitur hebat yang sama seharga \$49/bulan. Paket Anda saat ini akan terus berfungsi untuk sementara.';
 }

--- a/app/lib/l10n/app_localizations_id.dart
+++ b/app/lib/l10n/app_localizations_id.dart
@@ -9025,4 +9025,10 @@ class AppLocalizationsId extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Paket Unlimited Anda akan dihentikan. Beralih ke paket Operator — fitur hebat yang sama seharga \$49/bulan. Paket Anda saat ini akan terus berfungsi untuk sementara.';
+
+  @override
+  String get upgradeYourPlan => 'Tingkatkan Paket Anda';
+
+  @override
+  String get youAreOnAPaidPlan => 'Anda menggunakan paket berbayar.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9063,4 +9063,11 @@ class AppLocalizationsIt extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Impossibile eliminare il tuo account. Riprova.';
+
+  @override
+  String get planUpdate => 'Aggiornamento del piano';
+
+  @override
+  String get planDeprecationMessage =>
+      'Il tuo piano Unlimited viene ritirato. Passa al piano Operator — le stesse fantastiche funzionalità a \$49/mese. Il tuo piano attuale continuerà a funzionare nel frattempo.';
 }

--- a/app/lib/l10n/app_localizations_it.dart
+++ b/app/lib/l10n/app_localizations_it.dart
@@ -9070,4 +9070,10 @@ class AppLocalizationsIt extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Il tuo piano Unlimited viene ritirato. Passa al piano Operator — le stesse fantastiche funzionalità a \$49/mese. Il tuo piano attuale continuerà a funzionare nel frattempo.';
+
+  @override
+  String get upgradeYourPlan => 'Aggiorna il tuo piano';
+
+  @override
+  String get youAreOnAPaidPlan => 'Sei su un piano a pagamento.';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8866,4 +8866,10 @@ class AppLocalizationsJa extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Unlimitedプランは廃止予定です。Operatorプランに切り替えてください — 同じ優れた機能が月額\$49でご利用いただけます。現在のプランは当面の間引き続きご利用いただけます。';
+
+  @override
+  String get upgradeYourPlan => 'プランをアップグレード';
+
+  @override
+  String get youAreOnAPaidPlan => '有料プランをご利用中です。';
 }

--- a/app/lib/l10n/app_localizations_ja.dart
+++ b/app/lib/l10n/app_localizations_ja.dart
@@ -8859,4 +8859,11 @@ class AppLocalizationsJa extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'アカウントを削除できませんでした。もう一度お試しください。';
+
+  @override
+  String get planUpdate => 'プラン更新';
+
+  @override
+  String get planDeprecationMessage =>
+      'Unlimitedプランは廃止予定です。Operatorプランに切り替えてください — 同じ優れた機能が月額\$49でご利用いただけます。現在のプランは当面の間引き続きご利用いただけます。';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9040,4 +9040,11 @@ class AppLocalizationsKn extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'ನಿಮ್ಮ ಖಾತೆಯನ್ನು ಅಳಿಸಲಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ.';
+
+  @override
+  String get planUpdate => 'ಯೋಜನೆ ನವೀಕರಣ';
+
+  @override
+  String get planDeprecationMessage =>
+      'ನಿಮ್ಮ Unlimited ಯೋಜನೆಯನ್ನು ನಿಲ್ಲಿಸಲಾಗುತ್ತಿದೆ. Operator ಯೋಜನೆಗೆ ಬದಲಾಯಿಸಿ — ಅದೇ ಅದ್ಭುತ ವೈಶಿಷ್ಟ್ಯಗಳು \$49/ತಿಂಗಳಿಗೆ. ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಯೋಜನೆ ಈ ಮಧ್ಯೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಲೇ ಇರುತ್ತದೆ.';
 }

--- a/app/lib/l10n/app_localizations_kn.dart
+++ b/app/lib/l10n/app_localizations_kn.dart
@@ -9047,4 +9047,10 @@ class AppLocalizationsKn extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'ನಿಮ್ಮ Unlimited ಯೋಜನೆಯನ್ನು ನಿಲ್ಲಿಸಲಾಗುತ್ತಿದೆ. Operator ಯೋಜನೆಗೆ ಬದಲಾಯಿಸಿ — ಅದೇ ಅದ್ಭುತ ವೈಶಿಷ್ಟ್ಯಗಳು \$49/ತಿಂಗಳಿಗೆ. ನಿಮ್ಮ ಪ್ರಸ್ತುತ ಯೋಜನೆ ಈ ಮಧ್ಯೆ ಕಾರ್ಯನಿರ್ವಹಿಸುತ್ತಲೇ ಇರುತ್ತದೆ.';
+
+  @override
+  String get upgradeYourPlan => 'ನಿಮ್ಮ ಯೋಜನೆಯನ್ನು ಅಪ್‌ಗ್ರೇಡ್ ಮಾಡಿ';
+
+  @override
+  String get youAreOnAPaidPlan => 'ನೀವು ಪಾವತಿಸಿದ ಯೋಜನೆಯಲ್ಲಿದ್ದೀರಿ.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8860,4 +8860,11 @@ class AppLocalizationsKo extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => '계정을 삭제할 수 없습니다. 다시 시도해 주세요.';
+
+  @override
+  String get planUpdate => '플랜 업데이트';
+
+  @override
+  String get planDeprecationMessage =>
+      'Unlimited 플랜이 중단됩니다. Operator 플랜으로 전환하세요 — 동일한 훌륭한 기능을 월 \$49에 이용할 수 있습니다. 현재 플랜은 당분간 계속 사용할 수 있습니다.';
 }

--- a/app/lib/l10n/app_localizations_ko.dart
+++ b/app/lib/l10n/app_localizations_ko.dart
@@ -8867,4 +8867,10 @@ class AppLocalizationsKo extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Unlimited 플랜이 중단됩니다. Operator 플랜으로 전환하세요 — 동일한 훌륭한 기능을 월 \$49에 이용할 수 있습니다. 현재 플랜은 당분간 계속 사용할 수 있습니다.';
+
+  @override
+  String get upgradeYourPlan => '플랜 업그레이드';
+
+  @override
+  String get youAreOnAPaidPlan => '유료 플랜을 사용 중입니다.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9016,4 +9016,11 @@ class AppLocalizationsLt extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Nepavyko ištrinti tavo paskyros. Bandyk dar kartą.';
+
+  @override
+  String get planUpdate => 'Plano atnaujinimas';
+
+  @override
+  String get planDeprecationMessage =>
+      'Jūsų Unlimited planas nutraukiamas. Pereikite prie Operator plano — tos pačios puikios funkcijos už \$49/mėn. Jūsų dabartinis planas tuo tarpu veiks toliau.';
 }

--- a/app/lib/l10n/app_localizations_lt.dart
+++ b/app/lib/l10n/app_localizations_lt.dart
@@ -9023,4 +9023,10 @@ class AppLocalizationsLt extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Jūsų Unlimited planas nutraukiamas. Pereikite prie Operator plano — tos pačios puikios funkcijos už \$49/mėn. Jūsų dabartinis planas tuo tarpu veiks toliau.';
+
+  @override
+  String get upgradeYourPlan => 'Atnaujinkite savo planą';
+
+  @override
+  String get youAreOnAPaidPlan => 'Jūs naudojate mokamą planą.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9026,4 +9026,11 @@ class AppLocalizationsLv extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Tavu kontu nevarēja izdzēst. Lūdzu, mēģini vēlreiz.';
+
+  @override
+  String get planUpdate => 'Plāna atjauninājums';
+
+  @override
+  String get planDeprecationMessage =>
+      'Jūsu Unlimited plāns tiek pārtraukts. Pārejiet uz Operator plānu — tās pašas lieliskās funkcijas par \$49/mēnesī. Jūsu pašreizējais plāns turpinās darboties pa to laiku.';
 }

--- a/app/lib/l10n/app_localizations_lv.dart
+++ b/app/lib/l10n/app_localizations_lv.dart
@@ -9033,4 +9033,10 @@ class AppLocalizationsLv extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Jūsu Unlimited plāns tiek pārtraukts. Pārejiet uz Operator plānu — tās pašas lieliskās funkcijas par \$49/mēnesī. Jūsu pašreizējais plāns turpinās darboties pa to laiku.';
+
+  @override
+  String get upgradeYourPlan => 'Uzlabojiet savu plānu';
+
+  @override
+  String get youAreOnAPaidPlan => 'Jums ir maksas plāns.';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9064,4 +9064,10 @@ class AppLocalizationsMk extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Вашиот Unlimited план се укинува. Преминете на Operator план — истите одлични функции за \$49/мес. Вашиот тековен план ќе продолжи да работи во меѓувреме.';
+
+  @override
+  String get upgradeYourPlan => 'Надградете го вашиот план';
+
+  @override
+  String get youAreOnAPaidPlan => 'Вие сте на платен план.';
 }

--- a/app/lib/l10n/app_localizations_mk.dart
+++ b/app/lib/l10n/app_localizations_mk.dart
@@ -9057,4 +9057,11 @@ class AppLocalizationsMk extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Не успеавме да ја избришеме вашата сметка. Обидете се повторно.';
+
+  @override
+  String get planUpdate => 'Ажурирање на планот';
+
+  @override
+  String get planDeprecationMessage =>
+      'Вашиот Unlimited план се укинува. Преминете на Operator план — истите одлични функции за \$49/мес. Вашиот тековен план ќе продолжи да работи во меѓувреме.';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9026,4 +9026,10 @@ class AppLocalizationsMr extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'तुमचा Unlimited प्लॅन बंद केला जात आहे. Operator प्लॅनवर स्विच करा — तेच उत्कृष्ट वैशिष्ट्ये \$49/महिना. तुमचा सध्याचा प्लॅन तोपर्यंत काम करत राहील.';
+
+  @override
+  String get upgradeYourPlan => 'तुमचा प्लॅन अपग्रेड करा';
+
+  @override
+  String get youAreOnAPaidPlan => 'तुम्ही सशुल्क प्लॅनवर आहात.';
 }

--- a/app/lib/l10n/app_localizations_mr.dart
+++ b/app/lib/l10n/app_localizations_mr.dart
@@ -9019,4 +9019,11 @@ class AppLocalizationsMr extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'तुमचे खाते हटवता आले नाही. कृपया पुन्हा प्रयत्न करा.';
+
+  @override
+  String get planUpdate => 'प्लॅन अपडेट';
+
+  @override
+  String get planDeprecationMessage =>
+      'तुमचा Unlimited प्लॅन बंद केला जात आहे. Operator प्लॅनवर स्विच करा — तेच उत्कृष्ट वैशिष्ट्ये \$49/महिना. तुमचा सध्याचा प्लॅन तोपर्यंत काम करत राहील.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9032,4 +9032,11 @@ class AppLocalizationsMs extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Tidak dapat memadam akaun anda. Sila cuba lagi.';
+
+  @override
+  String get planUpdate => 'Kemas Kini Pelan';
+
+  @override
+  String get planDeprecationMessage =>
+      'Pelan Unlimited anda sedang ditamatkan. Tukar ke pelan Operator — ciri-ciri hebat yang sama pada \$49/bulan. Pelan semasa anda akan terus berfungsi buat sementara waktu.';
 }

--- a/app/lib/l10n/app_localizations_ms.dart
+++ b/app/lib/l10n/app_localizations_ms.dart
@@ -9039,4 +9039,10 @@ class AppLocalizationsMs extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Pelan Unlimited anda sedang ditamatkan. Tukar ke pelan Operator — ciri-ciri hebat yang sama pada \$49/bulan. Pelan semasa anda akan terus berfungsi buat sementara waktu.';
+
+  @override
+  String get upgradeYourPlan => 'Naik Taraf Pelan Anda';
+
+  @override
+  String get youAreOnAPaidPlan => 'Anda menggunakan pelan berbayar.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9036,4 +9036,11 @@ class AppLocalizationsNl extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Je account kon niet worden verwijderd. Probeer het opnieuw.';
+
+  @override
+  String get planUpdate => 'Abonnement bijwerken';
+
+  @override
+  String get planDeprecationMessage =>
+      'Uw Unlimited-abonnement wordt stopgezet. Schakel over naar het Operator-abonnement — dezelfde geweldige functies voor \$49/maand. Uw huidige abonnement blijft in de tussentijd werken.';
 }

--- a/app/lib/l10n/app_localizations_nl.dart
+++ b/app/lib/l10n/app_localizations_nl.dart
@@ -9043,4 +9043,10 @@ class AppLocalizationsNl extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Uw Unlimited-abonnement wordt stopgezet. Schakel over naar het Operator-abonnement — dezelfde geweldige functies voor \$49/maand. Uw huidige abonnement blijft in de tussentijd werken.';
+
+  @override
+  String get upgradeYourPlan => 'Upgrade je abonnement';
+
+  @override
+  String get youAreOnAPaidPlan => 'Je hebt een betaald abonnement.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9011,4 +9011,10 @@ class AppLocalizationsNo extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Ditt Unlimited-abonnement avvikles. Bytt til Operator-abonnementet — samme flotte funksjoner til \$49/md. Ditt nåværende abonnement vil fortsette å fungere i mellomtiden.';
+
+  @override
+  String get upgradeYourPlan => 'Oppgrader planen din';
+
+  @override
+  String get youAreOnAPaidPlan => 'Du er på en betalt plan.';
 }

--- a/app/lib/l10n/app_localizations_no.dart
+++ b/app/lib/l10n/app_localizations_no.dart
@@ -9004,4 +9004,11 @@ class AppLocalizationsNo extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Kunne ikke slette kontoen din. Prøv igjen.';
+
+  @override
+  String get planUpdate => 'Planoppdatering';
+
+  @override
+  String get planDeprecationMessage =>
+      'Ditt Unlimited-abonnement avvikles. Bytt til Operator-abonnementet — samme flotte funksjoner til \$49/md. Ditt nåværende abonnement vil fortsette å fungere i mellomtiden.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9035,4 +9035,10 @@ class AppLocalizationsPl extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Twój plan Unlimited jest wycofywany. Przejdź na plan Operator — te same świetne funkcje za \$49/mies. Twój obecny plan będzie nadal działać w międzyczasie.';
+
+  @override
+  String get upgradeYourPlan => 'Ulepsz swój plan';
+
+  @override
+  String get youAreOnAPaidPlan => 'Masz płatny plan.';
 }

--- a/app/lib/l10n/app_localizations_pl.dart
+++ b/app/lib/l10n/app_localizations_pl.dart
@@ -9028,4 +9028,11 @@ class AppLocalizationsPl extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Nie udało się usunąć Twojego konta. Spróbuj ponownie.';
+
+  @override
+  String get planUpdate => 'Aktualizacja planu';
+
+  @override
+  String get planDeprecationMessage =>
+      'Twój plan Unlimited jest wycofywany. Przejdź na plan Operator — te same świetne funkcje za \$49/mies. Twój obecny plan będzie nadal działać w międzyczasie.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9019,4 +9019,10 @@ class AppLocalizationsPt extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Seu plano Unlimited está sendo descontinuado. Mude para o plano Operator — os mesmos ótimos recursos por \$49/mês. Seu plano atual continuará funcionando enquanto isso.';
+
+  @override
+  String get upgradeYourPlan => 'Atualize seu plano';
+
+  @override
+  String get youAreOnAPaidPlan => 'Você está em um plano pago.';
 }

--- a/app/lib/l10n/app_localizations_pt.dart
+++ b/app/lib/l10n/app_localizations_pt.dart
@@ -9012,4 +9012,11 @@ class AppLocalizationsPt extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Não foi possível excluir sua conta. Tente novamente.';
+
+  @override
+  String get planUpdate => 'Atualização do plano';
+
+  @override
+  String get planDeprecationMessage =>
+      'Seu plano Unlimited está sendo descontinuado. Mude para o plano Operator — os mesmos ótimos recursos por \$49/mês. Seu plano atual continuará funcionando enquanto isso.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9051,4 +9051,11 @@ class AppLocalizationsRo extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Nu am putut șterge contul tău. Încearcă din nou.';
+
+  @override
+  String get planUpdate => 'Actualizare plan';
+
+  @override
+  String get planDeprecationMessage =>
+      'Planul dvs. Unlimited este retras. Treceți la planul Operator — aceleași funcții excelente la \$49/lună. Planul dvs. actual va continua să funcționeze între timp.';
 }

--- a/app/lib/l10n/app_localizations_ro.dart
+++ b/app/lib/l10n/app_localizations_ro.dart
@@ -9058,4 +9058,10 @@ class AppLocalizationsRo extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Planul dvs. Unlimited este retras. Treceți la planul Operator — aceleași funcții excelente la \$49/lună. Planul dvs. actual va continua să funcționeze între timp.';
+
+  @override
+  String get upgradeYourPlan => 'Îmbunătățește-ți planul';
+
+  @override
+  String get youAreOnAPaidPlan => 'Ești pe un plan plătit.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9044,4 +9044,10 @@ class AppLocalizationsRu extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Ваш план Unlimited прекращается. Перейдите на план Operator — те же отличные функции за \$49/мес. Ваш текущий план продолжит работать тем временем.';
+
+  @override
+  String get upgradeYourPlan => 'Улучшите свой план';
+
+  @override
+  String get youAreOnAPaidPlan => 'Вы на платном плане.';
 }

--- a/app/lib/l10n/app_localizations_ru.dart
+++ b/app/lib/l10n/app_localizations_ru.dart
@@ -9037,4 +9037,11 @@ class AppLocalizationsRu extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Не удалось удалить аккаунт. Попробуйте ещё раз.';
+
+  @override
+  String get planUpdate => 'Обновление плана';
+
+  @override
+  String get planDeprecationMessage =>
+      'Ваш план Unlimited прекращается. Перейдите на план Operator — те же отличные функции за \$49/мес. Ваш текущий план продолжит работать тем временем.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -9003,4 +9003,10 @@ class AppLocalizationsSk extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Váš plán Unlimited sa ruší. Prejdite na plán Operator — rovnaké skvelé funkcie za \$49/mes. Váš súčasný plán bude zatiaľ naďalej fungovať.';
+
+  @override
+  String get upgradeYourPlan => 'Vylepšite svoj plán';
+
+  @override
+  String get youAreOnAPaidPlan => 'Máte platený plán.';
 }

--- a/app/lib/l10n/app_localizations_sk.dart
+++ b/app/lib/l10n/app_localizations_sk.dart
@@ -8996,4 +8996,11 @@ class AppLocalizationsSk extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Váš účet sa nepodarilo odstrániť. Skúste to znova.';
+
+  @override
+  String get planUpdate => 'Aktualizácia plánu';
+
+  @override
+  String get planDeprecationMessage =>
+      'Váš plán Unlimited sa ruší. Prejdite na plán Operator — rovnaké skvelé funkcie za \$49/mes. Váš súčasný plán bude zatiaľ naďalej fungovať.';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9032,4 +9032,11 @@ class AppLocalizationsSl extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Vašega računa ni bilo mogoče izbrisati. Poskusite znova.';
+
+  @override
+  String get planUpdate => 'Posodobitev načrta';
+
+  @override
+  String get planDeprecationMessage =>
+      'Vaš načrt Unlimited se ukinja. Preklopite na načrt Operator — enake odlične funkcije za \$49/mesec. Vaš trenutni načrt bo medtem še naprej deloval.';
 }

--- a/app/lib/l10n/app_localizations_sl.dart
+++ b/app/lib/l10n/app_localizations_sl.dart
@@ -9039,4 +9039,10 @@ class AppLocalizationsSl extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Vaš načrt Unlimited se ukinja. Preklopite na načrt Operator — enake odlične funkcije za \$49/mesec. Vaš trenutni načrt bo medtem še naprej deloval.';
+
+  @override
+  String get upgradeYourPlan => 'Nadgradite svoj načrt';
+
+  @override
+  String get youAreOnAPaidPlan => 'Imate plačljiv načrt.';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9021,4 +9021,11 @@ class AppLocalizationsSr extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Брисање вашег налога није успело. Покушајте поново.';
+
+  @override
+  String get planUpdate => 'Ажурирање плана';
+
+  @override
+  String get planDeprecationMessage =>
+      'Ваш Unlimited план се укида. Пређите на Operator план — исте одличне функције за \$49/мес. Ваш тренутни план ће наставити да ради у међувремену.';
 }

--- a/app/lib/l10n/app_localizations_sr.dart
+++ b/app/lib/l10n/app_localizations_sr.dart
@@ -9028,4 +9028,10 @@ class AppLocalizationsSr extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Ваш Unlimited план се укида. Пређите на Operator план — исте одличне функције за \$49/мес. Ваш тренутни план ће наставити да ради у међувремену.';
+
+  @override
+  String get upgradeYourPlan => 'Надоградите свој план';
+
+  @override
+  String get youAreOnAPaidPlan => 'На плаћеном сте плану.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9019,4 +9019,10 @@ class AppLocalizationsSv extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Ditt Unlimited-abonnemang fasas ut. Byt till Operator-abonnemanget — samma fantastiska funktioner för \$49/mån. Ditt nuvarande abonnemang kommer att fortsätta fungera under tiden.';
+
+  @override
+  String get upgradeYourPlan => 'Uppgradera din plan';
+
+  @override
+  String get youAreOnAPaidPlan => 'Du har en betald plan.';
 }

--- a/app/lib/l10n/app_localizations_sv.dart
+++ b/app/lib/l10n/app_localizations_sv.dart
@@ -9012,4 +9012,11 @@ class AppLocalizationsSv extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Kunde inte radera ditt konto. Försök igen.';
+
+  @override
+  String get planUpdate => 'Planuppdatering';
+
+  @override
+  String get planDeprecationMessage =>
+      'Ditt Unlimited-abonnemang fasas ut. Byt till Operator-abonnemanget — samma fantastiska funktioner för \$49/mån. Ditt nuvarande abonnemang kommer att fortsätta fungera under tiden.';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9077,4 +9077,11 @@ class AppLocalizationsTa extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'உங்கள் கணக்கை நீக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.';
+
+  @override
+  String get planUpdate => 'திட்ட புதுப்பிப்பு';
+
+  @override
+  String get planDeprecationMessage =>
+      'உங்கள் Unlimited திட்டம் நிறுத்தப்படுகிறது. Operator திட்டத்திற்கு மாறுங்கள் — அதே சிறந்த அம்சங்கள் \$49/மாதம். உங்கள் தற்போதைய திட்டம் இதற்கிடையில் தொடர்ந்து செயல்படும்.';
 }

--- a/app/lib/l10n/app_localizations_ta.dart
+++ b/app/lib/l10n/app_localizations_ta.dart
@@ -9084,4 +9084,10 @@ class AppLocalizationsTa extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'உங்கள் Unlimited திட்டம் நிறுத்தப்படுகிறது. Operator திட்டத்திற்கு மாறுங்கள் — அதே சிறந்த அம்சங்கள் \$49/மாதம். உங்கள் தற்போதைய திட்டம் இதற்கிடையில் தொடர்ந்து செயல்படும்.';
+
+  @override
+  String get upgradeYourPlan => 'உங்கள் திட்டத்தை மேம்படுத்தவும்';
+
+  @override
+  String get youAreOnAPaidPlan => 'நீங்கள் கட்டண திட்டத்தில் உள்ளீர்கள்.';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9059,4 +9059,11 @@ class AppLocalizationsTe extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'మీ ఖాతాను తొలగించలేకపోయాము. దయచేసి మళ్ళీ ప్రయత్నించండి.';
+
+  @override
+  String get planUpdate => 'ప్లాన్ అప్‌డేట్';
+
+  @override
+  String get planDeprecationMessage =>
+      'మీ Unlimited ప్లాన్ ఆపివేయబడుతోంది. Operator ప్లాన్‌కి మారండి — అదే అద్భుతమైన ఫీచర్లు \$49/నెలకు. మీ ప్రస్తుత ప్లాన్ ఈలోగా పని చేస్తూనే ఉంటుంది.';
 }

--- a/app/lib/l10n/app_localizations_te.dart
+++ b/app/lib/l10n/app_localizations_te.dart
@@ -9066,4 +9066,10 @@ class AppLocalizationsTe extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'మీ Unlimited ప్లాన్ ఆపివేయబడుతోంది. Operator ప్లాన్‌కి మారండి — అదే అద్భుతమైన ఫీచర్లు \$49/నెలకు. మీ ప్రస్తుత ప్లాన్ ఈలోగా పని చేస్తూనే ఉంటుంది.';
+
+  @override
+  String get upgradeYourPlan => 'మీ ప్లాన్‌ను అప్‌గ్రేడ్ చేయండి';
+
+  @override
+  String get youAreOnAPaidPlan => 'మీరు చెల్లింపు ప్లాన్‌లో ఉన్నారు.';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8969,4 +8969,10 @@ class AppLocalizationsTh extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'แผน Unlimited ของคุณกำลังถูกยกเลิก เปลี่ยนไปใช้แผน Operator — ฟีเจอร์ดีเยี่ยมเหมือนเดิมในราคา \$49/เดือน แผนปัจจุบันของคุณจะยังคงใช้งานได้ในระหว่างนี้';
+
+  @override
+  String get upgradeYourPlan => 'อัปเกรดแผนของคุณ';
+
+  @override
+  String get youAreOnAPaidPlan => 'คุณอยู่ในแผนชำระเงิน';
 }

--- a/app/lib/l10n/app_localizations_th.dart
+++ b/app/lib/l10n/app_localizations_th.dart
@@ -8962,4 +8962,11 @@ class AppLocalizationsTh extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'ไม่สามารถลบบัญชีของคุณได้ โปรดลองอีกครั้ง';
+
+  @override
+  String get planUpdate => 'อัปเดตแผน';
+
+  @override
+  String get planDeprecationMessage =>
+      'แผน Unlimited ของคุณกำลังถูกยกเลิก เปลี่ยนไปใช้แผน Operator — ฟีเจอร์ดีเยี่ยมเหมือนเดิมในราคา \$49/เดือน แผนปัจจุบันของคุณจะยังคงใช้งานได้ในระหว่างนี้';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9100,4 +9100,10 @@ class AppLocalizationsTl extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Ang iyong Unlimited na plano ay inihihinto na. Lumipat sa Operator na plano — parehong magagandang feature sa \$49/buwan. Ang kasalukuyan mong plano ay patuloy na gagana samantala.';
+
+  @override
+  String get upgradeYourPlan => 'I-upgrade ang Iyong Plano';
+
+  @override
+  String get youAreOnAPaidPlan => 'Ikaw ay nasa bayad na plano.';
 }

--- a/app/lib/l10n/app_localizations_tl.dart
+++ b/app/lib/l10n/app_localizations_tl.dart
@@ -9093,4 +9093,11 @@ class AppLocalizationsTl extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Hindi ma-delete ang iyong account. Pakisubukan muli.';
+
+  @override
+  String get planUpdate => 'Update ng Plano';
+
+  @override
+  String get planDeprecationMessage =>
+      'Ang iyong Unlimited na plano ay inihihinto na. Lumipat sa Operator na plano — parehong magagandang feature sa \$49/buwan. Ang kasalukuyan mong plano ay patuloy na gagana samantala.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9028,4 +9028,10 @@ class AppLocalizationsTr extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Unlimited planınız kullanımdan kaldırılıyor. Operator planına geçin — aynı harika özellikler \$49/ay. Mevcut planınız bu süre zarfında çalışmaya devam edecek.';
+
+  @override
+  String get upgradeYourPlan => 'Planınızı Yükseltin';
+
+  @override
+  String get youAreOnAPaidPlan => 'Ücretli bir plandasınız.';
 }

--- a/app/lib/l10n/app_localizations_tr.dart
+++ b/app/lib/l10n/app_localizations_tr.dart
@@ -9021,4 +9021,11 @@ class AppLocalizationsTr extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Hesabınız silinemedi. Lütfen tekrar deneyin.';
+
+  @override
+  String get planUpdate => 'Plan Güncellemesi';
+
+  @override
+  String get planDeprecationMessage =>
+      'Unlimited planınız kullanımdan kaldırılıyor. Operator planına geçin — aynı harika özellikler \$49/ay. Mevcut planınız bu süre zarfında çalışmaya devam edecek.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9021,4 +9021,11 @@ class AppLocalizationsUk extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Не вдалося видалити ваш акаунт. Спробуйте ще раз.';
+
+  @override
+  String get planUpdate => 'Оновлення плану';
+
+  @override
+  String get planDeprecationMessage =>
+      'Ваш план Unlimited припиняється. Перейдіть на план Operator — ті самі чудові функції за \$49/міс. Ваш поточний план продовжить працювати тим часом.';
 }

--- a/app/lib/l10n/app_localizations_uk.dart
+++ b/app/lib/l10n/app_localizations_uk.dart
@@ -9028,4 +9028,10 @@ class AppLocalizationsUk extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Ваш план Unlimited припиняється. Перейдіть на план Operator — ті самі чудові функції за \$49/міс. Ваш поточний план продовжить працювати тим часом.';
+
+  @override
+  String get upgradeYourPlan => 'Покращіть свій план';
+
+  @override
+  String get youAreOnAPaidPlan => 'Ви на платному плані.';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9032,4 +9032,10 @@ class AppLocalizationsUr extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'آپ کا Unlimited پلان ختم کیا جا رہا ہے۔ Operator پلان پر سوئچ کریں — وہی شاندار فیچرز \$49/ماہ پر۔ آپ کا موجودہ پلان اس دوران کام کرتا رہے گا۔';
+
+  @override
+  String get upgradeYourPlan => 'اپنا پلان اپ گریڈ کریں';
+
+  @override
+  String get youAreOnAPaidPlan => 'آپ ایک ادا شدہ پلان پر ہیں۔';
 }

--- a/app/lib/l10n/app_localizations_ur.dart
+++ b/app/lib/l10n/app_localizations_ur.dart
@@ -9025,4 +9025,11 @@ class AppLocalizationsUr extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'آپ کا اکاؤنٹ حذف نہیں ہو سکا۔ براہ کرم دوبارہ کوشش کریں۔';
+
+  @override
+  String get planUpdate => 'پلان اپ ڈیٹ';
+
+  @override
+  String get planDeprecationMessage =>
+      'آپ کا Unlimited پلان ختم کیا جا رہا ہے۔ Operator پلان پر سوئچ کریں — وہی شاندار فیچرز \$49/ماہ پر۔ آپ کا موجودہ پلان اس دوران کام کرتا رہے گا۔';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9015,4 +9015,10 @@ class AppLocalizationsVi extends AppLocalizations {
   @override
   String get planDeprecationMessage =>
       'Gói Unlimited của bạn đang được ngừng cung cấp. Chuyển sang gói Operator — cùng các tính năng tuyệt vời với giá \$49/tháng. Gói hiện tại của bạn sẽ tiếp tục hoạt động trong thời gian chờ đợi.';
+
+  @override
+  String get upgradeYourPlan => 'Nâng cấp gói của bạn';
+
+  @override
+  String get youAreOnAPaidPlan => 'Bạn đang sử dụng gói trả phí.';
 }

--- a/app/lib/l10n/app_localizations_vi.dart
+++ b/app/lib/l10n/app_localizations_vi.dart
@@ -9008,4 +9008,11 @@ class AppLocalizationsVi extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => 'Không thể xóa tài khoản của bạn. Vui lòng thử lại.';
+
+  @override
+  String get planUpdate => 'Cập nhật gói';
+
+  @override
+  String get planDeprecationMessage =>
+      'Gói Unlimited của bạn đang được ngừng cung cấp. Chuyển sang gói Operator — cùng các tính năng tuyệt vời với giá \$49/tháng. Gói hiện tại của bạn sẽ tiếp tục hoạt động trong thời gian chờ đợi.';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8845,4 +8845,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get deleteAccountFailed => '无法删除您的账户。请重试。';
+
+  @override
+  String get planUpdate => '套餐更新';
+
+  @override
+  String get planDeprecationMessage => '您的 Unlimited 套餐即将停用。请切换到 Operator 套餐——同样出色的功能，每月 \$49。您当前的套餐在此期间将继续可用。';
 }

--- a/app/lib/l10n/app_localizations_zh.dart
+++ b/app/lib/l10n/app_localizations_zh.dart
@@ -8851,4 +8851,10 @@ class AppLocalizationsZh extends AppLocalizations {
 
   @override
   String get planDeprecationMessage => '您的 Unlimited 套餐即将停用。请切换到 Operator 套餐——同样出色的功能，每月 \$49。您当前的套餐在此期间将继续可用。';
+
+  @override
+  String get upgradeYourPlan => '升级你的计划';
+
+  @override
+  String get youAreOnAPaidPlan => '你正在使用付费计划。';
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Jūsų Unlimited planas nutraukiamas. Pereikite prie Operator plano — tos pačios puikios funkcijos už $49/mėn. Jūsų dabartinis planas tuo tarpu veiks toliau.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Atnaujinkite savo planą",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Jūs naudojate mokamą planą.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_lt.arb
+++ b/app/lib/l10n/app_lt.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Visam laikui ištrinti paskyrą",
     "keepMyAccount": "Palikti mano paskyrą",
-    "deleteAccountFailed": "Nepavyko ištrinti tavo paskyros. Bandyk dar kartą."
+    "deleteAccountFailed": "Nepavyko ištrinti tavo paskyros. Bandyk dar kartą.",
+    "planUpdate": "Plano atnaujinimas",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Jūsų Unlimited planas nutraukiamas. Pereikite prie Operator plano — tos pačios puikios funkcijos už $49/mėn. Jūsų dabartinis planas tuo tarpu veiks toliau.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Jūsu Unlimited plāns tiek pārtraukts. Pārejiet uz Operator plānu — tās pašas lieliskās funkcijas par $49/mēnesī. Jūsu pašreizējais plāns turpinās darboties pa to laiku.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Uzlabojiet savu plānu",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Jums ir maksas plāns.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_lv.arb
+++ b/app/lib/l10n/app_lv.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Neatgriezeniski dzēst kontu",
     "keepMyAccount": "Paturēt manu kontu",
-    "deleteAccountFailed": "Tavu kontu nevarēja izdzēst. Lūdzu, mēģini vēlreiz."
+    "deleteAccountFailed": "Tavu kontu nevarēja izdzēst. Lūdzu, mēģini vēlreiz.",
+    "planUpdate": "Plāna atjauninājums",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Jūsu Unlimited plāns tiek pārtraukts. Pārejiet uz Operator plānu — tās pašas lieliskās funkcijas par $49/mēnesī. Jūsu pašreizējais plāns turpinās darboties pa to laiku.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "Вашиот Unlimited план се укинува. Преминете на Operator план — истите одлични функции за $49/мес. Вашиот тековен план ќе продолжи да работи во меѓувреме.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Надградете го вашиот план",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Вие сте на платен план.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_mk.arb
+++ b/app/lib/l10n/app_mk.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Трајно избриши ја сметката",
     "keepMyAccount": "Задржи ја мојата сметка",
-    "deleteAccountFailed": "Не успеавме да ја избришеме вашата сметка. Обидете се повторно."
+    "deleteAccountFailed": "Не успеавме да ја избришеме вашата сметка. Обидете се повторно.",
+    "planUpdate": "Ажурирање на планот",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Вашиот Unlimited план се укинува. Преминете на Operator план — истите одлични функции за $49/мес. Вашиот тековен план ќе продолжи да работи во меѓувреме.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "खाते कायमचे हटवा",
     "keepMyAccount": "माझे खाते ठेवा",
-    "deleteAccountFailed": "तुमचे खाते हटवता आले नाही. कृपया पुन्हा प्रयत्न करा."
+    "deleteAccountFailed": "तुमचे खाते हटवता आले नाही. कृपया पुन्हा प्रयत्न करा.",
+    "planUpdate": "प्लॅन अपडेट",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "तुमचा Unlimited प्लॅन बंद केला जात आहे. Operator प्लॅनवर स्विच करा — तेच उत्कृष्ट वैशिष्ट्ये $49/महिना. तुमचा सध्याचा प्लॅन तोपर्यंत काम करत राहील.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_mr.arb
+++ b/app/lib/l10n/app_mr.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "तुमचा Unlimited प्लॅन बंद केला जात आहे. Operator प्लॅनवर स्विच करा — तेच उत्कृष्ट वैशिष्ट्ये $49/महिना. तुमचा सध्याचा प्लॅन तोपर्यंत काम करत राहील.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "तुमचा प्लॅन अपग्रेड करा",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "तुम्ही सशुल्क प्लॅनवर आहात.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Padam akaun secara kekal",
     "keepMyAccount": "Kekalkan akaun saya",
-    "deleteAccountFailed": "Tidak dapat memadam akaun anda. Sila cuba lagi."
+    "deleteAccountFailed": "Tidak dapat memadam akaun anda. Sila cuba lagi.",
+    "planUpdate": "Kemas Kini Pelan",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Pelan Unlimited anda sedang ditamatkan. Tukar ke pelan Operator — ciri-ciri hebat yang sama pada $49/bulan. Pelan semasa anda akan terus berfungsi buat sementara waktu.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_ms.arb
+++ b/app/lib/l10n/app_ms.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Pelan Unlimited anda sedang ditamatkan. Tukar ke pelan Operator — ciri-ciri hebat yang sama pada $49/bulan. Pelan semasa anda akan terus berfungsi buat sementara waktu.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Naik Taraf Pelan Anda",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Anda menggunakan pelan berbayar.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Account definitief verwijderen",
     "keepMyAccount": "Mijn account behouden",
-    "deleteAccountFailed": "Je account kon niet worden verwijderd. Probeer het opnieuw."
+    "deleteAccountFailed": "Je account kon niet worden verwijderd. Probeer het opnieuw.",
+    "planUpdate": "Abonnement bijwerken",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Uw Unlimited-abonnement wordt stopgezet. Schakel over naar het Operator-abonnement — dezelfde geweldige functies voor $49/maand. Uw huidige abonnement blijft in de tussentijd werken.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_nl.arb
+++ b/app/lib/l10n/app_nl.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Uw Unlimited-abonnement wordt stopgezet. Schakel over naar het Operator-abonnement — dezelfde geweldige functies voor $49/maand. Uw huidige abonnement blijft in de tussentijd werken.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Upgrade je abonnement",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Je hebt een betaald abonnement.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Ditt Unlimited-abonnement avvikles. Bytt til Operator-abonnementet — samme flotte funksjoner til $49/md. Ditt nåværende abonnement vil fortsette å fungere i mellomtiden.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Oppgrader planen din",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Du er på en betalt plan.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_no.arb
+++ b/app/lib/l10n/app_no.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Slett kontoen permanent",
     "keepMyAccount": "Behold kontoen min",
-    "deleteAccountFailed": "Kunne ikke slette kontoen din. Prøv igjen."
+    "deleteAccountFailed": "Kunne ikke slette kontoen din. Prøv igjen.",
+    "planUpdate": "Planoppdatering",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Ditt Unlimited-abonnement avvikles. Bytt til Operator-abonnementet — samme flotte funksjoner til $49/md. Ditt nåværende abonnement vil fortsette å fungere i mellomtiden.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2978,5 +2978,13 @@
     "planDeprecationMessage": "Twój plan Unlimited jest wycofywany. Przejdź na plan Operator — te same świetne funkcje za $49/mies. Twój obecny plan będzie nadal działać w międzyczasie.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Ulepsz swój plan",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Masz płatny plan.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_pl.arb
+++ b/app/lib/l10n/app_pl.arb
@@ -2970,5 +2970,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Usuń konto na zawsze",
     "keepMyAccount": "Zachowaj moje konto",
-    "deleteAccountFailed": "Nie udało się usunąć Twojego konta. Spróbuj ponownie."
+    "deleteAccountFailed": "Nie udało się usunąć Twojego konta. Spróbuj ponownie.",
+    "planUpdate": "Aktualizacja planu",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Twój plan Unlimited jest wycofywany. Przejdź na plan Operator — te same świetne funkcje za $49/mies. Twój obecny plan będzie nadal działać w międzyczasie.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2979,5 +2979,13 @@
     "planDeprecationMessage": "Seu plano Unlimited está sendo descontinuado. Mude para o plano Operator — os mesmos ótimos recursos por $49/mês. Seu plano atual continuará funcionando enquanto isso.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Atualize seu plano",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Você está em um plano pago.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_pt.arb
+++ b/app/lib/l10n/app_pt.arb
@@ -2971,5 +2971,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Excluir conta permanentemente",
     "keepMyAccount": "Manter minha conta",
-    "deleteAccountFailed": "Não foi possível excluir sua conta. Tente novamente."
+    "deleteAccountFailed": "Não foi possível excluir sua conta. Tente novamente.",
+    "planUpdate": "Atualização do plano",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Seu plano Unlimited está sendo descontinuado. Mude para o plano Operator — os mesmos ótimos recursos por $49/mês. Seu plano atual continuará funcionando enquanto isso.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Șterge contul definitiv",
     "keepMyAccount": "Păstrează contul meu",
-    "deleteAccountFailed": "Nu am putut șterge contul tău. Încearcă din nou."
+    "deleteAccountFailed": "Nu am putut șterge contul tău. Încearcă din nou.",
+    "planUpdate": "Actualizare plan",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Planul dvs. Unlimited este retras. Treceți la planul Operator — aceleași funcții excelente la $49/lună. Planul dvs. actual va continua să funcționeze între timp.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_ro.arb
+++ b/app/lib/l10n/app_ro.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Planul dvs. Unlimited este retras. Treceți la planul Operator — aceleași funcții excelente la $49/lună. Planul dvs. actual va continua să funcționeze între timp.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Îmbunătățește-ți planul",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Ești pe un plan plătit.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2978,5 +2978,13 @@
     "planDeprecationMessage": "Ваш план Unlimited прекращается. Перейдите на план Operator — те же отличные функции за $49/мес. Ваш текущий план продолжит работать тем временем.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Улучшите свой план",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Вы на платном плане.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ru.arb
+++ b/app/lib/l10n/app_ru.arb
@@ -2970,5 +2970,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Удалить аккаунт навсегда",
     "keepMyAccount": "Оставить аккаунт",
-    "deleteAccountFailed": "Не удалось удалить аккаунт. Попробуйте ещё раз."
+    "deleteAccountFailed": "Не удалось удалить аккаунт. Попробуйте ещё раз.",
+    "planUpdate": "Обновление плана",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Ваш план Unlimited прекращается. Перейдите на план Operator — те же отличные функции за $49/мес. Ваш текущий план продолжит работать тем временем.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2948,5 +2948,13 @@
     "planDeprecationMessage": "Váš plán Unlimited sa ruší. Prejdite na plán Operator — rovnaké skvelé funkcie za $49/mes. Váš súčasný plán bude zatiaľ naďalej fungovať.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Vylepšite svoj plán",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Máte platený plán.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_sk.arb
+++ b/app/lib/l10n/app_sk.arb
@@ -2940,5 +2940,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Trvalo odstrániť účet",
     "keepMyAccount": "Ponechať môj účet",
-    "deleteAccountFailed": "Váš účet sa nepodarilo odstrániť. Skúste to znova."
+    "deleteAccountFailed": "Váš účet sa nepodarilo odstrániť. Skúste to znova.",
+    "planUpdate": "Aktualizácia plánu",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Váš plán Unlimited sa ruší. Prejdite na plán Operator — rovnaké skvelé funkcie za $49/mes. Váš súčasný plán bude zatiaľ naďalej fungovať.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Trajno izbriši račun",
     "keepMyAccount": "Obdrži moj račun",
-    "deleteAccountFailed": "Vašega računa ni bilo mogoče izbrisati. Poskusite znova."
+    "deleteAccountFailed": "Vašega računa ni bilo mogoče izbrisati. Poskusite znova.",
+    "planUpdate": "Posodobitev načrta",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Vaš načrt Unlimited se ukinja. Preklopite na načrt Operator — enake odlične funkcije za $49/mesec. Vaš trenutni načrt bo medtem še naprej deloval.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_sl.arb
+++ b/app/lib/l10n/app_sl.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "Vaš načrt Unlimited se ukinja. Preklopite na načrt Operator — enake odlične funkcije za $49/mesec. Vaš trenutni načrt bo medtem še naprej deloval.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Nadgradite svoj načrt",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Imate plačljiv načrt.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "Ваш Unlimited план се укида. Пређите на Operator план — исте одличне функције за $49/мес. Ваш тренутни план ће наставити да ради у међувремену.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Надоградите свој план",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "На плаћеном сте плану.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_sr.arb
+++ b/app/lib/l10n/app_sr.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Трајно избриши налог",
     "keepMyAccount": "Задржи мој налог",
-    "deleteAccountFailed": "Брисање вашег налога није успело. Покушајте поново."
+    "deleteAccountFailed": "Брисање вашег налога није успело. Покушајте поново.",
+    "planUpdate": "Ажурирање плана",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Ваш Unlimited план се укида. Пређите на Operator план — исте одличне функције за $49/мес. Ваш тренутни план ће наставити да ради у међувремену.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Radera kontot permanent",
     "keepMyAccount": "Behåll mitt konto",
-    "deleteAccountFailed": "Kunde inte radera ditt konto. Försök igen."
+    "deleteAccountFailed": "Kunde inte radera ditt konto. Försök igen.",
+    "planUpdate": "Planuppdatering",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Ditt Unlimited-abonnemang fasas ut. Byt till Operator-abonnemanget — samma fantastiska funktioner för $49/mån. Ditt nuvarande abonnemang kommer att fortsätta fungera under tiden.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_sv.arb
+++ b/app/lib/l10n/app_sv.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Ditt Unlimited-abonnemang fasas ut. Byt till Operator-abonnemanget — samma fantastiska funktioner för $49/mån. Ditt nuvarande abonnemang kommer att fortsätta fungera under tiden.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Uppgradera din plan",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Du har en betald plan.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "உங்கள் Unlimited திட்டம் நிறுத்தப்படுகிறது. Operator திட்டத்திற்கு மாறுங்கள் — அதே சிறந்த அம்சங்கள் $49/மாதம். உங்கள் தற்போதைய திட்டம் இதற்கிடையில் தொடர்ந்து செயல்படும்.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "உங்கள் திட்டத்தை மேம்படுத்தவும்",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "நீங்கள் கட்டண திட்டத்தில் உள்ளீர்கள்.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_ta.arb
+++ b/app/lib/l10n/app_ta.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "கணக்கை நிரந்தரமாக நீக்கு",
     "keepMyAccount": "என் கணக்கை வைத்திரு",
-    "deleteAccountFailed": "உங்கள் கணக்கை நீக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்."
+    "deleteAccountFailed": "உங்கள் கணக்கை நீக்க முடியவில்லை. மீண்டும் முயற்சிக்கவும்.",
+    "planUpdate": "திட்ட புதுப்பிப்பு",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "உங்கள் Unlimited திட்டம் நிறுத்தப்படுகிறது. Operator திட்டத்திற்கு மாறுங்கள் — அதே சிறந்த அம்சங்கள் $49/மாதம். உங்கள் தற்போதைய திட்டம் இதற்கிடையில் தொடர்ந்து செயல்படும்.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "మీ Unlimited ప్లాన్ ఆపివేయబడుతోంది. Operator ప్లాన్‌కి మారండి — అదే అద్భుతమైన ఫీచర్లు $49/నెలకు. మీ ప్రస్తుత ప్లాన్ ఈలోగా పని చేస్తూనే ఉంటుంది.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "మీ ప్లాన్‌ను అప్‌గ్రేడ్ చేయండి",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "మీరు చెల్లింపు ప్లాన్‌లో ఉన్నారు.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_te.arb
+++ b/app/lib/l10n/app_te.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "ఖాతాను శాశ్వతంగా తొలగించండి",
     "keepMyAccount": "నా ఖాతాను ఉంచండి",
-    "deleteAccountFailed": "మీ ఖాతాను తొలగించలేకపోయాము. దయచేసి మళ్ళీ ప్రయత్నించండి."
+    "deleteAccountFailed": "మీ ఖాతాను తొలగించలేకపోయాము. దయచేసి మళ్ళీ ప్రయత్నించండి.",
+    "planUpdate": "ప్లాన్ అప్‌డేట్",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "మీ Unlimited ప్లాన్ ఆపివేయబడుతోంది. Operator ప్లాన్‌కి మారండి — అదే అద్భుతమైన ఫీచర్లు $49/నెలకు. మీ ప్రస్తుత ప్లాన్ ఈలోగా పని చేస్తూనే ఉంటుంది.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "แผน Unlimited ของคุณกำลังถูกยกเลิก เปลี่ยนไปใช้แผน Operator — ฟีเจอร์ดีเยี่ยมเหมือนเดิมในราคา $49/เดือน แผนปัจจุบันของคุณจะยังคงใช้งานได้ในระหว่างนี้",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "อัปเกรดแผนของคุณ",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "คุณอยู่ในแผนชำระเงิน",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_th.arb
+++ b/app/lib/l10n/app_th.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "ลบบัญชีถาวร",
     "keepMyAccount": "เก็บบัญชีของฉันไว้",
-    "deleteAccountFailed": "ไม่สามารถลบบัญชีของคุณได้ โปรดลองอีกครั้ง"
+    "deleteAccountFailed": "ไม่สามารถลบบัญชีของคุณได้ โปรดลองอีกครั้ง",
+    "planUpdate": "อัปเดตแผน",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "แผน Unlimited ของคุณกำลังถูกยกเลิก เปลี่ยนไปใช้แผน Operator — ฟีเจอร์ดีเยี่ยมเหมือนเดิมในราคา $49/เดือน แผนปัจจุบันของคุณจะยังคงใช้งานได้ในระหว่างนี้",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Tanggalin nang permanente ang account",
     "keepMyAccount": "Panatilihin ang aking account",
-    "deleteAccountFailed": "Hindi ma-delete ang iyong account. Pakisubukan muli."
+    "deleteAccountFailed": "Hindi ma-delete ang iyong account. Pakisubukan muli.",
+    "planUpdate": "Update ng Plano",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Ang iyong Unlimited na plano ay inihihinto na. Lumipat sa Operator na plano — parehong magagandang feature sa $49/buwan. Ang kasalukuyan mong plano ay patuloy na gagana samantala.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_tl.arb
+++ b/app/lib/l10n/app_tl.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "Ang iyong Unlimited na plano ay inihihinto na. Lumipat sa Operator na plano — parehong magagandang feature sa $49/buwan. Ang kasalukuyan mong plano ay patuloy na gagana samantala.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "I-upgrade ang Iyong Plano",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Ikaw ay nasa bayad na plano.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2978,5 +2978,13 @@
     "planDeprecationMessage": "Unlimited planınız kullanımdan kaldırılıyor. Operator planına geçin — aynı harika özellikler $49/ay. Mevcut planınız bu süre zarfında çalışmaya devam edecek.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Planınızı Yükseltin",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Ücretli bir plandasınız.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_tr.arb
+++ b/app/lib/l10n/app_tr.arb
@@ -2970,5 +2970,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Hesabı kalıcı olarak sil",
     "keepMyAccount": "Hesabımı koru",
-    "deleteAccountFailed": "Hesabınız silinemedi. Lütfen tekrar deneyin."
+    "deleteAccountFailed": "Hesabınız silinemedi. Lütfen tekrar deneyin.",
+    "planUpdate": "Plan Güncellemesi",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Unlimited planınız kullanımdan kaldırılıyor. Operator planına geçin — aynı harika özellikler $49/ay. Mevcut planınız bu süre zarfında çalışmaya devam edecek.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2943,5 +2943,13 @@
     "planDeprecationMessage": "Ваш план Unlimited припиняється. Перейдіть на план Operator — ті самі чудові функції за $49/міс. Ваш поточний план продовжить працювати тим часом.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Покращіть свій план",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Ви на платному плані.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_uk.arb
+++ b/app/lib/l10n/app_uk.arb
@@ -2935,5 +2935,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Видалити акаунт назавжди",
     "keepMyAccount": "Зберегти мій акаунт",
-    "deleteAccountFailed": "Не вдалося видалити ваш акаунт. Спробуйте ще раз."
+    "deleteAccountFailed": "Не вдалося видалити ваш акаунт. Спробуйте ще раз.",
+    "planUpdate": "Оновлення плану",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Ваш план Unlimited припиняється. Перейдіть на план Operator — ті самі чудові функції за $49/міс. Ваш поточний план продовжить працювати тим часом.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10658,5 +10658,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "اکاؤنٹ مستقل طور پر حذف کریں",
     "keepMyAccount": "میرا اکاؤنٹ برقرار رکھیں",
-    "deleteAccountFailed": "آپ کا اکاؤنٹ حذف نہیں ہو سکا۔ براہ کرم دوبارہ کوشش کریں۔"
+    "deleteAccountFailed": "آپ کا اکاؤنٹ حذف نہیں ہو سکا۔ براہ کرم دوبارہ کوشش کریں۔",
+    "planUpdate": "پلان اپ ڈیٹ",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "آپ کا Unlimited پلان ختم کیا جا رہا ہے۔ Operator پلان پر سوئچ کریں — وہی شاندار فیچرز $49/ماہ پر۔ آپ کا موجودہ پلان اس دوران کام کرتا رہے گا۔",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_ur.arb
+++ b/app/lib/l10n/app_ur.arb
@@ -10666,5 +10666,13 @@
     "planDeprecationMessage": "آپ کا Unlimited پلان ختم کیا جا رہا ہے۔ Operator پلان پر سوئچ کریں — وہی شاندار فیچرز $49/ماہ پر۔ آپ کا موجودہ پلان اس دوران کام کرتا رہے گا۔",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "اپنا پلان اپ گریڈ کریں",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "آپ ایک ادا شدہ پلان پر ہیں۔",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2940,5 +2940,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "Xóa tài khoản vĩnh viễn",
     "keepMyAccount": "Giữ tài khoản của tôi",
-    "deleteAccountFailed": "Không thể xóa tài khoản của bạn. Vui lòng thử lại."
+    "deleteAccountFailed": "Không thể xóa tài khoản của bạn. Vui lòng thử lại.",
+    "planUpdate": "Cập nhật gói",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "Gói Unlimited của bạn đang được ngừng cung cấp. Chuyển sang gói Operator — cùng các tính năng tuyệt vời với giá $49/tháng. Gói hiện tại của bạn sẽ tiếp tục hoạt động trong thời gian chờ đợi.",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/l10n/app_vi.arb
+++ b/app/lib/l10n/app_vi.arb
@@ -2948,5 +2948,13 @@
     "planDeprecationMessage": "Gói Unlimited của bạn đang được ngừng cung cấp. Chuyển sang gói Operator — cùng các tính năng tuyệt vời với giá $49/tháng. Gói hiện tại của bạn sẽ tiếp tục hoạt động trong thời gian chờ đợi.",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "Nâng cấp gói của bạn",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "Bạn đang sử dụng gói trả phí.",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2965,5 +2965,13 @@
     "planDeprecationMessage": "您的 Unlimited 套餐即将停用。请切换到 Operator 套餐——同样出色的功能，每月 $49。您当前的套餐在此期间将继续可用。",
     "@planDeprecationMessage": {
         "description": "Deprecation notice for legacy Unlimited subscribers"
+    },
+    "upgradeYourPlan": "升级你的计划",
+    "@upgradeYourPlan": {
+        "description": "Header for plan upgrade screen for non-paid users"
+    },
+    "youAreOnAPaidPlan": "你正在使用付费计划。",
+    "@youAreOnAPaidPlan": {
+        "description": "Subtitle for paid plan users on plans sheet"
     }
 }

--- a/app/lib/l10n/app_zh.arb
+++ b/app/lib/l10n/app_zh.arb
@@ -2957,5 +2957,13 @@
     "deleteConfirmationWord": "DELETE",
     "deleteAccountPermanently": "永久删除账户",
     "keepMyAccount": "保留我的账户",
-    "deleteAccountFailed": "无法删除您的账户。请重试。"
+    "deleteAccountFailed": "无法删除您的账户。请重试。",
+    "planUpdate": "套餐更新",
+    "@planUpdate": {
+        "description": "Header for plan deprecation notice"
+    },
+    "planDeprecationMessage": "您的 Unlimited 套餐即将停用。请切换到 Operator 套餐——同样出色的功能，每月 $49。您当前的套餐在此期间将继续可用。",
+    "@planDeprecationMessage": {
+        "description": "Deprecation notice for legacy Unlimited subscribers"
+    }
 }

--- a/app/lib/models/subscription.dart
+++ b/app/lib/models/subscription.dart
@@ -2,7 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'subscription.g.dart';
 
-enum PlanType { basic, unlimited, pro }
+enum PlanType { basic, unlimited, pro, operator }
 
 enum SubscriptionStatus { active, inactive }
 
@@ -17,6 +17,9 @@ class Subscription {
   final List<String> features;
   @JsonKey(defaultValue: false)
   final bool cancelAtPeriodEnd;
+  @JsonKey(defaultValue: false)
+  final bool deprecated;
+  final String? deprecationMessage;
 
   Subscription({
     required this.plan,
@@ -26,6 +29,8 @@ class Subscription {
     this.currentPriceId,
     this.features = const [],
     this.cancelAtPeriodEnd = false,
+    this.deprecated = false,
+    this.deprecationMessage,
   });
 
   factory Subscription.fromJson(Map<String, dynamic> json) => _$SubscriptionFromJson(json);

--- a/app/lib/models/subscription.dart
+++ b/app/lib/models/subscription.dart
@@ -2,7 +2,7 @@ import 'package:json_annotation/json_annotation.dart';
 
 part 'subscription.g.dart';
 
-enum PlanType { basic, unlimited, pro, operator }
+enum PlanType { basic, unlimited, architect, operator }
 
 enum SubscriptionStatus { active, inactive }
 

--- a/app/lib/models/subscription.g.dart
+++ b/app/lib/models/subscription.g.dart
@@ -37,7 +37,7 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
 const _$PlanTypeEnumMap = {
   PlanType.basic: 'basic',
   PlanType.unlimited: 'unlimited',
-  PlanType.pro: 'pro',
+  PlanType.architect: 'architect',
   PlanType.operator: 'operator',
 };
 

--- a/app/lib/models/subscription.g.dart
+++ b/app/lib/models/subscription.g.dart
@@ -17,6 +17,8 @@ Subscription _$SubscriptionFromJson(Map<String, dynamic> json) => Subscription(
               .toList() ??
           [],
       cancelAtPeriodEnd: json['cancel_at_period_end'] as bool? ?? false,
+      deprecated: json['deprecated'] as bool? ?? false,
+      deprecationMessage: json['deprecation_message'] as String?,
     );
 
 Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
@@ -28,12 +30,15 @@ Map<String, dynamic> _$SubscriptionToJson(Subscription instance) =>
       'current_price_id': instance.currentPriceId,
       'features': instance.features,
       'cancel_at_period_end': instance.cancelAtPeriodEnd,
+      'deprecated': instance.deprecated,
+      'deprecation_message': instance.deprecationMessage,
     };
 
 const _$PlanTypeEnumMap = {
   PlanType.basic: 'basic',
   PlanType.unlimited: 'unlimited',
   PlanType.pro: 'pro',
+  PlanType.operator: 'operator',
 };
 
 const _$SubscriptionStatusEnumMap = {

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -694,7 +694,7 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                         await usageProvider.fetchSubscription();
                                       }
                                       final p = usageProvider.subscription?.subscription.plan;
-                                      var isUnlimited = p == PlanType.unlimited || p == PlanType.operator || p == PlanType.pro;
+                                      var isUnlimited = p == PlanType.unlimited || p == PlanType.operator || p == PlanType.architect;
                                       if (!isUnlimited) {
                                         MixpanelManager().phoneCallUpsellShown(source: 'home');
                                         if (!context.mounted) return;

--- a/app/lib/pages/home/page.dart
+++ b/app/lib/pages/home/page.dart
@@ -693,8 +693,8 @@ class _HomePageState extends State<HomePage> with WidgetsBindingObserver, Ticker
                                       if (usageProvider.subscription == null) {
                                         await usageProvider.fetchSubscription();
                                       }
-                                      var isUnlimited =
-                                          usageProvider.subscription?.subscription.plan == PlanType.unlimited;
+                                      final p = usageProvider.subscription?.subscription.plan;
+                                      var isUnlimited = p == PlanType.unlimited || p == PlanType.operator || p == PlanType.pro;
                                       if (!isUnlimited) {
                                         MixpanelManager().phoneCallUpsellShown(source: 'home');
                                         if (!context.mounted) return;

--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -297,7 +297,8 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                 const Divider(height: 1, color: Color(0xFF3C3C43)),
                 Consumer<UsageProvider>(
                   builder: (context, usageProvider, child) {
-                    final isUnlimited = usageProvider.subscription?.subscription.plan == PlanType.unlimited;
+                    final sp = usageProvider.subscription?.subscription.plan;
+                    final isUnlimited = sp == PlanType.unlimited || sp == PlanType.operator || sp == PlanType.pro;
                     return _buildSettingsItem(
                       title: context.l10n.planAndUsage,
                       icon: const FaIcon(FontAwesomeIcons.chartLine, color: Color(0xFF8E8E93), size: 20),
@@ -373,7 +374,8 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                 ),
                 Consumer<UsageProvider>(
                   builder: (context, usageProvider, child) {
-                    final isUnlimited = usageProvider.subscription?.subscription.plan == PlanType.unlimited;
+                    final sp2 = usageProvider.subscription?.subscription.plan;
+                    final isUnlimited = sp2 == PlanType.unlimited || sp2 == PlanType.operator || sp2 == PlanType.pro;
                     if (!isUnlimited) return const SizedBox.shrink();
                     return Column(
                       children: [

--- a/app/lib/pages/settings/settings_drawer.dart
+++ b/app/lib/pages/settings/settings_drawer.dart
@@ -298,7 +298,7 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                 Consumer<UsageProvider>(
                   builder: (context, usageProvider, child) {
                     final sp = usageProvider.subscription?.subscription.plan;
-                    final isUnlimited = sp == PlanType.unlimited || sp == PlanType.operator || sp == PlanType.pro;
+                    final isUnlimited = sp == PlanType.unlimited || sp == PlanType.operator || sp == PlanType.architect;
                     return _buildSettingsItem(
                       title: context.l10n.planAndUsage,
                       icon: const FaIcon(FontAwesomeIcons.chartLine, color: Color(0xFF8E8E93), size: 20),
@@ -375,7 +375,7 @@ class _SettingsDrawerState extends State<SettingsDrawer> {
                 Consumer<UsageProvider>(
                   builder: (context, usageProvider, child) {
                     final sp2 = usageProvider.subscription?.subscription.plan;
-                    final isUnlimited = sp2 == PlanType.unlimited || sp2 == PlanType.operator || sp2 == PlanType.pro;
+                    final isUnlimited = sp2 == PlanType.unlimited || sp2 == PlanType.operator || sp2 == PlanType.architect;
                     if (!isUnlimited) return const SizedBox.shrink();
                     return Column(
                       children: [

--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -411,7 +411,7 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
     }
 
     final plan = provider.subscription!.subscription.plan;
-    final isUnlimited = plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.pro;
+    final isUnlimited = plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.architect;
 
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 24, 16, 0),

--- a/app/lib/pages/settings/usage_page.dart
+++ b/app/lib/pages/settings/usage_page.dart
@@ -410,7 +410,8 @@ class _UsagePageState extends State<UsagePage> with TickerProviderStateMixin {
       return const SizedBox.shrink();
     }
 
-    final isUnlimited = provider.subscription!.subscription.plan == PlanType.unlimited;
+    final plan = provider.subscription!.subscription.plan;
+    final isUnlimited = plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.pro;
 
     return Container(
       margin: const EdgeInsets.fromLTRB(16, 24, 16, 0),

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -379,7 +379,9 @@ class _PlansSheetState extends State<PlansSheet> {
     final provider = context.read<UsageProvider>();
     final currentSub = provider.subscription?.subscription;
     final isUpgradingFromMonthlyToAnnual =
-        currentSub?.plan == PlanType.unlimited && currentSub?.status == SubscriptionStatus.active && isYearly;
+        (currentSub?.plan == PlanType.unlimited || currentSub?.plan == PlanType.operator) &&
+            currentSub?.status == SubscriptionStatus.active &&
+            isYearly;
 
     if (isUpgradingFromMonthlyToAnnual && currentSub?.cancelAtPeriodEnd != true) {
       // Show confirmation popup for monthly to annual upgrade
@@ -486,7 +488,7 @@ class _PlansSheetState extends State<PlansSheet> {
 
     final currentSub = provider.subscription!.subscription;
 
-    if (currentSub.plan == PlanType.unlimited) {
+    if (currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator) {
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (ctx) => ConfirmationDialog(
@@ -508,8 +510,8 @@ class _PlansSheetState extends State<PlansSheet> {
     try {
       Map<String, dynamic>? result;
 
-      // If user already has unlimited monthly plan and it's not canceled
-      if (currentSub.plan == PlanType.unlimited &&
+      // If user already has a paid plan and it's not canceled
+      if ((currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator) &&
           currentSub.status == SubscriptionStatus.active &&
           !currentSub.cancelAtPeriodEnd) {
         result = await provider.upgradeUserSubscription(priceId: priceId);
@@ -580,7 +582,9 @@ class _PlansSheetState extends State<PlansSheet> {
         }
 
         final sub = provider.subscription?.subscription;
-        final isUnlimited = sub?.plan == PlanType.unlimited;
+        final isPaidPlan = sub?.plan == PlanType.unlimited || sub?.plan == PlanType.operator || sub?.plan == PlanType.pro;
+        final isUnlimited = isPaidPlan; // backward-compat alias for UI branching
+        final isDeprecated = sub?.deprecated ?? false;
         final isCancelled = sub?.cancelAtPeriodEnd ?? false;
 
         String renewalDate = 'N/A';
@@ -879,7 +883,7 @@ class _PlansSheetState extends State<PlansSheet> {
                                   );
                                 } else {
                                   return Text(
-                                    isUnlimited ? 'Change Plan' : 'Keep Omi Unlimited',
+                                    isUnlimited ? 'Change Plan' : 'Upgrade Your Plan',
                                     style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                                   );
                                 }
@@ -900,7 +904,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             } else {
                               return Text(
                                 isUnlimited
-                                    ? 'You are on the Unlimited Plan.'
+                                    ? 'You are on a paid plan.'
                                     : 'Choose your plan to unlock unlimited Omi.',
                                 textAlign: TextAlign.center,
                                 style: TextStyle(fontSize: 14, color: Colors.grey.shade400),
@@ -958,8 +962,42 @@ class _PlansSheetState extends State<PlansSheet> {
                             },
                           ),
                         ],
+                        // Deprecation notice for legacy Unlimited subscribers
+                        if (isDeprecated && sub?.deprecationMessage != null) ...[
+                          const SizedBox(height: 16),
+                          Container(
+                            margin: const EdgeInsets.symmetric(horizontal: 16),
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color: Colors.orange.withOpacity(0.1),
+                              borderRadius: BorderRadius.circular(12),
+                              border: Border.all(color: Colors.orange.withOpacity(0.3)),
+                            ),
+                            child: Column(
+                              children: [
+                                Row(
+                                  children: [
+                                    Icon(Icons.info_outline, color: Colors.orange.shade400, size: 20),
+                                    const SizedBox(width: 8),
+                                    const Expanded(
+                                      child: Text(
+                                        'Plan Update',
+                                        style: TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w600),
+                                      ),
+                                    ),
+                                  ],
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  sub!.deprecationMessage!,
+                                  style: TextStyle(color: Colors.grey.shade300, fontSize: 13, height: 1.4),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
                         const SizedBox(height: 24),
-                        // Features list - only for unlimited users
+                        // Features list - only for paid plan users
                         if (isUnlimited) ...[
                           Column(
                             children: [
@@ -1320,8 +1358,8 @@ class _PlansSheetState extends State<PlansSheet> {
                             }
 
                             final isLoading = _isUpgrading;
-                            // For basic users, show "Keep Unlimited". For unlimited users upgrading, show "Continue"
-                            final buttonText = isUnlimited ? 'Continue' : 'Keep Unlimited';
+                            // For basic users, show "Upgrade". For paid users upgrading, show "Continue"
+                            final buttonText = isUnlimited ? 'Continue' : 'Upgrade';
 
                             return SizedBox(
                               width: double.infinity,

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -963,7 +963,7 @@ class _PlansSheetState extends State<PlansSheet> {
                           ),
                         ],
                         // Deprecation notice for legacy Unlimited subscribers
-                        if (isDeprecated && sub?.deprecationMessage != null) ...[
+                        if (isDeprecated) ...[
                           const SizedBox(height: 16),
                           Container(
                             margin: const EdgeInsets.symmetric(horizontal: 16),
@@ -979,17 +979,17 @@ class _PlansSheetState extends State<PlansSheet> {
                                   children: [
                                     Icon(Icons.info_outline, color: Colors.orange.shade400, size: 20),
                                     const SizedBox(width: 8),
-                                    const Expanded(
+                                    Expanded(
                                       child: Text(
-                                        'Plan Update',
-                                        style: TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w600),
+                                        context.l10n.planUpdate,
+                                        style: const TextStyle(color: Colors.white, fontSize: 15, fontWeight: FontWeight.w600),
                                       ),
                                     ),
                                   ],
                                 ),
                                 const SizedBox(height: 8),
                                 Text(
-                                  sub!.deprecationMessage!,
+                                  context.l10n.planDeprecationMessage,
                                   style: TextStyle(color: Colors.grey.shade300, fontSize: 13, height: 1.4),
                                 ),
                               ],

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -379,7 +379,7 @@ class _PlansSheetState extends State<PlansSheet> {
     final provider = context.read<UsageProvider>();
     final currentSub = provider.subscription?.subscription;
     final isUpgradingFromMonthlyToAnnual =
-        (currentSub?.plan == PlanType.unlimited || currentSub?.plan == PlanType.operator) &&
+        (currentSub?.plan == PlanType.unlimited || currentSub?.plan == PlanType.operator || currentSub?.plan == PlanType.pro) &&
             currentSub?.status == SubscriptionStatus.active &&
             isYearly;
 
@@ -488,7 +488,7 @@ class _PlansSheetState extends State<PlansSheet> {
 
     final currentSub = provider.subscription!.subscription;
 
-    if (currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator) {
+    if (currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator || currentSub.plan == PlanType.pro) {
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (ctx) => ConfirmationDialog(
@@ -511,7 +511,7 @@ class _PlansSheetState extends State<PlansSheet> {
       Map<String, dynamic>? result;
 
       // If user already has a paid plan and it's not canceled
-      if ((currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator) &&
+      if ((currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator || currentSub.plan == PlanType.pro) &&
           currentSub.status == SubscriptionStatus.active &&
           !currentSub.cancelAtPeriodEnd) {
         result = await provider.upgradeUserSubscription(priceId: priceId);

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -883,7 +883,7 @@ class _PlansSheetState extends State<PlansSheet> {
                                   );
                                 } else {
                                   return Text(
-                                    isUnlimited ? 'Change Plan' : 'Upgrade Your Plan',
+                                    isUnlimited ? context.l10n.changePlan : context.l10n.upgradeYourPlan,
                                     style: const TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
                                   );
                                 }
@@ -904,7 +904,7 @@ class _PlansSheetState extends State<PlansSheet> {
                             } else {
                               return Text(
                                 isUnlimited
-                                    ? 'You are on a paid plan.'
+                                    ? context.l10n.youAreOnAPaidPlan
                                     : 'Choose your plan to unlock unlimited Omi.',
                                 textAlign: TextAlign.center,
                                 style: TextStyle(fontSize: 14, color: Colors.grey.shade400),
@@ -1359,7 +1359,7 @@ class _PlansSheetState extends State<PlansSheet> {
 
                             final isLoading = _isUpgrading;
                             // For basic users, show "Upgrade". For paid users upgrading, show "Continue"
-                            final buttonText = isUnlimited ? 'Continue' : 'Upgrade';
+                            final buttonText = isUnlimited ? context.l10n.continueText : context.l10n.upgrade;
 
                             return SizedBox(
                               width: double.infinity,

--- a/app/lib/pages/settings/widgets/plans_sheet.dart
+++ b/app/lib/pages/settings/widgets/plans_sheet.dart
@@ -379,7 +379,7 @@ class _PlansSheetState extends State<PlansSheet> {
     final provider = context.read<UsageProvider>();
     final currentSub = provider.subscription?.subscription;
     final isUpgradingFromMonthlyToAnnual =
-        (currentSub?.plan == PlanType.unlimited || currentSub?.plan == PlanType.operator || currentSub?.plan == PlanType.pro) &&
+        (currentSub?.plan == PlanType.unlimited || currentSub?.plan == PlanType.operator || currentSub?.plan == PlanType.architect) &&
             currentSub?.status == SubscriptionStatus.active &&
             isYearly;
 
@@ -488,7 +488,7 @@ class _PlansSheetState extends State<PlansSheet> {
 
     final currentSub = provider.subscription!.subscription;
 
-    if (currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator || currentSub.plan == PlanType.pro) {
+    if (currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator || currentSub.plan == PlanType.architect) {
       final confirmed = await showDialog<bool>(
         context: context,
         builder: (ctx) => ConfirmationDialog(
@@ -511,7 +511,7 @@ class _PlansSheetState extends State<PlansSheet> {
       Map<String, dynamic>? result;
 
       // If user already has a paid plan and it's not canceled
-      if ((currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator || currentSub.plan == PlanType.pro) &&
+      if ((currentSub.plan == PlanType.unlimited || currentSub.plan == PlanType.operator || currentSub.plan == PlanType.architect) &&
           currentSub.status == SubscriptionStatus.active &&
           !currentSub.cancelAtPeriodEnd) {
         result = await provider.upgradeUserSubscription(priceId: priceId);
@@ -582,7 +582,7 @@ class _PlansSheetState extends State<PlansSheet> {
         }
 
         final sub = provider.subscription?.subscription;
-        final isPaidPlan = sub?.plan == PlanType.unlimited || sub?.plan == PlanType.operator || sub?.plan == PlanType.pro;
+        final isPaidPlan = sub?.plan == PlanType.unlimited || sub?.plan == PlanType.operator || sub?.plan == PlanType.architect;
         final isUnlimited = isPaidPlan; // backward-compat alias for UI branching
         final isDeprecated = sub?.deprecated ?? false;
         final isCancelled = sub?.cancelAtPeriodEnd ?? false;

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -57,7 +57,8 @@ class UsageProvider with ChangeNotifier {
   bool get isOutOfCredits {
     if (_forceOutOfCredits) return true;
     if (_subscription == null) return false;
-    if (_subscription!.subscription.plan == PlanType.unlimited) return false;
+    final plan = _subscription!.subscription.plan;
+    if (plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.pro) return false;
     // For basic plan, check if used is >= limit and limit is not 0 (unlimited).
     if (_subscription!.transcriptionSecondsLimit > 0 &&
         _subscription!.transcriptionSecondsUsed >= _subscription!.transcriptionSecondsLimit) {

--- a/app/lib/providers/usage_provider.dart
+++ b/app/lib/providers/usage_provider.dart
@@ -58,7 +58,7 @@ class UsageProvider with ChangeNotifier {
     if (_forceOutOfCredits) return true;
     if (_subscription == null) return false;
     final plan = _subscription!.subscription.plan;
-    if (plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.pro) return false;
+    if (plan == PlanType.unlimited || plan == PlanType.operator || plan == PlanType.architect) return false;
     // For basic plan, check if used is >= limit and limit is not 0 (unlimited).
     if (_subscription!.transcriptionSecondsLimit > 0 &&
         _subscription!.transcriptionSecondsUsed >= _subscription!.transcriptionSecondsLimit) {

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -244,9 +244,9 @@ env:
     value: "price_1RrxXL1F8wnoWYvwIddzR902"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvw3kDbWmjs"
-  - name: STRIPE_PRO_MONTHLY_PRICE_ID
+  - name: STRIPE_ARCHITECT_MONTHLY_PRICE_ID
     value: "price_1TN7s21F8wnoWYvwG6JuEFm6"
-  - name: STRIPE_PRO_ANNUAL_PRICE_ID
+  - name: STRIPE_ARCHITECT_ANNUAL_PRICE_ID
     value: "price_1TN7sF1F8wnoWYvwd0QaLZNA"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
     value: "price_1TN7jS1F8wnoWYvwM5GqfxDw"

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -249,9 +249,9 @@ env:
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
     value: "price_1TAznX1F8wnoWYvwN8YmzbiC"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
-    value: ""
+    value: "price_1TN7jS1F8wnoWYvwM5GqfxDw"
   - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID
-    value: ""
+    value: "price_1TN7jo1F8wnoWYvw6Xu1zAtC"
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: BUCKET_PRIVATE_CLOUD_SYNC

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -245,9 +245,9 @@ env:
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvw3kDbWmjs"
   - name: STRIPE_PRO_MONTHLY_PRICE_ID
-    value: "price_1TAznX1F8wnoWYvwyaSVQbZW"
+    value: "price_1TN7s21F8wnoWYvwG6JuEFm6"
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
-    value: "price_1TAznX1F8wnoWYvwN8YmzbiC"
+    value: "price_1TN7sF1F8wnoWYvwd0QaLZNA"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
     value: "price_1TN7jS1F8wnoWYvwM5GqfxDw"
   - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID

--- a/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/dev_omi_backend_listen_values.yaml
@@ -248,6 +248,10 @@ env:
     value: "price_1TAznX1F8wnoWYvwyaSVQbZW"
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
     value: "price_1TAznX1F8wnoWYvwN8YmzbiC"
+  - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
+    value: ""
+  - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID
+    value: ""
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: BUCKET_PRIVATE_CLOUD_SYNC

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -275,6 +275,10 @@ env:
     value: "price_1TAfBB1F8wnoWYvw8XBFM1dX"
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
     value: "price_1TLFac1F8wnoWYvwtPxZhtzE"
+  - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
+    value: ""
+  - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID
+    value: ""
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: BUCKET_PRIVATE_CLOUD_SYNC

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -276,9 +276,9 @@ env:
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
     value: "price_1TLFac1F8wnoWYvwtPxZhtzE"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
-    value: ""
+    value: "price_1TMxVM1F8wnoWYvw9uaoYX7V"
   - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID
-    value: ""
+    value: "price_1TMxVM1F8wnoWYvwNfXdF6LW"
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: BUCKET_PRIVATE_CLOUD_SYNC

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -271,9 +271,9 @@ env:
     value: "price_1RtJPm1F8wnoWYvwhVJ38kLb"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RtJQ71F8wnoWYvwKMPaGlGY"
-  - name: STRIPE_PRO_MONTHLY_PRICE_ID
+  - name: STRIPE_ARCHITECT_MONTHLY_PRICE_ID
     value: "price_1TN7vz1F8wnoWYvwXbVLEX0Y"
-  - name: STRIPE_PRO_ANNUAL_PRICE_ID
+  - name: STRIPE_ARCHITECT_ANNUAL_PRICE_ID
     value: "price_1TN7vz1F8wnoWYvwkrqXVn5t"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
     value: "price_1TMxVM1F8wnoWYvw9uaoYX7V"

--- a/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
+++ b/backend/charts/backend-listen/prod_omi_backend_listen_values.yaml
@@ -272,9 +272,9 @@ env:
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RtJQ71F8wnoWYvwKMPaGlGY"
   - name: STRIPE_PRO_MONTHLY_PRICE_ID
-    value: "price_1TAfBB1F8wnoWYvw8XBFM1dX"
+    value: "price_1TN7vz1F8wnoWYvwXbVLEX0Y"
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
-    value: "price_1TLFac1F8wnoWYvwtPxZhtzE"
+    value: "price_1TN7vz1F8wnoWYvwkrqXVn5t"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
     value: "price_1TMxVM1F8wnoWYvw9uaoYX7V"
   - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -236,9 +236,9 @@ env:
     value: "price_1RrxXL1F8wnoWYvwIddzR902"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvw3kDbWmjs"
-  - name: STRIPE_PRO_MONTHLY_PRICE_ID
+  - name: STRIPE_ARCHITECT_MONTHLY_PRICE_ID
     value: "price_1TN7s21F8wnoWYvwG6JuEFm6"
-  - name: STRIPE_PRO_ANNUAL_PRICE_ID
+  - name: STRIPE_ARCHITECT_ANNUAL_PRICE_ID
     value: "price_1TN7sF1F8wnoWYvwd0QaLZNA"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
     value: "price_1TN7jS1F8wnoWYvwM5GqfxDw"

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -241,9 +241,9 @@ env:
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
     value: "price_1TAznX1F8wnoWYvwN8YmzbiC"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
-    value: ""
+    value: "price_1TN7jS1F8wnoWYvwM5GqfxDw"
   - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID
-    value: ""
+    value: "price_1TN7jo1F8wnoWYvw6Xu1zAtC"
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: SERVICE_ACCOUNT_JSON

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -237,9 +237,9 @@ env:
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvw3kDbWmjs"
   - name: STRIPE_PRO_MONTHLY_PRICE_ID
-    value: "price_1TAznX1F8wnoWYvwyaSVQbZW"
+    value: "price_1TN7s21F8wnoWYvwG6JuEFm6"
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
-    value: "price_1TAznX1F8wnoWYvwN8YmzbiC"
+    value: "price_1TN7sF1F8wnoWYvwd0QaLZNA"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
     value: "price_1TN7jS1F8wnoWYvwM5GqfxDw"
   - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID

--- a/backend/charts/pusher/dev_omi_pusher_values.yaml
+++ b/backend/charts/pusher/dev_omi_pusher_values.yaml
@@ -236,6 +236,14 @@ env:
     value: "price_1RrxXL1F8wnoWYvwIddzR902"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RrxXL1F8wnoWYvw3kDbWmjs"
+  - name: STRIPE_PRO_MONTHLY_PRICE_ID
+    value: "price_1TAznX1F8wnoWYvwyaSVQbZW"
+  - name: STRIPE_PRO_ANNUAL_PRICE_ID
+    value: "price_1TAznX1F8wnoWYvwN8YmzbiC"
+  - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
+    value: ""
+  - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID
+    value: ""
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: SERVICE_ACCOUNT_JSON

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -268,6 +268,14 @@ env:
     value: "price_1RtJPm1F8wnoWYvwhVJ38kLb"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RtJQ71F8wnoWYvwKMPaGlGY"
+  - name: STRIPE_PRO_MONTHLY_PRICE_ID
+    value: "price_1TAfBB1F8wnoWYvw8XBFM1dX"
+  - name: STRIPE_PRO_ANNUAL_PRICE_ID
+    value: "price_1TLFac1F8wnoWYvwtPxZhtzE"
+  - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
+    value: ""
+  - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID
+    value: ""
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: METRICS_SECRET

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -273,9 +273,9 @@ env:
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
     value: "price_1TLFac1F8wnoWYvwtPxZhtzE"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
-    value: ""
+    value: "price_1TMxVM1F8wnoWYvw9uaoYX7V"
   - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID
-    value: ""
+    value: "price_1TMxVM1F8wnoWYvwNfXdF6LW"
   - name: SUBSCRIPTION_LAUNCH_DATE
     value: "2025-08-21"
   - name: METRICS_SECRET

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -268,9 +268,9 @@ env:
     value: "price_1RtJPm1F8wnoWYvwhVJ38kLb"
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RtJQ71F8wnoWYvwKMPaGlGY"
-  - name: STRIPE_PRO_MONTHLY_PRICE_ID
+  - name: STRIPE_ARCHITECT_MONTHLY_PRICE_ID
     value: "price_1TN7vz1F8wnoWYvwXbVLEX0Y"
-  - name: STRIPE_PRO_ANNUAL_PRICE_ID
+  - name: STRIPE_ARCHITECT_ANNUAL_PRICE_ID
     value: "price_1TN7vz1F8wnoWYvwkrqXVn5t"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
     value: "price_1TMxVM1F8wnoWYvw9uaoYX7V"

--- a/backend/charts/pusher/prod_omi_pusher_values.yaml
+++ b/backend/charts/pusher/prod_omi_pusher_values.yaml
@@ -269,9 +269,9 @@ env:
   - name: STRIPE_UNLIMITED_ANNUAL_PRICE_ID
     value: "price_1RtJQ71F8wnoWYvwKMPaGlGY"
   - name: STRIPE_PRO_MONTHLY_PRICE_ID
-    value: "price_1TAfBB1F8wnoWYvw8XBFM1dX"
+    value: "price_1TN7vz1F8wnoWYvwXbVLEX0Y"
   - name: STRIPE_PRO_ANNUAL_PRICE_ID
-    value: "price_1TLFac1F8wnoWYvwtPxZhtzE"
+    value: "price_1TN7vz1F8wnoWYvwkrqXVn5t"
   - name: STRIPE_OPERATOR_MONTHLY_PRICE_ID
     value: "price_1TMxVM1F8wnoWYvw9uaoYX7V"
   - name: STRIPE_OPERATOR_ANNUAL_PRICE_ID

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -60,6 +60,8 @@ class Subscription(BaseModel):
     features: List[str] = []
     cancel_at_period_end: bool = False
     limits: PlanLimits = PlanLimits()
+    deprecated: bool = False
+    deprecation_message: Optional[str] = None
 
 
 class PricingOption(BaseModel):

--- a/backend/models/users.py
+++ b/backend/models/users.py
@@ -15,8 +15,15 @@ class WebhookType(str, Enum):
 class PlanType(str, Enum):
     basic = 'basic'  # display "Free"
     unlimited = 'unlimited'  # LEGACY — display "Unlimited (legacy)"; hidden from new users
-    pro = 'pro'  # display "Architect" — pure rename, same Stripe price IDs
-    operator = 'operator'  # new — display "Operator"
+    architect = 'architect'  # display "Architect"
+    operator = 'operator'  # display "Operator"
+
+    @classmethod
+    def _missing_(cls, value):
+        # Backward compat: 'pro' was renamed to 'architect'
+        if value == 'pro':
+            return cls.architect
+        return None
 
 
 class SubscriptionStatus(str, Enum):
@@ -30,7 +37,7 @@ class PlanLimits(BaseModel):
     insights_gained: Optional[int] = None
     memories_created: Optional[int] = None
     # Chat caps. Exactly one of these is set per plan: `free` and `unlimited`
-    # (displayed as "Plus") cap by question count; `pro` caps by cost_usd.
+    # (displayed as "Plus") cap by question count; `architect` caps by cost_usd.
     chat_questions_per_month: Optional[int] = None
     chat_cost_usd_per_month: Optional[float] = None
 
@@ -41,8 +48,8 @@ class ChatQuotaUnit(str, Enum):
 
 
 class ChatUsageQuota(BaseModel):
-    plan: str  # display name: "Free", "Plus", "Pro"
-    plan_type: str  # internal id: "basic" | "unlimited" | "pro"
+    plan: str  # display name: "Free", "Plus", "Architect"
+    plan_type: str  # internal id: "basic" | "unlimited" | "architect"
     unit: ChatQuotaUnit
     used: float
     limit: Optional[float] = None  # None = unlimited (fallback)

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -357,14 +357,14 @@ def upgrade_subscription_endpoint(request: UpgradeSubscriptionRequest, uid: str 
         target_interval = target_price.recurring.interval  # "month" or "year"
         current_plan = get_plan_type_from_price_id(current_price_id)
 
-        # Block downgrades from Pro to Unlimited
-        if current_plan == PlanType.pro and target_plan == PlanType.unlimited:
+        # Block downgrades from Architect to Unlimited
+        if current_plan == PlanType.architect and target_plan == PlanType.unlimited:
             raise HTTPException(
                 status_code=400,
-                detail="Downgrading from Pro to Unlimited is not available. Please contact support if you need to change your plan.",
+                detail="Downgrading from Architect to Unlimited is not available. Please contact support if you need to change your plan.",
             )
 
-        # Cross-plan change (e.g. Unlimited→Pro): immediate swap with proration
+        # Cross-plan change (e.g. Unlimited→Architect): immediate swap with proration
         if current_plan != target_plan:
             updated_sub = stripe.Subscription.modify(
                 stripe_sub['id'],

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -1,3 +1,5 @@
+import os
+
 from fastapi import Request, Header, HTTPException, APIRouter, Depends, Query
 import stripe
 from pydantic import BaseModel
@@ -231,6 +233,17 @@ def get_available_plans_endpoint(
         all_definitions = get_paid_plan_definitions()
         if not new_plans_enabled:
             all_definitions = adapt_plans_for_legacy_client(all_definitions)
+            # Operator subscriber on old client: map their Stripe price to Unlimited
+            # so is_active detection works against the legacy catalog.
+            if current_price_id and current_subscription and current_subscription.plan == PlanType.operator:
+                op_monthly = os.getenv('STRIPE_OPERATOR_MONTHLY_PRICE_ID', '')
+                op_annual = os.getenv('STRIPE_OPERATOR_ANNUAL_PRICE_ID', '')
+                unlim_monthly = os.getenv('STRIPE_UNLIMITED_MONTHLY_PRICE_ID', '')
+                unlim_annual = os.getenv('STRIPE_UNLIMITED_ANNUAL_PRICE_ID', '')
+                if current_price_id == op_monthly and unlim_monthly:
+                    current_price_id = unlim_monthly
+                elif current_price_id == op_annual and unlim_annual:
+                    current_price_id = unlim_annual
 
         current_plan = current_subscription.plan if current_subscription else PlanType.basic
         pricing_options: List[PricingOption] = []

--- a/backend/routers/payment.py
+++ b/backend/routers/payment.py
@@ -233,17 +233,20 @@ def get_available_plans_endpoint(
         all_definitions = get_paid_plan_definitions()
         if not new_plans_enabled:
             all_definitions = adapt_plans_for_legacy_client(all_definitions)
-            # Operator subscriber on old client: map their Stripe price to Unlimited
+            # Operator subscriber on old client: map their Stripe prices to Unlimited
             # so is_active detection works against the legacy catalog.
-            if current_price_id and current_subscription and current_subscription.plan == PlanType.operator:
+            if current_subscription and current_subscription.plan == PlanType.operator:
                 op_monthly = os.getenv('STRIPE_OPERATOR_MONTHLY_PRICE_ID', '')
                 op_annual = os.getenv('STRIPE_OPERATOR_ANNUAL_PRICE_ID', '')
                 unlim_monthly = os.getenv('STRIPE_UNLIMITED_MONTHLY_PRICE_ID', '')
                 unlim_annual = os.getenv('STRIPE_UNLIMITED_ANNUAL_PRICE_ID', '')
-                if current_price_id == op_monthly and unlim_monthly:
-                    current_price_id = unlim_monthly
-                elif current_price_id == op_annual and unlim_annual:
-                    current_price_id = unlim_annual
+                price_map = {}
+                if op_monthly and unlim_monthly:
+                    price_map[op_monthly] = unlim_monthly
+                if op_annual and unlim_annual:
+                    price_map[op_annual] = unlim_annual
+                current_price_id = price_map.get(current_price_id, current_price_id)
+                scheduled_price_id = price_map.get(scheduled_price_id, scheduled_price_id)
 
         current_plan = current_subscription.plan if current_subscription else PlanType.basic
         pricing_options: List[PricingOption] = []

--- a/backend/routers/users.py
+++ b/backend/routers/users.py
@@ -815,14 +815,20 @@ def get_user_subscription_endpoint(
     subscription.limits = get_plan_limits(subscription.plan)
     subscription.features = get_plan_features(subscription.plan)
 
-    # Backward-compat guard: old mobile builds (Flutter PlanType in
-    # app/lib/models/subscription.dart is a fixed {basic, unlimited, pro})
-    # will throw a Dart decoding exception on any new plan enum value. Map
-    # Operator subscribers -> "unlimited" for wire serialization so existing
-    # deployed clients keep working. Desktop/web clients distinguish Operator
-    # from Unlimited by matching current_price_id against Operator price IDs,
-    # which is unchanged.
-    if subscription.plan == PlanType.operator:
+    new_plans_enabled = should_show_new_plans(x_app_platform, x_app_version)
+
+    # Mark deprecated plans
+    if subscription.plan == PlanType.unlimited:
+        subscription.deprecated = True
+        subscription.deprecation_message = (
+            "Your Unlimited plan is being retired. Switch to the Operator plan "
+            "— same great features at $49/mo. Your current plan will continue "
+            "to work in the meantime."
+        )
+
+    # Backward-compat: old clients without the `operator` enum value would crash
+    # on deserialization. Only send the real plan type to clients that understand it.
+    if not new_plans_enabled and subscription.plan == PlanType.operator:
         subscription.plan = PlanType.unlimited
 
     # Get current usage
@@ -840,14 +846,8 @@ def get_user_subscription_endpoint(
     insights_gained_limit = subscription.limits.insights_gained or 0
     memories_created_limit = subscription.limits.memories_created or 0
 
-    # Build available plans for upgrading. Two gates applied in order:
-    #   1. Version-gate: only macOS desktop clients at NEW_PLANS_MIN_DESKTOP_VERSION
-    #      or newer see the new Operator + Architect catalog. Everyone else
-    #      (mobile, older desktop builds) gets the pre-v0.11.324 plan shape
-    #      so we don't break them while the beta rollout bakes.
-    #   2. Legacy-filter: existing Unlimited subscribers still see their plan;
-    #      brand-new users don't.
-    new_plans_enabled = should_show_new_plans(x_app_platform, x_app_version)
+    # Build available plans. Version-gated: new clients see Operator + Architect,
+    # old clients get legacy plan names. Legacy plans filtered from purchase catalog.
     all_definitions = get_paid_plan_definitions()
     if not new_plans_enabled:
         all_definitions = adapt_plans_for_legacy_client(all_definitions)

--- a/backend/scripts/unlock_soft_cap_locked.py
+++ b/backend/scripts/unlock_soft_cap_locked.py
@@ -29,7 +29,7 @@ from google.cloud.firestore_v1.base_query import FieldFilter
 logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
 logger = logging.getLogger(__name__)
 
-PAID_PLANS = {'unlimited', 'pro'}
+PAID_PLANS = {'unlimited', 'architect', 'pro'}
 
 
 def read_uids(filepath: str) -> list[str]:

--- a/backend/test.sh
+++ b/backend/test.sh
@@ -87,6 +87,9 @@ pytest tests/unit/test_desktop_migration.py -v
 pytest tests/unit/test_staged_tasks_batch_scores.py -v
 pytest tests/unit/test_dg_start_guard.py -v
 pytest tests/unit/test_available_plans_resilience.py -v
+pytest tests/unit/test_subscription_restructure.py -v
+pytest tests/unit/test_subscription_plans.py -v
+pytest tests/unit/test_payment_available_plans_source.py -v
 pytest tests/unit/test_voice_duration_limiter.py -v
 pytest tests/unit/test_async_webhooks.py -v
 pytest tests/unit/test_async_app_integrations.py -v

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -52,11 +52,27 @@ for _name in [
     "database.redis_db",
     "database.user_usage",
     "database.cache",
+    "database.announcements",
 ]:
     _m = types.ModuleType(_name)
     sys.modules[_name] = _m
     # Set as attribute on database package so `from database import X` works
     setattr(_db_mod, _name.split(".")[-1], _m)
+
+# database.announcements needs _compare_versions for should_show_new_plans()
+_announcements_mod = sys.modules["database.announcements"]
+
+
+def _compare_versions(a, b):
+    a_parts = [int(x) for x in a.split('.')]
+    b_parts = [int(x) for x in b.split('.')]
+    for x, y in zip(a_parts, b_parts):
+        if x != y:
+            return 1 if x > y else -1
+    return len(a_parts) - len(b_parts)
+
+
+_announcements_mod._compare_versions = _compare_versions
 
 # database.users needs the functions payment.py imports by name
 _users_mod = sys.modules["database.users"]
@@ -193,6 +209,48 @@ def test_all_valid_prices_returns_all_plans():
     plan_ids = {p["id"] for p in plans}
     assert plan_ids == {UNLIM_MONTHLY, UNLIM_ANNUAL, PRO_MONTHLY, PRO_ANNUAL}
     assert len(plans) == 4
+
+
+def test_legacy_unlimited_subscriber_sees_is_active():
+    """Legacy Unlimited subscriber gets their plan with is_active=True in catalog."""
+    from models.users import Subscription, SubscriptionStatus, PlanType
+
+    sub = Subscription(
+        plan=PlanType.unlimited,
+        status=SubscriptionStatus.active,
+        stripe_subscription_id="sub_legacy_123",
+        cancel_at_period_end=False,
+    )
+    _users_mod.get_user_subscription.return_value = sub
+
+    # Mock Stripe subscription retrieval to return the monthly price
+    stripe_sub = MagicMock()
+    stripe_sub.to_dict.return_value = {
+        "items": {"data": [{"price": {"id": UNLIM_MONTHLY}}]},
+        "customer": "cus_123",
+    }
+    stripe.Subscription.retrieve = MagicMock(return_value=stripe_sub)
+    stripe.SubscriptionSchedule.list = MagicMock(return_value=MagicMock(data=[]))
+
+    def _mock_retrieve(price_id):
+        intervals = {UNLIM_MONTHLY: "month", UNLIM_ANNUAL: "year", PRO_MONTHLY: "month", PRO_ANNUAL: "year"}
+        amounts = {UNLIM_MONTHLY: 1900, UNLIM_ANNUAL: 18000, PRO_MONTHLY: 990, PRO_ANNUAL: 9900}
+        if price_id not in intervals:
+            raise Exception(f"Unexpected price_id: {price_id}")
+        return _make_stripe_price(price_id, amounts[price_id], intervals[price_id])
+
+    stripe.Price.retrieve = MagicMock(side_effect=_mock_retrieve)
+
+    response = client.get("/v1/payments/available-plans")
+
+    assert response.status_code == 200
+    plans = response.json()["plans"]
+
+    # Legacy unlimited subscriber should have their monthly plan marked active
+    active_plans = [p for p in plans if p["is_active"]]
+    assert len(active_plans) == 1
+    assert active_plans[0]["id"] == UNLIM_MONTHLY
+    assert active_plans[0]["interval"] == "month"
 
 
 def test_all_prices_fail_returns_500():

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -18,13 +18,13 @@ os.environ.setdefault(
 # Real Stripe dev price IDs
 UNLIM_MONTHLY = "price_1RrxXL1F8wnoWYvwIddzR902"
 UNLIM_ANNUAL = "price_1RrxXL1F8wnoWYvw3kDbWmjs"
-PRO_MONTHLY = "price_1TAznX1F8wnoWYvwyaSVQbZW"
-PRO_ANNUAL = "price_1TAznX1F8wnoWYvwN8YmzbiC"
+ARCH_MONTHLY = "price_1TAznX1F8wnoWYvwyaSVQbZW"
+ARCH_ANNUAL = "price_1TAznX1F8wnoWYvwN8YmzbiC"
 
 os.environ["STRIPE_UNLIMITED_MONTHLY_PRICE_ID"] = UNLIM_MONTHLY
 os.environ["STRIPE_UNLIMITED_ANNUAL_PRICE_ID"] = UNLIM_ANNUAL
-os.environ["STRIPE_PRO_MONTHLY_PRICE_ID"] = PRO_MONTHLY
-os.environ["STRIPE_PRO_ANNUAL_PRICE_ID"] = PRO_ANNUAL
+os.environ["STRIPE_ARCHITECT_MONTHLY_PRICE_ID"] = ARCH_MONTHLY
+os.environ["STRIPE_ARCHITECT_ANNUAL_PRICE_ID"] = ARCH_ANNUAL
 
 # --- Stub heavy infrastructure before importing any project modules ---
 
@@ -156,12 +156,12 @@ def _make_stripe_price(price_id, amount, interval):
     return price
 
 
-def test_invalid_pro_price_skips_pro_but_unlimited_remains():
-    """When stripe.Price.retrieve fails for Pro prices, only Unlimited plans are returned."""
+def test_invalid_architect_price_skips_architect_but_unlimited_remains():
+    """When stripe.Price.retrieve fails for Architect prices, only Unlimited plans are returned."""
     _users_mod.get_user_subscription.return_value = None
 
     def _mock_retrieve(price_id):
-        if price_id in (PRO_MONTHLY, PRO_ANNUAL):
+        if price_id in (ARCH_MONTHLY, ARCH_ANNUAL):
             raise Exception(f"No such price: {price_id}")
         if price_id == UNLIM_MONTHLY:
             return _make_stripe_price(price_id, 1900, "month")
@@ -182,9 +182,9 @@ def test_invalid_pro_price_skips_pro_but_unlimited_remains():
     assert UNLIM_MONTHLY in plan_ids
     assert UNLIM_ANNUAL in plan_ids
 
-    # Pro prices should be absent (their retrieval failed)
-    assert PRO_MONTHLY not in plan_ids
-    assert PRO_ANNUAL not in plan_ids
+    # Architect prices should be absent (their retrieval failed)
+    assert ARCH_MONTHLY not in plan_ids
+    assert ARCH_ANNUAL not in plan_ids
 
     assert len(plans) == 2
 
@@ -194,8 +194,8 @@ def test_all_valid_prices_returns_all_plans():
     _users_mod.get_user_subscription.return_value = None
 
     def _mock_retrieve(price_id):
-        intervals = {UNLIM_MONTHLY: "month", UNLIM_ANNUAL: "year", PRO_MONTHLY: "month", PRO_ANNUAL: "year"}
-        amounts = {UNLIM_MONTHLY: 1900, UNLIM_ANNUAL: 18000, PRO_MONTHLY: 990, PRO_ANNUAL: 9900}
+        intervals = {UNLIM_MONTHLY: "month", UNLIM_ANNUAL: "year", ARCH_MONTHLY: "month", ARCH_ANNUAL: "year"}
+        amounts = {UNLIM_MONTHLY: 1900, UNLIM_ANNUAL: 18000, ARCH_MONTHLY: 990, ARCH_ANNUAL: 9900}
         if price_id not in intervals:
             raise Exception(f"Unexpected price_id: {price_id}")
         return _make_stripe_price(price_id, amounts[price_id], intervals[price_id])
@@ -207,7 +207,7 @@ def test_all_valid_prices_returns_all_plans():
     assert response.status_code == 200
     plans = response.json()["plans"]
     plan_ids = {p["id"] for p in plans}
-    assert plan_ids == {UNLIM_MONTHLY, UNLIM_ANNUAL, PRO_MONTHLY, PRO_ANNUAL}
+    assert plan_ids == {UNLIM_MONTHLY, UNLIM_ANNUAL, ARCH_MONTHLY, ARCH_ANNUAL}
     assert len(plans) == 4
 
 
@@ -233,8 +233,8 @@ def test_legacy_unlimited_subscriber_sees_is_active():
     stripe.SubscriptionSchedule.list = MagicMock(return_value=MagicMock(data=[]))
 
     def _mock_retrieve(price_id):
-        intervals = {UNLIM_MONTHLY: "month", UNLIM_ANNUAL: "year", PRO_MONTHLY: "month", PRO_ANNUAL: "year"}
-        amounts = {UNLIM_MONTHLY: 1900, UNLIM_ANNUAL: 18000, PRO_MONTHLY: 990, PRO_ANNUAL: 9900}
+        intervals = {UNLIM_MONTHLY: "month", UNLIM_ANNUAL: "year", ARCH_MONTHLY: "month", ARCH_ANNUAL: "year"}
+        amounts = {UNLIM_MONTHLY: 1900, UNLIM_ANNUAL: 18000, ARCH_MONTHLY: 990, ARCH_ANNUAL: 9900}
         if price_id not in intervals:
             raise Exception(f"Unexpected price_id: {price_id}")
         return _make_stripe_price(price_id, amounts[price_id], intervals[price_id])
@@ -277,8 +277,8 @@ def test_operator_subscriber_on_old_client_gets_remapped_is_active(monkeypatch):
     stripe.SubscriptionSchedule.list = MagicMock(return_value=MagicMock(data=[]))
 
     def _mock_retrieve(price_id):
-        intervals = {UNLIM_MONTHLY: "month", UNLIM_ANNUAL: "year", PRO_MONTHLY: "month", PRO_ANNUAL: "year"}
-        amounts = {UNLIM_MONTHLY: 1900, UNLIM_ANNUAL: 18000, PRO_MONTHLY: 990, PRO_ANNUAL: 9900}
+        intervals = {UNLIM_MONTHLY: "month", UNLIM_ANNUAL: "year", ARCH_MONTHLY: "month", ARCH_ANNUAL: "year"}
+        amounts = {UNLIM_MONTHLY: 1900, UNLIM_ANNUAL: 18000, ARCH_MONTHLY: 990, ARCH_ANNUAL: 9900}
         if price_id not in intervals:
             raise Exception(f"Unexpected price_id: {price_id}")
         return _make_stripe_price(price_id, amounts[price_id], intervals[price_id])

--- a/backend/tests/unit/test_available_plans_resilience.py
+++ b/backend/tests/unit/test_available_plans_resilience.py
@@ -253,6 +253,51 @@ def test_legacy_unlimited_subscriber_sees_is_active():
     assert active_plans[0]["interval"] == "month"
 
 
+def test_operator_subscriber_on_old_client_gets_remapped_is_active(monkeypatch):
+    """Operator subscriber on old client (no platform header) gets price remapped to Unlimited."""
+    from models.users import Subscription, SubscriptionStatus, PlanType
+
+    OP_MONTHLY = "price_operator_monthly_test"
+    monkeypatch.setenv("STRIPE_OPERATOR_MONTHLY_PRICE_ID", OP_MONTHLY)
+
+    sub = Subscription(
+        plan=PlanType.operator,
+        status=SubscriptionStatus.active,
+        stripe_subscription_id="sub_operator_123",
+        cancel_at_period_end=False,
+    )
+    _users_mod.get_user_subscription.return_value = sub
+
+    stripe_sub = MagicMock()
+    stripe_sub.to_dict.return_value = {
+        "items": {"data": [{"price": {"id": OP_MONTHLY}}]},
+        "customer": "cus_456",
+    }
+    stripe.Subscription.retrieve = MagicMock(return_value=stripe_sub)
+    stripe.SubscriptionSchedule.list = MagicMock(return_value=MagicMock(data=[]))
+
+    def _mock_retrieve(price_id):
+        intervals = {UNLIM_MONTHLY: "month", UNLIM_ANNUAL: "year", PRO_MONTHLY: "month", PRO_ANNUAL: "year"}
+        amounts = {UNLIM_MONTHLY: 1900, UNLIM_ANNUAL: 18000, PRO_MONTHLY: 990, PRO_ANNUAL: 9900}
+        if price_id not in intervals:
+            raise Exception(f"Unexpected price_id: {price_id}")
+        return _make_stripe_price(price_id, amounts[price_id], intervals[price_id])
+
+    stripe.Price.retrieve = MagicMock(side_effect=_mock_retrieve)
+
+    # No platform header → old client → adapt_plans_for_legacy_client + price remap
+    response = client.get("/v1/payments/available-plans")
+
+    assert response.status_code == 200
+    plans = response.json()["plans"]
+
+    # Operator price should be remapped to Unlimited monthly, so is_active is set
+    active_plans = [p for p in plans if p["is_active"]]
+    assert len(active_plans) == 1
+    assert active_plans[0]["id"] == UNLIM_MONTHLY
+    assert active_plans[0]["interval"] == "month"
+
+
 def test_all_prices_fail_returns_500():
     """When every stripe.Price.retrieve call fails, endpoint returns HTTP 500."""
     _users_mod.get_user_subscription.return_value = None

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -8,20 +8,20 @@ from models.users import PlanType
 from utils.subscription import get_plan_features, get_plan_limits, get_plan_type_from_price_id, is_paid_plan
 
 
-def test_pro_price_ids_map_to_pro_plan(monkeypatch):
+def test_architect_price_ids_map_to_architect_plan(monkeypatch):
     monkeypatch.setenv("STRIPE_UNLIMITED_MONTHLY_PRICE_ID", "price_unlimited_monthly")
     monkeypatch.setenv("STRIPE_UNLIMITED_ANNUAL_PRICE_ID", "price_unlimited_annual")
-    monkeypatch.setenv("STRIPE_PRO_MONTHLY_PRICE_ID", "price_pro_monthly")
-    monkeypatch.setenv("STRIPE_PRO_ANNUAL_PRICE_ID", "price_pro_annual")
+    monkeypatch.setenv("STRIPE_ARCHITECT_MONTHLY_PRICE_ID", "price_architect_monthly")
+    monkeypatch.setenv("STRIPE_ARCHITECT_ANNUAL_PRICE_ID", "price_architect_annual")
 
     assert get_plan_type_from_price_id("price_unlimited_monthly") == PlanType.unlimited
     assert get_plan_type_from_price_id("price_unlimited_annual") == PlanType.unlimited
-    assert get_plan_type_from_price_id("price_pro_monthly") == PlanType.pro
-    assert get_plan_type_from_price_id("price_pro_annual") == PlanType.pro
+    assert get_plan_type_from_price_id("price_architect_monthly") == PlanType.architect
+    assert get_plan_type_from_price_id("price_architect_annual") == PlanType.architect
 
 
-def test_pro_is_treated_as_paid_unlimited_plan():
-    assert is_paid_plan(PlanType.pro) is True
-    assert get_plan_limits(PlanType.pro).transcription_seconds is None
-    assert "Automations and vibe coding" in get_plan_features(PlanType.pro)
-    assert "Unlimited listening, memories, and insights" in get_plan_features(PlanType.pro)
+def test_architect_is_treated_as_paid_unlimited_plan():
+    assert is_paid_plan(PlanType.architect) is True
+    assert get_plan_limits(PlanType.architect).transcription_seconds is None
+    assert "Automations and vibe coding" in get_plan_features(PlanType.architect)
+    assert "Unlimited listening, memories, and insights" in get_plan_features(PlanType.architect)

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -24,5 +24,5 @@ def test_pro_price_ids_map_to_pro_plan(monkeypatch):
 def test_pro_is_treated_as_paid_unlimited_plan():
     assert is_paid_plan(PlanType.pro) is True
     assert get_plan_limits(PlanType.pro).transcription_seconds is None
-    assert "Automations" in get_plan_features(PlanType.pro)
-    assert "Unlimited actions" in get_plan_features(PlanType.pro)
+    assert "Automations and vibe coding" in get_plan_features(PlanType.pro)
+    assert "Unlimited listening, memories, and insights" in get_plan_features(PlanType.pro)

--- a/backend/tests/unit/test_subscription_plans.py
+++ b/backend/tests/unit/test_subscription_plans.py
@@ -1,7 +1,6 @@
 import sys
 import types
 
-sys.modules.setdefault("stripe", types.SimpleNamespace())
 sys.modules.setdefault("database.users", types.SimpleNamespace())
 sys.modules.setdefault("database.user_usage", types.SimpleNamespace())
 

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -1,0 +1,206 @@
+"""Tests for subscription restructure: Basic + Operator ($49) + Architect ($400),
+deprecate Unlimited for existing users. Issue #6734."""
+
+import sys
+import types
+
+# Mock external dependencies before importing app code
+_announcements_mod = types.ModuleType("database.announcements")
+_announcements_mod._compare_versions = lambda a, b: (a > b) - (a < b)
+sys.modules.setdefault("stripe", types.SimpleNamespace())
+sys.modules.setdefault("database.users", types.SimpleNamespace())
+sys.modules.setdefault("database.user_usage", types.SimpleNamespace())
+sys.modules.setdefault("database.announcements", _announcements_mod)
+
+from models.users import PlanType, PlanLimits, Subscription
+
+
+def test_operator_chat_cap_independent_from_unlimited(monkeypatch):
+    """F4: Operator and Unlimited chat caps must be independently configurable."""
+    monkeypatch.setenv("OPERATOR_CHAT_QUESTIONS_PER_MONTH", "750")
+    monkeypatch.setenv("PLUS_CHAT_QUESTIONS_PER_MONTH", "500")
+
+    # Re-import to pick up env vars
+    import importlib
+    import utils.subscription as sub_mod
+
+    importlib.reload(sub_mod)
+
+    operator_limits = sub_mod.get_plan_limits(PlanType.operator)
+    unlimited_limits = sub_mod.get_plan_limits(PlanType.unlimited)
+
+    assert operator_limits.chat_questions_per_month == 750
+    assert unlimited_limits.chat_questions_per_month == 500
+    assert operator_limits.chat_questions_per_month != unlimited_limits.chat_questions_per_month
+
+
+def test_operator_default_matches_unlimited_default(monkeypatch):
+    """Both default to 500 when no env override is set."""
+    monkeypatch.delenv("OPERATOR_CHAT_QUESTIONS_PER_MONTH", raising=False)
+    monkeypatch.delenv("PLUS_CHAT_QUESTIONS_PER_MONTH", raising=False)
+
+    import importlib
+    import utils.subscription as sub_mod
+
+    importlib.reload(sub_mod)
+
+    operator_limits = sub_mod.get_plan_limits(PlanType.operator)
+    unlimited_limits = sub_mod.get_plan_limits(PlanType.unlimited)
+
+    assert operator_limits.chat_questions_per_month == 500
+    assert unlimited_limits.chat_questions_per_month == 500
+
+
+def test_pro_architect_uses_dollar_cap():
+    """Pro (Architect) plan uses dollar cap, not question count."""
+    from utils.subscription import get_plan_limits
+
+    limits = get_plan_limits(PlanType.pro)
+    assert limits.chat_cost_usd_per_month is not None
+    assert limits.chat_questions_per_month is None
+    assert limits.transcription_seconds is None  # unlimited transcription
+
+
+def test_operator_is_paid():
+    from utils.subscription import is_paid_plan
+
+    assert is_paid_plan(PlanType.operator)
+    assert is_paid_plan(PlanType.pro)
+    assert is_paid_plan(PlanType.unlimited)
+    assert not is_paid_plan(PlanType.basic)
+
+
+def test_filter_plans_hides_legacy():
+    """Legacy plans (Unlimited) hidden from purchase catalog for all users."""
+    from utils.subscription import get_paid_plan_definitions, filter_plans_for_user
+
+    definitions = get_paid_plan_definitions()
+    filtered = filter_plans_for_user(definitions, PlanType.basic)
+
+    plan_ids = [d['plan_id'] for d in filtered]
+    assert 'unlimited' not in plan_ids
+    assert 'operator' in plan_ids
+    assert 'pro' in plan_ids
+
+
+def test_filter_plans_hides_legacy_even_for_unlimited_subscriber():
+    """Even Unlimited subscribers don't see Unlimited in purchase catalog."""
+    from utils.subscription import get_paid_plan_definitions, filter_plans_for_user
+
+    definitions = get_paid_plan_definitions()
+    filtered = filter_plans_for_user(definitions, PlanType.unlimited)
+
+    plan_ids = [d['plan_id'] for d in filtered]
+    assert 'unlimited' not in plan_ids
+
+
+def test_legacy_client_adaptation():
+    """Old clients see Unlimited Plan (not legacy suffix) and no Operator."""
+    from utils.subscription import get_paid_plan_definitions, adapt_plans_for_legacy_client
+
+    definitions = get_paid_plan_definitions()
+    adapted = adapt_plans_for_legacy_client(definitions)
+
+    plan_ids = [d['plan_id'] for d in adapted]
+    assert 'operator' not in plan_ids
+    assert 'unlimited' in plan_ids
+    assert 'pro' in plan_ids
+
+    unlimited_def = next(d for d in adapted if d['plan_id'] == 'unlimited')
+    assert unlimited_def['title'] == 'Unlimited Plan'
+    assert unlimited_def['legacy'] is False  # old clients don't know about legacy flag
+
+    pro_def = next(d for d in adapted if d['plan_id'] == 'pro')
+    assert pro_def['title'] == 'Omi Pro'
+
+
+def test_version_gating_macos_always_new():
+    """macOS always gets new plans (no version header = True)."""
+    # _compare_versions mocked at module level to do simple string comparison
+    from utils.subscription import should_show_new_plans
+
+    assert should_show_new_plans('macos', None) is True
+    assert should_show_new_plans('macos', '99.99.999') is True
+
+
+def test_version_gating_mobile_requires_version():
+    """Mobile requires version header and must meet minimum."""
+    from utils.subscription import should_show_new_plans
+
+    # No version header on mobile = legacy
+    assert should_show_new_plans('android', None) is False
+    assert should_show_new_plans('ios', None) is False
+
+    # With version >= min = new plans (simple string compare: '9' > '1')
+    assert should_show_new_plans('android', '99.99.999') is True
+    assert should_show_new_plans('ios', '99.99.999') is True
+
+
+def test_version_gating_old_mobile_gets_legacy():
+    """Old mobile builds get legacy catalog."""
+    from utils.subscription import should_show_new_plans
+
+    # '0.0.1' < '1.0.530' in string comparison
+    assert should_show_new_plans('android', '0.0.1') is False
+    assert should_show_new_plans('ios', '0.0.1') is False
+
+
+def test_version_gating_unknown_platform():
+    """Unknown platform gets legacy catalog."""
+    from utils.subscription import should_show_new_plans
+
+    assert should_show_new_plans(None, None) is False
+    assert should_show_new_plans('windows', '1.0.0') is False
+
+
+def test_subscription_deprecation_fields():
+    """Subscription model supports deprecated + deprecation_message."""
+    sub = Subscription(plan=PlanType.unlimited, deprecated=True, deprecation_message="Your plan is retiring.")
+
+    assert sub.deprecated is True
+    assert sub.deprecation_message == "Your plan is retiring."
+
+    # Non-deprecated plan
+    sub2 = Subscription(plan=PlanType.operator)
+    assert sub2.deprecated is False
+    assert sub2.deprecation_message is None
+
+
+def test_operator_price_id_mapping(monkeypatch):
+    """Operator price IDs resolve to operator plan type."""
+    monkeypatch.setenv("STRIPE_OPERATOR_MONTHLY_PRICE_ID", "price_op_monthly")
+    monkeypatch.setenv("STRIPE_OPERATOR_ANNUAL_PRICE_ID", "price_op_annual")
+
+    import importlib
+    import utils.subscription as sub_mod
+
+    importlib.reload(sub_mod)
+
+    assert sub_mod.get_plan_type_from_price_id("price_op_monthly") == PlanType.operator
+    assert sub_mod.get_plan_type_from_price_id("price_op_annual") == PlanType.operator
+
+
+def test_plan_features_differentiate_operator_unlimited(monkeypatch):
+    """Operator and Unlimited show separate feature lists with their own caps."""
+    monkeypatch.setenv("OPERATOR_CHAT_QUESTIONS_PER_MONTH", "600")
+    monkeypatch.setenv("PLUS_CHAT_QUESTIONS_PER_MONTH", "500")
+
+    import importlib
+    import utils.subscription as sub_mod
+
+    importlib.reload(sub_mod)
+
+    op_features = sub_mod.get_plan_features(PlanType.operator)
+    ul_features = sub_mod.get_plan_features(PlanType.unlimited)
+
+    assert "600 chat questions per month" in op_features
+    assert "500 chat questions per month" in ul_features
+
+
+def test_plan_display_names():
+    from utils.subscription import get_plan_display_name
+
+    assert get_plan_display_name(PlanType.basic) == 'Free'
+    assert get_plan_display_name(PlanType.operator) == 'Operator'
+    assert get_plan_display_name(PlanType.pro) == 'Architect'
+    assert 'legacy' in get_plan_display_name(PlanType.unlimited).lower()

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -83,15 +83,17 @@ def test_filter_plans_hides_legacy():
     assert 'pro' in plan_ids
 
 
-def test_filter_plans_hides_legacy_even_for_unlimited_subscriber():
-    """Even Unlimited subscribers don't see Unlimited in purchase catalog."""
+def test_filter_plans_keeps_legacy_for_current_subscriber():
+    """Unlimited subscribers see their plan in catalog for active-plan detection."""
     from utils.subscription import get_paid_plan_definitions, filter_plans_for_user
 
     definitions = get_paid_plan_definitions()
     filtered = filter_plans_for_user(definitions, PlanType.unlimited)
 
     plan_ids = [d['plan_id'] for d in filtered]
-    assert 'unlimited' not in plan_ids
+    assert 'unlimited' in plan_ids
+    assert 'operator' in plan_ids
+    assert 'pro' in plan_ids
 
 
 def test_legacy_client_adaptation():

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -6,7 +6,19 @@ import types
 
 # Mock external dependencies before importing app code
 _announcements_mod = types.ModuleType("database.announcements")
-_announcements_mod._compare_versions = lambda a, b: (a > b) - (a < b)
+
+
+def _compare_versions(a, b):
+    """Semantic version comparison matching the real _compare_versions."""
+    a_parts = [int(x) for x in a.split('.')]
+    b_parts = [int(x) for x in b.split('.')]
+    for x, y in zip(a_parts, b_parts):
+        if x != y:
+            return 1 if x > y else -1
+    return len(a_parts) - len(b_parts)
+
+
+_announcements_mod._compare_versions = _compare_versions
 sys.modules.setdefault("database.users", types.SimpleNamespace())
 sys.modules.setdefault("database.user_usage", types.SimpleNamespace())
 sys.modules.setdefault("database.announcements", _announcements_mod)
@@ -117,7 +129,6 @@ def test_legacy_client_adaptation():
 
 def test_version_gating_macos_always_new():
     """macOS always gets new plans (no version header = True)."""
-    # _compare_versions mocked at module level to do simple string comparison
     from utils.subscription import should_show_new_plans
 
     assert should_show_new_plans('macos', None) is True
@@ -128,11 +139,9 @@ def test_version_gating_mobile_requires_version():
     """Mobile requires version header and must meet minimum."""
     from utils.subscription import should_show_new_plans
 
-    # No version header on mobile = legacy
     assert should_show_new_plans('android', None) is False
     assert should_show_new_plans('ios', None) is False
 
-    # With version >= min = new plans (simple string compare: '9' > '1')
     assert should_show_new_plans('android', '99.99.999') is True
     assert should_show_new_plans('ios', '99.99.999') is True
 
@@ -141,9 +150,35 @@ def test_version_gating_old_mobile_gets_legacy():
     """Old mobile builds get legacy catalog."""
     from utils.subscription import should_show_new_plans
 
-    # '0.0.1' < '1.0.530' in string comparison
     assert should_show_new_plans('android', '0.0.1') is False
     assert should_show_new_plans('ios', '0.0.1') is False
+
+
+def test_version_gating_exact_threshold():
+    """Exact threshold version gets new plans."""
+    from utils.subscription import should_show_new_plans
+
+    assert should_show_new_plans('android', '1.0.530') is True
+    assert should_show_new_plans('ios', '1.0.530') is True
+    assert should_show_new_plans('macos', '0.11.324') is True
+
+
+def test_version_gating_just_below_threshold():
+    """One version below threshold gets legacy."""
+    from utils.subscription import should_show_new_plans
+
+    assert should_show_new_plans('android', '1.0.529') is False
+    assert should_show_new_plans('ios', '1.0.529') is False
+    assert should_show_new_plans('macos', '0.11.323') is False
+
+
+def test_version_gating_malformed_version():
+    """Malformed version: macOS fail-open, mobile fail-closed."""
+    from utils.subscription import should_show_new_plans
+
+    assert should_show_new_plans('macos', 'not.a.version') is True
+    assert should_show_new_plans('android', 'not.a.version') is False
+    assert should_show_new_plans('ios', 'not.a.version') is False
 
 
 def test_version_gating_unknown_platform():

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -62,11 +62,11 @@ def test_operator_default_matches_unlimited_default(monkeypatch):
     assert unlimited_limits.chat_questions_per_month == 500
 
 
-def test_pro_architect_uses_dollar_cap():
-    """Pro (Architect) plan uses dollar cap, not question count."""
+def test_architect_uses_dollar_cap():
+    """Architect plan uses dollar cap, not question count."""
     from utils.subscription import get_plan_limits
 
-    limits = get_plan_limits(PlanType.pro)
+    limits = get_plan_limits(PlanType.architect)
     assert limits.chat_cost_usd_per_month is not None
     assert limits.chat_questions_per_month is None
     assert limits.transcription_seconds is None  # unlimited transcription
@@ -76,7 +76,7 @@ def test_operator_is_paid():
     from utils.subscription import is_paid_plan
 
     assert is_paid_plan(PlanType.operator)
-    assert is_paid_plan(PlanType.pro)
+    assert is_paid_plan(PlanType.architect)
     assert is_paid_plan(PlanType.unlimited)
     assert not is_paid_plan(PlanType.basic)
 
@@ -91,7 +91,7 @@ def test_filter_plans_hides_legacy():
     plan_ids = [d['plan_id'] for d in filtered]
     assert 'unlimited' not in plan_ids
     assert 'operator' in plan_ids
-    assert 'pro' in plan_ids
+    assert 'architect' in plan_ids
 
 
 def test_filter_plans_keeps_legacy_for_current_subscriber():
@@ -104,7 +104,7 @@ def test_filter_plans_keeps_legacy_for_current_subscriber():
     plan_ids = [d['plan_id'] for d in filtered]
     assert 'unlimited' in plan_ids
     assert 'operator' in plan_ids
-    assert 'pro' in plan_ids
+    assert 'architect' in plan_ids
 
 
 def test_legacy_client_adaptation():
@@ -117,14 +117,14 @@ def test_legacy_client_adaptation():
     plan_ids = [d['plan_id'] for d in adapted]
     assert 'operator' not in plan_ids
     assert 'unlimited' in plan_ids
-    assert 'pro' in plan_ids
+    assert 'architect' in plan_ids
 
     unlimited_def = next(d for d in adapted if d['plan_id'] == 'unlimited')
     assert unlimited_def['title'] == 'Unlimited Plan'
     assert unlimited_def['legacy'] is False  # old clients don't know about legacy flag
 
-    pro_def = next(d for d in adapted if d['plan_id'] == 'pro')
-    assert pro_def['title'] == 'Omi Pro'
+    architect_def = next(d for d in adapted if d['plan_id'] == 'architect')
+    assert architect_def['title'] == 'Omi Pro'
 
 
 def test_version_gating_macos_always_new():
@@ -238,5 +238,5 @@ def test_plan_display_names():
 
     assert get_plan_display_name(PlanType.basic) == 'Free'
     assert get_plan_display_name(PlanType.operator) == 'Operator'
-    assert get_plan_display_name(PlanType.pro) == 'Architect'
+    assert get_plan_display_name(PlanType.architect) == 'Architect'
     assert 'legacy' in get_plan_display_name(PlanType.unlimited).lower()

--- a/backend/tests/unit/test_subscription_restructure.py
+++ b/backend/tests/unit/test_subscription_restructure.py
@@ -7,7 +7,6 @@ import types
 # Mock external dependencies before importing app code
 _announcements_mod = types.ModuleType("database.announcements")
 _announcements_mod._compare_versions = lambda a, b: (a > b) - (a < b)
-sys.modules.setdefault("stripe", types.SimpleNamespace())
 sys.modules.setdefault("database.users", types.SimpleNamespace())
 sys.modules.setdefault("database.user_usage", types.SimpleNamespace())
 sys.modules.setdefault("database.announcements", _announcements_mod)

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -12,7 +12,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-PAID_PLAN_TYPES = {PlanType.unlimited, PlanType.pro, PlanType.operator}
+PAID_PLAN_TYPES = {PlanType.unlimited, PlanType.architect, PlanType.operator}
 
 
 def is_paid_plan(plan: PlanType) -> bool:
@@ -22,10 +22,9 @@ def is_paid_plan(plan: PlanType) -> bool:
 def get_paid_plan_definitions() -> list[dict]:
     """All plan definitions.
 
-    Pro is displayed as "Architect" — pure rename. Unlimited is kept as legacy
-    so existing subscribers keep their access and Stripe webhooks still resolve,
-    but it's filtered out of the "new user" purchase catalog via
-    `filter_plans_for_user`.
+    Unlimited is kept as legacy so existing subscribers keep their access
+    and Stripe webhooks still resolve, but it's filtered out of the "new user"
+    purchase catalog via `filter_plans_for_user`.
     """
     return [
         {
@@ -38,11 +37,11 @@ def get_paid_plan_definitions() -> list[dict]:
             "legacy": False,
         },
         {
-            "plan_type": PlanType.pro,
-            "plan_id": "pro",
+            "plan_type": PlanType.architect,
+            "plan_id": "architect",
             "title": "Architect",
-            "monthly_price_id": os.getenv('STRIPE_PRO_MONTHLY_PRICE_ID'),
-            "annual_price_id": os.getenv('STRIPE_PRO_ANNUAL_PRICE_ID'),
+            "monthly_price_id": os.getenv('STRIPE_ARCHITECT_MONTHLY_PRICE_ID'),
+            "annual_price_id": os.getenv('STRIPE_ARCHITECT_ANNUAL_PRICE_ID'),
             "annual_description": "Save with annual billing.",
             "legacy": False,
         },
@@ -121,8 +120,10 @@ def adapt_plans_for_legacy_client(definitions: list[dict]) -> list[dict]:
         if d['plan_id'] in ('operator', 'pro'):
             continue
         adapted = dict(d)
-        if d['plan_id'] == 'unlimited':
-            adapted['title'] = 'Omi Unlimited'
+        if d['plan_id'] == 'architect':
+            adapted['title'] = 'Omi Pro'
+        elif d['plan_id'] == 'unlimited':
+            adapted['title'] = 'Unlimited Plan'
             adapted['legacy'] = False
         out.append(adapted)
     return out
@@ -134,7 +135,7 @@ def legacy_plan_features(plan: PlanType) -> List[str]:
     Mirrors what `get_plan_features` used to return before the Operator /
     Architect rename so older clients' UI doesn't change under them.
     """
-    if plan == PlanType.pro:
+    if plan == PlanType.architect:
         return [
             "Automations",
             "Vibe coding",
@@ -185,7 +186,7 @@ BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_MEMORIES
 FREE_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('FREE_CHAT_QUESTIONS_PER_MONTH', '30'))
 OPERATOR_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('OPERATOR_CHAT_QUESTIONS_PER_MONTH', '500'))
 PLUS_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('PLUS_CHAT_QUESTIONS_PER_MONTH', '500'))
-PRO_CHAT_COST_USD_PER_MONTH = float(os.getenv('PRO_CHAT_COST_USD_PER_MONTH', '400.0'))
+ARCHITECT_CHAT_COST_USD_PER_MONTH = float(os.getenv('ARCHITECT_CHAT_COST_USD_PER_MONTH', '400.0'))
 
 # Hard kill-switch for the cap. Default OFF so we can deploy the backend to
 # prod without immediately blocking any existing over-cap user. Flip to "true"
@@ -196,7 +197,7 @@ CHAT_CAP_ENFORCEMENT_ENABLED = os.getenv('CHAT_CAP_ENFORCEMENT_ENABLED', 'false'
 PLAN_DISPLAY_NAMES = {
     PlanType.basic: 'Free',
     PlanType.unlimited: 'Unlimited (legacy)',
-    PlanType.pro: 'Architect',
+    PlanType.architect: 'Architect',
     PlanType.operator: 'Operator',
 }
 
@@ -296,7 +297,7 @@ def get_plan_limits(plan: PlanType) -> PlanLimits:
       - Free: question count
       - Operator: question count (OPERATOR_CHAT_QUESTIONS_PER_MONTH, default 500)
       - Unlimited (legacy): question count (PLUS_CHAT_QUESTIONS_PER_MONTH, default 500)
-      - Pro (Architect): dollar cap ($400/mo default)
+      - Architect: dollar cap ($400/mo default)
     """
     if plan == PlanType.operator:
         return PlanLimits(
@@ -314,26 +315,26 @@ def get_plan_limits(plan: PlanType) -> PlanLimits:
             memories_created=None,
             chat_questions_per_month=PLUS_CHAT_QUESTIONS_PER_MONTH,
         )
-    if plan == PlanType.pro:
+    if plan == PlanType.architect:
         return PlanLimits(
             transcription_seconds=None,
             words_transcribed=None,
             insights_gained=None,
             memories_created=None,
-            chat_cost_usd_per_month=PRO_CHAT_COST_USD_PER_MONTH,
+            chat_cost_usd_per_month=ARCHITECT_CHAT_COST_USD_PER_MONTH,
         )
     return get_basic_plan_limits()
 
 
 def get_plan_features(plan: PlanType) -> List[str]:
     """Returns the list of feature strings for the given plan."""
-    if plan == PlanType.pro:
+    if plan == PlanType.architect:
         # Lead with what you GET, keep the $400 as a soft fair-use line at the bottom.
         return [
             "Automations and vibe coding",
             "Unlimited listening, memories, and insights",
             "Priority desktop AI features",
-            f"~${int(PRO_CHAT_COST_USD_PER_MONTH)} of monthly AI compute included (fair-use cap)",
+            f"~${int(ARCHITECT_CHAT_COST_USD_PER_MONTH)} of monthly AI compute included (fair-use cap)",
         ]
 
     if plan == PlanType.operator:

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -69,40 +69,44 @@ def filter_plans_for_user(definitions: list[dict], current_plan: PlanType) -> li
 
 
 # Minimum desktop build that ships with the new plan catalog + quota UI.
-# Clients below this threshold — older desktop, or any mobile build — get the
-# pre-Operator plan shape. Once a stable release catches up, lower this.
 NEW_PLANS_MIN_DESKTOP_VERSION = os.getenv('NEW_PLANS_MIN_DESKTOP_VERSION', '0.11.324')
+
+# Minimum mobile build that ships with the `operator` enum value and new plan UI.
+# Mobile builds below this version get the legacy catalog with operator→unlimited mapping.
+NEW_PLANS_MIN_MOBILE_VERSION = os.getenv('NEW_PLANS_MIN_MOBILE_VERSION', '1.0.530')
 
 
 def should_show_new_plans(platform: Optional[str], app_version: Optional[str]) -> bool:
-    """True iff this caller's client has the Swift code that understands the new
-    Operator + Architect plan shape and the /v1/users/me/usage-quota endpoint.
+    """True iff this caller's client understands the Operator + Architect plan shape.
 
-    Any macOS desktop build qualifies. iOS / Android clients always get the
-    legacy plan catalog so the rollout is gated to desktop without cross-
-    client breakage.
-
-    The existing APIClient.swift doesn't send an X-App-Version header, so we
-    cannot version-gate per-build — version is included only as an opt-in
-    tightening hook once the client starts sending it.
+    Desktop (macOS): any build at or above NEW_PLANS_MIN_DESKTOP_VERSION qualifies.
+    Mobile (android/ios): any build at or above NEW_PLANS_MIN_MOBILE_VERSION qualifies.
+    Unknown platform: legacy catalog.
     """
     from database.announcements import _compare_versions
 
-    if not platform or platform.lower() != 'macos':
+    if not platform:
         return False
 
-    # No version header: assume a recent-enough desktop build. Desktop clients
-    # don't currently send X-App-Version (see APIClient.swift buildHeaders),
-    # so requiring it here would fail-closed for every real desktop user.
-    if not app_version:
-        return True
+    platform_lower = platform.lower()
 
-    try:
-        return _compare_versions(app_version, NEW_PLANS_MIN_DESKTOP_VERSION) >= 0
-    except Exception:
-        # Malformed version — fail-open on macOS rather than show the old
-        # catalog to a desktop client.
-        return True
+    if platform_lower == 'macos':
+        if not app_version:
+            return True
+        try:
+            return _compare_versions(app_version, NEW_PLANS_MIN_DESKTOP_VERSION) >= 0
+        except Exception:
+            return True
+
+    if platform_lower in ('android', 'ios'):
+        if not app_version:
+            return False
+        try:
+            return _compare_versions(app_version, NEW_PLANS_MIN_MOBILE_VERSION) >= 0
+        except Exception:
+            return False
+
+    return False
 
 
 def adapt_plans_for_legacy_client(definitions: list[dict]) -> list[dict]:
@@ -181,6 +185,7 @@ BASIC_TIER_MEMORIES_CREATED_LIMIT_PER_MONTH = int(os.getenv('BASIC_TIER_MEMORIES
 
 # Chat caps per plan. Env-overridable for ops.
 FREE_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('FREE_CHAT_QUESTIONS_PER_MONTH', '30'))
+OPERATOR_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('OPERATOR_CHAT_QUESTIONS_PER_MONTH', '500'))
 PLUS_CHAT_QUESTIONS_PER_MONTH = int(os.getenv('PLUS_CHAT_QUESTIONS_PER_MONTH', '500'))
 PRO_CHAT_COST_USD_PER_MONTH = float(os.getenv('PRO_CHAT_COST_USD_PER_MONTH', '400.0'))
 
@@ -291,10 +296,19 @@ def get_plan_limits(plan: PlanType) -> PlanLimits:
 
     Chat caps:
       - Free: question count
-      - Oracle + legacy Unlimited: question count (200/mo default)
+      - Operator: question count (OPERATOR_CHAT_QUESTIONS_PER_MONTH, default 500)
+      - Unlimited (legacy): question count (PLUS_CHAT_QUESTIONS_PER_MONTH, default 500)
       - Pro (Architect): dollar cap ($400/mo default)
     """
-    if plan in (PlanType.unlimited, PlanType.operator):
+    if plan == PlanType.operator:
+        return PlanLimits(
+            transcription_seconds=None,
+            words_transcribed=None,
+            insights_gained=None,
+            memories_created=None,
+            chat_questions_per_month=OPERATOR_CHAT_QUESTIONS_PER_MONTH,
+        )
+    if plan == PlanType.unlimited:
         return PlanLimits(
             transcription_seconds=None,
             words_transcribed=None,
@@ -324,7 +338,15 @@ def get_plan_features(plan: PlanType) -> List[str]:
             f"~${int(PRO_CHAT_COST_USD_PER_MONTH)} of monthly AI compute included (fair-use cap)",
         ]
 
-    if plan in (PlanType.unlimited, PlanType.operator):
+    if plan == PlanType.operator:
+        return [
+            f"{OPERATOR_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
+            "Unlimited listening and transcription",
+            "Unlimited memories and insights",
+            "Shared with mobile and web",
+        ]
+
+    if plan == PlanType.unlimited:
         return [
             f"{PLUS_CHAT_QUESTIONS_PER_MONTH} chat questions per month",
             "Unlimited listening and transcription",

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -58,14 +58,13 @@ def get_paid_plan_definitions() -> list[dict]:
 
 
 def filter_plans_for_user(definitions: list[dict], current_plan: PlanType) -> list[dict]:
-    """Drop legacy plans from the purchase catalog — always.
+    """Drop legacy plans from the purchase catalog unless the user is on one.
 
-    Legacy subscribers still see their current plan at the top of the Settings
-    → Plan and Usage screen (rendered from `subscription.plan`, not from the
-    purchase catalog) and can manage it via the Stripe customer portal, so
-    there's no need to offer it as a picker card too.
+    Legacy subscribers need their plan kept in the catalog so the mobile app
+    can detect `is_active` for interval-change flows.  New users never see
+    legacy plans in the picker.
     """
-    return [d for d in definitions if not d.get('legacy')]
+    return [d for d in definitions if not d.get('legacy') or d.get('plan_type') == current_plan]
 
 
 # Minimum desktop build that ships with the new plan catalog + quota UI.

--- a/backend/utils/subscription.py
+++ b/backend/utils/subscription.py
@@ -5,6 +5,7 @@ import stripe
 
 import database.users as users_db
 import database.user_usage as user_usage_db
+from database.announcements import _compare_versions
 from models.users import PlanType, SubscriptionStatus, Subscription, PlanLimits
 from utils.log_sanitizer import sanitize
 import logging
@@ -82,8 +83,6 @@ def should_show_new_plans(platform: Optional[str], app_version: Optional[str]) -
     Mobile (android/ios): any build at or above NEW_PLANS_MIN_MOBILE_VERSION qualifies.
     Unknown platform: legacy catalog.
     """
-    from database.announcements import _compare_versions
-
     if not platform:
         return False
 

--- a/desktop/CHANGELOG.json
+++ b/desktop/CHANGELOG.json
@@ -1,5 +1,8 @@
 {
-  "unreleased": [],
+  "unreleased": [
+    "Chat limits now use server-side quota instead of local counter",
+    "Added deprecation notice for Unlimited plan subscribers with Operator upgrade option"
+  ],
   "releases": [
     {
       "version": "0.11.324",

--- a/desktop/Desktop/Sources/APIClient.swift
+++ b/desktop/Desktop/Sources/APIClient.swift
@@ -3903,13 +3903,16 @@ struct UserSubscriptionInfo: Codable {
   let features: [String]
   let cancelAtPeriodEnd: Bool
   let limits: SubscriptionLimitsResponse
+  let deprecated: Bool?
+  let deprecationMessage: String?
 
   enum CodingKeys: String, CodingKey {
-    case plan, status, features, limits
+    case plan, status, features, limits, deprecated
     case currentPeriodEnd = "current_period_end"
     case stripeSubscriptionId = "stripe_subscription_id"
     case currentPriceId = "current_price_id"
     case cancelAtPeriodEnd = "cancel_at_period_end"
+    case deprecationMessage = "deprecation_message"
   }
 }
 

--- a/desktop/Desktop/Sources/AuthService.swift
+++ b/desktop/Desktop/Sources/AuthService.swift
@@ -1066,6 +1066,7 @@ class AuthService {
         // Stop background services that make API calls before clearing caches
         Task {
             await AgentSyncService.shared.stop()
+            await FloatingBarUsageLimiter.shared.reset()
         }
 
         // Close database and invalidate all storage caches so the next sign-in

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -49,6 +49,14 @@ final class FloatingBarUsageLimiter: ObservableObject {
         UserDefaults.standard.set(plan.rawValue, forKey: Self.cachedPlanKey)
     }
 
+    /// Reset all quota state on sign-out so the next user starts clean.
+    func reset() {
+        serverQuota = nil
+        optimisticDelta = 0
+        hasPaidPlan = false
+        UserDefaults.standard.removeObject(forKey: Self.cachedPlanKey)
+    }
+
     var isLimitReached: Bool {
         guard let quota = serverQuota else {
             // No server data yet — allow the query (server will enforce).
@@ -72,6 +80,9 @@ final class FloatingBarUsageLimiter: ObservableObject {
     var limitDescription: String {
         guard let quota = serverQuota, let limit = quota.limit else {
             return "your monthly free message limit"
+        }
+        if quota.unit == "cost_usd" {
+            return String(format: "your $%.0f %@ monthly spend limit", limit, quota.plan)
         }
         return "\(Int(limit)) \(quota.plan) messages this month"
     }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -1,33 +1,30 @@
 import Foundation
 
-/// Tracks AI chat/query usage and enforces a shared monthly limit for free users.
+/// Tracks AI chat/query usage and enforces limits using the server-side quota.
 ///
 /// Shared between the floating bar (Ask omi / PTT queries) and the main chat page
-/// (ChatProvider.sendMessage). A single 30-message monthly pool is counted against
-/// both surfaces so the free tier can't be stretched by bouncing between the two.
+/// (ChatProvider.sendMessage). The server endpoint `/v1/users/me/usage-quota` is
+/// the single source of truth for the current month's usage and plan limit.
 @MainActor
 final class FloatingBarUsageLimiter: ObservableObject {
     static let shared = FloatingBarUsageLimiter()
 
-    /// Monthly free cap, shared across floating bar + main chat.
-    static let monthlyFreeLimit = 30
-
-    /// Rolling window in seconds (30 days).
-    static let windowSeconds: Double = 30 * 24 * 3600
-
-    private static let queryTimestampsKey = "floatingBar_queryTimestamps"
     private static let cachedPlanKey = "floatingBar_cachedPlan"
 
-    @Published private(set) var monthlyQueriesUsed: Int = 0
     @Published private(set) var hasPaidPlan: Bool = false
-    private var planFetched = false
+
+    /// Server-reported quota snapshot, plus an optimistic local delta for queries
+    /// sent since the last server sync.
+    private var serverQuota: APIClient.ChatUsageQuota?
+    private var optimisticDelta: Int = 0
 
     private init() {
-        hasPaidPlan = UserDefaults.standard.string(forKey: Self.cachedPlanKey).map { $0 != "basic" } ?? false
-        pruneAndCount()
+        hasPaidPlan =
+            UserDefaults.standard.string(forKey: Self.cachedPlanKey).map { $0 != "basic" } ?? false
     }
 
-    /// Fetch the user's subscription plan from the backend (call on app launch / sign-in).
+    /// Fetch the user's subscription plan and usage quota from the backend.
+    /// Call on app launch, sign-in, and after checkout completes.
     func fetchPlan() async {
         do {
             let response = try await APIClient.shared.getUserSubscription()
@@ -35,41 +32,53 @@ final class FloatingBarUsageLimiter: ObservableObject {
         } catch {
             log("FloatingBarUsageLimiter: failed to fetch plan: \(error.localizedDescription)")
         }
+        await syncQuota()
+    }
+
+    /// Sync quota from the server, resetting the optimistic delta.
+    func syncQuota() async {
+        if let quota = await APIClient.shared.fetchChatUsageQuota() {
+            serverQuota = quota
+            optimisticDelta = 0
+        }
     }
 
     /// Update cached plan directly from an already-fetched subscription (no extra API call).
     func applyPlan(plan: SubscriptionPlanType, status: SubscriptionStatusType) {
         hasPaidPlan = plan != .basic && status == .active
         UserDefaults.standard.set(plan.rawValue, forKey: Self.cachedPlanKey)
-        planFetched = true
     }
 
     var isLimitReached: Bool {
-        !hasPaidPlan && monthlyQueriesUsed >= Self.monthlyFreeLimit
+        guard let quota = serverQuota else {
+            // No server data yet — allow the query (server will enforce).
+            return false
+        }
+        if quota.allowed {
+            // Check optimistic delta against remaining headroom.
+            guard let limit = quota.limit else { return false }
+            return (quota.used + Double(optimisticDelta)) >= limit
+        }
+        return true
     }
 
     var remainingQueries: Int {
-        hasPaidPlan ? .max : max(0, Self.monthlyFreeLimit - monthlyQueriesUsed)
+        guard let quota = serverQuota else { return .max }
+        guard quota.unit == "questions", let limit = quota.limit else { return .max }
+        return max(0, Int(limit - quota.used) - optimisticDelta)
+    }
+
+    /// Human-readable limit text for error messages.
+    var limitDescription: String {
+        guard let quota = serverQuota, let limit = quota.limit else {
+            return "your monthly free message limit"
+        }
+        return "\(Int(limit)) \(quota.plan) messages this month"
     }
 
     /// Record a query. Call after successfully sending a query from the floating bar
     /// OR the main chat page — both surfaces share this pool.
     func recordQuery() {
-        var timestamps = loadTimestamps()
-        timestamps.append(Date().timeIntervalSince1970)
-        UserDefaults.standard.set(timestamps, forKey: Self.queryTimestampsKey)
-        pruneAndCount()
-    }
-
-    private func pruneAndCount() {
-        let cutoff = Date().timeIntervalSince1970 - Self.windowSeconds
-        var timestamps = loadTimestamps()
-        timestamps.removeAll { $0 < cutoff }
-        UserDefaults.standard.set(timestamps, forKey: Self.queryTimestampsKey)
-        monthlyQueriesUsed = timestamps.count
-    }
-
-    private func loadTimestamps() -> [Double] {
-        UserDefaults.standard.array(forKey: Self.queryTimestampsKey) as? [Double] ?? []
+        optimisticDelta += 1
     }
 }

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -63,8 +63,10 @@ final class FloatingBarUsageLimiter: ObservableObject {
             return false
         }
         if quota.allowed {
-            // Check optimistic delta against remaining headroom.
-            guard let limit = quota.limit else { return false }
+            // Optimistic delta only applies to question-based quotas.
+            // For cost_usd (Architect/Pro), we can't estimate cost per query
+            // locally — rely on the server snapshot alone.
+            guard quota.unit == "questions", let limit = quota.limit else { return false }
             return (quota.used + Double(optimisticDelta)) >= limit
         }
         return true

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingBarUsageLimiter.swift
@@ -15,10 +15,10 @@ final class FloatingBarUsageLimiter: ObservableObject {
 
     /// Server-reported quota snapshot, plus an optimistic local delta for queries
     /// sent since the last server sync.
-    private var serverQuota: APIClient.ChatUsageQuota?
-    private var optimisticDelta: Int = 0
+    private(set) var serverQuota: APIClient.ChatUsageQuota?
+    private(set) var optimisticDelta: Int = 0
 
-    private init() {
+    init() {
         hasPaidPlan =
             UserDefaults.standard.string(forKey: Self.cachedPlanKey).map { $0 != "basic" } ?? false
     }
@@ -38,9 +38,14 @@ final class FloatingBarUsageLimiter: ObservableObject {
     /// Sync quota from the server, resetting the optimistic delta.
     func syncQuota() async {
         if let quota = await APIClient.shared.fetchChatUsageQuota() {
-            serverQuota = quota
-            optimisticDelta = 0
+            applyQuota(quota)
         }
+    }
+
+    /// Apply a quota snapshot directly (used by syncQuota and tests).
+    func applyQuota(_ quota: APIClient.ChatUsageQuota) {
+        serverQuota = quota
+        optimisticDelta = 0
     }
 
     /// Update cached plan directly from an already-fetched subscription (no extra API call).

--- a/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
+++ b/desktop/Desktop/Sources/FloatingControlBar/FloatingControlBarWindow.swift
@@ -1473,7 +1473,7 @@ class FloatingControlBarManager {
             barWindow.state.isAILoading = false
             barWindow.state.showingAIResponse = true
             barWindow.state.currentAIMessage = ChatMessage(
-                text: "You've hit your monthly limit of \(FloatingBarUsageLimiter.monthlyFreeLimit) free messages. Upgrade to keep chatting without restrictions.",
+                text: "You've reached \(limiter.limitDescription). Upgrade to keep chatting without restrictions.",
                 sender: .ai
             )
             barWindow.resizeToResponseHeightPublic(animated: true)

--- a/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
+++ b/desktop/Desktop/Sources/MainWindow/Pages/SettingsPage.swift
@@ -1799,6 +1799,42 @@ struct SettingsContentView: View {
         }
       }
 
+      if let subscription = userSubscription?.subscription,
+        subscription.deprecated == true
+      {
+        settingsCard(settingId: "planusage.deprecation") {
+          VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 10) {
+              Image(systemName: "exclamationmark.triangle.fill")
+                .foregroundColor(OmiColors.warning)
+                .scaledFont(size: 16)
+              Text("Plan Retiring")
+                .scaledFont(size: 14, weight: .semibold)
+                .foregroundColor(OmiColors.textPrimary)
+            }
+
+            Text(
+              subscription.deprecationMessage
+                ?? "Your Unlimited plan is being retired. Try the new Operator plan — same great features at $49/mo."
+            )
+            .scaledFont(size: 13)
+            .foregroundColor(OmiColors.textSecondary)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Button(action: {
+              selectedPlanIdForCheckout = "operator"
+            }) {
+              Text("Try Operator")
+                .scaledFont(size: 13, weight: .semibold)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(OmiColors.success)
+          }
+        }
+      }
+
       if shouldShowPlanPurchaseOptions {
         settingsCard(settingId: "planusage.purchase") {
           VStack(alignment: .leading, spacing: 18) {
@@ -6521,11 +6557,8 @@ struct SettingsContentView: View {
             subscription.subscription.plan != .basic && subscription.subscription.status == .active
 
           if matchedPrice && hasPaidPlan {
+            await FloatingBarUsageLimiter.shared.fetchPlan()
             await MainActor.run {
-              FloatingBarUsageLimiter.shared.applyPlan(
-                plan: subscription.subscription.plan,
-                status: subscription.subscription.status
-              )
               userSubscription = subscription
               subscriptionError = nil
               pendingSubscriptionPriceId = nil

--- a/desktop/Desktop/Sources/Providers/ChatProvider.swift
+++ b/desktop/Desktop/Sources/Providers/ChatProvider.swift
@@ -2137,7 +2137,7 @@ A screenshot may be attached — use it silently only if relevant. Never mention
         let usageLimiter = FloatingBarUsageLimiter.shared
         if usageLimiter.isLimitReached {
             log("ChatProvider: sendMessage blocked — free-tier monthly chat limit reached")
-            errorMessage = "You've hit your monthly limit of \(FloatingBarUsageLimiter.monthlyFreeLimit) free messages. Upgrade to keep chatting."
+            errorMessage = "You've reached \(usageLimiter.limitDescription). Upgrade to keep chatting."
             NotificationCenter.default.post(
                 name: .showUsageLimitPopup,
                 object: nil,

--- a/desktop/Desktop/Tests/FloatingBarUsageLimiterTests.swift
+++ b/desktop/Desktop/Tests/FloatingBarUsageLimiterTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+
+@testable import Omi_Computer
+
+@MainActor
+final class FloatingBarUsageLimiterTests: XCTestCase {
+
+  private func makeQuota(
+    plan: String = "Free",
+    unit: String = "questions",
+    used: Double = 0,
+    limit: Double? = 30,
+    percent: Double = 0,
+    allowed: Bool = true,
+    resetAt: Int? = nil
+  ) throws -> APIClient.ChatUsageQuota {
+    var json: [String: Any] = [
+      "plan": plan,
+      "plan_type": "basic",
+      "unit": unit,
+      "used": used,
+      "percent": percent,
+      "allowed": allowed,
+    ]
+    if let limit { json["limit"] = limit }
+    if let resetAt { json["reset_at"] = resetAt }
+    let data = try JSONSerialization.data(withJSONObject: json)
+    return try JSONDecoder().decode(APIClient.ChatUsageQuota.self, from: data)
+  }
+
+  // MARK: - No quota snapshot
+
+  func testNoQuotaAllowsQuery() {
+    let limiter = FloatingBarUsageLimiter()
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, .max)
+    XCTAssertEqual(limiter.limitDescription, "your monthly free message limit")
+  }
+
+  // MARK: - Question-based quota (Free / Operator / Unlimited)
+
+  func testBelowLimitAllowsQuery() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 10, limit: 30, percent: 33, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, 20)
+  }
+
+  func testExactlyAtLimitBlocks() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 30, limit: 30, percent: 100, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertTrue(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, 0)
+  }
+
+  func testRecordQueryPushesToLimit() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 29, limit: 30, percent: 96, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, 1)
+
+    limiter.recordQuery()
+    XCTAssertTrue(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, 0)
+  }
+
+  func testServerDeniedBlocks() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 30, limit: 30, percent: 100, allowed: false)
+    limiter.applyQuota(quota)
+    XCTAssertTrue(limiter.isLimitReached)
+  }
+
+  // MARK: - Cost-based quota (Architect / Pro)
+
+  func testCostUsdDoesNotApplyOptimisticDelta() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(
+      plan: "Architect", unit: "cost_usd", used: 399, limit: 400, percent: 99, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertFalse(limiter.isLimitReached)
+    // recordQuery should NOT push to limit for cost_usd
+    limiter.recordQuery()
+    limiter.recordQuery()
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, .max)
+  }
+
+  func testCostUsdServerDeniedBlocks() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(
+      plan: "Architect", unit: "cost_usd", used: 420, limit: 400, percent: 105, allowed: false)
+    limiter.applyQuota(quota)
+    XCTAssertTrue(limiter.isLimitReached)
+  }
+
+  // MARK: - limitDescription
+
+  func testLimitDescriptionQuestions() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 10, limit: 30, percent: 33, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertEqual(limiter.limitDescription, "30 Free messages this month")
+  }
+
+  func testLimitDescriptionCostUsd() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(
+      plan: "Architect", unit: "cost_usd", used: 50, limit: 400, percent: 12, allowed: true)
+    limiter.applyQuota(quota)
+    XCTAssertEqual(limiter.limitDescription, "your $400 Architect monthly spend limit")
+  }
+
+  // MARK: - applyQuota resets optimistic delta
+
+  func testApplyQuotaResetsOptimisticDelta() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Free", used: 10, limit: 30, percent: 33, allowed: true)
+    limiter.applyQuota(quota)
+    limiter.recordQuery()
+    limiter.recordQuery()
+    XCTAssertEqual(limiter.optimisticDelta, 2)
+
+    let freshQuota = try makeQuota(plan: "Free", used: 12, limit: 30, percent: 40, allowed: true)
+    limiter.applyQuota(freshQuota)
+    XCTAssertEqual(limiter.optimisticDelta, 0)
+    XCTAssertEqual(limiter.remainingQueries, 18)
+  }
+
+  // MARK: - reset() clears all state
+
+  func testResetClearsAll() throws {
+    let limiter = FloatingBarUsageLimiter()
+    let quota = try makeQuota(plan: "Plus", used: 500, limit: 500, percent: 100, allowed: false)
+    limiter.applyQuota(quota)
+    limiter.applyPlan(plan: .unlimited, status: .active)
+    limiter.recordQuery()
+    XCTAssertTrue(limiter.hasPaidPlan)
+
+    limiter.reset()
+    XCTAssertNil(limiter.serverQuota)
+    XCTAssertEqual(limiter.optimisticDelta, 0)
+    XCTAssertFalse(limiter.hasPaidPlan)
+    XCTAssertFalse(limiter.isLimitReached)
+    XCTAssertEqual(limiter.remainingQueries, .max)
+  }
+
+  // MARK: - applyPlan
+
+  func testApplyPlanBasicIsNotPaid() {
+    let limiter = FloatingBarUsageLimiter()
+    limiter.applyPlan(plan: .basic, status: .active)
+    XCTAssertFalse(limiter.hasPaidPlan)
+  }
+
+  func testApplyPlanOperatorActiveIsPaid() {
+    let limiter = FloatingBarUsageLimiter()
+    limiter.applyPlan(plan: .operator, status: .active)
+    XCTAssertTrue(limiter.hasPaidPlan)
+  }
+
+  func testApplyPlanInactiveIsNotPaid() {
+    let limiter = FloatingBarUsageLimiter()
+    limiter.applyPlan(plan: .operator, status: .inactive)
+    XCTAssertFalse(limiter.hasPaidPlan)
+  }
+}

--- a/desktop/Desktop/Tests/SubscriptionInfoDecoderTests.swift
+++ b/desktop/Desktop/Tests/SubscriptionInfoDecoderTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+
+@testable import Omi_Computer
+
+final class SubscriptionInfoDecoderTests: XCTestCase {
+
+  // MARK: - Baseline decoding (no deprecation fields)
+
+  func testDecodeBasicSubscription() throws {
+    let json = """
+      {
+        "plan": "basic",
+        "status": "active",
+        "current_period_end": null,
+        "stripe_subscription_id": null,
+        "current_price_id": null,
+        "features": [],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": 3600,
+          "words_transcribed": 10000,
+          "insights_gained": 50,
+          "memories_created": 100
+        }
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .basic)
+    XCTAssertEqual(info.status, .active)
+    XCTAssertNil(info.deprecated)
+    XCTAssertNil(info.deprecationMessage)
+  }
+
+  func testDecodeOperatorPlan() throws {
+    let json = """
+      {
+        "plan": "operator",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_abc",
+        "current_price_id": "price_xyz",
+        "features": ["chat_500"],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        }
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .operator)
+    XCTAssertEqual(info.status, .active)
+    XCTAssertNil(info.deprecated)
+  }
+
+  // MARK: - Deprecation fields
+
+  func testDecodeDeprecatedUnlimited() throws {
+    let json = """
+      {
+        "plan": "unlimited",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_old",
+        "current_price_id": "price_old",
+        "features": ["chat_500"],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        },
+        "deprecated": true,
+        "deprecation_message": "Your Unlimited plan is being retired. Try the Operator plan."
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .unlimited)
+    XCTAssertEqual(info.deprecated, true)
+    XCTAssertEqual(
+      info.deprecationMessage, "Your Unlimited plan is being retired. Try the Operator plan.")
+  }
+
+  func testDecodeDeprecatedFalse() throws {
+    let json = """
+      {
+        "plan": "operator",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_new",
+        "current_price_id": "price_new",
+        "features": [],
+        "cancel_at_period_end": false,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        },
+        "deprecated": false
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.deprecated, false)
+    XCTAssertNil(info.deprecationMessage)
+  }
+
+  func testDecodeProPlan() throws {
+    let json = """
+      {
+        "plan": "pro",
+        "status": "active",
+        "current_period_end": 1700000000,
+        "stripe_subscription_id": "sub_pro",
+        "current_price_id": "price_pro",
+        "features": ["automations"],
+        "cancel_at_period_end": true,
+        "limits": {
+          "transcription_seconds": null,
+          "words_transcribed": null,
+          "insights_gained": null,
+          "memories_created": null
+        }
+      }
+      """
+    let info = try JSONDecoder().decode(UserSubscriptionInfo.self, from: json.data(using: .utf8)!)
+    XCTAssertEqual(info.plan, .pro)
+    XCTAssertTrue(info.cancelAtPeriodEnd)
+    XCTAssertNil(info.deprecated)
+  }
+}


### PR DESCRIPTION
## Summary
Restructures subscription plans to 3-tier: **Basic** (free) + **Operator** ($49/mo) + **Architect** ($400/mo). Deprecates Unlimited plan for existing subscribers with deprecation notice.

Closes #6734

### Changes

- **Backend** (`models/users.py`, `utils/subscription.py`, `routers/payment.py`):
  - `PlanType.architect` enum (renamed from `pro`, with `_missing_` backward compat for Firestore docs storing `'pro'`)
  - `PlanType.operator` enum for new $49/mo tier
  - Env vars: `STRIPE_ARCHITECT_MONTHLY/ANNUAL_PRICE_ID`, `STRIPE_OPERATOR_MONTHLY/ANNUAL_PRICE_ID`, `ARCHITECT_CHAT_COST_USD_PER_MONTH`
  - `get_plan_limits()` returns separate caps per tier (Operator: question-based, Architect: dollar-based)
  - `filter_plans_for_user()` hides legacy plans from purchase catalog (keeps for current subscribers)
  - `should_show_new_plans()` version-gates catalog by platform+version headers
  - `adapt_plans_for_legacy_client()` remaps Operator→Unlimited for backward compat
  - Operator price ID→Unlimited remap for `current_price_id` and `scheduled_price_id`
  - Per-price try/except so one invalid Stripe price doesn't hide all plans

- **Mobile** (`plans_sheet.dart`, `subscription.dart`, etc.):
  - `PlanType.architect` enum (renamed from `pro`)
  - Architect plan in paid plan checks (upgrade flow, plan change, checkout routing)
  - Deprecation banner using l10n (`planUpdate`, `planDeprecationMessage`)
  - Localized remaining hardcoded strings (`upgradeYourPlan`, `youAreOnAPaidPlan`)

- **Desktop** (noa's commits — Swift/macOS):
  - `PlanType.architect` Swift enum
  - Free-tier unification (F3)
  - Deprecation banner UI
  - Quota display with server-driven limits

- **Helm values**: All 4 charts updated with new Stripe price IDs:
  - Operator prod: `price_1TMxVM1F8wnoWYvw9uaoYX7V` / `price_1TMxVM1F8wnoWYvwNfXdF6LW`
  - Operator dev: `price_1TN7jS1F8wnoWYvwM5GqfxDw` / `price_1TN7jo1F8wnoWYvw6Xu1zAtC`
  - Architect prod: `price_1TN7vz1F8wnoWYvwXbVLEX0Y` / `price_1TN7vz1F8wnoWYvwkrqXVn5t`
  - Architect dev: `price_1TN7s21F8wnoWYvwG6JuEFm6` / `price_1TN7sF1F8wnoWYvwd0QaLZNA`

- **Localization**: 4 new keys across all 33 locales with real translations

### Feature Gating Coverage
All feature gates properly handle the new `operator` plan:
- `PAID_PLAN_TYPES = {unlimited, architect, operator}` — central set used by all gates
- `is_paid_plan()` — phone calls, fair use, transcription, chat quota all route through this
- Operator: 500 chat questions/month, unlimited transcription
- Architect: unlimited (cost-capped by `ARCHITECT_CHAT_COST_USD_PER_MONTH`)
- Mobile + Desktop: all plan checks updated to triple-condition (`unlimited || operator || architect`)

### Tests (25 unit tests)
- `test_subscription_restructure.py` — 18 tests: plan limits, filtering, version gating, deprecation fields, price ID mapping, display names, feature lists, legacy client adaptation
- `test_available_plans_resilience.py` — 5 tests: per-price resilience, all-valid, all-fail, legacy subscriber is_active, operator remap
- `test_subscription_plans.py` — 2 tests: plan definitions, feature descriptions

### E2E Evidence

#### Backend API (5 test cases — all PASS)
| # | Case | Headers | Expected Catalog | Result |
|---|------|---------|-----------------|--------|
| 1 | Non-subscribed, new mobile | `android` / `1.0.530` | Operator ($49) + Architect ($400) | ✅ |
| 2 | Non-subscribed, old mobile | `android` / `0.0.1` | "Omi Pro" ($400) + "Unlimited" ($19.99) | ✅ |
| 3 | Non-subscribed, new macOS | `macos` / `0.11.324` | Operator ($49) + Architect ($400) | ✅ |
| 4 | No headers (legacy fallback) | none | "Omi Pro" + "Unlimited" (legacy) | ✅ |
| 5 | Unlimited subscriber | `android` / `1.0.530` | Deprecated=true + Operator/Architect upgrade | ✅ |

[Full API evidence with JSON responses](https://github.com/BasedHardware/omi/pull/6744#issuecomment-4267561355)

#### Mobile (Flutter on Android emulator)

**Non-subscribed user** — Plans sheet shows Operator Annual ($40/mo POPULAR) + Operator Monthly ($49/mo) with upgrade button and freemium limitation warnings.

**Unlimited subscriber** — "Change Plan" title, renewal date, deprecation banner ("Your Unlimited plan is being retired. Switch to the Operator plan — same great features at $49/mo."), Operator upgrade options, Manage Payment Method, Cancel Subscription.

[Non-subscribed mobile evidence](https://github.com/BasedHardware/omi/pull/6744#issuecomment-4267561355) | [Unlimited subscriber mobile evidence](https://github.com/BasedHardware/omi/pull/6744#issuecomment-4267677074)

#### Desktop (macOS)

**Unlimited subscriber — Deprecation banner + Operator $49 + Architect $400 (current plan filtered out):**

![Desktop fixed](https://storage.googleapis.com/omi-pr-assets/pr-6744/desktop-fixed-no-dup.png)

**Deprecation banner close-up:**

![Desktop deprecation](https://storage.googleapis.com/omi-pr-assets/pr-6744/desktop-deprecation-full.png)

[Desktop evidence with kelvin's backend](https://github.com/BasedHardware/omi/pull/6744#issuecomment-4267878925) | [Desktop fix — filter current plan](https://github.com/BasedHardware/omi/pull/6744#issuecomment-4267985182)

### Risks
- Existing Firestore docs with `plan: "pro"` handled by `PlanType._missing_()` backward compat
- Old mobile clients (pre-1.0.530) see legacy catalog — intentional backward compat
- No migration needed — backward compat is automatic

---

## Deployment Steps

> Consulted with @mon-agent on deployment safety.

### Pre-deploy checklist
- [ ] Verify Stripe price IDs are active in **prod** dashboard:
  - `price_1TMxVM1F8wnoWYvw9uaoYX7V` (Operator monthly)
  - `price_1TMxVM1F8wnoWYvwNfXdF6LW` (Operator annual)
  - `price_1TN7vz1F8wnoWYvwXbVLEX0Y` (Architect monthly)
  - `price_1TN7vz1F8wnoWYvwkrqXVn5t` (Architect annual)
- [ ] All 25 unit tests pass
- [ ] E2E evidence reviewed (mobile + desktop)

### Step 1: Set Cloud Run env vars (BEFORE code deploy)

The payment router runs on all services. Cloud Run env vars are NOT in Helm charts — they must be set directly.

**Prod — 3 Cloud Run services** (`backend`, `backend-sync`, `backend-integration`):
```bash
# backend
gcloud run services update backend --region us-central1 --project based-hardware-prod \
  --update-env-vars STRIPE_OPERATOR_MONTHLY_PRICE_ID=price_1TMxVM1F8wnoWYvw9uaoYX7V \
  --update-env-vars STRIPE_OPERATOR_ANNUAL_PRICE_ID=price_1TMxVM1F8wnoWYvwNfXdF6LW \
  --update-env-vars STRIPE_ARCHITECT_MONTHLY_PRICE_ID=price_1TN7vz1F8wnoWYvwXbVLEX0Y \
  --update-env-vars STRIPE_ARCHITECT_ANNUAL_PRICE_ID=price_1TN7vz1F8wnoWYvwkrqXVn5t

# backend-sync
gcloud run services update backend-sync --region us-central1 --project based-hardware-prod \
  --update-env-vars STRIPE_OPERATOR_MONTHLY_PRICE_ID=price_1TMxVM1F8wnoWYvw9uaoYX7V \
  --update-env-vars STRIPE_OPERATOR_ANNUAL_PRICE_ID=price_1TMxVM1F8wnoWYvwNfXdF6LW \
  --update-env-vars STRIPE_ARCHITECT_MONTHLY_PRICE_ID=price_1TN7vz1F8wnoWYvwXbVLEX0Y \
  --update-env-vars STRIPE_ARCHITECT_ANNUAL_PRICE_ID=price_1TN7vz1F8wnoWYvwkrqXVn5t

# backend-integration
gcloud run services update backend-integration --region us-central1 --project based-hardware-prod \
  --update-env-vars STRIPE_OPERATOR_MONTHLY_PRICE_ID=price_1TMxVM1F8wnoWYvw9uaoYX7V \
  --update-env-vars STRIPE_OPERATOR_ANNUAL_PRICE_ID=price_1TMxVM1F8wnoWYvwNfXdF6LW \
  --update-env-vars STRIPE_ARCHITECT_MONTHLY_PRICE_ID=price_1TN7vz1F8wnoWYvwXbVLEX0Y \
  --update-env-vars STRIPE_ARCHITECT_ANNUAL_PRICE_ID=price_1TN7vz1F8wnoWYvwkrqXVn5t
```

**Dev — same 3 services** (use dev price IDs):
```bash
# backend (dev)
gcloud run services update backend --region us-central1 --project based-hardware-dev \
  --update-env-vars STRIPE_OPERATOR_MONTHLY_PRICE_ID=price_1TN7jS1F8wnoWYvwM5GqfxDw \
  --update-env-vars STRIPE_OPERATOR_ANNUAL_PRICE_ID=price_1TN7jo1F8wnoWYvw6Xu1zAtC \
  --update-env-vars STRIPE_ARCHITECT_MONTHLY_PRICE_ID=price_1TN7s21F8wnoWYvwG6JuEFm6 \
  --update-env-vars STRIPE_ARCHITECT_ANNUAL_PRICE_ID=price_1TN7sF1F8wnoWYvwd0QaLZNA

# Repeat for backend-sync and backend-integration (dev)
```

**Cleanup** (after deploy is verified): remove old `STRIPE_PRO_MONTHLY_PRICE_ID` and `STRIPE_PRO_ANNUAL_PRICE_ID` from all Cloud Run services.

### Step 2: Merge PR to `main` (no squash)

### Step 3: Deploy backend to dev (auto + manual Helm)
Auto-deploy on push to `main`:
- `gcp_backend_auto_dev.yml` → backend-listen code
- `gcp_backend_pusher_auto_deploy.yml` → pusher code

Manual Helm upgrade (new env vars for GKE):
```bash
gh workflow run gcp_backend_listen_helm.yml -f environment=development -f branch=main
gh workflow run gcp_backend_pusher.yml -f environment=development -f branch=main
```

### Step 4: Verify dev
- Check startup logs for `validate_stripe_price_ids()` errors
- Curl dev API to confirm new plans returned for new clients
- Curl dev API without headers to confirm legacy catalog still works

### Step 5: Deploy backend to prod (manual)
```bash
# Backend-listen code (Cloud Run + GKE)
gh workflow run gcp_backend.yml -f environment=prod -f branch=main

# Backend-listen Helm (new Stripe env vars for GKE)
gh workflow run gcp_backend_listen_helm.yml -f environment=prod -f branch=main

# Pusher code + Helm
gh workflow run gcp_backend_pusher.yml -f environment=prod -f branch=main
```

### Step 6: Verify prod
```bash
# New client sees Operator + Architect
curl -s https://api.omi.me/v1/payments/available-plans \
  -H "Authorization: Bearer <token>" \
  -H "X-App-Platform: android" -H "X-App-Version: 1.0.530"

# Old client sees legacy catalog
curl -s https://api.omi.me/v1/payments/available-plans \
  -H "Authorization: Bearer <token>"
```

### Step 7: Mobile + Desktop release
- **Mobile**: Auto via Codemagic on `main` push with `app/` changes. Bump build number in `pubspec.yaml` if needed.
- **Desktop**: Auto via GitHub Actions (`desktop_auto_release.yml`) → Codemagic build/sign/notarize.
- Version gating: mobile >= 1.0.530 and desktop >= 0.11.324 see new plans.

### Step 8: Cleanup old env vars
After verifying prod is stable, remove deprecated env vars from Cloud Run + Helm:
- `STRIPE_PRO_MONTHLY_PRICE_ID` (replaced by `STRIPE_ARCHITECT_MONTHLY_PRICE_ID`)
- `STRIPE_PRO_ANNUAL_PRICE_ID` (replaced by `STRIPE_ARCHITECT_ANNUAL_PRICE_ID`)

### Safety nets (no canary needed)
- **Version gating IS the canary** — old clients never see new plans until they update
- **Per-price resilience** — one bad Stripe price hides only that plan, not all
- **Firestore backward compat** — `_missing_("pro")` auto-maps, no migration needed
- **No Redis invalidation** — `set_credits_invalidation_signal` fires automatically on subscription changes
- **No database migration** — all backward compat is automatic
- **Chat cap enforcement** — disabled by default (`CHAT_CAP_ENFORCEMENT_ENABLED=false`)

### Post-deploy monitoring
- [ ] Startup logs: check for Stripe price validation errors
- [ ] Payment logs: subscription creation/upgrade errors on new price IDs
- [ ] Stripe dashboard: new Operator/Architect subscriptions appearing
- [ ] 5xx monitoring on `/v1/subscription`, `/v1/payments` endpoints
- [ ] Existing Unlimited subscribers: verify paid features still work

### Rollback
- Re-deploy previous commit: `gh workflow run gcp_backend.yml -f environment=prod -f branch=<prev-sha>`
- Helm values include old `STRIPE_UNLIMITED_*` alongside new — no breakage on revert
- Cloud Run env vars: revert `STRIPE_ARCHITECT_*` back to `STRIPE_PRO_*` if needed
- Mobile/Desktop: old clients unaffected by version gating

🤖 Generated with [Claude Code](https://claude.com/claude-code)