### PR TITLE
fix: convert seconds to milliseconds in merge_wav_files

### DIFF
--- a/backend/utils/audio.py
+++ b/backend/utils/audio.py
@@ -74,7 +74,7 @@ def merge_wav_files(dest_file_path: str, source_files: [str], silent_seconds: [i
         file_path = source_files[i]
         sound = AudioSegment.from_wav(file_path)
         silent_sec = silent_seconds[i]
-        combined_sounds = combined_sounds + sound + AudioSegment.silent(duration=silent_sec)
+        combined_sounds = combined_sounds + sound + AudioSegment.silent(duration=silent_sec * 1000)
     combined_sounds.export(dest_file_path, format="wav")
 
 


### PR DESCRIPTION
## Summary

`AudioSegment.silent(duration=...)` expects duration in **milliseconds**, but `merge_wav_files` was passing the raw `silent_seconds` value (in seconds) directly. This caused silence gaps to be ~1000× shorter than intended.

### Root cause

```python
# Before (wrong): silent_sec is seconds, but pydub expects ms
AudioSegment.silent(duration=silent_sec)

# After (correct): multiply by 1000 to convert seconds → milliseconds  
AudioSegment.silent(duration=silent_sec * 1000)
```

Closes #6745

Signed-off-by: Cocoon-Break <54054995+kuishou68@users.noreply.github.com>